### PR TITLE
Refactor command build options

### DIFF
--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -29,9 +29,10 @@ func deployCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 		rootOptions,
 		"deploy",
 		"Deploy the application's code to Azure.",
-		`Deploy the application's code to Azure.
+		&commands.BuildOptions{
+			Long: `Deploy the application's code to Azure.
 
-When no `+output.WithBackticks("--service")+` value is specified, all services in the `+output.WithBackticks("azure.yaml")+` file (found in the root of your project) are deployed.
+When no ` + output.WithBackticks("--service") + ` value is specified, all services in the ` + output.WithBackticks("azure.yaml") + ` file (found in the root of your project) are deployed.
 
 Examples:
 
@@ -40,7 +41,7 @@ Examples:
 	$ azd deploy –-service web
 	
 After the deployment is complete, the endpoint is printed. To start the service, select the endpoint or paste it in a browser.`,
-	)
+		})
 
 	return output.AddOutputParam(
 		cmd,

--- a/cli/azd/cmd/down.go
+++ b/cli/azd/cmd/down.go
@@ -15,7 +15,7 @@ func downCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 		rootOptions,
 		"down",
 		"Delete Azure resources for an application.",
-		"",
+		nil,
 	)
 
 	output.AddOutputParam(cmd,

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -87,7 +87,7 @@ func envSetCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 		rootOptions,
 		"set <key> <value>",
 		"Set a value in the environment.",
-		"",
+		nil,
 	)
 	cmd.Args = cobra.ExactArgs(2)
 	return cmd
@@ -112,7 +112,7 @@ func envSelectCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 		rootOptions,
 		"select <environment>",
 		"Set the default environment.",
-		"",
+		nil,
 	)
 	cmd.Args = cobra.ExactArgs(1)
 	return cmd
@@ -163,9 +163,10 @@ func envListCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 		rootOptions,
 		"list",
 		"List environments",
-		"",
+		&commands.BuildOptions{
+			Aliases: []string{"ls"},
+		},
 	)
-	cmd.Aliases = []string{"ls"}
 
 	return cmd
 }
@@ -176,7 +177,7 @@ func envNewCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 		rootOptions,
 		"new <environment>",
 		"Create a new environment.",
-		"",
+		nil,
 	)
 }
 
@@ -281,7 +282,7 @@ func envRefreshCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 		rootOptions,
 		"refresh",
 		"Refresh environment settings by using information from a previous infrastructure provision.",
-		"",
+		nil,
 	)
 }
 
@@ -320,7 +321,7 @@ func envGetValuesCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command 
 		rootOptions,
 		"get-values",
 		"Get all environment values.",
-		"",
+		nil,
 	)
 
 	return cmd

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -32,10 +32,11 @@ func infraCreateCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 		rootOptions,
 		"create",
 		"Create Azure resources for an application.",
-		"",
+		&commands.BuildOptions{
+			Aliases: []string{"provision"},
+		},
 	)
 
-	cmd.Aliases = []string{"provision"}
 	return cmd
 }
 

--- a/cli/azd/cmd/infra_delete.go
+++ b/cli/azd/cmd/infra_delete.go
@@ -25,7 +25,7 @@ func infraDeleteCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 		rootOptions,
 		"delete",
 		"Delete Azure resources for an application.",
-		"",
+		nil,
 	)
 }
 

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -40,12 +40,13 @@ func initCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 		rootOptions,
 		"init",
 		"Initialize a new application.",
-		`Initialize a new application.
+		&commands.BuildOptions{
+			Long: `Initialize a new application.
 
-When no template is supplied, you can optionally select an Azure Developer CLI template for cloning. Otherwise, `+output.WithBackticks("azd init")+` initializes the current directory and creates resources so that your project is compatible with Azure Developer CLI.
+When no template is supplied, you can optionally select an Azure Developer CLI template for cloning. Otherwise, ` + output.WithBackticks("azd init") + ` initializes the current directory and creates resources so that your project is compatible with Azure Developer CLI.
 
 When a template is provided, the sample code is cloned to the current directory.`,
-	)
+		})
 	return cmd
 }
 

