### PR TITLE
Adds support for custom docker options

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -43,6 +43,6 @@ sstore
 staticwebapp
 structs
 swacli
-unmarshaling
+unmarshalling
 westus2
 yacspin

--- a/cli/azd/pkg/environment/azd_context.go
+++ b/cli/azd/pkg/environment/azd_context.go
@@ -78,7 +78,7 @@ func (c *AzdContext) BicepParameters(env string, module string) (map[string]inte
 	var unmarshalled map[string]interface{}
 	err = json.Unmarshal(byts, &unmarshalled)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshaling parameters file: %w", err)
+		return nil, fmt.Errorf("unmarshalling parameters file: %w", err)
 	}
 
 	ret := make(map[string]interface{})

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -30,7 +30,7 @@ func (p *dockerProject) RequiredExternalTools() []tools.ExternalTool {
 }
 
 func (p *dockerProject) Package(ctx context.Context, progress chan<- string) (string, error) {
-	dockerOptions := getDockerOptionsWithDefaults(&p.config.Docker)
+	dockerOptions := getDockerOptionsWithDefaults(p.config.Docker)
 
 	log.Printf("building image for service %s, cwd: %s, path: %s, context: %s)", p.config.Name, p.config.Path(), dockerOptions.Path, dockerOptions.Context)
 
@@ -60,7 +60,7 @@ func NewDockerProject(config *ServiceConfig, env *environment.Environment, docke
 	}
 }
 
-func getDockerOptionsWithDefaults(options *DockerProjectOptions) DockerProjectOptions {
+func getDockerOptionsWithDefaults(options DockerProjectOptions) DockerProjectOptions {
 	if options.Path == "" {
 		options.Path = "./Dockerfile"
 	}
@@ -73,5 +73,5 @@ func getDockerOptionsWithDefaults(options *DockerProjectOptions) DockerProjectOp
 		options.Context = "."
 	}
 
-	return *options
+	return options
 }

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -1,0 +1,135 @@
+package project
+
+import (
+	"context"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/executil"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+	"github.com/azure/azure-dev/cli/azd/test/helpers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultDockerOptions(t *testing.T) {
+	const testProj = `
+name: test-proj
+metadata:
+  template: test-proj-template
+services:
+  web:
+    project: src/web
+    language: js
+    host: containerapp
+`
+
+	ctx := helpers.CreateTestContext(context.Background(), gblCmdOptions, azCli, mockHttpClient)
+	env := environment.Environment{Values: make(map[string]string)}
+	env.SetEnvName("test-env")
+
+	projectConfig, _ := ParseProjectConfig(testProj, &env)
+	prj, _ := projectConfig.GetProject(ctx, &env)
+	service := prj.Services[0]
+	ran := false
+
+	dockerArgs := tools.DockerArgs{
+		RunWithResultFn: func(ctx context.Context, args executil.RunArgs) (executil.RunResult, error) {
+			ran = true
+
+			require.Equal(t, []string{
+				"build", "-q",
+				"-f", "./Dockerfile",
+				"--platform", "amd64",
+				".",
+			}, args.Args)
+
+			return executil.RunResult{
+				Stdout:   "",
+				Stderr:   "",
+				ExitCode: 0,
+			}, nil
+		},
+	}
+
+	docker := tools.NewDocker(dockerArgs)
+
+	progress := make(chan string)
+	defer close(progress)
+
+	internalFramework := NewNpmProject(service.Config, &env)
+	status := ""
+
+	go func() {
+		for value := range progress {
+			status = value
+		}
+	}()
+
+	framework := NewDockerProject(service.Config, &env, docker, internalFramework)
+	framework.Package(ctx, progress)
+	require.Equal(t, "Building docker image", status)
+	require.Equal(t, true, ran)
+}
+
+func TestCustomDockerOptions(t *testing.T) {
+	const testProj = `
+name: test-proj
+metadata:
+  template: test-proj-template
+services:
+  web:
+    project: src/web
+    language: js
+    host: containerapp
+    docker:
+      path: ./Dockerfile.dev
+      context: ../
+`
+
+	ctx := helpers.CreateTestContext(context.Background(), gblCmdOptions, azCli, mockHttpClient)
+	env := environment.Environment{Values: make(map[string]string)}
+	env.SetEnvName("test-env")
+
+	projectConfig, _ := ParseProjectConfig(testProj, &env)
+	prj, _ := projectConfig.GetProject(ctx, &env)
+	service := prj.Services[0]
+	ran := false
+
+	dockerArgs := tools.DockerArgs{
+		RunWithResultFn: func(ctx context.Context, args executil.RunArgs) (executil.RunResult, error) {
+			ran = true
+
+			require.Equal(t, []string{
+				"build", "-q",
+				"-f", "./Dockerfile.dev",
+				"--platform", "amd64",
+				"../",
+			}, args.Args)
+
+			return executil.RunResult{
+				Stdout:   "",
+				Stderr:   "",
+				ExitCode: 0,
+			}, nil
+		},
+	}
+
+	docker := tools.NewDocker(dockerArgs)
+
+	progress := make(chan string)
+	defer close(progress)
+
+	internalFramework := NewNpmProject(service.Config, &env)
+	status := ""
+
+	go func() {
+		for value := range progress {
+			status = value
+		}
+	}()
+
+	framework := NewDockerProject(service.Config, &env, docker, internalFramework)
+	framework.Package(ctx, progress)
+	require.Equal(t, "Building docker image", status)
+	require.Equal(t, true, ran)
+}

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -44,7 +44,7 @@ services:
 			}, args.Args)
 
 			return executil.RunResult{
-				Stdout:   "",
+				Stdout:   "imageId",
 				Stderr:   "",
 				ExitCode: 0,
 			}, nil
