### PR TITLE
Reuse spinner instance when available

### DIFF
--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -152,9 +152,12 @@ func (d *deployAction) Run(ctx context.Context, cmd *cobra.Command, args []strin
 		}
 
 		if interactive {
-			deployMsg := fmt.Sprintf("Deploying service %s", svc.Config.Name)
-			fmt.Println(deployMsg)
+			deployMsg := fmt.Sprintf("Deploying service %s...", output.WithHighLightFormat(svc.Config.Name))
+			console.Message(ctx, deployMsg)
+
 			spinner := spin.NewSpinner(deployMsg)
+			ctx = spin.WithSpinner(ctx, spinner)
+
 			spinner.Start()
 			err = deployAndReportProgress(spinner.Title)
 			spinner.Stop()
@@ -207,7 +210,7 @@ func (d *deployAction) Run(ctx context.Context, cmd *cobra.Command, args []strin
 func reportServiceDeploymentResultInteractive(ctx context.Context, console input.Console, svc *project.Service, sdr *project.ServiceDeploymentResult) {
 	var builder strings.Builder
 
-	builder.WriteString(fmt.Sprintf("Deployed service %s\n", svc.Config.Name))
+	builder.WriteString(fmt.Sprintf("Deployed service %s\n", output.WithHighLightFormat(svc.Config.Name)))
 
 	for _, endpoint := range sdr.Endpoints {
 		builder.WriteString(fmt.Sprintf(" - Endpoint: %s\n", output.WithLinkFormat(endpoint)))

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -155,11 +155,7 @@ func (d *deployAction) Run(ctx context.Context, cmd *cobra.Command, args []strin
 			deployMsg := fmt.Sprintf("Deploying service %s...", output.WithHighLightFormat(svc.Config.Name))
 			console.Message(ctx, deployMsg)
 
-			spinner := spin.GetSpinner(ctx)
-			if spinner == nil {
-				spinner = spin.NewSpinner(deployMsg)
-				ctx = spin.WithSpinner(ctx, spinner)
-			}
+			spinner, ctx := spin.GetOrCreateSpinner(ctx, deployMsg)
 
 			spinner.Start()
 			err = deployAndReportProgress(ctx, spinner.Title)

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -259,13 +259,7 @@ func (m *Manager) runAction(ctx context.Context, title string, interactive bool,
 	var spinner *spin.Spinner
 
 	if interactive {
-		// Check whether there is already a spinner active in the current context
-		spinner = spin.GetSpinner(ctx)
-		// If we don't find a spinner then create one and set it on the context
-		if spinner == nil {
-			spinner = spin.NewSpinner(title)
-			ctx = spin.WithSpinner(ctx, spinner)
-		}
+		spinner, ctx = spin.GetOrCreateSpinner(ctx, title)
 		defer spinner.Stop()
 		defer m.console.SetWriter(nil)
 

--- a/cli/azd/pkg/spin/spin.go
+++ b/cli/azd/pkg/spin/spin.go
@@ -123,3 +123,17 @@ func GetSpinner(ctx context.Context) *Spinner {
 
 	return spinner
 }
+
+// Gets a spinner from the specified context, otherwise creates a new instance
+// Returns a new context when a new spinner is created
+func GetOrCreateSpinner(ctx context.Context, title string) (*Spinner, context.Context) {
+	spinner := GetSpinner(ctx)
+	if spinner == nil {
+		spinner = NewSpinner(title)
+		ctx = WithSpinner(ctx, spinner)
+	}
+
+	spinner.Title(title)
+
+	return spinner, ctx
+}

--- a/cli/azd/pkg/spin/spin.go
+++ b/cli/azd/pkg/spin/spin.go
@@ -1,6 +1,7 @@
 package spin
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sync"
@@ -99,4 +100,26 @@ func NewSpinner(title string) *Spinner {
 	return &Spinner{
 		spinner: spinner,
 	}
+}
+
+type contextKey string
+
+const (
+	spinnerContextKey contextKey = "spinner"
+)
+
+// Creates and returns new context with the specified spinner instance
+func WithSpinner(ctx context.Context, spinner *Spinner) context.Context {
+	return context.WithValue(ctx, spinnerContextKey, spinner)
+}
+
+// Attempts to retrieve a Spinner instance from the current context.
+// Returns the found instance when available or `nil` if not found.
+func GetSpinner(ctx context.Context) *Spinner {
+	spinner, ok := ctx.Value(spinnerContextKey).(*Spinner)
+	if !ok {
+		return nil
+	}
+
+	return spinner
 }

--- a/cli/azd/pkg/spin/spin_test.go
+++ b/cli/azd/pkg/spin/spin_test.go
@@ -2,11 +2,13 @@ package spin
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_Run(t *testing.T) {
@@ -59,4 +61,22 @@ func Test_Println(t *testing.T) {
 	assert.Contains(t, buf.String(), message)
 
 	spinner.Stop()
+}
+
+func Test_WithGetSpinner(t *testing.T) {
+	rootContext := context.Background()
+	spinner := GetSpinner(rootContext)
+
+	// Spinner hasn't been set yet
+	require.Nil(t, spinner)
+
+	spinner = NewSpinner("Test")
+	newContext := WithSpinner(rootContext, spinner)
+
+	existingOnNewContext := GetSpinner(newContext)
+	existingOnRootContext := GetSpinner(rootContext)
+	require.Same(t, spinner, existingOnNewContext)
+
+	// Still nil on the root context
+	require.Nil(t, existingOnRootContext)
 }

--- a/cli/azd/pkg/spin/spin_test.go
+++ b/cli/azd/pkg/spin/spin_test.go
@@ -63,7 +63,7 @@ func Test_Println(t *testing.T) {
 	spinner.Stop()
 }
 
-func Test_WithGetSpinner(t *testing.T) {
+func Test_GetAndSetSpinner(t *testing.T) {
 	rootContext := context.Background()
 	spinner := GetSpinner(rootContext)
 
@@ -79,4 +79,27 @@ func Test_WithGetSpinner(t *testing.T) {
 
 	// Still nil on the root context
 	require.Nil(t, existingOnRootContext)
+}
+
+func Test_GetOrCreate(t *testing.T) {
+	t.Run("New", func(t *testing.T) {
+		rootContext := context.Background()
+		spinner, newContext := GetOrCreateSpinner(rootContext, "New")
+
+		require.NotNil(t, spinner)
+		require.NotSame(t, rootContext, newContext)
+	})
+
+	t.Run("Existing", func(t *testing.T) {
+		// Create new context and manually add Spinner to context.
+		rootContext := context.Background()
+		existingSpinner := NewSpinner("Existing")
+		existingContext := WithSpinner(rootContext, existingSpinner)
+
+		// Get spinner or create spinner from context
+		newSpinner, newContext := GetOrCreateSpinner(existingContext, "Test")
+
+		require.Same(t, existingSpinner, newSpinner)
+		require.Same(t, existingContext, newContext)
+	})
 }


### PR DESCRIPTION
With the introduction of provisioning manager it is now possible that there could be multiple instances of spinner created within different components.  This PR introduces the spinner into the context where it can be leveraged by downstream components.  

Without reusing the spinner component we see flashing display as the 2 spinner instances attempt to overwrite each other.

Ex) Spinner is used in the `deploy` command that calls into the provisioning manager. 