### PR TITLE
Validate Mac install-over scenario

### DIFF
--- a/cli/installer/install-azd.sh
+++ b/cli/installer/install-azd.sh
@@ -202,10 +202,10 @@ chmod +x "$tmp_folder/$bin_name"
 
 install_location="$install_folder/azd"
 if [ -w "$install_folder/" ]; then
-    cp "$tmp_folder/$bin_name" "$install_location"
+    mv "$tmp_folder/$bin_name" "$install_location"
 else
     say "Writing to $install_folder/ requires elevated permission. You may be prompted to enter credentials."
-    sudo cp "$tmp_folder/$bin_name" "$install_location"
+    sudo mv "$tmp_folder/$bin_name" "$install_location"
 fi
 
 say_verbose "Cleaning up temp folder: $tmp_folder"

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -511,31 +511,16 @@ stages:
         steps: 
           - checkout: self
 
-          - bash: nohup npx -y http-server &
-            displayName: Start server in hosting/ (bash)
-            condition: and(succeeded(), not(contains(variables['Agent.OS'], 'Windows')))
-            workingDirectory: hosting
-
-          - pwsh: |
-              Start-Process npx.cmd `
-                -ArgumentList @('-y', 'http-server') `
-                -NoNewWindow `
-                -PassThru `
-                -RedirectStandardOutput ../server.log
-              Write-Host "Server started, waiting for server to initialize"
-              Start-Sleep -Seconds 15
-            displayName: Start server in hosting/ (pwsh)
-            condition: and(succeeded(), contains(variables['Agent.OS'], 'Windows'))
-            workingDirectory: hosting
-
-          - bash: curl -fsSL http://127.0.0.1:8080/install-azd.sh | bash -s -- --version daily --verbose
+          - bash: ./install-azd.sh --version daily --verbose
             displayName: Install "daily" version
+            workingDirectory: cli/installer/
 
           - pwsh: azd version
             displayName: Run azd version
 
-          - bash: curl -fsSL http://127.0.0.1:8080/install-azd.sh | bash -s -- --version latest --verbose
+          - bash: ./install-azd.sh --version latest --verbose
             displayName: Install "latest" version
+            workingDirectory: cli/installer/
 
           - pwsh: azd version
             displayName: Run azd version (expect no failure)

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -503,6 +503,43 @@ stages:
             env:
               GH_TOKEN: $(azuresdk-github-pat)
 
+      - job: Verify_Mac_InstallOver
+        pool: 
+          name: Azure Pipelines
+          vmImage: macOS-12
+        
+        steps: 
+          - checkout: self
+
+          - bash: nohup npx -y http-server &
+            displayName: Start server in hosting/ (bash)
+            condition: and(succeeded(), not(contains(variables['Agent.OS'], 'Windows')))
+            workingDirectory: hosting
+
+          - pwsh: |
+              Start-Process npx.cmd `
+                -ArgumentList @('-y', 'http-server') `
+                -NoNewWindow `
+                -PassThru `
+                -RedirectStandardOutput ../server.log
+              Write-Host "Server started, waiting for server to initialize"
+              Start-Sleep -Seconds 15
+            displayName: Start server in hosting/ (pwsh)
+            condition: and(succeeded(), contains(variables['Agent.OS'], 'Windows'))
+            workingDirectory: hosting
+
+          - bash: curl -fsSL http://127.0.0.1:8080/install-azd.sh | bash -s -- --version daily --verbose
+            displayName: Install "daily" version
+
+          - pwsh: azd version
+            displayName: Run azd version
+
+          - bash: curl -fsSL http://127.0.0.1:8080/install-azd.sh | bash -s -- --version latest --verbose
+            displayName: Install "latest" version
+
+          - pwsh: azd version
+            displayName: Run azd version (expect no failure)
+
       - job: Verify_Installers
         condition: >-
           and(


### PR DESCRIPTION
Fixes #430

Install-over scenario failing: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1818525&view=logs&s=62dbc4f1-f27c-5ddb-f6ac-c39a8a0ad4eb&j=3af97778-1b65-5cdf-4769-7545b9560ece

Install-over scenario succeeding after changing from `cp` to `mv`: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1824321&view=logs&j=3af97778-1b65-5cdf-4769-7545b9560ece&t=ff826ce0-844a-565c-9402-6d06ff212f8e