### PR TITLE
Repoman - Adding support for Rewrite Rules in repo yaml.

### DIFF
--- a/generators/repo/src/commands/generate.ts
+++ b/generators/repo/src/commands/generate.ts
@@ -6,7 +6,7 @@ import fs from "fs/promises";
 import ansiEscapes from "ansi-escapes";
 import chalk from "chalk";
 import { cleanDirectoryPath, copyFile, createRepoUrlFromRemote, ensureDirectoryPath, getGlobFiles, getRepoPropsFromRemote, isStringNullOrEmpty, RepoProps, writeHeader,isFilePath } from "../common/util";
-import { AssetRule, GitRemote, RepomanCommand, RepomanCommandOptions, RepoManifest } from "../models";
+import { AssetRule, RewriteRule, GitRemote, RepomanCommand, RepomanCommandOptions, RepoManifest } from "../models";
 import { GitRepo } from "../tools/git";
 
 export interface GenerateCommandOptions extends RepomanCommandOptions {
@@ -39,7 +39,7 @@ export class GenerateCommand implements RepomanCommand {
     private outputPath: string;
     private generatePath: string;
     private assetRules: AssetRule[];
-    private rewritePatterns: string[];
+    private rewriteRules: RewriteRule[];
 
     constructor(private options: GenerateCommandOptions) {
         this.sourcePath = path.resolve(path.normalize(options.source));
@@ -61,7 +61,7 @@ export class GenerateCommand implements RepomanCommand {
                 });
             }
 
-            this.rewritePatterns = this.manifest.repo.rewrite?.patterns || ["**/*.@(yml|yaml)"];
+            this.rewriteRules =(this.manifest.repo.rewrite) ? [...this.manifest.repo.rewrite?.rules] : [];
         }
         catch (err) {
             console.error(chalk.red(`Repo template manifest not found at '${this.templateFile}'`));
@@ -86,7 +86,10 @@ export class GenerateCommand implements RepomanCommand {
         }
 
         console.info();
-        await this.rewritePaths();
+
+        for (const rule of this.rewriteRules) {
+            await this.processRewriteRule(rule);
+        }
         console.info(chalk.cyan('Repo generation completed.'));
         console.info();
 
@@ -375,53 +378,51 @@ export class GenerateCommand implements RepomanCommand {
         }
     }
 
