### PR TITLE
Modify azdo pipeline to use pipeline variables for inputs.

### DIFF
--- a/templates/common/.azdo/pipelines/azure-dev.yml
+++ b/templates/common/.azdo/pipelines/azure-dev.yml
@@ -17,12 +17,12 @@ steps:
       inlineScript: |
         azd provision --no-prompt
     env:
-      AZURE_SUBSCRIPTION_ID: ${AZURE_SUBSCRIPTION_ID}
-      AZURE_ENV_NAME: ${AZURE_ENV_NAME}
-      AZURE_LOCATION: ${AZURE_LOCATION}
-      ARM_TENANT_ID: ${ARM_TENANT_ID}
-      ARM_CLIENT_ID: ${ARM_CLIENT_ID}
-      ARM_CLIENT_SECRET: ${ARM_CLIENT_SECRET}
+      AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
+      AZURE_ENV_NAME: $(AZURE_ENV_NAME)
+      AZURE_LOCATION: $(AZURE_LOCATION)
+      ARM_TENANT_ID: $(ARM_TENANT_ID)
+      ARM_CLIENT_ID: $(ARM_CLIENT_ID)
+      ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
   - task: AzureCLI@2
     displayName: Azure Dev Deploy
     inputs:
@@ -32,6 +32,6 @@ steps:
       inlineScript: |
         azd deploy --no-prompt
     env:
-      AZURE_SUBSCRIPTION_ID: ${AZURE_SUBSCRIPTION_ID}
-      AZURE_ENV_NAME: ${AZURE_ENV_NAME}
-      AZURE_LOCATION: ${AZURE_LOCATION}
+      AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
+      AZURE_ENV_NAME: $(AZURE_ENV_NAME)
+      AZURE_LOCATION: $(AZURE_LOCATION)


### PR DESCRIPTION
This pr introduces a change to the azdo pipeline used in all templates. To support the azdo pipeline provider, this modifies the pipeline to use pipeline variables instead of system environment variables.