### PR TITLE
Generate combined markdown docs file per build

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -46,3 +46,4 @@ swacli
 unmarshaling
 westus2
 yacspin
+Backticks

--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -23,6 +23,12 @@ dictionaryDefinitions:
 dictionaries:
   - azdProjectDictionary
 overrides:
+  - filename: docs/docgen.go
+    words:
+      - pname
+      - puichan
+      - devx
+      - azdevcli
   - filename: pkg/tools/python.go
     words:
       - venv

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -30,7 +30,7 @@ func deployCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		"Deploy the application's code to Azure.",
 		`Deploy the application's code to Azure.
 
-When no`+"`"+`--service`+"`"+` value is specified, all services in the *azure.yaml* file (found in the root of your project) are deployed.
+When no `+withBackticks("--service")+` value is specified, all services in the *azure.yaml* file (found in the root of your project) are deployed.
 
 Examples:
 

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -27,10 +27,10 @@ func deployCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		&deployAction{rootOptions: rootOptions},
 		rootOptions,
 		"deploy",
-		"Deploy the application's code to Azure",
+		"Deploy the application's code to Azure.",
 		`Deploy the application's code to Azure.
 
-When no "--service" is specified, all services in azure.yaml (found in the root of your project), are deployed.
+When no`+"`"+`--service`+"`"+` value is specified, all services in the *azure.yaml* file (found in the root of your project) are deployed.
 
 Examples:
 
@@ -38,9 +38,8 @@ Examples:
 	$ azd deploy –-service api
 	$ azd deploy –-service web
 	
-Once deployment is complete, the endpoint is printed. Click or copy and paste the endpoint in a browser to launch the service.`,
+After the deployment is complete, the endpoint is printed. To start the service, select the endpoint or paste it in a browser.`,
 	)
