### PR TITLE
Fix deployment error handling

### DIFF
--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -154,7 +154,7 @@ func (d *deployAction) Run(ctx context.Context, cmd *cobra.Command, args []strin
 			fmt.Println(deployMsg)
 			spinner := spin.NewSpinner(deployMsg)
 			spinner.Start()
-			err := deployAndReportProgress(spinner.Title)
+			err = deployAndReportProgress(spinner.Title)
 			spinner.Stop()
 
 			if err == nil {


### PR DESCRIPTION
The error variable was shadowed by mistake, causing deployment errors to be ignored