### PR TITLE
Print Azure deployment link only when deployment has started

### DIFF
--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -146,8 +146,6 @@ func TestBicepDeploy(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, deployResult)
 	require.Equal(t, deployResult.Deployment.Outputs["WEBSITE_URL"].Value, expectedWebsiteUrl)
-	require.Equal(t, 1, len(mockContext.Console.Output()))
-	require.True(t, strings.Contains(mockContext.Console.Output()[0], "Provisioning Azure resources"))
 }
 
 func TestBicepDestroy(t *testing.T) {

--- a/cli/azd/pkg/infra/provisioning/provisioning_progress_display_test.go
+++ b/cli/azd/pkg/infra/provisioning/provisioning_progress_display_test.go
@@ -5,14 +5,18 @@ package provisioning
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockResourceManager struct {
@@ -62,59 +66,71 @@ func (mock *mockResourceManager) MarkComplete(i int) {
 	mock.operations[i].Properties.Timestamp = time.Now().UTC()
 }
 
+func mockAzDeploymentShow(t *testing.T, m mocks.MockContext) {
+	deployment := azcli.AzCliDeployment{}
+	deploymentJson, err := json.Marshal(deployment)
+	require.NoError(t, err)
+	m.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.HasPrefix(command, "az deployment sub show")
+	}).Respond(exec.NewRunResult(0, string(deploymentJson), ""))
+}
+
 func TestReportProgress(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
-	scope := infra.NewSubscriptionScope(*mockContext.Context, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
 
+	scope := infra.NewSubscriptionScope(*mockContext.Context, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
+	mockAzDeploymentShow(t, *mockContext)
+
+	outputLength := 0
 	mockResourceManager := mockResourceManager{}
 	progressDisplay := NewProvisioningProgressDisplay(&mockResourceManager, mockContext.Console, scope)
 	progressReport, _ := progressDisplay.ReportProgress(*mockContext.Context)
-	assert.Empty(t, mockContext.Console.Output())
+	outputLength++
+	assert.Len(t, mockContext.Console.Output(), outputLength)
+	assert.Contains(t, mockContext.Console.Output()[0], deploymentStartedDisplayMessage)
 	assert.Equal(t, defaultProgressTitle, progressReport.Message)
 
 	mockResourceManager.AddInProgressOperation()
 	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context)
-	assert.Empty(t, mockContext.Console.Output())
+	assert.Len(t, mockContext.Console.Output(), outputLength)
 	assert.Equal(t, formatProgressTitle(0, 1), progressReport.Message)
 
 	mockResourceManager.AddInProgressOperation()
 	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context)
-	assert.Empty(t, mockContext.Console.Output())
+	assert.Len(t, mockContext.Console.Output(), outputLength)
 	assert.Equal(t, formatProgressTitle(0, 2), progressReport.Message)
 
 	mockResourceManager.AddInProgressSubResourceOperation()
 	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context)
-	assert.Empty(t, mockContext.Console.Output())
+	assert.Len(t, mockContext.Console.Output(), outputLength)
 	assert.Equal(t, formatProgressTitle(0, 3), progressReport.Message)
 
 	mockResourceManager.MarkComplete(0)
 	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context)
-	assert.Len(t, mockContext.Console.Output(), 1)
-	assertOperationLogged(t, 0, mockResourceManager.operations, mockContext.Console.Output())
+	outputLength++
+	assert.Len(t, mockContext.Console.Output(), outputLength)
+	assertLastOperationLogged(t, mockResourceManager.operations[0], mockContext.Console.Output())
 	assert.Equal(t, formatProgressTitle(1, 3), progressReport.Message)
 
 	mockResourceManager.MarkComplete(1)
 	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context)
-	assert.Len(t, mockContext.Console.Output(), 2)
-	assertOperationLogged(t, 1, mockResourceManager.operations, mockContext.Console.Output())
+	outputLength++
+	assert.Len(t, mockContext.Console.Output(), outputLength)
+	assertLastOperationLogged(t, mockResourceManager.operations[1], mockContext.Console.Output())
 	assert.Equal(t, formatProgressTitle(2, 3), progressReport.Message)
 
 	// Verify display does not log sub resource types
-	oldLogOutput := make([]string, len(mockContext.Console.Output()))
-	copy(mockContext.Console.Output(), oldLogOutput)
 	mockResourceManager.MarkComplete(2)
 	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context)
-	assert.Equal(t, oldLogOutput, mockContext.Console.Output())
+	assert.Len(t, mockContext.Console.Output(), outputLength)
 	assert.Equal(t, formatProgressTitle(3, 3), progressReport.Message)
 
 	// Verify display does not repeat logging for resources already logged.
-	copy(mockContext.Console.Output(), oldLogOutput)
 	progressReport, _ = progressDisplay.ReportProgress(*mockContext.Context)
-	assert.Equal(t, oldLogOutput, mockContext.Console.Output())
+	assert.Len(t, mockContext.Console.Output(), outputLength)
 	assert.Equal(t, formatProgressTitle(3, 3), progressReport.Message)
 }
 
-func assertOperationLogged(t *testing.T, i int, operations []azcli.AzCliResourceOperation, logOutput []string) {
-	assert.True(t, len(logOutput) > i)
-	assert.Equal(t, formatCreatedResourceLog(operations[i].Properties.TargetResource.ResourceType, operations[i].Properties.TargetResource.ResourceName), logOutput[i])
+func assertLastOperationLogged(t *testing.T, operation azcli.AzCliResourceOperation, logOutput []string) {
+	assert.Equal(t, formatCreatedResourceLog(operation.Properties.TargetResource.ResourceType, operation.Properties.TargetResource.ResourceName), logOutput[len(logOutput)-1])
 }


### PR DESCRIPTION
Fixes #490

The console interactive output is unchanged. Just that we'll print "Provisioning Azure resource..." while waiting for the deployment to be started. Once the deployment has been started (by querying ARM APIs), we'll print the deployment link once.

There still exists possibility of the user receiving a 404 if the ARM API reports deployment is running, but the Portal API which might end up hitting a different backend does not see the same.