-	cmd.Flags().BoolP("help", "h", false, "Help for "+cmd.Name())
 
 	return output.AddOutputParam(
 		cmd,
@@ -62,7 +61,7 @@ func (d *deployAction) SetupFlags(
 	persis *pflag.FlagSet,
 	local *pflag.FlagSet,
 ) {
-	local.StringVar(&d.serviceName, "service", "", "Deploy a specific service (when unset, all services listed in "+environment.ProjectFileName+" are deployed)")
+	local.StringVar(&d.serviceName, "service", "", "Deploys a specific service (when the string is unspecified, all services that are listed in the "+environment.ProjectFileName+" file are deployed).")
 }
 
 func (d *deployAction) Run(ctx context.Context, cmd *cobra.Command, args []string, azdCtx *environment.AzdContext) error {

--- a/cli/azd/cmd/down.go
+++ b/cli/azd/cmd/down.go
@@ -13,7 +13,7 @@ func downCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		},
 		rootOptions,
 		"down",
-		"Delete Azure resources for an application",
+		"Delete Azure resources for an application.",
 		"",
 	)
 

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -23,12 +23,12 @@ func envCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		Short: "Manage environments.",
 		Long: `Manage environments.
 
-This command group allows you to create a new environment or to get, set and list your application environments. An application can have multiple environments, e.g., dev, test, prod, each with different configuration (i.e., connectivity information) for accessing Azure resources. 
+With this command group, you can create a new environment or get, set, and list your application environments. An application can have multiple environments (for example, dev, test, prod), each with a different configuration (that is, connectivity information) for accessing Azure resources. 
 
-You can find all environment configurations under the .azure\<environment-name> folder(s). The environment name is stored as the AZURE_ENV_NAME environment variable in .azure\<environment-name>\folder\.env. `,
+You can find all environment configurations under the *.azure\<environment-name>* folder. The environment name is stored as the AZURE_ENV_NAME environment variable in the *.azure\<environment-name>\folder\.env* file.`,
 	}
 
-	root.Flags().BoolP("help", "h", false, "Help for "+root.Name())
+	root.Flags().BoolP("help", "h", false, fmt.Sprintf("Gets help for %s.", root.Name()))
 	root.AddCommand(envSetCmd(rootOptions))
 	root.AddCommand(envSelectCmd(rootOptions))
 	root.AddCommand(envNewCmd(rootOptions))
@@ -82,7 +82,7 @@ func envSetCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		commands.ActionFunc(actionFn),
 		rootOptions,
 		"set <key> <value>",
-		"Set a value in the environment",
+		"Set a value in the environment.",
 		"",
 	)
 	cmd.Args = cobra.ExactArgs(2)
@@ -107,7 +107,7 @@ func envSelectCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		action,
 		rootOptions,
 		"select <environment>",
-		"Set the default environment",
+		"Set the default environment.",
 		"",
 	)
 	cmd.Args = cobra.ExactArgs(1)
@@ -115,9 +115,9 @@ func envSelectCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 }
 
 func envListCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "list",
-		Short:   "List environments",
+		Short:   "List environments.",
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := environment.NewAzdContext()
@@ -164,6 +164,8 @@ func envListCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().BoolP("help", "h", false, fmt.Sprintf("Gets help for %s.", cmd.Name()))
+	return cmd
 }
 
 func envNewCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
@@ -197,7 +199,7 @@ func envNewCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		commands.ActionFunc(actionFn),
 		rootOptions,
 		"new <environment>",
-		"Create a new environment",
+		"Create a new environment.",
 		"",
 	)
 	cmd.Args = cobra.MaximumNArgs(1)
@@ -262,15 +264,15 @@ func envRefreshCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		commands.ActionFunc(actionFn),
 		rootOptions,
 		"refresh",
-		"Refresh environment settings using information from previous infrastructure provision",
+		"Refresh environment settings by using information from a previous infrastructure provision.",
 		"",
 	)
 }
 
 func envGetValuesCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "get-values",
-		Short: "Get all environment values",
+		Short: "Get all environment values.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -310,4 +312,6 @@ func envGetValuesCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command 
 			return nil
 		},
 	}
+	cmd.Flags().BoolP("help", "h", false, fmt.Sprintf("Gets help for %s.", cmd.Name()))
+	return cmd
 }

--- a/cli/azd/cmd/infra.go
+++ b/cli/azd/cmd/infra.go
@@ -4,6 +4,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/spf13/cobra"
@@ -12,8 +14,9 @@ import (
 func infraCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "infra",
-		Short: "Manage Azure resources",
+		Short: "Manage Azure resources.",
 	}
+	cmd.Flags().BoolP("help", "h", false, fmt.Sprintf("Gets help for %s.", cmd.Name()))
 
 	cmd.AddCommand(output.AddOutputParam(
 		infraCreateCmd(rootOptions),

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -37,7 +37,7 @@ func infraCreateCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		},
 		rootOptions,
 		"create",
-		"Create Azure resources for an application",
+		"Create Azure resources for an application.",
 		"",
 	)
 
@@ -46,7 +46,7 @@ func infraCreateCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 }
 
 func (ica *infraCreateAction) SetupFlags(persis, local *pflag.FlagSet) {
-	local.BoolVar(&ica.noProgress, "no-progress", false, "Suppress progress information")
+	local.BoolVar(&ica.noProgress, "no-progress", false, "Suppresses progress information.")
 }
 
 func (ica *infraCreateAction) Run(ctx context.Context, cmd *cobra.Command, args []string, azdCtx *environment.AzdContext) error {

--- a/cli/azd/cmd/infra_delete.go
+++ b/cli/azd/cmd/infra_delete.go
@@ -23,7 +23,7 @@ func infraDeleteCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		},
 		rootOptions,
 		"delete",
-		"Delete Azure resources for an application",
+		"Delete Azure resources for an application.",
 		"",
 	)
 }
@@ -38,8 +38,8 @@ func (a *infraDeleteAction) SetupFlags(
 	persis *pflag.FlagSet,
 	local *pflag.FlagSet,
 ) {
-	local.BoolVar(&a.forceDelete, "force", false, "Do not require confirmation before deleting resources")
-	local.BoolVar(&a.purgeDelete, "purge", false, "Permanently delete resources which are soft-deleted by default (e.g. Key Vaults)")
+	local.BoolVar(&a.forceDelete, "force", false, "Does not require confirmation before it deletes resources.")
+	local.BoolVar(&a.purgeDelete, "purge", false, "Permanently deletes resources that are soft-deleted by default (for example, key vaults).")
 }
 
 func (a *infraDeleteAction) Run(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -33,14 +33,13 @@ func initCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		},
 		rootOptions,
 		"init",
-		"Initialize a new application",
-		`Initialize a new application
+		"Initialize a new application.",
+		`Initialize a new application.
 
-When no template is supplied, you can optionally select an azd template for cloning. Otherwise, "azd init" initializes the current directory and creates resources so that your project is compatible with azd.
+When no template is supplied, you can optionally select an Azure Developer CLI template for cloning. Otherwise, `+"`"+`azd init`+"`"+`initializes the current directory and creates resources so that your project is compatible with Azure Developer CLI.
 
 When a template is provided, the sample code is cloned to the current directory.`,
 	)
