### PR TITLE
Fixes interactive exec support for posix environments

### DIFF
--- a/cli/azd/pkg/exec/command_runner.go
+++ b/cli/azd/pkg/exec/command_runner.go
@@ -174,7 +174,7 @@ func newCmdTree(ctx context.Context, cmd string, args []string, useShell bool, i
 	if runtime.GOOS == "windows" {
 		dir := os.Getenv("SYSTEMROOT")
 		if dir == "" {
-			return CmdTree{CmdTreeOptions: options}, errors.New("environment variable 'SYSTEMROOT' has no value")
+			return CmdTree{}, errors.New("environment variable 'SYSTEMROOT' has no value")
 		}
 
 		shellName = filepath.Join(dir, "System32", "cmd.exe")

--- a/cli/azd/pkg/exec/util.go
+++ b/cli/azd/pkg/exec/util.go
@@ -17,7 +17,7 @@ type CmdTreeOptions struct {
 // RunCommandList runs a list of commands in shell.
 // The command list is constructed using '&&' operator, so the first failing command causes the whole list run to fail.
 func RunCommandList(ctx context.Context, commands []string, env []string, cwd string) (RunResult, error) {
-	process, err := newCmdTree(ctx, "", commands, true)
+	process, err := newCmdTree(ctx, "", commands, true, false)
 	if err != nil {
 		return NewRunResult(-1, "", ""), err
 	}

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -19,6 +19,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -661,7 +662,11 @@ func randomEnvName() string {
 	}
 
 	// Adding first letter initial of the OS for CI identification
-	osInitial := os.Getenv("AZURE_DEV_CI_OS")[:1]
+	osName := os.Getenv("AZURE_DEV_CI_OS")
+	if osName == "" {
+		osName = runtime.GOOS
+	}
+	osInitial := osName[:1]
 
 	return ("azdtest-" + osInitial + hex.EncodeToString(bytes))[0:15]
 }
@@ -716,7 +721,7 @@ func Test_CLI_InfraCreateAndDeleteResourceTerraform(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Starting infra create\n")
-	err = cmd.Execute([]string{"infra", "create", "--cwd", dir})
+	_, err = cli.RunCommand(ctx, "infra", "create", "--cwd", dir)
 	require.NoError(t, err)
 
 	out, err := cli.RunCommand(ctx, "env", "get-values", "-o", "json", "--cwd", dir)
@@ -724,7 +729,7 @@ func Test_CLI_InfraCreateAndDeleteResourceTerraform(t *testing.T) {
 	_ = out
 
 	t.Logf("Starting infra delete\n")
-	err = cmd.Execute([]string{"infra", "delete", "--cwd", dir, "--force", "--purge"})
+	_, err = cli.RunCommand(ctx, "infra", "delete", "--cwd", dir, "--force", "--purge")
 	require.NoError(t, err)
 
 	t.Logf("Done\n")
@@ -800,11 +805,11 @@ func Test_CLI_InfraCreateAndDeleteResourceTerraformRemote(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Starting infra create\n")
-	err = cmd.Execute([]string{"infra", "create", "--cwd", dir})
+	_, err = cli.RunCommand(ctx, "infra", "create", "--cwd", dir)
 	require.NoError(t, err)
 
 	t.Logf("Starting infra delete\n")
-	err = cmd.Execute([]string{"infra", "delete", "--cwd", dir, "--force", "--purge"})
+	_, err = cli.RunCommand(ctx, "infra", "delete", "--cwd", dir, "--force", "--purge")
 	require.NoError(t, err)
 
 	t.Logf("Done\n")

--- a/cli/azd/test/samples/resourcegroupterraform/infra/provider.tf
+++ b/cli/azd/test/samples/resourcegroupterraform/infra/provider.tf
@@ -2,7 +2,7 @@
 
 # Configure the Azure Provider
 terraform {
-  required_version = "~> v1.1.7"
+  required_version = ">= 1.1.7, < 2.0.0"
   required_providers {
     azurerm = {
       version = "~>3.18.0"

--- a/cli/azd/test/samples/resourcegroupterraformremote/infra/provider.tf
+++ b/cli/azd/test/samples/resourcegroupterraformremote/infra/provider.tf
@@ -2,7 +2,7 @@
 
 # Configure the Azure Provider
 terraform {
-  required_version = "~> v1.1.7"
+  required_version = ">= 1.1.7, < 2.0.0"
   backend "azurerm" {
   }
   required_providers {

--- a/eng/pipelines/templates/steps/install-terraform.yml
+++ b/eng/pipelines/templates/steps/install-terraform.yml
@@ -1,5 +1,5 @@
 parameters:
-  TerraformVersion: v1.1.7
+  TerraformVersion: latest
 
 steps:
   - task: ms-devlabs.custom-terraform-tasks.custom-terraform-installer-task.TerraformInstaller@0


### PR DESCRIPTION
The `Interactive` flag was never being correctly set for posix environments which is used during command execution.  This now sets the correct value based on the `exec.RunArgs`.

Posix interactive usage:
https://github.com/Azure/azure-dev/blob/main/cli/azd/pkg/exec/cmdtree_posix.go#L28