### PR TITLE
Fixes missing git reference

### DIFF
--- a/cli/azd/pkg/commands/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/commands/pipeline/azdo_provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/git"
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/build"
 	azdoGit "github.com/microsoft/azure-devops-go-api/azuredevops/git"


### PR DESCRIPTION
Looks like `main` got into a corrupt state some how.

This PR fixes build issue in `main` branch.  Missing git package reference.