--- a/cli/azd/cmd/login.go
+++ b/cli/azd/cmd/login.go
@@ -28,7 +28,7 @@ func loginCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 		rootOptions,
 		"login",
 		"Log in to Azure.",
-		"",
+		nil,
 	)
 
 	return output.AddOutputParam(

--- a/cli/azd/cmd/monitor.go
+++ b/cli/azd/cmd/monitor.go
@@ -28,7 +28,8 @@ func monitorCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 		rootOptions,
 		"monitor",
 		"Monitor a deployed application.",
-		`Monitor a deployed application.
+		&commands.BuildOptions{
+			Long: `Monitor a deployed application.
 		
 Examples:
 
@@ -37,7 +38,7 @@ Examples:
 	$ azd monitor --logs
 		
 For more information, go to https://aka.ms/azure-dev/monitor.`,
-	)
+		})
 	return cmd
 }
 

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -47,10 +47,11 @@ func pipelineConfigCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Comman
 		rootOptions,
 		"config",
 		"Create and configure your deployment pipeline by using GitHub Actions.",
-		`Create and configure your deployment pipeline by using GitHub Actions.
+		&commands.BuildOptions{
+			Long: `Create and configure your deployment pipeline by using GitHub Actions.
 
 For more information, go to https://aka.ms/azure-dev/pipeline.`,
-	)
+		})
 	return cmd
 }
 

--- a/cli/azd/cmd/provision.go
+++ b/cli/azd/cmd/provision.go
@@ -15,7 +15,8 @@ func provisionCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 		rootOptions,
 		"provision",
 		"Provision the Azure resources for an application.",
-		`Provision the Azure resources for an application.
+		&commands.BuildOptions{
+			Long: `Provision the Azure resources for an application.
 
 The command prompts you for the following:
 - Environment name: The name of your environment.
@@ -23,7 +24,7 @@ The command prompts you for the following:
 - Azure subscription: The Azure subscription where your resources will be deployed.
 
 Depending on what Azure resources are created, running this command might take a while. To view progress, go to the Azure portal and search for the resource group that contains your environment name.`,
-	)
+		})
 
 	return output.AddOutputParam(
 		cmd,

--- a/cli/azd/cmd/restore.go
+++ b/cli/azd/cmd/restore.go
@@ -26,12 +26,13 @@ func restoreCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 		rootOptions,
 		"restore",
 		"Restore application dependencies.",
-		`Restore application dependencies.
+		&commands.BuildOptions{
+			Long: `Restore application dependencies.
 
 Run this command to download and install all the required libraries so that you can build, run, and debug the application locally.
 
 For the best local run and debug experience, go to https://aka.ms/azure-dev/vscode to learn how to use the Visual Studio Code extension.`,
-	)
+		})
 	return cmd
 }
 

--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -59,9 +59,10 @@ func templatesListCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command
 		rootOptions,
 		"list",
 		"List templates.",
-		"",
+		&commands.BuildOptions{
+			Aliases: []string{"ls"},
+		},
 	)
-	cmd.Aliases = []string{"ls"}
 
 	return cmd
 }
@@ -87,7 +88,7 @@ func templatesShowCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command
 		rootOptions,
 		"show <template>",
 		"Show the template details.",
-		"",
+		nil,
 	)
 	cmd.Args = cobra.ExactArgs(1)
 	return cmd

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -42,7 +42,8 @@ func upCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 		rootOptions,
 		"up",
 		"Initialize application, provision Azure resources, and deploy your project with a single command.",
-		`Initialize the project (if the project folder has not been initialized or cloned from a template), provision Azure resources, and deploy your project with a single command.
+		&commands.BuildOptions{
+			Long: `Initialize the project (if the project folder has not been initialized or cloned from a template), provision Azure resources, and deploy your project with a single command.
 
 This command executes the following in one step:
 