-	cmd.Flags().BoolP("help", "h", false, "Help for "+cmd.Name())
 	return cmd
 }
 
@@ -60,8 +59,8 @@ func (i *initAction) SetupFlags(
 	persis *pflag.FlagSet,
 	local *pflag.FlagSet,
 ) {
-	local.StringVarP(&i.templateName, "template", "t", "", "Template to use when initializing the project. You can use: 1. Full URI 2. <owner>/<repository> or 3. <repository> - if part of the azure-samples organization ")
-	local.StringVarP(&i.templateBranch, "branch", "b", "", "The template branch to initialize from")
+	local.StringVarP(&i.templateName, "template", "t", "", "The template to use when you initialize the project. You can use Full URI, <owner>/<repository>, or <repository> if it's part of the azure-samples organization.")
+	local.StringVarP(&i.templateBranch, "branch", "b", "", "The template branch to initialize from.")
 }
 
 func (i *initAction) Run(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -36,7 +36,7 @@ func initCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		"Initialize a new application.",
 		`Initialize a new application.
 
-When no template is supplied, you can optionally select an Azure Developer CLI template for cloning. Otherwise, `+"`"+`azd init`+"`"+`initializes the current directory and creates resources so that your project is compatible with Azure Developer CLI.
+When no template is supplied, you can optionally select an Azure Developer CLI template for cloning. Otherwise, `+withBackticks("azd init")+` initializes the current directory and creates resources so that your project is compatible with Azure Developer CLI.
 
 When a template is provided, the sample code is cloned to the current directory.`,
 	)

--- a/cli/azd/cmd/login.go
+++ b/cli/azd/cmd/login.go
@@ -25,7 +25,7 @@ func loginCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		},
 		rootOptions,
 		"login",
-		"Log in to Azure",
+		"Log in to Azure.",
 		"",
 	)
 
@@ -85,8 +85,8 @@ func (la *loginAction) Run(ctx context.Context, cmd *cobra.Command, args []strin
 }
 
 func (la *loginAction) SetupFlags(persistent *pflag.FlagSet, local *pflag.FlagSet) {
-	local.BoolVar(&la.onlyCheckStatus, "check-status", false, "Check login status, instead of logging in")
-	local.BoolVar(&la.useDeviceCode, "use-device-code", false, "When true, log on using a device code instead of a browser")
+	local.BoolVar(&la.onlyCheckStatus, "check-status", false, "Checks the log-in status instead of logging in.")
+	local.BoolVar(&la.useDeviceCode, "use-device-code", false, "When true, log in by using a device code instead of a browser.")
 }
 
 // ensureLoggedIn checks to see if the user is currently logged in. If not, the equivalent of `az login` is run.

--- a/cli/azd/cmd/monitor.go
+++ b/cli/azd/cmd/monitor.go
@@ -25,8 +25,8 @@ func monitorCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		},
 		rootOptions,
 		"monitor",
-		"Monitor a deployed application",
-		`Monitor a deployed application
+		"Monitor a deployed application.",
+		`Monitor a deployed application.
 		
 Examples:
 
@@ -34,9 +34,8 @@ Examples:
 	$ azd monitor -–live
 	$ azd monitor --logs
 		
-For more information, please visit: https://aka.ms/azure-dev/monitor`,
+For more information, go to https://aka.ms/azure-dev/monitor.`,
 	)
