### PR TITLE
Install terraform cli and vs code plugin in dev container

### DIFF
--- a/templates/todo/projects/python-mongo/.repo/terraform/.devcontainer/Dockerfile
+++ b/templates/todo/projects/python-mongo/.repo/terraform/.devcontainer/Dockerfile
@@ -10,4 +10,4 @@ RUN curl -fsSL https://aka.ms/install-azd.sh | bash \
         https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
         sudo tee /etc/apt/sources.list.d/hashicorp.list \
     && sudo apt update \
-    && sudo apt-get install terraform=1.1.7
+    && sudo apt-get install terraform

--- a/templates/todo/projects/python-mongo/.repo/terraform/.devcontainer/Dockerfile
+++ b/templates/todo/projects/python-mongo/.repo/terraform/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+ARG VARIANT=bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+RUN curl -fsSL https://aka.ms/install-azd.sh | bash \
+    # Install Terraform CLI
+    && sudo apt-get update && sudo apt-get install -y gnupg software-properties-common \
+    && wget -O- https://apt.releases.hashicorp.com/gpg | \
+        gpg --dearmor | \
+        sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
+        https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
+        sudo tee /etc/apt/sources.list.d/hashicorp.list \
+    && sudo apt update \
+    && sudo apt-get install terraform=1.1.7

--- a/templates/todo/projects/python-mongo/.repo/terraform/.devcontainer/devcontainer.json
+++ b/templates/todo/projects/python-mongo/.repo/terraform/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+    "name": "Azure Developer CLI",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "args": {
+            "VARIANT": "bullseye"
+        }
+    },
+    "features": {
+        "github-cli": "2",
+        "azure-cli": "2.38",
+        "python": "os-provided",
+        "docker-from-docker": "20.10",
+        "node": {
+            "version": "16",
+            "nodeGypDependencies": false
+        }
+    },
+    "extensions": [
+        "ms-azuretools.azure-dev",
+        "ms-azuretools.vscode-bicep",
+        "ms-azuretools.vscode-docker",
+        "ms-vscode.vscode-node-azure-pack",
+        "ms-python.python",
+        "hashicorp.terraform"
+    ],
+    "forwardPorts": [
+        3000,
+        3100
+    ],
+    "postCreateCommand": "",
+    "remoteUser": "vscode"
+}

--- a/templates/todo/projects/python-mongo/.repo/terraform/azure.yaml
+++ b/templates/todo/projects/python-mongo/.repo/terraform/azure.yaml
@@ -3,6 +3,8 @@
 name: todo-python-mongo-terraform
 metadata:
   template: todo-python-mongo-terraform@0.0.1-beta
+infra:
+  provider: terraform
 services:
   web:
     project: ../../web/react-fluent

--- a/templates/todo/projects/python-mongo/.repo/terraform/infra/provider.tf
+++ b/templates/todo/projects/python-mongo/.repo/terraform/infra/provider.tf
@@ -2,7 +2,7 @@
 
 # Configure the Azure Provider
 terraform {
-  required_version = "~> v1.1.7"
+  required_version = ">= 1.1.7, < 2.0.0"
   required_providers {
     azurerm = {
       version = "~>3.18.0"

--- a/templates/todo/projects/python-mongo/.repo/terraform/repo.yaml
+++ b/templates/todo/projects/python-mongo/.repo/terraform/repo.yaml
@@ -20,26 +20,26 @@ repo:
         to: ./modules/applicationinsights
         patterns:
           - "**/*.tf"
-      
+
       - from: ../../api/python
         to: ./src/api
-        patterns: 
+        patterns:
           - "**/azure.@(yml|yaml)"
 
       - from: ../../web/react-fluent
         to: ./src/web
-        patterns: 
+        patterns:
           - "**/azure.@(yml|yaml)"
-      
+
   assets:
-    # Common assets   
+    # Common assets
     - from: ./../../
       to: ./
-      ignore: 
+      ignore:
         - ".repo/**/*"
         - "repo.y[a]ml"
         - "azure.y[a]ml"
-        
+
     # openapi.yaml to root
     - from: ../../../../api/common
       to: ./
@@ -51,24 +51,16 @@ repo:
       to: ./src/api
       patterns:
         - openapi.yaml
-     
+
     # Templates common
     - from: ../../../../../common
       to: ./
-      ignore: 
-      - "infra/**/*"
-      - .devcontainer/**/*
+      ignore:
+        - "infra/**/*"
+        - .devcontainer/**/*
 
     - from: ../../../../../common/infra/terraform/applicationinsights
       to: ./infra/modules/applicationinsights
-
-    # .devcontainer common (devcontainer.json)
-    - from: ../../../../../common/.devcontainer/devcontainer.json/python
-      to: ./.devcontainer
-
-    # .devcontainer common (Dockerfile)
-    - from: ../../../../../common/.devcontainer/Dockerfile/base
-      to: ./.devcontainer
 
     # Assets common
     - from: ../../../../common/assets
@@ -92,9 +84,13 @@ repo:
         - "build/**/*"
         - "node_modules/**/*"
 
-    # Infra 
+    # Infra
     - from: ./infra/
       to: ./infra
+
+    # Devcontainer
+    - from: ./.devcontainer
+      to: ./.devcontainer
 
     # Azure.yml
     - from: ./azure.yaml


### PR DESCRIPTION
In terraform projects we need to ensure that both the Terraform CLI and the Terraform vs code extensions are installed by default in the dev container.