### PR TITLE
Fix Verify_Installers vmImage for Mac

### DIFF
--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -549,7 +549,7 @@ stages:
 
         pool:
           name: $(Pool)
-          OSVmImage: $(OSVmImage)
+          vmImage: $(OSVmImage)
 
         steps:
           - pwsh: $(TestInstallCommand)


### PR DESCRIPTION
I happened to notice the Mac jobs of Verify_Installers were actually running on `ubuntu-latest`.

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1787785&view=logs&j=ff4b8089-48d5-53de-a8b8-1b4437579a6d

The wrong variable was being set in the `pool` section, which doesn't matter for 1ES pools, but it was causing the default image to be used for the DevOps pool.

You may also want to add a step to verify the correct OS is being used, like https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/scripts/Verify-AgentOS.ps1.