-	cmd.Flags().BoolP("help", "h", false, "Help for "+cmd.Name())
 	return cmd
 }
 
@@ -51,9 +50,9 @@ func (m *monitorAction) SetupFlags(
 	persis *pflag.FlagSet,
 	local *pflag.FlagSet,
 ) {
-	persis.BoolVar(&m.monitorLive, "live", false, "Open a browser to Application Insights Live Metrics. Live Metrics is currently not supported for Python app")
-	persis.BoolVar(&m.monitorLogs, "logs", false, "Open a browser to Application Insights Logs")
-	persis.BoolVar(&m.monitorOverview, "overview", false, "Open a browser to Application Insights Overview Dashboard")
+	persis.BoolVar(&m.monitorLive, "live", false, "Open a browser to Application Insights Live Metrics. Live Metrics is currently not supported for Python applications.")
+	persis.BoolVar(&m.monitorLogs, "logs", false, "Open a browser to Application Insights Logs.")
+	persis.BoolVar(&m.monitorOverview, "overview", false, "Open a browser to Application Insights Overview Dashboard.")
 }
 
 func (m *monitorAction) Run(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -23,14 +23,14 @@ import (
 func pipelineCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pipeline",
-		Short: "Manage GitHub Actions pipelines",
-		Long: `Manage GitHub Actions pipelines
+		Short: "Manage GitHub Actions pipelines.",
+		Long: `Manage GitHub Actions pipelines.
 
-azd template includes a GitHub Actions pipeline configuration file (find within folder .github/workflows) that will deploy your application whenever code is pushed to the main branch.
-		
-For more information, please visit: https://aka.ms/azure-dev/pipeline`,
+The Azure Developer CLI template includes a GitHub Actions pipeline configuration file (in the *.github/workflows* folder) that deploys your application whenever code is pushed to the main branch.
+
+For more information, go to https://aka.ms/azure-dev/pipeline.`,
 	}
-	cmd.Flags().BoolP("help", "h", false, "Help for "+cmd.Name())
+	cmd.Flags().BoolP("help", "h", false, fmt.Sprintf("Gets help for %s.", cmd.Name()))
 	cmd.AddCommand(pipelineConfigCmd(rootOptions))
 	return cmd
 }
@@ -40,12 +40,11 @@ func pipelineConfigCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Comman
 		&pipelineConfigAction{rootOptions: rootOptions},
 		rootOptions,
 		"config",
-		"Create and configure your deployment pipeline using GitHub Actions",
-		`Create and configure your deployment pipeline using GitHub Actions
-		
-For more information, please visit: https://aka.ms/azure-dev/pipeline`,
+		"Create and configure your deployment pipeline by using GitHub Actions.",
+		`Create and configure your deployment pipeline by using GitHub Actions.
+
+For more information, go to https://aka.ms/azure-dev/pipeline.`,
 	)
-	cmd.Flags().BoolP("help", "h", false, "Help for "+cmd.Name())
 	return cmd
 }
 
@@ -60,9 +59,9 @@ func (p *pipelineConfigAction) SetupFlags(
 	persis *pflag.FlagSet,
 	local *pflag.FlagSet,
 ) {
-	local.StringVar(&p.pipelineServicePrincipalName, "principal-name", "", "The name of the service principal to use to grant access to Azure resources as part of the pipeline")
-	local.StringVar(&p.pipelineRemoteName, "remote-name", "origin", "The name of the git remote to configure the pipeline to run on")
-	local.StringVar(&p.pipelineRoleName, "principal-role", "Contributor", "Role to assign to the service principal")
+	local.StringVar(&p.pipelineServicePrincipalName, "principal-name", "", "The name of the service principal to use to grant access to Azure resources as part of the pipeline.")
+	local.StringVar(&p.pipelineRemoteName, "remote-name", "origin", "The name of the git remote to configure the pipeline to run on.")
+	local.StringVar(&p.pipelineRoleName, "principal-role", "Contributor", "The role to assign to the service principal.")
 }
 
 func (p *pipelineConfigAction) Run(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {

--- a/cli/azd/cmd/provision.go
+++ b/cli/azd/cmd/provision.go
@@ -13,17 +13,16 @@ func provisionCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		},
 		rootOptions,
 		"provision",
-		"Provision the Azure resources for an application",
-		`Provision the Azure resources for an application
+		"Provision the Azure resources for an application.",
+		`Provision the Azure resources for an application.
 
 The command prompts you for the following:
-	- Environment Name: Name of your environment.
-	- Azure Location: The Azure location where your resources will be deployed.
-	- Azure Subscription: The Azure Subscription where your resources will be deployed.
-	
-Depending on what Azure resources are created, this may take a while. To view progress, go to Azure portal and search for the resource group that contains your environment name.`,
+- Environment name: The name of your environment.
+- Azure location: The Azure location where your resources will be deployed.
+- Azure subscription: The Azure subscription where your resources will be deployed.
+
+Depending on what Azure resources are created, running this command might take a while. To view progress, go to the Azure portal and search for the resource group that contains your environment name.`,
 	)
