### PR TITLE
Fixes provisioning output for container app deployments

### DIFF
--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -11,6 +11,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -253,7 +254,7 @@ func envRefreshCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 			return fmt.Errorf("creating provisioning manager: %w", err)
 		}
 
-		scope := provisioning.NewSubscriptionScope(ctx, env.GetLocation(), env.GetSubscriptionId(), env.GetEnvName())
+		scope := infra.NewSubscriptionScope(ctx, env.GetLocation(), env.GetSubscriptionId(), env.GetEnvName())
 
 		getDeploymentResult, err := infraManager.GetDeployment(ctx, scope)
 		if err != nil {

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -86,7 +87,7 @@ func (ica *infraCreateAction) Run(ctx context.Context, cmd *cobra.Command, args 
 		return fmt.Errorf("previewing deployment: %w", err)
 	}
 
-	provisioningScope := provisioning.NewSubscriptionScope(ctx, env.GetLocation(), env.GetSubscriptionId(), env.GetEnvName())
+	provisioningScope := infra.NewSubscriptionScope(ctx, env.GetLocation(), env.GetSubscriptionId(), env.GetEnvName())
 	deployResult, err := infraManager.Deploy(ctx, &previewResult.Deployment, provisioningScope)
 	if err != nil {
 		return fmt.Errorf("deploying infrastructure: %w", err)

--- a/cli/azd/pkg/azure/resource_ids.go
+++ b/cli/azd/pkg/azure/resource_ids.go
@@ -17,6 +17,11 @@ func SubscriptionDeploymentRID(subscriptionId, deploymentId string) string {
 	return returnValue
 }
 
+func ResourceGroupDeploymentRID(subscriptionId string, resourceGroupName string, deploymentId string) string {
+	returnValue := fmt.Sprintf("%s/providers/Microsoft.Resources/deployments/%s", ResourceGroupRID(subscriptionId, resourceGroupName), deploymentId)
+	return returnValue
+}
+
 // Creates resource ID for an Azure resource group
 func ResourceGroupRID(subscriptionId, resourceGroupName string) string {
 	returnValue := fmt.Sprintf("%s/resourceGroups/%s", SubscriptionRID(subscriptionId), resourceGroupName)

--- a/cli/azd/pkg/azure/resource_ids.go
+++ b/cli/azd/pkg/azure/resource_ids.go
@@ -17,6 +17,7 @@ func SubscriptionDeploymentRID(subscriptionId, deploymentId string) string {
 	return returnValue
 }
 
+// Creates resource group level deployment resource ID
 func ResourceGroupDeploymentRID(subscriptionId string, resourceGroupName string, deploymentId string) string {
 	returnValue := fmt.Sprintf("%s/providers/Microsoft.Resources/deployments/%s", ResourceGroupRID(subscriptionId, resourceGroupName), deploymentId)
 	return returnValue

--- a/cli/azd/pkg/infra/azure_resource_manager_test.go
+++ b/cli/azd/pkg/infra/azure_resource_manager_test.go
@@ -135,7 +135,7 @@ func TestGetDeploymentResourceOperationsSuccess(t *testing.T) {
 	require.NotNil(t, operations)
 	require.Nil(t, err)
 
-	require.Len(t, operations, 2)
+	require.Len(t, operations, 4)
 	require.Equal(t, 1, subCalls)
 	require.Equal(t, 1, groupCalls)
 }
@@ -241,7 +241,7 @@ func TestGetDeploymentResourceOperationsWithNestedDeployments(t *testing.T) {
 
 	require.NotNil(t, operations)
 	require.Nil(t, err)
-	require.Len(t, operations, 4)
+	require.Len(t, operations, 6)
 	require.Equal(t, 1, subCalls)
 	require.Equal(t, 2, groupCalls)
 }

--- a/cli/azd/pkg/infra/azure_resource_manager_test.go
+++ b/cli/azd/pkg/infra/azure_resource_manager_test.go
@@ -110,6 +110,8 @@ func TestGetDeploymentResourceOperationsSuccess(t *testing.T) {
 	groupCalls := 0
 
 	mockContext := mocks.NewMockContext(context.Background())
+	scope := NewSubscriptionScope(*mockContext.Context, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
+
 	mockContext.CommandRunner.When(func(args executil.RunArgs, command string) bool {
 		return strings.Contains(command, "az deployment operation sub list")
 	}).RespondFn(func(args executil.RunArgs) (executil.RunResult, error) {
@@ -129,7 +131,7 @@ func TestGetDeploymentResourceOperationsSuccess(t *testing.T) {
 	})
 
 	arm := NewAzureResourceManager(*mockContext.Context)
-	operations, err := arm.GetDeploymentResourceOperations(*mockContext.Context, "subscription-id", "deployment-name")
+	operations, err := arm.GetDeploymentResourceOperations(*mockContext.Context, scope)
 	require.NotNil(t, operations)
 	require.Nil(t, err)
 
@@ -143,6 +145,8 @@ func TestGetDeploymentResourceOperationsFail(t *testing.T) {
 	groupCalls := 0
 
 	mockContext := mocks.NewMockContext(context.Background())
+	scope := NewSubscriptionScope(*mockContext.Context, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
+
 	mockContext.CommandRunner.When(func(args executil.RunArgs, command string) bool {
 		return strings.Contains(command, "az deployment operation sub list")
 	}).RespondFn(func(args executil.RunArgs) (executil.RunResult, error) {
@@ -160,7 +164,7 @@ func TestGetDeploymentResourceOperationsFail(t *testing.T) {
 	})
 
 	arm := NewAzureResourceManager(*mockContext.Context)
-	operations, err := arm.GetDeploymentResourceOperations(*mockContext.Context, "subscription-id", "deployment-name")
+	operations, err := arm.GetDeploymentResourceOperations(*mockContext.Context, scope)
 
 	require.Nil(t, operations)
 	require.NotNil(t, err)
@@ -174,6 +178,8 @@ func TestGetDeploymentResourceOperationsNoResourceGroup(t *testing.T) {
 	groupCalls := 0
 
 	mockContext := mocks.NewMockContext(context.Background())
+	scope := NewSubscriptionScope(*mockContext.Context, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
+
 	mockContext.CommandRunner.When(func(args executil.RunArgs, command string) bool {
 		return strings.Contains(command, "az deployment operation sub list")
 	}).RespondFn(func(args executil.RunArgs) (executil.RunResult, error) {
@@ -191,7 +197,7 @@ func TestGetDeploymentResourceOperationsNoResourceGroup(t *testing.T) {
 	})
 
 	arm := NewAzureResourceManager(*mockContext.Context)
-	operations, err := arm.GetDeploymentResourceOperations(*mockContext.Context, "subscription-id", "deployment-name")
+	operations, err := arm.GetDeploymentResourceOperations(*mockContext.Context, scope)
 
 	require.NotNil(t, operations)
 	require.Nil(t, err)
@@ -205,6 +211,8 @@ func TestGetDeploymentResourceOperationsWithNestedDeployments(t *testing.T) {
 	groupCalls := 0
 
 	mockContext := mocks.NewMockContext(context.Background())
+	scope := NewSubscriptionScope(*mockContext.Context, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
+
 	mockContext.CommandRunner.When(func(args executil.RunArgs, command string) bool {
 		return strings.Contains(command, "az deployment operation sub list")
 	}).RespondFn(func(args executil.RunArgs) (executil.RunResult, error) {
@@ -229,7 +237,7 @@ func TestGetDeploymentResourceOperationsWithNestedDeployments(t *testing.T) {
 	})
 
 	arm := NewAzureResourceManager(*mockContext.Context)
-	operations, err := arm.GetDeploymentResourceOperations(*mockContext.Context, "subscription-id", "deployment-name")
+	operations, err := arm.GetDeploymentResourceOperations(*mockContext.Context, scope)
 
 	require.NotNil(t, operations)
 	require.Nil(t, err)

--- a/cli/azd/pkg/infra/provisioning/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep_provider.go
@@ -169,7 +169,7 @@ func (p *BicepProvider) Deploy(ctx context.Context, deployment *Deployment, scop
 					case <-done:
 						return
 					case <-time.After(10 * time.Second):
-						progressReport, err := progressDisplay.ReportProgress(ctx, scope)
+						progressReport, err := progressDisplay.ReportProgress(ctx)
 						if err != nil {
 							// We don't want to fail the whole deployment if a progress reporting error occurs
 							log.Printf("error while reporting progress: %s", err.Error())

--- a/cli/azd/pkg/infra/provisioning/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep_provider_test.go
@@ -70,7 +70,7 @@ func TestBicepGetDeploymentPreview(t *testing.T) {
 	prepareDeployMocks(mockContext.CommandRunner)
 
 	infraProvider := createBicepProvider(*mockContext.Context)
-	scope := NewSubscriptionScope(*mockContext.Context, infraProvider.env.Values["AZURE_LOCATION"], infraProvider.env.GetSubscriptionId(), infraProvider.env.GetEnvName())
+	scope := infra.NewSubscriptionScope(*mockContext.Context, infraProvider.env.Values["AZURE_LOCATION"], infraProvider.env.GetSubscriptionId(), infraProvider.env.GetEnvName())
 	getDeploymentTask := infraProvider.GetDeployment(*mockContext.Context, scope)
 
 	go func() {
@@ -113,7 +113,7 @@ func TestBicepDeploy(t *testing.T) {
 	infraProvider := createBicepProvider(*mockContext.Context)
 	deployment := Deployment{}
 
-	scope := NewSubscriptionScope(*mockContext.Context, infraProvider.env.Values["AZURE_LOCATION"], infraProvider.env.GetSubscriptionId(), infraProvider.env.GetEnvName())
+	scope := infra.NewSubscriptionScope(*mockContext.Context, infraProvider.env.Values["AZURE_LOCATION"], infraProvider.env.GetSubscriptionId(), infraProvider.env.GetEnvName())
 	deployTask := infraProvider.Deploy(*mockContext.Context, &deployment, scope)
 
 	go func() {

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azureutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/spin"
@@ -41,7 +42,7 @@ func (m *Manager) Preview(ctx context.Context) (*PreviewResult, error) {
 }
 
 // Gets the latest deployment details for the specified scope
-func (m *Manager) GetDeployment(ctx context.Context, scope Scope) (*DeployResult, error) {
+func (m *Manager) GetDeployment(ctx context.Context, scope infra.Scope) (*DeployResult, error) {
 	var deployResult *DeployResult
 
 	err := m.runAction("Retrieving Azure Deployment", m.interactive, func(spinner *spin.Spinner) error {
@@ -73,7 +74,7 @@ func (m *Manager) GetDeployment(ctx context.Context, scope Scope) (*DeployResult
 }
 
 // Deploys the Azure infrastructure for the specified project
-func (m *Manager) Deploy(ctx context.Context, deployment *Deployment, scope Scope) (*DeployResult, error) {
+func (m *Manager) Deploy(ctx context.Context, deployment *Deployment, scope infra.Scope) (*DeployResult, error) {
 	// Ensure that a location has been set prior to provisioning
 	location, err := m.ensureLocation(ctx, deployment)
 	if err != nil {
@@ -150,7 +151,7 @@ func (m *Manager) preview(ctx context.Context) (*PreviewResult, error) {
 }
 
 // Applies the specified infrastructure provisioning and orchestrates the interactive terminal operations
-func (m *Manager) deploy(ctx context.Context, location string, deployment *Deployment, scope Scope) (*DeployResult, error) {
+func (m *Manager) deploy(ctx context.Context, location string, deployment *Deployment, scope infra.Scope) (*DeployResult, error) {
 	var deployResult *DeployResult
 
 	err := m.runAction("Provisioning Azure resources", m.interactive, func(spinner *spin.Spinner) error {

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
@@ -41,7 +42,7 @@ func TestManagerGetDeployment(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	mgr, _ := NewManager(*mockContext.Context, env, "", options, interactive)
 
-	provisioningScope := NewSubscriptionScope(*mockContext.Context, "eastus2", env.GetSubscriptionId(), env.GetEnvName())
+	provisioningScope := infra.NewSubscriptionScope(*mockContext.Context, "eastus2", env.GetSubscriptionId(), env.GetEnvName())
 	getResult, err := mgr.GetDeployment(*mockContext.Context, provisioningScope)
 
 	require.NotNil(t, getResult)
@@ -59,7 +60,7 @@ func TestManagerDeploy(t *testing.T) {
 	mgr, _ := NewManager(*mockContext.Context, env, "", options, interactive)
 
 	previewResult, _ := mgr.Preview(*mockContext.Context)
-	provisioningScope := NewSubscriptionScope(*mockContext.Context, "eastus2", env.GetSubscriptionId(), env.GetEnvName())
+	provisioningScope := infra.NewSubscriptionScope(*mockContext.Context, "eastus2", env.GetSubscriptionId(), env.GetEnvName())
 	deployResult, err := mgr.Deploy(*mockContext.Context, &previewResult.Deployment, provisioningScope)
 
 	require.NotNil(t, deployResult)

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 )
@@ -63,9 +64,9 @@ type DestroyProgress struct {
 type Provider interface {
 	Name() string
 	RequiredExternalTools() []tools.ExternalTool
-	GetDeployment(ctx context.Context, scope Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress]
+	GetDeployment(ctx context.Context, scope infra.Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress]
 	Preview(ctx context.Context) *async.InteractiveTaskWithProgress[*PreviewResult, *PreviewProgress]
-	Deploy(ctx context.Context, deployment *Deployment, scope Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress]
+	Deploy(ctx context.Context, deployment *Deployment, scope infra.Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress]
 	Destroy(ctx context.Context, deployment *Deployment, options DestroyOptions) *async.InteractiveTaskWithProgress[*DestroyResult, *DestroyProgress]
 }
 

--- a/cli/azd/pkg/infra/provisioning/provisioning_progress_display.go
+++ b/cli/azd/pkg/infra/provisioning/provisioning_progress_display.go
@@ -38,14 +38,14 @@ func NewProvisioningProgressDisplay(rm infra.ResourceManager, console input.Cons
 }
 
 // ReportProgress reports the current deployment progress, setting the currently executing operation title and logging progress.
-func (display *ProvisioningProgressDisplay) ReportProgress(ctx context.Context, scope infra.Scope) (*DeployProgress, error) {
+func (display *ProvisioningProgressDisplay) ReportProgress(ctx context.Context) (*DeployProgress, error) {
 	progress := DeployProgress{
 		Timestamp:  time.Now(),
 		Message:    defaultProgressTitle,
 		Operations: nil,
 	}
 
-	operations, err := display.resourceManager.GetDeploymentResourceOperations(ctx, scope)
+	operations, err := display.resourceManager.GetDeploymentResourceOperations(ctx, display.scope)
 	if err != nil {
 		// Status display is best-effort activity.
 		return &progress, err

--- a/cli/azd/pkg/infra/provisioning/provisioning_progress_display.go
+++ b/cli/azd/pkg/infra/provisioning/provisioning_progress_display.go
@@ -23,31 +23,29 @@ const succeededProvisioningState string = "Succeeded"
 type ProvisioningProgressDisplay struct {
 	// Keeps track of created resources
 	createdResources map[string]bool
-	subscriptionId   string
-	deploymentName   string
 	resourceManager  infra.ResourceManager
 	console          input.Console
+	scope            infra.Scope
 }
 
-func NewProvisioningProgressDisplay(rm infra.ResourceManager, console input.Console, subscriptionId string, deploymentName string) ProvisioningProgressDisplay {
+func NewProvisioningProgressDisplay(rm infra.ResourceManager, console input.Console, scope infra.Scope) ProvisioningProgressDisplay {
 	return ProvisioningProgressDisplay{
 		createdResources: map[string]bool{},
-		subscriptionId:   subscriptionId,
-		deploymentName:   deploymentName,
+		scope:            scope,
 		resourceManager:  rm,
 		console:          console,
 	}
 }
 
 // ReportProgress reports the current deployment progress, setting the currently executing operation title and logging progress.
-func (display *ProvisioningProgressDisplay) ReportProgress(ctx context.Context) (*DeployProgress, error) {
+func (display *ProvisioningProgressDisplay) ReportProgress(ctx context.Context, scope infra.Scope) (*DeployProgress, error) {
 	progress := DeployProgress{
 		Timestamp:  time.Now(),
 		Message:    defaultProgressTitle,
 		Operations: nil,
 	}
 
-	operations, err := display.resourceManager.GetDeploymentResourceOperations(ctx, display.subscriptionId, display.deploymentName)
+	operations, err := display.resourceManager.GetDeploymentResourceOperations(ctx, scope)
 	if err != nil {
 		// Status display is best-effort activity.
 		return &progress, err
@@ -92,7 +90,7 @@ func (display *ProvisioningProgressDisplay) logNewlyCreatedResources(ctx context
 	for _, newResource := range resources {
 		resourceTypeName := newResource.Properties.TargetResource.ResourceType
 		resourceTypeDisplayName, err := display.resourceManager.GetResourceTypeDisplayName(
-			ctx, display.subscriptionId, newResource.Properties.TargetResource.Id, infra.AzureResourceType(resourceTypeName))
+			ctx, display.scope.SubscriptionId(), newResource.Properties.TargetResource.Id, infra.AzureResourceType(resourceTypeName))
 
 		if err != nil {
 			// Dynamic resource type translation failed -- fallback to static translation

--- a/cli/azd/pkg/infra/provisioning/provisioning_progress_display_test.go
+++ b/cli/azd/pkg/infra/provisioning/provisioning_progress_display_test.go
@@ -68,33 +68,33 @@ func TestReportProgress(t *testing.T) {
 
 	mockResourceManager := mockResourceManager{}
 	progressDisplay := NewProvisioningProgressDisplay(&mockResourceManager, mockContext.Console, scope)
-	progressReport, _ := progressDisplay.ReportProgress(*mockContext.Context, scope)
+	progressReport, _ := progressDisplay.ReportProgress(*mockContext.Context)
 	assert.Empty(t, mockContext.Console.Output())
 	assert.Equal(t, defaultProgressTitle, progressReport.Message)
 
 	mockResourceManager.AddInProgressOperation()
-	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context, scope)
+	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context)
 	assert.Empty(t, mockContext.Console.Output())
 	assert.Equal(t, formatProgressTitle(0, 1), progressReport.Message)
 
 	mockResourceManager.AddInProgressOperation()
-	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context, scope)
+	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context)
 	assert.Empty(t, mockContext.Console.Output())
 	assert.Equal(t, formatProgressTitle(0, 2), progressReport.Message)
 
 	mockResourceManager.AddInProgressSubResourceOperation()
-	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context, scope)
+	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context)
 	assert.Empty(t, mockContext.Console.Output())
 	assert.Equal(t, formatProgressTitle(0, 3), progressReport.Message)
 
 	mockResourceManager.MarkComplete(0)
-	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context, scope)
+	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context)
 	assert.Len(t, mockContext.Console.Output(), 1)
 	assertOperationLogged(t, 0, mockResourceManager.operations, mockContext.Console.Output())
 	assert.Equal(t, formatProgressTitle(1, 3), progressReport.Message)
 
 	mockResourceManager.MarkComplete(1)
-	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context, scope)
+	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context)
 	assert.Len(t, mockContext.Console.Output(), 2)
 	assertOperationLogged(t, 1, mockResourceManager.operations, mockContext.Console.Output())
 	assert.Equal(t, formatProgressTitle(2, 3), progressReport.Message)
@@ -103,13 +103,13 @@ func TestReportProgress(t *testing.T) {
 	oldLogOutput := make([]string, len(mockContext.Console.Output()))
 	copy(mockContext.Console.Output(), oldLogOutput)
 	mockResourceManager.MarkComplete(2)
-	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context, scope)
+	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context)
 	assert.Equal(t, oldLogOutput, mockContext.Console.Output())
 	assert.Equal(t, formatProgressTitle(3, 3), progressReport.Message)
 
 	// Verify display does not repeat logging for resources already logged.
 	copy(mockContext.Console.Output(), oldLogOutput)
-	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context, scope)
+	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context)
 	assert.Equal(t, oldLogOutput, mockContext.Console.Output())
 	assert.Equal(t, formatProgressTitle(3, 3), progressReport.Message)
 }

--- a/cli/azd/pkg/infra/provisioning/test_provider.go
+++ b/cli/azd/pkg/infra/provisioning/test_provider.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
@@ -51,7 +52,7 @@ func (p *TestProvider) Preview(ctx context.Context) *async.InteractiveTaskWithPr
 		})
 }
 
-func (p *TestProvider) GetDeployment(ctx context.Context, scope Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress] {
+func (p *TestProvider) GetDeployment(ctx context.Context, scope infra.Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress] {
 	return async.RunInteractiveTaskWithProgress(
 		func(asyncContext *async.InteractiveTaskContextWithProgress[*DeployResult, *DeployProgress]) {
 			asyncContext.SetProgress(&DeployProgress{
@@ -75,7 +76,7 @@ func (p *TestProvider) GetDeployment(ctx context.Context, scope Scope) *async.In
 }
 
 // Provisioning the infrastructure within the specified template
-func (p *TestProvider) Deploy(ctx context.Context, deployment *Deployment, scope Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress] {
+func (p *TestProvider) Deploy(ctx context.Context, deployment *Deployment, scope infra.Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress] {
 	return async.RunInteractiveTaskWithProgress(
 		func(asyncContext *async.InteractiveTaskContextWithProgress[*DeployResult, *DeployProgress]) {
 			asyncContext.SetProgress(&DeployProgress{

--- a/cli/azd/pkg/infra/scope.go
+++ b/cli/azd/pkg/infra/scope.go
@@ -32,10 +32,12 @@ type ResourceGroupScope struct {
 	resourceGroup  string
 }
 
+// Gets the Azure subscription id
 func (s *ResourceGroupScope) SubscriptionId() string {
 	return s.subscriptionId
 }
 
+// Gets the deployment name
 func (s *ResourceGroupScope) Name() string {
 	return s.name
 }
@@ -45,14 +47,17 @@ func (s *ResourceGroupScope) Deploy(ctx context.Context, modulePath string, para
 	return err
 }
 
+// GetDeployment fetches the result of the most recent deployment.
 func (s *ResourceGroupScope) GetDeployment(ctx context.Context) (azcli.AzCliDeployment, error) {
 	return s.azCli.GetResourceGroupDeployment(ctx, s.subscriptionId, s.resourceGroup, s.name)
 }
 
+// Gets the resource deployment operations for the current scope
 func (s *ResourceGroupScope) GetResourceOperations(ctx context.Context) ([]azcli.AzCliResourceOperation, error) {
 	return s.azCli.ListResourceGroupDeploymentOperations(ctx, s.subscriptionId, s.resourceGroup, s.name)
 }
 
+// Gets the url to check deployment progress
 func (s *ResourceGroupScope) DeploymentUrl() string {
 	return azure.ResourceGroupDeploymentRID(s.subscriptionId, s.resourceGroup, s.name)
 }
@@ -73,31 +78,38 @@ type SubscriptionScope struct {
 	location       string
 }
 
+// Gets the deployment name
 func (s *SubscriptionScope) Name() string {
 	return s.name
 }
 
+// Gets the Azure subscription id
 func (s *SubscriptionScope) SubscriptionId() string {
 	return s.subscriptionId
 }
 
+// Gets the url to check deployment progress
 func (s *SubscriptionScope) DeploymentUrl() string {
 	return azure.SubscriptionDeploymentRID(s.subscriptionId, s.name)
 }
 
+// Gets the Azure location for the subscription deployment
 func (s *SubscriptionScope) Location() string {
 	return s.location
 }
 
+// Deploy a given template with a set of parameters.
 func (s *SubscriptionScope) Deploy(ctx context.Context, bicepPath string, parametersPath string) error {
 	_, err := s.azCli.DeployToSubscription(ctx, s.subscriptionId, s.name, bicepPath, parametersPath, s.location)
 	return err
 }
 
+// GetDeployment fetches the result of the most recent deployment.
 func (s *SubscriptionScope) GetDeployment(ctx context.Context) (azcli.AzCliDeployment, error) {
 	return s.azCli.GetSubscriptionDeployment(ctx, s.subscriptionId, s.name)
 }
 
+// Gets the resource deployment operations for the current scope
 func (s *SubscriptionScope) GetResourceOperations(ctx context.Context) ([]azcli.AzCliResourceOperation, error) {
 	return s.azCli.ListSubscriptionDeploymentOperations(ctx, s.subscriptionId, s.name)
 }

--- a/cli/azd/pkg/infra/scope.go
+++ b/cli/azd/pkg/infra/scope.go
@@ -1,19 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package provisioning
+package infra
 
 import (
 	"context"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 )
 
 type Scope interface {
+	// Gets the Azure subscription id
+	SubscriptionId() string
+	// Gets the deployment name
+	Name() string
+	// Gets the url to check deployment progress
+	DeploymentUrl() string
 	// Deploy a given template with a set of parameters.
 	Deploy(ctx context.Context, templatePath string, parametersPath string) error
 	// GetDeployment fetches the result of the most recent deployment.
 	GetDeployment(ctx context.Context) (azcli.AzCliDeployment, error)
+	// Gets the resource deployment operations for the current scope
+	GetResourceOperations(ctx context.Context) ([]azcli.AzCliResourceOperation, error)
 }
 
 type ResourceGroupScope struct {
@@ -23,6 +32,14 @@ type ResourceGroupScope struct {
 	resourceGroup  string
 }
 
+func (s *ResourceGroupScope) SubscriptionId() string {
+	return s.subscriptionId
+}
+
+func (s *ResourceGroupScope) Name() string {
+	return s.name
+}
+
 func (s *ResourceGroupScope) Deploy(ctx context.Context, modulePath string, parametersPath string) error {
 	_, err := s.azCli.DeployToResourceGroup(ctx, s.subscriptionId, s.resourceGroup, s.name, modulePath, parametersPath)
 	return err
@@ -30,6 +47,14 @@ func (s *ResourceGroupScope) Deploy(ctx context.Context, modulePath string, para
 
 func (s *ResourceGroupScope) GetDeployment(ctx context.Context) (azcli.AzCliDeployment, error) {
 	return s.azCli.GetResourceGroupDeployment(ctx, s.subscriptionId, s.resourceGroup, s.name)
+}
+
+func (s *ResourceGroupScope) GetResourceOperations(ctx context.Context) ([]azcli.AzCliResourceOperation, error) {
+	return s.azCli.ListResourceGroupDeploymentOperations(ctx, s.subscriptionId, s.resourceGroup, s.name)
+}
+
+func (s *ResourceGroupScope) DeploymentUrl() string {
+	return azure.ResourceGroupDeploymentRID(s.subscriptionId, s.resourceGroup, s.name)
 }
 
 func NewResourceGroupScope(ctx context.Context, subscriptionId string, resourceGroup string, deploymentName string) Scope {
@@ -56,6 +81,10 @@ func (s *SubscriptionScope) SubscriptionId() string {
 	return s.subscriptionId
 }
 
+func (s *SubscriptionScope) DeploymentUrl() string {
+	return azure.SubscriptionDeploymentRID(s.subscriptionId, s.name)
+}
+
 func (s *SubscriptionScope) Location() string {
 	return s.location
 }
@@ -67,6 +96,10 @@ func (s *SubscriptionScope) Deploy(ctx context.Context, bicepPath string, parame
 
 func (s *SubscriptionScope) GetDeployment(ctx context.Context) (azcli.AzCliDeployment, error) {
 	return s.azCli.GetSubscriptionDeployment(ctx, s.subscriptionId, s.name)
+}
+
+func (s *SubscriptionScope) GetResourceOperations(ctx context.Context) ([]azcli.AzCliResourceOperation, error) {
+	return s.azCli.ListSubscriptionDeploymentOperations(ctx, s.subscriptionId, s.name)
 }
 
 func NewSubscriptionScope(ctx context.Context, location string, subscriptionId string, deploymentName string) Scope {

--- a/cli/azd/pkg/infra/scope.go
+++ b/cli/azd/pkg/infra/scope.go
@@ -42,6 +42,11 @@ func (s *ResourceGroupScope) Name() string {
 	return s.name
 }
 
+// Gets the resource group name
+func (s *ResourceGroupScope) ResourceGroup() string {
+	return s.resourceGroup
+}
+
 func (s *ResourceGroupScope) Deploy(ctx context.Context, modulePath string, parametersPath string) error {
 	_, err := s.azCli.DeployToResourceGroup(ctx, s.subscriptionId, s.resourceGroup, s.name, modulePath, parametersPath)
 	return err

--- a/cli/azd/pkg/infra/scope_test.go
+++ b/cli/azd/pkg/infra/scope_test.go
@@ -1,0 +1,114 @@
+package infra
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/executil"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScopeGetDeployment(t *testing.T) {
+	outputs := make(map[string]azcli.AzCliDeploymentOutput)
+	outputs["APP_URL"] = azcli.AzCliDeploymentOutput{
+		Type:  "string",
+		Value: "https://www.myapp.com",
+	}
+
+	deployment := azcli.AzCliDeploymentResult{
+		Properties: azcli.AzCliDeploymentResultProperties{
+			Outputs: outputs,
+		},
+	}
+	deploymentBytes, _ := json.Marshal(deployment)
+
+	t.Run("SubscriptionScopeSuccess", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.When(func(args executil.RunArgs, command string) bool {
+			return strings.Contains(command, "az deployment sub show")
+		}).Respond(executil.NewRunResult(0, string(deploymentBytes), ""))
+
+		scope := NewSubscriptionScope(*mockContext.Context, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
+
+		deployment, err := scope.GetDeployment(*mockContext.Context)
+		require.NoError(t, err)
+		require.Equal(t, outputs["APP_URL"].Value, deployment.Properties.Outputs["APP_URL"].Value)
+	})
+
+	t.Run("ResourceGroupScopeSuccess", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.When(func(args executil.RunArgs, command string) bool {
+			return strings.Contains(command, "az deployment group show")
+		}).Respond(executil.NewRunResult(0, string(deploymentBytes), ""))
+
+		scope := NewResourceGroupScope(*mockContext.Context, "SUBSCRIPTION_ID", "RESOURCE_GROUP", "DEPLOYMENT_NAME")
+
+		deployment, err := scope.GetDeployment(*mockContext.Context)
+		require.NoError(t, err)
+		require.Equal(t, outputs["APP_URL"].Value, deployment.Properties.Outputs["APP_URL"].Value)
+	})
+}
+
+func TestScopeDeploy(t *testing.T) {
+	deployment := azcli.AzCliDeploymentResult{}
+	deploymentBytes, _ := json.Marshal(deployment)
+
+	t.Run("SubscriptionScopeSuccess", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.When(func(args executil.RunArgs, command string) bool {
+			return strings.Contains(command, "az deployment sub create")
+		}).Respond(executil.NewRunResult(0, string(deploymentBytes), ""))
+
+		scope := NewSubscriptionScope(*mockContext.Context, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
+
+		err := scope.Deploy(*mockContext.Context, "/path/to/template.bicep", "path/to/params.json")
+		require.NoError(t, err)
+	})
+
+	t.Run("ResourceGroupScopeSuccess", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.When(func(args executil.RunArgs, command string) bool {
+			return strings.Contains(command, "az deployment group create")
+		}).Respond(executil.NewRunResult(0, string(deploymentBytes), ""))
+
+		scope := NewResourceGroupScope(*mockContext.Context, "SUBSCRIPTION_ID", "RESOURCE_GROUP", "DEPLOYMENT_NAME")
+
+		err := scope.Deploy(*mockContext.Context, "/path/to/template.bicep", "path/to/params.json")
+		require.NoError(t, err)
+	})
+}
+
+func TestScopeGetResourceOperations(t *testing.T) {
+	operations := []azcli.AzCliResourceOperation{}
+	deploymentBytes, _ := json.Marshal(operations)
+
+	t.Run("SubscriptionScopeSuccess", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.When(func(args executil.RunArgs, command string) bool {
+			return strings.Contains(command, "az deployment operation sub list")
+		}).Respond(executil.NewRunResult(0, string(deploymentBytes), ""))
+
+		scope := NewSubscriptionScope(*mockContext.Context, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
+
+		operations, err := scope.GetResourceOperations(*mockContext.Context)
+		require.NoError(t, err)
+		require.Len(t, operations, 0)
+	})
+
+	t.Run("ResourceGroupScopeSuccess", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.When(func(args executil.RunArgs, command string) bool {
+			return strings.Contains(command, "az deployment operation group list")
+		}).Respond(executil.NewRunResult(0, string(deploymentBytes), ""))
+
+		scope := NewResourceGroupScope(*mockContext.Context, "SUBSCRIPTION_ID", "RESOURCE_GROUP", "DEPLOYMENT_NAME")
+
+		operations, err := scope.GetResourceOperations(*mockContext.Context)
+		require.NoError(t, err)
+		require.Len(t, operations, 0)
+	})
+}

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
@@ -43,7 +44,8 @@ func (at *containerAppTarget) Deploy(ctx context.Context, azdCtx *azdcontext.Azd
 		at.config.Infra.Module = at.config.Name
 	}
 
-	infraManager, err := provisioning.NewManager(ctx, *at.env, at.config.Project.Path, at.config.Infra, true)
+	commandOptions := internal.GetCommandOptions(ctx)
+	infraManager, err := provisioning.NewManager(ctx, *at.env, at.config.Project.Path, at.config.Infra, !commandOptions.NoPrompt)
 	if err != nil {
 		return ServiceDeploymentResult{}, fmt.Errorf("creating provisioning manager: %w", err)
 	}

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -13,6 +13,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
@@ -42,7 +43,7 @@ func (at *containerAppTarget) Deploy(ctx context.Context, azdCtx *azdcontext.Azd
 		at.config.Infra.Module = at.config.Name
 	}
 
-	infraManager, err := provisioning.NewManager(ctx, *at.env, at.config.Project.Path, at.config.Infra, false)
+	infraManager, err := provisioning.NewManager(ctx, *at.env, at.config.Project.Path, at.config.Infra, true)
 	if err != nil {
 		return ServiceDeploymentResult{}, fmt.Errorf("creating provisioning manager: %w", err)
 	}
@@ -93,7 +94,8 @@ func (at *containerAppTarget) Deploy(ctx context.Context, azdCtx *azdcontext.Azd
 	}
 
 	progress <- "Updating container app image reference"
-	scope := provisioning.NewResourceGroupScope(ctx, at.env.GetSubscriptionId(), at.scope.ResourceGroupName(), at.env.GetEnvName())
+	deploymentName := fmt.Sprintf("%s-%s", at.env.GetEnvName(), at.config.Name)
+	scope := infra.NewResourceGroupScope(ctx, at.env.GetSubscriptionId(), at.scope.ResourceGroupName(), deploymentName)
 	deployResult, err := infraManager.Deploy(ctx, &previewResult.Deployment, scope)
 
 	if err != nil {


### PR DESCRIPTION
Since container app deployments today use a resource group scoped Bicep deployment the output required some updates to correctly display the effected resources.

- [x] Updates resource manager to leverage `infra.Scope`
- [x] Adds support in `infra.Scope` for both subscription level and resource group deployments
- [x] Moves `Scope` from `provisioning` package to `infra` package.  