### PR TITLE
Use CDN instead of direct storage https host

### DIFF
--- a/cli/installer/install-azd.ps1
+++ b/cli/installer/install-azd.ps1
@@ -8,7 +8,7 @@ download locations
 
 .PARAMETER BaseUrl
 Specifies the base URL to use when downloading. Default is
-https://azuresdkreleasepreview.blob.core.windows.net/azd/standalone
+https://azure-dev.azureedge.net/azd/standalone
 
 .PARAMETER Version
 Specifies the version to use. Default is `latest`. Valid values include a
@@ -28,7 +28,7 @@ Download timeout in seconds. Default is 120 (2 minutes).
 #>
 
 param(
-    [string] $BaseUrl = "https://azuresdkreleasepreview.blob.core.windows.net/azd/standalone/release",
+    [string] $BaseUrl = "https://azure-dev.azureedge.net/azd/standalone/release",
     [string] $Version = "daily",
     [switch] $DryRun,
     [string] $InstallFolder = "$($env:LocalAppData)\Programs\Azure Dev CLI",

--- a/cli/installer/install-azd.sh
+++ b/cli/installer/install-azd.sh
@@ -81,7 +81,7 @@ extract() {
     fi
 }
 
-DEFAULT_BASE_URL="https://azuresdkreleasepreview.blob.core.windows.net/azd/standalone/release"
+DEFAULT_BASE_URL="https://azure-dev.azureedge.net/azd/standalone/release"
 
 base_url="$DEFAULT_BASE_URL"
 platform="$(get_platform)"


### PR DESCRIPTION
Anecdotally faster downloads on Windows and WSL hosts. 

After merge and publish, update aka.ms URLs to: 

* [x] https://azure-dev.azureedge.net/azd/standalone/installer/install-azd.sh
* [x] https://azure-dev.azureedge.net/azd/standalone/installer/install-azd.ps1
* [x] https://azure-dev.azureedge.net/azd/standalone/installer/uninstall-azd.sh
* [x] https://azure-dev.azureedge.net/azd/standalone/installer/uninstall-azd.ps1