-	cmd.Flags().BoolP("help", "h", false, "Help for "+cmd.Name())
 
 	return output.AddOutputParam(
 		cmd,

--- a/cli/azd/cmd/restore.go
+++ b/cli/azd/cmd/restore.go
@@ -23,14 +23,13 @@ func restoreCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		},
 		rootOptions,
 		"restore",
-		"Restore application dependencies",
-		`Restore application dependencies
+		"Restore application dependencies.",
+		`Restore application dependencies.
 
-Run this command to install/download all the required libraries so that you can build, run, and debug the application locally.
+Run this command to download and install all the required libraries so that you can build, run, and debug the application locally.
 
-For best local run and debug experience, refer to https://aka.ms/azure-dev/vscode to leverage the VS Code extension.`,
+For the best local run and debug experience, go to https://aka.ms/azure-dev/vscode to learn how to use the Visual Studio Code extension.`,
 	)
-	cmd.Flags().BoolP("help", "h", false, "Help for "+cmd.Name())
 	return cmd
 }
 
@@ -40,7 +39,7 @@ type restoreAction struct {
 }
 
 func (r *restoreAction) SetupFlags(persis, local *pflag.FlagSet) {
-	local.StringVar(&r.serviceName, "service", "", "Restores dependencies for a specific service (when unset, dependencies for all services listed in "+environment.ProjectFileName+" are restored)")
+	local.StringVar(&r.serviceName, "service", "", "Restores a specific service (when the string is unspecified, all services that are listed in the "+environment.ProjectFileName+" file are restored).")
 }
 
 func (r *restoreAction) Run(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -21,11 +21,11 @@ func NewRootCmd() *cobra.Command {
 		Short: "Azure Developer CLI is a command-line interface for developers who build Azure solutions.",
 		Long: `Azure Developer CLI is a command-line interface for developers who build Azure solutions.
 
-To begin working with Azure Developer CLI, run the ` + "`" + `azd up` + "`" + ` command by supplying a sample template in an empty directory:
+To begin working with Azure Developer CLI, run the ` + withBackticks("azd up") + ` command by supplying a sample template in an empty directory:
 
 	$ azd up –-template todo-nodejs-mongo
 
-You can pick a template by running ` + "`" + `azd template` + "`" + ` list and then supplying the repo name as a value to ` + "`" + `–-template` + "`" + `.
+You can pick a template by running ` + withBackticks("azd template list") + `and then supplying the repo name as a value to ` + withBackticks("--template") + `.
 
 The most common next commands are:
 

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -18,22 +18,22 @@ func NewRootCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "azd",
-		Short: "Azure Developer CLI (azd) - A CLI for developers building Azure solutions",
-		Long: `Azure Developer CLI (azd) - A CLI for developers building Azure solutions​
+		Short: "Azure Developer CLI is a command-line interface for developers who build Azure solutions.",
+		Long: `Azure Developer CLI is a command-line interface for developers who build Azure solutions.
 
-To begin working with azd, run the "azd up" command by supplying a sample template in an empty directory:​
-		
-	$ azd up –-template todo-nodejs-mongo​
-		
-You can pick a template by running "azd template list" and supply the repo name as value to "–-template".​
-		
-The most common commands from there are:​
-		
-	$ azd pipeline config​
+To begin working with Azure Developer CLI, run the ` + "`" + `azd up` + "`" + ` command by supplying a sample template in an empty directory:
+
+	$ azd up –-template todo-nodejs-mongo
+
+You can pick a template by running ` + "`" + `azd template` + "`" + ` list and then supplying the repo name as a value to ` + "`" + `–-template` + "`" + `.
+
+The most common next commands are:
+
+	$ azd pipeline config
 	$ azd deploy
 	$ azd monitor --overview
-		
-For more information, please visit the project page: https://aka.ms/azure-dev/devhub`,
+
+For more information, visit the Azure Developer CLI Dev Hub: https://aka.ms/azure-dev/devhub.`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.Cwd != "" {
 				current, err := os.Getwd()
@@ -70,11 +70,11 @@ For more information, please visit the project page: https://aka.ms/azure-dev/de
 
 	cmd.DisableAutoGenTag = true
 	cmd.CompletionOptions.HiddenDefaultCmd = true
-	cmd.Flags().BoolP("help", "h", false, "Help for "+cmd.Name())
-	cmd.PersistentFlags().StringVarP(&opts.EnvironmentName, "environment", "e", "", "The name of the environment to use")
-	cmd.PersistentFlags().StringVarP(&opts.Cwd, "cwd", "C", "", "Set the current working directory")
-	cmd.PersistentFlags().BoolVar(&opts.EnableDebugLogging, "debug", false, "Enables debug/diagnostic logging")
-	cmd.PersistentFlags().BoolVar(&opts.NoPrompt, "no-prompt", false, "Accept default value instead of prompting, or fail if there is no default")
+	cmd.Flags().BoolP("help", "h", false, fmt.Sprintf("Gets help for %s.", cmd.Name()))
+	cmd.PersistentFlags().StringVarP(&opts.EnvironmentName, "environment", "e", "", "The name of the environment to use.")
+	cmd.PersistentFlags().StringVarP(&opts.Cwd, "cwd", "C", "", "Sets the current working directory.")
+	cmd.PersistentFlags().BoolVar(&opts.EnableDebugLogging, "debug", false, "Enables debugging and diagnostics logging.")
+	cmd.PersistentFlags().BoolVar(&opts.NoPrompt, "no-prompt", false, "Accepts the default value instead of prompting, or it fails if there is no default.")
 	cmd.SetHelpTemplate(fmt.Sprintf("%s\nPlease let us know how we are doing: https://aka.ms/azure-dev/hats\n", cmd.HelpTemplate()))
 
 	// the equivalent of AZURE_CORE_COLLECT_TELEMETRY

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newRootCmd() *cobra.Command {
+func NewRootCmd() *cobra.Command {
 	prevDir := ""
 	opts := &commands.GlobalCommandOptions{}
 
@@ -68,6 +68,7 @@ For more information, please visit the project page: https://aka.ms/azure-dev/de
 		SilenceUsage: true,
 	}
 
+	cmd.DisableAutoGenTag = true
 	cmd.CompletionOptions.HiddenDefaultCmd = true
 	cmd.Flags().BoolP("help", "h", false, "Help for "+cmd.Name())
 	cmd.PersistentFlags().StringVarP(&opts.EnvironmentName, "environment", "e", "", "The name of the environment to use")
@@ -97,7 +98,7 @@ For more information, please visit the project page: https://aka.ms/azure-dev/de
 }
 
 func Execute(args []string) error {
-	tempRootCmd := newRootCmd()
+	tempRootCmd := NewRootCmd()
 	tempRootCmd.SetArgs(args)
 	return tempRootCmd.Execute()
 }

--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
@@ -17,7 +18,7 @@ import (
 func templatesCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 	root := &cobra.Command{
 		Use:   "template",
-		Short: "Manage templates",
+		Short: "Manage templates.",
 	}
 
 	root.AddCommand(output.AddOutputParam(
@@ -30,14 +31,15 @@ func templatesCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		[]output.Format{output.JsonFormat, output.TableFormat},
 		output.TableFormat,
 	))
+	root.Flags().BoolP("help", "h", false, fmt.Sprintf("Gets help for %s.", root.Name()))
 
 	return root
 }
 
 func templatesListCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "list",
-		Short:   "List templates",
+		Short:   "List templates.",
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			templateManager := templates.NewTemplateManager()
@@ -50,6 +52,8 @@ func templatesListCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command
 			return formatTemplates(cmd, templateList...)
 		},
 	}
