### PR TITLE
use 3 retries for pushing code

### DIFF
--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -66,8 +66,11 @@ func Test_CLI_Version_PrintsVersion(t *testing.T) {
 
 	rn := os.Getenv("GITHUB_RUN_NUMBER")
 	if rn != "" {
-		// TODO: This should be read from cli/version.txt (https://github.com/Azure/azure-dev/issues/36)
-		require.Contains(t, out, "0.2.0")
+		runningTestPath := azdcli.GetAzdLocation()
+		cliPath := strings.Split(runningTestPath, "cli")[0]
+		version, err := os.ReadFile(path.Join(cliPath, "cli", "version.txt"))
+		require.NoError(t, err)
+		require.Contains(t, out, strings.ReplaceAll(string(version), "\n", ""))
 	} else {
 		require.Contains(t, out, fmt.Sprintf("azd version %s", internal.Version))
 	}


### PR DESCRIPTION
fix https://github.com/Azure/azure-dev/issues/755

Adding 3 retry strategy for pushing code as part of azd pipeline config

This will workaround the issue about rotating credentials for git and the interaction with a git credential manager (caching credentials)

If this ever happens, or if the user manually made a mistake the first time while logging in to AzureDevOps, there would be another 2 times to re-enter the credentials (similar to running `sudo` in linux, where you have a few times to enter your password correctly)