### PR TITLE
Switch to azure resource list

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -33,6 +33,7 @@ functionapp
 GOARCH
 godotenv
 golangci
+jmes
 keychain
 ldflags
 mgmt

--- a/cli/azd/cmd/monitor.go
+++ b/cli/azd/cmd/monitor.go
@@ -98,7 +98,7 @@ func (m *monitorAction) Run(ctx context.Context, cmd *cobra.Command, args []stri
 	var portalResources []azcli.AzCliResource
 
 	for _, resourceGroup := range resourceGroups {
-		resources, err := azCli.ListResourceGroupResources(ctx, env.GetSubscriptionId(), resourceGroup)
+		resources, err := azCli.ListResourceGroupResources(ctx, env.GetSubscriptionId(), resourceGroup, nil)
 		if err != nil {
 			return fmt.Errorf("listing resources: %w", err)
 		}

--- a/cli/azd/pkg/infra/azure_resource_manager.go
+++ b/cli/azd/pkg/infra/azure_resource_manager.go
@@ -121,8 +121,7 @@ func (rm *AzureResourceManager) GetResourceGroupsForEnvironment(ctx context.Cont
 
 // GetDefaultResourceGroups gets the default resource groups regardless of azd-env-name setting
 // azd initially released with {envname}-rg for a default resource group name.  We now don't hardcode the default
-// We search graph for them instead using the rg- prefix or -rg suffix
-// The resource graph may not be immediately up to date and if not initially found will attempt to retry causing delays in retrieval.
+// We search for them instead using the rg- prefix or -rg suffix
 func (rm *AzureResourceManager) GetDefaultResourceGroups(ctx context.Context, env *environment.Environment) ([]azcli.AzCliResource, error) {
 	azCli := azcli.GetAzCli(ctx)
 	query := fmt.Sprintf("[?name=='rg-%[1]s' || name=='%[1]s-rg']", env.GetEnvName())

--- a/cli/azd/pkg/infra/azure_resource_manager.go
+++ b/cli/azd/pkg/infra/azure_resource_manager.go
@@ -8,17 +8,14 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azureutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
-	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 )
 
 type AzureResourceManager struct {
-	azCli         azcli.AzCli
-	retryStrategy *osutil.RetryStrategy
+	azCli azcli.AzCli
 }
 
 type ResourceManager interface {
@@ -31,8 +28,7 @@ func NewAzureResourceManager(ctx context.Context) *AzureResourceManager {
 	azCli := azcli.GetAzCli(ctx)
 
 	return &AzureResourceManager{
-		azCli:         azCli,
-		retryStrategy: osutil.NewRetryStrategy(10, time.Second*5),
+		azCli: azCli,
 	}
 }
 

--- a/cli/azd/pkg/infra/azure_resource_manager.go
+++ b/cli/azd/pkg/infra/azure_resource_manager.go
@@ -111,12 +111,13 @@ func (rm *AzureResourceManager) GetResourceGroupsForEnvironment(ctx context.Cont
 	res, err := azCli.ListResourceGroup(ctx, env.GetSubscriptionId(), &azcli.ListResourceGroupOptions{
 		TagFilter: &azcli.Filter{Key: "azd-env-name", Value: env.GetEnvName()},
 	})
+
 	if err != nil {
 		return nil, err
 	}
 
 	if len(res) == 0 {
-		return nil, azureutil.ResourceNotFound(fmt.Errorf("0 results for resource groups with azd-env-name with value: '%s'", env.GetEnvName()))
+		return nil, azureutil.ResourceNotFound(fmt.Errorf("0 resource groups with azd-env-name with value: '%s'", env.GetEnvName()))
 	}
 
 	return res, nil
@@ -138,7 +139,7 @@ func (rm *AzureResourceManager) GetDefaultResourceGroups(ctx context.Context, en
 	}
 
 	if len(res) == 0 {
-		return nil, azureutil.ResourceNotFound(fmt.Errorf("0 results for resource groups with azd-env-name with value: '%s'", env.GetEnvName()))
+		return nil, azureutil.ResourceNotFound(fmt.Errorf("0 resource groups with prefix or suffix with value: '%s'", env.GetEnvName()))
 	}
 
 	return res, nil

--- a/cli/azd/pkg/infra/provisioning/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep_provider.go
@@ -268,7 +268,7 @@ func (p *BicepProvider) getAllResources(ctx context.Context, asyncContext *async
 	asyncContext.SetProgress(&DestroyProgress{Message: "Fetching resources", Timestamp: time.Now()})
 
 	for _, resourceGroup := range resourceGroups {
-		resources, err := p.azCli.ListResourceGroupResources(ctx, p.env.GetSubscriptionId(), resourceGroup)
+		resources, err := p.azCli.ListResourceGroupResources(ctx, p.env.GetSubscriptionId(), resourceGroup, nil)
 		if err != nil {
 			return []azcli.AzCliResource{}, nil
 		}

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -23,6 +23,7 @@ services:
     project: src/web
     language: js
     host: containerapp
+    resourceName: test-containerapp-web
 `
 	ran := false
 
@@ -49,8 +50,11 @@ services:
 		}, nil
 	})
 
-	projectConfig, _ := ParseProjectConfig(testProj, &env)
-	prj, _ := projectConfig.GetProject(mockContext.Context, &env)
+	projectConfig, err := ParseProjectConfig(testProj, &env)
+	require.NoError(t, err)
+	prj, err := projectConfig.GetProject(mockContext.Context, &env)
+	require.NoError(t, err)
+
 	service := prj.Services[0]
 
 	dockerArgs := docker.DockerArgs{RunWithResultFn: mockContext.CommandRunner.RunWithResult}
@@ -92,6 +96,7 @@ services:
     project: src/web
     language: js
     host: containerapp
+    resourceName: test-containerapp-web
     docker:
       path: ./Dockerfile.dev
       context: ../
@@ -126,8 +131,12 @@ services:
 	dockerArgs := docker.DockerArgs{RunWithResultFn: mockContext.CommandRunner.RunWithResult}
 	docker := docker.NewDocker(dockerArgs)
 
-	projectConfig, _ := ParseProjectConfig(testProj, &env)
-	prj, _ := projectConfig.GetProject(mockContext.Context, &env)
+	projectConfig, err := ParseProjectConfig(testProj, &env)
+	require.NoError(t, err)
+
+	prj, err := projectConfig.GetProject(mockContext.Context, &env)
+	require.NoError(t, err)
+
 	service := prj.Services[0]
 
 	progress := make(chan string)

--- a/cli/azd/pkg/project/project_config_test.go
+++ b/cli/azd/pkg/project/project_config_test.go
@@ -7,9 +7,7 @@ import (
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
-	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
-	"github.com/azure/azure-dev/cli/azd/test/mocks/executil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -93,19 +91,7 @@ services:
     language: js
     host: appservice
 `
-	rg := "rg-test"
 	mockContext := mocks.NewMockContext(context.Background())
-	mockContext.CommandRunner.AddAzResourceListMock(&executil.AzResourceListMockOptions{
-		MatchResourceGroup: &rg,
-	},
-		[]azcli.AzCliResource{
-			{
-				Id:       "any",
-				Name:     "any",
-				Type:     "any",
-				Location: "any",
-			},
-		})
 
 	e := environment.Environment{Values: make(map[string]string)}
 	e.SetEnvName("test-env")

--- a/cli/azd/pkg/project/project_config_test.go
+++ b/cli/azd/pkg/project/project_config_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/executil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -91,7 +93,19 @@ services:
     language: js
     host: appservice
 `
+	rg := "rg-test"
 	mockContext := mocks.NewMockContext(context.Background())
+	mockContext.CommandRunner.AddAzResourceListMock(&executil.AzResourceListMockOptions{
+		MatchResourceGroup: &rg,
+	},
+		[]azcli.AzCliResource{
+			{
+				Id:       "any",
+				Name:     "any",
+				Type:     "any",
+				Location: "any",
+			},
+		})
 
 	e := environment.Environment{Values: make(map[string]string)}
 	e.SetEnvName("test-env")

--- a/cli/azd/pkg/project/service.go
+++ b/cli/azd/pkg/project/service.go
@@ -86,9 +86,7 @@ func (svc *Service) Deploy(ctx context.Context, azdCtx *azdcontext.AzdContext) (
 	return result, progress
 }
 
-// GetServiceResourceName attempts to query the azure resource graph and find the resource with the 'azd-service-name' tag set to the service key
-// If not found will assume resource name conventions
-// The resource graph may not be immediately up to date and if not initially found will attempt to retry causing delays in retrieval.
+// GetServiceResourceName attempts to find the name of the azure resource with the 'azd-service-name' tag set to the service key.
 func GetServiceResourceName(ctx context.Context, resourceGroupName string, serviceName string, env *environment.Environment) (string, error) {
 	azCli := azcli.GetAzCli(ctx)
 	query := fmt.Sprintf("[?tags.\"azd-service-name\" =='%s']", serviceName)

--- a/cli/azd/pkg/project/service.go
+++ b/cli/azd/pkg/project/service.go
@@ -91,7 +91,7 @@ func (svc *Service) Deploy(ctx context.Context, azdCtx *azdcontext.AzdContext) (
 // The resource graph may not be immediately up to date and if not initially found will attempt to retry causing delays in retrieval.
 func GetServiceResourceName(ctx context.Context, resourceGroupName string, serviceName string, env *environment.Environment) (string, error) {
 	azCli := azcli.GetAzCli(ctx)
-	query := fmt.Sprintf(`"[?tags.\"azd-service-name\" =='%s']"`, serviceName)
+	query := fmt.Sprintf("[?tags.\"azd-service-name\" =='%s']", serviceName)
 
 	res, err := azCli.ListResourceGroupResources(ctx, env.GetSubscriptionId(), resourceGroupName, &azcli.ListResourceGroupResourcesOptions{
 		JmesPathQuery: &query,

--- a/cli/azd/pkg/project/service.go
+++ b/cli/azd/pkg/project/service.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/azure/azure-dev/cli/azd/pkg/azureutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
@@ -99,9 +98,7 @@ func GetServiceResourceName(ctx context.Context, resourceGroupName string, servi
 		return "", err
 	}
 
-	if len(res) == 0 {
-		return "", azureutil.ResourceNotFound(fmt.Errorf("0 results for resources with group name '%s' and azd-service-name '%s'", resourceGroupName, serviceName))
-	} else if len(res) != 1 {
+	if len(res) != 1 {
 		log.Printf("Expecting only '1' resource match to override resource name but found '%d'", len(res))
 		return fmt.Sprintf("%s%s", env.GetEnvName(), serviceName), nil
 	}

--- a/cli/azd/pkg/project/service.go
+++ b/cli/azd/pkg/project/service.go
@@ -91,8 +91,10 @@ func (svc *Service) Deploy(ctx context.Context, azdCtx *azdcontext.AzdContext) (
 // The resource graph may not be immediately up to date and if not initially found will attempt to retry causing delays in retrieval.
 func GetServiceResourceName(ctx context.Context, resourceGroupName string, serviceName string, env *environment.Environment) (string, error) {
 	azCli := azcli.GetAzCli(ctx)
+	query := fmt.Sprintf(`"[?tags.\"azd-service-name\" =='%s']"`, serviceName)
+
 	res, err := azCli.ListResourceGroupResources(ctx, env.GetSubscriptionId(), resourceGroupName, &azcli.ListResourceGroupResourcesOptions{
-		TagFilter: &azcli.Filter{Key: "azd-env-name", Value: env.GetEnvName()},
+		JmesPathQuery: &query,
 	})
 
 	if err != nil {

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -1091,10 +1091,14 @@ func (cli *azCli) runAzCommandWithArgs(ctx context.Context, args executil.RunArg
 
 var isNotLoggedInMessageRegex = regexp.MustCompile(`Please run ('|")az login('|") to (setup account|access your accounts)\.`)
 
-// AADSTS70043: The refresh token has expired or is invalid due to sign-in frequency checks by conditional access.
+// Regex for "AADSTS70043: The refresh token has expired or is invalid due to sign-in frequency checks by conditional access."
 var isRefreshTokenExpiredMessageRegex = regexp.MustCompile(`AADSTS70043`)
 var isResourceSegmentMeNotFoundMessageRegex = regexp.MustCompile(`Resource not found for the segment 'me'.`)
+
+// Regex for "(DeploymentNotFound) Deployment '<name>' could not be found."
 var isDeploymentNotFoundMessageRegex = regexp.MustCompile(`\(DeploymentNotFound\)`)
+
+// Regex for "AADSTS700024: Client assertion is not within its valid time range."
 var isClientAssertionInvalidMessagedRegex = regexp.MustCompile(`AADSTS700024`)
 var isConfigurationIsNotSetMessageRegex = regexp.MustCompile(`Configuration '.*' is not set\.`)
 var isDeploymentErrorRegex = regexp.MustCompile(`ERROR: ({.+})`)

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -275,8 +275,6 @@ type ListResourceGroupOptions struct {
 
 // Optional list parameters for resource group resources listing.
 type ListResourceGroupResourcesOptions struct {
-	// An optional tag filter
-	TagFilter *Filter
 	// An optional JMES path query
 	JmesPathQuery *string
 }
@@ -761,10 +759,6 @@ func (cli *azCli) ListResourceGroup(ctx context.Context, subscriptionId string, 
 func (cli *azCli) ListResourceGroupResources(ctx context.Context, subscriptionId string, resourceGroupName string, listOptions *ListResourceGroupResourcesOptions) ([]AzCliResource, error) {
 	args := []string{"resource", "list", "--subscription", subscriptionId, "--resource-group", resourceGroupName, "--output", "json"}
 	if listOptions != nil {
-		if listOptions.TagFilter != nil {
-			args = append(args, "--tag", fmt.Sprintf("%s=%s", listOptions.TagFilter.Key, listOptions.TagFilter.Value))
-		}
-
 		if listOptions.JmesPathQuery != nil {
 			args = append(args, "--query", *listOptions.JmesPathQuery)
 		}

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -89,6 +89,11 @@ type AzCli interface {
 	GetSignedInUserId(ctx context.Context) (string, error)
 
 	GetAccessToken(ctx context.Context) (AzCliAccessToken, error)
+
+	// GraphQuery performs a query against Azure Resource Graph.
+	//
+	// This allows free-form querying of resources by any attribute, which is powerful.
+	// However, results may be delayed for multiple minutes. Ensure that your this fits your use-case.
 	GraphQuery(ctx context.Context, query string, subscriptions []string) (*AzCliGraphQuery, error)
 }
 
@@ -265,17 +270,17 @@ type AzCliGraphQuery struct {
 	TotalRecords int             `json:"totalRecords"`
 }
 
-// Optional list parameters for resource group listing.
+// Optional parameters for resource group listing.
 type ListResourceGroupOptions struct {
 	// An optional tag filter
 	TagFilter *Filter
-	// An optional JMES path query
+	// An optional JMES path query to filter or project the result
 	JmesPathQuery *string
 }
 
-// Optional list parameters for resource group resources listing.
+// Optional parameters for resource group resources listing.
 type ListResourceGroupResourcesOptions struct {
-	// An optional JMES path query
+	// An optional JMES path query to filter or project the result
 	JmesPathQuery *string
 }
 
@@ -1089,9 +1094,9 @@ var isNotLoggedInMessageRegex = regexp.MustCompile(`Please run ('|")az login('|"
 // AADSTS70043: The refresh token has expired or is invalid due to sign-in frequency checks by conditional access.
 var isRefreshTokenExpiredMessageRegex = regexp.MustCompile(`AADSTS70043`)
 var isResourceSegmentMeNotFoundMessageRegex = regexp.MustCompile(`Resource not found for the segment 'me'.`)
-var isDeploymentNotFoundMessageRegex = regexp.MustCompile(`ERROR: \(DeploymentNotFound\)`)
-var isClientAssertionInvalidMessagedRegex = regexp.MustCompile(`ERROR: AADSTS700024: Client assertion is not within its valid time range.`)
-var isConfigurationIsNotSetMessageRegex = regexp.MustCompile(`ERROR: Configuration '.*' is not set\.`)
+var isDeploymentNotFoundMessageRegex = regexp.MustCompile(`\(DeploymentNotFound\)`)
+var isClientAssertionInvalidMessagedRegex = regexp.MustCompile(`AADSTS700024`)
+var isConfigurationIsNotSetMessageRegex = regexp.MustCompile(`Configuration '.*' is not set\.`)
 var isDeploymentErrorRegex = regexp.MustCompile(`ERROR: ({.+})`)
 
 func isNotLoggedInMessage(s string) bool {

--- a/cli/azd/pkg/tools/azcli/azcli_test.go
+++ b/cli/azd/pkg/tools/azcli/azcli_test.go
@@ -126,7 +126,7 @@ func runAndCaptureUserAgent(t *testing.T, azcli *azCli, subscriptionID string) s
 
 	// the result doesn't matter here since we just want to see what the User-Agent is that we sent, which will
 	// happen regardless of whether the request succeeds or fails.
-	_, _ = azcli.ListResourceGroupResources(context.Background(), subscriptionID, "ResourceGroupThatDoesNotExist")
+	_, _ = azcli.ListResourceGroupResources(context.Background(), subscriptionID, "ResourceGroupThatDoesNotExist", nil)
 
 	// The outputted line will look like this:
 	// DEBUG: cli.azure.cli.core.sdk.policies:     'User-Agent': 'AZURECLI/2.35.0 (MSI) azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.3 (Windows-10-10.0.22621-SP0) azdev/0.0.0-dev.0 AZTesting=yes'

--- a/cli/azd/test/mocks/executil/mock_executil.go
+++ b/cli/azd/test/mocks/executil/mock_executil.go
@@ -36,7 +36,7 @@ func (m *MockCommandRunner) RunWithResult(ctx context.Context, args executil.Run
 	cmdArgs = append(cmdArgs, args.Args...)
 	command := strings.Join(cmdArgs, " ")
 
-	for i := len(m.expressions) - 1; i >= 0; i++ {
+	for i := len(m.expressions) - 1; i >= 0; i-- {
 		if m.expressions[i].predicateFn(args, command) {
 			match = m.expressions[i]
 			break

--- a/cli/azd/test/mocks/httputil/mock_http_client.go
+++ b/cli/azd/test/mocks/httputil/mock_http_client.go
@@ -80,7 +80,7 @@ func (e *HttpExpression) SetError(err error) *MockHttpClient {
 	return e.http
 }
 
-func AddDefaultMocks(mock *MockHttpClient) {
+func MockResourceGraphEmptyResources(mock *MockHttpClient) {
 	mock.When(func(req *httputil.HttpRequestMessage) bool {
 		return req.Method == http.MethodPost && strings.Contains(req.Url, "providers/Microsoft.ResourceGraph/resources")
 	}).RespondFn(func(request httputil.HttpRequestMessage) (*httputil.HttpResponseMessage, error) {

--- a/cli/azd/test/mocks/httputil/mock_http_client.go
+++ b/cli/azd/test/mocks/httputil/mock_http_client.go
@@ -32,7 +32,7 @@ func NewMockHttpUtil() *MockHttpClient {
 func (http *MockHttpClient) Send(req *httputil.HttpRequestMessage) (*httputil.HttpResponseMessage, error) {
 	var match *HttpExpression
 
-	for i := len(http.expressions) - 1; i >= 0; i++ {
+	for i := len(http.expressions) - 1; i >= 0; i-- {
 		if http.expressions[i].predicateFn(req) {
 			match = http.expressions[i]
 			break

--- a/cli/azd/test/mocks/httputil/mock_http_client.go
+++ b/cli/azd/test/mocks/httputil/mock_http_client.go
@@ -32,9 +32,9 @@ func NewMockHttpUtil() *MockHttpClient {
 func (http *MockHttpClient) Send(req *httputil.HttpRequestMessage) (*httputil.HttpResponseMessage, error) {
 	var match *HttpExpression
 
-	for _, expr := range http.expressions {
-		if expr.predicateFn(req) {
-			match = expr
+	for i := len(http.expressions) - 1; i >= 0; i++ {
+		if http.expressions[i].predicateFn(req) {
+			match = http.expressions[i]
 			break
 		}
 	}

--- a/cli/azd/test/mocks/mock_context.go
+++ b/cli/azd/test/mocks/mock_context.go
@@ -25,7 +25,6 @@ func NewMockContext(ctx context.Context) *MockContext {
 	http := mockhttp.NewMockHttpUtil()
 
 	mockexec.AddAzLoginMocks(execUtil)
-	mockhttp.AddDefaultMocks(http)
 
 	ctx = internal.WithCommandOptions(ctx, internal.GlobalCommandOptions{})
 	ctx = input.WithConsole(ctx, mockConsole)

--- a/cli/azd/test/mocks/mock_context.go
+++ b/cli/azd/test/mocks/mock_context.go
@@ -24,7 +24,8 @@ func NewMockContext(ctx context.Context) *MockContext {
 	execUtil := mockexec.NewMockCommandRunner()
 	http := mockhttp.NewMockHttpUtil()
 
-	mockexec.AddAzLoginMocks(execUtil)
+	execUtil.AddAzLoginMocks()
+	execUtil.AddDefaultMocks()
 
 	ctx = internal.WithCommandOptions(ctx, internal.GlobalCommandOptions{})
 	ctx = input.WithConsole(ctx, mockConsole)


### PR DESCRIPTION
- Switch to `az resource list` or `az group list` to fix resource query delays. 
- Remove "ERROR: " prefix from DeploymentNotFound error detection.
- Remove "ERROR: " prefix from ConfigNotFound error detection.

Fixes:
- #540
- #559 
- #539