### PR TITLE
Fix uncaught lint error in osversion_linux.go

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -14,7 +14,10 @@ permissions:
 
 jobs:
   azd-lint:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/cli/azd/pkg/osutil/osversion/osversion_linux.go
+++ b/cli/azd/pkg/osutil/osversion/osversion_linux.go
@@ -10,7 +10,7 @@ func GetVersion() (string, error) {
 	err := unix.Uname(&uname)
 
 	if err != nil {
-		return "", fmt.Errorf("unix.Uname returned error: %s", err)
+		return "", fmt.Errorf("unix.Uname returned error: %w", err)
 	}
 
 	return string(uname.Release[:cStringLen(uname.Release[:])]), nil


### PR DESCRIPTION
Use `%w` instead of `%s`