### PR TITLE
Update asset rules to copy the bicep python devcontainer only

### DIFF
--- a/templates/todo/projects/python-mongo/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/python-mongo/.repo/bicep/repo.yaml
@@ -150,8 +150,8 @@ repo:
       to: ./infra
 
     # .devcontainer common (devcontainer.json)
-    - from: ../../../../../common/.devcontainer/devcontainer.json/python
-      to: ./.devcontainer
+    - from: ../../../../../common/.devcontainer/devcontainer.json/python/devcontainer.json
+      to: ./.devcontainer/devcontainer.json
 
     # .devcontainer common (Dockerfile)
     - from: ../../../../../common/.devcontainer/Dockerfile/base


### PR DESCRIPTION
this PR fixes assets rules to copy the bicep dev container only.