### PR TITLE
Fix formatting issues

### DIFF
--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -207,5 +207,6 @@ func reportServiceDeploymentResultInteractive(svc *project.Service, sdr *project
 		builder.WriteString(fmt.Sprintf(" - Endpoint: %s\n", withLinkFormat(endpoint)))
 	}
 
-	fmt.Println(builder.String())
+	printWithStyling(builder.String())
+	fmt.Println()
 }

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -243,7 +243,7 @@ func (ica *infraCreateAction) Run(ctx context.Context, cmd *cobra.Command, args 
 		spinner.Stop()
 
 		if err == nil {
-			fmt.Println("Created Azure resources\n")
+			fmt.Println("Created Azure resources")
 		}
 	} else {
 		err = deployAndReportProgress(nil)

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -243,7 +243,7 @@ func (ica *infraCreateAction) Run(ctx context.Context, cmd *cobra.Command, args 
 		spinner.Stop()
 
 		if err == nil {
-			fmt.Println("Created Azure resources")
+			fmt.Println("Created Azure resources\n")
 		}
 	} else {
 		err = deployAndReportProgress(nil)

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -23,6 +23,22 @@ func upCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 			&infraCreateAction{
 				rootOptions: rootOptions,
 			},
+			// Print an additional newline to separate provision from deploy
+			commands.ActionFunc(
+				func(ctx context.Context, cmd *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
+					formatter, err := output.GetFormatter(cmd)
+					if err != nil {
+						return err
+					}
+
+					interactive := formatter.Kind() == output.NoneFormat
+					if interactive {
+						fmt.Println()
+					}
+
+					return nil
+				},
+			),
 			&deployAction{rootOptions: rootOptions},
 		),
 		rootOptions,


### PR DESCRIPTION
Formatting fixes:
- Print a newline between `provision` and `deploy` in `azd up`
- Print with styling for endpoint links in `deploy`

Before:
![MicrosoftTeams-image](https://user-images.githubusercontent.com/2322434/181814067-867c41d3-9fbc-48bc-88af-426f8173da44.png)

After:
![image](https://user-images.githubusercontent.com/2322434/181814343-8fe68b34-f039-4a6e-8403-a4d128e82db5.png)
