### PR TITLE
`log.Print` template contents when we fail to parse it

### DIFF
--- a/cli/azd/pkg/iac/bicep/compile.go
+++ b/cli/azd/pkg/iac/bicep/compile.go
@@ -22,7 +22,7 @@ func Compile(ctx context.Context, bicepCli tools.BicepCli, bicepPath string) (Co
 	// prompt.
 	var template CompiledTemplate
 	if err := json.Unmarshal([]byte(compiled), &template); err != nil {
-		log.Printf("failed un-marshaling compiled arm template to JSON (err: %v), template contents\n: %s", err, compiled)
+		log.Printf("failed un-marshaling compiled arm template to JSON (err: %v), template contents:\n%s", err, compiled)
 		return CompiledTemplate{}, fmt.Errorf("error un-marshaling arm template from json: %w", err)
 	}
 


### PR DESCRIPTION
This should help debugging issues like #40