### PR TITLE
Mark Daniel as an owner of the installers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 
 * @jongio @ellismg
 /cli/ @ellismg @wbreza @vhvb1989 @hemarina @jongio @weikanglim
+/cli/installer @ellismg @danieljurek
 /ext/ @karolz-ms @ellismg @jongio
 /generators/repo/ @wbreza @ellismg @danieljurek
 /.github/ @danieljurek @ellismg


### PR DESCRIPTION
He wrote them an is the expert, but due to how we have the source tree
laid out he wasn't being listed as a code-owner. Adjust things so that
he and I are the ones listed as owners for the installer.