### PR TITLE
Adds support to pass custom event args when raising project/service events

### DIFF
--- a/cli/azd/pkg/project/project_config.go
+++ b/cli/azd/pkg/project/project_config.go
@@ -55,6 +55,7 @@ const (
 // Project lifecycle event arguments
 type ProjectLifecycleEventArgs struct {
 	Project *ProjectConfig
+	Args    map[string]any
 }
 
 // Function definition for project events
@@ -178,10 +179,15 @@ func (pc *ProjectConfig) RemoveHandler(name Event, handler ProjectLifecycleEvent
 }
 
 // Raises the specified event and calls any registered event handlers
-func (pc *ProjectConfig) RaiseEvent(ctx context.Context, name Event) error {
+func (pc *ProjectConfig) RaiseEvent(ctx context.Context, name Event, args map[string]any) error {
 	handlerErrors := []error{}
 
+	if args == nil {
+		args = make(map[string]any)
+	}
+
 	eventArgs := ProjectLifecycleEventArgs{
+		Args:    args,
 		Project: pc,
 	}
 

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -41,6 +41,7 @@ type ServiceConfig struct {
 type ServiceLifecycleEventArgs struct {
 	Project *ProjectConfig
 	Service *ServiceConfig
+	Args    map[string]any
 }
 
 // Function definition for project events
@@ -154,12 +155,17 @@ func (sc *ServiceConfig) RemoveHandler(name Event, handler ServiceLifecycleEvent
 }
 
 // Raises the specified event and calls any registered event handlers
-func (sc *ServiceConfig) RaiseEvent(ctx context.Context, name Event) error {
+func (sc *ServiceConfig) RaiseEvent(ctx context.Context, name Event, args map[string]any) error {
 	handlerErrors := []error{}
+
+	if args == nil {
+		args = make(map[string]any)
+	}
 
 	eventArgs := ServiceLifecycleEventArgs{
 		Project: sc.Project,
 		Service: sc,
+		Args:    args,
 	}
 
 	handlers := sc.handlers[name]


### PR DESCRIPTION
- [x] Adds new `args` param to support custom map of data when raising project/service events
- [x] New `args` now available during event handlers 