### PR TITLE
Block Web UI until service is ready

### DIFF
--- a/templates/todo/web/react-fluent/src/components/todoItemListPane.tsx
+++ b/templates/todo/web/react-fluent/src/components/todoItemListPane.tsx
@@ -1,4 +1,4 @@
-import { CommandBar, DetailsList, DetailsListLayoutMode, IStackStyles, Selection, Stack, IIconProps, SearchBox, Text, IGroup, IColumn, MarqueeSelection, FontIcon, IObjectWithKey, CheckboxVisibility, IDetailsGroupRenderProps, getTheme } from '@fluentui/react';
+import { CommandBar, DetailsList, DetailsListLayoutMode, IStackStyles, Selection, Label, Spinner, SpinnerSize, Stack, IIconProps, SearchBox, Text, IGroup, IColumn, MarqueeSelection, FontIcon, IObjectWithKey, CheckboxVisibility, IDetailsGroupRenderProps, getTheme } from '@fluentui/react';
 import React, { ReactElement, useEffect, useState, FormEvent, FC } from 'react';
 import { useNavigate } from 'react-router';
 import { TodoItem, TodoItemState, TodoList } from '../models';
@@ -240,7 +240,13 @@ const TodoItemListPane: FC<TodoItemListPaneProps> = (props: TodoItemListPaneProp
                     </MarqueeSelection>
                 </Stack.Item>
             }
