### PR TITLE
Changes default Versions parameter value to match help

### DIFF
--- a/cli/installer/install-azd.ps1
+++ b/cli/installer/install-azd.ps1
@@ -29,7 +29,7 @@ Download timeout in seconds. Default is 120 (2 minutes).
 
 param(
     [string] $BaseUrl = "https://azuresdkreleasepreview.blob.core.windows.net/azd/standalone/release",
-    [string] $Version = "daily",
+    [string] $Version = "latest",
     [switch] $DryRun,
     [string] $InstallFolder = "$($env:LocalAppData)\Programs\Azure Dev CLI",
     [switch] $NoPath,


### PR DESCRIPTION
This PR closes #29 

In PowerShell install script, the help states that the default value is 'latest' but in the script, the default value is is 'daily'. If you'd like to adjust the help rather than the defualt value or change both, feel free to let me know and I'll adjust my change. 

