### PR TITLE
Add bicep outputs as user secrets to .NET projects

### DIFF
--- a/cli/azd/pkg/tools/dotnet.go
+++ b/cli/azd/pkg/tools/dotnet.go
@@ -15,6 +15,8 @@ type DotNetCli interface {
 	ExternalTool
 	Publish(ctx context.Context, project string, output string) error
 	Restore(ctx context.Context, project string) error
+	InitializeSecret(ctx context.Context, project string) error
+	SetSecret(ctx context.Context, key string, value string, project string) error
 }
 
 type dotNetCli struct {
@@ -74,12 +76,8 @@ func (cli *dotNetCli) Restore(ctx context.Context, project string) error {
 	return nil
 }
 
-func NewDotNetCli() DotNetCli {
-	return &dotNetCli{}
-}
-
 func (cli *dotNetCli) InitializeSecret(ctx context.Context, project string) error {
-	res, err := executil.RunCommandWithShell(ctx, "dotnet", "user-secrets", "init")
+	res, err := executil.RunCommandWithShell(ctx, "dotnet", "user-secrets", "init", "--project", project)
 	if err != nil {
 		return fmt.Errorf("failed to initialize secrets at project '%s': %w (%s)", project, err, res.String())
 	}
@@ -92,4 +90,8 @@ func (cli *dotNetCli) SetSecret(ctx context.Context, key string, value string, p
 		return fmt.Errorf("failed running %s secret set %s: %w", cli.Name(), res.String(), err)
 	}
 	return nil
+}
+
+func NewDotNetCli() DotNetCli {
+	return &dotNetCli{}
 }

--- a/cli/azd/pkg/tools/dotnet.go
+++ b/cli/azd/pkg/tools/dotnet.go
@@ -77,3 +77,19 @@ func (cli *dotNetCli) Restore(ctx context.Context, project string) error {
 func NewDotNetCli() DotNetCli {
 	return &dotNetCli{}
 }
+
+func (cli *dotNetCli) InitializeSecret(ctx context.Context, project string) error {
+	res, err := executil.RunCommandWithShell(ctx, "dotnet", "user-secrets", "init")
+	if err != nil {
+		return fmt.Errorf("failed to initialize secrets at project '%s': %w (%s)", project, err, res.String())
+	}
+	return nil
+}
+
+func (cli *dotNetCli) SetSecret(ctx context.Context, key string, value string, project string) error {
+	res, err := executil.RunCommand(ctx, "dotnet", "user-secrets", "set", key, value, "--project", project)
+	if err != nil {
+		return fmt.Errorf("failed running %s secret set %s: %w", cli.Name(), res.String(), err)
+	}
+	return nil
+}

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/cmd"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/executil"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/test/azdcli"
 	"github.com/joho/godotenv"
@@ -164,8 +165,6 @@ func Test_CLI_InfraCreateAndDelete(t *testing.T) {
 }
 
 func Test_CLI_InfraCreateAndDeleteWebApp(t *testing.T) {
-	t.Skip("flakiness in app service preventing infrastructure creation")
-
 	ctx, cancel := newTestContext(t)
 	defer cancel()
 
@@ -198,6 +197,13 @@ func Test_CLI_InfraCreateAndDeleteWebApp(t *testing.T) {
 
 	url, has := env["WEBSITE_URL"]
 	require.True(t, has, "WEBSITE_URL should be in environment after infra create")
+
+	output, err := executil.RunCommandWithShell(ctx, "dotnet", "user-secrets", "list", "--project", `C:\Users\hemarina\OneDrive - Microsoft\Documents\VSCode\azure-dev\cli\azd\test\samples\webapp\src\dotnet`)
+	t.Log("!!!", output)
+	if err != nil {
+		fmt.Errorf("failed to list secrets at project: %w (%s)", err, output.String())
+	}
+	require.NoError(t, err)
 
 	res, err := http.Get(url)
 	require.NoError(t, err)


### PR DESCRIPTION
Fix internal issue #571.
Checking if a project is dotnet project in azure.yaml and add its bicep outputs as dotnet user secrets.