### PR TITLE
Updates template testing script with additional options

### DIFF
--- a/templates/tests/test-templates.sh
+++ b/templates/tests/test-templates.sh
@@ -29,7 +29,7 @@ function usage {
     echo "  -r    Sets the number of retries for playwright tests (default: 1)"
     echo "  -l    Sets the Azure location for the template infrastructure (default: eastus2)"
     echo "  -s    Sets the environment suffix (default: RANDOM)"
-    echo "  -n    When set will only run test commands"
+    echo "  -n    When set will only run test commands (default: false)"
     echo "  -c    when set will clean up resources (default: true)"
     echo ""
     echo "Examples:"

--- a/templates/tests/test-templates.sh
+++ b/templates/tests/test-templates.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
-FOLDER_PATH=""
+# Default to user HOME directory if not specified
+FOLDER_PATH=$HOME
+# Default to 'main' if not specified
+BRANCH_NAME="main"
+# Default to current logged in user if not specified
+ENV_NAME_PREFIX=$(whoami)
 TEMPLATE_NAME=""
-BRANCH_NAME=""
-ENV_NAME_PREFIX=""
-PLAYWRIGHT_RETRIES="3"
+PLAYWRIGHT_RETRIES="1"
 LOCATION="eastus2"
+# Default to a random value if not specified
+ENV_SUFFIX="$RANDOM"
+# When set will only run tests without deployments
+TEST_ONLY=false
+# When set will clean up local and remote resources
+CLEANUP=true
 
 function usage {
     echo "Tests azd template init, provision & deploy"
@@ -17,8 +26,11 @@ function usage {
     echo "  -b    Sets the template branch name. Override to test a any custom branches (default: main)"
     echo "  -e    Sets the environment name prefix. Environment prefix is used in the azd environment name along with the template name (default: whoami)"
     echo "  -t    Sets the template name. Use values from 'azd template list'. When omitted will run for all templates available in 'azd template list'"
-    echo "  -r    Sets the number of retries for playwright tests (default: 3)"
+    echo "  -r    Sets the number of retries for playwright tests (default: 1)"
     echo "  -l    Sets the Azure location for the template infrastructure (default: eastus2)"
+    echo "  -s    Sets the environment suffix (default: RANDOM)"
+    echo "  -n    When set will only run test commands"
+    echo "  -c    when set will clean up resources (default: true)"
     echo ""
     echo "Examples:"
     echo "  Testing a single template with custom branch"
@@ -30,7 +42,7 @@ function usage {
     exit 1
 }
 
-while getopts "f:t:b:e:r:l:h" arg; do
+while getopts "f:t:b:e:r:l:s:n:c:h" arg; do
     case ${arg} in
     f) FOLDER_PATH=$OPTARG ;;
     t) TEMPLATE_NAME=$OPTARG ;;
@@ -38,35 +50,23 @@ while getopts "f:t:b:e:r:l:h" arg; do
     e) ENV_NAME_PREFIX=$OPTARG ;;
     r) PLAYWRIGHT_RETRIES=$OPTARG ;;
     l) LOCATION=$OPTARG ;;
+    s) ENV_SUFFIX=$OPTARG ;;
+    n) TEST_ONLY=true ;;
+    c) CLEANUP=$OPTARG ;;
     h)
         usage
         ;;
     :)
-        echo "$0: Must supply an argument to -$OPTARG." >&2
+        echo "$0: Must supply an argument to -$arg." >&2
         exit 1
         ;;
     ?)
-        echo "Invalid option -$OPTARG."
+        echo "Invalid option -$arg."
         exit 2
         ;;
     *) usage ;;
     esac
 done
-
-# Default to user HOME directory if not specified
-if [[ -z $FOLDER_PATH ]]; then
-    FOLDER_PATH=$HOME
-fi
-
-# Default to 'main' if not specified
-if [[ -z $BRANCH_NAME ]]; then
-    BRANCH_NAME='main'
-fi
-
-# Default to current logged in user if not specified
-if [[ -z $ENV_NAME_PREFIX ]]; then
-    ENV_NAME_PREFIX=$(whoami)
-fi
 
 # Deploys the specified template
 # $1 - The template name
@@ -96,7 +96,7 @@ function testTemplate {
     echo "Running template smoke tests for $3..."
     cd "$FOLDER_PATH/$3/tests"
     npm i && npx playwright install
-    npx playwright test --retries=$PLAYWRIGHT_RETRIES
+    npx -y playwright test --retries=$PLAYWRIGHT_RETRIES
 }
 
 # Cleans the specified template
@@ -122,33 +122,45 @@ if [[ -z $TEMPLATE_NAME ]]; then
     TEMPLATES_JSON=$(azd template list --output json)
 
     while read -r TEMPLATE; do