+	cmd.Flags().BoolP("help", "h", false, fmt.Sprintf("Gets help for %s.", cmd.Name()))
+	return cmd
 }
 
 func templatesShowCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
@@ -72,7 +76,7 @@ func templatesShowCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command
 		action,
 		rootOptions,
 		"show <template>",
-		"Show the template details",
+		"Show the template details.",
 		"",
 	)
 	cmd.Args = cobra.ExactArgs(1)

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -27,7 +27,7 @@ func upCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		),
 		rootOptions,
 		"up",
-		"Initialize application, provision Azure resources, and deploy your project with a single command",
+		"Initialize application, provision Azure resources, and deploy your project with a single command.",
 		`Initialize the project (if the project folder has not been initialized or cloned from a template), provision Azure resources, and deploy your project with a single command.
 
 This command executes the following in one step:
@@ -36,9 +36,8 @@ This command executes the following in one step:
 	$ azd provision
 	$ azd deploy
 
-When no template is supplied, you can optionally select an azd template for cloning. Otherwise, "azd up" initializes the current directory so that your project is compatible with azd.`,
+When no template is supplied, you can optionally select an Azure Developer CLI template for cloning. Otherwise, running azd up initializes the current directory so that your project is compatible with Azure Developer CLI.`,
 	)
-	cmd.Flags().BoolP("help", "h", false, "Help for "+cmd.Name())
 
 	output.AddOutputParam(cmd,
 		[]output.Format{output.JsonFormat, output.NoneFormat},

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -36,7 +36,7 @@ This command executes the following in one step:
 	$ azd provision
 	$ azd deploy
 
-When no template is supplied, you can optionally select an Azure Developer CLI template for cloning. Otherwise, running azd up initializes the current directory so that your project is compatible with Azure Developer CLI.`,
+When no template is supplied, you can optionally select an Azure Developer CLI template for cloning. Otherwise, running `+withBackticks("azd up")+` initializes the current directory so that your project is compatible with Azure Developer CLI.`,
 	)
 
 	output.AddOutputParam(cmd,

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -572,3 +572,8 @@ func printWithStyling(text string, a ...interface{}) {
 	colorTerminal := color.New()
 	colorTerminal.Printf(text, a...)
 }
+
+// withBackticks wraps text with the backtick (`) character.
+func withBackticks(text string) string {
+	return "`" + text + "`"
+}

