### PR TITLE
Add azd CLI installation and version check

### DIFF
--- a/ext/vscode/package.nls.json
+++ b/ext/vscode/package.nls.json
@@ -58,7 +58,7 @@
     "azure-dev.utils.quickPickWorkspaceFolder.title": "Open Folder",
     "azure-dev.utils.spawn.exited": "Process '{0}' exited with code {1}",
     "azure-dev.utils.spawn.exitError": "\nError: {0}",
-    "azure-dev.utils.azd.notInstalled": "Azure Developer CLI is not installed. Visit {0} to get it.",
+    "azure-dev.utils.azd.notInstalled": "This extension depends on having the Azure Developer CLI (azd) installed on your computer. Visit {0} to install it.",
     "azure-dev.utils.azd.goToInstallUrl": "Go to {0}",
     "azure-dev.utils.azd.later": "Later",
 

--- a/ext/vscode/package.nls.json
+++ b/ext/vscode/package.nls.json
@@ -58,6 +58,9 @@
     "azure-dev.utils.quickPickWorkspaceFolder.title": "Open Folder",
     "azure-dev.utils.spawn.exited": "Process '{0}' exited with code {1}",
     "azure-dev.utils.spawn.exitError": "\nError: {0}",
+    "azure-dev.utils.azd.notInstalled": "Azure Developer CLI is not installed. Visit {0} to get it.",
+    "azure-dev.utils.azd.goToInstallUrl": "Go to {0}",
+    "azure-dev.utils.azd.later": "Later",
 
     "azure-dev.tasks.dotenv.properties.file": "The .env file to use to populate the target task environment",
     "azure-dev.tasks.dotenv.properties.targetTasks": "Name of the task(s) that will be launched with environment populated from the .env file",

