### PR TITLE
Adds support for project/service lifecycle events

### DIFF
--- a/cli/azd/pkg/project/project_config.go
+++ b/cli/azd/pkg/project/project_config.go
@@ -33,10 +33,22 @@ type ProjectConfig struct {
 type Event string
 
 const (
-	Init      Event = "init"
-	Provision Event = "provision"
-	Deploy    Event = "deploy"
-	Destroy   Event = "destroy"
+	// Raised before project is initialized
+	Initializing Event = "initializing"
+	// Raised after project is initialized
+	Initialized Event = "initialized"
+	// Raised before project is provisioned
+	Provisioning Event = "provisioning"
+	// Raised after project is provisioned
+	Provisioned Event = "provisioned"
+	// Raised before project is deployed
+	Deploying Event = "deploying"
+	// Raised after project is deployed
+	Deployed Event = "deployed"
+	// Raised before project is destroyed
+	Destroying Event = "destroying"
+	// Raised after project is destroyed
+	Destroyed Event = "destroyed"
 )
 
 // Project lifecycle event arguments

--- a/cli/azd/pkg/project/project_config_test.go
+++ b/cli/azd/pkg/project/project_config_test.go
@@ -180,14 +180,14 @@ func TestProjectConfigAddHandler(t *testing.T) {
 		return nil
 	}
 
-	err := project.AddHandler(Deploy, handler)
+	err := project.AddHandler(Deployed, handler)
 	require.Nil(t, err)
 
 	// Expected error if attempting to register the same handler more than 1 time
-	err = project.AddHandler(Deploy, handler)
+	err = project.AddHandler(Deployed, handler)
 	require.NotNil(t, err)
 
-	project.RaiseEvent(ctx, Deploy)
+	project.RaiseEvent(ctx, Deployed)
 	require.True(t, handlerCalled)
 }
 
@@ -208,18 +208,18 @@ func TestProjectConfigRemoveHandler(t *testing.T) {
 	}
 
 	// Only handler 1 was registered
-	err := project.AddHandler(Deploy, handler1)
+	err := project.AddHandler(Deployed, handler1)
 	require.Nil(t, err)
 
-	err = project.RemoveHandler(Deploy, handler1)
+	err = project.RemoveHandler(Deployed, handler1)
 	require.Nil(t, err)
 
 	// Handler 2 wasn't registered so should error on remove
-	err = project.RemoveHandler(Deploy, handler2)
+	err = project.RemoveHandler(Deployed, handler2)
 	require.NotNil(t, err)
 
 	// No events are registered at the time event was raised
-	project.RaiseEvent(ctx, Deploy)
+	project.RaiseEvent(ctx, Deployed)
 	require.False(t, handler1Called)
 	require.False(t, handler2Called)
 }
@@ -242,12 +242,12 @@ func TestProjectConfigWithMultipleEventHandlers(t *testing.T) {
 		return nil
 	}
 
-	err := project.AddHandler(Deploy, handler1)
+	err := project.AddHandler(Deployed, handler1)
 	require.Nil(t, err)
-	err = project.AddHandler(Deploy, handler2)
+	err = project.AddHandler(Deployed, handler2)
 	require.Nil(t, err)
 
-	project.RaiseEvent(ctx, Deploy)
+	project.RaiseEvent(ctx, Deployed)
 	require.True(t, handlerCalled1)
 	require.True(t, handlerCalled2)
 }
@@ -269,12 +269,12 @@ func TestProjectConfigWithMultipleEvents(t *testing.T) {
 		return nil
 	}
 
-	err := project.AddHandler(Provision, provisionHandler)
+	err := project.AddHandler(Provisioned, provisionHandler)
 	require.Nil(t, err)
-	err = project.AddHandler(Deploy, deployHandler)
+	err = project.AddHandler(Deployed, deployHandler)
 	require.Nil(t, err)
 
-	err = project.RaiseEvent(ctx, Provision)
+	err = project.RaiseEvent(ctx, Provisioned)
 	require.Nil(t, err)
 
 	require.True(t, provisionHandlerCalled)

--- a/cli/azd/pkg/project/project_config_test.go
+++ b/cli/azd/pkg/project/project_config_test.go
@@ -188,7 +188,8 @@ func TestProjectConfigAddHandler(t *testing.T) {
 	err = project.AddHandler(Deployed, handler)
 	require.NotNil(t, err)
 
-	project.RaiseEvent(ctx, Deployed)
+	err = project.RaiseEvent(ctx, Deployed)
+	require.Nil(t, err)
 	require.True(t, handlerCalled)
 }
 
@@ -220,7 +221,8 @@ func TestProjectConfigRemoveHandler(t *testing.T) {
 	require.NotNil(t, err)
 
 	// No events are registered at the time event was raised
-	project.RaiseEvent(ctx, Deployed)
+	err = project.RaiseEvent(ctx, Deployed)
+	require.Nil(t, err)
 	require.False(t, handler1Called)
 	require.False(t, handler2Called)
 }
