### PR TITLE
Continue on AppInsights setup errors to simplify local development

### DIFF
--- a/templates/todo/api/csharp-cosmos-sql/Program.cs
+++ b/templates/todo/api/csharp-cosmos-sql/Program.cs
@@ -15,8 +15,7 @@ builder.Services.AddSingleton(_ => new CosmosClient(builder.Configuration["AZURE
     }
 }));
 builder.Services.AddControllers();
-var options = new ApplicationInsightsServiceOptions { ConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"] };
-builder.Services.AddApplicationInsightsTelemetry(options);
+builder.Services.AddApplicationInsightsTelemetry(builder.Configuration);
 
 var app = builder.Build();
 

--- a/templates/todo/api/csharp-sql/Program.cs
+++ b/templates/todo/api/csharp-sql/Program.cs
@@ -11,8 +11,7 @@ builder.Services.AddDbContext<TodoDb>(options =>
 });
 
 builder.Services.AddControllers();
-var options = new ApplicationInsightsServiceOptions { ConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"] };
-builder.Services.AddApplicationInsightsTelemetry(options);
+builder.Services.AddApplicationInsightsTelemetry(builder.Configuration);
 
 var app = builder.Build();
 

--- a/templates/todo/api/csharp/Program.cs
+++ b/templates/todo/api/csharp/Program.cs
@@ -9,9 +9,7 @@ builder.Configuration.AddAzureKeyVault(new Uri(builder.Configuration["AZURE_KEY_
 builder.Services.AddSingleton<ListsRepository>();
 builder.Services.AddSingleton(_ => new MongoClient(builder.Configuration[builder.Configuration["AZURE_COSMOS_CONNECTION_STRING_KEY"]]));
 builder.Services.AddControllers();
-
-var options = new ApplicationInsightsServiceOptions { ConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"] };
-builder.Services.AddApplicationInsightsTelemetry(options);
+builder.Services.AddApplicationInsightsTelemetry(builder.Configuration);
 
 var app = builder.Build();
 

--- a/templates/todo/api/js/src/config/observability.ts
+++ b/templates/todo/api/js/src/config/observability.ts
@@ -23,36 +23,41 @@ export const logger = winston.createLogger({
 });
 
 export const observability = (config: ObservabilityConfig) => {
-    applicationInsights
-        .setup(config.connectionString)
-        .setAutoDependencyCorrelation(true)
-        .setAutoCollectRequests(true)
-        .setAutoCollectPerformance(true, true)
-        .setAutoCollectExceptions(true)
-        .setAutoCollectDependencies(true)
-        .setAutoCollectConsole(true)
-        .setUseDiskRetryCaching(true)
-        .setSendLiveMetrics(true)
-        .setDistributedTracingMode(applicationInsights.DistributedTracingModes.AI_AND_W3C);
-
-    applicationInsights.defaultClient.context.tags[applicationInsights.defaultClient.context.keys.cloudRole] = config.roleName;
-    applicationInsights.defaultClient.setAutoPopulateAzureProperties(true);
-    applicationInsights.start();
-
     // Append App Insights to the winston logger
     logger.defaultMeta = {
         app: config.roleName
     };
 
-    const applicationInsightsTransport = new ApplicationInsightsTransport({
-        client: applicationInsights.defaultClient,
-        level: LogLevel.Information,
-        handleExceptions: true, // Handles node unhandled exceptions
-        handleRejections: true, // Handles node promise rejections
-    });
+    try {
+        applicationInsights
+            .setup(config.connectionString)
+            .setAutoDependencyCorrelation(true)
+            .setAutoCollectRequests(true)
+            .setAutoCollectPerformance(true, true)
+            .setAutoCollectExceptions(true)
+            .setAutoCollectDependencies(true)
+            .setAutoCollectConsole(true)
+            .setUseDiskRetryCaching(true)
+            .setSendLiveMetrics(true)
+            .setDistributedTracingMode(applicationInsights.DistributedTracingModes.AI_AND_W3C);
 
-    logger.add(applicationInsightsTransport);
-    logger.info("Added ApplicationInsights logger transport");
+        applicationInsights.defaultClient.context.tags[applicationInsights.defaultClient.context.keys.cloudRole] = config.roleName;
+        applicationInsights.defaultClient.setAutoPopulateAzureProperties(true);
+        applicationInsights.start();
+
+
+        const applicationInsightsTransport = new ApplicationInsightsTransport({
+            client: applicationInsights.defaultClient,
+            level: LogLevel.Information,
+            handleExceptions: true, // Handles node unhandled exceptions
+            handleRejections: true, // Handles node promise rejections
+        });
+
+        logger.add(applicationInsightsTransport);
+        logger.info("Added ApplicationInsights logger transport");
+    } catch (err) {
+        logger.error(`ApplicationInsights setup failed, ensure environment variable 'APPLICATIONINSIGHTS_CONNECTION_STRING' has been set. Error: ${err}`);
+    }
 };
 
 if (process.env.NODE_ENV !== "production") {

--- a/templates/todo/api/js/src/config/observability.ts
+++ b/templates/todo/api/js/src/config/observability.ts
@@ -45,7 +45,6 @@ export const observability = (config: ObservabilityConfig) => {
         applicationInsights.defaultClient.setAutoPopulateAzureProperties(true);
         applicationInsights.start();
 
-
         const applicationInsightsTransport = new ApplicationInsightsTransport({
             client: applicationInsights.defaultClient,
             level: LogLevel.Information,

--- a/templates/todo/web/react-fluent/src/services/telemetryService.ts
+++ b/templates/todo/web/react-fluent/src/services/telemetryService.ts
@@ -27,16 +27,20 @@ export const getApplicationInsights = (): ApplicationInsights => {
     }
 
     applicationInsights = new ApplicationInsights(ApplicationInsightsConfig);
-    applicationInsights.loadAppInsights();
-
-    applicationInsights.addTelemetryInitializer((telemetry: ITelemetryItem) => {
-        if (!telemetry) {
-            return;
-        }
-        if (telemetry.tags) {
-            telemetry.tags['ai.cloud.role'] = "webui";
-        }
-    });
+    try {
+        applicationInsights.loadAppInsights();
+        applicationInsights.addTelemetryInitializer((telemetry: ITelemetryItem) => {
+            if (!telemetry) {
+                return;
+            }
+            if (telemetry.tags) {
+                telemetry.tags['ai.cloud.role'] = "webui";
+            }
+        });
+    } catch(err) {
+        // TODO - proper logging for web
+        console.error("ApplicationInsights setup failed, ensure environment variable 'APPLICATIONINSIGHTS_CONNECTION_STRING' has been set.", err);
+    }
 
     return applicationInsights;
 }

--- a/templates/todo/web/react-fluent/src/services/telemetryService.ts
+++ b/templates/todo/web/react-fluent/src/services/telemetryService.ts
@@ -39,7 +39,7 @@ export const getApplicationInsights = (): ApplicationInsights => {
         });
     } catch(err) {
         // TODO - proper logging for web
-        console.error("ApplicationInsights setup failed, ensure environment variable 'APPLICATIONINSIGHTS_CONNECTION_STRING' has been set.", err);
+        console.error("ApplicationInsights setup failed, ensure environment variable 'REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING' has been set.", err);
     }
 
     return applicationInsights;


### PR DESCRIPTION
Fixes #105
With this change if Application Insights setup throws (e.g. when running apps locally), we log the error but let an application work. 