### PR TITLE
Fixes order of operations on container app deploy

### DIFF
--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -44,18 +44,6 @@ func (at *containerAppTarget) Deploy(ctx context.Context, azdCtx *azdcontext.Azd
 		at.config.Infra.Module = at.config.Name
 	}
 
-	commandOptions := internal.GetCommandOptions(ctx)
-	infraManager, err := provisioning.NewManager(ctx, *at.env, at.config.Project.Path, at.config.Infra, !commandOptions.NoPrompt)
-	if err != nil {
-		return ServiceDeploymentResult{}, fmt.Errorf("creating provisioning manager: %w", err)
-	}
-
-	progress <- "Creating deployment template"
-	deploymentPlan, err := infraManager.Plan(ctx)
-	if err != nil {
-		return ServiceDeploymentResult{}, fmt.Errorf("planning provisioning: %w", err)
-	}
-
 	// Login to container registry.
 	loginServer, has := at.env.Values[environment.ContainerRegistryEndpointEnvVarName]
 	if !has {
@@ -93,6 +81,18 @@ func (at *containerAppTarget) Deploy(ctx context.Context, azdCtx *azdcontext.Azd
 
 	if err := at.env.Save(); err != nil {
 		return ServiceDeploymentResult{}, fmt.Errorf("saving image name to environment: %w", err)
+	}
+
+	commandOptions := internal.GetCommandOptions(ctx)
+	infraManager, err := provisioning.NewManager(ctx, *at.env, at.config.Project.Path, at.config.Infra, !commandOptions.NoPrompt)
+	if err != nil {
+		return ServiceDeploymentResult{}, fmt.Errorf("creating provisioning manager: %w", err)
+	}
+
+	progress <- "Creating deployment template"
+	deploymentPlan, err := infraManager.Plan(ctx)
+	if err != nil {
+		return ServiceDeploymentResult{}, fmt.Errorf("planning provisioning: %w", err)
 	}
 
 	progress <- "Updating container app image reference"


### PR DESCRIPTION
Resolves initial container app deploy error during template tests.  The deployment plan that includes the input parameters was created before the container image is evaluated.

After the first failure the image name env var has been set allowing subsequent deployment to succeed.