### PR TITLE
Fix template-test CI pipeline with unique name for upper case env name test

### DIFF
--- a/eng/pipelines/template-tests.yml
+++ b/eng/pipelines/template-tests.yml
@@ -89,7 +89,7 @@ jobs:
           $envPrefixName = "azd-template-test"
           if($useUpperCaseName -eq "true") {
             # Use upper case name for env prefix name
-            $envPrefixName = "AZD-TEMPLATE-TEST"
+            $envPrefixName = "AZD-TEMPLATE-UPPER-TEST"
           } 
           $resourceGroupName = "rg-$envPrefixName-$templateName-$(Build.BuildId)"
           Write-Host "Resource group name: $resourceGroupName"


### PR DESCRIPTION
The environment name for each template test must be unique.
This PR updates the name used for the extra template-name (which validates using upper case letters for the env name)
to be unique. 
