### PR TITLE
Identify VSCode in telemetry

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -15,6 +15,7 @@ azdtest
 azsdk
 AZURECLI
 azurestaticapps
+azuretools
 azureutil
 Backticks
 BOOLSLICE

--- a/cli/azd/internal/telemetry/fields/fields.go
+++ b/cli/azd/internal/telemetry/fields/fields.go
@@ -83,3 +83,6 @@ const (
 	EnvTeamCity         = "TeamCity"
 	EnvJetBrainsSpace   = "JetBrains Space"
 )
+
+// The value used for ServiceNameKey
+const ServiceNameAzd = "azd"

--- a/cli/azd/internal/telemetry/resource/machine_id.go
+++ b/cli/azd/internal/telemetry/resource/machine_id.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package telemetry
+package resource
 
 import (
 	"crypto/sha256"
@@ -24,7 +24,8 @@ var invalidMacAddresses = map[string]struct{}{
 	"ac:de:48:00:11:22": {},
 }
 
-func sha256Hash(val string) string {
+// Sha256Hash returns the hex-encoded Sha256 hash of the given string.
+func Sha256Hash(val string) string {
 	sha := sha256.Sum256([]byte(val))
 	hash := hex.EncodeToString(sha[:])
 	return hash
@@ -41,7 +42,7 @@ func calculateMachineId() string {
 	mac, ok := getMacAddress()
 
 	if ok {
-		return sha256Hash(mac)
+		return Sha256Hash(mac)
 	} else {
 		// No valid mac address, return a GUID instead.
 		return uuid.NewString()

--- a/cli/azd/internal/telemetry/resource/resource.go
+++ b/cli/azd/internal/telemetry/resource/resource.go
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Package resource provides application-level resource attributes for telemetry purposes.
+package resource
+
+import (
+	"runtime"
+
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/internal/telemetry/fields"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil/osversion"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+)
+
+// New creates a resource with all application-level fields populated.
+func New() *resource.Resource {
+	r, _ := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			fields.ServiceNameKey.String(fields.ServiceNameAzd),
+			fields.ServiceVersionKey.String(internal.GetVersionNumber()),
+			fields.OSTypeKey.String(runtime.GOOS),
+			fields.OSVersionKey.String(getOsVersion()),
+			fields.HostArchKey.String(runtime.GOARCH),
+			fields.ProcessRuntimeVersionKey.String(runtime.Version()),
+			fields.ExecutionEnvironmentKey.String(getExecutionEnvironment()),
+			fields.MachineIdKey.String(getMachineId()),
+		),
+	)
+
+	return r
+}
+
+func getOsVersion() string {
+	ver, err := osversion.GetVersion()
+
+	if err != nil {
+		return "Unknown"
+	}
+
+	return ver
+}

--- a/cli/azd/internal/telemetry/telemetry.go
+++ b/cli/azd/internal/telemetry/telemetry.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	appinsightsexporter "github.com/azure/azure-dev/cli/azd/internal/telemetry/appinsights-exporter"
+	"github.com/azure/azure-dev/cli/azd/internal/telemetry/resource"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/benbjohnson/clock"
 	"github.com/gofrs/flock"
@@ -22,8 +23,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/trace"
 )
-
-const azdAppName = "azd"
 
 // the equivalent of AZURE_CORE_COLLECT_TELEMETRY
 const collectTelemetryEnvVar = "AZURE_DEV_COLLECT_TELEMETRY"
@@ -114,7 +113,7 @@ func initialize() (*TelemetrySystem, error) {
 
 	tp := trace.NewTracerProvider(
 		trace.WithBatcher(exporter),
-		trace.WithResource(newResource()),
+		trace.WithResource(resource.New()),
 	)
 	otel.SetTracerProvider(tp)
 

--- a/cli/azd/internal/telemetry/telemetry_context.go
+++ b/cli/azd/internal/telemetry/telemetry_context.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry/baggage"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry/fields"
+	"github.com/azure/azure-dev/cli/azd/internal/telemetry/resource"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -26,7 +27,7 @@ func ContextWithEnvironment(ctx context.Context, env *environment.Environment) c
 
 // ContextWithTemplate sets the template in context for telemetry purposes.
 func ContextWithTemplate(ctx context.Context, templateName string) context.Context {
-	return SetBaggageInContext(ctx, fields.TemplateIdKey.String(sha256Hash(strings.ToLower(templateName))))
+	return SetBaggageInContext(ctx, fields.TemplateIdKey.String(resource.Sha256Hash(strings.ToLower(templateName))))
 }
 
 // TemplateFromContext retrieves the template stored in context.

--- a/cli/azd/internal/telemetry/tracer.go
+++ b/cli/azd/internal/telemetry/tracer.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry/baggage"
+	"github.com/azure/azure-dev/cli/azd/internal/telemetry/fields"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 
@@ -138,5 +139,5 @@ func (s *wrapperSpan) TracerProvider() trace.TracerProvider {
 
 // GetTracer returns the application tracer for azd.
 func GetTracer() Tracer {
-	return &wrapperTracer{otel.Tracer(azdAppName)}
+	return &wrapperTracer{otel.Tracer(fields.ServiceNameAzd)}
 }

--- a/cli/azd/internal/useragent.go
+++ b/cli/azd/internal/useragent.go
@@ -7,12 +7,22 @@ import (
 	"strings"
 )
 
-const userSpecifiedAgentEnvironmentVariableName = "AZURE_DEV_USER_AGENT"
+// Environment variable that identifies a user agent calling into azd.
+// Any caller of azd can set this variable to identify themselves.
+const AzdUserAgentEnvVar = "AZURE_DEV_USER_AGENT"
+
+// Well-known user agents prefixes.
+const (
+	VsCodeAgentPrefix = "vscode:/extensions/ms-azuretools.azure-dev"
+)
+
 const githubActionsEnvironmentVariableName = "GITHUB_ACTIONS"
 
-const azDevProductIdentifierKey = "azdev"
-const templateProductIdentifierKey = "azdtempl"
-const githubActionsProductIdentifierKey = "GhActions"
+const (
+	azDevProductIdentifierKey         = "azdev"
+	templateProductIdentifierKey      = "azdtempl"
+	githubActionsProductIdentifierKey = "GhActions"
+)
 
 type UserAgent struct {
 	// Azure Developer CLI product identifier. Formatted as `azdev/<version>`
@@ -47,7 +57,7 @@ func appendIdentifier(sb *strings.Builder, identifier string) {
 func makeUserAgent(template string) UserAgent {
 	userAgent := UserAgent{}
 	userAgent.azDevCliIdentifier = getAzDevCliIdentifier()
-	userAgent.userSpecifiedIdentifier = getUserSpecifiedIdentifier()
+	userAgent.userSpecifiedIdentifier = GetCallerUserAgent()
 	userAgent.githubActionsIdentifier = getGithubActionsIdentifier()
 	userAgent.templateIdentifier = formatTemplateIdentifier(template)
 
@@ -76,14 +86,9 @@ func getPlatformInfo() string {
 	return fmt.Sprintf("(Go %s; %s/%s)", runtime.Version(), runtime.GOOS, runtime.GOARCH)
 }
 
-func getUserSpecifiedIdentifier() string {
-	// like the Azure CLI (via it's `AZURE_HTTP_USER_AGENT` env variable) we allow for a user to append
-	// information to the UserAgent by setting an environment variable.
-	if devUserAgent := os.Getenv(userSpecifiedAgentEnvironmentVariableName); devUserAgent != "" {
-		return devUserAgent
-	}
-
-	return ""
+// GetCallerUserAgent returns the user agent calling into azd.
+func GetCallerUserAgent() string {
+	return os.Getenv(AzdUserAgentEnvVar)
 }
 
 func getGithubActionsIdentifier() string {

--- a/cli/azd/internal/useragent_test.go
+++ b/cli/azd/internal/useragent_test.go
@@ -18,14 +18,14 @@ func TestGetAzDevCliIdentifier(t *testing.T) {
 func TestUserSpecifiedAgentIdentifier(t *testing.T) {
 	devUserAgent := "MyAgent/1.0.0"
 	restorer := EnvironmentVariablesSetter(map[string]string{
-		userSpecifiedAgentEnvironmentVariableName: devUserAgent,
+		AzdUserAgentEnvVar: devUserAgent,
 	})
 
-	require.Equal(t, devUserAgent, getUserSpecifiedIdentifier())
+	require.Equal(t, devUserAgent, GetCallerUserAgent())
 
 	// Empty case
-	os.Setenv(userSpecifiedAgentEnvironmentVariableName, "")
-	require.Equal(t, "", getUserSpecifiedIdentifier())
+	os.Setenv(AzdUserAgentEnvVar, "")
+	require.Equal(t, "", GetCallerUserAgent())
 
 	t.Cleanup(restorer)
 }
@@ -53,8 +53,8 @@ func TestFormatTemplate(t *testing.T) {
 // Scenario tests
 func TestUserAgentStringScenarios(t *testing.T) {
 	restorer := EnvironmentVariablesSetter(map[string]string{
-		userSpecifiedAgentEnvironmentVariableName: "",
-		githubActionsEnvironmentVariableName:      "",
+		AzdUserAgentEnvVar:                   "",
+		githubActionsEnvironmentVariableName: "",
 	})
 
 	version := GetVersionNumber()
@@ -66,9 +66,9 @@ func TestUserAgentStringScenarios(t *testing.T) {
 	require.Equal(t, azDevIdentifier, MakeUserAgentString(""))
 
 	// Scenario: user specifies agent variable
-	os.Setenv(userSpecifiedAgentEnvironmentVariableName, "dev_user_agent")
+	os.Setenv(AzdUserAgentEnvVar, "dev_user_agent")
 	require.Equal(t, fmt.Sprintf("%s dev_user_agent", azDevIdentifier), MakeUserAgentString(""))
-	os.Setenv(userSpecifiedAgentEnvironmentVariableName, "")
+	os.Setenv(AzdUserAgentEnvVar, "")
 
 	// Scenario: running on github actions
 	os.Setenv(githubActionsEnvironmentVariableName, "true")
@@ -79,7 +79,7 @@ func TestUserAgentStringScenarios(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("%s azdtempl/template@0.0.1", azDevIdentifier), MakeUserAgentString("template@0.0.1"))
 
 	// Scenario: full combination
-	os.Setenv(userSpecifiedAgentEnvironmentVariableName, "dev_user_agent")
+	os.Setenv(AzdUserAgentEnvVar, "dev_user_agent")
 	os.Setenv(githubActionsEnvironmentVariableName, "true")
 	require.Equal(t, fmt.Sprintf("%s dev_user_agent azdtempl/template@0.0.1 GhActions", azDevIdentifier), MakeUserAgentString("template@0.0.1"))
 


### PR DESCRIPTION
Check `AZURE_DEV_USER_AGENT` for the presence of VSCode's user agent. Set the execution environment based on this.

Also, moving app-level resource initialization into a smaller package `resource`.

Fixes #600 