### PR TITLE
Fix e2e test can not find 'Delete' element in the FireFox in Linux

### DIFF
--- a/templates/todo/common/tests/todo.spec.ts
+++ b/templates/todo/common/tests/todo.spec.ts
@@ -21,6 +21,13 @@ test("Create and delete item test", async ({ page }) => {
   await expect(page.locator(`text=${guid}`).first()).toBeVisible()
 
   await page.locator(`text=${guid}`).click();
+
+  const itemMoreOperation = await page.$('button[role="menuitem"]:has-text("")');
+
+  if(itemMoreOperation){
+    await itemMoreOperation.click();
+  };
+
   await page.locator('button[role="menuitem"]:has-text("Delete")').click();
 
   await expect(page.locator(`text=${guid}`).first()).toBeHidden()


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-dev/issues/291

Update files:
- ./templates/todo/common/tests/todo.spec.ts

@jongio for notification.

Migrated from azure/azure-dev-pr#1362