### PR TITLE
Embrace `*Environment` over `Environment`

### DIFF
--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -87,7 +87,7 @@ func (d *deployAction) Run(ctx context.Context, cmd *cobra.Command, args []strin
 		return fmt.Errorf("loading environment: %w", err)
 	}
 
-	projConfig, err := project.LoadProjectConfig(azdCtx.ProjectPath(), &env)
+	projConfig, err := project.LoadProjectConfig(azdCtx.ProjectPath(), env)
 	if err != nil {
 		return fmt.Errorf("loading project: %w", err)
 	}
@@ -96,7 +96,7 @@ func (d *deployAction) Run(ctx context.Context, cmd *cobra.Command, args []strin
 		return fmt.Errorf("service name '%s' doesn't exist", d.serviceName)
 	}
 
-	proj, err := projConfig.GetProject(&ctx, &env)
+	proj, err := projConfig.GetProject(&ctx, env)
 	if err != nil {
 		return fmt.Errorf("creating project: %w", err)
 	}
@@ -184,7 +184,7 @@ func (d *deployAction) Run(ctx context.Context, cmd *cobra.Command, args []strin
 	}
 
 	resourceManager := infra.NewAzureResourceManager(ctx)
-	resourceGroup, err := resourceManager.FindResourceGroupForEnvironment(ctx, &env)
+	resourceGroup, err := resourceManager.FindResourceGroupForEnvironment(ctx, env)
 	if err != nil {
 		return fmt.Errorf("discovering resource group from deployment: %w", err)
 	}

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
-	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
@@ -243,7 +242,7 @@ func envRefreshCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 			return fmt.Errorf("loading environment: %w", err)
 		}
 
-		prj, err := project.LoadProjectConfig(azdCtx.ProjectPath(), &environment.Environment{})
+		prj, err := project.LoadProjectConfig(azdCtx.ProjectPath(), env)
 		if err != nil {
 			return fmt.Errorf("loading project: %w", err)
 		}
@@ -263,7 +262,7 @@ func envRefreshCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 			return fmt.Errorf("getting deployment: %w", err)
 		}
 
