### PR TITLE
Fix C# + SQL Azure template

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -18,7 +18,7 @@ azurestaticapps
 azureutil
 Backticks
 BOOLSLICE
-byts
+cmdsubst
 containerapp
 csharpapp
 devel

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -83,13 +83,13 @@ func (ica *infraCreateAction) Run(ctx context.Context, cmd *cobra.Command, args 
 		return fmt.Errorf("creating provisioning manager: %w", err)
 	}
 
-	previewResult, err := infraManager.Preview(ctx)
+	deploymentPlan, err := infraManager.Plan(ctx)
 	if err != nil {
-		return fmt.Errorf("previewing deployment: %w", err)
+		return fmt.Errorf("planning deployment: %w", err)
 	}
 
 	provisioningScope := infra.NewSubscriptionScope(ctx, env.GetLocation(), env.GetSubscriptionId(), env.GetEnvName())
-	deployResult, err := infraManager.Deploy(ctx, &previewResult.Deployment, provisioningScope)
+	deployResult, err := infraManager.Deploy(ctx, deploymentPlan, provisioningScope)
 	if err != nil {
 		return fmt.Errorf("deploying infrastructure: %w", err)
 	}

--- a/cli/azd/cmd/infra_delete.go
+++ b/cli/azd/cmd/infra_delete.go
@@ -74,13 +74,13 @@ func (a *infraDeleteAction) Run(ctx context.Context, cmd *cobra.Command, args []
 		return fmt.Errorf("creating provisioning manager: %w", err)
 	}
 
-	previewResult, err := infraManager.Preview(ctx)
+	deploymentPlan, err := infraManager.Plan(ctx)
 	if err != nil {
-		return fmt.Errorf("preparing destroy: %w", err)
+		return fmt.Errorf("planning destroy: %w", err)
 	}
 
 	destroyOptions := provisioning.NewDestroyOptions(a.forceDelete, a.purgeDelete)
-	destroyResult, err := infraManager.Destroy(ctx, &previewResult.Deployment, destroyOptions)
+	destroyResult, err := infraManager.Destroy(ctx, &deploymentPlan.Deployment, destroyOptions)
 	if err != nil {
 		return fmt.Errorf("destroying infrastructure: %w", err)
 	}

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"math/rand"
 	"net/http"
 	"os"
 	"os/user"