--- a/ext/vscode/src/commands/cmdUtil.ts
+++ b/ext/vscode/src/commands/cmdUtil.ts
@@ -120,7 +120,7 @@ export type EnvironmentInfo = {
 };
 
 export async function getEnvironments(context: IActionContext, cwd: string): Promise<EnvironmentInfo[]> {
-    const azureCli = createAzureDevCli();
+    const azureCli = await createAzureDevCli(context);
     const command = azureCli.commandBuilder
         .withArg('env').withArg('list')
         .withArg('--output').withArg('json')

--- a/ext/vscode/src/commands/deploy.ts
+++ b/ext/vscode/src/commands/deploy.ts
@@ -11,7 +11,7 @@ import { getAzDevTerminalTitle, getWorkingFolder } from './cmdUtil';
 export async function deploy(context: IActionContext, selectedFile?: vscode.Uri): Promise<void> {
     const workingFolder = await getWorkingFolder(context, selectedFile);
 
-    const azureCli = createAzureDevCli();
+    const azureCli = await createAzureDevCli(context);
 
     // Only supporting "deploy all" mode (no support for deploying individual services)
     // until https://github.com/Azure/azure-dev/issues/696 is resolved.

--- a/ext/vscode/src/commands/env.ts
+++ b/ext/vscode/src/commands/env.ts
@@ -37,7 +37,7 @@ export async function selectEnvironment(context: IActionContext, selectedFile?: 
         title: localize('azure-dev.commands.cli.env-select.choose-environment', 'What environment should be set as default?')
     });
 
-    const azureCli = createAzureDevCli();
+    const azureCli = await createAzureDevCli(context);
     azureCli.commandBuilder.withArg('env').withArg('select').withQuotedArg(selectedEnv.data.Name);
     await spawnAsync(azureCli.commandBuilder.build(), azureCli.spawnOptions(cwd));
     await vscode.window.showInformationMessage(
@@ -50,7 +50,7 @@ export async function newEnvironment(context: IActionContext, selectedFile?: vsc
         folder = await quickPickWorkspaceFolder(context, localize('azure-dev.commands.util.needWorkspaceFolder', "To run '{0}' command you must first open a folder or workspace in VS Code", 'env new'));
     }
 
-    const azureCli = createAzureDevCli();
+    const azureCli = await createAzureDevCli(context);
     const command = azureCli.commandBuilder.withArg('env').withArg('new');
     const options: vscode.TerminalOptions = {
         name: getAzDevTerminalTitle(),
@@ -68,7 +68,7 @@ export async function refreshEnvironment(context: IActionContext, selectedFile?:
     }
     const cwd = folder.uri.fsPath;
 
-    const azureCli = createAzureDevCli();
+    const azureCli = await createAzureDevCli(context);
     const progressOptions: vscode.ProgressOptions = {
         location: vscode.ProgressLocation.Notification,
         title: localize('azure-dev.commands.cli.env-refresh.refreshing', 'Refreshing environment values...'),

--- a/ext/vscode/src/commands/infra.ts
+++ b/ext/vscode/src/commands/infra.ts
@@ -33,7 +33,7 @@ export async function infraDelete(context: IActionContext, selectedFile?: vscode
     });
     context.telemetry.properties.purge = purgeChoice ? 'true' : 'false';
 
-    const azureCli = createAzureDevCli();
+    const azureCli = await createAzureDevCli(context);
     let command = azureCli.commandBuilder.withArg('infra').withArg('delete').withArg('--force');
     if (purgeChoice.data) {
         command = command.withArg('--purge');

--- a/ext/vscode/src/commands/init.ts
+++ b/ext/vscode/src/commands/init.ts
@@ -18,7 +18,7 @@ export async function init(context: IActionContext, selectedFile?: vscode.Uri, a
 
     const templateUrl = await selectApplicationTemplate(context);
 
-    const azureCli = createAzureDevCli();
+    const azureCli = await createAzureDevCli(context);
     const command = azureCli.commandBuilder
         .withArg('init')
         .withNamedArg('-t', {value: templateUrl, quoting: vscode.ShellQuoting.Strong});

--- a/ext/vscode/src/commands/monitor.ts
+++ b/ext/vscode/src/commands/monitor.ts
@@ -40,7 +40,7 @@ export async function monitor(context: IActionContext, selectedFile?: vscode.Uri
         throw new UserCancelledError();
     }
 
-    const azureCli = createAzureDevCli();
+    const azureCli = await createAzureDevCli(context);
     let command = azureCli.commandBuilder.withArg('monitor');
     for (const choice of monitorChoices) {
         command = command.withArg(choice.data);

--- a/ext/vscode/src/commands/pipeline.ts
+++ b/ext/vscode/src/commands/pipeline.ts
@@ -11,7 +11,7 @@ import { TelemetryId } from '../telemetry/telemetryId';
 export async function pipelineConfig(context: IActionContext, selectedFile?: vscode.Uri): Promise<void> {
     const workingFolder = await getWorkingFolder(context, selectedFile);
 
-    const azureCli = createAzureDevCli();
+    const azureCli = await createAzureDevCli(context);
     const command = azureCli.commandBuilder.withArg('pipeline').withArg('config').build();
 
     void executeAsTask(command, getAzDevTerminalTitle(), {

--- a/ext/vscode/src/commands/provision.ts
+++ b/ext/vscode/src/commands/provision.ts
@@ -11,7 +11,7 @@ import { TelemetryId } from '../telemetry/telemetryId';
 export async function provision(context: IActionContext, selectedFile?: vscode.Uri): Promise<void> {
     const workingFolder = await getWorkingFolder(context, selectedFile);
 
-    const azureCli = createAzureDevCli();
+    const azureCli = await createAzureDevCli(context);
     const command = azureCli.commandBuilder.withArg('provision').build();
 
     // Don't wait

--- a/ext/vscode/src/commands/restore.ts
+++ b/ext/vscode/src/commands/restore.ts
@@ -11,7 +11,7 @@ import { getAzDevTerminalTitle, getWorkingFolder } from './cmdUtil';
 export async function restore(context: IActionContext, selectedFile?: vscode.Uri): Promise<void> {
     const workingFolder = await getWorkingFolder(context, selectedFile);
 
-    const azureCli = createAzureDevCli();
+    const azureCli = await createAzureDevCli(context);
 
     const command = azureCli.commandBuilder.withArg('restore').build();
 

--- a/ext/vscode/src/commands/up.ts
+++ b/ext/vscode/src/commands/up.ts
@@ -17,7 +17,7 @@ export async function up(context: IActionContext, selectedFile?: vscode.Uri): Pr
         folder = await quickPickWorkspaceFolder(context, localize('azure-dev.commands.cli.init.needWorkspaceFolder', "To run '{0}' command you must first open a folder or workspace in VS Code", 'up'));
     }
 
-    const azureCli = createAzureDevCli();
+    const azureCli = await createAzureDevCli(context);
     let command = azureCli.commandBuilder
         .withArg('up');
     let workingDir = folder.uri;

--- a/ext/vscode/src/extension.ts
+++ b/ext/vscode/src/extension.ts
@@ -11,6 +11,7 @@ import { TelemetryId } from './telemetry/telemetryId';
 import { scheduleSurveys } from './telemetry/surveyScheduler';
 import { SurveyOne } from './telemetry/surveyOne';
 import { ActivityStatisticsService } from './telemetry/activityStatisticsService';
+import { scheduleAzdInstalledCheck } from './utils/azureDevCli';
 
 type LoadStats = {
     // Both are the values returned by Date.now()==milliseconds since Unix epoch.
@@ -46,6 +47,7 @@ export async function activateInternal(vscodeCtx: vscode.ExtensionContext, loadS
         registerCommands();
         registerDisposable(vscode.tasks.registerTaskProvider('dotenv', new DotEnvTaskProvider()));
         scheduleSurveys(vscodeCtx.globalState, [SurveyOne]);
+        scheduleAzdInstalledCheck();
     });
 }
 

--- a/ext/vscode/src/test/suite/unit/lazy.test.ts
+++ b/ext/vscode/src/test/suite/unit/lazy.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { assert } from 'chai';
+import { delay } from '../../testUtil/async';
+import { AsyncLazy } from '../../../utils/lazy';
+
+suite('lazy creation utilities', () => {
+    suite('AsyncLazy tests', () => {
+        test('factory called once', async () => {
+            let factoryCallCount = 0;
+            const lazy: AsyncLazy<boolean> = new AsyncLazy(async () => {
+                factoryCallCount++;
+                await delay(5);
+                return true;
+            });
+
+            await lazy.getValue();
+            await lazy.getValue();
+
+            assert.equal(factoryCallCount, 1, 'Incorrect number of value factory calls.');
+        });
+
+        test('simultaneous callers', async () => {
+            let factoryCallCount = 0;
+            const lazy: AsyncLazy<boolean> = new AsyncLazy(async () => {
+                factoryCallCount++;
+                await delay(5);
+                return true;
+            });
+
+            const p1 = lazy.getValue();
+            const p2 = lazy.getValue();
+            await Promise.all([p1, p2]);
+
+            assert.equal(factoryCallCount, 1, 'Incorrect number of value factory calls.');
+        });
+
+        test('with lifetime', async () => {
+            let factoryCallCount = 0;
+            const lazy: AsyncLazy<boolean> = new AsyncLazy(async () => {
+                factoryCallCount++;
+                await delay(5);
+                return true;
+            }, 20);
+
+            await lazy.getValue();
+            await lazy.getValue();
+
+            assert.equal(factoryCallCount, 1, 'Incorrect number of value factory calls.');
+
+            await delay(50);
+            await lazy.getValue();
+            await lazy.getValue();
+
+            assert.equal(factoryCallCount, 2, 'Incorrect number of value factory calls.');
+        });
+
+        test('simultaneous callers with lifetime', async () => {
+            let factoryCallCount = 0;
+            const lazy: AsyncLazy<boolean> = new AsyncLazy(async () => {
+                factoryCallCount++;
+                await delay(5);
+                return true;
+            }, 20);
+
+            const p1 = lazy.getValue();
+            const p2 = lazy.getValue();
+            await Promise.all([p1, p2]);
+
+            assert.equal(factoryCallCount, 1, 'Incorrect number of value factory calls.');
+
+            await delay(50);
+            const p3 = lazy.getValue();
+            const p4 = lazy.getValue();
+            await Promise.all([p3, p4]);
+
+            assert.equal(factoryCallCount, 2, 'Incorrect number of value factory calls.');
+        });
+    });
+});

--- a/ext/vscode/src/test/suite/unitTests.ts
+++ b/ext/vscode/src/test/suite/unitTests.ts
@@ -9,7 +9,8 @@ export function run(): Promise<void> {
     const opts: Mocha.MochaOptions = {
         ui: 'tdd',
         color: true,
-        timeout: process.env.TEST_TIMEOUT ?? "10s"
+        timeout: process.env.TEST_TIMEOUT ?? "10s",
+        slow: 200
     };
     
     const mocha = new Mocha(opts);

--- a/ext/vscode/src/test/testUtil/async.ts
+++ b/ext/vscode/src/test/testUtil/async.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as vscode from 'vscode';
+
+export async function delay(ms: number, token?: vscode.CancellationToken): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        let cancellationListener: vscode.Disposable;
+
+        const timeout = setTimeout(() => {
+            cancellationListener?.dispose();
+            resolve();
+        }, ms);
+
+        if (token) {
+            cancellationListener = token.onCancellationRequested(() => {
+                cancellationListener.dispose();
+                clearTimeout(timeout);
+                reject();
+            });
+        }
+    });
+}

--- a/ext/vscode/src/utils/lazy.ts
+++ b/ext/vscode/src/utils/lazy.ts
@@ -26,3 +26,55 @@ export class Lazy<T> {
         return this.val;
     }
 }
+
+export class AsyncLazy<T> {
+    private isValueCreated: boolean = false;
+    private val: T | undefined;
+    private valuePromise: Promise<T> | undefined;
+
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    public constructor(private readonly valueFactory: () => Promise<T>, private valueLifetime?: number) {
+    }
+
+    public get hasValue(): boolean {
+        return this.isValueCreated;
+    }
+
+    public clear(): void {
+        this.isValueCreated = false;
+        this.valuePromise = undefined;
+    }
+
+    public async getValue(): Promise<T> {
+        if (this.isValueCreated) {
+            return this.val as T;
+        }
+
+        const meStartedFactory = this.valuePromise === undefined;
+
+        if (meStartedFactory) {
+            this.valuePromise = this.valueFactory();
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const result = await this.valuePromise!;
+
+        if (meStartedFactory) {
+            this.val = result;
+            this.valuePromise = undefined;
+            this.isValueCreated = true;
+
+            if (this.valueLifetime) {
+                const timer = setTimeout(() => {
+                    this.isValueCreated = false;
+                    this.val = undefined;
+                }, this.valueLifetime);
+
+                // Do not hold the process waiting for the lifetime of the value to expire.
+                timer.unref(); 
+            }
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
This change will detect that `azd` CLI is not installed and if that is the case, offer to open the web page with installation instructions.

It will also track the `azd` CLI version in VS Code telemetry.