### PR TITLE
Fix syntax issue in playwrite tests

### DIFF
--- a/templates/todo/common/tests/todo.spec.ts
+++ b/templates/todo/common/tests/todo.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 import { v4 as uuidv4 } from "uuid";
 
 test("Create and delete item test", async ({ page }) => {
-  await page.goto("/", {waitUntil：'networkidle'});
+  await page.goto("/", { waitUntil: 'networkidle' });
 
   await expect(page.locator("text=My List").first()).toBeVisible({
     timeout: 240 * 1000,


### PR DESCRIPTION
The file had some characters that looked like colons but were not the
colons that JavaScript was looking for.