-        ENV_NAME="${ENV_NAME_PREFIX}-${TEMPLATE:14}-$RANDOM"
+        ENV_NAME="${ENV_NAME_PREFIX}-${TEMPLATE:14}-$ENV_SUFFIX"
         ENV_TEMPLATE_MAP[$TEMPLATE]=$ENV_NAME
-    done < <( echo "$TEMPLATES_JSON" | jq -r '.[].name' | sed 's/\\n/\n/g' )
+    done < <(echo "$TEMPLATES_JSON" | jq -r '.[].name' | sed 's/\\n/\n/g')
 
-    # Deploy the templates in parallel
-    for TEMPLATE in "${!ENV_TEMPLATE_MAP[@]}"; do
-        (deployTemplate "$TEMPLATE" "$BRANCH_NAME" "${ENV_TEMPLATE_MAP[$TEMPLATE]}" || continue) &
-    done
+    if [ $TEST_ONLY == false ]; then
+        # Deploy the templates in parallel
+        for TEMPLATE in "${!ENV_TEMPLATE_MAP[@]}"; do
+            (deployTemplate "$TEMPLATE" "$BRANCH_NAME" "${ENV_TEMPLATE_MAP[$TEMPLATE]}" || continue) &
+        done
 
-    wait
+        wait
+    fi
 
     # Test the templates serially
     for TEMPLATE in "${!ENV_TEMPLATE_MAP[@]}"; do
         testTemplate "$TEMPLATE" "$BRANCH_NAME" "${ENV_TEMPLATE_MAP[$TEMPLATE]}" || continue
     done
 
-    # Cleanup the templates in parallel
-    for TEMPLATE in "${!ENV_TEMPLATE_MAP[@]}"; do
-        (cleanupTemplate "$TEMPLATE" "$BRANCH_NAME" "${ENV_TEMPLATE_MAP[$TEMPLATE]}" || continue) &
-    done
+    if [ "$CLEANUP" == true ]; then
+        # Cleanup the templates in parallel
+        for TEMPLATE in "${!ENV_TEMPLATE_MAP[@]}"; do
+            (cleanupTemplate "$TEMPLATE" "$BRANCH_NAME" "${ENV_TEMPLATE_MAP[$TEMPLATE]}" || continue) &
+        done
 
-    wait
+        wait
+    fi
 
     echo ""
     echo "Done!"
 else
     # Run test for the specified template name
-    ENV_NAME="${ENV_NAME_PREFIX}-${TEMPLATE_NAME:14}-$RANDOM"
+    ENV_NAME="${ENV_NAME_PREFIX}-${TEMPLATE_NAME:14}-$ENV_SUFFIX"
+    if [ $TEST_ONLY == false ]; then
+        deployTemplate "$TEMPLATE_NAME" "$BRANCH_NAME" "$ENV_NAME"
+    fi
+
     testTemplate "$TEMPLATE_NAME" "$BRANCH_NAME" "$ENV_NAME"
+
+    if [ "$CLEANUP" == true ]; then
+        cleanupTemplate "$TEMPLATE_NAME" "$BRANCH_NAME" "$ENV_NAME"
+    fi
 fi

--- a/templates/tests/test-templates.sh
+++ b/templates/tests/test-templates.sh
@@ -5,6 +5,8 @@ FOLDER_PATH=""
 TEMPLATE_NAME=""
 BRANCH_NAME=""
 ENV_NAME_PREFIX=""
+PLAYWRIGHT_RETRIES="3"
+LOCATION="eastus2"
 
 function usage {
     echo "Tests azd template init, provision & deploy"
@@ -15,6 +17,8 @@ function usage {
     echo "  -b    Sets the template branch name. Override to test a any custom branches (default: main)"
     echo "  -e    Sets the environment name prefix. Environment prefix is used in the azd environment name along with the template name (default: whoami)"
     echo "  -t    Sets the template name. Use values from 'azd template list'. When omitted will run for all templates available in 'azd template list'"
+    echo "  -r    Sets the number of retries for playwright tests (default: 3)"
+    echo "  -l    Sets the Azure location for the template infrastructure (default: eastus2)"
     echo ""
     echo "Examples:"
     echo "  Testing a single template with custom branch"
@@ -26,12 +30,14 @@ function usage {
     exit 1
 }
 
-while getopts "f:t:b:e:h" arg; do
+while getopts "f:t:b:e:r:l:h" arg; do
     case ${arg} in
     f) FOLDER_PATH=$OPTARG ;;
     t) TEMPLATE_NAME=$OPTARG ;;
     b) BRANCH_NAME=$OPTARG ;;
     e) ENV_NAME_PREFIX=$OPTARG ;;