@@ -29,6 +30,9 @@ import (
 )
 
 func main() {
+	// Ensure random numbers from default random number generator are unpredictable
+	rand.Seed(time.Now().UTC().UnixNano())
+
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
 	if !isDebugEnabled() {

--- a/cli/azd/pkg/azureutil/principal.go
+++ b/cli/azd/pkg/azureutil/principal.go
@@ -53,7 +53,7 @@ func getOidClaimFromAccessToken(token string) (string, error) {
 		return "", errors.New("malformed access token")
 	}
 
-	byts, err := base64.RawURLEncoding.DecodeString(matches[1])
+	bytes, err := base64.RawURLEncoding.DecodeString(matches[1])
 	if err != nil {
 		return "", err
 	}
@@ -62,7 +62,7 @@ func getOidClaimFromAccessToken(token string) (string, error) {
 		Oid *string
 	}
 
-	if err := json.Unmarshal(byts, &claims); err != nil {
+	if err := json.Unmarshal(bytes, &claims); err != nil {
 		return "", err
 	}
 

--- a/cli/azd/pkg/cmdsubst/cmdsubst.go
+++ b/cli/azd/pkg/cmdsubst/cmdsubst.go
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmdsubst
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type CommandExecutor interface {
+	// Returns true + replacement string if a command is recognized and runs successfully.
+	// Returns false and no error if the command was not recognized by the executor, or in other "no-op" cases.
+	Run(commandName string, args []string) (bool, string, error)
+}
+
+// This package is designed to be used in the context of Azure CLI parameter file templates,
+// which are relatively simple, JSON-format documents.
+// The package relies on regular expressions and does not include a full parser.
+//
+// The command invocation is dollar sign, followed by open parenthesis and optional whitespace
+// followed by command name (word chars), followed by optional argument list
+// (word chars, whitespace, and dashes), followed by closing parenthesis.
+var commandInvocationRegex = regexp.MustCompile(`\$\(\s*(\w+)([\w\s-]*)\)`)
+
+// Similar to commandInvocationRegex, this format string is used to construct a regular expression
+// that tests whether specific command is being invoked by a given document.
+// We are looking for dollar sign, followed by open parenthesis and optional whitespace
+// followed by command name (which will be filled in by the fmt.Sprintf() call),
+// followed by optional argument list (word chars, whitespace, and dashes), followed by closing parenthesis.
+const commandInvocationFmt = "\\$\\(\\s*%s[\\w\\s-]*\\)"
+
+const (
+	wholeMatchStart  = 0
+	wholeMatchEnd    = 1
+	commandNameStart = 2
+	commandNameEnd   = 3
+	argsStart        = 4
+	argsEnd          = 5
+)
+
+// Eval replaces all occurrences of bash-like command output substitution $(command arg1 arg2 ...)
+// with the result provided by the command executor.
+// Any error from the command executor will result in an error reported from Eval().
+func Eval(input string, cmd CommandExecutor) (string, error) {
+	var sb strings.Builder
+
+	allMatches := commandInvocationRegex.FindAllStringSubmatchIndex(input, -1)
+	if len(allMatches) == 0 {
+		return input, nil // No substitution necessary
+	}
+
+	contentBeforeMatchIndex := 0
+
+	for _, match := range allMatches {
+		// Write "content before match"
+		sb.WriteString(input[contentBeforeMatchIndex:match[wholeMatchStart]])
+		contentBeforeMatchIndex = match[wholeMatchEnd]
+
+		// Extract invocation data and call evaluator
+		commandName := input[match[commandNameStart]:match[commandNameEnd]]
+		argumentStr := input[match[argsStart]:match[argsEnd]]
+		args := strings.Fields(strings.TrimSpace(argumentStr))
+
+		ran, result, err := cmd.Run(commandName, args)
+		if err != nil {
+			return "", err
+		} else if ran {
+			// Successful substitution
+			sb.WriteString(result)
+		} else {
+			// Unrecognized command--write original content in and continue
+			sb.WriteString(input[match[wholeMatchStart]:match[wholeMatchEnd]])
+		}
+	}
+
+	// Write content after last match
+	restStartIndex := allMatches[len(allMatches)-1][wholeMatchEnd]
+	sb.WriteString(input[restStartIndex:])
+
+	return sb.String(), nil
+}
+
+// Returns true if the document 'doc' contains an invocation of a command.
+func ContainsCommandInvocation(doc, commandName string) bool {
+	if len(commandName) == 0 || len(doc) == 0 {
+		return false
+	}
+	regexStr := fmt.Sprintf(commandInvocationFmt, commandName)
+	commandInvocationRegex := regexp.MustCompile(regexStr)
+	return commandInvocationRegex.MatchString(doc)
+}

--- a/cli/azd/pkg/cmdsubst/cmdsubst_test.go
+++ b/cli/azd/pkg/cmdsubst/cmdsubst_test.go
@@ -1,0 +1,305 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmdsubst
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testCommandExecutor struct {
+	runImpl func(name string, args []string) (bool, string, error)
+}
+
+func (tc testCommandExecutor) Run(name string, args []string) (bool, string, error) {
+	return tc.runImpl(name, args)
+}
+
+func TestEvalWorksWithEmptyInput(t *testing.T) {
+	evaluatorCalled := false
+	result, err := Eval("", testCommandExecutor{
+		runImpl: func(name string, args []string) (bool, string, error) {
+			evaluatorCalled = true
+			return false, "", nil
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "", result)
+	require.False(t, evaluatorCalled)
+}
+
+func TestEmptyInvocation(t *testing.T) {
+	// This is not a valid command, so it should be left alone
+	evaluatorCalled := false
+	result, err := Eval(" $()  ", testCommandExecutor{
+		runImpl: func(name string, args []string) (bool, string, error) {
+			evaluatorCalled = true
+			return false, "", nil
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, " $()  ", result)
+	require.False(t, evaluatorCalled)
+}
+
+func TestEvalNoSubstitution(t *testing.T) {
+	const input = `{
+		"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+		"contentVersion": "1.0.0.0",
+		"parameters": {
+		  "name": {
+			"value": "${AZURE_ENV_NAME}"
+		  },
+		  "location": {
+			"value": "${AZURE_LOCATION}"
+		  },
+		  "principalId": {
+			"value": "${AZURE_PRINCIPAL_ID}"
+		  }
+		}
+	  }`
+
+	evaluatorCalled := false
+	result, err := Eval(input, testCommandExecutor{
+		runImpl: func(name string, args []string) (bool, string, error) {
+			evaluatorCalled = true
+			return false, "", nil
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, input, result)
+	require.False(t, evaluatorCalled)
+}
+
+func TestSubstitution(t *testing.T) {
+	const input = `{
+		"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+		"contentVersion": "1.0.0.0",
+		"parameters": {
+		  "name": {
+			"value": "${AZURE_ENV_NAME}"
+		  },
+		  "password": {
+			"value": "$(randomPassword)"
+		  } 
+		}
+	  }`
+	const expected = `{
+		"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+		"contentVersion": "1.0.0.0",
+		"parameters": {
+		  "name": {
+			"value": "${AZURE_ENV_NAME}"
+		  },
+		  "password": {
+			"value": "very-secret"
+		  } 
+		}
+	  }`
+
+	result, err := Eval(input, testCommandExecutor{
+		runImpl: func(name string, args []string) (bool, string, error) {
+			if name == "randomPassword" {
+				return true, "very-secret", nil
+			} else {
+				return false, "", nil
+			}
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
+}
+
+func TestEvaluatorReportingUnknownCommand(t *testing.T) {
+	const input = `{
+		"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+		"contentVersion": "1.0.0.0",
+		"parameters": {
+		  "name": {
+			"value": "${AZURE_ENV_NAME}"
+		  },
+		  "password": {
+			"value": "$(unknownCmd)"
+		  } 
+		}
+	  }`
+
+	evaluatorCalled := false
+	result, err := Eval(input, testCommandExecutor{
+		runImpl: func(name string, args []string) (bool, string, error) {
+			evaluatorCalled = true
+			return false, "", nil
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, input, result) // No substitution, input preserved
+	require.True(t, evaluatorCalled)
+}
+
+func TestEvaluatorError(t *testing.T) {
+	const input = `{
+		"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+		"contentVersion": "1.0.0.0",
+		"parameters": {
+		  "name": {
+			"value": "${AZURE_ENV_NAME}"
+		  },
+		  "password": {
+			"value": "$(causesError 1 alpha)"
+		  } 
+		}
+	  }`
+
+	evaluatorErr := fmt.Errorf("Something bad happened")
+	_, err := Eval(input, testCommandExecutor{
+		runImpl: func(name string, args []string) (bool, string, error) {
+			return false, "", evaluatorErr
+		},
+	})
+
+	require.Error(t, err)
+	require.Equal(t, evaluatorErr, err)
+}
+
+func TestParameterExtraction(t *testing.T) {
+	const input = `{
+		"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+		"contentVersion": "1.0.0.0",
+		"parameters": {
+		  "name": {
+			"value": "${AZURE_ENV_NAME}"
+		  },
+		  "password": {
+			"value": "$( randomPassword alpha  bravo 17 foobar-1)"
+		  } 
+		}
+	  }`
+
+	const expected = `{
+		"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+		"contentVersion": "1.0.0.0",
+		"parameters": {
+		  "name": {
+			"value": "${AZURE_ENV_NAME}"
+		  },
+		  "password": {
+			"value": "randomPassword called with [alpha bravo 17 foobar-1]"
+		  } 
+		}
+	  }`
+
+	result, err := Eval(input, testCommandExecutor{
+		runImpl: func(name string, args []string) (bool, string, error) {
+			if name == "randomPassword" {
+				return true, fmt.Sprintf("%s called with %v", name, args), nil
+			} else {
+				return false, "", fmt.Errorf("Unknown command '%s', should not happen", name)
+			}
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
+}
+
+func TestMultipleSubstitutions(t *testing.T) {
+	const input = `$(say alpha maybe) bravo $(say charlie)
+	$(say delta) echo
+	$(say foxtrot) golf $(say hotel for sure)`
+
+	const expected = `alpha bravo charlie
+	delta echo
+	foxtrot golf hotel`
+
+	result, err := Eval(input, testCommandExecutor{
+		runImpl: func(name string, args []string) (bool, string, error) {
+			if name == "say" {
+				return true, args[0], nil
+			} else {
+				return false, "", fmt.Errorf("Unknown command '%s', should not happen", name)
+			}
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
+}
+
+func TestFullSubstitution(t *testing.T) {
+	cmd := testCommandExecutor{
+		runImpl: func(name string, args []string) (bool, string, error) {
+			if name == "say" {
+				return true, args[0], nil
+			} else {
+				return false, "", fmt.Errorf("Unknown command '%s', should not happen", name)
+			}
+		},
+	}
+
+	// The whole input needs to be substituted
+	var input = `$(say alpha)`
+	var expected = `alpha`
+	result, err := Eval(input, cmd)
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
+
+	// Special case that is important for us
+	input = `"$(say alpha)"`
+	expected = `"alpha"`
+	result, err = Eval(input, cmd)
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
+
+	// Once more, with whitespace, which should be preserved
+	input = ` " $(say alpha)"  `
+	expected = ` " alpha"  `
+	result, err = Eval(input, cmd)
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
+}
+
+func TestCommandContainsInvocation(t *testing.T) {
+	// Empty doc
+	var input = ""
+	require.False(t, ContainsCommandInvocation(input, "cmd"))
+
+	// No commands
+	input = "alpha bravo charlie"
+	require.False(t, ContainsCommandInvocation(input, "cmd"))
+
+	// Empty command (invalid invocation)
+	input = "alpha bravo $() charlie"
+	require.False(t, ContainsCommandInvocation(input, "cmd"))
+
+	// Invocation, but different command
+	input = "alpha $(otherCmd) charlie"
+	require.False(t, ContainsCommandInvocation(input, "Cmd"))
+
+	// Invocation at the beginning
+	input = "$(cmd)alpha bravo charlie"
+	require.True(t, ContainsCommandInvocation(input, "cmd"))
+
+	// Invocation at the end
+	input = "alpha bravo charlie$(cmd)"
+	require.True(t, ContainsCommandInvocation(input, "cmd"))
+
+	// Invocation in the middle
+	input = "alpha bravo$(cmd) charlie"
+	require.True(t, ContainsCommandInvocation(input, "cmd"))
+
+	// Multiple invocations
+	input = "alpha $(cmd) bravo charlie$(cmd)"
+	require.True(t, ContainsCommandInvocation(input, "cmd"))
+
+	// Parameters with dash characters
+	input = "$(cmd foo-1 foo-2)"
+	require.True(t, ContainsCommandInvocation(input, "cmd"))
+}

--- a/cli/azd/pkg/cmdsubst/secretOrRandomPassword.go
+++ b/cli/azd/pkg/cmdsubst/secretOrRandomPassword.go
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmdsubst
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/password"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
+)
+
+const COMMAND_NAME string = "secretOrRandomPassword"
+
+type SecretOrRandomPasswordCommandExecutor struct {
+	ctx            context.Context
+	azCli          azcli.AzCli
+	vaults         []azcli.AzCliKeyVault
+	subscriptionId string
+}
+
+func (e *SecretOrRandomPasswordCommandExecutor) SetRunContext(ctx context.Context, azCli azcli.AzCli, vaults []azcli.AzCliKeyVault, subscriptionId string) {
+	e.ctx = ctx
+	e.azCli = azCli
+	e.vaults = vaults
+	e.subscriptionId = subscriptionId
+}
+
+func (e *SecretOrRandomPasswordCommandExecutor) ContainsCommandInvocation(doc string) bool {
+	return ContainsCommandInvocation(doc, COMMAND_NAME)
+}
+
+func (e SecretOrRandomPasswordCommandExecutor) Run(commandName string, args []string) (bool, string, error) {
+	if commandName != COMMAND_NAME {
+		return false, "", nil
+	}
+
+	generatePassword := func() (bool, string, error) {
+		substitute, err := password.Generate(password.PasswordComposition{NumLowercase: 5, NumUppercase: 5, NumDigits: 5})
+		return err == nil, substitute, err
+	}
+
+	// We expect two arguments: the KeyVault name and the secret name
+	// If any is missing, we assume it is a "keyvault does not exist" case and fall back to random password generation.
+	if len(args) != 2 {
+		return generatePassword()
+	}
+
+	keyVaultName := args[0]
+	secretName := args[1]
+	if e.ctx == nil || e.azCli == nil || len(e.subscriptionId) == 0 {
+		// Should never happen really...
+		return false, "", fmt.Errorf("context not set for executing %s command", COMMAND_NAME)
+	}
+
+	if len(e.vaults) == 0 {
+		return generatePassword()
+	}
+
+	for _, v := range e.vaults {
+		if v.Name != keyVaultName {
+			continue
+		}
+
+		secret, err := e.azCli.GetKeyVaultSecret(e.ctx, e.subscriptionId, keyVaultName, secretName)
+		if err != nil {
+			if errors.Is(err, azcli.ErrAzCliSecretNotFound) {
+				continue
+			} else {
+				return false, "", fmt.Errorf("reading secret '%s' from vault '%s': %w", secretName, keyVaultName, err)
+			}
+		} else if len(secret.Value) > 0 {
+			return true, secret.Value, nil
+		} else {
+			continue // Do not use empty password secret even if the secret exists
+		}
+	}
+
+	return generatePassword()
+}

--- a/cli/azd/pkg/cmdsubst/secretOrRandomPassword.go
+++ b/cli/azd/pkg/cmdsubst/secretOrRandomPassword.go
@@ -7,33 +7,31 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/password"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 )
 
-const COMMAND_NAME string = "secretOrRandomPassword"
+const SecretOrRandomPasswordCommandName string = "secretOrRandomPassword"
 
 type SecretOrRandomPasswordCommandExecutor struct {
 	ctx            context.Context
 	azCli          azcli.AzCli
-	vaults         []azcli.AzCliKeyVault
 	subscriptionId string
 }
 
-func (e *SecretOrRandomPasswordCommandExecutor) SetRunContext(ctx context.Context, azCli azcli.AzCli, vaults []azcli.AzCliKeyVault, subscriptionId string) {
-	e.ctx = ctx
-	e.azCli = azCli
-	e.vaults = vaults
-	e.subscriptionId = subscriptionId
-}
-
-func (e *SecretOrRandomPasswordCommandExecutor) ContainsCommandInvocation(doc string) bool {
-	return ContainsCommandInvocation(doc, COMMAND_NAME)
+func NewSecretOrRandomPasswordExecutor(ctx context.Context, azCli azcli.AzCli, subscriptionId string) SecretOrRandomPasswordCommandExecutor {
+	return SecretOrRandomPasswordCommandExecutor{
+		ctx:            ctx,
+		azCli:          azCli,
+		subscriptionId: subscriptionId,
+	}
 }
 
 func (e SecretOrRandomPasswordCommandExecutor) Run(commandName string, args []string) (bool, string, error) {
-	if commandName != COMMAND_NAME {
+	if commandName != SecretOrRandomPasswordCommandName {
 		return false, "", nil
 	}
 
@@ -47,36 +45,28 @@ func (e SecretOrRandomPasswordCommandExecutor) Run(commandName string, args []st
 	if len(args) != 2 {
 		return generatePassword()
 	}
-
 	keyVaultName := args[0]
 	secretName := args[1]
+
 	if e.ctx == nil || e.azCli == nil || len(e.subscriptionId) == 0 {
 		// Should never happen really...
-		return false, "", fmt.Errorf("context not set for executing %s command", COMMAND_NAME)
+		return false, "", fmt.Errorf("missing context information for %s command", SecretOrRandomPasswordCommandName)
 	}
 
-	if len(e.vaults) == 0 {
-		return generatePassword()
-	}
-
-	for _, v := range e.vaults {
-		if v.Name != keyVaultName {
-			continue
-		}
-
-		secret, err := e.azCli.GetKeyVaultSecret(e.ctx, e.subscriptionId, keyVaultName, secretName)
-		if err != nil {
-			if errors.Is(err, azcli.ErrAzCliSecretNotFound) {
-				continue
-			} else {
-				return false, "", fmt.Errorf("reading secret '%s' from vault '%s': %w", secretName, keyVaultName, err)
-			}
-		} else if len(secret.Value) > 0 {
-			return true, secret.Value, nil
+	secret, err := e.azCli.GetKeyVaultSecret(e.ctx, e.subscriptionId, keyVaultName, secretName)
+	if err != nil {
+		if errors.Is(err, azcli.ErrAzCliSecretNotFound) {
+			log.Printf("%s: secret '%s' not found in vault '%s', using random password...", SecretOrRandomPasswordCommandName, secretName, keyVaultName)
+			return generatePassword()
 		} else {
-			continue // Do not use empty password secret even if the secret exists
+			return false, "", fmt.Errorf("reading secret '%s' from vault '%s': %w", secretName, keyVaultName, err)
 		}
 	}
 
-	return generatePassword()
+	if len(strings.TrimSpace(secret.Value)) == 0 {
+		log.Printf("%s: secret '%s' in vault '%s' has empty value, using random password...", SecretOrRandomPasswordCommandName, secretName, keyVaultName)
+		return generatePassword() // Do not use empty password secret even if the secret exists
+	}
+
+	return true, secret.Value, nil
 }

--- a/cli/azd/pkg/environment/azdcontext/azdcontext.go
+++ b/cli/azd/pkg/environment/azdcontext/azdcontext.go
@@ -115,7 +115,7 @@ func (c *AzdContext) GetDefaultEnvironmentName() (string, error) {
 
 func (c *AzdContext) SetDefaultEnvironmentName(name string) error {
 	path := filepath.Join(c.EnvironmentDirectory(), ConfigFileName)
-	byts, err := json.Marshal(configFile{
+	bytes, err := json.Marshal(configFile{
 		Version:            ConfigFileVersion,
 		DefaultEnvironment: name,
 	})
@@ -123,7 +123,7 @@ func (c *AzdContext) SetDefaultEnvironmentName(name string) error {
 		return fmt.Errorf("serializing config file: %w", err)
 	}
 
-	if err := os.WriteFile(path, byts, osutil.PermissionFile); err != nil {
+	if err := os.WriteFile(path, bytes, osutil.PermissionFile); err != nil {
 		return fmt.Errorf("writing config file: %w", err)
 	}
 

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -17,10 +17,12 @@ import (
 	"time"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
+	"github.com/azure/azure-dev/cli/azd/pkg/cmdsubst"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	. "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
@@ -29,8 +31,7 @@ import (
 )
 
 type BicepTemplate struct {
-	//nolint:all
-	Schema         string                          `json:"$schema`
+	Schema         string                          `json:"$schema"`
 	ContentVersion string                          `json:"contentVersion"`
 	Parameters     map[string]BicepInputParameter  `json:"parameters"`
 	Outputs        map[string]BicepOutputParameter `json:"outputs"`
@@ -45,6 +46,10 @@ type BicepInputParameter struct {
 type BicepOutputParameter struct {
 	Type  string      `json:"type"`
 	Value interface{} `json:"value"`
+}
+
+type BicepDeploymentDetails struct {
+	ParameterFilePath string
 }
 
 // BicepProvider exposes infrastructure provisioning using Azure Bicep templates
@@ -97,19 +102,19 @@ func (p *BicepProvider) GetDeployment(ctx context.Context, scope infra.Scope) *a
 		})
 }
 
-// Previews the infrastructure provisioning
-func (p *BicepProvider) Preview(ctx context.Context) *async.InteractiveTaskWithProgress[*PreviewResult, *PreviewProgress] {
+// Plans the infrastructure provisioning
+func (p *BicepProvider) Plan(ctx context.Context) *async.InteractiveTaskWithProgress[*DeploymentPlan, *DeploymentPlanningProgress] {
 	return async.RunInteractiveTaskWithProgress(
-		func(asyncContext *async.InteractiveTaskContextWithProgress[*PreviewResult, *PreviewProgress]) {
-			asyncContext.SetProgress(&PreviewProgress{Message: "Generating Bicep parameters file", Timestamp: time.Now()})
-			bicepTemplate, err := p.createParametersFile()
+		func(asyncContext *async.InteractiveTaskContextWithProgress[*DeploymentPlan, *DeploymentPlanningProgress]) {
+			asyncContext.SetProgress(&DeploymentPlanningProgress{Message: "Generating Bicep parameters file", Timestamp: time.Now()})
+			bicepTemplate, parameterFilePath, err := p.createParametersFile(ctx, asyncContext)
 			if err != nil {
 				asyncContext.SetError(fmt.Errorf("creating parameters file: %w", err))
 				return
 			}
 
 			modulePath := p.modulePath()
-			asyncContext.SetProgress(&PreviewProgress{Message: "Compiling Bicep template", Timestamp: time.Now()})
+			asyncContext.SetProgress(&DeploymentPlanningProgress{Message: "Compiling Bicep template", Timestamp: time.Now()})
 			deployment, err := p.createDeployment(ctx, modulePath)
 			if err != nil {
 				asyncContext.SetError(fmt.Errorf("creating template: %w", err))
@@ -131,14 +136,17 @@ func (p *BicepProvider) Preview(ctx context.Context) *async.InteractiveTaskWithP
 			}
 
 			if updated {
-				if err := p.updateParametersFile(ctx, deployment); err != nil {
+				if err := p.updateParametersFile(ctx, deployment, parameterFilePath); err != nil {
 					asyncContext.SetError(fmt.Errorf("updating deployment parameters: %w", err))
 					return
 				}
 			}
 
-			result := PreviewResult{
+			result := DeploymentPlan{
 				Deployment: *deployment,
+				Details: BicepDeploymentDetails{
+					ParameterFilePath: parameterFilePath,
+				},
 			}
 
 			asyncContext.SetResult(&result)
@@ -146,7 +154,7 @@ func (p *BicepProvider) Preview(ctx context.Context) *async.InteractiveTaskWithP
 }
 
 // Provisioning the infrastructure within the specified template
-func (p *BicepProvider) Deploy(ctx context.Context, deployment *Deployment, scope infra.Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress] {
+func (p *BicepProvider) Deploy(ctx context.Context, pd *DeploymentPlan, scope infra.Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress] {
 	return async.RunInteractiveTaskWithProgress(
 		func(asyncContext *async.InteractiveTaskContextWithProgress[*DeployResult, *DeployProgress]) {
 			done := make(chan bool)
@@ -185,21 +193,22 @@ func (p *BicepProvider) Deploy(ctx context.Context, deployment *Deployment, scop
 
 			// Start the deployment
 			modulePath := p.modulePath()
-			parametersFilePath := p.parametersFilePath()
-			deployResult, err := p.deployModule(ctx, scope, modulePath, parametersFilePath)
+			bicepDeploymentData := pd.Details.(BicepDeploymentDetails)
+			deployResult, err := p.deployModule(ctx, scope, modulePath, bicepDeploymentData.ParameterFilePath)
 
 			if err != nil {
 				asyncContext.SetError(err)
 				return
 			}
 
+			deployment := pd.Deployment
 			if deployResult != nil {
-				deployment.Outputs = p.createOutputParameters(deployment, deployResult.Properties.Outputs)
+				deployment.Outputs = p.createOutputParameters(&pd.Deployment, deployResult.Properties.Outputs)
 			}
 
 			result := &DeployResult{
 				Operations: operations,
-				Deployment: deployment,
+				Deployment: &deployment,
 			}
 
 			asyncContext.SetResult(result)
@@ -210,19 +219,22 @@ func (p *BicepProvider) Deploy(ctx context.Context, deployment *Deployment, scop
 func (p *BicepProvider) Destroy(ctx context.Context, deployment *Deployment, options DestroyOptions) *async.InteractiveTaskWithProgress[*DestroyResult, *DestroyProgress] {
 	return async.RunInteractiveTaskWithProgress(
 		func(asyncContext *async.InteractiveTaskContextWithProgress[*DestroyResult, *DestroyProgress]) {
-			resourceGroups, err := p.getResourceGroups(ctx, asyncContext)
+			asyncContext.SetProgress(&DestroyProgress{Message: "Fetching resource groups", Timestamp: time.Now()})
+			resourceGroups, err := p.getResourceGroups(ctx)
 			if err != nil {
 				asyncContext.SetError(err)
 				return
 			}
 
-			allResources, err := p.getAllResources(ctx, asyncContext, resourceGroups)
+			asyncContext.SetProgress(&DestroyProgress{Message: "Fetching resources", Timestamp: time.Now()})
+			allResources, err := p.getAllResources(ctx, resourceGroups)
 			if err != nil {
 				asyncContext.SetError(fmt.Errorf("getting resources to delete: %w", err))
 				return
 			}
 
-			keyVaults, err := p.getKeyVaultsToPurge(ctx, asyncContext, allResources)
+			asyncContext.SetProgress(&DestroyProgress{Message: "Getting KeyVaults to purge", Timestamp: time.Now()})
+			keyVaults, err := p.getKeyVaultsToPurge(ctx, allResources)
 			if err != nil {
 				asyncContext.SetError(fmt.Errorf("getting key vaults to purge: %w", err))
 				return
@@ -252,9 +264,7 @@ func (p *BicepProvider) Destroy(ctx context.Context, deployment *Deployment, opt
 		})
 }
 
-func (p *BicepProvider) getResourceGroups(ctx context.Context, asyncContext *async.InteractiveTaskContextWithProgress[*DestroyResult, *DestroyProgress]) ([]string, error) {
-	asyncContext.SetProgress(&DestroyProgress{Message: "Fetching resource groups", Timestamp: time.Now()})
-
+func (p *BicepProvider) getResourceGroups(ctx context.Context) ([]string, error) {
 	resourceManager := infra.NewAzureResourceManager(ctx)
 	resourceGroups, err := resourceManager.GetResourceGroupsForDeployment(ctx, p.env.GetSubscriptionId(), p.env.GetEnvName())
 	if err != nil {
@@ -264,9 +274,8 @@ func (p *BicepProvider) getResourceGroups(ctx context.Context, asyncContext *asy
 	return resourceGroups, nil
 }
 
-func (p *BicepProvider) getAllResources(ctx context.Context, asyncContext *async.InteractiveTaskContextWithProgress[*DestroyResult, *DestroyProgress], resourceGroups []string) ([]azcli.AzCliResource, error) {
+func (p *BicepProvider) getAllResources(ctx context.Context, resourceGroups []string) ([]azcli.AzCliResource, error) {
 	allResources := []azcli.AzCliResource{}
-	asyncContext.SetProgress(&DestroyProgress{Message: "Fetching resources", Timestamp: time.Now()})
 
 	for _, resourceGroup := range resourceGroups {
 		resources, err := p.azCli.ListResourceGroupResources(ctx, p.env.GetSubscriptionId(), resourceGroup)
@@ -319,8 +328,8 @@ func (p *BicepProvider) destroyResourceGroups(ctx context.Context, asyncContext 
 	return nil
 }
 
-func (p *BicepProvider) getKeyVaultsToPurge(ctx context.Context, asyncContext *async.InteractiveTaskContextWithProgress[*DestroyResult, *DestroyProgress], resources []azcli.AzCliResource) ([]azcli.AzCliKeyVault, error) {
-	keyVaultsToPurge := []azcli.AzCliKeyVault{}
+func (p *BicepProvider) getKeyVaults(ctx context.Context, resources []azcli.AzCliResource) ([]azcli.AzCliKeyVault, error) {
+	vaults := []azcli.AzCliKeyVault{}
 
 	for _, resource := range resources {
 		if resource.Type == string(infra.AzureResourceTypeKeyVault) {
@@ -328,13 +337,27 @@ func (p *BicepProvider) getKeyVaultsToPurge(ctx context.Context, asyncContext *a
 			if err != nil {
 				return []azcli.AzCliKeyVault{}, fmt.Errorf("listing key vault %s properties: %w", resource.Name, err)
 			}
-			if vault.Properties.EnableSoftDelete && !vault.Properties.EnablePurgeProtection {
-				keyVaultsToPurge = append(keyVaultsToPurge, vault)
-			}
+			vaults = append(vaults, vault)
 		}
 	}
 
-	return keyVaultsToPurge, nil
+	return vaults, nil
+}
+
+func (p *BicepProvider) getKeyVaultsToPurge(ctx context.Context, resources []azcli.AzCliResource) ([]azcli.AzCliKeyVault, error) {
+	vaults, err := p.getKeyVaults(ctx, resources)
+	if err != nil {
+		return []azcli.AzCliKeyVault{}, err
+	}
+
+	vaultsToPurge := []azcli.AzCliKeyVault{}
+	for _, v := range vaults {
+		if v.Properties.EnableSoftDelete && !v.Properties.EnablePurgeProtection {
+			vaultsToPurge = append(vaultsToPurge, v)
+		}
+	}
+
+	return vaultsToPurge, nil
 }
 
 // Azure KeyVaults have a "soft delete" functionality (now enabled by default) where a vault may be marked
@@ -416,7 +439,7 @@ func (p *BicepProvider) deleteDeployment(ctx context.Context, asyncContext *asyn
 }
 
 // Converts the specified deployment to a bicep template parameters file and writes the file to disk.
-func (p *BicepProvider) updateParametersFile(ctx context.Context, deployment *Deployment) error {
+func (p *BicepProvider) updateParametersFile(ctx context.Context, deployment *Deployment, parameterFilePath string) error {
 	bicepFile := BicepTemplate{
 		Schema:         "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
 		ContentVersion: "1.0.0.0",
@@ -435,8 +458,7 @@ func (p *BicepProvider) updateParametersFile(ctx context.Context, deployment *De
 		return fmt.Errorf("marshaling parameters: %w", err)
 	}
 
-	parametersFilePath := p.parametersFilePath()
-	err = os.WriteFile(parametersFilePath, bytes, 0644)
+	err = os.WriteFile(parameterFilePath, bytes, osutil.PermissionFile)
 	if err != nil {
 		return fmt.Errorf("writing parameters file: %w", err)
 	}
@@ -472,44 +494,78 @@ func (p *BicepProvider) createOutputParameters(template *Deployment, azureOutput
 	return outputParams
 }
 
-// Copies the Bicep parameters file from the project template into the .azure environment folder
-func (p *BicepProvider) createParametersFile() (*BicepTemplate, error) {
-	// Copy the parameter template file to the environment working directory and do substitutions.
+// createParametersFile will read the parameters file template for environment/module specified by Options,
+// do environment and command substitutions, and write out the result into a temporary file.
+//
+// The caller of the method is responsible for deleting the file when it is no longer necessary.
+func (p *BicepProvider) createParametersFile(ctx context.Context, asyncContext *async.InteractiveTaskContextWithProgress[*DeploymentPlan, *DeploymentPlanningProgress]) (*BicepTemplate, string, error) {
 	parametersTemplateFilePath := p.parametersTemplateFilePath()
 	log.Printf("Reading parameters template file from: %s", parametersTemplateFilePath)
 	parametersBytes, err := os.ReadFile(parametersTemplateFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("reading parameter file template: %w", err)
+		return nil, "", fmt.Errorf("reading parameter file template: %w", err)
 	}
+
 	replaced, err := envsubst.Eval(string(parametersBytes), func(name string) string {
 		if val, has := p.env.Values[name]; has {
 			return val
 		}
 		return os.Getenv(name)
 	})
-
 	if err != nil {
-		return nil, fmt.Errorf("substituting parameter file: %w", err)
+		return nil, "", fmt.Errorf("substituting environment variables inside parameter file: %w", err)
 	}
 
-	parametersFilePath := p.parametersFilePath()
-	writeDir := filepath.Dir(parametersFilePath)
-	if err := os.MkdirAll(writeDir, 0755); err != nil {
-		return nil, fmt.Errorf("creating directory structure: %w", err)
-	}
+	cmdExecutor := cmdsubst.SecretOrRandomPasswordCommandExecutor{}
+	if cmdExecutor.ContainsCommandInvocation(replaced) {
+		keyVaults := []azcli.AzCliKeyVault{}
 
-	log.Printf("Writing parameters file to: %s", parametersFilePath)
-	err = os.WriteFile(parametersFilePath, []byte(replaced), 0644)
-	if err != nil {
-		return nil, fmt.Errorf("writing parameter file: %w", err)
+		asyncContext.SetProgress(&DeploymentPlanningProgress{Message: "Fetching existing resource groups", Timestamp: time.Now()})
+		resourceGroups, err := p.getResourceGroups(ctx)
+		if err != nil {
+			if !errors.Is(err, azcli.ErrDeploymentNotFound) {
+				return nil, "", err
+			}
+			// We are fine--there is no existing deployments, so we can pass empty KeyVaults slice to command executor
+		} else {
+			asyncContext.SetProgress(&DeploymentPlanningProgress{Message: "Fetching existing resources", Timestamp: time.Now()})
+			allResources, err := p.getAllResources(ctx, resourceGroups)
+			if err != nil {
+				return nil, "", err
+			}
+
+			asyncContext.SetProgress(&DeploymentPlanningProgress{Message: "Fetching existing KeyVaults", Timestamp: time.Now()})
+			keyVaults, err = p.getKeyVaults(ctx, allResources)
+			if err != nil {
+				return nil, "", err
+			}
+		}
+
+		cmdExecutor.SetRunContext(ctx, p.azCli, keyVaults, p.env.GetSubscriptionId())
+		replaced, err = cmdsubst.Eval(replaced, cmdExecutor)
+		if err != nil {
+			return nil, "", fmt.Errorf("substituting command output inside parameter file: %w", err)
+		}
 	}
 
 	var bicepTemplate BicepTemplate
 	if err := json.Unmarshal([]byte(replaced), &bicepTemplate); err != nil {
-		return nil, fmt.Errorf("error unmarshalling Bicep template parameters: %w", err)
+		return nil, "", fmt.Errorf("error unmarshalling Bicep template parameters: %w", err)
 	}
 
-	return &bicepTemplate, nil
+	file, err := os.CreateTemp("", "deploymentParameters")
+	if err != nil {
+		return nil, "", err
+	}
+
+	_, err = file.Write([]byte(replaced))
+	file.Close() // Errors OK to ignore (see the docs) and we need to close the file whether Write() succeeded or not.
+	if err != nil {
+		os.Remove(file.Name()) // Error OK to ignore as well.
+		return nil, "", err
+	}
+
+	return &bicepTemplate, file.Name(), nil
 }
 
 // Creates the compiled template from the specified module path
@@ -592,12 +648,6 @@ func (p *BicepProvider) parametersTemplateFilePath() string {
 
 	parametersFilename := fmt.Sprintf("%s.parameters.json", p.options.Module)
 	return filepath.Join(p.projectPath, infraPath, parametersFilename)
-}
-
-// Gets the path to the staging .azure parameters file path
-func (p *BicepProvider) parametersFilePath() string {
-	parametersFilename := fmt.Sprintf("%s.parameters.json", p.options.Module)
-	return filepath.Join(p.projectPath, ".azure", p.env.GetEnvName(), p.options.Path, parametersFilename)
 }
 
 // Gets the folder path to the specified module

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -20,46 +20,46 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBicepPreview(t *testing.T) {
+func TestBicepPlan(t *testing.T) {
 	progressLog := []string{}
 	interactiveLog := []bool{}
 	progressDone := make(chan bool)
 
 	mockContext := mocks.NewMockContext(context.Background())
 	prepareGenericMocks(mockContext.CommandRunner)
-	preparePreviewMocks(mockContext.CommandRunner)
+	preparePlanningMocks(mockContext.CommandRunner)
 
 	infraProvider := createBicepProvider(*mockContext.Context)
-	previewTask := infraProvider.Preview(*mockContext.Context)
+	planningTask := infraProvider.Plan(*mockContext.Context)
 
 	go func() {
-		for progressReport := range previewTask.Progress() {
+		for progressReport := range planningTask.Progress() {
 			progressLog = append(progressLog, progressReport.Message)
 		}
 		progressDone <- true
 	}()
 
 	go func() {
-		for previewInteractive := range previewTask.Interactive() {
-			interactiveLog = append(interactiveLog, previewInteractive)
+		for planningInteractive := range planningTask.Interactive() {
+			interactiveLog = append(interactiveLog, planningInteractive)
 		}
 	}()
 
-	previewResult, err := previewTask.Await()
+	deploymentPlan, err := planningTask.Await()
 	<-progressDone
 
 	require.Nil(t, err)
-	require.NotNil(t, previewResult.Deployment)
+	require.NotNil(t, deploymentPlan.Deployment)
 
 	require.Len(t, progressLog, 2)
 	require.Contains(t, progressLog[0], "Generating Bicep parameters file")
 	require.Contains(t, progressLog[1], "Compiling Bicep template")
 
-	require.Equal(t, infraProvider.env.Values["AZURE_LOCATION"], previewResult.Deployment.Parameters["location"].Value)
-	require.Equal(t, infraProvider.env.Values["AZURE_ENV_NAME"], previewResult.Deployment.Parameters["name"].Value)
+	require.Equal(t, infraProvider.env.Values["AZURE_LOCATION"], deploymentPlan.Deployment.Parameters["location"].Value)
+	require.Equal(t, infraProvider.env.Values["AZURE_ENV_NAME"], deploymentPlan.Deployment.Parameters["name"].Value)
 }
 
-func TestBicepGetDeploymentPreview(t *testing.T) {
+func TestBicepGetDeploymentPlan(t *testing.T) {
 	progressLog := []string{}
 	interactiveLog := []bool{}
 	progressDone := make(chan bool)
@@ -67,7 +67,7 @@ func TestBicepGetDeploymentPreview(t *testing.T) {
 
 	mockContext := mocks.NewMockContext(context.Background())
 	prepareGenericMocks(mockContext.CommandRunner)
-	preparePreviewMocks(mockContext.CommandRunner)
+	preparePlanningMocks(mockContext.CommandRunner)
 	prepareDeployMocks(mockContext.CommandRunner)
 
 	infraProvider := createBicepProvider(*mockContext.Context)
@@ -82,8 +82,8 @@ func TestBicepGetDeploymentPreview(t *testing.T) {
 	}()
 
 	go func() {
-		for previewInteractive := range getDeploymentTask.Interactive() {
-			interactiveLog = append(interactiveLog, previewInteractive)
+		for deploymentInteractive := range getDeploymentTask.Interactive() {
+			interactiveLog = append(interactiveLog, deploymentInteractive)
 		}
 	}()
 
@@ -108,14 +108,18 @@ func TestBicepDeploy(t *testing.T) {
 
 	mockContext := mocks.NewMockContext(context.Background())
 	prepareGenericMocks(mockContext.CommandRunner)
-	preparePreviewMocks(mockContext.CommandRunner)
+	preparePlanningMocks(mockContext.CommandRunner)
 	prepareDeployMocks(mockContext.CommandRunner)
 
 	infraProvider := createBicepProvider(*mockContext.Context)
-	deployment := Deployment{}
+	deploymentPlan := DeploymentPlan{
+		Details: BicepDeploymentDetails{
+			ParameterFilePath: "",
+		},
+	}
 
 	scope := infra.NewSubscriptionScope(*mockContext.Context, infraProvider.env.Values["AZURE_LOCATION"], infraProvider.env.GetSubscriptionId(), infraProvider.env.GetEnvName())
-	deployTask := infraProvider.Deploy(*mockContext.Context, &deployment, scope)
+	deployTask := infraProvider.Deploy(*mockContext.Context, &deploymentPlan, scope)
 
 	go func() {
 		for deployProgress := range deployTask.Progress() {
@@ -144,7 +148,7 @@ func TestBicepDestroy(t *testing.T) {
 	t.Run("Interactive", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		prepareGenericMocks(mockContext.CommandRunner)
-		preparePreviewMocks(mockContext.CommandRunner)
+		preparePlanningMocks(mockContext.CommandRunner)
 		prepareDestroyMocks(mockContext.CommandRunner)
 
 		progressLog := []string{}
@@ -196,18 +200,19 @@ func TestBicepDestroy(t *testing.T) {
 		require.Contains(t, consoleOutput[5], "Deleted deployment")
 
 		// Verify progress output
-		require.Len(t, progressLog, 5)
+		require.Len(t, progressLog, 6)
 		require.Contains(t, progressLog[0], "Fetching resource groups")
 		require.Contains(t, progressLog[1], "Fetching resources")
-		require.Contains(t, progressLog[2], "Deleting resource group")
-		require.Contains(t, progressLog[3], "Purging key vault")
-		require.Contains(t, progressLog[4], "Deleting deployment")
+		require.Contains(t, progressLog[2], "Getting KeyVaults to purge")
+		require.Contains(t, progressLog[3], "Deleting resource group")
+		require.Contains(t, progressLog[4], "Purging key vault")
+		require.Contains(t, progressLog[5], "Deleting deployment")
 	})
 
 	t.Run("InteractiveForceAndPurge", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		prepareGenericMocks(mockContext.CommandRunner)
-		preparePreviewMocks(mockContext.CommandRunner)
+		preparePlanningMocks(mockContext.CommandRunner)
 		prepareDestroyMocks(mockContext.CommandRunner)
 
 		progressLog := []string{}
@@ -247,12 +252,13 @@ func TestBicepDestroy(t *testing.T) {
 		require.Contains(t, consoleOutput[2], "Deleted deployment")
 
 		// Verify progress output
-		require.Len(t, progressLog, 5)
+		require.Len(t, progressLog, 6)
 		require.Contains(t, progressLog[0], "Fetching resource groups")
 		require.Contains(t, progressLog[1], "Fetching resources")
-		require.Contains(t, progressLog[2], "Deleting resource group")
-		require.Contains(t, progressLog[3], "Purging key vault")
-		require.Contains(t, progressLog[4], "Deleting deployment")
+		require.Contains(t, progressLog[2], "Getting KeyVaults to purge")
+		require.Contains(t, progressLog[3], "Deleting resource group")
+		require.Contains(t, progressLog[4], "Purging key vault")
+		require.Contains(t, progressLog[5], "Deleting deployment")
 	})
 }
 
@@ -279,7 +285,7 @@ func prepareGenericMocks(execUtil *execmock.MockCommandRunner) {
 	})
 }
 
-// Sets up all the mocks required for the bicep preview & deploy operation
+// Sets up all the mocks required for the bicep plan & deploy operation
 func prepareDeployMocks(execUtil *execmock.MockCommandRunner) {
 	// Gets deployment progress
 	execUtil.When(
@@ -299,7 +305,7 @@ func prepareDeployMocks(execUtil *execmock.MockCommandRunner) {
 	})
 }
 
-func preparePreviewMocks(execUtil *execmock.MockCommandRunner) {
+func preparePlanningMocks(execUtil *execmock.MockCommandRunner) {
 	expectedWebsiteUrl := "http://myapp.azurewebsites.net"
 	bicepInputParams := make(map[string]BicepInputParameter)
 	bicepInputParams["name"] = BicepInputParameter{Value: "${AZURE_ENV_NAME}"}

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -32,13 +32,13 @@ type Manager struct {
 }
 
 // Prepares for an infrastructure provision operation
-func (m *Manager) Preview(ctx context.Context) (*PreviewResult, error) {
-	previewResult, err := m.preview(ctx)
+func (m *Manager) Plan(ctx context.Context) (*DeploymentPlan, error) {
+	deploymentPlan, err := m.plan(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return previewResult, nil
+	return deploymentPlan, nil
 }
 
 // Gets the latest deployment details for the specified scope
@@ -74,15 +74,15 @@ func (m *Manager) GetDeployment(ctx context.Context, scope infra.Scope) (*Deploy
 }
 
 // Deploys the Azure infrastructure for the specified project
-func (m *Manager) Deploy(ctx context.Context, deployment *Deployment, scope infra.Scope) (*DeployResult, error) {
+func (m *Manager) Deploy(ctx context.Context, plan *DeploymentPlan, scope infra.Scope) (*DeployResult, error) {
 	// Ensure that a location has been set prior to provisioning
-	location, err := m.ensureLocation(ctx, deployment)
+	location, err := m.ensureLocation(ctx, &plan.Deployment)
 	if err != nil {
 		return nil, err
 	}
 
 	// Apply the infrastructure deployment
-	deployResult, err := m.deploy(ctx, location, deployment, scope)
+	deployResult, err := m.deploy(ctx, location, plan, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -116,46 +116,46 @@ func (m *Manager) Destroy(ctx context.Context, deployment *Deployment, options D
 	return destroyResult, nil
 }
 
-// Previews the infrastructure provisioning and orchestrates interactive terminal operations
-func (m *Manager) preview(ctx context.Context) (*PreviewResult, error) {
-	var previewResult *PreviewResult
+// Plans the infrastructure provisioning and orchestrates interactive terminal operations
+func (m *Manager) plan(ctx context.Context) (*DeploymentPlan, error) {
+	var deploymentPlan *DeploymentPlan
 
-	err := m.runAction("Preparing infrastructure provisioning", m.interactive, func(spinner *spin.Spinner) error {
-		previewTask := m.provider.Preview(ctx)
+	err := m.runAction("Planning infrastructure provisioning", m.interactive, func(spinner *spin.Spinner) error {
+		planningTask := m.provider.Plan(ctx)
 
 		go func() {
-			for progress := range previewTask.Progress() {
+			for progress := range planningTask.Progress() {
 				m.updateSpinnerTitle(spinner, progress.Message)
 			}
 		}()
 
-		go m.monitorInteraction(spinner, previewTask.Interactive())
+		go m.monitorInteraction(spinner, planningTask.Interactive())
 
-		result, err := previewTask.Await()
+		result, err := planningTask.Await()
 		if err != nil {
 			return err
 		}
 
-		previewResult = result
+		deploymentPlan = result
 
 		return nil
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("previewing infrastructure: %w", err)
+		return nil, fmt.Errorf("planning infrastructure provisioning: %w", err)
 	}
 
-	m.console.Message(ctx, "\nPrepared infrastructure provisioning")
+	m.console.Message(ctx, "\nInfrastructure provisioning planned")
 
-	return previewResult, nil
+	return deploymentPlan, nil
 }
 
 // Applies the specified infrastructure provisioning and orchestrates the interactive terminal operations
-func (m *Manager) deploy(ctx context.Context, location string, deployment *Deployment, scope infra.Scope) (*DeployResult, error) {
+func (m *Manager) deploy(ctx context.Context, location string, plan *DeploymentPlan, scope infra.Scope) (*DeployResult, error) {
 	var deployResult *DeployResult
 
 	err := m.runAction("Provisioning Azure resources", m.interactive, func(spinner *spin.Spinner) error {
-		deployTask := m.provider.Deploy(ctx, deployment, scope)
+		deployTask := m.provider.Deploy(ctx, plan, scope)
 
 		go func() {
 			for progress := range deployTask.Progress() {

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestManagerPreview(t *testing.T) {
+func TestManagerPlan(t *testing.T) {
 	env := environment.Environment{Values: make(map[string]string)}
 	env.Values["AZURE_LOCATION"] = "eastus2"
 	env.SetEnvName("test-env")
@@ -28,11 +28,11 @@ func TestManagerPreview(t *testing.T) {
 	test.RegisterTestProvider()
 	mgr, _ := NewManager(*mockContext.Context, env, "", options, interactive)
 
-	previewResult, err := mgr.Preview(*mockContext.Context)
+	deploymentPlan, err := mgr.Plan(*mockContext.Context)
 
-	require.NotNil(t, previewResult)
+	require.NotNil(t, deploymentPlan)
 	require.Nil(t, err)
-	require.Equal(t, previewResult.Deployment.Parameters["location"].Value, env.Values["AZURE_LOCATION"])
+	require.Equal(t, deploymentPlan.Deployment.Parameters["location"].Value, env.Values["AZURE_LOCATION"])
 }
 
 func TestManagerGetDeployment(t *testing.T) {
@@ -64,9 +64,9 @@ func TestManagerDeploy(t *testing.T) {
 	test.RegisterTestProvider()
 	mgr, _ := NewManager(*mockContext.Context, env, "", options, interactive)
 
-	previewResult, _ := mgr.Preview(*mockContext.Context)
+	deploymentPlan, _ := mgr.Plan(*mockContext.Context)
 	provisioningScope := infra.NewSubscriptionScope(*mockContext.Context, "eastus2", env.GetSubscriptionId(), env.GetEnvName())
-	deployResult, err := mgr.Deploy(*mockContext.Context, &previewResult.Deployment, provisioningScope)
+	deployResult, err := mgr.Deploy(*mockContext.Context, deploymentPlan, provisioningScope)
 
 	require.NotNil(t, deployResult)
 	require.Nil(t, err)
@@ -87,9 +87,9 @@ func TestManagerDestroyWithPositiveConfirmation(t *testing.T) {
 	test.RegisterTestProvider()
 	mgr, _ := NewManager(*mockContext.Context, env, "", options, interactive)
 
-	previewResult, _ := mgr.Preview(*mockContext.Context)
+	deploymentPlan, _ := mgr.Plan(*mockContext.Context)
 	destroyOptions := NewDestroyOptions(false, false)
-	destroyResult, err := mgr.Destroy(*mockContext.Context, &previewResult.Deployment, destroyOptions)
+	destroyResult, err := mgr.Destroy(*mockContext.Context, &deploymentPlan.Deployment, destroyOptions)
 
 	require.NotNil(t, destroyResult)
 	require.Nil(t, err)
@@ -111,9 +111,9 @@ func TestManagerDestroyWithNegativeConfirmation(t *testing.T) {
 	test.RegisterTestProvider()
 	mgr, _ := NewManager(*mockContext.Context, env, "", options, interactive)
 
-	previewResult, _ := mgr.Preview(*mockContext.Context)
+	deploymentPlan, _ := mgr.Plan(*mockContext.Context)
 	destroyOptions := NewDestroyOptions(false, false)
-	destroyResult, err := mgr.Destroy(*mockContext.Context, &previewResult.Deployment, destroyOptions)
+	destroyResult, err := mgr.Destroy(*mockContext.Context, &deploymentPlan.Deployment, destroyOptions)
 
 	require.Nil(t, destroyResult)
 	require.NotNil(t, err)

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -38,11 +38,14 @@ type Options struct {
 	Module   string       `yaml:"module"`
 }
 
-type PreviewResult struct {
+type DeploymentPlan struct {
 	Deployment Deployment
+
+	// Additional information about deployment, provider-specific.
+	Details interface{}
 }
 
-type PreviewProgress struct {
+type DeploymentPlanningProgress struct {
 	Message   string
 	Timestamp time.Time
 }
@@ -72,8 +75,8 @@ type Provider interface {
 	Name() string
 	RequiredExternalTools() []tools.ExternalTool
 	GetDeployment(ctx context.Context, scope infra.Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress]
-	Preview(ctx context.Context) *async.InteractiveTaskWithProgress[*PreviewResult, *PreviewProgress]
-	Deploy(ctx context.Context, deployment *Deployment, scope infra.Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress]
+	Plan(ctx context.Context) *async.InteractiveTaskWithProgress[*DeploymentPlan, *DeploymentPlanningProgress]
+	Deploy(ctx context.Context, plan *DeploymentPlan, scope infra.Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress]
 	Destroy(ctx context.Context, deployment *Deployment, options DestroyOptions) *async.InteractiveTaskWithProgress[*DestroyResult, *DestroyProgress]
 }
 

--- a/cli/azd/pkg/infra/provisioning/test/test_provider.go
+++ b/cli/azd/pkg/infra/provisioning/test/test_provider.go
@@ -33,23 +33,23 @@ func (p *TestProvider) RequiredExternalTools() []tools.ExternalTool {
 	return []tools.ExternalTool{}
 }
 
-func (p *TestProvider) Preview(ctx context.Context) *async.InteractiveTaskWithProgress[*PreviewResult, *PreviewProgress] {
+func (p *TestProvider) Plan(ctx context.Context) *async.InteractiveTaskWithProgress[*DeploymentPlan, *DeploymentPlanningProgress] {
 	return async.RunInteractiveTaskWithProgress(
-		func(asyncContext *async.InteractiveTaskContextWithProgress[*PreviewResult, *PreviewProgress]) {
-			asyncContext.SetProgress(&PreviewProgress{Message: "Preparing deployment", Timestamp: time.Now()})
+		func(asyncContext *async.InteractiveTaskContextWithProgress[*DeploymentPlan, *DeploymentPlanningProgress]) {
+			asyncContext.SetProgress(&DeploymentPlanningProgress{Message: "Planning deployment", Timestamp: time.Now()})
 
 			params := make(map[string]InputParameter)
 			params["location"] = InputParameter{Value: p.env.Values["AZURE_LOCATION"]}
 
-			previewResult := PreviewResult{
+			deploymentPlan := DeploymentPlan{
 				Deployment: Deployment{
 					Parameters: params,
 					Outputs:    make(map[string]OutputParameter),
 				},
 			}
 
-			asyncContext.SetProgress(&PreviewProgress{Message: "Deployment preparation completed", Timestamp: time.Now()})
-			asyncContext.SetResult(&previewResult)
+			asyncContext.SetProgress(&DeploymentPlanningProgress{Message: "Deployment planning completed", Timestamp: time.Now()})
+			asyncContext.SetResult(&deploymentPlan)
 		})
 }
 
@@ -77,7 +77,7 @@ func (p *TestProvider) GetDeployment(ctx context.Context, scope infra.Scope) *as
 }
 
 // Provisioning the infrastructure within the specified template
-func (p *TestProvider) Deploy(ctx context.Context, deployment *Deployment, scope infra.Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress] {
+func (p *TestProvider) Deploy(ctx context.Context, pd *DeploymentPlan, scope infra.Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress] {
 	return async.RunInteractiveTaskWithProgress(
 		func(asyncContext *async.InteractiveTaskContextWithProgress[*DeployResult, *DeployProgress]) {
 			asyncContext.SetProgress(&DeployProgress{

--- a/cli/azd/pkg/password/generator.go
+++ b/cli/azd/pkg/password/generator.go
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package password
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+)
+
+const (
+	LowercaseLetters = "abcdefghijklmnopqrstuvwxyz"
+	UppercaseLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	Digits           = "0123456789"
+	Symbols          = "~!@#$%^&*()_+`-={}|[]\\:\"<>?,./"
+)
+
+type PasswordComposition struct {
+	NumLowercase, NumUppercase, NumDigits, NumSymbols uint
+}
+
+// Generate password consisting of given number of lowercase letters, uppercase letters, digits, and "symbol" characters.
+func Generate(cmp PasswordComposition) (string, error) {
+	length := cmp.NumLowercase + cmp.NumUppercase + cmp.NumDigits + cmp.NumSymbols
+	if length == 0 {
+		return "", fmt.Errorf("Empty passwords are insecure")
+	}
+
+	chars := make([]byte, length)
+	var pos uint = 0
+	var err error
+
+	err = addRandomChars(chars, &pos, cmp.NumLowercase, LowercaseLetters)
+	if err != nil {
+		return "", err
+	}
+	err = addRandomChars(chars, &pos, cmp.NumUppercase, UppercaseLetters)
+	if err != nil {
+		return "", err
+	}
+	err = addRandomChars(chars, &pos, cmp.NumDigits, Digits)
+	if err != nil {
+		return "", err
+	}
+	err = addRandomChars(chars, &pos, cmp.NumSymbols, Symbols)
+	if err != nil {
+		return "", err
+	}
+
+	err = Shuffle(chars)
+	if err != nil {
+		return "", err
+	}
+	return string(chars), nil
+}
+
+func addRandomChars(buf []byte, pos *uint, count uint, choices string) error {
+	var i uint
+	for i = 0; i < count; i++ {
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(choices))))
+		if err != nil {
+			return err
+		}
+		buf[i+*pos] = choices[n.Int64()]
+	}
+
+	*pos += count
+	return nil
+}

--- a/cli/azd/pkg/password/generator_test.go
+++ b/cli/azd/pkg/password/generator_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package password
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestZeroLengthPasswordError(t *testing.T) {
+	_, err := Generate(PasswordComposition{})
+	require.Error(t, err)
+}
+
+func TestOneCharPassword(t *testing.T) {
+	// Really weak, so not practically usable, but we should be able to generate these 1-char passwords without errors
+
+	var pwd string
+	var err error
+
+	pwd, err = Generate(PasswordComposition{NumLowercase: 1})
+	require.NoError(t, err)
+	require.Len(t, pwd, 1)
+	require.Equal(t, 1, countCharsFrom(pwd, LowercaseLetters))
+
+	pwd, err = Generate(PasswordComposition{NumUppercase: 1})
+	require.NoError(t, err)
+	require.Len(t, pwd, 1)
+	require.Equal(t, 1, countCharsFrom(pwd, UppercaseLetters))
+
+	pwd, err = Generate(PasswordComposition{NumDigits: 1})
+	require.NoError(t, err)
+	require.Len(t, pwd, 1)
+	require.Equal(t, 1, countCharsFrom(pwd, Digits))
+
+	pwd, err = Generate(PasswordComposition{NumSymbols: 1})
+	require.NoError(t, err)
+	require.Len(t, pwd, 1)
+	require.Equal(t, 1, countCharsFrom(pwd, Symbols))
+}
+
+func TestPasswordContainsRequestedChars(t *testing.T) {
+	pwd, err := Generate(PasswordComposition{
+		NumLowercase: 3,
+		NumUppercase: 4,
+		NumDigits:    5,
+		NumSymbols:   6,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, 3, countCharsFrom(pwd, LowercaseLetters))
+	require.Equal(t, 4, countCharsFrom(pwd, UppercaseLetters))
+	require.Equal(t, 5, countCharsFrom(pwd, Digits))
+	require.Equal(t, 6, countCharsFrom(pwd, Symbols))
+}
+
+func TestPasswordShuffled(t *testing.T) {
+	pwd, err := Generate(PasswordComposition{NumLowercase: 10, NumUppercase: 20})
+	require.NoError(t, err)
+
+	// Should be super improbable for the lowercase letters to remain at the front
+	require.Less(t, countCharsFrom(string(pwd[0:20]), LowercaseLetters), 20)
+}
+
+func countCharsFrom(s, choices string) int {
+	count := 0
+	for i := 0; i < len(choices); i++ {
+		count += strings.Count(s, string(choices[i]))
+	}
+	return count
+}

--- a/cli/azd/pkg/password/shuffle.go
+++ b/cli/azd/pkg/password/shuffle.go
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package password
+
+import (
+	"crypto/rand"
+	"math/big"
+)
+
+// Fisher-Yates shuffle
+func Shuffle[T any](s []T) error {
+	N := len(s)
+	for i := N - 1; i > 0; i-- {
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(i+1))) // from 0 to i, inclusive
+		if err != nil {
+			return err
+		}
+		j := n.Int64()
+		s[j], s[i] = s[i], s[j]
+	}
+	return nil
+}

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -51,9 +51,9 @@ func (at *containerAppTarget) Deploy(ctx context.Context, azdCtx *azdcontext.Azd
 	}
 
 	progress <- "Creating deployment template"
-	previewResult, err := infraManager.Preview(ctx)
+	deploymentPlan, err := infraManager.Plan(ctx)
 	if err != nil {
-		return ServiceDeploymentResult{}, fmt.Errorf("previewing provisioning: %w", err)
+		return ServiceDeploymentResult{}, fmt.Errorf("planning provisioning: %w", err)
 	}
 
 	// Login to container registry.
@@ -98,7 +98,7 @@ func (at *containerAppTarget) Deploy(ctx context.Context, azdCtx *azdcontext.Azd
 	progress <- "Updating container app image reference"
 	deploymentName := fmt.Sprintf("%s-%s", at.env.GetEnvName(), at.config.Name)
 	scope := infra.NewResourceGroupScope(ctx, at.env.GetSubscriptionId(), at.scope.ResourceGroupName(), deploymentName)
-	deployResult, err := infraManager.Deploy(ctx, &previewResult.Deployment, scope)
+	deployResult, err := infraManager.Deploy(ctx, deploymentPlan, scope)
 
 	if err != nil {
 		return ServiceDeploymentResult{}, fmt.Errorf("provisioning infrastructure for app deployment: %w", err)

--- a/templates/todo/api/csharp-sql/Program.cs
+++ b/templates/todo/api/csharp-sql/Program.cs
@@ -1,13 +1,15 @@
-using Microsoft.ApplicationInsights.AspNetCore.Extensions;
+using Azure.Identity;
 using Microsoft.EntityFrameworkCore;
 using SimpleTodo.Api;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Configuration.AddAzureKeyVault(new Uri(builder.Configuration["AZURE_KEY_VAULT_ENDPOINT"]), new DefaultAzureCredential());
 
 builder.Services.AddScoped<ListsRepository>();
 builder.Services.AddDbContext<TodoDb>(options =>
 {
-    options.UseSqlServer(builder.Configuration["AZURE_SQL_CONNECTION_STRING"], sqlOptions => sqlOptions.EnableRetryOnFailure());
+    var connectionString = builder.Configuration[builder.Configuration["AZURE_SQL_CONNECTION_STRING_KEY"]];
+    options.UseSqlServer(connectionString, sqlOptions => sqlOptions.EnableRetryOnFailure());
 });
 
 builder.Services.AddControllers();

--- a/templates/todo/api/csharp-sql/Todo.Api.csproj
+++ b/templates/todo/api/csharp-sql/Todo.Api.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.5.0" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="4.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />

--- a/templates/todo/projects/csharp-sql/.vscode/launch.json
+++ b/templates/todo/projects/csharp-sql/.vscode/launch.json
@@ -1,0 +1,48 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Web",
+            "request": "launch",
+            "type": "msedge",
+            "webRoot": "${workspaceFolder}/src/web/src",
+            "url": "http://localhost:3000",
+            "sourceMapPathOverrides": {
+                "webpack:///src/*": "${webRoot}/*"
+            }, 
+        },
+
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+            "name": "Debug API",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build API",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/api/bin/Debug/net6.0/Todo.Api.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/api",
+            "stopAtEntry": false,
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "envFile": "${input:dotEnvFilePath}"
+        },
+
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ],
+
+    "inputs": [
+        {
+            "id": "dotEnvFilePath",
+            "type": "command",
+            "command": "azure-dev.commands.getDotEnvFilePath"
+        }
+    ]
+}

--- a/templates/todo/projects/csharp-sql/.vscode/tasks.json
+++ b/templates/todo/projects/csharp-sql/.vscode/tasks.json
@@ -1,0 +1,101 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Start API",
+            "type": "dotenv",
+            "targetTasks": "API dotnet run",
+            "file": "${input:dotEnvFilePath}"
+        },
+        {
+            "label": "API dotnet run",
+            "detail": "Helper task--use 'Start API' task to ensure environment is set up correctly",
+            "type": "shell",
+            "command": "dotnet run",
+            "options": {
+                "cwd": "${workspaceFolder}/src/api/"
+            },
+            "presentation": {
+                "panel": "dedicated",
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Build API",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/api/Todo.Api.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Watch API",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/src/api/Todo.Api.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+
+        {
+            "label": "Start Web",
+            "type": "dotenv",
+            "targetTasks": [
+                "Restore Web",
+                "Web npm start"
+            ],
+            "file": "${input:dotEnvFilePath}"
+        },
+        {
+            "label": "Restore Web",
+            "type": "shell",
+            "command": "azd restore --service web",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Web npm start",
+            "detail": "Helper task--use 'Start Web' task to ensure environment is set up correctly",
+            "type": "shell",
+            "command": "npm run start",
+            "options": {
+                "cwd": "${workspaceFolder}/src/web/",
+                "env": {
+                    "REACT_APP_API_BASE_URL": "http://localhost:3100",
+                    "BROWSER": "none"
+                }
+            },
+            "presentation": {
+                "panel": "dedicated",
+            },
+            "problemMatcher": []
+        },
+
+        {
+            "label": "Start API and Web",
+            "dependsOn":[
+                "Start API",
+                "Start Web"
+            ],
+            "problemMatcher": []
+        }
+    ],
+
+    "inputs": [
+        {
+            "id": "dotEnvFilePath",
+            "type": "command",
+            "command": "azure-dev.commands.getDotEnvFilePath"
+        }
+    ]
+}

--- a/templates/todo/projects/csharp-sql/infra/db.bicep
+++ b/templates/todo/projects/csharp-sql/infra/db.bicep
@@ -1,0 +1,93 @@
+param location string
+param resourceToken string
+param tags object
+
+param appUser string = 'todoApp'
+param sqlAdmin string = 'sqlAdmin'
+@secure()
+param sqlAdminPassword string
+@secure()
+param appUserPassword string
+
+var abbrs = loadJsonContent('../../../../common/infra/bicep/abbreviations.json')
+
+resource sqlServer 'Microsoft.Sql/servers@2022-02-01-preview' = {
+  name: '${abbrs.sqlServers}${resourceToken}'
+  location: location
+  tags: tags
+  properties: {
+    version: '12.0'
+    minimalTlsVersion: '1.2'
+    publicNetworkAccess: 'Enabled'
+    administratorLogin: sqlAdmin
+    administratorLoginPassword: sqlAdminPassword
+  }
+
+  resource database 'databases' = {
+    name: 'ToDo'
+    location: location
+  }
+
+  resource firewall 'firewallRules' = {
+    name: 'Azure Services'
+    properties: {
+      // Allow all clients 
+      // Note: range [0.0.0.0-0.0.0.0] means "allow all Azure-hosted clients only".
+      // This is not sufficient, because we also want to allow direct access from developer machine, for debugging purposes.
+      startIpAddress: '0.0.0.1'
+      endIpAddress: '255.255.255.254'
+    }
+  }
+}
+
+resource sqlDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: 'script-${resourceToken}'
+  location: location
+  kind: 'AzureCLI'
+  properties: {
+    azCliVersion: '2.37.0'
+    retentionInterval: 'PT1H' // Retain the script resource for 1 hour after it ends running
+    timeout: 'PT5M' // Five minutes
+    cleanupPreference: 'OnSuccess'
+    environmentVariables: [
+      {
+        name: 'DBSERVER'
+        value: sqlServer.properties.fullyQualifiedDomainName
+      }
+      {
+        name: 'SQLADMIN'
+        value: sqlAdmin
+      }
+      {
+        name: 'APPUSERNAME'
+        value: appUser
+      }
+      {
+        name: 'APPUSERPASSWORD'
+        secureValue: appUserPassword
+      }
+      {
+        name: 'SQLCMDPASSWORD'
+        secureValue: sqlAdminPassword
+      }
+    ]
+
+    scriptContent: '''
+wget https://github.com/microsoft/go-sqlcmd/releases/download/v0.8.1/sqlcmd-v0.8.1-linux-x64.tar.bz2
+tar x -f sqlcmd-v0.8.1-linux-x64.tar.bz2 -C .
+
+cat <<SCRIPT_END > ./initDb.sql
+drop user ${APPUSERNAME}
+go
+create user ${APPUSERNAME} with password = '${APPUSERPASSWORD}'
+go
+alter role db_owner add member ${APPUSERNAME}
+go
+SCRIPT_END
+
+./sqlcmd -S ${DBSERVER} -d ToDo -U ${SQLADMIN} -i ./initDb.sql
+    '''
+  }
+}
+
+output AZURE_SQL_CONNECTION_STRING string = 'Server=${sqlServer.properties.fullyQualifiedDomainName}; Database=${sqlServer::database.name}; User=${appUser}'

--- a/templates/todo/projects/csharp-sql/infra/main.bicep
+++ b/templates/todo/projects/csharp-sql/infra/main.bicep
@@ -9,6 +9,17 @@ param name string
 @description('Primary location for all resources')
 param location string
 
+@description('User identity to use as resource administrator')
+param principalId string = ''
+
+@secure()
+@description('SQL Server administrator password')
+param sqlAdminPassword string
+
+@secure()
+@description('Application user password')
+param appUserPassword string
+
 var resourceToken = toLower(uniqueString(subscription().id, name, location))
 var tags = { 'azd-env-name': name }
 var abbrs = loadJsonContent('../../../../common/infra/bicep/abbreviations.json')
@@ -24,14 +35,19 @@ module resources 'resources.bicep' = {
   scope: rg
   params: {
     location: location
+    principalId: principalId
     resourceToken: resourceToken
     tags: tags
+    sqlAdminPassword: sqlAdminPassword
+    appUserPassword: appUserPassword
   }
 }
 
-output AZURE_SQL_CONNECTION_STRING string = resources.outputs.AZURE_SQL_CONNECTION_STRING
 output APPLICATIONINSIGHTS_CONNECTION_STRING string = resources.outputs.APPLICATIONINSIGHTS_CONNECTION_STRING
 output REACT_APP_WEB_BASE_URL string = resources.outputs.WEB_URI
 output REACT_APP_API_BASE_URL string = resources.outputs.API_URI
 output REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING string = resources.outputs.APPLICATIONINSIGHTS_CONNECTION_STRING
 output AZURE_LOCATION string = location
+output AZURE_KEY_VAULT_ENDPOINT string = resources.outputs.AZURE_KEY_VAULT_ENDPOINT
+output AZURE_SQL_CONNECTION_STRING_KEY string = resources.outputs.AZURE_SQL_CONNECTION_STRING_KEY
+output KEYVAULT_NAME string = resources.outputs.KEYVAULT_NAME

--- a/templates/todo/projects/csharp-sql/infra/main.parameters.json
+++ b/templates/todo/projects/csharp-sql/infra/main.parameters.json
@@ -7,6 +7,15 @@
     },
     "location": {
       "value": "${AZURE_LOCATION}"
+    },
+    "principalId": {
+      "value": "${AZURE_PRINCIPAL_ID}"
+    },
+    "sqlAdminPassword" : {
+      "value": "$(secretOrRandomPassword ${KEYVAULT_NAME} sqlAdminPassword)"
+    },
+    "appUserPassword" : {
+      "value": "$(secretOrRandomPassword ${KEYVAULT_NAME} appUserPassword)"
     }
   }
 }

--- a/templates/todo/projects/csharp-sql/infra/resources.bicep
+++ b/templates/todo/projects/csharp-sql/infra/resources.bicep
@@ -1,7 +1,13 @@
 param location string
+param principalId string = ''
 param resourceToken string
 param tags object
+@secure()
+param sqlAdminPassword string
+@secure()
+param appUserPassword string
 
+var sqlConnectionStringSecretName = 'AZURE-SQL-CONNECTION-STRING'
 var abbrs = loadJsonContent('../../../../common/infra/bicep/abbreviations.json')
 
 resource web 'Microsoft.Web/sites@2022-03-01' = {
@@ -71,8 +77,9 @@ resource api 'Microsoft.Web/sites@2022-03-01' = {
   resource appSettings 'config' = {
     name: 'appsettings'
     properties: {
-      AZURE_SQL_CONNECTION_STRING: AZURE_SQL_CONNECTION_STRING
+      AZURE_SQL_CONNECTION_STRING_KEY: sqlConnectionStringSecretName
       APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsightsResources.outputs.APPLICATIONINSIGHTS_CONNECTION_STRING
+      AZURE_KEY_VAULT_ENDPOINT: keyVault.properties.vaultUri
     }
   }
 
@@ -136,44 +143,77 @@ module applicationInsightsResources '../../../../common/infra/bicep/applicationi
   }
 }
 
-// 2021-11-01-preview because that is latest valid version
-resource sqlServer 'Microsoft.Sql/servers@2022-02-01-preview' = {
-  name: '${abbrs.sqlServers}${resourceToken}'
+resource keyVault 'Microsoft.KeyVault/vaults@2021-10-01' = {
+  name: '${abbrs.keyVaultVaults}${resourceToken}'
   location: location
   tags: tags
   properties: {
-    version: '12.0'
-    minimalTlsVersion: '1.2'
-    publicNetworkAccess: 'Enabled'
-    administrators: {
-      administratorType: 'ActiveDirectory'
-      principalType: 'User'
-      sid: api.identity.principalId
-      login: 'activedirectoryadmin'
-      tenantId: api.identity.tenantId
-      azureADOnlyAuthentication: true
+  tenantId: subscription().tenantId
+  sku: {
+    family: 'A'
+    name: 'standard'
+  }
+  accessPolicies: concat([
+      {
+        objectId: api.identity.principalId
+        permissions: {
+          secrets: [
+            'get'
+            'list'
+          ]
+        }
+        tenantId: subscription().tenantId
+      }
+    ], !empty(principalId) ? [
+      {
+        objectId: principalId
+        permissions: {
+          secrets: [
+            'get'
+            'list'
+          ]
+        }
+        tenantId: subscription().tenantId
+      }
+    ] : [])
+  }
+
+  resource sqlAdminPasswordSecret 'secrets' = {
+    name: 'sqlAdminPassword'
+    properties: {
+      value: sqlAdminPassword
     }
   }
 
-  resource database 'databases' = {
-    name: 'ToDo'
-    location: location
+  resource appUserPasswordSecret 'secrets' = {
+    name: 'appUserPassword'
+    properties: {
+      value: appUserPassword
+    }
   }
 
-  resource firewall 'firewallRules' = {
-    name: 'Azure Services'
+  resource sqlAzureConnectionStringSercret 'secrets' = {
+    name: sqlConnectionStringSecretName
     properties: {
-      startIpAddress: '0.0.0.0'
-      endIpAddress: '0.0.0.0'
+      value: '${db.outputs.AZURE_SQL_CONNECTION_STRING}; Password=${appUserPassword}'
     }
   }
 }
 
-// Defined as a var here because it is used above
+module db './db.bicep' = {
+  name: 'db-${resourceToken}'
+  params: {
+    location: location
+    resourceToken: resourceToken
+    tags: tags
+    sqlAdminPassword: sqlAdminPassword
+    appUserPassword: appUserPassword
+  }
+}
 
-var AZURE_SQL_CONNECTION_STRING = 'Server=${sqlServer.properties.fullyQualifiedDomainName}; Authentication=Active Directory Default; Database=${sqlServer::database.name};'
-
-output AZURE_SQL_CONNECTION_STRING string = AZURE_SQL_CONNECTION_STRING
+output AZURE_KEY_VAULT_ENDPOINT string = keyVault.properties.vaultUri
 output APPLICATIONINSIGHTS_CONNECTION_STRING string = applicationInsightsResources.outputs.APPLICATIONINSIGHTS_CONNECTION_STRING
 output WEB_URI string = 'https://${web.properties.defaultHostName}'
 output API_URI string = 'https://${api.properties.defaultHostName}'
+output AZURE_SQL_CONNECTION_STRING_KEY string = sqlConnectionStringSecretName
+output KEYVAULT_NAME string = keyVault.name


### PR DESCRIPTION
A bigger change than just the template because we need to add password-generation capability to AZD (for Bicep). Note that if we decide to have an equivalent Terraform template, no extra work will be necessary because Terraform already has password generation built-in.

The changes to deployment provider (renaming `Preview()` to `Prepare()` method and having `Deploy()` take a `PreparedDeployment` is something @ellismg @HadwaAbdelhalem and @wbreza discussed offline.

I will need some help with making this template subject to automated tests and flipping the corresponding repo to public--TIA!

Fixes https://github.com/Azure/azure-dev/issues/450