@@ -50,8 +51,8 @@ This command executes the following in one step:
 	$ azd provision
 	$ azd deploy
 
-When no template is supplied, you can optionally select an Azure Developer CLI template for cloning. Otherwise, running `+output.WithBackticks("azd up")+` initializes the current directory so that your project is compatible with Azure Developer CLI.`,
-	)
+When no template is supplied, you can optionally select an Azure Developer CLI template for cloning. Otherwise, running ` + output.WithBackticks("azd up") + ` initializes the current directory so that your project is compatible with Azure Developer CLI.`,
+		})
 
 	output.AddOutputParam(cmd,
 		[]output.Format{output.JsonFormat, output.NoneFormat},

--- a/cli/azd/cmd/version.go
+++ b/cli/azd/cmd/version.go
@@ -20,7 +20,7 @@ func versionCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 		rootOptions,
 		"version",
 		"Print the version number of Azure Developer CLI.",
-		"",
+		nil,
 	)
 
 	return output.AddOutputParam(

--- a/cli/azd/pkg/commands/builder.go
+++ b/cli/azd/pkg/commands/builder.go
@@ -27,12 +27,14 @@ type BuildOptions struct {
 //
 // Use is the one-line usage message.
 // Recommended syntax is as follow:
-//   [ ] identifies an optional argument. Arguments that are not enclosed in brackets are required.
-//   ... indicates that you can specify multiple values for the previous argument.
-//   |   indicates mutually exclusive information. You can use the argument to the left of the separator or the
-//       argument to the right of the separator. You cannot use both arguments in a single use of the command.
-//   { } delimits a set of mutually exclusive arguments when one of the arguments is required. If the arguments are
-//       optional, they are enclosed in brackets ([ ]).
+//
+//	[ ] identifies an optional argument. Arguments that are not enclosed in brackets are required.
+//	... indicates that you can specify multiple values for the previous argument.
+//	|   indicates mutually exclusive information. You can use the argument to the left of the separator or the
+//	    argument to the right of the separator. You cannot use both arguments in a single use of the command.
+//	{ } delimits a set of mutually exclusive arguments when one of the arguments is required. If the arguments are
+//	    optional, they are enclosed in brackets ([ ]).
+//
 // Example: add [-F file | -D dir]... [-f format] profile
 func Build(action Action, rootOptions *internal.GlobalCommandOptions, use string, short string, buildOptions *BuildOptions) *cobra.Command {
 	if buildOptions == nil {

--- a/cli/azd/pkg/commands/builder.go
+++ b/cli/azd/pkg/commands/builder.go
@@ -12,13 +12,38 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Build builds a Cobra command, attaching an action
-// All command should be built with this command builder vs manually instantiating cobra commands.
-func Build(action Action, rootOptions *internal.GlobalCommandOptions, use string, short string, long string) *cobra.Command {
+// BuildOptions contains the optional parameters for the Build function.
+type BuildOptions struct {
+	// Long is the long message shown in the 'help <this-command>' output. If Long is not provided, the Short message is used instead.
+	Long string
+
+	// Aliases is an array of aliases that can be used instead of the first word in Use.
+	Aliases []string
+}
+
+// Build builds a Cobra command, attaching an action.
+//
+// All commands should be built with this command builder vs manually instantiating cobra commands.
+//
+// Use is the one-line usage message.
+// Recommended syntax is as follow:
+//   [ ] identifies an optional argument. Arguments that are not enclosed in brackets are required.
+//   ... indicates that you can specify multiple values for the previous argument.
+//   |   indicates mutually exclusive information. You can use the argument to the left of the separator or the
+//       argument to the right of the separator. You cannot use both arguments in a single use of the command.
+//   { } delimits a set of mutually exclusive arguments when one of the arguments is required. If the arguments are
+//       optional, they are enclosed in brackets ([ ]).
+// Example: add [-F file | -D dir]... [-f format] profile
+func Build(action Action, rootOptions *internal.GlobalCommandOptions, use string, short string, buildOptions *BuildOptions) *cobra.Command {
+	if buildOptions == nil {
+		buildOptions = &BuildOptions{}
+	}
+
 	cmd := &cobra.Command{
-		Use:   use,
-		Short: short,
-		Long:  long,
+		Use:     use,
+		Short:   short,
+		Long:    buildOptions.Long,
+		Aliases: buildOptions.Aliases,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, azdCtx, err := createRootContext(context.Background(), cmd, rootOptions)
 			if err != nil {

--- a/cli/azd/pkg/commands/builder_test.go
+++ b/cli/azd/pkg/commands/builder_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/internal"

--- a/cli/azd/pkg/commands/builder_test.go
+++ b/cli/azd/pkg/commands/builder_test.go
@@ -66,35 +66,3 @@ func TestBuild(t *testing.T) {
 		})
 	}
 }
-
-func Test_createRootContext(t *testing.T) {
-	type args struct {
-		ctx         context.Context
-		cmd         *cobra.Command
-		rootOptions *internal.GlobalCommandOptions
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    context.Context
-		want1   *azdcontext.AzdContext
-		wantErr bool
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, got1, err := createRootContext(tt.args.ctx, tt.args.cmd, tt.args.rootOptions)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("createRootContext() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("createRootContext() got = %v, want %v", got, tt.want)
-			}
-			if !reflect.DeepEqual(got1, tt.want1) {
-				t.Errorf("createRootContext() got1 = %v, want %v", got1, tt.want1)
-			}
-		})
-	}
-}

--- a/cli/azd/pkg/commands/builder_test.go
+++ b/cli/azd/pkg/commands/builder_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
@@ -10,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBasicBuild(t *testing.T) {
+func TestBuild(t *testing.T) {
 	testAction := ActionFunc(
 		func(context.Context, *cobra.Command, []string, *azdcontext.AzdContext) error {
 			return nil
@@ -23,14 +24,77 @@ func TestBasicBuild(t *testing.T) {
 		EnableTelemetry:    true,
 	}
 
-	cmd := Build(
-		testAction,
-		rootOptions,
-		"test2",
-		"This is a test of the builder",
-		"lorem")
+	type args struct {
+		use          string
+		short        string
+		buildOptions *BuildOptions
+	}
+	tests := []struct {
+		name string
+		args args
+		want *cobra.Command
+	}{
+		{name: "RequiredOnly",
+			args: args{
+				"basic",
+				"basic-short",
+				nil,
+			},
+		},
+		{name: "Extended",
+			args: args{
+				"ext",
+				"ext-short",
+				&BuildOptions{
+					Long:    "lorem",
+					Aliases: []string{"alias1", "alias2"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := Build(testAction, rootOptions, tt.args.use, tt.args.short, tt.args.buildOptions)
 
-	assert.Equal(t, cmd.Short, "This is a test of the builder")
-	assert.Equal(t, cmd.Long, "lorem")
-	assert.Equal(t, cmd.Use, "test2")
+			assert.Equal(t, cmd.Short, tt.args.short)
+			assert.Equal(t, cmd.Use, tt.args.use)
+
+			if tt.args.buildOptions != nil {
+				assert.Equal(t, cmd.Long, tt.args.buildOptions.Long)
+				assert.Equal(t, cmd.Aliases, tt.args.buildOptions.Aliases)
+			}
+		})
+	}
+}
+
+func Test_createRootContext(t *testing.T) {
+	type args struct {
+		ctx         context.Context
+		cmd         *cobra.Command
+		rootOptions *internal.GlobalCommandOptions
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    context.Context
+		want1   *azdcontext.AzdContext
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := createRootContext(tt.args.ctx, tt.args.cmd, tt.args.rootOptions)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("createRootContext() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("createRootContext() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("createRootContext() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Introduce a `BuildOptions` struct for optional build parameters so that we can easily customize build options in the future, such as in upcoming PR #483 

Refactor `Long` and `Aliases` to use it.