### PR TITLE
Moves infra modules into seperate packages

### DIFF
--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/cmd"
 	"github.com/azure/azure-dev/cli/azd/internal"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/bicep"
+	"github.com/azure/azure-dev/cli/azd/pkg/container"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/blang/semver/v4"
@@ -35,7 +35,7 @@ func main() {
 		log.SetOutput(io.Discard)
 	}
 
-	registerProviders()
+	container.RegisterDependencies()
 
 	latest := make(chan semver.Version)
 	go fetchLatestVersion(latest)
@@ -243,8 +243,4 @@ func readToEndAndClose(r io.ReadCloser) (string, error) {
 	var buf strings.Builder
 	_, err := io.Copy(&buf, r)
 	return buf.String(), err
-}
-
-func registerProviders() {
-	bicep.Register()
 }

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/cmd"
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/bicep"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/blang/semver/v4"
@@ -33,6 +34,8 @@ func main() {
 	if !isDebugEnabled() {
 		log.SetOutput(io.Discard)
 	}
+
+	registerProviders()
 
 	latest := make(chan semver.Version)
 	go fetchLatestVersion(latest)
@@ -240,4 +243,8 @@ func readToEndAndClose(r io.ReadCloser) (string, error) {
 	var buf strings.Builder
 	_, err := io.Copy(&buf, r)
 	return buf.String(), err
+}
+
+func registerProviders() {
+	bicep.Register()
 }

--- a/cli/azd/pkg/container/dependencies.go
+++ b/cli/azd/pkg/container/dependencies.go
@@ -1,0 +1,13 @@
+package container
+
+import "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/bicep"
+
+// Register azd dependencies
+func RegisterDependencies() {
+	registerInfraProviders()
+}
+
+// Register infra provisioning providers.
+func registerInfraProviders() {
+	bicep.Register()
+}

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -19,7 +19,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	. "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -52,7 +51,7 @@ type BicepOutputParameter struct {
 type BicepProvider struct {
 	env         *environment.Environment
 	projectPath string
-	options     provisioning.Options
+	options     Options
 	console     input.Console
 	bicepCli    bicep.BicepCli
 	azCli       azcli.AzCli

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -676,7 +676,11 @@ func NewBicepProvider(ctx context.Context, env *environment.Environment, project
 
 // Registers the Bicep provider with the provisioning module
 func Register() {
-	RegisterProvider(Bicep, func(ctx context.Context, env *environment.Environment, projectPath string, options Options) (Provider, error) {
+	err := RegisterProvider(Bicep, func(ctx context.Context, env *environment.Environment, projectPath string, options Options) (Provider, error) {
 		return NewBicepProvider(ctx, env, projectPath, options), nil
 	})
+
+	if err != nil {
+		panic(err)
+	}
 }

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package provisioning
+package bicep
 
 import (
 	"context"
@@ -19,6 +19,8 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
+	. "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
@@ -50,7 +52,7 @@ type BicepOutputParameter struct {
 type BicepProvider struct {
 	env         *environment.Environment
 	projectPath string
-	options     Options
+	options     provisioning.Options
 	console     input.Console
 	bicepCli    bicep.BicepCli
 	azCli       azcli.AzCli
@@ -671,4 +673,11 @@ func NewBicepProvider(ctx context.Context, env *environment.Environment, project
 		bicepCli:    bicepCli,
 		azCli:       azCli,
 	}
+}
+
+// Registers the Bicep provider with the provisioning module
+func Register() {
+	RegisterProvider(Bicep, func(ctx context.Context, env *environment.Environment, projectPath string, options Options) (Provider, error) {
+		return NewBicepProvider(ctx, env, projectPath, options), nil
+	})
 }

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package provisioning
+package bicep
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/executil"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	. "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -256,7 +257,7 @@ func TestBicepDestroy(t *testing.T) {
 }
 
 func createBicepProvider(ctx context.Context) *BicepProvider {
-	projectDir := "../../../test/samples/webapp"
+	projectDir := "../../../../test/samples/webapp"
 	options := Options{
 		Module: "main",
 	}

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package provisioning
+package provisioning_test
 
 import (
 	"context"
@@ -10,6 +10,8 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	. "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/test"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
@@ -23,6 +25,7 @@ func TestManagerPreview(t *testing.T) {
 	interactive := false
 
 	mockContext := mocks.NewMockContext(context.Background())
+	test.RegisterTestProvider()
 	mgr, _ := NewManager(*mockContext.Context, env, "", options, interactive)
 
 	previewResult, err := mgr.Preview(*mockContext.Context)
@@ -40,6 +43,7 @@ func TestManagerGetDeployment(t *testing.T) {
 	interactive := false
 
 	mockContext := mocks.NewMockContext(context.Background())
+	test.RegisterTestProvider()
 	mgr, _ := NewManager(*mockContext.Context, env, "", options, interactive)
 
 	provisioningScope := infra.NewSubscriptionScope(*mockContext.Context, "eastus2", env.GetSubscriptionId(), env.GetEnvName())
@@ -57,6 +61,7 @@ func TestManagerDeploy(t *testing.T) {
 	interactive := false
 
 	mockContext := mocks.NewMockContext(context.Background())
+	test.RegisterTestProvider()
 	mgr, _ := NewManager(*mockContext.Context, env, "", options, interactive)
 
 	previewResult, _ := mgr.Preview(*mockContext.Context)
@@ -79,6 +84,7 @@ func TestManagerDestroyWithPositiveConfirmation(t *testing.T) {
 		return strings.Contains(options.Message, "Are you sure you want to destroy?")
 	}).Respond(true)
 
+	test.RegisterTestProvider()
 	mgr, _ := NewManager(*mockContext.Context, env, "", options, interactive)
 
 	previewResult, _ := mgr.Preview(*mockContext.Context)
@@ -102,6 +108,7 @@ func TestManagerDestroyWithNegativeConfirmation(t *testing.T) {
 		return strings.Contains(options.Message, "Are you sure you want to destroy?")
 	}).Respond(false)
 
+	test.RegisterTestProvider()
 	mgr, _ := NewManager(*mockContext.Context, env, "", options, interactive)
 
 	previewResult, _ := mgr.Preview(*mockContext.Context)

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -17,6 +17,12 @@ import (
 
 type ProviderKind string
 
+type NewProviderFn func(ctx context.Context, env *environment.Environment, projectPath string, infraOptions Options) (Provider, error)
+
+var (
+	providers map[ProviderKind]NewProviderFn = make(map[ProviderKind]NewProviderFn)
+)
+
 const (
 	Bicep     ProviderKind = "bicep"
 	Arm       ProviderKind = "arm"
@@ -70,23 +76,29 @@ type Provider interface {
 	Destroy(ctx context.Context, deployment *Deployment, options DestroyOptions) *async.InteractiveTaskWithProgress[*DestroyResult, *DestroyProgress]
 }
 
+// Registers a provider creation function for the specified provider kind
+func RegisterProvider(kind ProviderKind, newFn NewProviderFn) error {
+	providers[kind] = newFn
+
+	return nil
+}
+
 func NewProvider(ctx context.Context, env *environment.Environment, projectPath string, infraOptions Options) (Provider, error) {
 	var provider Provider
 
-	switch infraOptions.Provider {
-	case Bicep:
-		provider = NewBicepProvider(ctx, env, projectPath, infraOptions)
-	case Test:
-		provider = NewTestProvider(ctx, env, projectPath, infraOptions)
-	default:
-		provider = NewBicepProvider(ctx, env, projectPath, infraOptions)
+	if infraOptions.Provider == "" {
+		infraOptions.Provider = Bicep
 	}
 
-	if provider != nil {
-		return provider, nil
+	newProviderFn, ok := providers[infraOptions.Provider]
+	if !ok {
+		return nil, fmt.Errorf("provider '%s' is not supported", infraOptions.Provider)
 	}
 
-	return nil, fmt.Errorf("provider '%s' is not supported", infraOptions.Provider)
+	provider, err := newProviderFn(ctx, env, projectPath, infraOptions)
+	if err != nil {
+		return nil, fmt.Errorf("error creating provider for type '%s'", infraOptions.Provider)
+	}
+
+	return provider, nil
 }
-
-var _ BicepProvider = BicepProvider{}

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -5,6 +5,7 @@ package provisioning
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -78,8 +79,11 @@ type Provider interface {
 
 // Registers a provider creation function for the specified provider kind
 func RegisterProvider(kind ProviderKind, newFn NewProviderFn) error {
-	providers[kind] = newFn
+	if newFn == nil {
+		return errors.New("NewProviderFn is required")
+	}
 
+	providers[kind] = newFn
 	return nil
 }
 
@@ -97,7 +101,7 @@ func NewProvider(ctx context.Context, env *environment.Environment, projectPath 
 
 	provider, err := newProviderFn(ctx, env, projectPath, infraOptions)
 	if err != nil {
-		return nil, fmt.Errorf("error creating provider for type '%s'", infraOptions.Provider)
+		return nil, fmt.Errorf("error creating provider for type '%s' : %w", infraOptions.Provider, err)
 	}
 
 	return provider, nil

--- a/cli/azd/pkg/infra/provisioning/test/test_provider.go
+++ b/cli/azd/pkg/infra/provisioning/test/test_provider.go
@@ -151,7 +151,11 @@ func NewTestProvider(ctx context.Context, env *environment.Environment, projectP
 
 // Registers the Test provider with the provisioning module
 func RegisterTestProvider() {
-	RegisterProvider(Test, func(ctx context.Context, env *environment.Environment, projectPath string, options Options) (Provider, error) {
+	err := RegisterProvider(Test, func(ctx context.Context, env *environment.Environment, projectPath string, options Options) (Provider, error) {
 		return NewTestProvider(ctx, env, projectPath, options), nil
 	})
+
+	if err != nil {
+		panic(err)
+	}
 }

--- a/cli/azd/pkg/infra/provisioning/test/test_provider.go
+++ b/cli/azd/pkg/infra/provisioning/test/test_provider.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package provisioning
+package test
 
 import (
 	"context"
@@ -11,6 +11,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	. "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
@@ -146,4 +147,11 @@ func NewTestProvider(ctx context.Context, env *environment.Environment, projectP
 		options:     options,
 		console:     input.GetConsole(ctx),
 	}
+}
+
+// Registers the Test provider with the provisioning module
+func RegisterTestProvider() {
+	RegisterProvider(Test, func(ctx context.Context, env *environment.Environment, projectPath string, options Options) (Provider, error) {
+		return NewTestProvider(ctx, env, projectPath, options), nil
+	})
 }

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/cmd"
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/container"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/executil"
@@ -676,6 +677,8 @@ func getTestEnvPath(dir string, envName string) string {
 // the provided `testing.T` has a deadline applied, the returned context
 // respects the deadline.
 func newTestContext(t *testing.T) (context.Context, context.CancelFunc) {
+	container.RegisterDependencies()
+
 	ctx := context.Background()
 	ctx = internal.WithCommandOptions(ctx, internal.GlobalCommandOptions{})
 


### PR DESCRIPTION
Moves the `bicep` and `test` infra providers into their respective packages.
Also introduces a **registration** concept for providers to register themselves with azd and to avoid circular dependencies.