-		if err := provisioning.UpdateEnvironment(&env, &getDeploymentResult.Deployment.Outputs); err != nil {
+		if err := provisioning.UpdateEnvironment(env, &getDeploymentResult.Deployment.Outputs); err != nil {
 			return err
 		}
 

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
-	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
@@ -66,12 +65,12 @@ func (ica *infraCreateAction) Run(ctx context.Context, cmd *cobra.Command, args 
 		return fmt.Errorf("loading environment: %w", err)
 	}
 
-	prj, err := project.LoadProjectConfig(azdCtx.ProjectPath(), &environment.Environment{})
+	prj, err := project.LoadProjectConfig(azdCtx.ProjectPath(), env)
 	if err != nil {
 		return fmt.Errorf("loading project: %w", err)
 	}
 
-	if err = prj.Initialize(ctx, &env); err != nil {
+	if err = prj.Initialize(ctx, env); err != nil {
 		return err
 	}
 

--- a/cli/azd/cmd/infra_delete.go
+++ b/cli/azd/cmd/infra_delete.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
-	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -64,7 +63,7 @@ func (a *infraDeleteAction) Run(ctx context.Context, cmd *cobra.Command, args []
 		return fmt.Errorf("loading environment: %w", err)
 	}
 
-	prj, err := project.LoadProjectConfig(azdCtx.ProjectPath(), &environment.Environment{})
+	prj, err := project.LoadProjectConfig(azdCtx.ProjectPath(), env)
 	if err != nil {
 		return fmt.Errorf("loading project: %w", err)
 	}

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -220,7 +220,8 @@ func (i *initAction) Run(ctx context.Context, cmd *cobra.Command, args []string,
 		return environment.NewEnvironmentInitError(envName)
 	}
 
-	_, err = project.LoadProjectConfig(azdCtx.ProjectPath(), &environment.Environment{})
+	// Check to see if `azure.yaml` exists, and if it doesn't, create it.
+	_, err = os.Stat(azdCtx.ProjectPath())
 
 	if errors.Is(err, os.ErrNotExist) {
 		fmt.Printf("Creating a new %s file.\n", azdcontext.ProjectFileName)

--- a/cli/azd/cmd/monitor.go
+++ b/cli/azd/cmd/monitor.go
@@ -89,7 +89,7 @@ func (m *monitorAction) Run(ctx context.Context, cmd *cobra.Command, args []stri
 	}
 
 	resourceManager := infra.NewAzureResourceManager(ctx)
-	resourceGroups, err := resourceManager.GetResourceGroupsForEnvironment(ctx, &env)
+	resourceGroups, err := resourceManager.GetResourceGroupsForEnvironment(ctx, env)
 	if err != nil {
 		return fmt.Errorf("discovering resource groups from deployment: %w", err)
 	}

--- a/cli/azd/pkg/commands/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/commands/pipeline/azdo_provider.go
@@ -90,7 +90,7 @@ func (p *AzdoCiProvider) name() string {
 // configureConnection set up Azure DevOps with the Azure credential
 func (p *AzdoCiProvider) configureConnection(
 	ctx context.Context,
-	azdEnvironment environment.Environment,
+	azdEnvironment *environment.Environment,
 	repoDetails *gitRepositoryDetails,
 	provisioningProvider provisioning.Options,
 	credentials json.RawMessage,

--- a/cli/azd/pkg/commands/pipeline/github_provider.go
+++ b/cli/azd/pkg/commands/pipeline/github_provider.go
@@ -296,7 +296,7 @@ func (p *GitHubCiProvider) name() string {
 // and make changes on behalf of a user.
 func (p *GitHubCiProvider) configureConnection(
 	ctx context.Context,
-	azdEnvironment environment.Environment,
+	azdEnvironment *environment.Environment,
 	repoDetails *gitRepositoryDetails,
 	infraOptions provisioning.Options,
 	credentials json.RawMessage,

--- a/cli/azd/pkg/commands/pipeline/pipeline.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline.go
@@ -66,7 +66,7 @@ type CiProvider interface {
 	// to Azure
 	configureConnection(
 		ctx context.Context,
-		azdEnvironment environment.Environment,
+		azdEnvironment *environment.Environment,
 		gitRepo *gitRepositoryDetails,
 		provisioningProvider provisioning.Options,
 		credential json.RawMessage,

--- a/cli/azd/pkg/commands/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline_manager.go
@@ -30,7 +30,7 @@ type PipelineManager struct {
 	PipelineServicePrincipalName string
 	PipelineRemoteName           string
 	PipelineRoleName             string
-	Environment                  environment.Environment
+	Environment                  *environment.Environment
 }
 
 // requiredTools get all the provider's required tools.
@@ -223,7 +223,7 @@ func (manager *PipelineManager) Configure(ctx context.Context) error {
 	}
 
 	// Figure out what is the expected provider to use for provisioning
-	prj, err := project.LoadProjectConfig(manager.AzdCtx.ProjectPath(), &manager.Environment)
+	prj, err := project.LoadProjectConfig(manager.AzdCtx.ProjectPath(), manager.Environment)
 	if err != nil {
 		return fmt.Errorf("finding provisioning provider: %w", err)
 	}

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -54,10 +54,10 @@ func IsValidEnvironmentName(name string) bool {
 // FromFile loads an environment from a file on disk. On error,
 // an valid empty environment file, configured to persist its contents
 // to file, is returned.
-func FromFile(file string) (Environment, error) {
-	env := Environment{
-		Values: make(map[string]string),
+func FromFile(file string) (*Environment, error) {
+	env := &Environment{
 		File:   file,
+		Values: make(map[string]string),
 	}
 
 	e, err := godotenv.Read(file)
@@ -70,17 +70,39 @@ func FromFile(file string) (Environment, error) {
 	return env, nil
 }
 
-func GetEnvironment(azdContext *azdcontext.AzdContext, name string) (Environment, error) {
+func GetEnvironment(azdContext *azdcontext.AzdContext, name string) (*Environment, error) {
 	return FromFile(azdContext.GetEnvironmentFilePath(name))
 }
 
-// Empty returns an empty environment, which will be persisted
+// EmptyWithFile returns an empty environment, which will be persisted
 // to a given file when saved.
-func Empty(file string) Environment {
-	return Environment{
+func EmptyWithFile(file string) *Environment {
+	return &Environment{
 		File:   file,
 		Values: make(map[string]string),
 	}
+}
+
+func Ephemeral() *Environment {
+	return &Environment{
+		Values: make(map[string]string),
+	}
+}
+
+// EphemeralWithValues returns an ephemeral environment (i.e. not backed by a file) with a set
+// of values. Useful for testing. The name parameter is added to the environment with the
+// AZURE_ENV_NAME key, replacing an existing value in the provided values map. A nil values is
+// treated the same way as an empty map.
+func EphemeralWithValues(name string, values map[string]string) *Environment {
+	env := Ephemeral()
+
+	if values != nil {
+		env.Values = values
+	}
+
+	env.Values[EnvNameEnvVarName] = name
+
+	return env
 }
 
 // If `File` is set, Save writes the current contents of the environment to

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -268,11 +268,11 @@ func createBicepProvider(ctx context.Context) *BicepProvider {
 		Module: "main",
 	}
 
-	env := environment.Environment{Values: make(map[string]string)}
-	env.SetLocation("westus2")
-	env.SetEnvName("test-env")
+	env := environment.EphemeralWithValues("test-env", map[string]string{
+		"AZURE_LOCATION": "westus2",
+	})
 
-	return NewBicepProvider(ctx, &env, projectDir, options)
+	return NewBicepProvider(ctx, env, projectDir, options)
 }
 
 func prepareGenericMocks(commandRunner *execmock.MockCommandRunner) {

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -23,7 +23,7 @@ import (
 // Manages the orchestration of infrastructure provisioning
 type Manager struct {
 	azCli       azcli.AzCli
-	env         environment.Environment
+	env         *environment.Environment
 	provider    Provider
 	formatter   output.Formatter
 	writer      io.Writer
@@ -87,7 +87,7 @@ func (m *Manager) Deploy(ctx context.Context, plan *DeploymentPlan, scope infra.
 		return nil, err
 	}
 
-	if err := UpdateEnvironment(&m.env, &deployResult.Deployment.Outputs); err != nil {
+	if err := UpdateEnvironment(m.env, &deployResult.Deployment.Outputs); err != nil {
 		return nil, fmt.Errorf("updating environment with deployment outputs: %w", err)
 	}
 
@@ -302,8 +302,8 @@ func (m *Manager) monitorInteraction(spinner *spin.Spinner, interactiveChannel <
 }
 
 // Creates a new instance of the Provisioning Manager
-func NewManager(ctx context.Context, env environment.Environment, projectPath string, infraOptions Options, interactive bool) (*Manager, error) {
-	infraProvider, err := NewProvider(ctx, &env, projectPath, infraOptions)
+func NewManager(ctx context.Context, env *environment.Environment, projectPath string, infraOptions Options, interactive bool) (*Manager, error) {
+	infraProvider, err := NewProvider(ctx, env, projectPath, infraOptions)
 	if err != nil {
 		return nil, fmt.Errorf("error creating infra provider: %w", err)
 	}

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -18,9 +18,9 @@ import (
 )
 
 func TestManagerPlan(t *testing.T) {
-	env := environment.Environment{Values: make(map[string]string)}
-	env.Values["AZURE_LOCATION"] = "eastus2"
-	env.SetEnvName("test-env")
+	env := environment.EphemeralWithValues("test-env", map[string]string{
+		"AZURE_LOCATION": "eastus2",
+	})
 	options := Options{Provider: "test"}
 	interactive := false
 
@@ -36,9 +36,9 @@ func TestManagerPlan(t *testing.T) {
 }
 
 func TestManagerGetDeployment(t *testing.T) {
-	env := environment.Environment{Values: make(map[string]string)}
-	env.Values["AZURE_LOCATION"] = "eastus2"
-	env.SetEnvName("test-env")
+	env := environment.EphemeralWithValues("test-env", map[string]string{
+		"AZURE_LOCATION": "eastus2",
+	})
 	options := Options{Provider: "test"}
 	interactive := false
 
@@ -54,9 +54,9 @@ func TestManagerGetDeployment(t *testing.T) {
 }
 
 func TestManagerDeploy(t *testing.T) {
-	env := environment.Environment{Values: make(map[string]string)}
-	env.Values["AZURE_LOCATION"] = "eastus2"
-	env.SetEnvName("test-env")
+	env := environment.EphemeralWithValues("test-env", map[string]string{
+		"AZURE_LOCATION": "eastus2",
+	})
 	options := Options{Provider: "test"}
 	interactive := false
 
@@ -73,9 +73,9 @@ func TestManagerDeploy(t *testing.T) {
 }
 
 func TestManagerDestroyWithPositiveConfirmation(t *testing.T) {
-	env := environment.Environment{Values: make(map[string]string)}
-	env.Values["AZURE_LOCATION"] = "eastus2"
-	env.SetEnvName("test-env")
+	env := environment.EphemeralWithValues("test-env", map[string]string{
+		"AZURE_LOCATION": "eastus2",
+	})
 	options := Options{Provider: "test"}
 	interactive := false
 
@@ -97,9 +97,9 @@ func TestManagerDestroyWithPositiveConfirmation(t *testing.T) {
 }
 
 func TestManagerDestroyWithNegativeConfirmation(t *testing.T) {
-	env := environment.Environment{Values: make(map[string]string)}
-	env.Values["AZURE_LOCATION"] = "eastus2"
-	env.SetEnvName("test-env")
+	env := environment.EphemeralWithValues("test-env", map[string]string{
+		"AZURE_LOCATION": "eastus2",
+	})
 	options := Options{Provider: "test"}
 	interactive := false
 

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
@@ -200,11 +200,11 @@ func createTerraformProvider(ctx context.Context) *TerraformProvider {
 		Module: "main",
 	}
 
-	env := environment.Environment{Values: make(map[string]string)}
-	env.SetLocation("westus2")
-	env.SetEnvName("test-env")
+	env := environment.EphemeralWithValues("test-env", map[string]string{
+		"AZURE_LOCATION": "westus2",
+	})
 
-	return NewTerraformProvider(ctx, &env, projectDir, options)
+	return NewTerraformProvider(ctx, env, projectDir, options)
 }
 
 func prepareGenericMocks(commandRunner *execmock.MockCommandRunner) {

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -27,9 +27,7 @@ services:
 `
 	ran := false
 
-	env := environment.Environment{Values: make(map[string]string)}
-	env.SetEnvName("test-env")
-
+	env := environment.EphemeralWithValues("test-env", nil)
 	mockContext := mocks.NewMockContext(context.Background())
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 		return strings.Contains(command, "docker build")
@@ -50,9 +48,9 @@ services:
 		}, nil
 	})
 
-	projectConfig, err := ParseProjectConfig(testProj, &env)
+	projectConfig, err := ParseProjectConfig(testProj, env)
 	require.NoError(t, err)
-	prj, err := projectConfig.GetProject(mockContext.Context, &env)
+	prj, err := projectConfig.GetProject(mockContext.Context, env)
 	require.NoError(t, err)
 
 	service := prj.Services[0]
@@ -62,7 +60,7 @@ services:
 	progress := make(chan string)
 	done := make(chan bool)
 
-	internalFramework := NewNpmProject(*mockContext.Context, service.Config, &env)
+	internalFramework := NewNpmProject(*mockContext.Context, service.Config, env)
 	progressMessages := []string{}
 
 	go func() {
@@ -72,7 +70,7 @@ services:
 		done <- true
 	}()
 
-	framework := NewDockerProject(service.Config, &env, docker, internalFramework)
+	framework := NewDockerProject(service.Config, env, docker, internalFramework)
 	res, err := framework.Package(*mockContext.Context, progress)
 	close(progress)
 	<-done
@@ -101,9 +99,7 @@ services:
       context: ../
 `
 
-	env := environment.Environment{Values: make(map[string]string)}
-	env.SetEnvName("test-env")
-
+	env := environment.EphemeralWithValues("test-env", nil)
 	mockContext := mocks.NewMockContext(context.Background())
 
 	ran := false
@@ -129,10 +125,10 @@ services:
 
 	docker := docker.NewDocker(*mockContext.Context)
 
-	projectConfig, err := ParseProjectConfig(testProj, &env)
+	projectConfig, err := ParseProjectConfig(testProj, env)
 	require.NoError(t, err)
 
-	prj, err := projectConfig.GetProject(mockContext.Context, &env)
+	prj, err := projectConfig.GetProject(mockContext.Context, env)
 	require.NoError(t, err)
 
 	service := prj.Services[0]
@@ -140,7 +136,7 @@ services:
 	progress := make(chan string)
 	done := make(chan bool)
 
-	internalFramework := NewNpmProject(*mockContext.Context, service.Config, &env)
+	internalFramework := NewNpmProject(*mockContext.Context, service.Config, env)
 	status := ""
 
 	go func() {
@@ -150,7 +146,7 @@ services:
 		done <- true
 	}()
 
-	framework := NewDockerProject(service.Config, &env, docker, internalFramework)
+	framework := NewDockerProject(service.Config, env, docker, internalFramework)
 	res, err := framework.Package(*mockContext.Context, progress)
 	close(progress)
 	<-done

--- a/cli/azd/pkg/project/project_config_test.go
+++ b/cli/azd/pkg/project/project_config_test.go
@@ -28,10 +28,9 @@ services:
     host: appservice
 `
 
-	e := environment.Environment{Values: make(map[string]string)}
-	e.SetEnvName("test-env")
+	e := environment.EphemeralWithValues("test-env", nil)
 
-	projectConfig, err := ParseProjectConfig(testProj, &e)
+	projectConfig, err := ParseProjectConfig(testProj, e)
 	require.Nil(t, err)
 	require.NotNil(t, projectConfig)
 
@@ -64,10 +63,9 @@ services:
     host: appservice
 `
 
-	e := environment.Environment{Values: make(map[string]string)}
-	e.SetEnvName("test-env")
+	e := environment.EphemeralWithValues("test-env", nil)
 
-	projectConfig, err := ParseProjectConfig(testProj, &e)
+	projectConfig, err := ParseProjectConfig(testProj, e)
 	require.Nil(t, err)
 
 	require.True(t, projectConfig.HasService("web"))
@@ -93,13 +91,12 @@ services:
 `
 	mockContext := mocks.NewMockContext(context.Background())
 
-	e := environment.Environment{Values: make(map[string]string)}
-	e.SetEnvName("test-env")
+	e := environment.EphemeralWithValues("test-env", nil)
 
-	projectConfig, err := ParseProjectConfig(testProj, &e)
+	projectConfig, err := ParseProjectConfig(testProj, e)
 	require.Nil(t, err)
 
-	project, err := projectConfig.GetProject(mockContext.Context, &e)
+	project, err := projectConfig.GetProject(mockContext.Context, e)
 	require.Nil(t, err)
 	require.NotNil(t, project)
 
@@ -129,10 +126,9 @@ services:
       path: ./Dockerfile.dev
       context: ../
 `
-	e := environment.Environment{Values: make(map[string]string)}
-	e.SetEnvName("test-env")
+	e := environment.EphemeralWithValues("test-env", nil)
 
-	projectConfig, err := ParseProjectConfig(testProj, &e)
+	projectConfig, err := ParseProjectConfig(testProj, e)
 
 	require.NotNil(t, projectConfig)
 	require.Nil(t, err)
@@ -157,10 +153,9 @@ services:
     module: ./api/api
 `
 
-	e := environment.Environment{Values: make(map[string]string)}
-	e.SetEnvName("test-env")
+	e := environment.EphemeralWithValues("test-env", nil)
 
-	projectConfig, err := ParseProjectConfig(testProj, &e)
+	projectConfig, err := ParseProjectConfig(testProj, e)
 
 	require.NotNil(t, projectConfig)
 	require.Nil(t, err)
@@ -321,10 +316,9 @@ services:
     module: ./api/api
 `
 
-	e := environment.Environment{Values: make(map[string]string)}
-	e.SetEnvName("test-env")
+	e := environment.EphemeralWithValues("test-env", nil)
 
-	projectConfig, _ := ParseProjectConfig(testProj, &e)
+	projectConfig, _ := ParseProjectConfig(testProj, e)
 
 	return projectConfig
 }

--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -40,12 +40,11 @@ services:
 `
 	mockContext := mocks.NewMockContext(context.Background())
 
-	e := environment.Environment{Values: make(map[string]string)}
-	e.SetEnvName("envA")
-	projectConfig, err := ParseProjectConfig(testProj, &e)
+	e := environment.EphemeralWithValues("envA", nil)
+	projectConfig, err := ParseProjectConfig(testProj, e)
 	assert.Nil(t, err)
 
-	project, err := projectConfig.GetProject(mockContext.Context, &e)
+	project, err := projectConfig.GetProject(mockContext.Context, e)
 	assert.Nil(t, err)
 
 	azCli := azcli.GetAzCli(*mockContext.Context)
@@ -91,12 +90,11 @@ services:
 `
 	mockContext := mocks.NewMockContext(context.Background())
 
-	e := environment.Environment{Values: make(map[string]string)}
-	e.SetEnvName("envA")
-	projectConfig, err := ParseProjectConfig(testProj, &e)
+	e := environment.EphemeralWithValues("envA", nil)
+	projectConfig, err := ParseProjectConfig(testProj, e)
 	assert.Nil(t, err)
 
-	project, err := projectConfig.GetProject(mockContext.Context, &e)
+	project, err := projectConfig.GetProject(mockContext.Context, e)
 	assert.Nil(t, err)
 
 	assertHasService(t,
@@ -137,12 +135,11 @@ services:
 				Location: "westus2",
 			}})
 
-	e := environment.Environment{Values: make(map[string]string)}
-	e.SetEnvName("envA")
-	projectConfig, err := ParseProjectConfig(testProj, &e)
+	e := environment.EphemeralWithValues("envA", nil)
+	projectConfig, err := ParseProjectConfig(testProj, e)
 	assert.Nil(t, err)
 
-	project, err := projectConfig.GetProject(mockContext.Context, &e)
+	project, err := projectConfig.GetProject(mockContext.Context, e)
 	assert.Nil(t, err)
 
 	// Deployment resource name comes from the found tag on the graph query request
@@ -172,12 +169,11 @@ services:
 `
 	mockContext := mocks.NewMockContext(context.Background())
 
-	e := environment.Environment{Values: make(map[string]string)}
-	e.SetEnvName("envA")
-	projectConfig, err := ParseProjectConfig(testProj, &e)
+	e := environment.EphemeralWithValues("envA", nil)
+	projectConfig, err := ParseProjectConfig(testProj, e)
 	assert.Nil(t, err)
 
-	project, err := projectConfig.GetProject(mockContext.Context, &e)
+	project, err := projectConfig.GetProject(mockContext.Context, e)
 	assert.Nil(t, err)
 
 	assertHasService(t,
@@ -212,14 +208,15 @@ services:
 	mockContext := mocks.NewMockContext(context.Background())
 
 	expectedResourceGroupName := "custom-name-from-env-rg"
-	values := map[string]string{"AZURE_RESOURCE_GROUP": expectedResourceGroupName}
-	e := environment.Environment{Values: values}
 
-	e.SetEnvName("envA")
-	projectConfig, err := ParseProjectConfig(testProj, &e)
+	e := environment.EphemeralWithValues("envA", map[string]string{
+		"AZURE_RESOURCE_GROUP": expectedResourceGroupName,
+	})
+
+	projectConfig, err := ParseProjectConfig(testProj, e)
 	assert.Nil(t, err)
 
-	project, err := projectConfig.GetProject(mockContext.Context, &e)
+	project, err := projectConfig.GetProject(mockContext.Context, e)
 	assert.Nil(t, err)
 
 	assertHasService(t,

--- a/cli/azd/pkg/project/service_config_test.go
+++ b/cli/azd/pkg/project/service_config_test.go
@@ -162,10 +162,9 @@ services:
     module: ./api/api
 `
 
-	e := environment.Environment{Values: make(map[string]string)}
-	e.SetEnvName("test-env")
+	e := environment.EphemeralWithValues("test-env", nil)
 
-	projectConfig, _ := ParseProjectConfig(testProj, &e)
+	projectConfig, _ := ParseProjectConfig(testProj, e)
 
 	return projectConfig.Services["api"]
 }

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -84,7 +84,7 @@ func (at *containerAppTarget) Deploy(ctx context.Context, azdCtx *azdcontext.Azd
 	}
 
 	commandOptions := internal.GetCommandOptions(ctx)
-	infraManager, err := provisioning.NewManager(ctx, *at.env, at.config.Project.Path, at.config.Infra, !commandOptions.NoPrompt)
+	infraManager, err := provisioning.NewManager(ctx, at.env, at.config.Project.Path, at.config.Infra, !commandOptions.NoPrompt)
 	if err != nil {
 		return ServiceDeploymentResult{}, fmt.Errorf("creating provisioning manager: %w", err)
 	}

--- a/cli/azd/pkg/project/service_test.go
+++ b/cli/azd/pkg/project/service_test.go
@@ -23,7 +23,6 @@ services:
     language: js
     host: appservice
 `
-	env             = &environment.Environment{}
 	deploymentScope = environment.NewDeploymentScope("test-subscription-id", "test-resource-group-name", "test-resource-name")
 	mockEndpoints   = []string{"https://test-resource.azurewebsites.net"}
 )
@@ -71,6 +70,8 @@ func (st *mockServiceTarget) Endpoints(_ context.Context) ([]string, error) {
 
 func TestDeployProgressMessages(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
+
+	env := environment.Ephemeral()
 
 	projectConfig, _ := ParseProjectConfig(projectYaml, env)
 	project, _ := projectConfig.GetProject(mockContext.Context, env)

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -109,7 +109,7 @@ func Test_CLI_Init_AsksForSubscriptionIdAndCreatesEnvAndProjectFile(t *testing.T
 	require.Regexp(t, regexp.MustCompile(`AZURE_SUBSCRIPTION_ID="MY_SUB_ID"`+"\n"), string(file))
 	require.Regexp(t, regexp.MustCompile(`AZURE_ENV_NAME="TESTENV"`+"\n"), string(file))
 
-	proj, err := project.LoadProjectConfig(filepath.Join(dir, azdcontext.ProjectFileName), &environment.Environment{})
+	proj, err := project.LoadProjectConfig(filepath.Join(dir, azdcontext.ProjectFileName), environment.Ephemeral())
 	require.NoError(t, err)
 
 	require.Equal(t, filepath.Base(dir), proj.Name)
@@ -224,7 +224,7 @@ func Internal_Test_CLI_ResourceGroupsName(t *testing.T, envName string, rgName s
 
 	// Verify that resource group is found or not found correctly
 	resourceManager := infra.NewAzureResourceManager(ctx)
-	foundRg, err := resourceManager.FindResourceGroupForEnvironment(ctx, &env)
+	foundRg, err := resourceManager.FindResourceGroupForEnvironment(ctx, env)
 
 	if createResources {
 		if createMultipleResourceGroups {
@@ -283,7 +283,7 @@ func Test_CLI_InfraCreateAndDelete(t *testing.T) {
 
 	// Verify that resource groups are created with tag
 	resourceManager := infra.NewAzureResourceManager(ctx)
-	rgs, err := resourceManager.GetResourceGroupsForEnvironment(ctx, &env)
+	rgs, err := resourceManager.GetResourceGroupsForEnvironment(ctx, env)
 	require.NoError(t, err)
 	require.NotNil(t, rgs)
 
@@ -329,7 +329,7 @@ func Test_CLI_InfraCreateAndDeleteUpperCase(t *testing.T) {
 
 	// Verify that resource groups are created with tag
 	resourceManager := infra.NewAzureResourceManager(ctx)
-	rgs, err := resourceManager.GetResourceGroupsForEnvironment(ctx, &env)
+	rgs, err := resourceManager.GetResourceGroupsForEnvironment(ctx, env)
 	require.NoError(t, err)
 	require.NotNil(t, rgs)
 


### PR DESCRIPTION
Today the `Environment` object just holds a go map of values which represent the environment. Different parts of the system had different opinions as to if a pointer to an environment or the entire object should be passed around.  We intend to chage the internal shape of this object, so to prepare, I've done a pass over the codebase to do the following:

- Environments are now only created by code in the environment package, and all the "constructors" return `*Environment`.

- `Ephemeral` and `EphemeralWithValues` have been introduced to the environment package for testing purposes. They can be used to replace explicit construction of environments.

- Methods that return an environment along with an error now return `nil`, instead of the zero value for `Environment` (which is itself invalid since the map of values is nil) to prevent accidently use.

As part of this change, I noticed a few places where we would load an environment and then not pass it to our project reading logic (in favor of using an invalid one with no values). For `restore` this required actually loading the environment, which we didn't do previously.