### PR TITLE
Fix error check in `rzip.CreateFromDirectory`.

### DIFF
--- a/cli/azd/pkg/rzip/rzip.go
+++ b/cli/azd/pkg/rzip/rzip.go
@@ -15,12 +15,12 @@ import (
 func CreateFromDirectory(source string, buf *os.File) error {
 	w := zip.NewWriter(buf)
 	err := filepath.Walk(source, func(path string, info fs.FileInfo, err error) error {
-		if info.IsDir() {
-			return nil
-		}
-
 		if err != nil {
 			return err
+		}
+
+		if info.IsDir() {
+			return nil
 		}
 
 		header := &zip.FileHeader{


### PR DESCRIPTION
We need to check `err` first in `walkFn`. If `err` is non-nil, `fs.FileInfo` will be `nil`

Fixes internal issue #1258