### PR TITLE
Fixes azd monitor for terraform

### DIFF
--- a/cli/azd/cmd/monitor.go
+++ b/cli/azd/cmd/monitor.go
@@ -89,13 +89,7 @@ func (m *monitorAction) Run(ctx context.Context, cmd *cobra.Command, args []stri
 	}
 
 	resourceManager := infra.NewAzureResourceManager(ctx)
-	resourceGroupsResources, err := resourceManager.GetResourceGroupsForEnvironment(ctx, &env)
-	resourceGroups := []string{}
-
-	for _, value := range resourceGroupsResources {
-		resourceGroups = append(resourceGroups, value.Name)
-	}
-
+	resourceGroups, err := resourceManager.GetResourceGroupsForEnvironment(ctx, &env)
 	if err != nil {
 		return fmt.Errorf("discovering resource groups from deployment: %w", err)
 	}
@@ -104,7 +98,7 @@ func (m *monitorAction) Run(ctx context.Context, cmd *cobra.Command, args []stri
 	var portalResources []azcli.AzCliResource
 
 	for _, resourceGroup := range resourceGroups {
-		resources, err := azCli.ListResourceGroupResources(ctx, env.GetSubscriptionId(), resourceGroup, nil)
+		resources, err := azCli.ListResourceGroupResources(ctx, env.GetSubscriptionId(), resourceGroup.Name, nil)
 		if err != nil {
 			return fmt.Errorf("listing resources: %w", err)
 		}

--- a/cli/azd/cmd/monitor.go
+++ b/cli/azd/cmd/monitor.go
@@ -89,7 +89,13 @@ func (m *monitorAction) Run(ctx context.Context, cmd *cobra.Command, args []stri
 	}
 
 	resourceManager := infra.NewAzureResourceManager(ctx)
-	resourceGroups, err := resourceManager.GetResourceGroupsForDeployment(ctx, env.GetSubscriptionId(), env.GetEnvName())
+	resourceGroupsResources, err := resourceManager.GetResourceGroupsForEnvironment(ctx, &env)
+	resourceGroups := []string{}
+
+	for _, value := range resourceGroupsResources {
+		resourceGroups = append(resourceGroups, value.Name)
+	}
+
 	if err != nil {
 		return fmt.Errorf("discovering resource groups from deployment: %w", err)
 	}


### PR DESCRIPTION
This fix addresses the issue where the `azd monitor` commands fail for terraform deployed apps.

This change modifies the discovery to query resource groups by environment instead of by ARM deployment since Terraform deployments do not utilize ARM.