### PR TITLE
Fix JSON tag of bicepTemplate `$schema`

### DIFF
--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -29,8 +29,7 @@ import (
 )
 
 type BicepTemplate struct {
-	//nolint:all
-	Schema         string                          `json:"$schema`
+	Schema         string                          `json:"$schema"`
 	ContentVersion string                          `json:"contentVersion"`
 	Parameters     map[string]BicepInputParameter  `json:"parameters"`
 	Outputs        map[string]BicepOutputParameter `json:"outputs"`


### PR DESCRIPTION
Fix invalid JSON tag.


Verification program:
```go
package main

import (
	"encoding/json"
	"fmt"
)

type Before struct {
	InternalSchema string `json:"$schema`
}
type After struct {
	InternalSchema string `json:"$schema"`
}

func print(prefix string, v any) {
	bytes, err := json.Marshal(v)
	if err != nil {
		panic(err)
	}
	fmt.Println(prefix + " " + string(bytes))
}

func main() {
	print("Before:", Before{InternalSchema: "foo"})
	print("After:", After{InternalSchema: "foo"})
}
```

Output:
```bash
Before: {"InternalSchema":"foo"}
After: {"$schema":"foo"}
```
```