### PR TITLE
Fix debug message when --help is passed to CLI

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Release History
+
+## 0.1.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+- Fixed an issue where passing `--help` to `azd` would result in an error message being printed to standard error before the help was printed.
+
+### Other Changes
+
+## 0.1.0-beta.1 (2022-07-11)
+
+Initial public release of the Azure Developer CLI.

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -217,6 +217,7 @@ type updateCacheFile struct {
 // value.
 func isDebugEnabled() bool {
 	debug := false
+	help := false
 	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
 
 	// Since we are running this parse logic on the full command line, there may be additional flags
@@ -227,9 +228,16 @@ func isDebugEnabled() bool {
 	flags.ParseErrorsWhitelist.UnknownFlags = true
 	flags.BoolVar(&debug, "debug", false, "")
 
+	// pflag treats "help" as special and if you don't define a help flag returns `ErrHelp` from
+	// Parse when `--help` is on the command line. Add an explicit help parameter (which we ignore)
+	// so pflag doesn't fail in this case.  If `--help` is passed, the help for `azd` will be shown later
+	// when `cmd.Execute` is run
+	flags.BoolVar(&help, "help", false, "")
+
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		log.Printf("could not parse flags: %v", err)
 	}
+
 	return debug
 }
 

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -375,6 +376,23 @@ func Test_ProjectIsNeeded(t *testing.T) {
 			assert.Regexp(t, "no project exists; to create a new project, run `azd init`", out)
 		})
 	}
+}
+
+func Test_NoDebugSpewWhenHelpPassedWithoutDebug(t *testing.T) {
+	stdErrBuf := bytes.Buffer{}
+
+	cmd := exec.Command(azdcli.GetAzdLocation(), "--help")
+	cmd.Stderr = &stdErrBuf
+
+	// Run the command and wait for it to complete, we don't expect any errors.
+	err := cmd.Start()
+	assert.NoError(t, err)
+
+	err = cmd.Wait()
+	assert.NoError(t, err)
+
+	// Ensure no output was written to stderr
+	assert.Equal(t, "", stdErrBuf.String(), "no output should be written to stderr when --help is passed")
 }
 
 // filterEnviron returns a new copy of os.Environ after removing all specified keys, ignoring case.


### PR DESCRIPTION
We have logic very early in the startup process of `azd` to do an
initial parse of the command line arguments to see if `--debug` has
been passed (so we can set up our debugging channels to output to the
correct location).

That logic uses `pflag` to parse the command line with a very limited
set of flags (just `--debug`) with it configured to ignore all other
flags. However, pflag treats `--help` as special and when the flag is
not defined returns `ErrHelp` from `Parse` to denote that help was
requested.

Our logic would write any failure from `Parse` to the debug log, which
meant that we would end up printing something like this to stderr at
the start of the command when `--help` was passed:

```
Usage of :
      --debug
```

This change adds a `help` parameter so that we don't hit this behavior
if `pflag`.  The `--help` parameter will be interpreted correctly
later when we parse the command line "for real" using the normal cobra
logic.