### PR TITLE
Fix version tests on Windows

### DIFF
--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -66,11 +66,9 @@ func Test_CLI_Version_PrintsVersion(t *testing.T) {
 
 	rn := os.Getenv("GITHUB_RUN_NUMBER")
 	if rn != "" {
-		runningTestPath := azdcli.GetAzdLocation()
-		cliPath := strings.Split(runningTestPath, "cli")[0]
-		version, err := os.ReadFile(path.Join(cliPath, "cli", "version.txt"))
-		require.NoError(t, err)
-		require.Contains(t, out, strings.ReplaceAll(string(version), "\n", ""))
+		version := os.Getenv("CLI_VERSION")
+		require.NotEmpty(t, version)
+		require.Contains(t, out, version)
 	} else {
 		require.Contains(t, out, fmt.Sprintf("azd version %s", internal.Version))
 	}


### PR DESCRIPTION
Switch to `CLI_VERSION`:
1. Avoids newline endings
2. Avoids introducing another dependency to `version.txt`. `CLI_VERSION` is set by the CI runner which also sets the other environment variable we're already dependent on.