@@ -66,7 +66,10 @@ services:
 	}()
 
 	framework := NewDockerProject(service.Config, &env, docker, internalFramework)
-	framework.Package(ctx, progress)
+	res, err := framework.Package(ctx, progress)
+
+	require.Equal(t, "imageId", res)
+	require.Nil(t, err)
 	require.Equal(t, "Building docker image", status)
 	require.Equal(t, true, ran)
 }
@@ -107,7 +110,7 @@ services:
 			}, args.Args)
 
 			return executil.RunResult{
-				Stdout:   "",
+				Stdout:   "imageId",
 				Stderr:   "",
 				ExitCode: 0,
 			}, nil
@@ -129,7 +132,10 @@ services:
 	}()
 
 	framework := NewDockerProject(service.Config, &env, docker, internalFramework)
-	framework.Package(ctx, progress)
+	res, err := framework.Package(ctx, progress)
+
+	require.Equal(t, "imageId", res)
+	require.Nil(t, err)
 	require.Equal(t, "Building docker image", status)
 	require.Equal(t, true, ran)
 }

--- a/cli/azd/pkg/project/project_config_test.go
+++ b/cli/azd/pkg/project/project_config_test.go
@@ -109,3 +109,32 @@ services:
 		require.NotNil(t, svc.Scope)
 	}
 }
