### PR TITLE
Fix experimentation-related telemetry

### DIFF
--- a/ext/vscode/src/extension.ts
+++ b/ext/vscode/src/extension.ts
@@ -31,7 +31,8 @@ export async function activateInternal(vscodeCtx: vscode.ExtensionContext, loadS
     // The following is necessary for telemetry to work, so do this before callWithTelemetryAndErrorHandling()
     ext.context = vscodeCtx;
     ext.ignoreBundle = false;
-    ext.outputChannel = registerDisposable(createAzExtOutputChannel('Azure Developer', 'az dev'));
+    ext.outputChannel = registerDisposable(createAzExtOutputChannel('Azure Developer', "azure-dev"));
+    registerUIExtensionVariables(ext);
     
     await callWithTelemetryAndErrorHandling(TelemetryId.Activation, async (activationCtx: IActionContext) => {
         activationCtx.errorHandling.rethrow = true;
@@ -43,7 +44,6 @@ export async function activateInternal(vscodeCtx: vscode.ExtensionContext, loadS
         ext.userAgent = `${ext.azureDevExtensionNamespace}/v${vscodeCtx.extension.packageJSON.version}`;
         ext.experimentationSvc = await createExperimentationService(vscodeCtx, undefined);
         ext.activitySvc = new ActivityStatisticsService(vscodeCtx.globalState);
-        registerUIExtensionVariables(ext);
         registerCommands();
         registerDisposable(vscode.tasks.registerTaskProvider('dotenv', new DotEnvTaskProvider()));
         scheduleSurveys(vscodeCtx.globalState, activeSurveys);


### PR DESCRIPTION
The call to `registerUIExtensionVariables()` needs to happen before the call to `createExperimentationService()`,
because the former is what actually creates the telemetry reporter. Without the telemetry reporter present, the experimentation service is unable to hook into the telemetry pipeline and enrich the telemetry with experiment data.

Also making sure the configuration prefix passed to `createAzExtOutputChannel()`, but that is a minor issue.