### PR TITLE
Repoman - Adding relative base path ./ to path rewrites.

### DIFF
--- a/generators/repo/src/commands/generate.ts
+++ b/generators/repo/src/commands/generate.ts
@@ -5,7 +5,7 @@ import os from "os";
 import fs from "fs/promises";
 import ansiEscapes from "ansi-escapes";
 import chalk from "chalk";
-import { cleanDirectoryPath, copyFile, createRepoUrlFromRemote, ensureDirectoryPath, getGlobFiles, getRepoPropsFromRemote, isStringNullOrEmpty, RepoProps, writeHeader,isFilePath } from "../common/util";
+import { cleanDirectoryPath, ensureRelativeBasePath, copyFile, createRepoUrlFromRemote, ensureDirectoryPath, getGlobFiles, getRepoPropsFromRemote, isStringNullOrEmpty, RepoProps, writeHeader,isFilePath } from "../common/util";
 import { AssetRule, GitRemote, RepomanCommand, RepomanCommandOptions, RepoManifest } from "../models";
 import { GitRepo } from "../tools/git";
 
@@ -411,6 +411,7 @@ export class GenerateCommand implements RepomanCommand {
                     let refPath = path.resolve(destFolderPath, path.normalize(match))
                     // Generate the relative path between the current processed file dir path & the referenced match path
                     let relativePath = path.relative(destFolderPath, refPath)
+                    relativePath = ensureRelativeBasePath(relativePath);
                     // Finally convert the path back to a POSIX compatible path
                     relativePath = relativePath.split(path.sep).join(path.posix.sep)
 

--- a/generators/repo/src/common/util.ts
+++ b/generators/repo/src/common/util.ts
@@ -66,6 +66,16 @@ export const cleanDirectoryPath = async (directoryPath: string, cleanGit: boolea
     await del(patterns, { cwd: directoryPath, force: true, dot: true });
 }
 
+export const ensureRelativeBasePath  = (input : string) => {
+    if(!input.startsWith("./") && !input.startsWith("../")) {
+        input = `.${path.sep}${input}`
+    }
+    else{
+        console.warn(chalk.yellowBright(` - ${input} already contains a relative base path.`));
+    }
+    return input
+}
+
 export const toArray = (data: Buffer): string[] => {
     if (!(data instanceof Buffer)) {
         throw new Error("Not an instance of buffer");

--- a/generators/repo/src/common/util.ts
+++ b/generators/repo/src/common/util.ts
@@ -72,7 +72,9 @@ export const ensureRelativeBasePath  = (input : string) => {
         input = `${basePath}${input}`
     }
     else{
-        console.warn(chalk.yellowBright(` - ${input} already contains a relative base path.`));
+        if (isDebug()) {
+            console.warn(chalk.yellowBright(` - ${input} already contains a relative base path.`));
+        }
     }
     return input;
 }

--- a/generators/repo/src/common/util.ts
+++ b/generators/repo/src/common/util.ts
@@ -67,13 +67,14 @@ export const cleanDirectoryPath = async (directoryPath: string, cleanGit: boolea
 }
 
 export const ensureRelativeBasePath  = (input : string) => {
-    if(!input.startsWith("./") && !input.startsWith("../")) {
-        input = `.${path.sep}${input}`
+    const basePath =`.${path.sep}`
+    if(!input.startsWith(basePath) && !input.startsWith(`.${basePath}`)) {
+        input = `${basePath}${input}`
     }
     else{
         console.warn(chalk.yellowBright(` - ${input} already contains a relative base path.`));
     }
-    return input
+    return input;
 }
 
 export const toArray = (data: Buffer): string[] => {


### PR DESCRIPTION
This PR addresses part of #524 , specifically adding ./ to local paths. This is needed to support Terraform local modules PR #532. A separate PR will be provided to add the ReWrite Rules section.

This PR introduces:

- A utility method in repoman utils to add a base path that is platform specific "./" or ".\\".
- Changes to the repoman path rewrite normalization to add a base prefix.

Tests were conducted to verify the CI workflow for repoman generate and a test azd deployment was conducted against a test repo with the relative base path included "./"

[Repo generation CI (on fork)](https://dev.azure.com/csedevops/Azure-dev/_build/results?buildId=15093&view=logs&s=2f4b62b5-8d35-5570-0513-04a0c5199809
)


Resources Deployed via modified template:
![image](https://user-images.githubusercontent.com/268713/187097843-7dfce78f-faaf-4409-8aad-c94a8ac89e12.png)

Running Application:
![image](https://user-images.githubusercontent.com/268713/187097846-835a48cb-ed5b-4096-b0f4-4a95b17bee0d.png)
 