+
+func TestProjectWithCustomDockerOptions(t *testing.T) {
+	const testProj = `
+name: test-proj
+metadata:
+  template: test-proj-template
+services:
+  web:
+    project: src/web
+    language: js
+    host: containerapp
+    docker:
+      path: ./Dockerfile.dev
+      context: ../
+`
+
+	e := environment.Environment{Values: make(map[string]string)}
+	e.SetEnvName("test-env")
+
+	projectConfig, err := ParseProjectConfig(testProj, &e)
+
+	require.NotNil(t, projectConfig)
+	require.Nil(t, err)
+
+	service := projectConfig.Services["web"]
+
+	require.Equal(t, "./Dockerfile.dev", service.Docker.Path)
+	require.Equal(t, "../", service.Docker.Context)
+}

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -67,7 +67,7 @@ func (sc *ServiceConfig) GetServiceTarget(ctx context.Context, env *environment.
 	case "", string(AppServiceTarget):
 		target = NewAppServiceTarget(sc, env, scope, azCli)
 	case string(ContainerAppTarget):
-		target = NewContainerAppTarget(sc, env, scope, azCli, tools.NewDocker())
+		target = NewContainerAppTarget(sc, env, scope, azCli, tools.NewDocker(tools.DockerArgs{}))
 	case string(AzureFunctionTarget):
 		target = NewFunctionAppTarget(sc, env, scope, azCli)
 	case string(StaticWebAppTarget):
@@ -97,7 +97,7 @@ func (sc *ServiceConfig) GetFrameworkService(ctx context.Context, env *environme
 	// For containerized applications we use a nested framework service
 	if sc.Host == string(ContainerAppTarget) {
 		sourceFramework := frameworkService
-		frameworkService = NewDockerProject(sc, env, tools.NewDocker(), sourceFramework)
+		frameworkService = NewDockerProject(sc, env, tools.NewDocker(tools.DockerArgs{}), sourceFramework)
 	}
 
 	return &frameworkService, nil

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -27,8 +27,8 @@ type ServiceConfig struct {
 	OutputPath string `yaml:"dist"`
 	// The infrastructure module name to use for this project
 	ModuleName string `yaml:"moduleName"`
-	// The custom service type options
-	Docker DockerProjectOptions `yaml:"options"`
+	// The optional docker options
+	Docker DockerProjectOptions `yaml:"docker"`
 }
 
 // Path returns the fully qualified path to the project

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -27,6 +27,8 @@ type ServiceConfig struct {
 	OutputPath string `yaml:"dist"`
 	// The infrastructure module name to use for this project
 	ModuleName string `yaml:"moduleName"`
+	// The custom service type options
+	Options map[string]interface{} `yaml:"options"`
 }
 
 // Path returns the fully qualified path to the project

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -28,7 +28,7 @@ type ServiceConfig struct {
 	// The infrastructure module name to use for this project
 	ModuleName string `yaml:"moduleName"`
 	// The custom service type options
-	Options map[string]interface{} `yaml:"options"`
+	Docker DockerProjectOptions `yaml:"options"`
 }
 
 // Path returns the fully qualified path to the project

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -58,7 +58,7 @@ func (at *containerAppTarget) Deploy(ctx context.Context, azdCtx *environment.Az
 	// Tag image.
 	log.Printf("tagging image %s as %s", path, fullTag)
 	progress <- "Tagging image"
-	if err := at.docker.Tag(ctx, path, fullTag); err != nil {
+	if err := at.docker.Tag(ctx, at.config.Path(), path, fullTag); err != nil {
 		return ServiceDeploymentResult{}, fmt.Errorf("tagging image: %w", err)
 	}
 
@@ -66,7 +66,7 @@ func (at *containerAppTarget) Deploy(ctx context.Context, azdCtx *environment.Az
 
 	// Push image.
 	progress <- "Pushing container image"
-	if err := at.docker.Push(ctx, fullTag); err != nil {
+	if err := at.docker.Push(ctx, at.config.Path(), fullTag); err != nil {
 		return ServiceDeploymentResult{}, fmt.Errorf("pushing image: %w", err)
 	}
 

--- a/cli/azd/pkg/tools/azcli.go
+++ b/cli/azd/pkg/tools/azcli.go
@@ -259,7 +259,7 @@ func (tok *AzCliAccessToken) UnmarshalJSON(data []byte) error {
 	}
 
 	if err := json.Unmarshal(data, &wire); err != nil {
-		return fmt.Errorf("unmarshaling json: %w", err)
+		return fmt.Errorf("unmarshalling json: %w", err)
 	}
 
 	tok.AccessToken = wire.AccessToken

--- a/cli/azd/pkg/tools/docker.go
+++ b/cli/azd/pkg/tools/docker.go
@@ -8,10 +8,18 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/executil"
 )
 
-func NewDocker() *Docker {
-	return &Docker{
-		runWithResultFn: executil.RunWithResult,
+func NewDocker(args DockerArgs) *Docker {
+	if args.RunWithResultFn == nil {
+		args.RunWithResultFn = executil.RunWithResult
 	}
+
+	return &Docker{
+		runWithResultFn: args.RunWithResultFn,
+	}
+}
+
+type DockerArgs struct {
+	RunWithResultFn func(ctx context.Context, args executil.RunArgs) (executil.RunResult, error)
 }
 
 type Docker struct {

--- a/cli/azd/pkg/tools/docker.go
+++ b/cli/azd/pkg/tools/docker.go
@@ -26,7 +26,7 @@ type Docker struct {
 	runWithResultFn func(ctx context.Context, args executil.RunArgs) (executil.RunResult, error)
 }
 
-// Build runs a docker build for a given Dockerfile, forcing the amd64 platform. If successful, it
+// Runs a Docker build for a given Dockerfile. If the platform is not specified (empty), it defaults to amd64. If the build is successful, the function
 // returns the image id of the built image.
 func (d *Docker) Build(ctx context.Context, cwd string, dockerFilePath string, platform string, buildContext string) (string, error) {
 	if strings.TrimSpace(platform) == "" {

--- a/cli/azd/pkg/tools/docker_test.go
+++ b/cli/azd/pkg/tools/docker_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Test_DockerBuild(t *testing.T) {
-	docker := NewDocker()
+	docker := NewDocker(DockerArgs{})
 
 	cwd := "."
 	dockerFile := "./Dockerfile"
@@ -83,7 +83,7 @@ func Test_DockerBuild(t *testing.T) {
 }
 
 func Test_DockerBuildEmptyPlatform(t *testing.T) {
-	docker := NewDocker()
+	docker := NewDocker(DockerArgs{})
 
 	ran := false
 	cwd := "."
@@ -119,7 +119,7 @@ func Test_DockerBuildEmptyPlatform(t *testing.T) {
 }
 
 func Test_DockerTag(t *testing.T) {
-	docker := NewDocker()
+	docker := NewDocker(DockerArgs{})
 
 	cwd := "."
 	imageName := "image-name"
@@ -184,7 +184,7 @@ func Test_DockerTag(t *testing.T) {
 }
 
 func Test_DockerPush(t *testing.T) {
-	docker := NewDocker()
+	docker := NewDocker(DockerArgs{})
 
 	cwd := "."
 	tag := "customTag"

--- a/cli/azd/pkg/tools/docker_test.go
+++ b/cli/azd/pkg/tools/docker_test.go
@@ -1,0 +1,246 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/executil"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_DockerBuild(t *testing.T) {
+	docker := NewDocker()
+
+	cwd := "."
+	dockerFile := "./Dockerfile"
+	dockerContext := "../"
+	platform := "amd64"
+
+	t.Run("NoError", func(t *testing.T) {
+		ran := false
+
+		docker.runWithResultFn = func(ctx context.Context, args executil.RunArgs) (executil.RunResult, error) {
+			ran = true
+
+			require.Equal(t, "docker", args.Cmd)
+			require.Equal(t, cwd, args.Cwd)
+			require.Equal(t, []string{
+				"build",
+				"-q",
+				"-f", dockerFile,
+				"--platform", platform,
+				dockerContext,
+			}, args.Args)
+
+			return executil.RunResult{
+				Stdout:   "Docker build output",
+				Stderr:   "",
+				ExitCode: 0,
+			}, nil
+		}
+
+		result, err := docker.Build(context.Background(), cwd, dockerFile, platform, dockerContext)
+
+		require.Equal(t, true, ran)
+		require.Nil(t, err)
+		require.Equal(t, "Docker build output", result)
+	})
+
+	t.Run("WithError", func(t *testing.T) {
+		ran := false
+		stdErr := "Error tagging DockerFile"
+		customErrorMessage := "example error message"
+
+		docker.runWithResultFn = func(ctx context.Context, args executil.RunArgs) (executil.RunResult, error) {
+			ran = true
+
+			require.Equal(t, "docker", args.Cmd)
+			require.Equal(t, cwd, args.Cwd)
+			require.Equal(t, []string{
+				"build",
+				"-q",
+				"-f", dockerFile,
+				"--platform", platform,
+				dockerContext,
+			}, args.Args)
+
+			return executil.RunResult{
+				Stdout:   "",
+				Stderr:   stdErr,
+				ExitCode: 1,
+			}, errors.New(customErrorMessage)
+		}
+
+		result, err := docker.Build(context.Background(), cwd, dockerFile, platform, dockerContext)
+
+		require.Equal(t, true, ran)
+		require.NotNil(t, err)
+		require.Equal(t, fmt.Sprintf("building image: exit code: 1, stdout: , stderr: %s: %s", stdErr, customErrorMessage), err.Error())
+		require.Equal(t, "", result)
+	})
+}
+
+func Test_DockerBuildEmptyPlatform(t *testing.T) {
+	docker := NewDocker()
+
+	ran := false
+	cwd := "."
+	dockerFile := "./Dockerfile"
+	dockerContext := "../"
+	platform := "amd64"
+
+	docker.runWithResultFn = func(ctx context.Context, args executil.RunArgs) (executil.RunResult, error) {
+		ran = true
+
+		require.Equal(t, "docker", args.Cmd)
+		require.Equal(t, cwd, args.Cwd)
+		require.Equal(t, []string{
+			"build",
+			"-q",
+			"-f", dockerFile,
+			"--platform", platform,
+			dockerContext,
+		}, args.Args)
+
+		return executil.RunResult{
+			Stdout:   "Docker build output",
+			Stderr:   "",
+			ExitCode: 0,
+		}, nil
+	}
+
+	result, err := docker.Build(context.Background(), cwd, dockerFile, "", dockerContext)
+
+	require.Equal(t, true, ran)
+	require.Nil(t, err)
+	require.Equal(t, "Docker build output", result)
+}
+
+func Test_DockerTag(t *testing.T) {
+	docker := NewDocker()
+
+	cwd := "."
+	imageName := "image-name"
+	tag := "customTag"
+
+	t.Run("NoError", func(t *testing.T) {
+		ran := false
+
+		docker.runWithResultFn = func(ctx context.Context, args executil.RunArgs) (executil.RunResult, error) {
+			ran = true
+
+			require.Equal(t, "docker", args.Cmd)
+			require.Equal(t, cwd, args.Cwd)
+			require.Equal(t, []string{
+				"tag",
+				imageName,
+				tag,
+			}, args.Args)
+
+			return executil.RunResult{
+				Stdout:   "Docker build output",
+				Stderr:   "",
+				ExitCode: 0,
+			}, nil
+		}
+
+		err := docker.Tag(context.Background(), cwd, imageName, tag)
+
+		require.Equal(t, true, ran)
+		require.Nil(t, err)
+	})
+
+	t.Run("WithError", func(t *testing.T) {
+		ran := false
+		stdErr := "Error tagging DockerFile"
+		customErrorMessage := "example error message"
+
+		docker.runWithResultFn = func(ctx context.Context, args executil.RunArgs) (executil.RunResult, error) {
+			ran = true
+
+			require.Equal(t, "docker", args.Cmd)
+			require.Equal(t, cwd, args.Cwd)
+			require.Equal(t, []string{
+				"tag",
+				imageName,
+				tag,
+			}, args.Args)
+
+			return executil.RunResult{
+				Stdout:   "",
+				Stderr:   stdErr,
+				ExitCode: 1,
+			}, errors.New(customErrorMessage)
+		}
+
+		err := docker.Tag(context.Background(), cwd, imageName, tag)
+
+		require.Equal(t, true, ran)
+		require.NotNil(t, err)
+		require.Equal(t, fmt.Sprintf("tagging image: exit code: 1, stdout: , stderr: %s: %s", stdErr, customErrorMessage), err.Error())
+	})
+}
+
+func Test_DockerPush(t *testing.T) {
+	docker := NewDocker()
+
+	cwd := "."
+	tag := "customTag"
+
+	t.Run("NoError", func(t *testing.T) {
+		ran := false
+
+		docker.runWithResultFn = func(ctx context.Context, args executil.RunArgs) (executil.RunResult, error) {
+			ran = true
+
+			require.Equal(t, "docker", args.Cmd)
+			require.Equal(t, cwd, args.Cwd)
+			require.Equal(t, []string{
+				"push",
+				tag,
+			}, args.Args)
+
+			return executil.RunResult{
+				Stdout:   "Docker build output",
+				Stderr:   "",
+				ExitCode: 0,
+			}, nil
+		}
+
+		err := docker.Push(context.Background(), cwd, tag)
+
+		require.Equal(t, true, ran)
+		require.Nil(t, err)
+	})
+
+	t.Run("WithError", func(t *testing.T) {
+		ran := false
+		stdErr := "Error pushing DockerFile"
+		customErrorMessage := "example error message"
+
+		docker.runWithResultFn = func(ctx context.Context, args executil.RunArgs) (executil.RunResult, error) {
+			ran = true
+
+			require.Equal(t, "docker", args.Cmd)
+			require.Equal(t, cwd, args.Cwd)
+			require.Equal(t, []string{
+				"push",
+				tag,
+			}, args.Args)
+
+			return executil.RunResult{
+				Stdout:   "",
+				Stderr:   stdErr,
+				ExitCode: 1,
+			}, errors.New(customErrorMessage)
+		}
+
+		err := docker.Push(context.Background(), cwd, tag)
+
+		require.Equal(t, true, ran)
+		require.NotNil(t, err)
+		require.Equal(t, fmt.Sprintf("pushing image: exit code: 1, stdout: , stderr: %s: %s", stdErr, customErrorMessage), err.Error())
+	})
+}

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -1,25 +1,28 @@
 {
     "$schema": "http://json-schema.org/schema#",
     "$id": "https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json",
-
     "type": "object",
-
     "required": [
-        "name", "services"
+        "name",
+        "services"
     ],
-
     "properties": {
-        "name": { 
-            "type": "string", 
+        "name": {
+            "type": "string",
             "minLength": 2,
             "title": "Name of the application"
         },
-
+        "resourceGroup": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 64,
+            "title": "Name of the Azure resource group",
+            "description": "When specified will override the resource group name used for infrastructure provisioning."
+        },
         "metadata": {
             "type": "object",
-
             "properties": {
-                "template": { 
+                "template": {
                     "type": "string",
                     "title": "Identifier of the template from which the application was created. Optional.",
                     "examples": [
@@ -28,53 +31,64 @@
                 }
             }
         },
-
         "services": {
             "type": "object",
             "title": "Definition of services that comprise the application",
-
             "additionalProperties": {
                 "type": "object",
-
                 "properties": {
-                    "resourceName": { 
+                    "resourceName": {
                         "type": "string",
                         "title": "Name of the Azure resource that implements the service",
                         "description": "Optional. If not specified, the resource name will be constructed from current environment name concatenated with service name (<environment-name><resource-name>, for example 'prodapi')."
                     },
-
-                    "project": { 
+                    "project": {
                         "type": "string",
                         "title": "Path to the service source code directory"
                     },
-
                     "host": {
                         "type": "string",
                         "title": "Type of Azure resource used for service implementation",
                         "description": "If omitted, App Service will be assumed.",
-                        "enum": [ "", "appservice", "containerapp", "function", "staticwebapp" ]
+                        "enum": [
+                            "",
+                            "appservice",
+                            "containerapp",
+                            "function",
+                            "staticwebapp"
+                        ]
                     },
-
                     "language": {
                         "type": "string",
                         "title": "Service implementation language",
                         "description": "If omitted, .NET will be assumed.",
-                        "enum": [ "", "dotnet", "csharp", "fsharp", "py", "python", "js", "ts" ]
+                        "enum": [
+                            "",
+                            "dotnet",
+                            "csharp",
+                            "fsharp",
+                            "py",
+                            "python",
+                            "js",
+                            "ts"
+                        ]
                     },
-
                     "moduleName": {
                         "type": "string",
                         "title": "Name of the module used to deploy the service",
                         "description": "If omitted, the CLI will assume the module name is the same as the service name."
                     },
-
                     "dist": {
                         "type": "string",
                         "title": "Relative path to service deployment artifacts",
                         "description": "The CLI will use files under this path to create the deployment artifact (ZIP file). If omitted, all files under service project directory will be included."
+                    },
+                    "options": {
+                        "type": "object",
+                        "title": "Custom service options",
+                        "description": "When specified, will configure underlying framework and platform targets."
                     }
                 },
-
                 "required": [
                     "project"
                 ]

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -1,11 +1,12 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json",
     "type": "object",
     "required": [
         "name",
         "services"
     ],
+    "additionalProperties": false,
     "properties": {
         "name": {
             "type": "string",
@@ -35,63 +36,104 @@
             "type": "object",
             "title": "Definition of services that comprise the application",
             "additionalProperties": {
-                "type": "object",
-                "properties": {
-                    "resourceName": {
-                        "type": "string",
-                        "title": "Name of the Azure resource that implements the service",
-                        "description": "Optional. If not specified, the resource name will be constructed from current environment name concatenated with service name (<environment-name><resource-name>, for example 'prodapi')."
-                    },
-                    "project": {
-                        "type": "string",
-                        "title": "Path to the service source code directory"
-                    },
-                    "host": {
-                        "type": "string",
-                        "title": "Type of Azure resource used for service implementation",
-                        "description": "If omitted, App Service will be assumed.",
-                        "enum": [
-                            "",
-                            "appservice",
-                            "containerapp",
-                            "function",
-                            "staticwebapp"
-                        ]
-                    },
-                    "language": {
-                        "type": "string",
-                        "title": "Service implementation language",
-                        "description": "If omitted, .NET will be assumed.",
-                        "enum": [
-                            "",
-                            "dotnet",
-                            "csharp",
-                            "fsharp",
-                            "py",
-                            "python",
-                            "js",
-                            "ts"
-                        ]
-                    },
-                    "moduleName": {
-                        "type": "string",
-                        "title": "Name of the module used to deploy the service",
-                        "description": "If omitted, the CLI will assume the module name is the same as the service name."
-                    },
-                    "dist": {
-                        "type": "string",
-                        "title": "Relative path to service deployment artifacts",
-                        "description": "The CLI will use files under this path to create the deployment artifact (ZIP file). If omitted, all files under service project directory will be included."
-                    },
-                    "options": {
-                        "type": "object",
-                        "title": "Custom service options",
-                        "description": "When specified, will configure underlying framework and platform targets."
-                    }
+                "$ref": "#/$defs/service"
+            }
+        }
+    },
+    "$defs": {
+        "service": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "resourceName": {
+                    "type": "string",
+                    "title": "Name of the Azure resource that implements the service",
+                    "description": "Optional. If not specified, the resource name will be constructed from current environment name concatenated with service name (<environment-name><resource-name>, for example 'prodapi')."
                 },
-                "required": [
-                    "project"
-                ]
+                "project": {
+                    "type": "string",
+                    "title": "Path to the service source code directory"
+                },
+                "host": {
+                    "type": "string",
+                    "title": "Type of Azure resource used for service implementation",
+                    "description": "If omitted, App Service will be assumed.",
+                    "enum": [
+                        "",
+                        "appservice",
+                        "containerapp",
+                        "function",
+                        "staticwebapp"
+                    ]
+                },
+                "language": {
+                    "type": "string",
+                    "title": "Service implementation language",
+                    "description": "If omitted, .NET will be assumed.",
+                    "enum": [
+                        "",
+                        "dotnet",
+                        "csharp",
+                        "fsharp",
+                        "py",
+                        "python",
+                        "js",
+                        "ts"
+                    ]
+                },
+                "moduleName": {
+                    "type": "string",
+                    "title": "Name of the module used to deploy the service",
+                    "description": "If omitted, the CLI will assume the module name is the same as the service name."
+                },
+                "dist": {
+                    "type": "string",
+                    "title": "Relative path to service deployment artifacts",
+                    "description": "The CLI will use files under this path to create the deployment artifact (ZIP file). If omitted, all files under service project directory will be included."
+                },
+                "docker": {
+                    "$ref": "#/$defs/dockerOptions"
+                }
+            },
+            "if": {
+                "not": {
+                    "properties": {
+                        "host": {
+                            "const": "containerapp"
+                        }
+                    }
+                }
+            },
+            "then": {
+                "properties": {
+                    "docker": false
+                }
+            },
+            "required": [
+                "project"
+            ]
+        },
+        "dockerOptions": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "title": "The path to the Dockerfile",
+                    "description": "Path to the Dockerfile is relative to your service",
+                    "default": "./Dockerfile"
+                },
+                "context": {
+                    "type": "string",
+                    "title": "The docker build context",
+                    "description": "When specified overrides the default context",
+                    "default": "."
+                },
+                "platform": {
+                    "type": "string",
+                    "title": "The platform target",
+                    "default": "amd64"
+                }
             }
         }
     }


### PR DESCRIPTION
Adds support for custom docker options.

**Example**
```yaml
name: todo-nodejs-mongo-aca
metadata:
  template: todo-nodejs-mongo-aca@0.0.1-beta
services:
  api:
    project: src/api
    language: js
    host: containerapp
    docker:
      path: ./Dockerfile
      context: ../
  web:
    project: src/web
    language: js
    host: containerapp

```

Resolves Azure/azure-dev-pr#1298