### PR TITLE
Improves performance of dependent tool checking

### DIFF
--- a/cli/azd/pkg/tools/ensure_test.go
+++ b/cli/azd/pkg/tools/ensure_test.go
@@ -1,0 +1,34 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_EnsureInstalledOnlyOnce(t *testing.T) {
+	tool := TestTool{}
+
+	EnsureInstalled(context.Background(), &tool)
+	EnsureInstalled(context.Background(), &tool)
+
+	require.Equal(t, tool.installChecks, 1)
+}
+
+type TestTool struct {
+	installChecks int
+}
+
+func (t *TestTool) CheckInstalled(ctx context.Context) (bool, error) {
+	t.installChecks++
+	return true, nil
+}
+
+func (t *TestTool) InstallUrl() string {
+	return "http://www.microsoft.com"
+}
+
+func (t *TestTool) Name() string {
+	return "Test Tool"
+}

--- a/cli/azd/pkg/tools/ensure_test.go
+++ b/cli/azd/pkg/tools/ensure_test.go
@@ -8,10 +8,11 @@ import (
 )
 
 func Test_EnsureInstalledOnlyOnce(t *testing.T) {
+	ctx := context.Background()
 	tool := TestTool{}
 
-	EnsureInstalled(context.Background(), &tool)
-	EnsureInstalled(context.Background(), &tool)
+	EnsureInstalled(ctx, &tool)
+	EnsureInstalled(ctx, &tool)
 
 	require.Equal(t, tool.installChecks, 1)
 }

--- a/cli/azd/pkg/tools/ensure_test.go
+++ b/cli/azd/pkg/tools/ensure_test.go
@@ -11,8 +11,8 @@ func Test_EnsureInstalledOnlyOnce(t *testing.T) {
 	ctx := context.Background()
 	tool := TestTool{}
 
-	EnsureInstalled(ctx, &tool)
-	EnsureInstalled(ctx, &tool)
+	_ = EnsureInstalled(ctx, &tool)
+	_ = EnsureInstalled(ctx, &tool)
 
 	require.Equal(t, tool.installChecks, 1)
 }

--- a/cli/azd/pkg/tools/tool_test.go
+++ b/cli/azd/pkg/tools/tool_test.go
@@ -71,11 +71,15 @@ func Test_EnsureInstalled(t *testing.T) {
 	}
 
 	t.Run("HaveAll", func(t *testing.T) {
+		resetConfirmedTools()
+
 		err := EnsureInstalled(context.Background(), installedToolOne, installedToolTwo)
 		assert.NoError(t, err)
 	})
 
 	t.Run("MissingOne", func(t *testing.T) {
+		resetConfirmedTools()
+
 		err := EnsureInstalled(context.Background(), installedToolOne, missingToolOne)
 		assert.Error(t, err)
 		assert.Regexp(t, regexp.MustCompile(regexp.QuoteMeta(missingToolOne.Name())), err.Error())
@@ -83,6 +87,8 @@ func Test_EnsureInstalled(t *testing.T) {
 	})
 
 	t.Run("MissingMany", func(t *testing.T) {
+		resetConfirmedTools()
+
 		err := EnsureInstalled(context.Background(), installedToolOne, missingToolOne, missingToolTwo)
 		assert.Error(t, err)
 		assert.Regexp(t, regexp.MustCompile(regexp.QuoteMeta(missingToolOne.Name())), err.Error())
@@ -110,4 +116,8 @@ func (m *mockTool) InstallUrl() string {
 
 func (m *mockTool) Name() string {
 	return m.name
+}
+
+func resetConfirmedTools() {
+	confirmedTools = map[string]bool{}
 }


### PR DESCRIPTION
With multiple components requiring various external tools at different levels we are getting to a point where the tools install check is slowing down the executing of our commands.

This fix effectively introduces a cache and ensures that tool checks are only ever checked a single time.