### PR TITLE
Use out of source docs folder for generating docs artifacts

### DIFF
--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -237,7 +237,7 @@ stages:
             displayName: Generate azure.yaml schema
 
           # Upload docs for CLI ref and azure.yaml schema
-          - pwsh: Get-ChildItem docs
+          - pwsh: Get-ChildItem .
             workingDirectory: $(Pipeline.Workspace)/docs
             displayName: Show doc artifacts to publish
 

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -214,13 +214,15 @@ stages:
 
           # CLI ref docs
           - pwsh: New-Item -Force -ItemType Directory -Path docs
+            workingDirectory: $(Pipeline.Workspace)
             displayName: Create docs artifact folder
 
           - pwsh: go run docgen.go
             workingDirectory: cli/azd/docs
             displayName: Generate CLI documentation
 
-          - pwsh: Copy-Item cli/azd/docs/md/* docs/ -Recurse
+          - pwsh: Copy-Item $(Build.SourcesDirectory)/cli/azd/docs/md/* docs/ -Recurse
+            workingDirectory: $(Pipeline.Workspace)
             displayName: Copy CLI docs for pipeline artifact staging
 
           # azure.yaml.json schema docs
@@ -231,14 +233,15 @@ stages:
           - pwsh: pip install jsonschema2md
             displayName: Install jsonschema2md
 
-          - pwsh: jsonschema2md schemas/v1.0/azure.yaml.json docs/azure.yaml.schema.md
+          - pwsh: jsonschema2md schemas/v1.0/azure.yaml.json $(Pipeline.Workspace)/docs/azure.yaml.schema.md
             displayName: Generate azure.yaml schema
 
           # Upload docs for CLI ref and azure.yaml schema
           - pwsh: Get-ChildItem docs
+            workingDirectory: $(Pipeline.Workspace)/docs
             displayName: Show doc artifacts to publish
 
-          - publish: docs/
+          - publish: $(Pipeline.Workspace)/docs/
             artifact: docs
             displayName: Upload generated documentation
 

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -213,7 +213,7 @@ stages:
               targetPath: installer
 
           # CLI ref docs
-          - pwsh: New-Item -Force -ItemType Directory -Path docs
+          - pwsh: New-Item -ItemType Directory -Path docs
             workingDirectory: $(Pipeline.Workspace)
             displayName: Create docs artifact folder
 


### PR DESCRIPTION
A [recent PR](https://github.com/Azure/azure-dev/pull/674) added a `docs/` folder into the root of the repo. 

Because that PR did not change anything that would necessitate a build of the CLI, the CLI CI did not trigger. 

Azure DevOps' default working directory is the root of the repo. 

It's not uncommon for work done in Azure DevOps (like product builds, artifact generation, etc.) to work from the root of the repo and mutate the file structure... However, the `docs` folder does leave itself open to collisions in a way that other folders might not. 

To fix: Do the work in the `docs` folder outside of the source directory. 

Successful run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1881382&view=logs&s=2b1cf740-7e83-5b38-9f56-89c750cf5d77&j=dab3e848-2257-5774-eb9b-38eb96e299cc

fix https://github.com/Azure/azure-dev/issues/763