### PR TITLE
Fix cosmos SQL template tests failing due to KeyVault secret failure

### DIFF
--- a/templates/todo/projects/csharp-sql/.repo/bicep/infra/resources.bicep
+++ b/templates/todo/projects/csharp-sql/.repo/bicep/infra/resources.bicep
@@ -83,6 +83,6 @@ module monitoring '../../../../../../common/infra/bicep/core/monitor/monitoring.
 output API_URI string = api.outputs.API_URI
 output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.applicationInsightsConnectionString
 output AZURE_KEY_VAULT_ENDPOINT string = keyVault.outputs.keyVaultEndpoint
-output AZURE_KEY_VAULT_NAME string = keyVault.name
+output AZURE_KEY_VAULT_NAME string = keyVault.outputs.keyVaultName
 output AZURE_SQL_CONNECTION_STRING_KEY string = sqlServer.outputs.sqlConnectionStringKey
 output WEB_URI string = web.outputs.WEB_URI


### PR DESCRIPTION
Fix #697

As part of bicep refactor, `KeyVault` was migrated from a resource to a bicep module. `keyVault.Name` now refers to the module name, whereas `keyVault.outputs.keyVaultName` is the actual KeyVault name created.