### PR TITLE
fix `disabled actions` detector

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -35,9 +35,7 @@ jobs:
         with:
           node-version: "16"
       - run: npm install -g cspell
-      - run: cspell lint '**/*' --config ./.vscode/cspell.yaml --relative --no-progress
       - run: cspell lint '**/*.go' --config ./cli/azd/.vscode/cspell.yaml --root ./cli/azd --no-progress
-      - run: cspell lint '**/*.ts' --config ./ext/vscode/.vscode/cspell.yaml --root ./ext/vscode --no-progress
 
   bicep-lint:
     uses: ./.github/workflows/lint-bicep.yml

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fixed an issue where passing `--help` to `azd` would result in an error message being printed to standard error before the help was printed.
+- [[#71]](https://github.com/Azure/azure-dev/issues/71) Fixed detection for disabled GitHub actions on new created repos.
 
 ### Other Changes
 

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -97,6 +97,10 @@ func (p *pipelineConfigAction) Run(ctx context.Context, _ *cobra.Command, args [
 		return fmt.Errorf("failed to ensure login to GitHub: %w", err)
 	}
 
+	// This flag is used later to skip checking GitHub Actions.
+	// For new repositories, there's no need to check
+	var newGitHubRepoCreated = false
+
 	getSlugOrInit := func() (string, error) {
 		for {
 			repoSlug, err := github.EnsureRemote(ctx, azdCtx.ProjectDirectory(), p.pipelineRemoteName, gitCli)
@@ -166,6 +170,7 @@ func (p *pipelineConfigAction) Run(ctx context.Context, _ *cobra.Command, args [
 					if err != nil {
 						return "", fmt.Errorf("getting remote from new repository: %w", err)
 					}
+					newGitHubRepoCreated = true
 					remoteUrl = url
 				// Enter a URL directly.
 				case 2:
@@ -247,7 +252,12 @@ You can view the GitHub Actions here: https://github.com/%s/actions
 		return fmt.Errorf("prompting to push: %w", err)
 	}
 
-	if doPush {
+	// Check if GitHub actions are disabled *Only* when user requested to push changes AND this is NOT a just-created repo
+	//
+	// A repo that is just created would return zero GitHub Actions and might be confused by azd
+	// as a repo where Actions are disabled. Sadly, there's not GitHub API to fetch exact information
+	// to distinguish between disabled-after-fork v/s repo-disabled-actions v/s similar scenarios).
+	if doPush && !newGitHubRepoCreated {
 		cancelPushing, err := notifyWhenGitHubActionsAreDisabled(ctx, gitCli, ghCli, azdCtx, repoSlug, p.pipelineRemoteName, currentBranch, askOne)
 		if err != nil {
 			return fmt.Errorf("ensure github actions: %w", err)
@@ -425,9 +435,12 @@ func (selection gitHubActionsEnablingChoice) String() string {
 // notifyWhenGitHubActionsAreDisabled checks if gh-actions are disabled on the repo
 // This can happen when a template is first forked and user calls `pipeline config`
 // GitHub disables actions by default when a repo is forked.
-// Fix this by adding a commit to rename the current workflow file and re-store it
-// as part of the repo-push
-// Returns nil, true if user decides to cancel pushing changes.
+//
+// A user can also disable Actions from /settings/actions, which is different from
+// what GitHub does after a template is forked. However, for both cases, calling API
+// /repos/<repoSlug>/actions/workflows would return the same.
+//
+// Returns true, nil if user decides to cancel pushing changes.
 func notifyWhenGitHubActionsAreDisabled(
 	ctx context.Context,
 	gitCli tools.GitCli,
@@ -461,10 +474,20 @@ func notifyWhenGitHubActionsAreDisabled(
 			if e != nil {
 				return e
 			}
-
-			fileExtension := filepath.Ext(file.Name())
+			fileName := file.Name()
+			fileExtension := filepath.Ext(fileName)
 			if fileExtension == ".yml" || fileExtension == ".yaml" {
-				ghLocalWorkflowFiles = true
+				// ** workflow file found.
+				// Now check if this file is already tracked by git.
+				// If the file is not tracked, it means this is a new file (never pushed to mainstream)
+				// A git untracked file should not be considered as GitHub workflow until it is pushed.
+				newFile, err := gitCli.IsUntrackedFile(ctx, azdCtx.ProjectDirectory(), folderName)
+				if err != nil {
+					return fmt.Errorf("checking workflow file %w", err)
+				}
+				if !newFile {
+					ghLocalWorkflowFiles = true
+				}
 			}
 
 			return nil
@@ -476,10 +499,11 @@ func notifyWhenGitHubActionsAreDisabled(
 
 	if ghLocalWorkflowFiles {
 		printWithStyling("\n%s\n"+
-			"This can happen after a template is forked.\n"+
-			"Please enable actions here: %s.\n",
+			" - If you forked and cloned a template, please enable actions here: %s.\n"+
+			" - Otherwise, check the GitHub Actions permissions here: %s.\n",
 			withHighLightFormat("GitHub actions are currently disabled for your repository."),
-			withHighLightFormat("https://github.com/%s/actions", repoSlug))
+			withHighLightFormat("https://github.com/%s/actions", repoSlug),
+			withHighLightFormat("https://github.com/%s/settings/actions", repoSlug))
 
 		var rawSelection int
 		if err := askOne(&survey.Select{

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -99,7 +99,7 @@ func (p *pipelineConfigAction) Run(ctx context.Context, _ *cobra.Command, args [
 
 	// This flag is used later to skip checking GitHub Actions.
 	// For new repositories, there's no need to check
-	var newGitHubRepoCreated = false
+	newGitHubRepoCreated := false
 
 	getSlugOrInit := func() (string, error) {
 		for {

--- a/cli/azd/pkg/tools/gh.go
+++ b/cli/azd/pkg/tools/gh.go
@@ -161,6 +161,8 @@ type GitHubActionsResponse struct {
 	TotalCount int `json:"total_count"`
 }
 
+// GitHubActionsExists gets the information from upstream about the workflows and
+// return true if there is at least one workflow in the repo.
 func (cli *ghCli) GitHubActionsExists(ctx context.Context, repoSlug string) (bool, error) {
 	res, err := executil.RunCommand(ctx, "gh", "api", "/repos/"+repoSlug+"/actions/workflows")
 	if err != nil {


### PR DESCRIPTION
fix https://github.com/Azure/azure-dev/issues/71

Check if GitHub actions are disabled *Only* when user requested to push changes AND this is NOT a just-created repo

A repo that is just created would return zero GitHub Actions and might be confused by azd
as a repo where Actions are disabled. Sadly, there's not GitHub API to fetch exact information
to distinguish between disabled-after-fork v/s repo-disabled-actions v/s similar scenarios).

check if workflow file is already tracked by git.
If the file is not tracked, it means this is a new file (never pushed to mainstream)
A git untracked file should not be considered as GitHub workflow until it is pushed.