### PR TITLE
Add a note to README.md for supported regions

### DIFF
--- a/templates/todo/projects/nodejs-mongo-aca/README.md
+++ b/templates/todo/projects/nodejs-mongo-aca/README.md
@@ -45,6 +45,27 @@ You will be prompted for the following information:
 - `Azure Location`: The Azure location where your resources will be deployed.
 - `Azure Subscription`: The Azure Subscription where your resources will be deployed.
 
+> NOTE: This template may only be used with the following Azure locations:
+>
+> - Australia East
+> - Brazil South
+> - Canada Central
+> - Central US
+> - East Asia
+> - East US
+> - East US 2
+> - Germany West Central
+> - Japan East
+> - Korea Central
+> - North Central US
+> - North Europe
+> - South Central US
+> - UK South
+> - West Europe
+> - West US
+>
+> If you attempt to use the template with an unsupported region, the provision step will fail.
+
 > NOTE: This may take a while to complete as it executes three commands: `azd init` (initializes environment), `azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it provisions and deploys your application.
 
 When `azd up` is complete it will output the following URLs:

--- a/templates/todo/projects/nodejs-mongo-swa-func/README.md
+++ b/templates/todo/projects/nodejs-mongo-swa-func/README.md
@@ -45,6 +45,16 @@ You will be prompted for the following information:
 - `Azure Location`: The Azure location where your resources will be deployed.
 - `Azure Subscription`: The Azure Subscription where your resources will be deployed.
 
+> NOTE: This template may only be used used with following Azure locations:
+>
+> - Central US
+> - East Asia
+> - East US 2
+> - West Europe
+> - West US 2
+>
+> If you attempt to use the template with an unsupported region, the provision step will fail.
+
 > NOTE: This may take a while to complete as it executes three commands: `azd init` (initializes environment), `azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it provisions and deploys your application.
 
 When `azd up` is complete it will output the following URLs:

--- a/templates/todo/projects/python-mongo-aca/README.md
+++ b/templates/todo/projects/python-mongo-aca/README.md
@@ -47,6 +47,27 @@ You will be prompted for the following information:
 - `Azure Location`: The Azure location where your resources will be deployed.
 - `Azure Subscription`: The Azure Subscription where your resources will be deployed.
 
+> NOTE: This template may only be used with the following Azure locations:
+>
+> - Australia East
+> - Brazil South
+> - Canada Central
+> - Central US
+> - East Asia
+> - East US
+> - East US 2
+> - Germany West Central
+> - Japan East
+> - Korea Central
+> - North Central US
+> - North Europe
+> - South Central US
+> - UK South
+> - West Europe
+> - West US
+>
+> If you attempt to use the template with an unsupported region, the provision step will fail.
+
 > NOTE: This may take a while to complete as it executes three commands: `azd init` (initializes environment), `azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it provisions and deploys your application.
 
 When `azd up` is complete it will output the following URLs:

--- a/templates/todo/projects/python-mongo-swa-func/README.md
+++ b/templates/todo/projects/python-mongo-swa-func/README.md
@@ -46,6 +46,16 @@ You will be prompted for the following information:
 - `Azure Location`: The Azure location where your resources will be deployed.
 - `Azure Subscription`: The Azure Subscription where your resources will be deployed.
 
+> NOTE: This template may only be used with the following Azure locations:
+>
+> - Central US
+> - East Asia
+> - East US 2
+> - West Europe
+> - West US 2
+>
+> If you attempt to use it with another region, the provision step will fail.
+
 > NOTE: This may take a while to complete as it executes three commands: `azd init` (initializes environment), `azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it provisions and deploys your application.
 
 When `azd up` is complete it will output the following URLs:


### PR DESCRIPTION
Some of our templates use services which are not supported in all
Azure regions. Long term we hope to encode this information in a way
such that the CLI can restrict the list of locations to offer user to
pick from when they are doing a deployment, but that work is still in
progress. For now, add a note to some of our templates calling out
supported regions.

This list was generated by looking at every RP used for each template
and then fetching information from ARM to see what locations the
resources were suported in. When then intersect all these sets of
locations.

Unsurprisingly, the lists are the same between the node and python
versions of our templates.