### PR TITLE
Improve login detection

### DIFF
--- a/cli/azd/cmd/login.go
+++ b/cli/azd/cmd/login.go
@@ -93,7 +93,7 @@ func (la *loginAction) SetupFlags(persistent *pflag.FlagSet, local *pflag.FlagSe
 func ensureLoggedIn(ctx context.Context) error {
 	azCli := commands.GetAzCliFromContext(ctx)
 	_, err := azCli.GetAccessToken(ctx)
-	if errors.Is(err, tools.ErrAzCliNotLoggedIn) {
+	if errors.Is(err, tools.ErrAzCliNotLoggedIn) || errors.Is(err, tools.ErrAzCliRefreshTokenExpired) {
 		if err := runLogin(ctx, false); err != nil {
 			return fmt.Errorf("logging in: %w", err)
 		}

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -172,6 +172,12 @@ func ensureEnvironmentInitialized(ctx context.Context, environmentName string, e
 		env.SetEnvName(environmentName)
 	}
 
+	if !hasSubID || !hasPrincipalID || !hasLocation {
+		if err := ensureLoggedIn(ctx); err != nil {
+			return fmt.Errorf("logging in: %w", err)
+		}
+	}
+
 	if !hasLocation {
 		var location string
 		location, err := promptLocation(ctx, "Please select an Azure location to use:", askOne)
@@ -180,12 +186,6 @@ func ensureEnvironmentInitialized(ctx context.Context, environmentName string, e
 		}
 
 		env.Values[environment.LocationEnvVarName] = strings.TrimSpace(location)
-	}
-
-	if !hasSubID || !hasPrincipalID {
-		if err := ensureLoggedIn(ctx); err != nil {
-			return fmt.Errorf("logging in: %w", err)
-		}
 	}
 
 	azCli := commands.GetAzCliFromContext(ctx)
@@ -467,10 +467,6 @@ func promptTemplate(ctx context.Context, message string, askOne Asker) (string, 
 
 // promptLocation asks the user to select a location from a list of supported azure location
 func promptLocation(ctx context.Context, message string, askOne Asker) (string, error) {
-	if err := ensureLoggedIn(ctx); err != nil {
-		return "", fmt.Errorf("listing locations: %w", err)
-	}
-
 	azCli := commands.GetAzCliFromContext(ctx)
 
 	locations, err := azCli.ListAccountLocations(ctx)

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -467,7 +467,12 @@ func promptTemplate(ctx context.Context, message string, askOne Asker) (string, 
 
 // promptLocation asks the user to select a location from a list of supported azure location
 func promptLocation(ctx context.Context, message string, askOne Asker) (string, error) {
+	if err := ensureLoggedIn(ctx); err != nil {
+		return "", fmt.Errorf("listing locations: %w", err)
+	}
+
 	azCli := commands.GetAzCliFromContext(ctx)
+
 	locations, err := azCli.ListAccountLocations(ctx)
 	if err != nil {
 		return "", fmt.Errorf("listing locations: %w", err)


### PR DESCRIPTION
- Fix internal #1392 : Location prompt now first attempts `az login`
- Fix #10: Update error message to include `run azd login`
- Fix #48: Detect when refresh token is expired and run automatic login