### PR TITLE
Fix error in `deploy` with multiple resource groups

### DIFF
--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -12,7 +12,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
@@ -182,24 +181,6 @@ func (d *deployAction) Run(ctx context.Context, cmd *cobra.Command, args []strin
 			return fmt.Errorf("deployment result could not be displayed: %w", fmtErr)
 		}
 	}
-
-	resourceManager := infra.NewAzureResourceManager(ctx)
-	resourceGroup, err := resourceManager.FindResourceGroupForEnvironment(ctx, env)
-	if err != nil {
-		return fmt.Errorf("discovering resource group from deployment: %w", err)
-	}
-
-	resourcesGroupURL := fmt.Sprintf(
-		"https://portal.azure.com/#@/resource/subscriptions/%s/resourceGroups/%s/overview",
-		env.GetSubscriptionId(),
-		resourceGroup)
-
-	message := fmt.Sprintf(
-		"View the resources created under the resource group %s in Azure Portal:\n%s\n",
-		output.WithHighLightFormat(resourceGroup),
-		output.WithLinkFormat(resourcesGroupURL),
-	)
-	console.Message(ctx, message)
 
 	return nil
 }

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -16,7 +16,7 @@ import (
 )
 
 func upCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
-	infaCreateFinalOutput := []string{}
+	infraCreateFinalOutput := []string{}
 
 	cmd := commands.Build(
 		commands.CompositeAction(
@@ -27,7 +27,7 @@ func upCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 			},
 			&infraCreateAction{
 				// Delay print final output from infra create
-				finalOutputRedirect: &infaCreateFinalOutput,
+				finalOutputRedirect: &infraCreateFinalOutput,
 				rootOptions:         rootOptions,
 			},
 			// Print an additional newline to separate provision from deploy
@@ -47,7 +47,7 @@ func upCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 			commands.ActionFunc(
 				func(ctx context.Context, cmd *cobra.Command, args []string, azdCtx *azdcontext.AzdContext) error {
 					console := input.GetConsole(ctx)
-					for _, message := range infaCreateFinalOutput {
+					for _, message := range infraCreateFinalOutput {
 						console.Message(ctx, message)
 					}
 					return nil

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -9,12 +9,15 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
 func upCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
+	infaCreateFinalOutput := []string{}
+
 	cmd := commands.Build(
 		commands.CompositeAction(
 			&ignoreInitErrorAction{
@@ -23,7 +26,9 @@ func upCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 				},
 			},
 			&infraCreateAction{
-				rootOptions: rootOptions,
+				// Delay print final output from infra create
+				finalOutputRedirect: &infaCreateFinalOutput,
+				rootOptions:         rootOptions,
 			},
 			// Print an additional newline to separate provision from deploy
 			commands.ActionFunc(
@@ -38,6 +43,16 @@ func upCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 				},
 			),
 			&deployAction{rootOptions: rootOptions},
+			// Print the final output from infra create
+			commands.ActionFunc(
+				func(ctx context.Context, cmd *cobra.Command, args []string, azdCtx *azdcontext.AzdContext) error {
+					console := input.GetConsole(ctx)
+					for _, message := range infaCreateFinalOutput {
+						console.Message(ctx, message)
+					}
+					return nil
+				},
+			),
 		),
 		rootOptions,
 		"up",

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -80,10 +80,9 @@ func NewProject(path string, name string) (*Project, error) {
 //
 // The resource group name is resolved in the following order:
 //   - The user defined value in `azure.yaml`
-//   - The user defined environment value "AZURE_RESOURCE_GROUP"
-//   - Resource group discovery by querying Azure Resources (see FindResourceGroupForEnvironment for more details)
+//   - The user defined environment value `AZURE_RESOURCE_GROUP`
+//   - Resource group discovery by querying Azure Resources (see `resourceManager.FindResourceGroupForEnvironment` for more details)
 func GetResourceGroupName(ctx context.Context, projectConfig *ProjectConfig, env *environment.Environment) (string, error) {
-	// If ResourceGroupName not set in azure.yaml, then look for it in the AZURE_RESOURCE_GROUP env var
 	if strings.TrimSpace(projectConfig.ResourceGroupName) != "" {
 		return projectConfig.ResourceGroupName, nil
 	}

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -9,8 +9,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"gopkg.in/yaml.v3"
 )
@@ -20,10 +22,12 @@ const (
 )
 
 type Project struct {
-	Name     string
-	Config   *ProjectConfig
-	Metadata *ProjectMetadata
-	Services []*Service
+	Name string
+	// The resource group targeted by the current project
+	ResourceGroupName string
+	Config            *ProjectConfig
+	Metadata          *ProjectMetadata
+	Services          []*Service
 }
 
 // ReadProject reads a project file and sets the configured template
@@ -70,4 +74,30 @@ func NewProject(path string, name string) (*Project, error) {
 		Name:     name,
 		Services: make([]*Service, 0),
 	}, nil
+}
+
+// GetResourceGroupName gets the resource group name for the project.
+//
+// The resource group name is resolved in the following order:
+//   - The user defined value in `azure.yaml`
+//   - The user defined environment value "AZURE_RESOURCE_GROUP"
+//   - Resource group discovery by querying Azure Resources (see FindResourceGroupForEnvironment for more details)
+func GetResourceGroupName(ctx context.Context, projectConfig *ProjectConfig, env *environment.Environment) (string, error) {
+	// If ResourceGroupName not set in azure.yaml, then look for it in the AZURE_RESOURCE_GROUP env var
+	if strings.TrimSpace(projectConfig.ResourceGroupName) != "" {
+		return projectConfig.ResourceGroupName, nil
+	}
+
+	envResourceGroupName := environment.GetResourceGroupNameFromEnvVar(env)
+	if envResourceGroupName != "" {
+		return envResourceGroupName, nil
+	}
+
+	resourceManager := infra.NewAzureResourceManager(ctx)
+	resourceGroupName, err := resourceManager.FindResourceGroupForEnvironment(ctx, env)
+	if err != nil {
+		return "", err
+	}
+
+	return resourceGroupName, nil
 }

--- a/cli/azd/pkg/project/project_config.go
+++ b/cli/azd/pkg/project/project_config.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/drone/envsubst"
@@ -99,22 +98,17 @@ func (pc *ProjectConfig) GetProject(ctx *context.Context, env *environment.Envir
 		*ctx = telemetry.ContextWithTemplate(*ctx, project.Metadata.Template)
 	}
 
-	if pc.ResourceGroupName == "" {
-		// We won't have a ResourceGroupName yet if it hasn't been set in either azure.yaml or AZURE_RESOURCE_GROUP env var
-		// Let's try to find the right resource group for this environment
-		resourceManager := infra.NewAzureResourceManager(*ctx)
-		resourceGroupName, err := resourceManager.FindResourceGroupForEnvironment(*ctx, env)
-		if err != nil {
-			return nil, err
-		}
-		pc.ResourceGroupName = resourceGroupName
+	resourceGroupName, err := GetResourceGroupName(*ctx, pc, env)
+	if err != nil {
+		return nil, err
 	}
+	project.ResourceGroupName = resourceGroupName
 
 	for key, serviceConfig := range pc.Services {
 		// If the 'resourceName' was not overridden in the project yaml
 		// Retrieve the resource name from the provisioned resources if available
 		if strings.TrimSpace(serviceConfig.ResourceName) == "" {
-			resolvedResourceName, err := GetServiceResourceName(*ctx, pc.ResourceGroupName, serviceConfig.Name, env)
+			resolvedResourceName, err := GetServiceResourceName(*ctx, project.ResourceGroupName, serviceConfig.Name, env)
 			if err != nil {
 				return nil, fmt.Errorf("getting resource name: %w", err)
 			}
@@ -122,7 +116,7 @@ func (pc *ProjectConfig) GetProject(ctx *context.Context, env *environment.Envir
 			serviceConfig.ResourceName = resolvedResourceName
 		}
 
-		deploymentScope := environment.NewDeploymentScope(env.GetSubscriptionId(), pc.ResourceGroupName, serviceConfig.ResourceName)
+		deploymentScope := environment.NewDeploymentScope(env.GetSubscriptionId(), project.ResourceGroupName, serviceConfig.ResourceName)
 		service, err := serviceConfig.GetService(*ctx, &project, env, deploymentScope)
 
 		if err != nil {
@@ -243,11 +237,6 @@ func ParseProjectConfig(yamlContent string, env *environment.Environment) (*Proj
 	}
 
 	projectFile.handlers = make(map[Event][]ProjectLifecycleEventHandlerFn)
-
-	// If ResourceGroupName not set in azure.yaml, then look for it in the AZURE_RESOURCE_GROUP env var
-	if strings.TrimSpace(projectFile.ResourceGroupName) == "" {
-		projectFile.ResourceGroupName = environment.GetResourceGroupNameFromEnvVar(env)
-	}
 
 	for key, svc := range projectFile.Services {
 		svc.handlers = make(map[Event][]ServiceLifecycleEventHandlerFn)

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -425,7 +425,7 @@ func Test_CLI_InfraCreateAndDeleteWebApp(t *testing.T) {
 	require.NoError(t, err)
 
 	commandRunner := exec.NewCommandRunner()
-	runArgs := exec.NewRunArgs("dotnet", "user-secrets", "list", "--project", filepath.Join(dir, "/src/dotnet/webapp.csproj"))
+	runArgs := newRunArgs("dotnet", "user-secrets", "list", "--project", filepath.Join(dir, "/src/dotnet/webapp.csproj"))
 	secrets, err := commandRunner.Run(ctx, runArgs)
 	require.NoError(t, err)
 
@@ -799,25 +799,26 @@ func Test_CLI_InfraCreateAndDeleteResourceTerraformRemote(t *testing.T) {
 
 	//Create remote state resources
 	commandRunner := exec.NewCommandRunner()
-	runArgs := exec.NewRunArgs("az", "group", "create", "--name", backendResourceGroupName, "--location", location)
+	runArgs := newRunArgs("az", "group", "create", "--name", backendResourceGroupName, "--location", location)
+
 	_, err = commandRunner.Run(ctx, runArgs)
 	require.NoError(t, err)
 
 	defer func() {
 		commandRunner := exec.NewCommandRunner()
-		runArgs := exec.NewRunArgs("az", "group", "delete", "--name", backendResourceGroupName, "--yes")
+		runArgs := newRunArgs("az", "group", "delete", "--name", backendResourceGroupName, "--yes")
 		_, err = commandRunner.Run(ctx, runArgs)
 		require.NoError(t, err)
 	}()
 
 	//Create storage account
-	runArgs = exec.NewRunArgs("az", "storage", "account", "create", "--resource-group", backendResourceGroupName,
+	runArgs = newRunArgs("az", "storage", "account", "create", "--resource-group", backendResourceGroupName,
 		"--name", backendStorageAccountName, "--sku", "Standard_LRS", "--encryption-services", "blob")
 	_, err = commandRunner.Run(ctx, runArgs)
 	require.NoError(t, err)
 
 	//Get Account Key
-	runArgs = exec.NewRunArgs("az", "storage", "account", "keys", "list", "--resource-group",
+	runArgs = newRunArgs("az", "storage", "account", "keys", "list", "--resource-group",
 		backendResourceGroupName, "--account-name", backendStorageAccountName, "--query", "[0].value",
 		"-o", "tsv")
 	cmdResult, err := commandRunner.Run(ctx, runArgs)
@@ -825,7 +826,7 @@ func Test_CLI_InfraCreateAndDeleteResourceTerraformRemote(t *testing.T) {
 	storageAccountKey := cmdResult.Stdout
 
 	// Create storage container
-	runArgs = exec.NewRunArgs("az", "storage", "container", "create", "--name", backendContainerName,
+	runArgs = newRunArgs("az", "storage", "container", "create", "--name", backendContainerName,
 		"--account-name", backendStorageAccountName, "--account-key", storageAccountKey)
 	result, err := commandRunner.Run(ctx, runArgs)
 	_ = result
@@ -853,6 +854,11 @@ func Test_CLI_InfraCreateAndDeleteResourceTerraformRemote(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Done\n")
+}
+
+func newRunArgs(cmd string, args ...string) exec.RunArgs {
+	runArgs := exec.NewRunArgs(cmd, args...)
+	return runArgs.WithEnrichError(true)
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
Fixes #689

## Background
As part of Terraform refactor, we had switched the display logic to directly use ARM: `resourceManager.FindResourceGroupForEnvironment`. This misses out on the override abilities that the user can provide through `AZURE_RESOURCE_GROUP` or specifying a `resourceGroup` in `azure.yaml` that helps in resolving multiple resource group cases (which `azd` doesn't currently fully support).

## Changes
- Refactor resource group resolution logic to a central place as `project.GetResourceGroup`. `projectConfig.ResourceGroupName` now always refers to the design-time YAML key defined, `project.ResourceGroupName` refers to the runtime resolved resource group name.
- Move display output of created resources from `deploy` to `provision`. The logic being in `deploy` has always been weird as most code deployments don't actually touch the Azure Resources directly.

Manually tested changes to work.