### PR TITLE
Consolidate and refactor to single asker/console

### DIFF
--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -65,7 +65,7 @@ func (d *deployAction) SetupFlags(
 
 func (d *deployAction) Run(ctx context.Context, cmd *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
 	azCli := commands.GetAzCliFromContext(ctx)
-	console := input.NewAskerConsole(!d.rootOptions.NoPrompt)
+	console := input.NewConsole(!d.rootOptions.NoPrompt)
 
 	if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 		return err

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -65,7 +65,7 @@ func (d *deployAction) SetupFlags(
 
 func (d *deployAction) Run(ctx context.Context, cmd *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
 	azCli := commands.GetAzCliFromContext(ctx)
-	console := input.NewAskerConsole(d.rootOptions.NoPrompt)
+	console := input.NewAskerConsole(!d.rootOptions.NoPrompt)
 
 	if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 		return err

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azureutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/pkg/spin"
@@ -64,7 +65,7 @@ func (d *deployAction) SetupFlags(
 
 func (d *deployAction) Run(ctx context.Context, cmd *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
 	azCli := commands.GetAzCliFromContext(ctx)
-	askOne := makeAskOne(d.rootOptions.NoPrompt)
+	console := input.NewAskerConsole(d.rootOptions.NoPrompt)
 
 	if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 		return err
@@ -78,7 +79,7 @@ func (d *deployAction) Run(ctx context.Context, cmd *cobra.Command, args []strin
 		return fmt.Errorf("failed to ensure login: %w", err)
 	}
 
-	env, err := loadOrInitEnvironment(ctx, &d.rootOptions.EnvironmentName, azdCtx, askOne)
+	env, err := loadOrInitEnvironment(ctx, &d.rootOptions.EnvironmentName, azdCtx, console)
 	if err != nil {
 		return fmt.Errorf("loading environment: %w", err)
 	}

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -55,7 +55,7 @@ You can find all environment configurations under the *.azure\<environment-name>
 
 func envSetCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 	actionFn := func(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
-		console := input.NewAskerConsole(!rootOptions.NoPrompt)
+		console := input.NewConsole(!rootOptions.NoPrompt)
 		azCli := commands.GetAzCliFromContext(ctx)
 
 		if err := ensureProject(azdCtx.ProjectPath()); err != nil {
@@ -202,7 +202,7 @@ func (en *envNewAction) Run(ctx context.Context, _ *cobra.Command, args []string
 		return err
 	}
 
-	console := input.NewAskerConsole(!en.rootOptions.NoPrompt)
+	console := input.NewConsole(!en.rootOptions.NoPrompt)
 	envSpec := environmentSpec{
 		environmentName: en.rootOptions.EnvironmentName,
 		subscription:    en.subscription,
@@ -223,7 +223,7 @@ func envRefreshCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 	actionFn := func(ctx context.Context, cmd *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
 		azCli := commands.GetAzCliFromContext(ctx)
 		bicepCli := tools.NewBicepCli(tools.NewBicepCliArgs{AzCli: azCli})
-		console := input.NewAskerConsole(!rootOptions.NoPrompt)
+		console := input.NewConsole(!rootOptions.NoPrompt)
 
 		if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 			return err
@@ -291,7 +291,7 @@ func envGetValuesCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command 
 			ctx := context.Background()
 			ctx = context.WithValue(ctx, environment.OptionsContextKey, rootOptions)
 
-			console := input.NewAskerConsole(!rootOptions.NoPrompt)
+			console := input.NewConsole(!rootOptions.NoPrompt)
 			azCli := commands.GetAzCliFromContext(ctx)
 
 			azdCtx, err := environment.NewAzdContext()

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -12,6 +12,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/iac/bicep"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/spf13/cobra"
@@ -54,7 +55,7 @@ You can find all environment configurations under the *.azure\<environment-name>
 
 func envSetCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 	actionFn := func(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
-		askOne := makeAskOne(rootOptions.NoPrompt)
+		console := input.NewAskerConsole(rootOptions.NoPrompt)
 		azCli := commands.GetAzCliFromContext(ctx)
 
 		if err := ensureProject(azdCtx.ProjectPath()); err != nil {
@@ -65,7 +66,7 @@ func envSetCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 			return err
 		}
 
-		env, err := loadOrInitEnvironment(ctx, &rootOptions.EnvironmentName, azdCtx, askOne)
+		env, err := loadOrInitEnvironment(ctx, &rootOptions.EnvironmentName, azdCtx, console)
 		if err != nil {
 			return fmt.Errorf("loading environment: %w", err)
 		}
@@ -201,13 +202,13 @@ func (en *envNewAction) Run(ctx context.Context, _ *cobra.Command, args []string
 		return err
 	}
 
-	askOne := makeAskOne(en.rootOptions.NoPrompt)
+	console := input.NewAskerConsole(en.rootOptions.NoPrompt)
 	envSpec := environmentSpec{
 		environmentName: en.rootOptions.EnvironmentName,
 		subscription:    en.subscription,
 		location:        en.location,
 	}
-	if _, err := createAndInitEnvironment(ctx, &envSpec, azdCtx, askOne); err != nil {
+	if _, err := createAndInitEnvironment(ctx, &envSpec, azdCtx, console); err != nil {
 		return fmt.Errorf("creating new environment: %w", err)
 	}
 
@@ -222,7 +223,7 @@ func envRefreshCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 	actionFn := func(ctx context.Context, cmd *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
 		azCli := commands.GetAzCliFromContext(ctx)
 		bicepCli := tools.NewBicepCli(tools.NewBicepCliArgs{AzCli: azCli})
-		askOne := makeAskOne(rootOptions.NoPrompt)
+		console := input.NewAskerConsole(rootOptions.NoPrompt)
 
 		if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 			return err
@@ -236,7 +237,7 @@ func envRefreshCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 			return fmt.Errorf("failed to ensure login: %w", err)
 		}
 
-		env, err := loadOrInitEnvironment(ctx, &rootOptions.EnvironmentName, azdCtx, askOne)
+		env, err := loadOrInitEnvironment(ctx, &rootOptions.EnvironmentName, azdCtx, console)
 		if err != nil {
 			return fmt.Errorf("loading environment: %w", err)
 		}
@@ -290,7 +291,7 @@ func envGetValuesCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command 
 			ctx := context.Background()
 			ctx = context.WithValue(ctx, environment.OptionsContextKey, rootOptions)
 
-			askOne := makeAskOne(rootOptions.NoPrompt)
+			console := input.NewAskerConsole(rootOptions.NoPrompt)
 			azCli := commands.GetAzCliFromContext(ctx)
 
 			azdCtx, err := environment.NewAzdContext()
@@ -311,7 +312,7 @@ func envGetValuesCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command 
 				return err
 			}
 
-			env, err := loadOrInitEnvironment(ctx, &rootOptions.EnvironmentName, azdCtx, askOne)
+			env, err := loadOrInitEnvironment(ctx, &rootOptions.EnvironmentName, azdCtx, console)
 			if err != nil {
 				return err
 			}

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -55,7 +55,7 @@ You can find all environment configurations under the *.azure\<environment-name>
 
 func envSetCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 	actionFn := func(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
-		console := input.NewAskerConsole(rootOptions.NoPrompt)
+		console := input.NewAskerConsole(!rootOptions.NoPrompt)
 		azCli := commands.GetAzCliFromContext(ctx)
 
 		if err := ensureProject(azdCtx.ProjectPath()); err != nil {
@@ -202,7 +202,7 @@ func (en *envNewAction) Run(ctx context.Context, _ *cobra.Command, args []string
 		return err
 	}
 
-	console := input.NewAskerConsole(en.rootOptions.NoPrompt)
+	console := input.NewAskerConsole(!en.rootOptions.NoPrompt)
 	envSpec := environmentSpec{
 		environmentName: en.rootOptions.EnvironmentName,
 		subscription:    en.subscription,
@@ -223,7 +223,7 @@ func envRefreshCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command {
 	actionFn := func(ctx context.Context, cmd *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
 		azCli := commands.GetAzCliFromContext(ctx)
 		bicepCli := tools.NewBicepCli(tools.NewBicepCliArgs{AzCli: azCli})
-		console := input.NewAskerConsole(rootOptions.NoPrompt)
+		console := input.NewAskerConsole(!rootOptions.NoPrompt)
 
 		if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 			return err
@@ -291,7 +291,7 @@ func envGetValuesCmd(rootOptions *commands.GlobalCommandOptions) *cobra.Command 
 			ctx := context.Background()
 			ctx = context.WithValue(ctx, environment.OptionsContextKey, rootOptions)
 
-			console := input.NewAskerConsole(rootOptions.NoPrompt)
+			console := input.NewAskerConsole(!rootOptions.NoPrompt)
 			azCli := commands.GetAzCliFromContext(ctx)
 
 			azdCtx, err := environment.NewAzdContext()

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -52,7 +52,7 @@ func (ica *infraCreateAction) SetupFlags(persis, local *pflag.FlagSet) {
 func (ica *infraCreateAction) Run(ctx context.Context, cmd *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
 	azCli := commands.GetAzCliFromContext(ctx)
 	bicepCli := tools.NewBicepCli(tools.NewBicepCliArgs{AzCli: azCli})
-	console := input.NewAskerConsole(!ica.rootOptions.NoPrompt)
+	console := input.NewConsole(!ica.rootOptions.NoPrompt)
 
 	if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 		return err

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -52,7 +52,7 @@ func (ica *infraCreateAction) SetupFlags(persis, local *pflag.FlagSet) {
 func (ica *infraCreateAction) Run(ctx context.Context, cmd *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
 	azCli := commands.GetAzCliFromContext(ctx)
 	bicepCli := tools.NewBicepCli(tools.NewBicepCliArgs{AzCli: azCli})
-	console := input.NewAskerConsole(ica.rootOptions.NoPrompt)
+	console := input.NewAskerConsole(!ica.rootOptions.NoPrompt)
 
 	if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 		return err

--- a/cli/azd/cmd/infra_delete.go
+++ b/cli/azd/cmd/infra_delete.go
@@ -45,7 +45,7 @@ func (a *infraDeleteAction) SetupFlags(
 func (a *infraDeleteAction) Run(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
 	azCli := commands.GetAzCliFromContext(ctx)
 	bicepCli := tools.NewBicepCli(tools.NewBicepCliArgs{AzCli: azCli})
-	console := input.NewAskerConsole(!a.rootOptions.NoPrompt)
+	console := input.NewConsole(!a.rootOptions.NoPrompt)
 
 	if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 		return err

--- a/cli/azd/cmd/infra_delete.go
+++ b/cli/azd/cmd/infra_delete.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/azure/azure-dev/cli/azd/pkg/azureutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/iac/bicep"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/spin"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/spf13/cobra"
@@ -45,7 +45,7 @@ func (a *infraDeleteAction) SetupFlags(
 func (a *infraDeleteAction) Run(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
 	azCli := commands.GetAzCliFromContext(ctx)
 	bicepCli := tools.NewBicepCli(tools.NewBicepCliArgs{AzCli: azCli})
-	askOne := makeAskOne(a.rootOptions.NoPrompt)
+	console := input.NewAskerConsole(a.rootOptions.NoPrompt)
 
 	if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 		return err
@@ -59,7 +59,7 @@ func (a *infraDeleteAction) Run(ctx context.Context, _ *cobra.Command, args []st
 		return fmt.Errorf("failed to ensure login: %w", err)
 	}
 
-	env, err := loadOrInitEnvironment(ctx, &a.rootOptions.EnvironmentName, azdCtx, askOne)
+	env, err := loadOrInitEnvironment(ctx, &a.rootOptions.EnvironmentName, azdCtx, console)
 	if err != nil {
 		return fmt.Errorf("loading environment: %w", err)
 	}
@@ -95,14 +95,13 @@ func (a *infraDeleteAction) Run(ctx context.Context, _ *cobra.Command, args []st
 	}
 
 	if len(allResources) > 0 && !a.forceDelete {
-		var ok bool
-		err := askOne(&survey.Confirm{
+		ok, err := console.Confirm(ctx, input.ConsoleOptions{
 			Message: fmt.Sprintf(
 				"This will delete %d resources, are you sure you want to continue?\n"+
 					"You can use --force to skip this confirmation.",
 				len(allResources)),
-			Default: false,
-		}, &ok)
+			DefaultValue: false,
+		})
 		if err != nil {
 			return fmt.Errorf("prompting for confirmation: %w", err)
 		}
@@ -145,10 +144,11 @@ func (a *infraDeleteAction) Run(ctx context.Context, _ *cobra.Command, args []st
 			"of time after deletion. During this period, their names may not be reused.\n"+
 			"You can use argument --purge to skip this confirmation.\n",
 			len(keyVaultsToPurge))
-		err := askOne(&survey.Confirm{
-			Message: "Would you like to *permanently* delete these Key Vaults instead, allowing their names to be reused?",
-			Default: false,
-		}, &purgeDelete)
+		purgeDelete, err = console.Confirm(ctx, input.ConsoleOptions{
+			Message:      "Would you like to *permanently* delete these Key Vaults instead, allowing their names to be reused?",
+			DefaultValue: false,
+		})
+
 		if err != nil {
 			return fmt.Errorf("prompting for purge confirmation: %w", err)
 		}

--- a/cli/azd/cmd/infra_delete.go
+++ b/cli/azd/cmd/infra_delete.go
@@ -45,7 +45,7 @@ func (a *infraDeleteAction) SetupFlags(
 func (a *infraDeleteAction) Run(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
 	azCli := commands.GetAzCliFromContext(ctx)
 	bicepCli := tools.NewBicepCli(tools.NewBicepCliArgs{AzCli: azCli})
-	console := input.NewAskerConsole(a.rootOptions.NoPrompt)
+	console := input.NewAskerConsole(!a.rootOptions.NoPrompt)
 
 	if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 		return err

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -79,7 +79,7 @@ func (i *initAction) Run(ctx context.Context, _ *cobra.Command, args []string, a
 		return errors.New("template name required when specifying a branch name")
 	}
 
-	console := input.NewAskerConsole(!i.rootOptions.NoPrompt)
+	console := input.NewConsole(!i.rootOptions.NoPrompt)
 	azCli := commands.GetAzCliFromContext(ctx)
 	gitCli := tools.NewGitCli()
 

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
@@ -68,8 +67,6 @@ func (i *initAction) Run(ctx context.Context, _ *cobra.Command, args []string, a
 	// current ProjectDirectory will be set to that folder. That's not what we want here. We want
 	// to force using the current working directory as a project root (since we are initializing a
 	// new project).
-	time.Sleep(10 * time.Second)
-
 	wd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("getting cwd: %w", err)
@@ -82,7 +79,7 @@ func (i *initAction) Run(ctx context.Context, _ *cobra.Command, args []string, a
 		return errors.New("template name required when specifying a branch name")
 	}
 
-	console := input.NewAskerConsole(i.rootOptions.NoPrompt)
+	console := input.NewAskerConsole(!i.rootOptions.NoPrompt)
 	azCli := commands.GetAzCliFromContext(ctx)
 	gitCli := tools.NewGitCli()
 

--- a/cli/azd/cmd/monitor.go
+++ b/cli/azd/cmd/monitor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/pbnj/go-open"
 	"github.com/spf13/cobra"
@@ -57,7 +58,7 @@ func (m *monitorAction) SetupFlags(
 
 func (m *monitorAction) Run(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
 	azCli := commands.GetAzCliFromContext(ctx)
-	askOne := makeAskOne(m.rootOptions.NoPrompt)
+	console := input.NewAskerConsole(m.rootOptions.NoPrompt)
 
 	if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 		return err
@@ -75,7 +76,7 @@ func (m *monitorAction) Run(ctx context.Context, _ *cobra.Command, args []string
 		m.monitorLive = true
 	}
 
-	env, err := loadOrInitEnvironment(ctx, &m.rootOptions.EnvironmentName, azdCtx, askOne)
+	env, err := loadOrInitEnvironment(ctx, &m.rootOptions.EnvironmentName, azdCtx, console)
 	if err != nil {
 		return fmt.Errorf("loading environment: %w", err)
 	}

--- a/cli/azd/cmd/monitor.go
+++ b/cli/azd/cmd/monitor.go
@@ -58,7 +58,7 @@ func (m *monitorAction) SetupFlags(
 
 func (m *monitorAction) Run(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
 	azCli := commands.GetAzCliFromContext(ctx)
-	console := input.NewAskerConsole(!m.rootOptions.NoPrompt)
+	console := input.NewConsole(!m.rootOptions.NoPrompt)
 
 	if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 		return err

--- a/cli/azd/cmd/monitor.go
+++ b/cli/azd/cmd/monitor.go
@@ -58,7 +58,7 @@ func (m *monitorAction) SetupFlags(
 
 func (m *monitorAction) Run(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
 	azCli := commands.GetAzCliFromContext(ctx)
-	console := input.NewAskerConsole(m.rootOptions.NoPrompt)
+	console := input.NewAskerConsole(!m.rootOptions.NoPrompt)
 
 	if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 		return err

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -11,10 +11,10 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/github"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -65,14 +65,14 @@ func (p *pipelineConfigAction) SetupFlags(
 }
 
 func (p *pipelineConfigAction) Run(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
-	askOne := makeAskOne(p.rootOptions.NoPrompt)
 	azCli := commands.GetAzCliFromContext(ctx)
+	console := input.NewAskerConsole(p.rootOptions.NoPrompt)
 
 	if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 		return err
 	}
 
-	env, err := loadOrInitEnvironment(ctx, &p.rootOptions.EnvironmentName, azdCtx, askOne)
+	env, err := loadOrInitEnvironment(ctx, &p.rootOptions.EnvironmentName, azdCtx, console)
 	if err != nil {
 		return fmt.Errorf("loading environment: %w", err)
 	}
@@ -92,7 +92,7 @@ func (p *pipelineConfigAction) Run(ctx context.Context, _ *cobra.Command, args [
 		return fmt.Errorf("failed to ensure login: %w", err)
 	}
 
-	if err := ensureGitHubLogin(ctx, ghCli, tools.GitHubHostName, askOne); err != nil {
+	if err := ensureGitHubLogin(ctx, ghCli, tools.GitHubHostName, console); err != nil {
 		return fmt.Errorf("failed to ensure login to GitHub: %w", err)
 	}
 
@@ -106,16 +106,16 @@ func (p *pipelineConfigAction) Run(ctx context.Context, _ *cobra.Command, args [
 			switch {
 			case errors.Is(err, tools.ErrNotRepository):
 				// Offer the user a chance to init a new repository if one does not exist.
-				initRepo := false
-				if askErr := askOne(&survey.Confirm{
-					Message: "Initialize a new git repository?",
-					Default: true,
-				}, &initRepo); askErr != nil {
+				initRepo, err := console.Confirm(ctx, input.ConsoleOptions{
+					Message:      "Initialize a new git repository?",
+					DefaultValue: true,
+				})
+				if err != nil {
 					return "", fmt.Errorf("prompting for git init: %w", err)
 				}
 
 				if !initRepo {
-					return "", err
+					return "", errors.New("confirmation declined")
 				}
 
 				if err := gitCli.InitRepo(ctx, azdCtx.ProjectDirectory()); err != nil {
@@ -126,11 +126,11 @@ func (p *pipelineConfigAction) Run(ctx context.Context, _ *cobra.Command, args [
 				continue
 			case errors.Is(err, tools.ErrNoSuchRemote):
 				// Offer the user a chance to create the remote if one does not exist.
-				addRemote := false
-				if err := askOne(&survey.Confirm{
-					Message: fmt.Sprintf("A remote named \"%s\" was not found. Would you like to configure one?", p.pipelineRemoteName),
-					Default: true,
-				}, &addRemote); err != nil {
+				addRemote, err := console.Confirm(ctx, input.ConsoleOptions{
+					Message:      fmt.Sprintf("A remote named \"%s\" was not found. Would you like to configure one?", p.pipelineRemoteName),
+					DefaultValue: true,
+				})
+				if err != nil {
 					return "", fmt.Errorf("prompting for remote init: %w", err)
 				}
 
@@ -139,33 +139,29 @@ func (p *pipelineConfigAction) Run(ctx context.Context, _ *cobra.Command, args [
 				}
 
 				// There are a few ways to configure the remote so offer a choice to the user.
-				var idx int
-
-				if err := askOne(&survey.Select{
+				idx, err := console.Select(ctx, input.ConsoleOptions{
 					Message: "How would you like to configure your remote?",
 					Options: []string{
 						"Select an existing GitHub project",
 						"Create a new private GitHub repository",
 						"Enter a remote URL directly",
 					},
-					Default: "Create a new private GitHub repository",
-				}, &idx); err != nil {
-					return "", fmt.Errorf("prompting for remote configuration type: %w", err)
-				}
+					DefaultValue: "Create a new private GitHub repository",
+				})
 
 				var remoteUrl string
 
 				switch idx {
 				// Select from an existing GitHub project
 				case 0:
-					url, err := getRemoteUrlFromExisting(ctx, ghCli, askOne)
+					url, err := getRemoteUrlFromExisting(ctx, ghCli, console)
 					if err != nil {
 						return "", fmt.Errorf("getting remote from existing repository: %w", err)
 					}
 					remoteUrl = url
 				// Create a new project
 				case 1:
-					url, err := getRemoteUrlFromNewRepository(ctx, ghCli, azdCtx, askOne)
+					url, err := getRemoteUrlFromNewRepository(ctx, ghCli, azdCtx, console)
 					if err != nil {
 						return "", fmt.Errorf("getting remote from new repository: %w", err)
 					}
@@ -173,7 +169,7 @@ func (p *pipelineConfigAction) Run(ctx context.Context, _ *cobra.Command, args [
 					remoteUrl = url
 				// Enter a URL directly.
 				case 2:
-					url, err := p.getRemoteUrlFromPrompt(askOne)
+					url, err := p.getRemoteUrlFromPrompt(ctx, console)
 					if err != nil {
 						return "", fmt.Errorf("getting remote from prompt: %w", err)
 					}
@@ -242,12 +238,12 @@ func (p *pipelineConfigAction) Run(ctx context.Context, _ *cobra.Command, args [
 You can view the GitHub Actions here: https://github.com/%s/actions
 `, repoSlug)
 
-	var doPush bool
+	doPush, err := console.Confirm(ctx, input.ConsoleOptions{
+		Message:      "Would you like to commit and push your local changes to start a new GitHub Actions run?",
+		DefaultValue: true,
+	})
 
-	if err := askOne(&survey.Confirm{
-		Message: "Would you like to commit and push your local changes to start a new GitHub Actions run?",
-		Default: true,
-	}, &doPush); err != nil {
+	if err != nil {
 		return fmt.Errorf("prompting to push: %w", err)
 	}
 
@@ -257,7 +253,7 @@ You can view the GitHub Actions here: https://github.com/%s/actions
 	// as a repo where Actions are disabled. Sadly, there's not GitHub API to fetch exact information
 	// to distinguish between disabled-after-fork v/s repo-disabled-actions v/s similar scenarios).
 	if doPush && !newGitHubRepoCreated {
-		cancelPushing, err := notifyWhenGitHubActionsAreDisabled(ctx, gitCli, ghCli, azdCtx, repoSlug, p.pipelineRemoteName, currentBranch, askOne)
+		cancelPushing, err := notifyWhenGitHubActionsAreDisabled(ctx, gitCli, ghCli, azdCtx, repoSlug, p.pipelineRemoteName, currentBranch, console)
 		if err != nil {
 			return fmt.Errorf("ensure github actions: %w", err)
 		}
@@ -288,13 +284,15 @@ You can view the GitHub Actions here: https://github.com/%s/actions
 
 // getRemoteUrlFromPrompt interactively prompts the user for a URL for a GitHub repository. It validates
 // that the URL is well formed and is in the correct format for a GitHub repository.
-func (p *pipelineConfigAction) getRemoteUrlFromPrompt(askOne Asker) (string, error) {
+func (p *pipelineConfigAction) getRemoteUrlFromPrompt(ctx context.Context, console input.Console) (string, error) {
 	remoteUrl := ""
 
 	for remoteUrl == "" {
-		if err := askOne(&survey.Input{
+		remoteUrl, err := console.Prompt(ctx, input.ConsoleOptions{
 			Message: fmt.Sprintf("Please enter the url to use for remote %s:", p.pipelineRemoteName),
-		}, &remoteUrl); err != nil {
+		})
+
+		if err != nil {
 			return "", fmt.Errorf("prompting for remote url: %w", err)
 		}
 
@@ -309,21 +307,22 @@ func (p *pipelineConfigAction) getRemoteUrlFromPrompt(askOne Asker) (string, err
 	return remoteUrl, nil
 }
 
-func getRemoteUrlFromNewRepository(ctx context.Context, ghCli tools.GitHubCli, azdCtx *environment.AzdContext, askOne Asker) (string, error) {
+func getRemoteUrlFromNewRepository(ctx context.Context, ghCli tools.GitHubCli, azdCtx *environment.AzdContext, console input.Console) (string, error) {
 	var repoName string
 
 	currentPathName := azdCtx.ProjectDirectory()
 	currentFolderName := filepath.Base(currentPathName)
 
 	for {
-		if err := askOne(&survey.Input{
-			Message: "Enter the name for your new repository OR Hit enter to use this name:",
-			Default: currentFolderName,
-		}, &repoName); err != nil {
+		repoName, err := console.Prompt(ctx, input.ConsoleOptions{
+			Message:      "Enter the name for your new repository OR Hit enter to use this name:",
+			DefaultValue: currentFolderName,
+		})
+		if err != nil {
 			return "", fmt.Errorf("asking for new repository name: %w", err)
 		}
 
-		err := ghCli.CreatePrivateRepository(ctx, repoName)
+		err = ghCli.CreatePrivateRepository(ctx, repoName)
 		if errors.Is(err, tools.ErrRepositoryNameInUse) {
 			fmt.Printf("error: the repository name '%s' is already in use\n", repoName)
 			continue // try again
@@ -343,7 +342,7 @@ func getRemoteUrlFromNewRepository(ctx context.Context, ghCli tools.GitHubCli, a
 
 }
 
-func getRemoteUrlFromExisting(ctx context.Context, ghCli tools.GitHubCli, askOne Asker) (string, error) {
+func getRemoteUrlFromExisting(ctx context.Context, ghCli tools.GitHubCli, console input.Console) (string, error) {
 	repos, err := ghCli.ListRepositories(ctx)
 	if err != nil {
 		return "", fmt.Errorf("listing existing repositories: %w", err)
@@ -354,11 +353,12 @@ func getRemoteUrlFromExisting(ctx context.Context, ghCli tools.GitHubCli, askOne
 		options[idx] = repo.NameWithOwner
 	}
 
-	var repoIdx int
-	if err := askOne(&survey.Select{
+	repoIdx, err := console.Select(ctx, input.ConsoleOptions{
 		Message: "Please choose an existing GitHub repository",
 		Options: options,
-	}, &repoIdx); err != nil {
+	})
+
+	if err != nil {
 		return "", fmt.Errorf("prompting for repository: %w", err)
 	}
 
@@ -383,7 +383,7 @@ func selectRemoteUrl(ctx context.Context, ghCli tools.GitHubCli, repo tools.GhCl
 
 // ensureGitHubLogin ensures the user is logged into the GitHub CLI. If not, it prompt the user
 // if they would like to log in and if so runs `gh auth login` interactively.
-func ensureGitHubLogin(ctx context.Context, ghCli tools.GitHubCli, hostname string, askOne Asker) error {
+func ensureGitHubLogin(ctx context.Context, ghCli tools.GitHubCli, hostname string, console input.Console) error {
 	loggedIn, err := ghCli.CheckAuth(ctx, hostname)
 	if err != nil {
 		return err
@@ -395,10 +395,11 @@ func ensureGitHubLogin(ctx context.Context, ghCli tools.GitHubCli, hostname stri
 
 	for {
 		var accept bool
-		if err := askOne(&survey.Confirm{
-			Message: "This command requires you to be logged into GitHub. Log in using the GitHub CLI?",
-			Default: true,
-		}, &accept); err != nil {
+		accept, err := console.Confirm(ctx, input.ConsoleOptions{
+			Message:      "This command requires you to be logged into GitHub. Log in using the GitHub CLI?",
+			DefaultValue: true,
+		})
+		if err != nil {
 			return fmt.Errorf("prompting to log in to github: %w", err)
 		}
 
@@ -448,7 +449,7 @@ func notifyWhenGitHubActionsAreDisabled(
 	repoSlug string,
 	origin string,
 	branch string,
-	askOne Asker) (bool, error) {
+	console input.Console) (bool, error) {
 
 	ghActionsInUpstreamRepo, err := ghCli.GitHubActionsExists(ctx, repoSlug)
 	if err != nil {
@@ -504,15 +505,16 @@ func notifyWhenGitHubActionsAreDisabled(
 			withHighLightFormat("https://github.com/%s/actions", repoSlug),
 			withHighLightFormat("https://github.com/%s/settings/actions", repoSlug))
 
-		var rawSelection int
-		if err := askOne(&survey.Select{
+		rawSelection, err := console.Select(ctx, input.ConsoleOptions{
 			Message: "What would you like to do now?",
 			Options: []string{
 				manualChoice.String(),
 				cancelChoice.String(),
 			},
-			Default: manualChoice,
-		}, &rawSelection); err != nil {
+			DefaultValue: manualChoice,
+		})
+
+		if err != nil {
 			return false, fmt.Errorf("prompting to enable github actions: %w", err)
 		}
 		choice := gitHubActionsEnablingChoice(rawSelection)

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -66,7 +66,7 @@ func (p *pipelineConfigAction) SetupFlags(
 
 func (p *pipelineConfigAction) Run(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
 	azCli := commands.GetAzCliFromContext(ctx)
-	console := input.NewAskerConsole(p.rootOptions.NoPrompt)
+	console := input.NewAskerConsole(!p.rootOptions.NoPrompt)
 
 	if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 		return err

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -66,7 +66,7 @@ func (p *pipelineConfigAction) SetupFlags(
 
 func (p *pipelineConfigAction) Run(ctx context.Context, _ *cobra.Command, args []string, azdCtx *environment.AzdContext) error {
 	azCli := commands.GetAzCliFromContext(ctx)
-	console := input.NewAskerConsole(!p.rootOptions.NoPrompt)
+	console := input.NewConsole(!p.rootOptions.NoPrompt)
 
 	if err := ensureProject(azdCtx.ProjectPath()); err != nil {
 		return err

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -149,6 +149,10 @@ func (p *pipelineConfigAction) Run(ctx context.Context, _ *cobra.Command, args [
 					DefaultValue: "Create a new private GitHub repository",
 				})
 
+				if err != nil {
+					return "", fmt.Errorf("prompting for remote configuration type: %w", err)
+				}
+
 				var remoteUrl string
 
 				switch idx {
@@ -288,13 +292,15 @@ func (p *pipelineConfigAction) getRemoteUrlFromPrompt(ctx context.Context, conso
 	remoteUrl := ""
 
 	for remoteUrl == "" {
-		remoteUrl, err := console.Prompt(ctx, input.ConsoleOptions{
+		promptValue, err := console.Prompt(ctx, input.ConsoleOptions{
 			Message: fmt.Sprintf("Please enter the url to use for remote %s:", p.pipelineRemoteName),
 		})
 
 		if err != nil {
 			return "", fmt.Errorf("prompting for remote url: %w", err)
 		}
+
+		remoteUrl = promptValue
 
 		if _, err := github.GetSlugForRemote(remoteUrl); errors.Is(err, github.ErrRemoteHostIsNotGitHub) {
 			fmt.Printf("error: \"%s\" is not a valid GitHub URL.\n", remoteUrl)

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -4,12 +4,9 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"log"
 	"os"
 	"sort"
 	"strings"
@@ -18,10 +15,9 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azureutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
-	"github.com/azure/azure-dev/cli/azd/pkg/templates"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/fatih/color"
-	"github.com/mattn/go-isatty"
 	"github.com/mgutz/ansi"
 )
 
@@ -37,15 +33,17 @@ func invalidEnvironmentNameMsg(environmentName string) string {
 
 // ensureValidEnvironmentName ensures the environment name is valid, if it is not, an error is printed
 // and the user is prompted for a new name.
-func ensureValidEnvironmentName(environmentName *string, askOneFn Asker) error {
+func ensureValidEnvironmentName(ctx context.Context, environmentName *string, console input.Console) error {
 	for !environment.IsValidEnvironmentName(*environmentName) {
-		err := askOneFn(&survey.Input{
+		userInput, err := console.Prompt(ctx, input.ConsoleOptions{
 			Message: "Please enter a new environment name:",
-		}, environmentName)
+		})
 
 		if err != nil {
 			return fmt.Errorf("reading environment name: %w", err)
 		}
+
+		*environmentName = userInput
 
 		if !environment.IsValidEnvironmentName(*environmentName) {
 			fmt.Print(invalidEnvironmentNameMsg(*environmentName))
@@ -63,14 +61,14 @@ type environmentSpec struct {
 
 // createEnvironment creates a new named environment. If an environment with this name already
 // exists, and error is return.
-func createAndInitEnvironment(ctx context.Context, envSpec *environmentSpec, azdCtx *environment.AzdContext, askOne Asker) (environment.Environment, error) {
+func createAndInitEnvironment(ctx context.Context, envSpec *environmentSpec, azdCtx *environment.AzdContext, console input.Console) (environment.Environment, error) {
 	if envSpec.environmentName != "" && !environment.IsValidEnvironmentName(envSpec.environmentName) {
 		errMsg := invalidEnvironmentNameMsg(envSpec.environmentName)
 		fmt.Print(errMsg)
 		return environment.Environment{}, fmt.Errorf(errMsg)
 	}
 
-	if err := ensureValidEnvironmentName(&envSpec.environmentName, askOne); err != nil {
+	if err := ensureValidEnvironmentName(ctx, &envSpec.environmentName, console); err != nil {
 		return environment.Environment{}, err
 	}
 
@@ -84,14 +82,14 @@ func createAndInitEnvironment(ctx context.Context, envSpec *environmentSpec, azd
 		return environment.Environment{}, fmt.Errorf("environment '%s' already exists", envSpec.environmentName)
 	}
 
-	if err := ensureEnvironmentInitialized(ctx, *envSpec, &env, askOne); err != nil {
+	if err := ensureEnvironmentInitialized(ctx, *envSpec, &env, console); err != nil {
 		return environment.Environment{}, fmt.Errorf("initializing environment: %w", err)
 	}
 
 	return env, nil
 }
 
-func loadOrInitEnvironment(ctx context.Context, environmentName *string, azdCtx *environment.AzdContext, askOne Asker) (environment.Environment, error) {
+func loadOrInitEnvironment(ctx context.Context, environmentName *string, azdCtx *environment.AzdContext, console input.Console) (environment.Environment, error) {
 	loadOrCreateEnvironment := func() (environment.Environment, bool, error) {
 		// If there's a default environment, use that
 		if *environmentName == "" {
@@ -106,12 +104,11 @@ func loadOrInitEnvironment(ctx context.Context, environmentName *string, azdCtx 
 			env, err := azdCtx.GetEnvironment(*environmentName)
 			switch {
 			case errors.Is(err, os.ErrNotExist):
-				var shouldCreate bool
 				msg := fmt.Sprintf("Environment '%s' does not exist, would you like to create it?", *environmentName)
-				promptErr := askOne(&survey.Confirm{
-					Message: msg,
-					Default: true,
-				}, &shouldCreate)
+				shouldCreate, promptErr := console.Confirm(ctx, input.ConsoleOptions{
+					Message:      msg,
+					DefaultValue: true,
+				})
 				if promptErr != nil {
 					return environment.Environment{}, false, fmt.Errorf("prompting to create environment '%s': %w", *environmentName, promptErr)
 				}
@@ -134,7 +131,7 @@ func loadOrInitEnvironment(ctx context.Context, environmentName *string, azdCtx 
 			return environment.Environment{}, false, fmt.Errorf("environment name '%s' is invalid (it should contain only alphanumeric characters and hyphens)", *environmentName)
 		}
 
-		if err := ensureValidEnvironmentName(environmentName, askOne); err != nil {
+		if err := ensureValidEnvironmentName(ctx, environmentName, console); err != nil {
 			return environment.Environment{}, false, err
 		}
 
@@ -149,7 +146,7 @@ func loadOrInitEnvironment(ctx context.Context, environmentName *string, azdCtx 
 		return environment.Environment{}, err
 	}
 
-	if err := ensureEnvironmentInitialized(ctx, environmentSpec{environmentName: *environmentName}, &env, askOne); err != nil {
+	if err := ensureEnvironmentInitialized(ctx, environmentSpec{environmentName: *environmentName}, &env, console); err != nil {
 		return environment.Environment{}, fmt.Errorf("initializing environment: %w", err)
 	}
 
@@ -165,7 +162,7 @@ func loadOrInitEnvironment(ctx context.Context, environmentName *string, azdCtx 
 // ensureEnvironmentInitialized ensures the environment is initialized, i.e. it contains values for `AZURE_ENV_NAME`, `AZURE_LOCATION`, `AZURE_SUBSCRIPTION_ID` and `AZURE_PRINCIPAL_ID`.
 // It will use the values from the "environment spec" passed in, and prompt for any missing values as necessary.
 // Existing environment value are left unchanged, even if the "spec" has different values.
-func ensureEnvironmentInitialized(ctx context.Context, envSpec environmentSpec, env *environment.Environment, askOne Asker) error {
+func ensureEnvironmentInitialized(ctx context.Context, envSpec environmentSpec, env *environment.Environment, console input.Console) error {
 	if env.Values == nil {
 		env.Values = make(map[string]string)
 	}
@@ -198,7 +195,7 @@ func ensureEnvironmentInitialized(ctx context.Context, envSpec environmentSpec, 
 	if !hasLocation && envSpec.location != "" {
 		env.SetLocation(envSpec.location)
 	} else {
-		location, err := promptLocation(ctx, "Please select an Azure location to use:", askOne)
+		location, err := console.PromptLocation(ctx, "Please select an Azure location to use:")
 		if err != nil {
 			return fmt.Errorf("prompting for location: %w", err)
 		}
@@ -215,20 +212,23 @@ func ensureEnvironmentInitialized(ctx context.Context, envSpec environmentSpec, 
 
 		var subscriptionId = ""
 		for subscriptionId == "" {
-			var subscriptionSelection string
-			err := askOne(&survey.Select{
-				Message: "Please select an Azure Subscription to use:",
-				Options: subscriptionOptions,
-				Default: defaultSubscription,
-			}, &subscriptionSelection)
+			subscriptionSelectionIndex, err := console.Select(ctx, input.ConsoleOptions{
+				Message:      "Please select an Azure Subscription to use:",
+				Options:      subscriptionOptions,
+				DefaultValue: defaultSubscription,
+			})
+
 			if err != nil {
 				return fmt.Errorf("reading subscription id: %w", err)
 			}
 
+			subscriptionSelection := subscriptionOptions[subscriptionSelectionIndex]
+
 			if subscriptionSelection == manualSubscriptionEntryOption {
-				err = askOne(&survey.Input{
+				subscriptionId, err = console.Prompt(ctx, input.ConsoleOptions{
 					Message: "Enter an Azure Subscription to use:",
-				}, &subscriptionId)
+				})
+
 				if err != nil {
 					return fmt.Errorf("reading subscription id: %w", err)
 				}
@@ -289,265 +289,6 @@ func getSubscriptionOptions(ctx context.Context) ([]string, string, error) {
 
 	subscriptionOptions[len(subscriptionOptions)-1] = manualSubscriptionEntryOption
 	return subscriptionOptions, defaultSubscription, nil
-}
-
-func makeAskOne(noPrompt bool) Asker {
-	if noPrompt {
-		return askOneNoPrompt
-	}
-
-	return askOnePrompt
-}
-
-func askOneNoPrompt(p survey.Prompt, response interface{}) error {
-	switch v := p.(type) {
-	case *survey.Input:
-		if v.Default == "" {
-			return fmt.Errorf("no default response for prompt '%s'", v.Message)
-		}
-
-		*(response.(*string)) = v.Default
-	case *survey.Select:
-		if v.Default == nil {
-			return fmt.Errorf("no default response for prompt '%s'", v.Message)
-		}
-
-		switch ptr := response.(type) {
-		case *int:
-			didSet := false
-			for idx, item := range v.Options {
-				if v.Default.(string) == item {
-					*ptr = idx
-					didSet = true
-				}
-			}
-
-			if !didSet {
-				return fmt.Errorf("default response not in list of options for prompt '%s'", v.Message)
-			}
-		case *string:
-			*ptr = v.Default.(string)
-		default:
-			return fmt.Errorf("bad type %T for result, should be (*int or *string)", response)
-		}
-	case *survey.Confirm:
-		*(response.(*bool)) = v.Default
-	default:
-		panic(fmt.Sprintf("don't know how to prompt for type %T", p))
-	}
-
-	return nil
-}
-
-func withShowCursor(o *survey.AskOptions) error {
-	o.PromptConfig.ShowCursor = true
-	return nil
-}
-
-func askOnePrompt(p survey.Prompt, response interface{}) error {
-	// Like (*bufio.Reader).ReadString(byte) except that it does not buffer input from the input stream.
-	// instead, it reads a byte at a time until a delimiter is found, without consuming any extra characters.
-	readStringNoBuffer := func(r io.Reader, delim byte) (string, error) {
-		strBuf := bytes.Buffer{}
-		readBuf := make([]byte, 1)
-		for {
-			if _, err := r.Read(readBuf); err != nil {
-				return strBuf.String(), err
-			}
-
-			// discard err, per documentation, WriteByte always succeeds.
-			_ = strBuf.WriteByte(readBuf[0])
-
-			if readBuf[0] == delim {
-				return strBuf.String(), nil
-			}
-		}
-	}
-
-	if isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd()) && os.Getenv("AZD_DEBUG_FORCE_NO_TTY") != "1" {
-		opts := []survey.AskOpt{}
-
-		// When asking a question which requires a text response, show the cursor, it helps
-		// users understand we need some input.
-		if _, ok := p.(*survey.Input); ok {
-			opts = append(opts, withShowCursor)
-		}
-
-		return survey.AskOne(p, response, opts...)
-	}
-
-	switch v := p.(type) {
-	case *survey.Input:
-		var pResponse = response.(*string)
-		fmt.Printf("%s", v.Message[0:len(v.Message)-1])
-		if v.Default != "" {
-			fmt.Printf(" (or hit enter to use the default %s)", v.Default)
-		}
-		fmt.Printf("%s ", v.Message[len(v.Message)-1:])
-		result, err := readStringNoBuffer(os.Stdin, '\n')
-		if err != nil && !errors.Is(err, io.EOF) {
-			return fmt.Errorf("reading response: %w", err)
-		}
-		result = strings.TrimSpace(result)
-		if result == "" && v.Default != "" {
-			result = v.Default
-		}
-		*pResponse = result
-		return nil
-	case *survey.Select:
-		for {
-			fmt.Printf("%s", v.Message[0:len(v.Message)-1])
-			if v.Default != nil {
-				fmt.Printf(" (or hit enter to use the default %v)", v.Default)
-			}
-			fmt.Printf("%s ", v.Message[len(v.Message)-1:])
-			result, err := readStringNoBuffer(os.Stdin, '\n')
-			if err != nil && !errors.Is(err, io.EOF) {
-				return fmt.Errorf("reading response: %w", err)
-			}
-			result = strings.TrimSpace(result)
-			if result == "" && v.Default != nil {
-				result = v.Default.(string)
-			}
-			for idx, val := range v.Options {
-				if val == result {
-					switch ptr := response.(type) {
-					case *string:
-						*ptr = val
-					case *int:
-						*ptr = idx
-					default:
-						return fmt.Errorf("bad type %T for result, should be (*int or *string)", response)
-					}
-
-					return nil
-				}
-			}
-			fmt.Printf("error: %s is not an allowed choice\n", result)
-		}
-	case *survey.Confirm:
-		var pResponse = response.(*bool)
-
-		for {
-			fmt.Print(v.Message)
-			if *pResponse {
-				fmt.Print(" (Y/n)")
-			} else {
-				fmt.Printf(" (y/N)")
-			}
-			result, err := readStringNoBuffer(os.Stdin, '\n')
-			if err != nil && !errors.Is(err, io.EOF) {
-				return fmt.Errorf("reading response: %w", err)
-			}
-			switch strings.TrimSpace(result) {
-			case "Y", "y":
-				*pResponse = true
-				return nil
-			case "N", "n":
-				*pResponse = false
-				return nil
-			case "":
-				return nil
-			}
-		}
-	default:
-		panic(fmt.Sprintf("don't know how to prompt for type %T", p))
-	}
-}
-
-// promptTemplate ask the user to select a template.
-// A template with empty values is returned if the user selects 'Empty Template' from the choices
-func promptTemplate(ctx context.Context, message string, askOne Asker) (templates.Template, error) {
-	var result templates.Template
-	templateManager := templates.NewTemplateManager()
-	templatesSet, err := templateManager.ListTemplates()
-
-	if err != nil {
-		return result, fmt.Errorf("prompting for template: %w", err)
-	}
-
-	templateNames := []string{"Empty Template"}
-
-	for name := range templatesSet {
-		templateNames = append(templateNames, name)
-	}
-
-	var selectedTemplateIndex int
-
-	if err := askOne(&survey.Select{
-		Message: message,
-		Options: templateNames,
-		Default: templateNames[0],
-	}, &selectedTemplateIndex); err != nil {
-		return result, fmt.Errorf("prompting for template: %w", err)
-	}
-
-	if selectedTemplateIndex == 0 {
-		return result, nil
-	}
-
-	selectedTemplateName := templateNames[selectedTemplateIndex]
-	log.Printf("Selected template: %s", fmt.Sprint(selectedTemplateName))
-
-	return templatesSet[selectedTemplateName], nil
-}
-
-// promptLocation asks the user to select a location from a list of supported azure location
-func promptLocation(ctx context.Context, message string, askOne Asker) (string, error) {
-	azCli := commands.GetAzCliFromContext(ctx)
-
-	locations, err := azCli.ListAccountLocations(ctx)
-	if err != nil {
-		return "", fmt.Errorf("listing locations: %w", err)
-	}
-
-	sort.Sort(azureutil.Locs(locations))
-
-	// Allow the environment variable `AZURE_LOCATION` to control the default value for the location
-	// selection.
-	defaultLocation := os.Getenv(environment.LocationEnvVarName)
-
-	// If no location is set in the process environment, see what the CLI default is.
-	if defaultLocation == "" {
-		defaultLocationConfig, err := azCli.GetCliConfigValue(ctx, "defaults.location")
-		if errors.Is(err, tools.ErrNoConfigurationValue) {
-			// If no value has been configured, that's okay we just won't have a default
-			// in our list.
-		} else if err != nil {
-			return "", fmt.Errorf("detecting default location: %w", err)
-		} else {
-			defaultLocation = defaultLocationConfig.Value
-		}
-	}
-
-	// If we still couldn't figure out a default location, offer eastus2 as a default
-	if defaultLocation == "" {
-		defaultLocation = "eastus2"
-	}
-
-	var defaultOption string
-
-	locationOptions := make([]string, len(locations))
-	for index, location := range locations {
-		locationOptions[index] = fmt.Sprintf("%2d. %s (%s)", index+1, location.RegionalDisplayName, location.Name)
-
-		if strings.EqualFold(defaultLocation, location.Name) ||
-			strings.EqualFold(defaultLocation, location.DisplayName) {
-			defaultOption = locationOptions[index]
-		}
-	}
-
-	var locationSelectionIndex int
-
-	if err := askOne(&survey.Select{
-		Message: message,
-		Options: locationOptions,
-		Default: defaultOption,
-	}, &locationSelectionIndex); err != nil {
-		return "", fmt.Errorf("prompting for location: %w", err)
-	}
-
-	return locations[locationSelectionIndex].Name, nil
 }
 
 func saveEnvironmentValues(res tools.AzCliDeployment, env environment.Environment) error {

--- a/cli/azd/cmd/util_test.go
+++ b/cli/azd/cmd/util_test.go
@@ -6,20 +6,24 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/azure/azure-dev/cli/azd/pkg/azureutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_promptEnvironmentName(t *testing.T) {
 	t.Run("valid name", func(t *testing.T) {
+		mockConsole := mocks.NewMockConsole()
+		mockConsole.WhenPrompt(func(options input.ConsoleOptions) bool {
+			return true
+		}).SetError(errors.New("prompt should not be called for valid environment name"))
+
 		environmentName := "hello"
 
-		err := ensureValidEnvironmentName(&environmentName, func(p survey.Prompt, response interface{}) error {
-			return errors.New("prompt should not be called for valid environment name")
-		})
+		err := ensureValidEnvironmentName(context.Background(), &environmentName, mockConsole)
 
 		require.NoError(t, err)
 	})
@@ -27,13 +31,12 @@ func Test_promptEnvironmentName(t *testing.T) {
 	t.Run("empty name gets prompted", func(t *testing.T) {
 		environmentName := ""
 
-		err := ensureValidEnvironmentName(&environmentName, func(p survey.Prompt, response interface{}) error {
-			ptr, ok := response.(*string)
-			require.True(t, ok)
+		mockConsole := mocks.NewMockConsole()
+		mockConsole.WhenPrompt(func(options input.ConsoleOptions) bool {
+			return true
+		}).Respond("someEnv")
 
-			*ptr = "someEnv"
-			return nil
-		})
+		err := ensureValidEnvironmentName(context.Background(), &environmentName, mockConsole)
 
 		require.NoError(t, err)
 		require.Equal(t, "someEnv", environmentName)

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -301,7 +301,7 @@ func NewManager(ctx context.Context, env environment.Environment, projectPath st
 	}
 
 	if console == nil {
-		console = input.NewAskerConsole(interactive)
+		console = input.NewConsole(interactive)
 	}
 
 	return &Manager{

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -68,6 +68,7 @@ func (c *AskerConsole) Prompt(ctx context.Context, options ConsoleOptions) (stri
 func (c *AskerConsole) Select(ctx context.Context, options ConsoleOptions) (int, error) {
 	survey := &survey.Select{
 		Message: options.Message,
+		Options: options.Options,
 		Default: options.DefaultValue,
 	}
 

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -102,7 +102,7 @@ func (c *AskerConsole) Confirm(ctx context.Context, options ConsoleOptions) (boo
 }
 
 // PromptTemplate ask the user to select a template.
-// An empty string is returned if the user selects 'Empty Template' from the choices
+// An empty Template with default values is returned if the user selects 'Empty Template' from the choices
 func (c *AskerConsole) PromptTemplate(ctx context.Context, message string) (templates.Template, error) {
 	var result templates.Template
 	templateManager := templates.NewTemplateManager()
@@ -196,7 +196,7 @@ func (c *AskerConsole) PromptLocation(ctx context.Context, message string) (stri
 	return locations[locationSelectionIndex].Name, nil
 }
 
-func NewAskerConsole(interactive bool) Console {
+func NewConsole(interactive bool) Console {
 	asker := NewAsker(!interactive)
 
 	return &AskerConsole{

--- a/cli/azd/test/mocks/mock_console.go
+++ b/cli/azd/test/mocks/mock_console.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/templates"
 )
 
 // A predicate function definition for registering expressions
@@ -49,10 +50,10 @@ func (c *MockConsole) Prompt(ctx context.Context, options input.ConsoleOptions) 
 }
 
 // Writes a multiple choice selection to the console for the user to choose
-func (c *MockConsole) Select(ctx context.Context, options input.ConsoleOptions) (string, error) {
+func (c *MockConsole) Select(ctx context.Context, options input.ConsoleOptions) (int, error) {
 	c.log = append(c.log, options.Message)
 	value, err := c.respond("Select", options)
-	return value.(string), err
+	return value.(int), err
 }
 
 // Writes a location selection choice to the console for the user to choose
@@ -63,10 +64,10 @@ func (c *MockConsole) PromptLocation(ctx context.Context, message string) (strin
 }
 
 // Writes a template selection choice to the console for the user to choose
-func (c *MockConsole) PromptTemplate(ctx context.Context, message string) (string, error) {
+func (c *MockConsole) PromptTemplate(ctx context.Context, message string) (templates.Template, error) {
 	c.log = append(c.log, message)
 	value, err := c.respond("PromptTemplate", input.ConsoleOptions{})
-	return value.(string), err
+	return value.(templates.Template), err
 }
 
 // Finds a matching mock expression and returns the configured value


### PR DESCRIPTION
Merges the old asker Fn implementation with the new `input.Console` interface to support easier testing and usage with standard return values rather than forcing function parameters with pointers.