### PR TITLE
Add more detailed log for failed `dotnet` commands

### DIFF
--- a/cli/azd/pkg/tools/dotnet.go
+++ b/cli/azd/pkg/tools/dotnet.go
@@ -59,9 +59,9 @@ func (cli *dotNetCli) CheckInstalled(ctx context.Context) (bool, error) {
 }
 
 func (cli *dotNetCli) Publish(ctx context.Context, project string, output string) error {
-	_, err := executil.RunCommandWithShell(ctx, "dotnet", "publish", project, "-c", "Release", "--output", output)
+	res, err := executil.RunCommandWithShell(ctx, "dotnet", "publish", project, "-c", "Release", "--output", output)
 	if err != nil {
-		return fmt.Errorf("failed to publish project %s (%w)", project, err)
+		return fmt.Errorf("dotnet publish on project '%s' failed: %s: %w", project, res.String(), err)
 	}
 	return nil
 }
@@ -69,7 +69,7 @@ func (cli *dotNetCli) Publish(ctx context.Context, project string, output string
 func (cli *dotNetCli) Restore(ctx context.Context, project string) error {
 	res, err := executil.RunCommandWithShell(ctx, "dotnet", "restore", project)
 	if err != nil {
-		return fmt.Errorf("failed to restore project '%s': %w (%s)", project, err, res.String())
+		return fmt.Errorf("dotnet restore on project '%s' failed: %s: %w", project, res.String(), err)
 	}
 	return nil
 }


### PR DESCRIPTION
Add stderr, stdout output to error logged when `dotnet` command fails.

Before:
![image](https://user-images.githubusercontent.com/2322434/179617307-2e2ebcfc-f639-4fcc-907e-99376ffd4280.png)

After:
![image](https://user-images.githubusercontent.com/2322434/179617359-aa7a4586-a435-4537-bd9f-5ba01724e5f8.png)
