### PR TITLE
Use `eastus2` not `eastus` as default location

### DIFF
--- a/eng/pipelines/template-tests.yml
+++ b/eng/pipelines/template-tests.yml
@@ -68,8 +68,8 @@ jobs:
 
       - pwsh: |
           if (!$env:DEPLOYLOCATION) {
-            Write-Host "DeployLocation variable not set. Using 'eastus'"
-            Write-Host "##vso[task.setvariable variable=DeployLocation]eastus"
+            Write-Host "DeployLocation variable not set. Using 'eastus2'"
+            Write-Host "##vso[task.setvariable variable=DeployLocation]eastus2"
           } else {
             Write-Host "Using specified azd version: $(DeployLocation)"
           }


### PR DESCRIPTION
Some of our templates require resources that are not supported in
eastus, just eastus2. The script itself defaults to eastus2, so the
pipeline should as well.