+    r) PLAYWRIGHT_RETRIES=$OPTARG ;;
+    l) LOCATION=$OPTARG ;;
     h)
         usage
         ;;
@@ -62,11 +68,11 @@ if [[ -z $ENV_NAME_PREFIX ]]; then
     ENV_NAME_PREFIX=$(whoami)
 fi
 
-# Tests the specified template
+# Deploys the specified template
 # $1 - The template name
 # $2 - The branch name
 # $3 - The environment name
-function testTemplate {
+function deployTemplate {
     echo "Creating new project folder @ '$FOLDER_PATH/$3'..."
     cd "$FOLDER_PATH"
     mkdir "$3"
@@ -80,28 +86,64 @@ function testTemplate {
 
     echo "Deploying apps for $3..."
     azd deploy -e "$3"
+}
 
+# Tests the specified template
+# $1 - The template name
+# $2 - The branch name
+# $3 - The environment name
+function testTemplate {
     echo "Running template smoke tests for $3..."
-    cd tests
+    cd "$FOLDER_PATH/$3/tests"
     npm i && npx playwright install
-    npx playwright test
+    npx playwright test --retries=$PLAYWRIGHT_RETRIES
+}
 
+# Cleans the specified template
+# $1 - The template name
+# $2 - The branch name
+# $3 - The environment name
+function cleanupTemplate {
     echo "Deprovisioning infrastructure for $3..."
+    cd "$FOLDER_PATH/$3"
     azd down -e "$3" --force --purge
 
     echo "Cleaning up local project @ '$FOLDER_PATH/$3'..."
     rm -rf "$FOLDER_PATH/$3"
 }
 
+export AZURE_LOCATION="$LOCATION"
+
 if [[ -z $TEMPLATE_NAME ]]; then
+    declare -A ENV_TEMPLATE_MAP
+
     # If a template is not specified, run for all templates from output of 'azd template list'
+    echo "Getting list of availabe templates..."
     TEMPLATES_JSON=$(azd template list --output json)
 
-    echo "$TEMPLATES_JSON" | jq -r '.[].name' | sed 's/\\n/\n/g' | while read -r TEMPLATE; do
+    while read -r TEMPLATE; do
         ENV_NAME="${ENV_NAME_PREFIX}-${TEMPLATE:14}-$RANDOM"
+        ENV_TEMPLATE_MAP[$TEMPLATE]=$ENV_NAME
+    done < <( echo "$TEMPLATES_JSON" | jq -r '.[].name' | sed 's/\\n/\n/g' )
 
-        testTemplate "$TEMPLATE" "$BRANCH_NAME" "$ENV_NAME" || continue
+    # Deploy the templates in parallel
+    for TEMPLATE in "${!ENV_TEMPLATE_MAP[@]}"; do
+        (deployTemplate "$TEMPLATE" "$BRANCH_NAME" "${ENV_TEMPLATE_MAP[$TEMPLATE]}" || continue) &
     done
+
+    wait
+
+    # Test the templates serially
+    for TEMPLATE in "${!ENV_TEMPLATE_MAP[@]}"; do
+        testTemplate "$TEMPLATE" "$BRANCH_NAME" "${ENV_TEMPLATE_MAP[$TEMPLATE]}" || continue
+    done
+
+    # Cleanup the templates in parallel
+    for TEMPLATE in "${!ENV_TEMPLATE_MAP[@]}"; do
+        (cleanupTemplate "$TEMPLATE" "$BRANCH_NAME" "${ENV_TEMPLATE_MAP[$TEMPLATE]}" || continue) &
+    done
+
+    wait
 
     echo ""
     echo "Done!"

--- a/templates/tests/test-templates.sh
+++ b/templates/tests/test-templates.sh
@@ -96,7 +96,7 @@ function testTemplate {
     echo "Running template smoke tests for $3..."
     cd "$FOLDER_PATH/$3/tests"
     npm i && npx playwright install
-    npx -y playwright test --retries=$PLAYWRIGHT_RETRIES
+    npx -y playwright test --retries="$PLAYWRIGHT_RETRIES"
 }
 
 # Cleans the specified template
@@ -109,7 +109,7 @@ function cleanupTemplate {
     azd down -e "$3" --force --purge
 
     echo "Cleaning up local project @ '$FOLDER_PATH/$3'..."
-    rm -rf "$FOLDER_PATH/$3"
+    rm -rf "$FOLDER_PATH/${3:?}"
 }
 
 export AZURE_LOCATION="$LOCATION"


### PR DESCRIPTION
Updates the template testing scripts with the following options:

- Adds support to specify azure location/region to use (defaults to eastus2)
- Adds configurable Playwright retries (defaults to 3)
- Adds parallelism for azd up/down
- Adds output to specify `TEST_ONLY` run
- Adds option to specify whether local & remote cleanup should be performed