### PR TITLE
Fix flaky test `TestDefaultDockerOptions`

### DIFF
--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -54,23 +54,27 @@ services:
 	docker := tools.NewDocker(dockerArgs)
 
 	progress := make(chan string)
-	defer close(progress)
+	done := make(chan struct{})
 
 	internalFramework := NewNpmProject(service.Config, &env)
-	status := ""
+	progressMessages := []string{}
 
 	go func() {
 		for value := range progress {
-			status = value
+			progressMessages = append(progressMessages, value)
 		}
+		done <- struct{}{}
 	}()
 
 	framework := NewDockerProject(service.Config, &env, docker, internalFramework)
 	res, err := framework.Package(ctx, progress)
+	close(progress)
+	<-done
 
 	require.Equal(t, "imageId", res)
 	require.Nil(t, err)
-	require.Equal(t, "Building docker image", status)
+	require.Len(t, progressMessages, 1)
+	require.Equal(t, "Building docker image", progressMessages[0])
 	require.Equal(t, true, ran)
 }
 


### PR DESCRIPTION
Add synchronization to remove non-determistic assertions.

Fixes #204

Verified that the test still passes with introduced delay (it was failing before)
```golang
go func() {
		for value := range progress {
                        time.Sleep(10 * time.Seconds) // Add delay to verify determistic program
			status = value
			progressMessages = append(progressMessages, value)
		}
		done <- struct{}{}
	}()
```