### PR TITLE
Installer: PATH registry type

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - [[#77]](https://github.com/Azure/azure-dev/issues/77) Use the correct command to log into the GitHub CLI in error messages. Thanks to community member [@TheEskhaton](https://github.com/TheEskhaton) for the fix!
 - [[#115]](https://github.com/Azure/azure-dev/issues/115) Fix deploy error when using a resource name with capital letters.
+- [[#245]](https://github.com/Azure/azure-dev/issues/245) Fix Windows installer script modifying `PATH` environment varaible to `REG_SZ` (reported by [@alexandair](https://github.com/alexandair))
 
 ### Other Changes
 - [[#188]](https://github.com/Azure/azure-dev/issues/188) Update the minimum Bicep version to `v0.8.9`.

--- a/cli/installer/install-azd.ps1
+++ b/cli/installer/install-azd.ps1
@@ -61,6 +61,51 @@ param(
     [int] $DownloadTimeoutSeconds = 120
 )
 
+
+# Windows specific:
+# This functions sends a WM_SETTINGCHANGE message which causes new processes to
+# pick up the updates to environment variables. Not calling this funciton after
+# updating environment variables means that new processes will use an older view
+# of the environment variables.
+function broadcastSettingChange {
+    $SEND_MESSAGE_TIMEOUT_DEFINITION = @"
+    [DllImport("user32.dll")]public static extern IntPtr SendMessageTimeout(
+        IntPtr hWnd,
+        uint Msg,
+        UIntPtr wParam,
+        string lParam,
+        uint fuFlags,
+        uint uTimeout,
+        out UIntPtr lpdwResult
+    );
+"@
+
+    # Broadcast environment variable change to Windows. Processes launched after
+    # this broadcast will use the new PATH environment variable.
+    # Use "Environment" as the lParam
+    # https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-settingchange
+    Write-Verbose "Broadcasting environment variable change to Windows"
+    $sendMessageTimeout = Add-Type `
+        -MemberDefinition $SEND_MESSAGE_TIMEOUT_DEFINITION `
+        -Name 'Win322SendMessageTimeout' `
+        -Namespace Win32Functions `
+        -PassThru
+    $messageResult = [UIntPtr]::Zero
+    $result = $sendMessageTimeout::SendMessageTimeout(
+        [IntPtr] 0xffff,        # HWND_BROADCAST
+        0x001A,                 # WM_SETTINGCHANGE
+        [UIntPtr]::Zero,
+        "Environment",
+        0x0002,                 # SMTO_ABORTIFHUNG
+        1000,                   # Wait 1000ms per window
+        [ref] $messageResult
+    )
+
+    if ($result -eq 0) {
+        Write-Error "Windows runtime environment variable update did not succeed. To use azd, log out of Windows and log back in."
+    }
+}
+
 function isLinuxOrMac {
     return $IsLinux -or $IsMacOS
 }
@@ -208,13 +253,12 @@ if (!$NoPath -and !(isLinuxOrMac)) {
         if (!($pathParts -contains $InstallFolder)) {
             Write-Host "Adding $InstallFolder to PATH"
 
-            # Set-ItemProperty preserves value type and also broadcasts the
-            # environment variable change to Windows.
-            Set-ItemProperty `
-                -Path HKCU:\Environment\ `
-                -Name 'PATH' `
-                -Value "$originalPath;$InstallFolder" `
-                -Type $originalValueKind
+            $registryKey.SetValue( `
+                'PATH', `
+                "$originalPath;$InstallFolder", `
+                $originalValueKind `
+            )
+            broadcastSettingChange
 
             # Also add the path to the current session
             $env:PATH += ";$InstallFolder"

--- a/cli/installer/install-azd.ps1
+++ b/cli/installer/install-azd.ps1
@@ -61,51 +61,6 @@ param(
     [int] $DownloadTimeoutSeconds = 120
 )
 
-
-# Windows specific:
-# This functions sends a WM_SETTINGCHANGE message which causes new processes to
-# pick up the updates to environment variables. Not calling this funciton after
-# updating environment variables means that new processes will use an older view
-# of the environment variables.
-function broadcastSettingChange {
-    $SEND_MESSAGE_TIMEOUT_DEFINITION = @"
-    [DllImport("user32.dll")]public static extern IntPtr SendMessageTimeout(
-        IntPtr hWnd,
-        uint Msg,
-        UIntPtr wParam,
-        string lParam,
-        uint fuFlags,
-        uint uTimeout,
-        out UIntPtr lpdwResult
-    );
-"@
-
-    # Broadcast environment variable change to Windows. Processes launched after
-    # this broadcast will use the new PATH environment variable.
-    # Use "Environment" as the lParam
-    # https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-settingchange
-    Write-Verbose "Broadcasting environment variable change to Windows"
-    $sendMessageTimeout = Add-Type `
-        -MemberDefinition $SEND_MESSAGE_TIMEOUT_DEFINITION `
-        -Name 'Win322SendMessageTimeout' `
-        -Namespace Win32Functions `
-        -PassThru
-    $messageResult = [UIntPtr]::Zero
-    $result = $sendMessageTimeout::SendMessageTimeout(
-        [IntPtr] 0xffff,        # HWND_BROADCAST
-        0x001A,                 # WM_SETTINGCHANGE
-        [UIntPtr]::Zero,
-        "Environment",
-        0x0002,                 # SMTO_ABORTIFHUNG
-        1000,                   # Wait 1000ms per window
-        [ref] $messageResult
-    )
-
-    if ($result -eq 0) {
-        Write-Error "Windows runtime environment variable update did not succeed. To use azd, log out of Windows and log back in."
-    }
-}
-
 function isLinuxOrMac {
     return $IsLinux -or $IsMacOS
 }
@@ -240,7 +195,7 @@ if (!$NoPath -and !(isLinuxOrMac)) {
         # the type intializer from attempting to initialize those objects in
         # non-Windows environments.
         . {
-            $registryKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $false)
+            $registryKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
             $originalPath = $registryKey.GetValue(`
                 'PATH', `
                 '', `
@@ -258,7 +213,15 @@ if (!$NoPath -and !(isLinuxOrMac)) {
                 "$originalPath;$InstallFolder", `
                 $originalValueKind `
             )
-            broadcastSettingChange
+
+            # Calling this method ensures that a WM_SETTINGCHANGE message is
+            # sent to top level windows without having to pinvoke from
+            # PowerShell. Setting to $null deletes the variable if it exists.
+            [Environment]::SetEnvironmentVariable( `
+                'AZD_INSTALLER_NOOP', `
+                $null, `
+                [EnvironmentVariableTarget]::User `
+            )
 
             # Also add the path to the current session
             $env:PATH += ";$InstallFolder"

--- a/cli/installer/install-azd.ps1
+++ b/cli/installer/install-azd.ps1
@@ -188,7 +188,7 @@ Remove-Item $tempFolder -Recurse -Force | Out-Null
 # and setx all expand variables (e.g. %JAVA_HOME%) in the value. Writing the
 # expanded paths back into the environment would be destructive so instead, read
 # the PATH entry directly from the registry with the DoNotExpandEnvironmentNames
-# option and update the PATH entry using Set-ItemProperty
+# option and update the PATH entry in the registry.
 if (!$NoPath -and !(isLinuxOrMac)) {
     try {
         # Wrap the Microsoft.Win32.Registry calls in a script block to prevent

--- a/cli/installer/test-pwsh-win-install.ps1
+++ b/cli/installer/test-pwsh-win-install.ps1
@@ -37,6 +37,14 @@ if (!$currentPath.Contains($expectedPathEntry)) {
   exit 1
 }
 
+$afterInstallPathType = $regKey.GetValueKind('PATH')
+if ($originalPathType -ne $afterInstallPathType) {
+    Write-Error "Path registry key type does not match"
+    Write-Error "Expected: $originalPathType"
+    Write-Error "Actual: $afterInstallPathType"
+    exit 1
+}
+
 & $InstallFolder/azd version
 
 if ($LASTEXITCODE) {
@@ -56,7 +64,7 @@ $currentPath = $regKey.GetValue( `
     '', `
     [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames `
 )
-$currentPathType = $regKey.GetValueKind('PATH')
+$afterUninstallPathType = $regKey.GetValueKind('PATH')
 
 if ($currentPath -ne $originalPath) {
     Write-Error "Path does not match original path after uninstall"
@@ -65,10 +73,10 @@ if ($currentPath -ne $originalPath) {
     exit 1
 }
 
-if ($originalPathType -ne $currentPathType) {
+if ($originalPathType -ne $afterUninstallPathType) {
     Write-Error "Path registry key type does not match"
     Write-Error "Expected: $originalPathType"
-    Write-Error "Actual: $currentPathType"
+    Write-Error "Actual: $afterUninstallPathType"
     exit 1
 }
 

--- a/cli/installer/test-pwsh-win-install.ps1
+++ b/cli/installer/test-pwsh-win-install.ps1
@@ -10,6 +10,7 @@ $originalPath = $regKey.GetValue( `
     '', `
     [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames `
 )
+$originalPathType = $regKey.GetValueKind('PATH')
 
 & $PSScriptRoot/install-azd.ps1 `
     -BaseUrl $BaseUrl `
@@ -55,11 +56,19 @@ $currentPath = $regKey.GetValue( `
     '', `
     [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames `
 )
+$currentPathType = $regKey.GetValueKind('PATH')
 
 if ($currentPath -ne $originalPath) {
     Write-Error "Path does not match original path after uninstall"
     Write-Error "Expected: $originalPath"
     Write-Error "Actual: $currentPath"
+    exit 1
+}
+
+if ($originalPathType -ne $currentPathType) {
+    Write-Error "Path registry key type does not match"
+    Write-Error "Expected: $originalPathType"
+    Write-Error "Actual: $currentPathType"
     exit 1
 }
 

--- a/cli/installer/uninstall-azd.ps1
+++ b/cli/installer/uninstall-azd.ps1
@@ -3,6 +3,51 @@ param(
     [string] $InstallFolder = ""
 )
 
+
+# Windows specific:
+# This functions sends a WM_SETTINGCHANGE message which causes new processes to
+# pick up the updates to environment variables. Not calling this funciton after
+# updating environment variables means that new processes will use an older view
+# of the environment variables.
+function broadcastSettingChange {
+    $SEND_MESSAGE_TIMEOUT_DEFINITION = @"
+    [DllImport("user32.dll")]public static extern IntPtr SendMessageTimeout(
+        IntPtr hWnd,
+        uint Msg,
+        UIntPtr wParam,
+        string lParam,
+        uint fuFlags,
+        uint uTimeout,
+        out UIntPtr lpdwResult
+    );
+"@
+
+    # Broadcast environment variable change to Windows. Processes launched after
+    # this broadcast will use the new PATH environment variable.
+    # Use "Environment" as the lParam
+    # https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-settingchange
+    Write-Verbose "Broadcasting environment variable change to Windows"
+    $sendMessageTimeout = Add-Type `
+        -MemberDefinition $SEND_MESSAGE_TIMEOUT_DEFINITION `
+        -Name 'Win322SendMessageTimeout' `
+        -Namespace Win32Functions `
+        -PassThru
+    $messageResult = [UIntPtr]::Zero
+    $result = $sendMessageTimeout::SendMessageTimeout(
+        [IntPtr] 0xffff,        # HWND_BROADCAST
+        0x001A,                 # WM_SETTINGCHANGE
+        [UIntPtr]::Zero,
+        "Environment",
+        0x0002,                 # SMTO_ABORTIFHUNG
+        1000,                   # Wait 1000ms per window
+        [ref] $messageResult
+    )
+
+    if ($result -eq 0) {
+        Write-Error "Windows runtime environment variable update did not succeed. To use azd, log out of Windows and log back in."
+    }
+}
+
 function isLinuxOrMac {
     return $IsLinux -or $IsMacOS
 }
@@ -69,13 +114,12 @@ if (isLinuxOrMac) {
             $newPathParts = $pathParts.Where({ $_ -ne $InstallFolder })
             $newPath = $newPathParts -join ';'
 
-            # Set-ItemProperty preserves value type and also broadcasts the
-            # environment variable change to Windows.
-            Set-ItemProperty `
-                -Path HKCU:\Environment\ `
-                -Name 'PATH' `
-                -Value $newPath `
-                -Type $originalValueKind
+            $registryKey.SetValue( `
+                'PATH', `
+                $newPath, `
+                $originalValueKind `
+            )
+            broadcastSettingChange
         } else {
             Write-Host "Could not find an entry for $InstallFolder in PATH"
         }

--- a/cli/installer/uninstall-azd.ps1
+++ b/cli/installer/uninstall-azd.ps1
@@ -48,7 +48,7 @@ if (isLinuxOrMac) {
     # and setx all expand variables (e.g. %JAVA_HOME%) in the value. Writing the
     # expanded paths back into the environment would be destructive so instead, read
     # the PATH entry directly from the registry with the DoNotExpandEnvironmentNames
-    # option and update the PATH entry using Set-ItemProperty
+    # option and update the PATH entry in the registry.
     try {
         . {
             # Wrap the Microsoft.Win32.Registry calls in a script block to


### PR DESCRIPTION
What this change does: 

* Stops using `[Environment]::SetEnvironmentVariable` when setting `PATH` as it changes the registry entry type and sets the type directly using registry APIs. Also of note, the install script preserves the registry key type as it is read from the system and do not attempt to mutate the type. 
* Sends a message to other windows using a "noop" invocation `[Environment]::SetEnvironmentVariable` which deletes a nonexistent variable. The result is a safe invocation of code which sends a `WM_SETTINGCHANGE` message (thus allow users to start using `azd` without having to restart or log out). The nonexistant variable is `AZD_INSTALLER_NOOP`

Also explored a couple of alternatives: 

* `Set-ItemProperty` -- Does not send `WM_SETTINGCHANGE` message
* PInvoke `SendMessageTimeout` from PowerShell script -- This does work but it adds a considerable amount of overhead code to both the install and uninstall scripts as well as the potential for interference from the garbage collector during the `SendMessageTimeout` call. It's safer to invoke the code in .NET and should have a lower cost of maintenance. 

Fixes https://github.com/Azure/azure-dev/issues/245