-            {items.length === 0 &&
+            {!props.items &&
+                <Stack.Item align="center" tokens={stackItemPadding}>
+                    <Label>Loading List Items...</Label>
+                    <Spinner size={SpinnerSize.large} labelPosition="top" /> 
+                </Stack.Item>
+            }
+            {props.items && items.length === 0 &&
                 <Stack.Item align="center" tokens={stackItemPadding}>
                     <Text>This list is empty.</Text>
                 </Stack.Item>

--- a/templates/todo/web/react-fluent/src/components/todoItemListPane.tsx
+++ b/templates/todo/web/react-fluent/src/components/todoItemListPane.tsx
@@ -1,4 +1,4 @@
-import { CommandBar, DetailsList, DetailsListLayoutMode, ICommandBarItemProps, IStackStyles, Selection, Stack, IIconProps, SearchBox, Text, IGroup, IColumn, MarqueeSelection, FontIcon, IObjectWithKey, CheckboxVisibility, IDetailsGroupRenderProps, getTheme } from '@fluentui/react';
+import { CommandBar, DetailsList, DetailsListLayoutMode, IStackStyles, Selection, Stack, IIconProps, SearchBox, Text, IGroup, IColumn, MarqueeSelection, FontIcon, IObjectWithKey, CheckboxVisibility, IDetailsGroupRenderProps, getTheme } from '@fluentui/react';
 import React, { ReactElement, useEffect, useState, FormEvent, FC } from 'react';
 import { useNavigate } from 'react-router';
 import { TodoItem, TodoItemState, TodoList } from '../models';
@@ -8,6 +8,7 @@ interface TodoItemListPaneProps {
     list?: TodoList
     items?: TodoItem[]
     selectedItem?: TodoItem;
+    disabled: boolean
     onCreated: (item: TodoItem) => void
     onDelete: (item: TodoItem) => void
     onComplete: (item: TodoItem) => void
@@ -156,11 +157,6 @@ const TodoItemListPane: FC<TodoItemListPaneProps> = (props: TodoItemListPaneProp
         { key: 'completedDate', name: 'Completed', fieldName: 'completedDate', minWidth: 100 },
     ];
 
-    const commandItems: ICommandBarItemProps[] = [
-        { key: 'markComplete', text: 'Mark Complete', iconProps: { iconName: 'Completed' }, onClick: () => { completeItems() } },
-        { key: 'delete', text: 'Delete', iconProps: { iconName: 'Delete' }, onClick: () => { deleteItems() } },
-    ];
-
     const groupRenderProps: IDetailsGroupRenderProps = {
         headerProps: {
             styles: {
@@ -198,11 +194,26 @@ const TodoItemListPane: FC<TodoItemListPaneProps> = (props: TodoItemListPaneProp
                 <form onSubmit={onFormSubmit}>
                     <Stack horizontal styles={stackStyles}>
                         <Stack.Item grow={1}>
-                            <SearchBox value={newItemName} placeholder="Add an item" iconProps={addIconProps} onChange={onNewItemChanged} />
+                            <SearchBox value={newItemName} placeholder="Add an item" iconProps={addIconProps} onChange={onNewItemChanged} disabled={props.disabled} />
                         </Stack.Item>
                         <Stack.Item>
                             <CommandBar
-                                items={commandItems}
+                                items={[
+                                    {
+                                        key: 'markComplete',
+                                        text: 'Mark Complete',
+                                        disabled: props.disabled,
+                                        iconProps: { iconName: 'Completed' },
+                                        onClick: () => { completeItems() }
+                                    },
+                                    {
+                                        key: 'delete',
+                                        text: 'Delete',
+                                        disabled: props.disabled,
+                                        iconProps: { iconName: 'Delete' },
+                                        onClick: () => { deleteItems() }
+                                    }
+                                ]}
                                 ariaLabel="Todo actions" />
                         </Stack.Item>
                     </Stack>

--- a/templates/todo/web/react-fluent/src/components/todoListMenu.tsx
+++ b/templates/todo/web/react-fluent/src/components/todoListMenu.tsx
@@ -73,6 +73,7 @@ const TodoListMenu: FC<TodoListMenuProps> = (props: TodoListMenuProps): ReactEle
                         borderless
                         iconProps={iconProps}
                         value={newListName}
+                        disabled={props.selectedList == null}
                         placeholder="New List"
                         onChange={onNewListNameChange} />
                 </form>

--- a/templates/todo/web/react-fluent/src/pages/homePage.tsx
+++ b/templates/todo/web/react-fluent/src/pages/homePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext, useMemo } from 'react';
+import React, { useEffect, useContext, useMemo, useState } from 'react';
 import { IconButton, IContextualMenuProps, IIconProps, Stack, Text } from '@fluentui/react';
 import TodoItemListPane from '../components/todoItemListPane';
 import { TodoItem, TodoItemState } from '../models';
@@ -22,6 +22,8 @@ const HomePage = () => {
         items: bindActionCreators(itemActions, appContext.dispatch) as unknown as ItemActions,
     }), [appContext.dispatch]);
 
+    const [isReady, setIsReady] = useState(false)
+
     // Create default list of does not exist
     useEffect(() => {
         if (appContext.state.lists?.length === 0) {
@@ -34,7 +36,6 @@ const HomePage = () => {
         if (appContext.state.lists?.length && !listId && !appContext.state.selectedList) {
             const defaultList = appContext.state.lists[0];
             navigate(`/lists/${defaultList.id}`);
-            console.log('selected default list');
         }
     }, [appContext.state.lists, appContext.state.selectedList, listId, navigate])
 
@@ -55,7 +56,12 @@ const HomePage = () => {
     // Load items for selected list
     useEffect(() => {
         if (appContext.state.selectedList?.id && !appContext.state.selectedList.items) {
-            actions.items.list(appContext.state.selectedList.id);
+            const loadListItems = async (listId: string) => {
+                await actions.items.list(listId);
+                setIsReady(true)
+            }
+
+            loadListItems(appContext.state.selectedList.id)
         }
     }, [actions.items, appContext.state.selectedList?.id, appContext.state.selectedList?.items])
 
@@ -117,6 +123,7 @@ const HomePage = () => {
                     </Stack.Item>
                     <Stack.Item>
                         <IconButton
+                            disabled={!isReady}
                             menuProps={menuProps}
                             iconProps={iconProps}
                             styles={{ root: { fontSize: 16 } }}
@@ -130,6 +137,7 @@ const HomePage = () => {
                     list={appContext.state.selectedList}
                     items={appContext.state.selectedList?.items}
                     selectedItem={appContext.state.selectedItem}
+                    disabled={!isReady}
                     onSelect={onItemSelected}
                     onCreated={onItemCreated}
                     onComplete={onItemCompleted}

--- a/templates/todo/web/react-fluent/src/pages/homePage.tsx
+++ b/templates/todo/web/react-fluent/src/pages/homePage.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useContext, useMemo, useState } from 'react';
-import { IconButton, IContextualMenuProps, IIconProps, Stack, Text } from '@fluentui/react';
+import React, { useEffect, useContext, useMemo, useState, Fragment } from 'react';
+import { IconButton, IContextualMenuProps, IIconProps, Stack, Text, Shimmer, ShimmerElementType } from '@fluentui/react';
 import TodoItemListPane from '../components/todoItemListPane';
 import { TodoItem, TodoItemState } from '../models';
 import * as itemActions from '../actions/itemActions';
@@ -118,8 +118,18 @@ const HomePage = () => {
             <Stack.Item>
                 <Stack horizontal styles={titleStackStyles} tokens={stackPadding}>
                     <Stack.Item grow={1}>
-                        <Text block variant="xLarge">{appContext.state.selectedList?.name}</Text>
-                        <Text variant="small">{appContext.state.selectedList?.description}</Text>
+                        <Shimmer width={300}
+                            isDataLoaded={!!appContext.state.selectedList}
+                            shimmerElements={
+                                [
+                                    { type: ShimmerElementType.line, height: 20 }
+                                ]
+                            } >
+                            <Fragment>
+                                <Text block variant="xLarge">{appContext.state.selectedList?.name}</Text>
+                                <Text variant="small">{appContext.state.selectedList?.description}</Text>
+                            </Fragment>
+                        </Shimmer>
                     </Stack.Item>
                     <Stack.Item>
                         <IconButton


### PR DESCRIPTION
This PR addresses the issue where the UI allows you to attempt to create new items before the default list has loaded.  
This adds a `ready` state that will disable the UI input controls until the required service calls have completed successfully.

- [x] Disables input controls if list is not ready
- [x] Adds loading spinner animation while list items are loading
- [x] Adder shimmer loading effect to list title  