### PR TITLE
Modify Azdo provider default branch to be use the current git branch.

### DIFF
--- a/cli/azd/pkg/azdo/azdo.go
+++ b/cli/azd/pkg/azdo/azdo.go
@@ -23,7 +23,7 @@ var (
 	AzurePipelineName            = "Azure Dev Deploy"                                       // name of the azure pipeline that will be created
 	AzurePipelineYamlPath        = ".azdo/pipelines/azure-dev.yml"                          // path to the azure pipeline yaml
 	CloudEnvironment             = "AzureCloud"                                             // target Azure Cloud
-	DefaultBranch                = "master"                                                 // default branch for pipeline and branch policy
+	DefaultBranch                = "main"                                                   // default branch for pipeline and branch policy
 	AzDoProjectDescription       = "Azure Developer CLI Project"                            // azure devops project description
 	ServiceConnectionName        = "azconnection"                                           // name of the service connection that will be used in the AzDo project. This will store the Azure service principal
 )

--- a/cli/azd/pkg/commands/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/commands/pipeline/azdo_provider.go
@@ -309,7 +309,23 @@ func (p *AzdoScmProvider) configureGitRemote(ctx context.Context, repoPath strin
 			return "", err
 		}
 	}
+
+	branch, err := p.getCurrentGitBranch(ctx, repoPath)
+	if err != nil {
+		return "", err
+	}
+	azdo.DefaultBranch = branch
+
 	return remoteUrl, nil
+}
+
+func (p *AzdoScmProvider) getCurrentGitBranch(ctx context.Context, repoPath string) (string, error) {
+	gitCli := git.NewGitCli(ctx)
+	branch, err := gitCli.GetCurrentBranch(ctx, repoPath)
+	if err != nil {
+		return "", err
+	}
+	return branch, nil
 }
 
 // returns the git remote for a newly created repo that is part of a newly created AzDo project


### PR DESCRIPTION
Modify AzDo provider to use main as default and to also fetch the current branch and use that if there is a different default branch set by the tool.

This is to go along with #764 , but it does not depend on that PR.