@@ -248,7 +250,8 @@ func TestProjectConfigWithMultipleEventHandlers(t *testing.T) {
 	err = project.AddHandler(Deployed, handler2)
 	require.Nil(t, err)
 
-	project.RaiseEvent(ctx, Deployed)
+	err = project.RaiseEvent(ctx, Deployed)
+	require.Nil(t, err)
 	require.True(t, handlerCalled1)
 	require.True(t, handlerCalled2)
 }

--- a/cli/azd/pkg/project/service_config_test.go
+++ b/cli/azd/pkg/project/service_config_test.go
@@ -1,0 +1,144 @@
+package project
+
+import (
+	"context"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceConfigAddHandler(t *testing.T) {
+	ctx := context.Background()
+	service := getServiceConfig()
+	handlerCalled := false
+
+	handler := func(ctx context.Context, args ServiceLifecycleEventArgs) error {
+		handlerCalled = true
+		return nil
+	}
+
+	err := service.AddHandler(Deploy, handler)
+	require.Nil(t, err)
+
+	// Expected error if attempting to register the same handler more than 1 time
+	err = service.AddHandler(Deploy, handler)
+	require.NotNil(t, err)
+
+	service.RaiseEvent(ctx, Deploy)
+	require.True(t, handlerCalled)
+}
+
+func TestServiceConfigRemoveHandler(t *testing.T) {
+	ctx := context.Background()
+	service := getServiceConfig()
+	handler1Called := false
+	handler2Called := false
+
+	handler1 := func(ctx context.Context, args ServiceLifecycleEventArgs) error {
+		handler1Called = true
+		return nil
+	}
+
+	handler2 := func(ctx context.Context, args ServiceLifecycleEventArgs) error {
+		handler2Called = true
+		return nil
+	}
+
+	// Only handler 1 was registered
+	err := service.AddHandler(Deploy, handler1)
+	require.Nil(t, err)
+
+	err = service.RemoveHandler(Deploy, handler1)
+	require.Nil(t, err)
+
+	// Handler 2 wasn't registered so should error on remove
+	err = service.RemoveHandler(Deploy, handler2)
+	require.NotNil(t, err)
+
+	// No events are registered at the time event was raised
+	service.RaiseEvent(ctx, Deploy)
+	require.False(t, handler1Called)
+	require.False(t, handler2Called)
+}
+
+func TestServiceConfigWithMultipleEventHandlers(t *testing.T) {
+	ctx := context.Background()
+	service := getServiceConfig()
+	handlerCalled1 := false
+	handlerCalled2 := false
+
+	handler1 := func(ctx context.Context, args ServiceLifecycleEventArgs) error {
+		require.Equal(t, service.Project, args.Project)
+		require.Equal(t, service, args.Service)
+		handlerCalled1 = true
+		return nil
+	}
+
+	handler2 := func(ctx context.Context, args ServiceLifecycleEventArgs) error {
+		require.Equal(t, service.Project, args.Project)
+		require.Equal(t, service, args.Service)
+		handlerCalled2 = true
+		return nil
+	}
+
+	err := service.AddHandler(Deploy, handler1)
+	require.Nil(t, err)
+	err = service.AddHandler(Deploy, handler2)
+	require.Nil(t, err)
+
+	service.RaiseEvent(ctx, Deploy)
+	require.True(t, handlerCalled1)
+	require.True(t, handlerCalled2)
+}
+
+func TestServiceConfigWithMultipleEvents(t *testing.T) {
+	ctx := context.Background()
+	service := getServiceConfig()
+
+	provisionHandlerCalled := false
+	deployHandlerCalled := false
+
+	provisionHandler := func(ctx context.Context, args ServiceLifecycleEventArgs) error {
+		provisionHandlerCalled = true
+		return nil
+	}
+
+	deployHandler := func(ctx context.Context, args ServiceLifecycleEventArgs) error {
+		deployHandlerCalled = true
+		return nil
+	}
+
+	err := service.AddHandler(Provision, provisionHandler)
+	require.Nil(t, err)
+	err = service.AddHandler(Deploy, deployHandler)
+	require.Nil(t, err)
+
+	err = service.RaiseEvent(ctx, Provision)
+	require.Nil(t, err)
+
+	require.True(t, provisionHandlerCalled)
+	require.False(t, deployHandlerCalled)
+}
+
+func getServiceConfig() *ServiceConfig {
+	const testProj = `
+name: test-proj
+metadata:
+  template: test-proj-template
+resourceGroup: rg-test
+services:
+  api:
+    project: src/api
+    language: js
+    host: containerapp
+    module: ./api/api
+`
+
+	e := environment.Environment{Values: make(map[string]string)}
+	e.SetEnvName("test-env")
+
+	projectConfig, _ := ParseProjectConfig(testProj, &e)
+
+	return projectConfig.Services["api"]
+}

--- a/cli/azd/pkg/project/service_config_test.go
+++ b/cli/azd/pkg/project/service_config_test.go
@@ -18,14 +18,14 @@ func TestServiceConfigAddHandler(t *testing.T) {
 		return nil
 	}
 
-	err := service.AddHandler(Deploy, handler)
+	err := service.AddHandler(Deployed, handler)
 	require.Nil(t, err)
 
 	// Expected error if attempting to register the same handler more than 1 time
-	err = service.AddHandler(Deploy, handler)
+	err = service.AddHandler(Deployed, handler)
 	require.NotNil(t, err)
 
-	service.RaiseEvent(ctx, Deploy)
+	service.RaiseEvent(ctx, Deployed)
 	require.True(t, handlerCalled)
 }
 
