### PR TITLE
Support more `docker --version` schemes

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -25,6 +25,7 @@ cmdsubst
 containerapp
 csharpapp
 devel
+dockerproject
 eastus
 envname
 errcheck

--- a/cli/azd/pkg/tools/docker/docker.go
+++ b/cli/azd/pkg/tools/docker/docker.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"log"
 	"regexp"
 	"strconv"
 	"strings"
@@ -65,27 +66,70 @@ func (d *Docker) versionInfo() tools.VersionInfo {
 	}
 }
 
-func (d *Docker) extractDockerVersionSemVer(cliOutput string) (semver.Version, error) {
-	ver := regexp.MustCompile(`\d+\.\d+\.\d+`).FindString(cliOutput)
+// dockerVersionRegexp is a regular expression which matches the text printed by "docker --version"
+// and captures the version and build components.
+var dockerVersionStringRegexp = regexp.MustCompile(`Docker version ([^,]*), build ([a-f0-9]*)`)
 
-	// Skip leading zeroes to allow inexact parsing for version formats that are not truly SemVer compliant.
-	// Example: docker has versions like 17.09.0 (non semver) instead of 17.9.0 (semver)
-	versionSplit := strings.Split(ver, ".")
-	for key, val := range versionSplit {
-		verInt, err := strconv.Atoi(val)
+// dockerVersionReleaseBuildRegexp is a regular expression which matches the three part version number
+// from a docker version from an official release. The major and minor components are captured.
+var dockerVersionReleaseBuildRegexp = regexp.MustCompile(`^(\d+).(\d+).\d+`)
+
+// dockerVersionMasterBuildRegexp is a regular expression which matches the three part version number
+// from a docker version from a release from master. Each version component is captured independently.
+var dockerVersionMasterBuildRegexp = regexp.MustCompile(`^master-dockerproject-(\d+)-(\d+)-(\d+)`)
+
+// isSupportedDockerVersion returns true if the version string appears to be for a docker version
+// of 17.09 or later and false if it does not.
+func isSupportedDockerVersion(cliOutput string) (bool, error) {
+	log.Printf("determining version from docker --version string: %s", cliOutput)
+
+	matches := dockerVersionStringRegexp.FindStringSubmatch(cliOutput)
+
+	// (3 matches, the entire string, and the two captures)
+	if len(matches) != 3 {
+		return false, fmt.Errorf("could not extract version component from docker version string")
+	}
+
+	version := matches[1]
+	build := matches[2]
+
+	log.Printf("extracted docker version: %s, build: %s from version string", version, build)
+
+	// For official release builds, the version number looks something like:
+	//
+	// 17.09.0-ce or 20.10.17+azure-1
+	//
+	// Note this is not a semver (the leading zero in the second component of the 17.09 string is not allowed per semver)
+	// so we need to take this apart ourselves.
+	if releaseVersionMatches := dockerVersionReleaseBuildRegexp.FindStringSubmatch(version); releaseVersionMatches != nil {
+		major, err := strconv.Atoi(releaseVersionMatches[1])
 		if err != nil {
-			return semver.Version{}, err
+			return false, fmt.Errorf("failed to convert major version component %s to an integer: %w", releaseVersionMatches[1], err)
 		}
-		versionSplit[key] = strconv.Itoa(verInt)
+
+		minor, err := strconv.Atoi(releaseVersionMatches[2])
+		if err != nil {
+			return false, fmt.Errorf("failed to convert minor version component %s to an integer: %w", releaseVersionMatches[2], err)
+		}
+
+		return (major > 17 || (major == 17 && minor >= 9)), nil
 	}
 
-	semver, err := semver.Parse(strings.Join(versionSplit, "."))
-	if err != nil {
-		return semver, err
-	}
-	return semver, nil
+	// For builds which come out of master, we'll assume any build from 2018 or later will work
+	// (since we support 17.09 which was released in September of 2017)
+	if masterVersionMatches := dockerVersionMasterBuildRegexp.FindStringSubmatch(version); masterVersionMatches != nil {
+		year, err := strconv.Atoi(masterVersionMatches[1])
+		if err != nil {
+			return false, fmt.Errorf("failed to convert major version component %s to an integer: %w", masterVersionMatches[1], err)
+		}
 
+		return year >= 2018, nil
+	}
+
+	// If we reach this point, we don't understand how to validate the version based on its scheme.
+	return false, fmt.Errorf("could not determine version from docker version string: %s", version)
 }
+
 func (d *Docker) CheckInstalled(ctx context.Context) (bool, error) {
 	found, err := tools.ToolInPath("docker")
 	if !found {
@@ -95,13 +139,12 @@ func (d *Docker) CheckInstalled(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("checking %s version: %w", d.Name(), err)
 	}
-	dockerSemver, err := d.extractDockerVersionSemVer(dockerRes)
+	supported, err := isSupportedDockerVersion(dockerRes)
 	if err != nil {
-		return false, fmt.Errorf("converting to semver version fails: %w", err)
+		return false, err
 	}
-	updateDetail := d.versionInfo()
-	if dockerSemver.LT(updateDetail.MinimumVersion) {
-		return false, &tools.ErrSemver{ToolName: d.Name(), VersionInfo: updateDetail}
+	if !supported {
+		return false, &tools.ErrSemver{ToolName: d.Name(), VersionInfo: d.versionInfo()}
 	}
 	return true, nil
 }

--- a/cli/azd/pkg/tools/docker/docker_test.go
+++ b/cli/azd/pkg/tools/docker/docker_test.go
@@ -272,3 +272,61 @@ func Test_DockerPush(t *testing.T) {
 		require.Equal(t, fmt.Sprintf("pushing image: exit code: 1, stdout: , stderr: %s: %s", stdErr, customErrorMessage), err.Error())
 	})
 }
+
+func Test_IsSupportedDockerVersion(t *testing.T) {
+	cases := []struct {
+		name        string
+		version     string
+		supported   bool
+		expectError bool
+	}{
+		{
+			name:        "CI_Linux",
+			version:     "Docker version 20.10.17+azure-1, build 100c70180fde3601def79a59cc3e996aa553c9b9",
+			supported:   true,
+			expectError: false,
+		},
+		{
+			name:        "CI_Mac",
+			version:     "Docker version 17.09.0-ce, build afdb6d4",
+			supported:   true,
+			expectError: false,
+		},
+		{
+			name:        "CI_Windows",
+			version:     "Docker version master-dockerproject-2022-03-26, build dd7397342a",
+			supported:   true,
+			expectError: false,
+		},
+		{
+			name:        "DockerDesktop_Windows",
+			version:     "Docker version 20.10.17, build 100c701",
+			supported:   true,
+			expectError: false,
+		},
+		{
+			name:        "NotNewEnough",
+			version:     "Docker version 17.06.0-ce, build badf00d",
+			supported:   false,
+			expectError: false,
+		},
+		{
+			name:        "UnknownScheme",
+			version:     "Docker version some-new-scheme-we-don-t-know-about-2021-01-01, build badf00d",
+			supported:   false,
+			expectError: true,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			supported, err := isSupportedDockerVersion(testCase.version)
+			require.Equal(t, testCase.supported, supported)
+			if testCase.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -76,11 +76,6 @@ stages:
               dockerVersion: 17.09.0-ce
               releaseType: stable
 
-          - pwsh: |
-              docker --version
-              docker version
-            displayName: Print Docker Version Info
-
           - task: PowerShell@2
             inputs:
               pwsh: true

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -75,6 +75,12 @@ stages:
             inputs:
               dockerVersion: 17.09.0-ce
               releaseType: stable
+
+          - pwsh: |
+              docker --version
+              docker version
+            displayName: Print Docker Version Info
+
           - task: PowerShell@2
             inputs:
               pwsh: true


### PR DESCRIPTION
Docker EE has been replaced with Docker CE / Moby for the windows images used by both GitHub Actions and the ones we use for our internal AzDo runs.

With this change, docker --version started to report a version number like:

```
Docker version master-dockerproject-2022-03-26, build dd7397342a
```

Our logic to parse the version number could not handle this scheme. It has now been rewritten to support this, as well as the older scheme which is still used by the Mac and Linux images (as well as for folks who have installed Docker Desktop on Windows)