### PR TITLE
Change gitattributes for Windows file endings

### DIFF
--- a/templates/common/.gitattributes
+++ b/templates/common/.gitattributes
@@ -1,1 +1,3 @@
-*.sh text eol=lf
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
According to the issue I reported in #694 I changed the sample template for the `.gitattributes` file in accordance to the proposed troubleshooting described in the Visual Studio Code documentation ([link](https://code.visualstudio.com/docs/remote/troubleshooting#_resolving-git-line-ending-issues-in-containers-resulting-in-many-modified-files)).

I successfully tested the changed setup with Windows 11 and WSL2 and it fixes the issue. 