-    private rewritePaths = async () => {
-        console.info(chalk.cyan("Rewriting relative paths found in files"));
-
-        const globOptions: IOptions = { cwd: this.generatePath, matchBase: true };
-        const tasks = this.rewritePatterns.map(pattern => getGlobFiles(pattern, globOptions));
-        const files = (await Promise.all(tasks)).flat();
-
-        const pathRegex = new RegExp(/((?:\.{1,2}[\/\\]{1,2})+[^'"\s]*)/gm);
-
-        for (const filePath of files) {
-            const destFilePath = path.join(this.generatePath, filePath);
-            const destFolderPath = path.dirname(destFilePath)
-
-            if (this.options.debug) {
-                console.debug(chalk.whiteBright(`Processing file: ${destFilePath}`));
+    private processRewriteRule = async(rule: RewriteRule) => {
+        const globOptions: IOptions = { 
+            cwd: this.generatePath, 
+            ignore: rule.ignore,
+            matchBase: true 
+        };
+        const patterns = rule.patterns ?? [];
+        for (const pattern of patterns) {
+            const files = await getGlobFiles(pattern, globOptions);
+            for (const filePath of files) {
+                await this.rewritePath(rule, filePath);
             }
+        }
+    }
 
-            const buffer = await fs.readFile(destFilePath);
-            let contents = buffer.toString('utf8');
-
-            // Replace relative path updates
-            for (const rule of this.assetRules) {
-                if (this.options.debug) {
-                    console.debug(chalk.white(`- Processing ${rule.from} => ${rule.to}`));
-                }
-                contents = contents.replaceAll(rule.from, rule.to);
-            }
-
+    private rewritePath = async(rule: RewriteRule, filePath: string) => {
+        const destFilePath = path.join(this.generatePath, filePath);
+        const destFolderPath = path.dirname(destFilePath);
+        const buffer = await fs.readFile(destFilePath);
+        let contents = buffer.toString('utf8');
+        if(contents.indexOf(rule.from) > -1) {
+            console.info(chalk.cyan(` -> Rewriting relative paths ${rule.from} => ${rule.to} for file "${filePath}"`));
+            contents = contents.replaceAll(rule.from, rule.to);
+        
             // Normalize transformed paths
+            const pathRegex = new RegExp(/((?:\.{1,2}[\/\\]{1,2})+[^'"\s]*)/gm);
             const matches = contents.match(pathRegex);
             if (matches && matches.length > 0) {
                 for (const match of matches) {
-                    // Generate the absolute path to the referenced match
-                    let refPath = path.resolve(destFolderPath, path.normalize(match))
-                    // Generate the relative path between the current processed file dir path & the referenced match path
-                    let relativePath = path.relative(destFolderPath, refPath)
-                    // Finally convert the path back to a POSIX compatible path
-                    relativePath = relativePath.split(path.sep).join(path.posix.sep)
+                    if(match.indexOf(rule.to) > -1){
+                        // Generate the absolute path to the referenced match
+                        let refPath = path.resolve(destFolderPath, path.normalize(match))
+                        // Generate the relative path between the current processed file dir path & the referenced match path
+                        let relativePath = path.relative(destFolderPath, refPath)
+                        // Finally convert the path back to a POSIX compatible path
+                        relativePath = relativePath.split(path.sep).join(path.posix.sep)
 
-                    contents = contents.replaceAll(match, relativePath);
+                        contents = contents.replaceAll(match, relativePath);
 
-                    if (this.options.debug) {
-                        console.log(chalk.grey(` -> Rewriting relative path ${match} => ${relativePath}`));
+                        if (this.options.debug) {
+                            console.log(chalk.grey(` -> Rewriting relative path ${match} => ${relativePath} in ${destFilePath}`));
+                        }
                     }
                 }
             }
-
             await fs.writeFile(destFilePath, contents);
         }
     }

--- a/generators/repo/src/models/index.ts
+++ b/generators/repo/src/models/index.ts
@@ -10,7 +10,7 @@ export interface RepoManifest {
 
         assets: AssetRule[]
         rewrite?: {
-            patterns: string[]
+            rules: RewriteRule[]
         }
     }
 }
@@ -27,6 +27,8 @@ export interface AssetRule {
     patterns?: string[]
     ignore?: string[]
 }
+
+export type RewriteRule = AssetRule;
 
 export interface RepomanCommandOptions {
     debug: true

--- a/templates/todo/projects/csharp-cosmos-sql/repo.yaml
+++ b/templates/todo/projects/csharp-cosmos-sql/repo.yaml
@@ -15,17 +15,24 @@ repo:
       branch: staging
 
   rewrite:
-    patterns:
-      - "**/azure.@(yml|yaml)"
-      - "**/*.bicep"
+    rules:
+      - from: ../../../../common/infra/bicep
+        to: ./
+        patterns:
+          - "**/*.bicep"
+
+      - from: ../../api/csharp-cosmos-sql
+        to: ./src/api
+        patterns:
+          - "**/azure.@(yml|yaml)"
+
+      - from: ../../web/react-fluent
+        to: ./src/web
+        patterns:
+          - "**/azure.@(yml|yaml)"
 
   assets:
     # Common assets
-    # Rule for Path Rewrite Only
-    - from: ../../../../common/infra/bicep
-      to: ./
-      ignore: 
-        - "**/*"
 
     # openapi.yaml to root
     - from: ../../api/common

--- a/templates/todo/projects/csharp-mongo/repo.yaml
+++ b/templates/todo/projects/csharp-mongo/repo.yaml
@@ -15,17 +15,24 @@ repo:
       branch: staging
   
   rewrite:
-    patterns:
-      - "**/azure.@(yml|yaml)"
-      - "**/*.bicep"
+    rules:
+      - from: ../../../../common/infra/bicep
+        to: ./
+        patterns:
+          - "**/*.bicep"
+
+      - from: ../../api/csharp
+        to: ./src/api
+        patterns:
+          - "**/azure.@(yml|yaml)"
+
+      - from: ../../web/react-fluent
+        to: ./src/web
+        patterns:
+          - "**/azure.@(yml|yaml)"
 
   assets:
     # Common assets
-    # Rule for Path Rewrite Only
-    - from: ../../../../common/infra/bicep
-      to: ./
-      ignore: 
-        - "**/*"
 
     # openapi.yaml to root
     - from: ../../api/common

--- a/templates/todo/projects/csharp-sql/repo.yaml
+++ b/templates/todo/projects/csharp-sql/repo.yaml
@@ -16,17 +16,24 @@ repo:
       branch: staging
 
   rewrite:
-    patterns:
-      - "**/azure.@(yml|yaml)"
-      - "**/*.bicep"
+    rules:
+      - from: ../../../../common/infra/bicep
+        to: ./
+        patterns:
+          - "**/*.bicep"
+
+      - from: ../../api/csharp-sql
+        to: ./src/api
+        patterns:
+          - "**/azure.@(yml|yaml)"
+
+      - from: ../../web/react-fluent
+        to: ./src/web
+        patterns:
+          - "**/azure.@(yml|yaml)"
 
   assets:
     # Common assets
-    # Rule for Path Rewrite Only
-    - from: ../../../../common/infra/bicep
-      to: ./
-      ignore: 
-        - "**/*"
 
     # openapi.yaml to root
     - from: ../../api/common

--- a/templates/todo/projects/nodejs-mongo-aca/repo.yaml
+++ b/templates/todo/projects/nodejs-mongo-aca/repo.yaml
@@ -15,17 +15,24 @@ repo:
       branch: staging
 
   rewrite:
-    patterns:
-      - "**/azure.@(yml|yaml)"
-      - "**/*.bicep"
+    rules:
+      - from: ../../../../../common/infra/bicep
+        to: ./
+        patterns:
+          - "**/*.bicep"
+
+      - from: ../../api/js
+        to: ./src/api
+        patterns:
+          - "**/azure.@(yml|yaml)"
+
+      - from: ../../web/react-fluent
+        to: ./src/web
+        patterns:
+          - "**/azure.@(yml|yaml)"
 
   assets:
     # Common assets
-    # Rule for Path Rewrite Only
-    - from: ../../../../../common/infra/bicep
-      to: ./
-      ignore: 
-        - "**/*"
 
     # openapi.yaml to root
     - from: ../../api/common

--- a/templates/todo/projects/nodejs-mongo-swa-func/repo.yaml
+++ b/templates/todo/projects/nodejs-mongo-swa-func/repo.yaml
@@ -15,17 +15,24 @@ repo:
       branch: staging
 
   rewrite:
-    patterns:
-      - "**/azure.@(yml|yaml)"
-      - "**/*.bicep"
+    rules:
+      - from: ../../../../common/infra/bicep
+        to: ./
+        patterns:
+          - "**/*.bicep"
+
+      - from: ../../api/js
+        to: ./src/api
+        patterns:
+          - "**/azure.@(yml|yaml)"
+
+      - from: ../../web/react-fluent
+        to: ./src/web
+        patterns:
+          - "**/azure.@(yml|yaml)"
 
   assets:
     # Common assets
-    # Rule for Path Rewrite Only
-    - from: ../../../../common/infra/bicep
-      to: ./
-      ignore: 
-        - "**/*"
 
     # openapi.yaml to root
     - from: ../../api/common

--- a/templates/todo/projects/nodejs-mongo/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/nodejs-mongo/.repo/bicep/repo.yaml
@@ -15,29 +15,24 @@ repo:
       branch: staging
 
   rewrite:
-    patterns:
-      - "**/azure.@(yml|yaml)"
-      - "**/*.bicep"
+    rules:
+      - from: ../../../../../../common/infra/bicep
+        to: ./
+        patterns:
+          - "**/*.bicep"
+      
+      - from: ../../api/js
+        to: ./src/api
+        patterns:
+          - "**/azure.@(yml|yaml)"
+
+      - from: ../../web/react-fluent
+        to: ./src/web
+        patterns:
+          - "**/azure.@(yml|yaml)"
 
   assets:
     # Common assets
-    # Rules for Path Rewrite Only
-    - from: ../../../../../../common/infra/bicep
-      to: ./
-      ignore: 
-        - ".repo/**/*"
-    
-    - from: ../../api/js
-      to: ./src/api
-      ignore: 
-        - ".repo/**/*"
-
-    - from: ../../web/react-fluent
-      to: ./src/web
-      ignore: 
-        - ".repo/**/*"
-    # End Path Rewrite Rules
-
     - from: ./../../
       to: ./
       ignore: 

--- a/templates/todo/projects/python-mongo-aca/repo.yaml
+++ b/templates/todo/projects/python-mongo-aca/repo.yaml
@@ -15,17 +15,25 @@ repo:
       branch: staging
 
   rewrite:
-    patterns:
-      - "**/azure.@(yml|yaml)"
-      - "**/*.bicep"
+    rules:
+      - from: ../../../../../common/infra/bicep
+        to: ./
+        patterns:
+          - "**/*.bicep"
+
+      - from: ../../api/python
+        to: ./src/api
+        patterns: 
+            - "**/azure.@(yml|yaml)"
+
+
+      - from: ../../web/react-fluent
+        to: ./src/web
+        patterns: 
+            - "**/azure.@(yml|yaml)"
 
   assets:
     # Common assets
-    # Rule for Path Rewrite Only
-    - from: ../../../../../common/infra/bicep
-      to: ./
-      ignore: 
-        - "**/*"
 
     # openapi.yaml to root
     - from: ../../api/common

--- a/templates/todo/projects/python-mongo-aca/repo.yaml
+++ b/templates/todo/projects/python-mongo-aca/repo.yaml
@@ -26,7 +26,6 @@ repo:
         patterns: 
             - "**/azure.@(yml|yaml)"
 
-
       - from: ../../web/react-fluent
         to: ./src/web
         patterns: 

--- a/templates/todo/projects/python-mongo-swa-func/repo.yaml
+++ b/templates/todo/projects/python-mongo-swa-func/repo.yaml
@@ -15,17 +15,24 @@ repo:
       branch: staging
 
   rewrite:
-    patterns:
-      - "**/azure.@(yml|yaml)"
-      - "**/*.bicep"
+    rules:
+      - from: ../../../../common/infra/bicep
+        to: ./
+        patterns: 
+          - "**/*.bicep"
+
+      - from: ../../api/python
+        to: ./src/api
+        patterns:
+          - "**/azure.@(yml|yaml)"
+          
+      - from: ../../web/react-fluent
+        to: ./src/web
+        patterns:
+          - "**/azure.@(yml|yaml)"
 
   assets:
     # Common assets
-    # Rule for Path Rewrite Only
-    - from: ../../../../common/infra/bicep
-      to: ./
-      ignore: 
-        - "**/*"
 
     # openapi.yaml to root
     - from: ../../api/common

--- a/templates/todo/projects/python-mongo/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/python-mongo/.repo/bicep/repo.yaml
@@ -15,30 +15,25 @@ repo:
       branch: staging
 
   rewrite:
-    patterns:
-      - "**/azure.@(yml|yaml)"
-      - "**/*.bicep"
+    rules:
+      - from: ../../../../../../common/infra/bicep
+        to: ./
+        patterns:
+          - "**/*.bicep"
 
+      - from: ../../api/python
+        to: ./src/api
+        patterns: 
+          - "**/azure.@(yml|yaml)"
+
+      - from: ../../web/react-fluent
+        to: ./src/web
+        patterns: 
+          - "**/azure.@(yml|yaml)"
+          
   assets:
     # Common assets
-
-    # Rules for Path Rewrite Only
-    - from: ../../../../../../common/infra/bicep
-      to: ./
-      ignore: 
-        - ".repo/**/*"
-
-    - from: ../../api/python
-      to: ./src/api
-      ignore: 
-        - ".repo/**/*"
-
-    - from: ../../web/react-fluent
-      to: ./src/web
-      ignore: 
-        - ".repo/**/*"
-    # End Path Rewrite Rules
-    
+  
     - from: ./../../
       to: ./
       ignore: 


### PR DESCRIPTION
This PR addresses #524 and provides an update to the repoman.yaml file structure to introduce a new property for Rewrite rules. The rules property replaces the previously used patterns list. 

Changes:
- Introduce new rewrite.rules section.
- Add Rewrite rules section to all repo.yaml files for all existing templates.

```yaml
 rewrite:
    rules:
      - from: ../../../../common/infra/bicep
        to: ./
        patterns:
          - "**/*.bicep"
```

Similar to AssertRules, Rewrite rules supports the following options per rule:

- from: the path string to replace. 
- to: the replacement string.
- patterns: A list of glob patterns to apply the replacement to.
- ignore: pattern of files to ignore in the glob search.

Testing:
- Generated all templates locally and verified that azure.yaml and IAC paths were rewritten correctly.
- Deployed a generated fork repo via `azd up` to ensure templates are still functioning.
- Tested CI Generation of all templates on fork.

