### PR TITLE
Repoman: Disable CI trigger 

### DIFF
--- a/eng/pipelines/repoman.yml
+++ b/eng/pipelines/repoman.yml
@@ -1,12 +1,4 @@
-trigger:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - generators/
-      - templates/
-      - eng/pipelines/repoman.yml
+trigger: none
 
 pr:
   paths:


### PR DESCRIPTION
Today, whenever a change to templates or generators is made in `main` the updates are propagated to samples repos immediately. This eliminates the CI trigger and requires a manual run to update the template repos. 

When working on template changes in a PR, the change report generated by the pipeline will include changes accumulating in `main` which have not yet been pushed to the sample repos. 