--- a/cli/azd/cmd/version.go
+++ b/cli/azd/cmd/version.go
@@ -23,7 +23,7 @@ func versionCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 		),
 		rootOptions,
 		"version",
-		"Print the version number of azd",
+		"Print the version number of Azure Developer CLI.",
 		"",
 	)
 }

--- a/cli/azd/docs/.gitignore
+++ b/cli/azd/docs/.gitignore
@@ -1,0 +1,2 @@
+# Exclude the generated documentation.
+md/

--- a/cli/azd/docs/docgen.go
+++ b/cli/azd/docs/docgen.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -34,6 +35,9 @@ ms.prod: azure
 
 `
 
+// directoryMode is the mode applied to output directory we create.
+const directoryMode fs.FileMode = 0755
+
 func main() {
 	fmt.Println("Generating documentation")
 
@@ -42,25 +46,25 @@ func main() {
 	basename := strings.Replace(cmd.CommandPath(), " ", "_", -1) + ".md"
 	filename := filepath.Join("./md", basename)
 
-	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filename), directoryMode); err != nil {
 		fmt.Printf("Error: %v", err)
 		os.Exit(1)
 	}
 
-	f, err := os.Create(filename)
+	docFile, err := os.Create(filename)
 	if err != nil {
 		fmt.Printf("Error: %v", err)
 		os.Exit(1)
 	}
-	defer f.Close()
+	defer docFile.Close()
 
 	// Write front-matter to the file:
-	if _, err := f.WriteString(fmt.Sprintf(fontMatterFormatString, time.Now().Format("01/02/06"))); err != nil {
+	if _, err := docFile.WriteString(fmt.Sprintf(fontMatterFormatString, time.Now().Format("01/02/06"))); err != nil {
 		fmt.Printf("Error: %v", err)
 		os.Exit(1)
 	}
 
-	if err := genMarkdownFile(f, cmd); err != nil {
+	if err := genMarkdownFile(docFile, cmd); err != nil {
 		fmt.Printf("Error: %v", err)
 		os.Exit(1)
 	}

--- a/cli/azd/pkg/commands/builder.go
+++ b/cli/azd/pkg/commands/builder.go
@@ -10,7 +10,7 @@ import (
 
 //Build builds a Cobra command, attaching an action
 func Build(action Action, rootOptions *GlobalCommandOptions, use string, short string, long string) *cobra.Command {
-	cobraCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   use,
 		Short: short,
 		Long:  long,
@@ -32,9 +32,10 @@ func Build(action Action, rootOptions *GlobalCommandOptions, use string, short s
 			return action.Run(ctx, cmd, args, azdCtx)
 		},
 	}
+	cmd.Flags().BoolP("help", "h", false, fmt.Sprintf("Gets help for %s.", cmd.Name()))
 	action.SetupFlags(
-		cobraCommand.PersistentFlags(),
-		cobraCommand.Flags(),
+		cmd.PersistentFlags(),
+		cmd.Flags(),
 	)
-	return cobraCommand
+	return cmd
 }

--- a/cli/azd/pkg/output/parameter.go
+++ b/cli/azd/pkg/output/parameter.go
@@ -21,7 +21,7 @@ func AddOutputParam(cmd *cobra.Command, supportedFormats []Format, defaultFormat
 		formatNames[i] = string(f)
 	}
 
-	description := fmt.Sprintf("Output format (supported formats are %s)", strings.Join(formatNames, ", "))
+	description := fmt.Sprintf("The output format (the supported formats are %s).", strings.Join(formatNames, ", "))
 	cmd.Flags().StringP(outputFlagName, "o", string(defaultFormat), description)
 
 	// Only error that can occur is "flag not found", which is not possible given we just added the flag on the previous line

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -152,13 +152,14 @@ stages:
             condition: always()
             displayName: Upload azd binary to artifact store
 
-      - job: UploadInstallScript
+      - job: GenerateReleaseArtifacts
         pool:
           name: azsdk-pool-mms-ubuntu-2004-general
           vmImage: MMSUbuntu20.04
 
         steps:
           - checkout: self
+          - template: /eng/pipelines/templates/steps/setup-go.yml
           - pwsh: |
               New-Item -ItemType Directory -Path installer
               Copy-Item cli/installer/*install-azd.ps1 installer/
@@ -168,6 +169,13 @@ stages:
             inputs:
               artifactName: install-pwsh
               targetPath: installer
+          - bash: go run docgen.go
+            workingDirectory: cli/azd/docs
+            displayName: Generate CLI documentation
+          - publish: cli/azd/docs/md
+            artifact: docs
+            displayName: Upload generated documentation
+
 
   - stage: Sign
     dependsOn: BuildAndTest


### PR DESCRIPTION
Our current story for generating docs suitable for ingestion in
docs.microsoft.com is "generate a single markdown file with all the
commands and use anchors to cross reference". Since that's not
something the Cobra markdown formatters support out of the box, PC has
manually been merging these files together and doing some small
tweaks.

This PR attempts to automate that logic.

My first attempt at these changes had us to continue to use the Cobra
logic directly (by importing the package it was in) and then try to
clean up small things with some post processing. However, once I
realized that we would need to re-order the default output of the list
commands from SEE ALSO I decided to just take the existing code and
bring it in here and make small tweaks.

At some point, we will move to a different strategy where we have
multiple files and TOC that stitches them together, but until that
point this frees up a bunch of PC's time.