@@ -46,18 +46,18 @@ func TestServiceConfigRemoveHandler(t *testing.T) {
 	}
 
 	// Only handler 1 was registered
-	err := service.AddHandler(Deploy, handler1)
+	err := service.AddHandler(Deployed, handler1)
 	require.Nil(t, err)
 
-	err = service.RemoveHandler(Deploy, handler1)
+	err = service.RemoveHandler(Deployed, handler1)
 	require.Nil(t, err)
 
 	// Handler 2 wasn't registered so should error on remove
-	err = service.RemoveHandler(Deploy, handler2)
+	err = service.RemoveHandler(Deployed, handler2)
 	require.NotNil(t, err)
 
 	// No events are registered at the time event was raised
-	service.RaiseEvent(ctx, Deploy)
+	service.RaiseEvent(ctx, Deployed)
 	require.False(t, handler1Called)
 	require.False(t, handler2Called)
 }
@@ -82,12 +82,12 @@ func TestServiceConfigWithMultipleEventHandlers(t *testing.T) {
 		return nil
 	}
 
-	err := service.AddHandler(Deploy, handler1)
+	err := service.AddHandler(Deployed, handler1)
 	require.Nil(t, err)
-	err = service.AddHandler(Deploy, handler2)
+	err = service.AddHandler(Deployed, handler2)
 	require.Nil(t, err)
 
-	service.RaiseEvent(ctx, Deploy)
+	service.RaiseEvent(ctx, Deployed)
 	require.True(t, handlerCalled1)
 	require.True(t, handlerCalled2)
 }
@@ -109,12 +109,12 @@ func TestServiceConfigWithMultipleEvents(t *testing.T) {
 		return nil
 	}
 
-	err := service.AddHandler(Provision, provisionHandler)
+	err := service.AddHandler(Provisioned, provisionHandler)
 	require.Nil(t, err)
-	err = service.AddHandler(Deploy, deployHandler)
+	err = service.AddHandler(Deployed, deployHandler)
 	require.Nil(t, err)
 
-	err = service.RaiseEvent(ctx, Provision)
+	err = service.RaiseEvent(ctx, Provisioned)
 	require.Nil(t, err)
 
 	require.True(t, provisionHandlerCalled)

--- a/cli/azd/pkg/project/service_config_test.go
+++ b/cli/azd/pkg/project/service_config_test.go
@@ -26,7 +26,8 @@ func TestServiceConfigAddHandler(t *testing.T) {
 	err = service.AddHandler(Deployed, handler)
 	require.NotNil(t, err)
 
-	service.RaiseEvent(ctx, Deployed)
+	err = service.RaiseEvent(ctx, Deployed)
+	require.Nil(t, err)
 	require.True(t, handlerCalled)
 }
 
@@ -58,7 +59,8 @@ func TestServiceConfigRemoveHandler(t *testing.T) {
 	require.NotNil(t, err)
 
 	// No events are registered at the time event was raised
-	service.RaiseEvent(ctx, Deployed)
+	err = service.RaiseEvent(ctx, Deployed)
+	require.Nil(t, err)
 	require.False(t, handler1Called)
 	require.False(t, handler2Called)
 }
@@ -88,7 +90,8 @@ func TestServiceConfigWithMultipleEventHandlers(t *testing.T) {
 	err = service.AddHandler(Deployed, handler2)
 	require.Nil(t, err)
 
-	service.RaiseEvent(ctx, Deployed)
+	err = service.RaiseEvent(ctx, Deployed)
+	require.Nil(t, err)
 	require.True(t, handlerCalled1)
 	require.True(t, handlerCalled2)
 }


### PR DESCRIPTION
Adds the ability the register event handlers for project/service lifecycle events and raise events to call all registered handlers

This event driven design will allow for framework services and service targets to create more robust integrations based on lifecycle events versus having tightly coupled code changes spread throughout the codebase.