### PR TITLE
Update CHANGELOG on release

### DIFF
--- a/eng/common/pipelines/templates/steps/create-pull-request.yml
+++ b/eng/common/pipelines/templates/steps/create-pull-request.yml
@@ -1,0 +1,59 @@
+# Expects azuresdk-github-pat is set to the PAT for azure-sdk
+# Expects the buildtools to be cloned
+
+parameters:
+  BaseBranchName: $(Build.SourceBranch)
+  PRBranchName: not-specified
+  PROwner: azure-sdk
+  CommitMsg: not-specified
+  RepoOwner: Azure
+  RepoName: $(Build.Repository.Name)
+  PushArgs:
+  WorkingDirectory: $(System.DefaultWorkingDirectory)
+  PRTitle: not-specified
+  PRBody: ''
+  ScriptDirectory: eng/common/scripts
+  GHReviewersVariable: ''
+  GHTeamReviewersVariable: ''
+  GHAssignessVariable: ''
+  # Multiple labels seperated by comma, e.g. "bug, APIView"
+  PRLabels: ''
+  SkipCheckingForChanges: false
+  CloseAfterOpenForTesting: false
+  OpenAsDraft: false
+
+steps:
+- template: /eng/common/pipelines/templates/steps/git-push-changes.yml
+  parameters:
+    BaseRepoBranch: ${{ parameters.PRBranchName }}
+    BaseRepoOwner: ${{ parameters.PROwner }}
+    CommitMsg: ${{ parameters.CommitMsg }}
+    TargetRepoOwner: ${{ parameters.RepoOwner }}
+    TargetRepoName: ${{ parameters.RepoName }}
+    PushArgs: ${{ parameters.PushArgs }}
+    WorkingDirectory: ${{ parameters.WorkingDirectory }}
+    ScriptDirectory: ${{ parameters.ScriptDirectory }}
+    SkipCheckingForChanges: ${{ parameters.SkipCheckingForChanges }}
+
+- task: PowerShell@2
+  displayName: Create pull request
+  condition: and(succeeded(), eq(variables['HasChanges'], 'true'))
+  inputs:
+    pwsh: true
+    workingDirectory: ${{ parameters.WorkingDirectory }}
+    filePath: ${{ parameters.ScriptDirectory }}/Submit-PullRequest.ps1
+    arguments: >
+      -RepoOwner "${{ parameters.RepoOwner }}"
+      -RepoName "$(RepoNameWithoutOwner)"
+      -BaseBranch "${{ parameters.BaseBranchName }}"
+      -PROwner "${{ parameters.PROwner }}"
+      -PRBranch "${{ parameters.PRBranchName }}"
+      -AuthToken "$(azuresdk-github-pat)"
+      -PRTitle "${{ parameters.PRTitle }}"
+      -PRBody "${{ coalesce(parameters.PRBody, parameters.CommitMsg, parameters.PRTitle) }}"
+      -PRLabels "${{ parameters.PRLabels }}"
+      -UserReviewers "$(${{ parameters.GHReviewersVariable }})"
+      -TeamReviewers "$(${{ parameters.GHTeamReviewersVariable }})"
+      -Assignees "$(${{ parameters.GHAssignessVariable }})"
+      -CloseAfterOpenForTesting $${{ coalesce(parameters.CloseAfterOpenForTesting, 'false') }}
+      -OpenAsDraft $${{ parameters.OpenAsDraft }}

--- a/eng/common/pipelines/templates/steps/git-push-changes.yml
+++ b/eng/common/pipelines/templates/steps/git-push-changes.yml
@@ -1,0 +1,54 @@
+parameters:
+  BaseRepoBranch: not-specified
+  BaseRepoOwner: azure-sdk
+  CommitMsg: not-specified
+  TargetRepoOwner: Azure
+  TargetRepoName: $(Build.Repository.Name)
+  PushArgs:
+  WorkingDirectory: $(System.DefaultWorkingDirectory)'
+  ScriptDirectory: eng/common/scripts
+  SkipCheckingForChanges: false
+
+steps:
+- pwsh: |
+    echo "git add -A"
+    git add -A
+
+    echo "git diff --name-status --cached --exit-code"
+    git diff --name-status --cached --exit-code
+
+    if ($LastExitCode -ne 0) {
+      echo "##vso[task.setvariable variable=HasChanges]$true"
+      echo "Changes detected so setting HasChanges=true"
+    }
+    else {
+      echo "##vso[task.setvariable variable=HasChanges]$false"
+      echo "No changes so skipping code push"
+    }
+  displayName: Check for changes
+  condition: and(succeeded(), eq(${{ parameters.SkipCheckingForChanges }}, false))
+  workingDirectory: ${{ parameters.WorkingDirectory }}
+  ignoreLASTEXITCODE: true
+
+- pwsh: |
+    # Remove the repo owner from the front of the repo name if it exists there
+    $repoName = "${{ parameters.TargetRepoName }}" -replace "^${{ parameters.TargetRepoOwner }}/", ""
+    echo "##vso[task.setvariable variable=RepoNameWithoutOwner]$repoName"
+    echo "RepoName = $repoName"
+  displayName: Remove Repo Owner from Repo Name
+  condition: succeeded()
+  workingDirectory: ${{ parameters.WorkingDirectory }}
+
+- task: PowerShell@2
+  displayName: Push changes
+  condition: and(succeeded(), eq(variables['HasChanges'], 'true'))
+  inputs:
+    pwsh: true
+    workingDirectory: ${{ parameters.WorkingDirectory }}
+    filePath: ${{ parameters.ScriptDirectory }}/git-branch-push.ps1
+    arguments: >
+      -PRBranchName "${{ parameters.BaseRepoBranch }}"
+      -CommitMsg "${{ parameters.CommitMsg }}"
+      -GitUrl "https://$(azuresdk-github-pat)@github.com/${{ parameters.BaseRepoOwner }}/$(RepoNameWithoutOwner).git"
+      -PushArgs "${{ parameters.PushArgs }}"
+      -SkipCommit $${{ parameters.SkipCheckingForChanges }}

--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -1,0 +1,402 @@
+# Common Changelog Operations
+. "${PSScriptRoot}\logging.ps1"
+. "${PSScriptRoot}\SemVer.ps1"
+
+$RELEASE_TITLE_REGEX = "(?<releaseNoteTitle>^\#+\s+(?<version>$([AzureEngSemanticVersion]::SEMVER_REGEX))(\s+(?<releaseStatus>\(.+\))))"
+$SECTION_HEADER_REGEX_SUFFIX = "##\s(?<sectionName>.*)"
+$CHANGELOG_UNRELEASED_STATUS = "(Unreleased)"
+$CHANGELOG_DATE_FORMAT = "yyyy-MM-dd"
+$RecommendedSectionHeaders = @("Features Added", "Breaking Changes", "Bugs Fixed", "Other Changes")
+
+# Returns a Collection of changeLogEntry object containing changelog info for all version present in the gived CHANGELOG
+function Get-ChangeLogEntries {
+  param (
+    [Parameter(Mandatory = $true)]
+    [String]$ChangeLogLocation
+  )
+
+  if (!(Test-Path $ChangeLogLocation)) {
+    LogError "ChangeLog[${ChangeLogLocation}] does not exist"
+    return $null
+  }
+  LogDebug "Extracting entries from [${ChangeLogLocation}]."
+  return Get-ChangeLogEntriesFromContent (Get-Content -Path $ChangeLogLocation)
+}
+
+function Get-ChangeLogEntriesFromContent {
+  param (
+    [Parameter(Mandatory = $true)]
+    $changeLogContent
+  )
+
+  if ($changeLogContent -is [string])
+  {
+    $changeLogContent = $changeLogContent.Split("`n")
+  }
+  elseif($changeLogContent -isnot [array])
+  {
+    LogError "Invalid ChangelogContent passed"
+    return $null
+  }
+
+  $changelogEntry = $null
+  $sectionName = $null
+  $changeLogEntries = [Ordered]@{}
+  $initialAtxHeader= "#"
+
+  if ($changeLogContent[0] -match "(?<HeaderLevel>^#+)\s.*")
+  {
+    $initialAtxHeader = $matches["HeaderLevel"]
+  }
+
+  $sectionHeaderRegex = "^${initialAtxHeader}${SECTION_HEADER_REGEX_SUFFIX}"
+  $changeLogEntries | Add-Member -NotePropertyName "InitialAtxHeader" -NotePropertyValue $initialAtxHeader
+  $releaseTitleAtxHeader = $initialAtxHeader + "#"
+
+  try {
+    # walk the document, finding where the version specifiers are and creating lists
+    foreach ($line in $changeLogContent) {
+      if ($line -match $RELEASE_TITLE_REGEX) {
+        $changeLogEntry = [pscustomobject]@{
+          ReleaseVersion = $matches["version"]
+          ReleaseStatus  =  $matches["releaseStatus"]
+          ReleaseTitle   = "$releaseTitleAtxHeader {0} {1}" -f $matches["version"], $matches["releaseStatus"]
+          ReleaseContent = @()
+          Sections = @{}
+        }
+        $changeLogEntries[$changeLogEntry.ReleaseVersion] = $changeLogEntry
+      }
+      else {
+        if ($changeLogEntry) {
+          if ($line.Trim() -match $sectionHeaderRegex)
+          {
+            $sectionName = $matches["sectionName"].Trim()
+            $changeLogEntry.Sections[$sectionName] = @()
+            $changeLogEntry.ReleaseContent += $line
+            continue
+          }
+
+          if ($sectionName)
+          {
+            $changeLogEntry.Sections[$sectionName] += $line
+          }
+
+          $changeLogEntry.ReleaseContent += $line
+        }
+      }
+    }
+  }
+  catch {
+    Write-Error "Error parsing Changelog."
+    Write-Error $_
+  }
+  return $changeLogEntries
+}
+
+# Returns single changeLogEntry object containing the ChangeLog for a particular version
+function Get-ChangeLogEntry {
+  param (
+    [Parameter(Mandatory = $true)]
+    [String]$ChangeLogLocation,
+    [Parameter(Mandatory = $true)]
+    [String]$VersionString
+  )
+  $changeLogEntries = Get-ChangeLogEntries -ChangeLogLocation $ChangeLogLocation
+
+  if ($changeLogEntries -and $changeLogEntries.Contains($VersionString)) {
+    return $changeLogEntries[$VersionString]
+  }
+  return $null
+}
+
+#Returns the changelog for a particular version as string
+function Get-ChangeLogEntryAsString {
+  param (
+    [Parameter(Mandatory = $true)]
+    [String]$ChangeLogLocation,
+    [Parameter(Mandatory = $true)]
+    [String]$VersionString
+  )
+
+  $changeLogEntry = Get-ChangeLogEntry -ChangeLogLocation $ChangeLogLocation -VersionString $VersionString
+  return ChangeLogEntryAsString $changeLogEntry
+}
+
+function ChangeLogEntryAsString($changeLogEntry) {
+  if (!$changeLogEntry) {
+    return "[Missing change log entry]"
+  }
+  [string]$releaseTitle = $changeLogEntry.ReleaseTitle
+  [string]$releaseContent = $changeLogEntry.ReleaseContent -Join [Environment]::NewLine
+  return $releaseTitle, $releaseContent -Join [Environment]::NewLine
+}
+
+function Confirm-ChangeLogEntry {
+  param (
+    [Parameter(Mandatory = $true)]
+    [String]$ChangeLogLocation,
+    [Parameter(Mandatory = $true)]
+    [String]$VersionString,
+    [boolean]$ForRelease = $false,
+    [Switch]$SantizeEntry
+  )
+
+  $changeLogEntries = Get-ChangeLogEntries -ChangeLogLocation $ChangeLogLocation
+  $changeLogEntry = $changeLogEntries[$VersionString]
+
+  if (!$changeLogEntry) {
+    LogError "ChangeLog[${ChangeLogLocation}] does not have an entry for version ${VersionString}."
+    return $false
+  }
+
+  if ($SantizeEntry)
+  {
+    Remove-EmptySections -ChangeLogEntry $changeLogEntry -InitialAtxHeader $changeLogEntries.InitialAtxHeader
+    Set-ChangeLogContent -ChangeLogLocation $ChangeLogLocation -ChangeLogEntries $changeLogEntries
+  }
+
+  Write-Host "Found the following change log entry for version '${VersionString}' in [${ChangeLogLocation}]."
+  Write-Host "-----"
+  Write-Host (ChangeLogEntryAsString $changeLogEntry)
+  Write-Host "-----"
+
+  if ([System.String]::IsNullOrEmpty($changeLogEntry.ReleaseStatus)) {
+    LogError "Entry does not have a correct release status. Please ensure the status is set to a date '($CHANGELOG_DATE_FORMAT)' or '$CHANGELOG_UNRELEASED_STATUS' if not yet released. See https://aka.ms/azsdk/guideline/changelogs for more info."
+    return $false
+  }
+
+  if ($ForRelease -eq $True)
+  {
+    LogDebug "Verifying as a release build because ForRelease parameter is set to true"
+    return Confirm-ChangeLogForRelease -changeLogEntry $changeLogEntry -changeLogEntries $changeLogEntries
+  }
+
+  # If the release status is a valid date then verify like its about to be released
+  $status = $changeLogEntry.ReleaseStatus.Trim().Trim("()")
+  if ($status -as [DateTime])
+  {
+    LogDebug "Verifying like it's a release build because the changelog entry has a valid date."
+    return Confirm-ChangeLogForRelease -changeLogEntry $changeLogEntry -changeLogEntries $changeLogEntries
+  }
+
+  return $true
+}
+
+function New-ChangeLogEntry {
+  param (
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [String]$Version,
+    [String]$Status=$CHANGELOG_UNRELEASED_STATUS,
+    [String]$InitialAtxHeader="#",
+    [String[]]$Content
+  )
+
+  # Validate RelaseStatus
+  $Status = $Status.Trim().Trim("()")
+  if ($Status -ne "Unreleased") {
+    try {
+      $Status = ([DateTime]$Status).ToString($CHANGELOG_DATE_FORMAT)
+    }
+    catch {
+        LogWarning "Invalid date [ $Status ] passed as status for Version [$Version]. Please use a valid date in the format '$CHANGELOG_DATE_FORMAT' or use '$CHANGELOG_UNRELEASED_STATUS'"
+        return $null
+    }
+  }
+  $Status = "($Status)"
+
+  # Validate Version
+  try {
+    $Version = ([AzureEngSemanticVersion]::ParseVersionString($Version)).ToString()
+  }
+  catch {
+    LogWarning "Invalid version [ $Version ]."
+    return $null
+  }
+
+  if (!$Content) {
+    $Content = @()
+    $Content += ""
+
+    $sectionsAtxHeader = $InitialAtxHeader + "##"
+    foreach ($recommendedHeader in $RecommendedSectionHeaders)
+    {
+      $Content += "$sectionsAtxHeader $recommendedHeader"
+      $Content += ""
+    }
+  }
+
+  $releaseTitleAtxHeader = $initialAtxHeader + "#"
+
+  $newChangeLogEntry = [pscustomobject]@{
+    ReleaseVersion = $Version
+    ReleaseStatus  = $Status
+    ReleaseTitle   = "$releaseTitleAtxHeader $Version $Status"
+    ReleaseContent = $Content
+  }
+
+  return $newChangeLogEntry
+}
+
+function Set-ChangeLogContent {
+  param (
+    [Parameter(Mandatory = $true)]
+    [String]$ChangeLogLocation,
+    [Parameter(Mandatory = $true)]
+    $ChangeLogEntries
+  )
+
+  $changeLogContent = @()
+  $changeLogContent += "$($ChangeLogEntries.InitialAtxHeader) Release History"
+  $changeLogContent += ""
+
+  $ChangeLogEntries = Sort-ChangeLogEntries -changeLogEntries $ChangeLogEntries
+
+  foreach ($changeLogEntry in $ChangeLogEntries) {
+    $changeLogContent += $changeLogEntry.ReleaseTitle
+    if ($changeLogEntry.ReleaseContent.Count -eq 0) {
+      $changeLogContent += @("","")
+    }
+    else {
+      $changeLogContent += $changeLogEntry.ReleaseContent
+    }
+  }
+
+  Set-Content -Path $ChangeLogLocation -Value $changeLogContent
+}
+
+function Remove-EmptySections {
+  param (
+    [Parameter(Mandatory = $true)]
+    $ChangeLogEntry,
+    $InitialAtxHeader = "#"
+  )
+
+  $sectionHeaderRegex = "^${InitialAtxHeader}${SECTION_HEADER_REGEX_SUFFIX}"
+  $releaseContent = $ChangeLogEntry.ReleaseContent
+
+  if ($releaseContent.Count -gt 0)
+  {
+    $parsedSections = $ChangeLogEntry.Sections
+    $sanitizedReleaseContent = New-Object System.Collections.ArrayList(,$releaseContent)
+  
+    foreach ($key in @($parsedSections.Keys)) 
+    {
+      if ([System.String]::IsNullOrWhiteSpace($parsedSections[$key]))
+      {
+        for ($i = 0; $i -lt $sanitizedReleaseContent.Count; $i++)
+        {
+          $line = $sanitizedReleaseContent[$i]
+          if ($line -match $sectionHeaderRegex -and $matches["sectionName"].Trim() -eq $key)
+          {
+            $sanitizedReleaseContent.RemoveAt($i)
+            while($i -lt $sanitizedReleaseContent.Count -and [System.String]::IsNullOrWhiteSpace($sanitizedReleaseContent[$i]))
+            {
+              $sanitizedReleaseContent.RemoveAt($i)
+            }
+            $ChangeLogEntry.Sections.Remove($key)
+            break
+          }
+        }
+      }
+    }
+    $ChangeLogEntry.ReleaseContent = $sanitizedReleaseContent.ToArray()
+  }
+}
+
+function  Get-LatestReleaseDateFromChangeLog
+{
+  param (
+    [Parameter(Mandatory = $true)]
+    $ChangeLogLocation
+  )
+  $changeLogEntries = Get-ChangeLogEntries -ChangeLogLocation $ChangeLogLocation
+  $latestVersion = $changeLogEntries[0].ReleaseStatus.Trim("()")
+  return ($latestVersion -as [DateTime])
+}
+
+function Sort-ChangeLogEntries {
+  param (
+    [Parameter(Mandatory = $true)]
+    $changeLogEntries
+  )
+
+  try
+  {
+    $changeLogEntries = $ChangeLogEntries.Values | Sort-Object -Descending -Property ReleaseStatus, `
+      @{e = {[AzureEngSemanticVersion]::new($_.ReleaseVersion)}}
+  }
+  catch {
+    LogError "Problem sorting version in ChangeLogEntries"
+    exit(1)
+  }
+  return $changeLogEntries
+}
+
+function Confirm-ChangeLogForRelease {
+  param (
+    [Parameter(Mandatory = $true)]
+    $changeLogEntry,
+    [Parameter(Mandatory = $true)]
+    $changeLogEntries
+  )
+
+  $entries = Sort-ChangeLogEntries -changeLogEntries $changeLogEntries
+
+  $isValid = $true
+  if ($changeLogEntry.ReleaseStatus -eq $CHANGELOG_UNRELEASED_STATUS) {
+    LogError "Entry has no release date set. Please ensure to set a release date with format '$CHANGELOG_DATE_FORMAT'. See https://aka.ms/azsdk/guideline/changelogs for more info."
+    $isValid = $false
+  }
+  else {
+    $status = $changeLogEntry.ReleaseStatus.Trim().Trim("()")
+    try {
+      $releaseDate = [DateTime]$status
+      if ($status -ne ($releaseDate.ToString($CHANGELOG_DATE_FORMAT)))
+      {
+        LogError "Date must be in the format $($CHANGELOG_DATE_FORMAT). See https://aka.ms/azsdk/guideline/changelogs for more info."
+        $isValid = $false
+      }
+
+      if (@($entries.ReleaseStatus)[0] -ne $changeLogEntry.ReleaseStatus)
+      {
+        LogError "Invalid date [ $status ]. The date for the changelog being released must be the latest in the file."
+        $isValid = $false
+      }
+    }
+    catch {
+        LogError "Invalid date [ $status ] passed as status for Version [$($changeLogEntry.ReleaseVersion)]. See https://aka.ms/azsdk/guideline/changelogs for more info."
+        $isValid = $false
+    }
+  }
+
+  if ([System.String]::IsNullOrWhiteSpace($changeLogEntry.ReleaseContent)) {
+    LogError "Entry has no content. Please ensure to provide some content of what changed in this version. See https://aka.ms/azsdk/guideline/changelogs for more info."
+    $isValid = $false
+  }
+
+  $foundRecommendedSection = $false
+  $emptySections = @()
+  foreach ($key in $changeLogEntry.Sections.Keys)
+  {
+    $sectionContent = $changeLogEntry.Sections[$key]
+    if ([System.String]::IsNullOrWhiteSpace(($sectionContent | Out-String)))
+    {
+      $emptySections += $key
+    }
+    if ($RecommendedSectionHeaders -contains $key)
+    {
+      $foundRecommendedSection = $true
+    }
+  }
+  if ($emptySections.Count -gt 0)
+  {
+    LogError "The changelog entry has the following sections with no content ($($emptySections -join ', ')). Please ensure to either remove the empty sections or add content to the section."
+    $isValid = $false
+  }
+  if (!$foundRecommendedSection)
+  {
+    LogWarning "The changelog entry did not contain any of the recommended sections ($($RecommendedSectionHeaders -join ', ')), please add at least one. See https://aka.ms/azsdk/guideline/changelogs for more info."
+  }
+  return $isValid
+}

--- a/eng/common/scripts/Helpers/git-helpers.ps1
+++ b/eng/common/scripts/Helpers/git-helpers.ps1
@@ -1,0 +1,38 @@
+# cSpell:ignore Committish
+# cSpell:ignore PULLREQUEST
+# cSpell:ignore TARGETBRANCH
+# cSpell:ignore SOURCECOMMITID
+function Get-ChangedFiles {
+  param (
+    [string]$SourceCommittish= "${env:SYSTEM_PULLREQUEST_SOURCECOMMITID}",
+    [string]$TargetCommittish = ("origin/${env:SYSTEM_PULLREQUEST_TARGETBRANCH}" -replace "refs/heads/"),
+    [string]$DiffPath,
+    [string]$DiffFilterType = "d"
+  )
+  # If ${env:SYSTEM_PULLREQUEST_TARGETBRANCH} is empty, then return empty.
+  if (!$TargetCommittish -or ($TargetCommittish -eq "origin/")) {
+    Write-Host "There is no target branch passed in. "
+    return ""
+  }
+
+  # Add config to disable the quote and encoding on file name. 
+  # Ref: https://github.com/msysgit/msysgit/wiki/Git-for-Windows-Unicode-Support#disable-quoted-file-names
+  # Ref: https://github.com/msysgit/msysgit/wiki/Git-for-Windows-Unicode-Support#disable-commit-message-transcoding
+  # Git PR diff: https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons
+  $command = "git -c core.quotepath=off -c i18n.logoutputencoding=utf-8 diff `"$TargetCommittish...$SourceCommittish`" --name-only --diff-filter=$DiffFilterType"
+  if ($DiffPath) {
+  $command = $command + " -- `'$DiffPath`'"
+  }
+  Write-Host $command
+  $changedFiles = Invoke-Expression -Command $command
+  if(!$changedFiles) {
+    Write-Host "No changed files in git diff between $TargetCommittish and $SourceCommittish"
+  }
+  else {
+  Write-Host "Here are the diff files:"
+  foreach ($file in $changedFiles) {
+      Write-Host "    $file"
+  }
+  }
+  return $changedFiles
+}

--- a/eng/common/scripts/Invoke-DevOpsAPI.ps1
+++ b/eng/common/scripts/Invoke-DevOpsAPI.ps1
@@ -1,0 +1,162 @@
+. "${PSScriptRoot}\logging.ps1"
+
+$DevOpsAPIBaseURI = "https://dev.azure.com/{0}/{1}/_apis/{2}/{3}?{4}api-version=6.0"
+
+function Get-DevOpsApiHeaders ($Base64EncodedToken) {
+  $headers = @{
+    Authorization = "Basic $Base64EncodedToken"
+  }
+  return $headers
+}
+
+function Start-DevOpsBuild {
+  param (
+    $Organization="azure-sdk",
+    $Project="internal",
+    $SourceBranch,
+    [Parameter(Mandatory = $true)]
+    $DefinitionId,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $Base64EncodedAuthToken,
+    [Parameter(Mandatory = $false)]
+    [string]$BuildParametersJson
+  )
+
+  $uri = "$DevOpsAPIBaseURI" -F $Organization, $Project , "build" , "builds", ""
+
+  $parameters = @{
+    sourceBranch = $SourceBranch
+    definition = @{ id = $DefinitionId }
+    parameters = $BuildParametersJson
+  }
+
+  return Invoke-RestMethod `
+          -Method POST `
+          -Body ($parameters | ConvertTo-Json) `
+          -Uri $uri `
+          -Headers (Get-DevOpsApiHeaders -Base64EncodedToken $Base64EncodedAuthToken) `
+          -MaximumRetryCount 3 `
+          -ContentType "application/json"
+}
+
+function Update-DevOpsBuild {
+  param (
+    $Organization="azure-sdk",
+    $Project="internal",
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $BuildId,
+    $Status, # pass canceling to cancel build
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $Base64EncodedAuthToken
+  )
+
+  $uri = "$DevOpsAPIBaseURI" -F $Organization, $Project, "build", "builds/$BuildId", ""
+  $parameters = @{}
+
+  if ($Status) { $parameters["status"] = $Status}
+
+  return Invoke-RestMethod `
+          -Method PATCH `
+          -Body ($parameters | ConvertTo-Json) `
+          -Uri $uri `
+          -Headers (Get-DevOpsApiHeaders -Base64EncodedToken $Base64EncodedAuthToken) `
+          -MaximumRetryCount 3 `
+          -ContentType "application/json"
+}
+
+function Get-DevOpsBuilds {
+  param (
+    $Organization="azure-sdk",
+    $Project="internal",
+    $BranchName, #Should start with 'refs/heads/'
+    $Definitions, # Comma seperated string of definition IDs
+    $StatusFilter, # Comma seperated string 'cancelling, completed, inProgress, notStarted'
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $Base64EncodedAuthToken
+  )
+
+  $query = ""
+
+  if ($BranchName) { $query += "branchName=$BranchName&" }
+  if ($Definitions) { $query += "definitions=$Definitions&" }
+  if ($StatusFilter) { $query += "statusFilter=$StatusFilter&" }
+  $uri = "$DevOpsAPIBaseURI" -F $Organization, $Project , "build" , "builds", $query
+
+  return Invoke-RestMethod `
+          -Method GET `
+          -Uri $uri `
+          -Headers (Get-DevOpsApiHeaders -Base64EncodedToken $Base64EncodedAuthToken) `
+          -MaximumRetryCount 3
+}
+
+function Delete-RetentionLease {
+  param (
+    $Organization,
+    $Project,
+    $LeaseId,
+    $Base64EncodedAuthToken
+  )
+
+  $uri = "https://dev.azure.com/$Organization/$Project/_apis/build/retention/leases?ids=$LeaseId&api-version=6.0-preview.1"
+
+  return Invoke-RestMethod `
+    -Method DELETE `
+    -Uri $uri `
+    -Headers (Get-DevOpsApiHeaders -Base64EncodedToken $Base64EncodedAuthToken) `
+    -MaximumRetryCount 3
+}
+
+function Get-RetentionLeases {
+  param (
+    $Organization,
+    $Project,
+    $DefinitionId,
+    $RunId,
+    $OwnerId,
+    $Base64EncodedAuthToken
+  )
+
+  $uri = "https://dev.azure.com/$Organization/$Project/_apis/build/retention/leases?ownerId=$OwnerId&definitionId=$DefinitionId&runId=$RunId&api-version=6.0-preview.1"
+
+  return Invoke-RestMethod `
+    -Method GET `
+    -Uri $uri `
+    -Headers (Get-DevOpsApiHeaders -Base64EncodedToken $Base64EncodedAuthToken) `
+    -MaximumRetryCount 3
+}
+
+function Add-RetentionLease {
+  param (
+    $Organization,
+    $Project,
+    $DefinitionId,
+    $RunId,
+    $OwnerId,
+    $DaysValid,
+    $Base64EncodedAuthToken
+  )
+
+  $parameter = @{}
+  $parameter["definitionId"] = $DefinitionId
+  $parameter["runId"] = $RunId
+  $parameter["ownerId"] = $OwnerId
+  $parameter["daysValid"] = $DaysValid
+
+
+  $body = $parameter | ConvertTo-Json
+
+  $uri = "https://dev.azure.com/$Organization/$Project/_apis/build/retention/leases?api-version=6.0-preview.1"
+
+  return Invoke-RestMethod `
+          -Method POST `
+          -Body "[$body]" `
+          -Uri $uri `
+          -Headers (Get-DevOpsApiHeaders -Base64EncodedToken $Base64EncodedAuthToken) `
+          -MaximumRetryCount 3 `
+          -ContentType "application/json"
+
+}

--- a/eng/common/scripts/Invoke-GitHubAPI.ps1
+++ b/eng/common/scripts/Invoke-GitHubAPI.ps1
@@ -1,0 +1,453 @@
+. "${PSScriptRoot}\logging.ps1"
+
+$GithubAPIBaseURI = "https://api.github.com/repos"
+
+function Get-GitHubApiHeaders ($token) {
+  $headers = @{
+    Authorization = "bearer $token"
+  }
+  return $headers
+}
+
+function SplitParameterArray($members) {
+    if ($null -ne $members) {
+      if ($members -is [array])
+      {
+        return $members
+      }
+      else {
+        return (@($members.Split(",") | % { $_.Trim() } | ? { return $_ }))
+      }
+    }
+}
+
+function Set-GitHubAPIParameters ($members,  $parameterName, $parameters, $allowEmptyMembers = $false) {
+  if ($null -ne $members) {
+    [array]$memberAdditions = SplitParameterArray -members $members
+
+    if ($null -eq $memberAdditions -and $allowEmptyMembers){ $memberAdditions = @() }
+
+    if ($memberAdditions.Count -gt 0 -or $allowEmptyMembers) {
+      $parameters[$parameterName] = $memberAdditions
+    }
+  }
+
+  return $parameters
+}
+
+function Get-GitHubPullRequests {
+  param (
+    $RepoOwner,
+    $RepoName,
+    $RepoId = "$RepoOwner/$RepoName",
+    [ValidateSet("open","closed","all")]
+    $State = "open",
+    $Head,
+    $Base,
+    [ValidateSet("created","updated","popularity","long-running")]
+    $Sort,
+    [ValidateSet("asc","desc")]
+    $Direction,
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    $AuthToken
+  )
+  $uri = "$GithubAPIBaseURI/$RepoId/pulls"
+  if ($State -or $Head -or $Base -or $Sort -or $Direction) { $uri += '?' }
+  if ($State) { $uri += "state=$State&" }
+  if ($Head) { $uri += "head=$Head&" }
+  if ($Base) { $uri += "base=$Base&" }
+  if ($Sort) { $uri += "sort=$Sort&" }
+  if ($Direction){ $uri += "direction=$Direction&" }
+
+  return Invoke-RestMethod `
+          -Method GET `
+          -Uri $uri `
+          -Headers (Get-GitHubApiHeaders -token $AuthToken) `
+          -MaximumRetryCount 3
+}
+
+# 
+<#
+.PARAMETER Ref
+Ref to search for
+Pass 'heads/<branchame> ,tags/<tag name>, or nothing
+#>
+function Get-GitHubSourceReferences {
+  param (
+    $RepoOwner,
+    $RepoName,
+    $RepoId = "$RepoOwner/$RepoName",
+    $Ref,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $AuthToken
+  )
+  $uri = "$GithubAPIBaseURI/$RepoId/git/matching-refs/"
+  if ($Ref) { $uri += "$Ref" }
+
+  return Invoke-RestMethod `
+          -Method GET `
+          -Uri $uri `
+          -Headers (Get-GitHubApiHeaders -token $AuthToken) `
+          -MaximumRetryCount 3
+}
+
+function Get-GitHubPullRequest {
+  param (
+    $RepoOwner,
+    $RepoName,
+    $RepoId = "$RepoOwner/$RepoName",
+    [Parameter(Mandatory = $true)]
+    $PullRequestNumber,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $AuthToken
+  )
+
+  $uri = "$GithubAPIBaseURI/$RepoId/pulls/$PullRequestNumber"
+
+  return Invoke-RestMethod `
+          -Method GET `
+          -Uri $uri `
+          -Headers (Get-GitHubApiHeaders -token $AuthToken) `
+          -MaximumRetryCount 3
+}
+
+function New-GitHubPullRequest {
+  param (
+    $RepoOwner,
+    [Parameter(Mandatory = $true)]
+    $RepoName,
+    [Parameter(Mandatory = $true)]
+    $Title,
+    [Parameter(Mandatory = $true)]
+    $Head,
+    [Parameter(Mandatory = $true)]
+    $Base,
+    $Body=$Title,
+    [Boolean]$Maintainer_Can_Modify=$false,
+    [Boolean]$Draft=$false,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $AuthToken
+  )
+
+  $parameters = @{
+    title                 = $Title
+    head                  = $Head
+    base                  = $Base
+    body                  = $Body
+    maintainer_can_modify = $Maintainer_Can_Modify
+    draft                = $Draft
+  }
+
+  $uri = "$GithubAPIBaseURI/$RepoOwner/$RepoName/pulls"
+  return Invoke-RestMethod `
+          -Method POST `
+          -Body ($parameters | ConvertTo-Json) `
+          -Uri $uri `
+          -Headers (Get-GitHubApiHeaders -token $AuthToken) `
+          -MaximumRetryCount 3
+}
+
+function Close-GitHubPullRequest {
+  param (
+    [Parameter(Mandatory = $true)]
+    $apiurl,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $AuthToken
+  )
+
+  $parameters = @{
+    state                 = "closed"
+  }
+
+  return Invoke-RestMethod `
+          -Method PATCH `
+          -Uri $apiurl `
+          -Body ($parameters | ConvertTo-Json) `
+          -Headers (Get-GitHubApiHeaders -token $AuthToken) `
+          -MaximumRetryCount 3
+}
+
+function New-GitHubIssue {
+  param (
+    [Parameter(Mandatory = $true)]
+    $RepoOwner,
+    [Parameter(Mandatory = $true)]
+    $RepoName,
+    [Parameter(Mandatory = $true)]
+    $Title,
+    [Parameter(Mandatory = $true)]
+    $Description,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $AuthToken
+  )
+
+  $uri = "$GithubAPIBaseURI/$RepoOwner/$RepoName/issues"
+
+  $parameters = @{
+    title = $Title
+    body = $Description
+  }
+
+  return Invoke-RestMethod `
+    -Method POST `
+    -Body ($parameters | ConvertTo-Json) `
+    -Uri $uri `
+    -Headers (Get-GitHubApiHeaders -token $AuthToken) `
+    -MaximumRetryCount 3
+}
+
+function Get-GitHubIssues {
+  param (
+    [Parameter(Mandatory = $true)]
+    $RepoOwner,
+    [Parameter(Mandatory = $true)]
+    $RepoName,
+    $CreatedBy,
+    [Parameter(Mandatory = $true)]
+    $Labels,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $AuthToken
+  )
+
+  $uri = "$GithubAPIBaseURI/$RepoOwner/$RepoName/issues?labels=$Labels&per_page=100"
+
+  if ($CreatedBy) {
+    $uri += "&creator=$CreatedBy"
+  }
+
+  return Invoke-RestMethod `
+    -Method GET `
+    -Uri $uri `
+    -Headers (Get-GitHubApiHeaders -token $AuthToken) `
+    -MaximumRetryCount 3
+}
+
+function Add-GitHubIssueComment {
+  param (
+    [Parameter(Mandatory = $true)]
+    $RepoOwner,
+    [Parameter(Mandatory = $true)]
+    $RepoName,
+    [Parameter(Mandatory = $true)]
+    $IssueNumber,
+    [Parameter(Mandatory = $true)]
+    $Comment,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $AuthToken
+
+  )
+  $uri = "$GithubAPIBaseURI/$RepoOwner/$RepoName/issues/$IssueNumber/comments"
+
+  $parameters = @{
+    body = $Comment
+  }
+
+  return Invoke-RestMethod `
+          -Method POST `
+          -Body ($parameters | ConvertTo-Json) `
+          -Uri $uri `
+          -Headers (Get-GitHubApiHeaders -token $AuthToken) `
+          -MaximumRetryCount 3
+}
+
+# Will add labels to existing labels on the issue
+function Add-GitHubIssueLabels {
+  param (
+    [Parameter(Mandatory = $true)]
+    $RepoOwner,
+    [Parameter(Mandatory = $true)]
+    $RepoName,
+    [Parameter(Mandatory = $true)]
+    $IssueNumber,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $Labels,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $AuthToken
+  )
+
+  if ($Labels.Trim().Length -eq 0)
+  {
+    throw " The 'Labels' parameter should not not be whitespace.
+    Use the 'Update-Issue' function if you plan to reset the labels"
+  }
+
+  $uri = "$GithubAPIBaseURI/$RepoOwner/$RepoName/issues/$IssueNumber/labels"
+  $parameters = @{}
+  $parameters = Set-GitHubAPIParameters -members $Labels -parameterName "labels" `
+  -parameters $parameters
+
+  return Invoke-RestMethod `
+          -Method POST `
+          -Body ($parameters | ConvertTo-Json) `
+          -Uri $uri `
+          -Headers (Get-GitHubApiHeaders -token $AuthToken) `
+          -MaximumRetryCount 3
+}
+
+# Will add assignees to existing assignees on the issue
+function Add-GitHubIssueAssignees {
+  param (
+    [Parameter(Mandatory = $true)]
+    $RepoOwner,
+    [Parameter(Mandatory = $true)]
+    $RepoName,
+    [Parameter(Mandatory = $true)]
+    $IssueNumber,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $Assignees,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $AuthToken
+  )
+
+  if ($Assignees.Trim().Length -eq 0)
+  {
+    throw "The 'Assignees' parameter should not be whitespace.
+    You can use the 'Update-Issue' function if you plan to reset the Assignees"
+  }
+
+  $uri = "$GithubAPIBaseURI/$RepoOwner/$RepoName/issues/$IssueNumber/assignees"
+  $parameters = @{}
+  $parameters = Set-GitHubAPIParameters -members $Assignees -parameterName "assignees" `
+  -parameters $parameters
+
+  return Invoke-RestMethod `
+          -Method POST `
+          -Body ($parameters | ConvertTo-Json) `
+          -Uri $uri `
+          -Headers (Get-GitHubApiHeaders -token $AuthToken) `
+          -MaximumRetryCount 3
+}
+
+function Add-GitHubPullRequestReviewers {
+  param (
+    [Parameter(Mandatory = $true)]
+    $RepoOwner,
+    [Parameter(Mandatory = $true)]
+    $RepoName,
+    [Parameter(Mandatory = $true)]
+    $PrNumber,
+    $Users,
+    $Teams,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $AuthToken
+  )
+
+  $uri = "$GithubAPIBaseURI/$RepoOwner/$RepoName/pulls/$PrNumber/requested_reviewers"
+  $parameters = @{}
+
+  $parameters = Set-GitHubAPIParameters -members $Users -parameterName "reviewers" `
+  -parameters $parameters
+
+  $parameters = Set-GitHubAPIParameters -members $Teams -parameterName "team_reviewers" `
+  -parameters $parameters
+
+  return Invoke-RestMethod `
+          -Method POST `
+          -Body ($parameters | ConvertTo-Json) `
+          -Uri $uri `
+          -Headers (Get-GitHubApiHeaders -token $AuthToken) `
+          -MaximumRetryCount 3
+}
+
+# For labels and assignee pass comma delimited string, to replace existing labels or assignees.
+# Or pass white space " " to remove all labels or assignees
+function Update-GitHubIssue {
+  param (
+    [Parameter(Mandatory = $true)]
+    $RepoOwner,
+    [Parameter(Mandatory = $true)]
+    $RepoName,
+    [Parameter(Mandatory = $true)]
+    $IssueNumber,
+    [string]$Title,
+    [string]$Body,
+    [ValidateSet("open","closed")]
+    [string]$State,
+    [int]$Milestome,
+    $Labels,
+    $Assignees,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $AuthToken
+  )
+
+  $uri = "$GithubAPIBaseURI/$RepoOwner/$RepoName/issues/$IssueNumber"
+  $parameters = @{}
+  if ($Title) { $parameters["title"] = $Title }
+  if ($Body) { $parameters["body"] = $Body }
+  if ($State) { $parameters["state"] = $State }
+  if ($Milestone) { $parameters["milestone"] = $Milestone }
+
+  $parameters = Set-GitHubAPIParameters -members $Labels -parameterName "labels" `
+  -parameters $parameters -allowEmptyMembers $true
+
+  $parameters = Set-GitHubAPIParameters -members $Assignees -parameterName "assignees" `
+  -parameters $parameters -allowEmptyMembers $true
+
+  return Invoke-RestMethod `
+          -Method PATCH `
+          -Body ($parameters | ConvertTo-Json) `
+          -Uri $uri `
+          -Headers (Get-GitHubApiHeaders -token $AuthToken) `
+          -MaximumRetryCount 3
+}
+
+function Remove-GitHubSourceReferences  {
+  param (
+    $RepoOwner,
+    $RepoName,
+    $RepoId = "$RepoOwner/$RepoName",
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $Ref, # Using the format of "refs/heads/<branch>" or "heads/<branch>" for branch, and "tags/<tag>" for tag
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $AuthToken
+  )
+  if ($Ref.Trim().Length -eq 0)
+  {
+    throw "You must supply a valid 'Ref' Parameter to 'Delete-GithubSourceReferences'."
+  }
+  # Github is using branch in format of "heads/{branch_name}". Trim the "refs/heads/..." to "heads/..."
+  $Ref = $Ref -replace "refs/"
+  $uri = "$GithubAPIBaseURI/$RepoId/git/refs/$Ref"
+
+  return Invoke-RestMethod `
+          -Method DELETE `
+          -Uri $uri `
+          -Headers (Get-GitHubApiHeaders -token $AuthToken) `
+          -MaximumRetryCount 3
+}
+
+
+function Get-GithubReferenceCommitDate($commitUrl, $AuthToken) {
+  $commitResponse = ""
+  if ($AuthToken) 
+  {
+    $commitResponse = Invoke-RestMethod $commitUrl `
+                        -Headers (Get-GitHubApiHeaders -token $AuthToken) `
+                        -MaximumRetryCount 3 
+  }
+  else 
+  {
+    $commitResponse = Invoke-RestMethod $commitUrl -MaximumRetryCount 3 
+  }
+  if (!$commitResponse.committer -or !$commitResponse.committer.date) {
+    LogDebug "No date returned from the commit sha. "
+    return $null
+  }
+  return $commitResponse.committer.date
+}

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -1,0 +1,167 @@
+# Helper functions for retireving useful information from azure-sdk-for-* repo
+. "${PSScriptRoot}\logging.ps1"
+
+class PackageProps
+{
+    [string]$Name
+    [string]$Version
+    [string]$DevVersion
+    [string]$DirectoryPath
+    [string]$ServiceDirectory
+    [string]$ReadMePath
+    [string]$ChangeLogPath
+    [string]$Group
+    [string]$SdkType
+    [boolean]$IsNewSdk
+    [string]$ArtifactName
+    [string]$ReleaseStatus
+
+    PackageProps([string]$name, [string]$version, [string]$directoryPath, [string]$serviceDirectory)
+    {
+        $this.Initialize($name, $version, $directoryPath, $serviceDirectory)
+    }
+
+    PackageProps([string]$name, [string]$version, [string]$directoryPath, [string]$serviceDirectory, [string]$group = "")
+    {
+        $this.Initialize($name, $version, $directoryPath, $serviceDirectory, $group)
+    }
+
+    hidden [void]Initialize(
+        [string]$name,
+        [string]$version,
+        [string]$directoryPath,
+        [string]$serviceDirectory
+    )
+    {
+        $this.Name = $name
+        $this.Version = $version
+        $this.DirectoryPath = $directoryPath
+        $this.ServiceDirectory = $serviceDirectory
+
+        if (Test-Path (Join-Path $directoryPath "README.md"))
+        {
+            $this.ReadMePath = Join-Path $directoryPath "README.md"
+        }
+        else
+        {
+            $this.ReadMePath = $null
+        }
+
+        if (Test-Path (Join-Path $directoryPath "CHANGELOG.md"))
+        {
+            $this.ChangeLogPath = Join-Path $directoryPath "CHANGELOG.md"
+            # Get release date for current version and set in package property
+            $changeLogEntry = Get-ChangeLogEntry -ChangeLogLocation $this.ChangeLogPath -VersionString $this.Version
+            if ($changeLogEntry -and $changeLogEntry.ReleaseStatus)
+            {
+              $this.ReleaseStatus = $changeLogEntry.ReleaseStatus.Trim().Trim("()")
+            } 
+        }
+        else
+        {
+            $this.ChangeLogPath = $null
+        }
+    }
+
+    hidden [void]Initialize(
+        [string]$name,
+        [string]$version,
+        [string]$directoryPath,
+        [string]$serviceDirectory,
+        [string]$group
+    )
+    {
+        $this.Initialize($name, $version, $directoryPath, $serviceDirectory)
+        $this.Group = $group
+    }
+}
+
+# Takes package name and service Name
+# Returns important properties of the package as related to the language repo
+# Returns a PS Object with properties @ { pkgName, pkgVersion, pkgDirectoryPath, pkgReadMePath, pkgChangeLogPath }
+# Note: python is required for parsing python package properties.
+function Get-PkgProperties
+{
+    Param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$PackageName,
+        [string]$ServiceDirectory
+    )
+
+    $allPkgProps = Get-AllPkgProperties -ServiceDirectory $ServiceDirectory
+    $pkgProps = $allPkgProps.Where({ $_.Name -eq $PackageName -or $_.ArtifactName -eq $PackageName });
+
+    if ($pkgProps.Count -ge 1)
+    {
+        if ($pkgProps.Count -gt 1)
+        {
+            Write-Host "Found more than one project with the name [$PackageName], choosing the first one under $($pkgProps[0].DirectoryPath)"
+        }
+        return $pkgProps[0]
+    }
+
+    LogError "Failed to retrive Properties for [$PackageName]"
+    return $null
+}
+
+# Takes ServiceName and Repo Root Directory
+# Returns important properties for each package in the specified service, or entire repo if the serviceName is not specified
+# Returns an Table of service key to array values of PS Object with properties @ { pkgName, pkgVersion, pkgDirectoryPath, pkgReadMePath, pkgChangeLogPath }
+function Get-AllPkgProperties ([string]$ServiceDirectory = $null)
+{
+    $pkgPropsResult = @()
+
+    if (Test-Path "Function:Get-AllPackageInfoFromRepo")
+    {
+        $pkgPropsResult = Get-AllPackageInfoFromRepo -ServiceDirectory $serviceDirectory
+    }
+    else
+    {
+        if ([string]::IsNullOrEmpty($ServiceDirectory))
+        {
+            foreach ($dir in (Get-ChildItem (Join-Path $RepoRoot "sdk") -Directory))
+            {
+                $pkgPropsResult += Get-PkgPropsForEntireService -serviceDirectoryPath $dir.FullName
+            }
+        }
+        else
+        {
+            $pkgPropsResult = Get-PkgPropsForEntireService -serviceDirectoryPath (Join-Path $RepoRoot "sdk" $ServiceDirectory)
+        }
+    }
+
+    return $pkgPropsResult
+}
+
+# Given the metadata url under https://github.com/Azure/azure-sdk/tree/main/_data/releases/latest,
+# the function will return the csv metadata back as part of response.
+function Get-CSVMetadata ([string]$MetadataUri=$MetadataUri)
+{
+    $metadataResponse = Invoke-RestMethod -Uri $MetadataUri -method "GET" -MaximumRetryCount 3 -RetryIntervalSec 10 | ConvertFrom-Csv
+    return $metadataResponse
+}
+
+function Get-PkgPropsForEntireService ($serviceDirectoryPath)
+{
+    $projectProps = @() # Properties from very project inthe service
+    $serviceDirectory = $serviceDirectoryPath -replace '^.*[\\/]+sdk[\\/]+([^\\/]+).*$', '$1'
+
+    if (!$GetPackageInfoFromRepoFn -or !(Test-Path "Function:$GetPackageInfoFromRepoFn"))
+    {
+        LogError "The function for '$GetPackageInfoFromRepoFn' was not found.`
+        Make sure it is present in eng/scripts/Language-Settings.ps1 and referenced in eng/common/scripts/common.ps1.`
+        See https://github.com/Azure/azure-sdk-tools/blob/main/doc/common/common_engsys.md#code-structure"
+    }
+
+    foreach ($directory in (Get-ChildItem $serviceDirectoryPath -Directory))
+    {
+        $pkgProps = &$GetPackageInfoFromRepoFn $directory.FullName $serviceDirectory
+        if ($null -ne $pkgProps)
+        {
+            $projectProps += $pkgProps
+        }
+    }
+
+    return $projectProps
+}

--- a/eng/common/scripts/SemVer.ps1
+++ b/eng/common/scripts/SemVer.ps1
@@ -1,0 +1,365 @@
+<#
+.DESCRIPTION
+Parses a semver version string into its components and supports operations around it that we use for versioning our packages.
+
+See https://azure.github.io/azure-sdk/policies_releases.html#package-versioning
+
+Example: 1.2.3-beta.4
+Components: Major.Minor.Patch-PrereleaseLabel.PrereleaseNumber
+
+Example: 1.2.3-alpha.20200828.4
+Components: Major.Minor.Patch-PrereleaseLabel.PrereleaseNumber.BuildNumber
+
+Note: A builtin Powershell version of SemVer exists in 'System.Management.Automation'. At this time, it does not parsing of PrereleaseNumber. It's name is also type accelerated to 'SemVer'.
+#>
+
+class AzureEngSemanticVersion : IComparable {
+  [int] $Major
+  [int] $Minor
+  [int] $Patch
+  [string] $PrereleaseLabelSeparator
+  [string] $PrereleaseLabel
+  [string] $PrereleaseNumberSeparator
+  [string] $BuildNumberSeparator
+  # BuildNumber is string to preserve zero-padding where applicable
+  [string] $BuildNumber
+  [int] $PrereleaseNumber
+  [bool] $IsPrerelease
+  [string] $VersionType
+  [string] $RawVersion
+  [bool] $IsSemVerFormat
+  [string] $DefaultPrereleaseLabel
+  [string] $DefaultAlphaReleaseLabel
+
+  # Regex inspired but simplified from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+  # Validation: https://regex101.com/r/vkijKf/426
+  static [string] $SEMVER_REGEX = "(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:(?<presep>-?)(?<prelabel>[a-zA-Z]+)(?:(?<prenumsep>\.?)(?<prenumber>[0-9]{1,8})(?:(?<buildnumsep>\.?)(?<buildnumber>\d{1,3}))?)?)?"
+
+  static [AzureEngSemanticVersion] ParseVersionString([string] $versionString)
+  {
+    $version = [AzureEngSemanticVersion]::new($versionString)
+
+    if (!$version.IsSemVerFormat) {
+      return $null
+    }
+    return $version
+  }
+
+  static [AzureEngSemanticVersion] ParsePythonVersionString([string] $versionString)
+  {
+    $version = [AzureEngSemanticVersion]::ParseVersionString($versionString)
+
+    if (!$version) {
+      return $null
+    }
+
+    $version.SetupPythonConventions()
+    return $version
+  }
+  
+  AzureEngSemanticVersion([string] $versionString)
+  {
+    if ($versionString -match "^$([AzureEngSemanticVersion]::SEMVER_REGEX)$")
+    {
+      $this.IsSemVerFormat = $true
+      $this.RawVersion = $versionString
+      $this.Major = [int]$matches.Major
+      $this.Minor = [int]$matches.Minor
+      $this.Patch = [int]$matches.Patch
+
+      # If Language exists and is set to python setup the python conventions.
+      $parseLanguage = (Get-Variable -Name "Language" -ValueOnly -ErrorAction "Ignore")
+      if ($parseLanguage -eq "python") {
+        $this.SetupPythonConventions()
+      }
+      else {
+        $this.SetupDefaultConventions()
+      }
+
+      if ($null -eq $matches['prelabel'])
+      {
+        # artifically provide these values for non-prereleases to enable easy sorting of them later than prereleases.
+        $this.PrereleaseLabel = "zzz"
+        $this.PrereleaseNumber = 99999999
+        $this.IsPrerelease = $false
+        $this.VersionType = "GA"
+        if ($this.Major -eq 0) {
+           # Treat initial 0 versions as a prerelease beta's
+          $this.VersionType = "Beta"
+          $this.IsPrerelease = $true
+        }
+        elseif ($this.Patch -ne 0) {
+          $this.VersionType = "Patch"
+        }
+      }
+      else
+      {
+        $this.PrereleaseLabel = $matches["prelabel"]
+        $this.PrereleaseLabelSeparator = $matches["presep"]
+        $this.PrereleaseNumber = [int]$matches["prenumber"]
+        $this.PrereleaseNumberSeparator = $matches["prenumsep"]
+        $this.IsPrerelease = $true
+        $this.VersionType = "Beta"
+
+        $this.BuildNumberSeparator = $matches["buildnumsep"]
+        $this.BuildNumber = $matches["buildnumber"]
+      }
+    }
+    else
+    {
+      $this.RawVersion = $versionString
+      $this.IsSemVerFormat = $false
+    }
+  }
+
+  # If a prerelease label exists, it must be 'beta', and similar semantics used in our release guidelines
+  # See https://azure.github.io/azure-sdk/policies_releases.html#package-versioning
+  [bool] HasValidPrereleaseLabel()
+  {
+    if ($this.IsPrerelease -eq $true) {
+      if ($this.PrereleaseLabel -ne $this.DefaultPrereleaseLabel -and $this.PrereleaseLabel -ne $this.DefaultAlphaReleaseLabel) {
+        Write-Host "Unexpected pre-release identifier '$($this.PrereleaseLabel)', "`
+                   "should be '$($this.DefaultPrereleaseLabel)' or '$($this.DefaultAlphaReleaseLabel)'"
+        return $false;
+      }
+      if ($this.PrereleaseNumber -lt 1)
+      {
+        Write-Host "Unexpected pre-release version '$($this.PrereleaseNumber)', should be >= '1'"
+        return $false;
+      }
+    }
+
+    return $true;
+  }
+
+  [string] ToString()
+  {
+    $versionString = "{0}.{1}.{2}" -F $this.Major, $this.Minor, $this.Patch
+
+    if ($this.IsPrerelease -and $this.PrereleaseLabel -ne "zzz")
+    {
+      $versionString += $this.PrereleaseLabelSeparator + $this.PrereleaseLabel + `
+                        $this.PrereleaseNumberSeparator + $this.PrereleaseNumber
+      if ($this.BuildNumber) {
+          $versionString += $this.BuildNumberSeparator + $this.BuildNumber
+      }
+    }
+    return $versionString;
+  }
+
+  [void] IncrementAndSetToPrerelease() {
+    if ($this.IsPrerelease -eq $false)
+    {
+      $this.PrereleaseLabel = $this.DefaultPrereleaseLabel
+      $this.PrereleaseNumber = 1
+      $this.Minor++
+      $this.Patch = 0
+      $this.IsPrerelease = $true
+    }
+    else
+    {
+      if ($this.BuildNumber) {
+        throw "Cannot increment releases tagged with azure pipelines build numbers"
+      }
+      $this.PrereleaseNumber++
+    }
+  }
+
+  [void] SetupPythonConventions()
+  {
+    # Python uses no separators and "b" for beta so this sets up the the object to work with those conventions
+    $this.PrereleaseLabelSeparator = $this.PrereleaseNumberSeparator = $this.BuildNumberSeparator = ""
+    $this.DefaultPrereleaseLabel = "b"
+    $this.DefaultAlphaReleaseLabel = "a"
+  }
+
+  [void] SetupDefaultConventions()
+  {
+    # Use the default common conventions
+    $this.PrereleaseLabelSeparator = "-"
+    $this.PrereleaseNumberSeparator = "."
+    $this.BuildNumberSeparator = "."
+    $this.DefaultPrereleaseLabel = "beta"
+    $this.DefaultAlphaReleaseLabel = "alpha"
+  }
+
+  [int] CompareTo($other)
+  {
+    if ($other -isnot [AzureEngSemanticVersion]) {
+      throw "Cannot compare $other with $this"
+    }
+
+    $ret = $this.Major.CompareTo($other.Major)
+    if ($ret) { return $ret }
+
+    $ret = $this.Minor.CompareTo($other.Minor)
+    if ($ret) { return $ret }
+
+    $ret = $this.Patch.CompareTo($other.Patch)
+    if ($ret) { return $ret }
+
+    # Mimic PowerShell that uses case-insensitive comparisons by default.
+    $ret = [string]::Compare($this.PrereleaseLabel, $other.PrereleaseLabel, $true)
+    if ($ret) { return $ret }
+
+    $ret = $this.PrereleaseNumber.CompareTo($other.PrereleaseNumber)
+    if ($ret) { return $ret }
+
+    return ([int] $this.BuildNumber).CompareTo([int] $other.BuildNumber)
+  }
+
+  static [string[]] SortVersionStrings([string[]] $versionStrings)
+  {
+    $versions = $versionStrings | ForEach-Object { [AzureEngSemanticVersion]::ParseVersionString($_) }
+    $sortedVersions = [AzureEngSemanticVersion]::SortVersions($versions)
+    return ($sortedVersions | ForEach-Object { $_.RawVersion })
+  }
+
+  static [AzureEngSemanticVersion[]] SortVersions([AzureEngSemanticVersion[]] $versions)
+  {
+    return $versions | Sort-Object -Descending
+  }
+
+  static [void] QuickTests()
+  {
+    $global:Language = ""
+    $versions = @(
+      "1.0.1",
+      "2.0.0",
+      "2.0.0-alpha.20200920",
+      "2.0.0-alpha.20200920.1",
+      "2.0.0-beta.2",
+      "1.0.10",
+      "2.0.0-alpha.20201221.03",
+      "2.0.0-alpha.20201221.1",
+      "2.0.0-alpha.20201221.5",
+      "2.0.0-alpha.20201221.2",
+      "2.0.0-alpha.20201221.10",
+      "2.0.0-beta.1",
+      "2.0.0-beta.10",
+      "1.0.0",
+      "1.0.0b2",
+      "1.0.2")
+
+    $expectedSort = @(
+      "2.0.0",
+      "2.0.0-beta.10",
+      "2.0.0-beta.2",
+      "2.0.0-beta.1",
+      "2.0.0-alpha.20201221.10",
+      "2.0.0-alpha.20201221.5",
+      "2.0.0-alpha.20201221.03",
+      "2.0.0-alpha.20201221.2",
+      "2.0.0-alpha.20201221.1",
+      "2.0.0-alpha.20200920.1",
+      "2.0.0-alpha.20200920",
+      "1.0.10",
+      "1.0.2",
+      "1.0.1",
+      "1.0.0",
+      "1.0.0b2")
+
+    $sort = [AzureEngSemanticVersion]::SortVersionStrings($versions)
+
+    for ($i = 0; $i -lt $expectedSort.Count; $i++)
+    {
+      if ($sort[$i] -ne $expectedSort[$i]) {
+        Write-Host "Error: Incorrect version sort:"
+        Write-Host "Expected: "
+        Write-Host $expectedSort
+        Write-Host "Actual:"
+        Write-Host $sort
+        break
+      }
+    }
+
+    $alphaVerString = "1.2.3-alpha.20200828.9"
+    $alphaVer = [AzureEngSemanticVersion]::new($alphaVerString)
+    if (!$alphaVer.IsPrerelease) {
+      Write-Host "Expected alpha version to be marked as prerelease"
+    }
+    if ($alphaVer.Major -ne 1 -or $alphaVer.Minor -ne 2 -or $alphaVer.Patch -ne 3 -or `
+        $alphaVer.PrereleaseLabel -ne "alpha" -or $alphaVer.PrereleaseNumber -ne 20200828 -or $alphaVer.BuildNumber -ne 9) {
+      Write-Host "Error: Didn't correctly parse alpha version string $alphaVerString"
+    }
+    if ($alphaVerString -ne $alphaVer.ToString()) {
+      Write-Host "Error: alpha string did not correctly round trip with ToString. Expected: $($alphaVerString), Actual: $($alphaVer)"
+    }
+
+    $global:Language = "python"
+    $pythonAlphaVerString = "1.2.3a20200828009"
+    $pythonAlphaVer = [AzureEngSemanticVersion]::new($pythonAlphaVerString)
+    if (!$pythonAlphaVer.IsPrerelease) {
+      Write-Host "Expected python alpha version to be marked as prerelease"
+    }
+    # Note: For python we lump build number into prerelease number, since it simplifies the code and regex, and is behaviorally the same
+    if ($pythonAlphaVer.Major -ne 1 -or $pythonAlphaVer.Minor -ne 2 -or $pythonAlphaVer.Patch -ne 3 `
+        -or $pythonAlphaVer.PrereleaseLabel -ne "a" -or $pythonAlphaVer.PrereleaseNumber -ne 20200828 `
+        -or $pythonAlphaVer.BuildNumber -ne "009") {
+      Write-Host "Error: Didn't correctly parse python alpha version string $pythonAlphaVerString"
+    }
+    if ($pythonAlphaVerString -ne $pythonAlphaVer.ToString()) {
+      Write-Host "Error: python alpha string did not correctly round trip with ToString. Expected: $($pythonAlphaVerString), Actual: $($pythonAlphaVer)"
+    }
+
+    $versions = @("1.0.1", "2.0.0", "2.0.0a20201208001", "2.0.0a20201105020", "2.0.0a20201208012", `
+                  "2.0.0b2", "1.0.10", "2.0.0b1", "2.0.0b10", "1.0.0", "1.0.0b2", "1.0.2")
+    $expectedSort = @("2.0.0", "2.0.0b10", "2.0.0b2", "2.0.0b1", "2.0.0a20201208012", "2.0.0a20201208001", `
+                      "2.0.0a20201105020", "1.0.10", "1.0.2", "1.0.1", "1.0.0", "1.0.0b2")
+    $sort = [AzureEngSemanticVersion]::SortVersionStrings($versions)
+    for ($i = 0; $i -lt $expectedSort.Count; $i++)
+    {
+      if ($sort[$i] -ne $expectedSort[$i]) { 
+        Write-Host "Error: Incorrect python version sort:"
+        Write-Host "Expected: "
+        Write-Host $expectedSort
+        Write-Host "Actual:"
+        Write-Host $sort
+        break
+      }
+    }
+
+    $global:Language = ""
+
+    $gaVerString = "1.2.3"
+    $gaVer = [AzureEngSemanticVersion]::ParseVersionString($gaVerString)
+    if ($gaVer.Major -ne 1 -or $gaVer.Minor -ne 2 -or $gaVer.Patch -ne 3) {
+      Write-Host "Error: Didn't correctly parse ga version string $gaVerString"
+    }
+    if ($gaVerString -ne $gaVer.ToString()) {
+      Write-Host "Error: Ga string did not correctly round trip with ToString. Expected: $($gaVerString), Actual: $($gaVer)"
+    }
+    $gaVer.IncrementAndSetToPrerelease()
+    if ("1.3.0-beta.1" -ne $gaVer.ToString()) {
+      Write-Host "Error: Ga string did not correctly increment"
+    }
+
+    $betaVerString = "1.2.3-beta.4"
+    $betaVer = [AzureEngSemanticVersion]::ParseVersionString($betaVerString)
+    if ($betaVer.Major -ne 1 -or $betaVer.Minor -ne 2 -or $betaVer.Patch -ne 3 -or $betaVer.PrereleaseLabel -ne "beta" -or $betaVer.PrereleaseNumber -ne 4) {
+      Write-Host "Error: Didn't correctly parse beta version string $betaVerString"
+    }
+    if ($betaVerString -ne $betaVer.ToString()) {
+      Write-Host "Error: beta string did not correctly round trip with ToString. Expected: $($betaVerString), Actual: $($betaVer)"
+    }
+    $betaVer.IncrementAndSetToPrerelease()
+    if ("1.2.3-beta.5" -ne $betaVer.ToString()) {
+      Write-Host "Error: Beta string did not correctly increment"
+    }
+
+    $pythonBetaVerString = "1.2.3b4"
+    $pbetaVer = [AzureEngSemanticVersion]::ParsePythonVersionString($pythonBetaVerString)
+    if ($pbetaVer.Major -ne 1 -or $pbetaVer.Minor -ne 2 -or $pbetaVer.Patch -ne 3 -or $pbetaVer.PrereleaseLabel -ne "b" -or $pbetaVer.PrereleaseNumber -ne 4) {
+      Write-Host "Error: Didn't correctly parse python beta string $pythonBetaVerString"
+    }
+    if ($pythonBetaVerString -ne $pbetaVer.ToString()) {
+      Write-Host "Error: python beta string did not correctly round trip with ToString"
+    }
+    $pbetaVer.IncrementAndSetToPrerelease()
+    if ("1.2.3b5" -ne $pbetaVer.ToString()) {
+      Write-Host "Error: Python beta string did not correctly increment"
+    }
+
+    Write-Host "QuickTests done"
+  }
+}

--- a/eng/common/scripts/Submit-PullRequest.ps1
+++ b/eng/common/scripts/Submit-PullRequest.ps1
@@ -1,0 +1,141 @@
+ #!/usr/bin/env pwsh -c
+
+<#
+.DESCRIPTION
+Creates a GitHub pull request for a given branch if it doesn't already exist
+.PARAMETER RepoOwner
+The GitHub repository owner to create the pull request against.
+.PARAMETER RepoName
+The GitHub repository name to create the pull request against.
+.PARAMETER BaseBranch
+The base or target branch we want the pull request to be against.
+.PARAMETER PROwner
+The owner of the branch we want to create a pull request for.
+.PARAMETER PRBranch
+The branch which we want to create a pull request for.
+.PARAMETER AuthToken
+A personal access token
+.PARAMETER PRTitle
+The title of the pull request.
+.PARAMETER PRBody
+The body message for the pull request. 
+.PARAMETER PRLabels
+The labels added to the PRs. Multple labels seperated by comma, e.g "bug, service"
+.PARAMETER UserReviewers
+User reviewers to request after opening the PR. Users should be a comma-
+separated list with no preceeding `@` symbol (e.g. "user1,usertwo,user3")
+.PARAMETER TeamReviewers
+List of github teams to add as reviewers
+.PARAMETER Assignees
+Users to assign to the PR after opening. Users should be a comma-separated list
+with no preceeding `@` symbol (e.g. "user1,usertwo,user3")
+.PARAMETER CloseAfterOpenForTesting
+Close the PR after opening to save on CI resources and prevent alerts to code
+owners, assignees, requested reviewers, or others.
+.PARAMETER OpenAsDraft
+Opens the PR as a draft
+#>
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$RepoOwner,
+
+  [Parameter(Mandatory = $true)]
+  [string]$RepoName,
+
+  [Parameter(Mandatory = $true)]
+  [string]$BaseBranch,
+
+  [Parameter(Mandatory = $true)]
+  [string]$PROwner,
+
+  [Parameter(Mandatory = $true)]
+  [string]$PRBranch,
+
+  [Parameter(Mandatory = $true)]
+  [string]$AuthToken,
+
+  [Parameter(Mandatory = $true)]
+  [string]$PRTitle,
+
+  [Parameter(Mandatory = $false)]
+  [string]$PRBody = $PRTitle,
+
+  [string]$PRLabels,
+
+  [string]$UserReviewers,
+
+  [string]$TeamReviewers,
+
+  [string]$Assignees,
+
+  [boolean]$CloseAfterOpenForTesting=$false,
+
+  [boolean]$OpenAsDraft=$false
+)
+
+. (Join-Path $PSScriptRoot common.ps1)
+
+try {
+  $resp = Get-GitHubPullRequests -RepoOwner $RepoOwner -RepoName $RepoName `
+  -Head "${PROwner}:${PRBranch}" -Base $BaseBranch -AuthToken $AuthToken
+}
+catch { 
+  LogError "Get-GitHubPullRequests failed with exception:`n$_"
+  exit 1
+}
+
+$resp | Write-Verbose
+
+if ($resp.Count -gt 0) {
+  LogDebug "Pull request already exists $($resp[0].html_url)"
+  # setting variable to reference the pull request by number
+  Write-Host "##vso[task.setvariable variable=Submitted.PullRequest.Number]$($resp[0].number)"
+}
+else {
+  try {
+    $resp = New-GitHubPullRequest `
+      -RepoOwner $RepoOwner `
+      -RepoName $RepoName `
+      -Title $PRTitle `
+      -Head "${PROwner}:${PRBranch}" `
+      -Base $BaseBranch `
+      -Body $PRBody `
+      -Maintainer_Can_Modify $true `
+      -Draft:$OpenAsDraft `
+      -AuthToken $AuthToken
+
+    $resp | Write-Verbose
+    LogDebug "Pull request created https://github.com/$RepoOwner/$RepoName/pull/$($resp.number)"
+  
+    $prOwnerUser = $resp.user.login
+
+    # setting variable to reference the pull request by number
+    Write-Host "##vso[task.setvariable variable=Submitted.PullRequest.Number]$($resp.number)"
+
+    # ensure that the user that was used to create the PR is not attempted to add as a reviewer
+    # we cast to an array to ensure that length-1 arrays actually stay as array values
+    $cleanedUsers = @(SplitParameterArray -members $UserReviewers) | ? { $_ -ne $prOwnerUser -and $null -ne $_ }
+    $cleanedTeamReviewers = @(SplitParameterArray -members $TeamReviewers) | ? { $_ -ne $prOwnerUser -and $null -ne $_ }
+
+    if ($cleanedUsers -or $cleanedTeamReviewers) {
+      Add-GitHubPullRequestReviewers -RepoOwner $RepoOwner -RepoName $RepoName -PrNumber $resp.number `
+      -Users $cleanedUsers -Teams $cleanedTeamReviewers -AuthToken $AuthToken
+    }
+
+    if ($CloseAfterOpenForTesting) {
+      $prState = "closed"
+      LogDebug "Updating https://github.com/$RepoOwner/$RepoName/pull/$($resp.number) state to closed because this was only testing."
+    }
+    else {
+      $prState = "open"
+    }
+
+    Update-GitHubIssue -RepoOwner $RepoOwner -RepoName $RepoName -IssueNumber $resp.number `
+    -State $prState -Labels $PRLabels -Assignees $Assignees -AuthToken $AuthToken
+  }
+  catch {
+    LogError "Call to GitHub API failed with exception:`n$_"
+    exit 1
+  }
+}

--- a/eng/common/scripts/Update-ChangeLog.ps1
+++ b/eng/common/scripts/Update-ChangeLog.ps1
@@ -1,0 +1,140 @@
+# Note: This script will add or replace version title in change log
+
+# Parameter description
+# Version : Version to add or replace in change log
+# Unreleased: Default is true. If it is set to false, then today's date will be set in verion title. If it is True then title will show "Unreleased"
+# ReplaceLatestEntryTitle: Replaces the latest changelog entry title.
+
+[CmdletBinding()]
+param (
+  [Parameter(Mandatory = $true)]
+  [String]$Version,
+  [String]$ServiceDirectory,
+  [String]$PackageName,
+  [Boolean]$Unreleased = $true,
+  [Boolean]$ReplaceLatestEntryTitle = $false,
+  [String]$ChangelogPath,
+  [String]$ReleaseDate
+)
+Set-StrictMode -Version 3
+
+. (Join-Path $PSScriptRoot common.ps1)
+
+if ($ReleaseDate -and $Unreleased) {
+    LogError "Do not pass 'ReleaseDate' arguement when 'Unreleased' is true"
+    exit 1
+}
+
+if (!$PackageName -and !$ChangelogPath) {
+    LogError "You must pass either the PackageName or ChangelogPath arguument."
+    exit 1
+}
+
+if ($ReleaseDate)
+{
+    try {
+        $ReleaseStatus = ([DateTime]$ReleaseDate).ToString($CHANGELOG_DATE_FORMAT)
+        $ReleaseStatus = "($ReleaseStatus)"
+    }
+    catch {
+        LogError "Invalid 'ReleaseDate'. Please use a valid date in the format '$CHANGELOG_DATE_FORMAT'. See https://aka.ms/azsdk/changelogguide"
+        exit 1
+    }
+}
+elseif ($Unreleased)
+{
+    $ReleaseStatus = $CHANGELOG_UNRELEASED_STATUS
+}
+else
+{
+    $ReleaseStatus = "$(Get-Date -Format $CHANGELOG_DATE_FORMAT)"
+    $ReleaseStatus = "($ReleaseStatus)"
+}
+
+if ($null -eq [AzureEngSemanticVersion]::ParseVersionString($Version))
+{
+    LogError "Version [$Version] is invalid. Please use a valid SemVer. See https://aka.ms/azsdk/changelogguide"
+    exit 1
+}
+
+if ([string]::IsNullOrEmpty($ChangelogPath))
+{
+    $pkgProperties = Get-PkgProperties -PackageName $PackageName -ServiceDirectory $ServiceDirectory
+    $ChangelogPath = $pkgProperties.ChangeLogPath
+}
+
+if (!(Test-Path $ChangelogPath))
+{
+    LogError "Changelog path [$ChangelogPath] is invalid."
+    exit 1
+}
+
+$ChangeLogEntries = Get-ChangeLogEntries -ChangeLogLocation $ChangelogPath
+
+if ($ChangeLogEntries.Contains($Version))
+{
+    if ($ChangeLogEntries[$Version].ReleaseStatus -eq $ReleaseStatus)
+    {
+        LogDebug "Version [$Version] is already present in change log with specificed ReleaseStatus [$ReleaseStatus]. No Change made."
+        exit(0)
+    }
+
+    if ($Unreleased -and ($ChangeLogEntries[$Version].ReleaseStatus -ne $ReleaseStatus))
+    {
+        LogDebug "Version [$Version] is already present in change log with a release date. Please review [$ChangelogPath]. No Change made."
+        exit(0)
+    }
+
+    if (!$Unreleased -and ($ChangeLogEntries[$Version].ReleaseStatus -ne $CHANGELOG_UNRELEASED_STATUS))
+    {
+        if ((Get-Date ($ChangeLogEntries[$Version].ReleaseStatus).Trim("()")) -gt (Get-Date $ReleaseStatus.Trim("()")))
+        {
+            LogDebug "New ReleaseDate for version [$Version] is older than existing release date in changelog. Please review [$ChangelogPath]. No Change made."
+            exit(0)
+        }
+    }
+}
+
+$PresentVersionsSorted = [AzureEngSemanticVersion]::SortVersionStrings($ChangeLogEntries.Keys)
+$LatestVersion = $PresentVersionsSorted[0]
+
+LogDebug "The latest release note entry in the changelog is for version [$($LatestVersion)]"
+
+$LatestsSorted = [AzureEngSemanticVersion]::SortVersionStrings(@($LatestVersion, $Version))
+if ($LatestsSorted[0] -ne $Version) {
+    LogWarning "Version [$Version] is older than the latestversion [$LatestVersion] in the changelog. Consider using a more recent version."
+}
+
+if ($ReplaceLatestEntryTitle)
+{
+    $newChangeLogEntry = New-ChangeLogEntry -Version $Version -Status $ReleaseStatus -InitialAtxHeader $ChangeLogEntries.InitialAtxHeader -Content $ChangeLogEntries[$LatestVersion].ReleaseContent
+    LogDebug "Resetting latest entry title to [$($newChangeLogEntry.ReleaseTitle)]"
+    $ChangeLogEntries.Remove($LatestVersion)
+    if ($newChangeLogEntry) {
+        $ChangeLogEntries.Insert(0, $Version, $newChangeLogEntry)
+    }
+    else {
+        LogError "Failed to create new changelog entry"
+        exit 1
+    }
+}
+elseif ($ChangeLogEntries.Contains($Version))
+{
+    LogDebug "Updating ReleaseStatus for Version [$Version] to [$($ReleaseStatus)]"
+    $ChangeLogEntries[$Version].ReleaseStatus = $ReleaseStatus
+    $ChangeLogEntries[$Version].ReleaseTitle = "$($ChangeLogEntries.InitialAtxHeader)# $Version $ReleaseStatus"
+}
+else
+{
+    LogDebug "Adding new ChangeLog entry for Version [$Version]"
+    $newChangeLogEntry = New-ChangeLogEntry -Version $Version -Status $ReleaseStatus -InitialAtxHeader $ChangeLogEntries.InitialAtxHeader
+    if ($newChangeLogEntry) {
+        $ChangeLogEntries.Insert(0, $Version, $newChangeLogEntry)
+    }
+    else {
+        LogError "Failed to create new changelog entry"
+        exit 1
+    }
+}
+
+Set-ChangeLogContent -ChangeLogLocation $ChangelogPath -ChangeLogEntries $ChangeLogEntries

--- a/eng/common/scripts/Verify-ChangeLog.ps1
+++ b/eng/common/scripts/Verify-ChangeLog.ps1
@@ -1,0 +1,30 @@
+# Wrapper Script for ChangeLog Verification
+[CmdletBinding()]
+param (
+  [String]$ChangeLogLocation,
+  [String]$VersionString,
+  [string]$PackageName,
+  [string]$ServiceDirectory,
+  [boolean]$ForRelease = $False
+)
+Set-StrictMode -Version 3
+
+. (Join-Path $PSScriptRoot common.ps1)
+
+$validChangeLog = $false
+if ($ChangeLogLocation -and $VersionString)
+{
+  $validChangeLog = Confirm-ChangeLogEntry -ChangeLogLocation $ChangeLogLocation -VersionString $VersionString -ForRelease $ForRelease
+}
+else
+{
+  $PackageProp = Get-PkgProperties -PackageName $PackageName -ServiceDirectory $ServiceDirectory
+  $validChangeLog = Confirm-ChangeLogEntry -ChangeLogLocation $PackageProp.ChangeLogPath -VersionString $PackageProp.Version -ForRelease $ForRelease
+}
+
+if (!$validChangeLog)
+{
+  exit 1
+}
+
+exit 0

--- a/eng/common/scripts/artifact-metadata-parsing.ps1
+++ b/eng/common/scripts/artifact-metadata-parsing.ps1
@@ -1,0 +1,199 @@
+. (Join-Path $EngCommonScriptsDir SemVer.ps1)
+
+$SDIST_PACKAGE_REGEX = "^(?<package>.*)\-(?<versionstring>$([AzureEngSemanticVersion]::SEMVER_REGEX))"
+
+# Posts a github release for each item of the pkgList variable. SilentlyContinue
+function CreateReleases($pkgList, $releaseApiUrl, $releaseSha) {
+  foreach ($pkgInfo in $pkgList) {
+    Write-Host "Creating release $($pkgInfo.Tag)"
+
+    $releaseNotes = ""
+    if ($pkgInfo.ReleaseNotes -ne $null) {
+      $releaseNotes = $pkgInfo.ReleaseNotes
+    }
+    # As github api limit the body param length with 125000 characters, we have to truncate the release note if needed.
+    if ($releaseNotes.Length -gt 124996) {
+      $releaseNotes = $releaseNotes.SubString(0, 124996) + " ..."
+    }
+
+    $isPrerelease = $False
+
+    $parsedSemver = [AzureEngSemanticVersion]::ParseVersionString($pkgInfo.PackageVersion)
+
+    if ($parsedSemver) {
+      $isPrerelease = $parsedSemver.IsPrerelease
+    }
+
+    $url = $releaseApiUrl
+    $body = ConvertTo-Json @{
+      tag_name         = $pkgInfo.Tag
+      target_commitish = $releaseSha
+      name             = $pkgInfo.Tag
+      draft            = $False
+      prerelease       = $isPrerelease
+      body             = $releaseNotes
+    }
+
+    $headers = @{
+      "Content-Type"  = "application/json"
+      "Authorization" = "token $($env:GH_TOKEN)"
+    }
+
+    Invoke-RestMethod -Uri $url -Body $body -Headers $headers -Method "Post" -MaximumRetryCount 3 -RetryIntervalSec 10
+  }
+}
+
+# Retrieves the list of all tags that exist on the target repository
+function GetExistingTags($apiUrl) {
+  try {
+    $headers = @{
+      "Authorization" = "token $($env:GH_TOKEN)"
+    }
+    return (Invoke-RestMethod -Method "GET" -Uri "$apiUrl/git/refs/tags" -Headers $headers -MaximumRetryCount 3 -RetryIntervalSec 10) | % { $_.ref.Replace("refs/tags/", "") }
+  }
+  catch {
+    Write-Host $_
+    $statusCode = $_.Exception.Response.StatusCode.value__
+    $statusDescription = $_.Exception.Response.StatusDescription
+
+    Write-Host "Failed to retrieve tags from repository."
+    Write-Host "StatusCode:" $statusCode
+    Write-Host "StatusDescription:" $statusDescription
+
+    # Return an empty list if there are no tags in the repo
+    if ($statusCode -eq 404) {
+      return ,@()
+    }
+
+    exit(1)
+  }
+}
+
+# Retrieve release tag for artiface package. If multiple packages, then output the first one.
+function RetrieveReleaseTag($artifactLocation, $continueOnError = $true) {
+  if (!$artifactLocation) {
+    return ""
+  }
+  try {
+    $pkgs, $parsePkgInfoFn = RetrievePackages -artifactLocation $artifactLocation
+    if (!$pkgs -or !$pkgs[0]) {
+      Write-Host "No packages retrieved from artifact location."
+      return ""
+    }
+    if ($pkgs.Count -gt 1) {
+      Write-Host "There are more than 1 packages retieved from artifact location."
+      foreach ($pkg in $pkgs) {
+        Write-Host "The package name is $($pkg.BaseName)"
+      }
+      return ""
+    }
+    $parsedPackage = &$parsePkgInfoFn -pkg $pkgs[0] -workingDirectory $artifactLocation
+    return $parsedPackage.ReleaseTag
+  }
+  catch {
+    if ($continueOnError) {
+      return ""
+    }
+    Write-Error "No release tag retrieved from $artifactLocation"
+  }
+}
+
+function RetrievePackages($artifactLocation) {
+  $pkgs = Get-ChildItem -Path $artifactLocation -Include $packagePattern -Recurse -File
+  if ($GetPackageInfoFromPackageFileFn -and (Test-Path "Function:$GetPackageInfoFromPackageFileFn"))
+  {
+    return $pkgs, $GetPackageInfoFromPackageFileFn
+  }
+  else
+  {
+    LogError "The function for '$GetPackageInfoFromPackageFileFn' was not found.`
+    Make sure it is present in eng/scripts/Language-Settings.ps1 and referenced in eng/common/scripts/common.ps1.`
+    See https://github.com/Azure/azure-sdk-tools/blob/main/doc/common/common_engsys.md#code-structure"
+  }
+}
+
+# Walk across all build artifacts, check them against the appropriate repository, return a list of tags/releases
+function VerifyPackages($artifactLocation, $workingDirectory, $apiUrl, $releaseSha,  $continueOnError = $false) {
+  $pkgList = [array]@()
+  $pkgs, $parsePkgInfoFn = RetrievePackages -artifactLocation $artifactLocation
+
+  foreach ($pkg in $pkgs) {
+    try {
+      $parsedPackage = &$parsePkgInfoFn -pkg $pkg -workingDirectory $workingDirectory
+
+      if ($parsedPackage -eq $null) {
+        continue
+      }
+
+      if ($parsedPackage.Deployable -ne $True -and !$continueOnError) {
+        Write-Host "Package $($parsedPackage.PackageId) is marked with version $($parsedPackage.PackageVersion), the version $($parsedPackage.PackageVersion) has already been deployed to the target repository."
+        Write-Host "Maybe a pkg version wasn't updated properly?"
+        exit(1)
+      }
+      $docsReadMeName = $parsedPackage.PackageId
+      if ($parsedPackage.DocsReadMeName) {
+        $docsReadMeName = $parsedPackage.DocsReadMeName
+      }
+      $pkgList += New-Object PSObject -Property @{
+        PackageId      = $parsedPackage.PackageId
+        PackageVersion = $parsedPackage.PackageVersion
+        GroupId        = $parsedPackage.GroupId
+        Tag            = $parsedPackage.ReleaseTag
+        ReleaseNotes   = $parsedPackage.ReleaseNotes
+        ReadmeContent  = $parsedPackage.ReadmeContent
+        DocsReadMeName = $docsReadMeName
+        IsPrerelease   = [AzureEngSemanticVersion]::ParseVersionString($parsedPackage.PackageVersion).IsPrerelease
+      }
+    }
+    catch {
+      Write-Host $_.Exception.Message
+      exit(1)
+    }
+  }
+
+  $results = @([array]$pkgList | Sort-Object -Property Tag -uniq)
+
+  $existingTags = GetExistingTags($apiUrl)
+  
+  $intersect = $results | % { $_.Tag } | ? { $existingTags -contains $_ }
+
+  if ($intersect.Length -gt 0 -and !$continueOnError) {
+    CheckArtifactShaAgainstTagsList -priorExistingTagList $intersect -releaseSha $releaseSha -apiUrl $apiUrl -continueOnError $continueOnError
+
+    # all the tags are clean. remove them from the list of releases we will publish.
+    $results = $results | ? { -not ($intersect -contains $_.Tag ) }
+  }
+
+  return $results
+}
+
+# given a set of tags that we want to release, we need to ensure that if they already DO exist.
+# if they DO exist, quietly exit if the commit sha of the artifact matches that of the tag
+# if the commit sha does not match, exit with error and report both problem shas
+function CheckArtifactShaAgainstTagsList($priorExistingTagList, $releaseSha, $apiUrl, $continueOnError) {
+  $headers = @{
+    "Content-Type"  = "application/json"
+    "Authorization" = "token $($env:GH_TOKEN)"
+  }
+
+  $unmatchedTags = @()
+
+  foreach ($tag in $priorExistingTagList) {
+    $tagSha = (Invoke-RestMethod -Method "Get" -Uri "$apiUrl/git/refs/tags/$tag" -Headers $headers -MaximumRetryCount 3 -RetryIntervalSec 10)."object".sha
+
+    if ($tagSha -eq $releaseSha) {
+      Write-Host "This package has already been released. The existing tag commit SHA $releaseSha matches the artifact SHA being processed. Skipping release step for this tag."
+    }
+    else {
+      Write-Host "The artifact SHA $releaseSha does not match that of the currently existing tag."
+      Write-Host "Tag with issues is $tag with commit SHA $tagSha"
+
+      $unmatchedTags += $tag
+    }
+  }
+
+  if ($unmatchedTags.Length -gt 0 -and !$continueOnError) {
+    Write-Host "Tags already existing with different SHA versions. Exiting."
+    exit(1)
+  }
+}

--- a/eng/common/scripts/common.ps1
+++ b/eng/common/scripts/common.ps1
@@ -1,0 +1,58 @@
+# cSpell:ignore Apireview
+# cSpell:ignore Onboarded
+$RepoRoot = Resolve-Path "${PSScriptRoot}..\..\..\.."
+$EngDir = Join-Path $RepoRoot "eng"
+$EngCommonDir = Join-Path $EngDir "common"
+$EngCommonScriptsDir = Join-Path $EngCommonDir "scripts"
+$EngScriptsDir = Join-Path $EngDir "scripts"
+
+# Import required scripts
+. (Join-Path $EngCommonScriptsDir SemVer.ps1)
+. (Join-Path $EngCommonScriptsDir ChangeLog-Operations.ps1)
+. (Join-Path $EngCommonScriptsDir Package-Properties.ps1)
+. (Join-Path $EngCommonScriptsDir logging.ps1)
+. (Join-Path $EngCommonScriptsDir Invoke-GitHubAPI.ps1)
+. (Join-Path $EngCommonScriptsDir Invoke-DevOpsAPI.ps1)
+. (Join-Path $EngCommonScriptsDir artifact-metadata-parsing.ps1)
+. (Join-Path $EngCommonScriptsDir "Helpers" git-helpers.ps1)
+
+# Setting expected from common languages settings
+$Language = "Unknown"
+$PackageRepository = "Unknown"
+$packagePattern = "Unknown"
+$MetadataUri = "Unknown"
+
+# Import common language settings
+$EngScriptsLanguageSettings = Join-path $EngScriptsDir "Language-Settings.ps1"
+if (Test-Path $EngScriptsLanguageSettings) {
+  . $EngScriptsLanguageSettings
+}
+
+if (!(Get-Variable -Name "LanguageShort" -ValueOnly -ErrorAction "Ignore"))
+{
+  $LanguageShort = $Language
+}
+
+if (!(Get-Variable -Name "LanguageDisplayName" -ValueOnly -ErrorAction "Ignore"))
+{
+  $LanguageDisplayName = $Language
+}
+
+# Transformed Functions
+$GetPackageInfoFromRepoFn = "Get-${Language}-PackageInfoFromRepo"
+$GetPackageInfoFromPackageFileFn = "Get-${Language}-PackageInfoFromPackageFile"
+$PublishGithubIODocsFn = "Publish-${Language}-GithubIODocs"
+$UpdateDocsMsPackagesFn = "Update-${Language}-DocsMsPackages"
+$GetDocsMsMetadataForPackageFn = "Get-${Language}-DocsMsMetadataForPackage"
+$GetDocsMsDevLanguageSpecificPackageInfoFn = "Get-${Language}-DocsMsDevLanguageSpecificPackageInfo"
+$GetGithubIoDocIndexFn = "Get-${Language}-GithubIoDocIndex"
+$FindArtifactForApiReviewFn = "Find-${Language}-Artifacts-For-Apireview"
+$TestProxyTrustCertFn = "Import-Dev-Cert-${Language}"
+$ValidateDocsMsPackagesFn = "Validate-${Language}-DocMsPackages"
+$GetOnboardedDocsMsPackagesFn = "Get-${Language}-OnboardedDocsMsPackages"
+$GetOnboardedDocsMsPackagesForMonikerFn = "Get-${Language}-OnboardedDocsMsPackagesForMoniker"
+$GetDocsMsTocDataFn = "Get-${Language}-DocsMsTocData"
+$GetDocsMsTocChildrenForManagementPackagesFn = "Get-${Language}-DocsMsTocChildrenForManagementPackages"
+$UpdateDocsMsTocFn = "Get-${Language}-UpdatedDocsMsToc"
+$GetPackageLevelReadmeFn = "Get-${Language}-PackageLevelReadme"
+$GetRepositoryLinkFn = "Get-${Language}-RepositoryLink"

--- a/eng/common/scripts/git-branch-push.ps1
+++ b/eng/common/scripts/git-branch-push.ps1
@@ -1,0 +1,191 @@
+ #!/usr/bin/env pwsh -c
+
+<#
+.DESCRIPTION
+Create local branch of the given repo and attempt to push changes. The push may fail if
+there has been other changes pushed to the same branch, if so, fetch, rebase and try again.
+.PARAMETER PRBranchName
+The name of the github branch the changes are being put into
+.PARAMETER CommitMsg
+The message for this particular commit
+.PARAMETER GitUrl
+The GitHub repository URL
+.PARAMETER PushArgs
+Optional arguments to the push command
+#>
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $PRBranchName,
+
+    [Parameter(Mandatory = $true)]
+    [string] $CommitMsg,
+
+    [Parameter(Mandatory = $true)]
+    [string] $GitUrl,
+
+    [Parameter(Mandatory = $false)]
+    [string] $PushArgs = "",
+
+    [Parameter(Mandatory = $false)]
+    [string] $RemoteName = "azure-sdk-fork",
+
+    [Parameter(Mandatory = $false)]
+    [boolean] $SkipCommit = $false,
+
+    [Parameter(Mandatory = $false)]
+    [boolean] $AmendCommit = $false
+)
+
+# This is necessary because of the git command output writing to stderr.
+# Without explicitly setting the ErrorActionPreference to continue the script
+# would fail the first time git wrote command output.
+$ErrorActionPreference = "Continue"
+
+if ((git remote) -contains $RemoteName)
+{
+  Write-Host "git remote get-url $RemoteName"
+  $remoteUrl = git remote get-url $RemoteName
+  if ($remoteUrl -ne $GitUrl)
+  {
+    Write-Error "Remote with name $RemoteName already exists with an incompatible url [$remoteUrl] which should be [$GitUrl]."
+    exit 1
+  }
+}
+else 
+{
+  Write-Host "git remote add $RemoteName $GitUrl"
+  git remote add $RemoteName $GitUrl
+  if ($LASTEXITCODE -ne 0)
+  {
+    Write-Error "Unable to add remote LASTEXITCODE=$($LASTEXITCODE), see command output above."
+    exit $LASTEXITCODE
+  }
+}
+# Checkout to $PRBranch, create new one if not exists.
+git show-ref --verify --quiet refs/heads/$PRBranchName
+if ($LASTEXITCODE -eq 0) {
+  Write-Host "git checkout $PRBranchName."
+  git checkout $PRBranchName 
+} 
+else {
+  Write-Host "git checkout -b $PRBranchName."
+  git checkout -b $PRBranchName
+}
+if ($LASTEXITCODE -ne 0)
+{
+    Write-Error "Unable to create branch LASTEXITCODE=$($LASTEXITCODE), see command output above."
+    exit $LASTEXITCODE
+}
+
+if (!$SkipCommit) {
+    if ($AmendCommit) {
+        $amendOption = "--amend"
+    }
+    else {
+        $amendOption = ""
+    }
+    Write-Host "git -c user.name=`"azure-sdk`" -c user.email=`"azuresdk@microsoft.com`" commit $amendOption -am `"$($CommitMsg)`""
+    git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" commit $amendOption -am "$($CommitMsg)"
+    if ($LASTEXITCODE -ne 0)
+    {
+        Write-Error "Unable to add files and create commit LASTEXITCODE=$($LASTEXITCODE), see command output above."
+        exit $LASTEXITCODE
+    }
+}
+else {
+    Write-Host "Skipped applying commit"
+}
+
+# The number of retries can be increased if necessary. In theory, the number of retries
+# should be the max number of libraries in the largest pipeline -1 as everything except
+# the first commit could hit issues and need to rebase. The reason this isn't set to that
+# is because the largest pipeline is cognitive services which has 18 libraries in its
+# pipeline and that just seemed a bit too large and 10 seemed like a good starting value.
+$numberOfRetries = 10
+$needsRetry = $false
+$tryNumber = 0
+do
+{
+    $needsRetry = $false
+    Write-Host "git push $RemoteName $PRBranchName $PushArgs"
+    git push $RemoteName $PRBranchName $PushArgs
+    $tryNumber++
+    if ($LASTEXITCODE -ne 0)
+    {
+        $needsRetry = $true
+        Write-Host "Git push failed with LASTEXITCODE=$($LASTEXITCODE) Need to fetch and rebase: attempt number=$($tryNumber)"
+ 
+        Write-Host "git fetch $RemoteName $PRBranchName"
+        # Full fetch will fail when the repo is in a sparse-checkout state, and single branch fetch is faster anyway.
+        git fetch $RemoteName $PRBranchName
+        if ($LASTEXITCODE -ne 0)
+        {
+            Write-Error "Unable to fetch remote LASTEXITCODE=$($LASTEXITCODE), see command output above."
+            exit $LASTEXITCODE
+        }
+
+        try
+        {
+            $TempPatchFile = New-TemporaryFile
+            Write-Host "git diff ${PRBranchName}~ ${PRBranchName} --output $TempPatchFile"
+            git diff ${PRBranchName}~ ${PRBranchName} --output $TempPatchFile
+            if ($LASTEXITCODE -ne 0)
+            {
+                Write-Error "Unable to create diff file LASTEXITCODE=$($LASTEXITCODE), see command output above."
+                continue
+            }
+
+            Write-Host "git reset --hard $RemoteName/${PRBranchName}"
+            git reset --hard $RemoteName/${PRBranchName}
+            if ($LASTEXITCODE -ne 0)
+            {
+                Write-Error "Unable to hard reset branch LASTEXITCODE=$($LASTEXITCODE), see command output above."
+                continue
+            }
+
+            # -C0 means to use no extra before or after lines of context to enable us to avoid adjacent line merge conflicts
+            Write-Host "git apply -C0 $TempPatchFile"
+            git apply -C0 $TempPatchFile
+            if ($LASTEXITCODE -ne 0)
+            {
+                Write-Error "Unable to apply diff file LASTEXITCODE=$($LASTEXITCODE), see command output above."
+                exit $LASTEXITCODE
+            }
+
+
+            Write-Host "git add -A"
+            git add -A
+            if ($LASTEXITCODE -ne 0)
+            {
+                Write-Error "Unable to git add LASTEXITCODE=$($LASTEXITCODE), see command output above."
+                continue
+            }
+
+            Write-Host "git -c user.name=`"azure-sdk`" -c user.email=`"azuresdk@microsoft.com`" commit -m `"$($CommitMsg)`""
+            git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" commit -m "$($CommitMsg)"
+            if ($LASTEXITCODE -ne 0)
+            {
+                Write-Error "Unable to commit LASTEXITCODE=$($LASTEXITCODE), see command output above."
+                continue
+            }
+        }
+        finally
+        {
+            if ( Test-Path $TempPatchFile )
+            {
+                Remove-Item $TempPatchFile
+            }
+        }
+    }
+} while($needsRetry -and $tryNumber -le $numberOfRetries)
+
+if ($LASTEXITCODE -ne 0 -or $tryNumber -gt $numberOfRetries)
+{
+    Write-Error "Unable to push commit after $($tryNumber) retries LASTEXITCODE=$($LASTEXITCODE), see command output above."
+    if (0 -eq $LASTEXITCODE) 
+    {
+        exit 1
+    }
+    exit $LASTEXITCODE
+}

--- a/eng/common/scripts/git-helpers.ps1
+++ b/eng/common/scripts/git-helpers.ps1
@@ -1,0 +1,38 @@
+# cSpell:ignore Committish
+# cSpell:ignore PULLREQUEST
+# cSpell:ignore TARGETBRANCH
+# cSpell:ignore SOURCECOMMITID
+function Get-ChangedFiles {
+  param (
+    [string]$SourceCommittish= "${env:SYSTEM_PULLREQUEST_SOURCECOMMITID}",
+    [string]$TargetCommittish = ("origin/${env:SYSTEM_PULLREQUEST_TARGETBRANCH}" -replace "refs/heads/"),
+    [string]$DiffPath,
+    [string]$DiffFilterType = "d"
+  )
+  # If ${env:SYSTEM_PULLREQUEST_TARGETBRANCH} is empty, then return empty.
+  if (!$TargetCommittish -or ($TargetCommittish -eq "origin/")) {
+    Write-Host "There is no target branch passed in. "
+    return ""
+  }
+
+  # Add config to disable the quote and encoding on file name. 
+  # Ref: https://github.com/msysgit/msysgit/wiki/Git-for-Windows-Unicode-Support#disable-quoted-file-names
+  # Ref: https://github.com/msysgit/msysgit/wiki/Git-for-Windows-Unicode-Support#disable-commit-message-transcoding
+  # Git PR diff: https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons
+  $command = "git -c core.quotepath=off -c i18n.logoutputencoding=utf-8 diff `"$TargetCommittish...$SourceCommittish`" --name-only --diff-filter=$DiffFilterType"
+  if ($DiffPath) {
+  $command = $command + " -- `'$DiffPath`'"
+  }
+  Write-Host $command
+  $changedFiles = Invoke-Expression -Command $command
+  if(!$changedFiles) {
+    Write-Host "No changed files in git diff between $TargetCommittish and $SourceCommittish"
+  }
+  else {
+  Write-Host "Here are the diff files:"
+  foreach ($file in $changedFiles) {
+      Write-Host "    $file"
+  }
+  }
+  return $changedFiles
+}

--- a/eng/common/scripts/logging.ps1
+++ b/eng/common/scripts/logging.ps1
@@ -1,0 +1,37 @@
+$isDevOpsRun = ($null -ne $env:SYSTEM_TEAMPROJECTID)
+
+function LogWarning
+{
+    if ($isDevOpsRun) 
+    {
+        Write-Host "##vso[task.LogIssue type=warning;]$args"
+    }
+    else
+    {
+        Write-Warning "$args"
+    }
+}
+
+function LogError
+{
+    if ($isDevOpsRun) 
+    {
+        Write-Host "##vso[task.LogIssue type=error;]$args"
+    }
+    else 
+    {
+        Write-Error "$args"
+    }
+}
+
+function LogDebug
+{
+    if ($isDevOpsRun) 
+    {
+        Write-Host "[debug]$args"
+    }
+    else 
+    {
+        Write-Debug "$args"
+    }
+}

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -604,17 +604,12 @@ stages:
                     filePath: eng/scripts/Update-CliVersion.ps1
                   displayName: Increment CLI version
 
-                - pwsh: |
-                    $branchName = "cli-version-increment-$(Build.BuildId)"
-                    git checkout -b $branchName
-                    git add .
-                    git commit -m "Increment version after release"
-
-                    gh pr create `
-                      --base main `
-                      --fill `
-
-
+                - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
+                  PRBranchName: cli-version-increment-$(Build.BuildId)
+                  CommitMsg: Increment CLI version after release
+                  PRTitle: Increment CLI version after release
+                  # TODO: Remove before merge
+                  OpenAsDraft: true
 
       - deployment: Publish_Release
         condition: >-

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -608,11 +608,12 @@ stages:
                   displayName: Increment CLI version
 
                 - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
-                  PRBranchName: cli-version-increment-$(Build.BuildId)
-                  CommitMsg: Increment CLI version after release
-                  PRTitle: Increment CLI version after release
-                  # TODO: Remove before merge
-                  OpenAsDraft: true
+                  parameters:
+                    PRBranchName: cli-version-increment-$(Build.BuildId)
+                    CommitMsg: Increment CLI version after release
+                    PRTitle: Increment CLI version after release
+                    # TODO: Remove before merge
+                    OpenAsDraft: true
 
       # TODO: Re-enable before merge
       # - deployment: Publish_Release

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -579,7 +579,49 @@ stages:
         )
       )
     jobs:
+      - deployment: Increment_Version
+        condition: >-
+          and(
+            succeeded(),
+            ne('true', variables['Skip.IncrementVersion'])
+          )
+        environment: azure-dev
+
+        pool:
+          name: azsdk-pool-mms-ubuntu-2004-general
+          OSVmImage: MMSUbuntu20.04
+
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: self
+
+                - task: PowerShell@2
+                  inputs:
+                    pwsh: true
+                    targetType: filePath
+                    filePath: eng/scripts/Update-CliVersion.ps1
+                  displayName: Increment CLI version
+
+                - pwsh: |
+                    $branchName = "cli-version-increment-$(Build.BuildId)"
+                    git checkout -b $branchName
+                    git add .
+                    git commit -m "Increment version after release"
+
+                    gh pr create `
+                      --base main `
+                      --fill `
+
+
+
       - deployment: Publish_Release
+        condition: >-
+          and(
+            succeeded(),
+            ne('true', variables['Skip.Publish'])
+          )
         environment: azure-dev
 
         pool:

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -591,6 +591,9 @@ stages:
           name: azsdk-pool-mms-ubuntu-2004-general
           OSVmImage: MMSUbuntu20.04
 
+        # TODO: Should this have a dependsOn and only increment on successful
+        # tag and release?
+
         strategy:
           runOnce:
             deploy:
@@ -611,37 +614,38 @@ stages:
                   # TODO: Remove before merge
                   OpenAsDraft: true
 
-      - deployment: Publish_Release
-        condition: >-
-          and(
-            succeeded(),
-            ne('true', variables['Skip.Publish'])
-          )
-        environment: azure-dev
+      # TODO: Re-enable before merge
+      # - deployment: Publish_Release
+      #   condition: >-
+      #     and(
+      #       succeeded(),
+      #       ne('true', variables['Skip.Publish'])
+      #     )
+      #   environment: azure-dev
 
-        pool:
-          name: azsdk-pool-mms-ubuntu-2004-general
-          OSVmImage: MMSUbuntu20.04
+      #   pool:
+      #     name: azsdk-pool-mms-ubuntu-2004-general
+      #     OSVmImage: MMSUbuntu20.04
 
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - checkout: self
-                - task: PowerShell@2
-                  inputs:
-                    pwsh: true
-                    targetType: filePath
-                    filePath: eng/scripts/Set-CliVersionVariable.ps1
-                  displayName: Set CLI_VERSION
+      #   strategy:
+      #     runOnce:
+      #       deploy:
+      #         steps:
+      #           - checkout: self
+      #           - task: PowerShell@2
+      #             inputs:
+      #               pwsh: true
+      #               targetType: filePath
+      #               filePath: eng/scripts/Set-CliVersionVariable.ps1
+      #             displayName: Set CLI_VERSION
 
-                - template: /eng/pipelines/templates/steps/publish-cli.yml
-                  parameters:
-                    CreateGitHubRelease: true
-                    PublishUploadLocations: release/$(CLI_VERSION);release/latest
-                    PublishShield: true
-                    DockerImageTags: $(CLI_VERSION);latest
-                    ReleaseSyndicatedDockerContainer: true
+      #           - template: /eng/pipelines/templates/steps/publish-cli.yml
+      #             parameters:
+      #               CreateGitHubRelease: true
+      #               PublishUploadLocations: release/$(CLI_VERSION);release/latest
+      #               PublishShield: true
+      #               DockerImageTags: $(CLI_VERSION);latest
+      #               ReleaseSyndicatedDockerContainer: true
 
   - stage: PublishIntegration
     dependsOn: Sign

--- a/eng/pipelines/release-vscode.yml
+++ b/eng/pipelines/release-vscode.yml
@@ -182,24 +182,63 @@ stages:
         )
       )
     jobs:
-      - deployment: Publish_Release
+
+      - deployment: Increment_Version
+        condition: >-
+          and(
+            succeeded(),
+            ne('true', variables['Skip.IncrementVersion'])
+          )
         environment: azure-dev
+
         pool:
           name: azsdk-pool-mms-ubuntu-2004-general
           OSVmImage: MMSUbuntu20.04
+
+        # TODO: Should this have a dependsOn and only increment on successful
+        # tag and release?
+
         strategy:
           runOnce:
             deploy:
               steps:
                 - checkout: self
 
-                - template: /eng/pipelines/templates/steps/set-vscode-version.yml
+                - task: PowerShell@2
+                  inputs:
+                    pwsh: true
+                    targetType: filePath
+                    filePath: eng/scripts/Update-VscodeExtensionVersion.ps1
+                  displayName: Increment VSCode Extension version
 
-                - template: /eng/pipelines/templates/steps/publish-vscode.yml
+                - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
                   parameters:
-                    PublishLocations: vscode/release/$(VSIX_VERSION);vscode/release/latest
-                    TagRepository: true
-                    UpdateShield: true
+                    PRBranchName: vscode-version-increment-$(Build.BuildId)
+                    CommitMsg: Increment VSCode Extesnion version after release
+                    PRTitle: Increment VSCode Extesnion version after release
+                    # TODO: Remove before merge
+                    OpenAsDraft: true
+
+      # TODO: Uncomment before merge
+      # - deployment: Publish_Release
+      #   environment: azure-dev
+      #   pool:
+      #     name: azsdk-pool-mms-ubuntu-2004-general
+      #     OSVmImage: MMSUbuntu20.04
+      #   strategy:
+      #     runOnce:
+      #       deploy:
+      #         steps:
+      #           - checkout: self
+
+      #           - template: /eng/pipelines/templates/steps/set-vscode-version.yml
+
+      #           - template: /eng/pipelines/templates/steps/publish-vscode.yml
+      #             parameters:
+      #               PublishLocations: vscode/release/$(VSIX_VERSION);vscode/release/latest
+      #               TagRepository: true
+      #               UpdateShield: true
+
 
   - stage: PublishIntegration
     dependsOn: Sign

--- a/eng/scripts/Update-CliVersion.ps1
+++ b/eng/scripts/Update-CliVersion.ps1
@@ -23,6 +23,7 @@ if (!$version) {
     if ($version.IsPrerelease) {
         if ($version.HasValidPrereleaseLabel()) {
             # 0.1.0-beta.1 -> 0.1.0-beta.2
+            # 1.0.0-beta.1 -> 1.0.0-beta.2
             $version.PrereleaseNumber++
         } else {
             # 0.1.0 -> 0.2.0-beta.1
@@ -31,7 +32,6 @@ if (!$version) {
             $version.PrereleaseNumber = 1
         }
     } else {
-        # 1.0.0-beta.1 -> 1.0.0-beta.2
         # 1.0.0 -> 1.1.0-beta.1
         $version.IncrementAndSetToPrerelease()
     }

--- a/eng/scripts/Update-CliVersion.ps1
+++ b/eng/scripts/Update-CliVersion.ps1
@@ -1,0 +1,49 @@
+param(
+    [string] $NewVersion
+)
+
+$CLI_VERSION_FILE = "$PSScriptRoot../../../cli/version.txt"
+. "$PSScriptRoot../../common/scripts/common.ps1"
+
+Set-StrictMode -Version 3
+
+function getVersion {
+    $versionString = Get-Content $CLI_VERSION_FILE
+    return [AzureEngSemanticVersion]::new($versionString)
+}
+
+$version = $NewVersion
+$unreleased = $false
+$replaceLatestEntryTitle = $true
+
+if (!$version) {
+    # Increment after release
+    $version = getVersion
+
+    if ($version.IsPrerelease) {
+        if ($version.HasValidPrereleaseLabel()) {
+            # 0.1.0-beta.1 -> 0.1.0-beta.2
+            $version.PrereleaseNumber++
+        } else {
+            # 0.1.0 -> 0.2.0-beta.1
+            $version.Minor++
+            $version.PrereleaseLabel = 'beta'
+            $version.PrereleaseNumber = 1
+        }
+    } else {
+        # 1.0.0-beta.1 -> 1.0.0-beta.2
+        # 1.0.0 -> 1.1.0-beta.1
+        $version.IncrementAndSetToPrerelease()
+    }
+
+    $unreleased = $true
+    $replaceLatestEntryTitle = $false
+}
+
+Set-Content -Path $CLI_VERSION_FILE -Value $version
+
+. "$PSScriptRoot/../common/scripts/Update-ChangeLog.ps1" `
+    -Version $version.ToString() `
+    -ChangeLogPath "$PSScriptRoot/../../cli/azd/CHANGELOG.md" `
+    -Unreleased $unreleased `
+    -ReplaceLatestEntryTitle $replaceLatestEntryTitle

--- a/eng/scripts/Update-CliVersion.ps1
+++ b/eng/scripts/Update-CliVersion.ps1
@@ -5,7 +5,7 @@ param(
 $CLI_VERSION_FILE = "$PSScriptRoot../../../cli/version.txt"
 . "$PSScriptRoot../../common/scripts/common.ps1"
 
-Set-StrictMode -Version 3
+Set-StrictMode -Version 4
 
 function getVersion {
     $versionString = Get-Content $CLI_VERSION_FILE

--- a/eng/scripts/Update-VscodeExtensionVersion.Tests.ps1
+++ b/eng/scripts/Update-VscodeExtensionVersion.Tests.ps1
@@ -1,0 +1,88 @@
+Set-StrictMode -Version 4
+
+BeforeAll {
+    $ExtPackageJsonFile = "$PSScriptRoot../../../ext/vscode/package.json"
+    $ExtChangelogFile = "$PSScriptRoot../../../ext/vscode/CHANGELOG.md"
+
+    function SetPackageJsonVersion([string] $version) {
+        @{ name = "test-package"; version = $version } `
+        | ConvertTo-Json -Depth 100 `
+        | Set-Content $ExtPackageJsonFile
+    }
+
+    function GetPackageVersion {
+        return (Get-Content $ExtPackageJsonFile | ConvertFrom-Json).version
+    }
+
+    function ResetChangeLog {
+@"
+# Change Log
+
+All notable changes to the Azure Dev CLI extension will be documented in this file.
+
+Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+
+## 99.99.9 (2022-01-01)
+
+### Changed
+- Fictional change
+
+### Added
+- Fictional addition
+
+### Fixed
+- Fictionall fix
+
+"@ | Set-Content $ExtChangelogFile
+    }
+
+}
+
+AfterAll {
+    git checkout $ExtPackageJsonFile
+    git checkout $ExtChangelogFile
+}
+
+Describe 'Update-VscodeExtensionVersion' ` {
+    Context "Increments version number" {
+        It "Increments from <existing> to <expected>" -TestCases @(
+            @{ existing = '0.1.0'; expected = '0.2.0-alpha' },
+            @{ existing = '0.1.0-alpha'; expected = '0.2.0-alpha' },
+            @{ existing = '0.1.0-beta'; expected = '0.2.0-alpha' },
+            @{ existing = '1.0.0'; expected = '1.1.0-alpha' }
+        ) {
+            SetPackageJsonVersion $existing
+            & $PSScriptRoot/Update-VscodeExtensionVersion.ps1
+            GetPackageVersion | Should -Be $expected
+        }
+    }
+
+    Context "Sets specified version number" {
+        BeforeEach {
+            ResetChangeLog
+        }
+        It "Sets version number from <existing> to <newVersion>" -TestCases @(
+            @{ existing = '0.1.0'; newVersion = '1.0.0' },
+            @{ existing = '1.2.3'; newVersion = '1.2.4' },
+            @{ existing = '0.1.0-alpha'; newVersion = '0.1.0' },
+            @{ existing = '0.1.0-alpha'; newVersion = '1.1.0-alpha' }
+        ) {
+            SetPackageJsonVersion $existing
+            & $PSScriptRoot/Update-VscodeExtensionVersion.ps1 -NewVersion $newVersion
+            GetPackageVersion | Should -Be $newVersion
+        }
+    }
+
+    Context "Adds CHANGELOG entry" {
+        BeforeEach {
+            ResetChangeLog
+        }
+
+        It "Adds the expected version to the CHANGELOG.md file" {
+            $newVersionNumber = "1.2.3"
+            $ExtChangelogFile | Should -Not -FileContentMatchMultiline "## $newVersionNumber"
+            & $PSScriptRoot/Update-VscodeExtensionVersion.ps1 -NewVersion $newVersionNumber
+            $ExtChangelogFile | Should -FileContentMatchMultiline "## $newVersionNumber"
+        }
+    }
+}

--- a/eng/scripts/Update-VscodeExtensionVersion.ps1
+++ b/eng/scripts/Update-VscodeExtensionVersion.ps1
@@ -1,0 +1,71 @@
+param(
+    [string] $NewVersion
+)
+
+$PACKAGE_JSON = "$PSScriptRoot../../../ext/vscode/package.json"
+. "$PSScriptRoot../../common/scripts/common.ps1"
+
+Set-StrictMode -Version 4
+
+function getPackageJson {
+    $packageJsonContent = Get-Content $PACKAGE_JSON -Raw
+    $packageJson = ConvertFrom-Json $packageJsonContent
+    return $packageJson
+}
+
+function getVersion {
+    $versionString = (getPackageJson).version
+    return [AzureEngSemanticVersion]::new($versionString)
+}
+
+function setVersion([string] $version) {
+    $packageJson = getPackageJson
+    $packageJson.version = $version
+
+    $packageJsonString = ConvertTo-Json $packageJson -Depth 100
+    Set-Content -Path $PACKAGE_JSON -Value $packageJsonString
+}
+
+function vscodeSemVerToString($version) {
+    $output = "$($version.Major).$($version.Minor).$($version.Patch)"
+    if ($version.IsPrerelease) {
+        $output = "$output-$($version.PrereleaseLabel)"
+    }
+
+    return $output
+}
+
+$versionString = $NewVersion
+$unreleased = $false
+$replaceLatestEntryTitle = $true
+
+if (!$versionString) {
+    # Increment after release
+    $currentVersion = getVersion
+
+    if ($currentVersion.IsPrerelease) {
+        # 0.1.0 -> 0.2.0-alpha
+        $currentVersion.Minor++
+        $currentVersion.PrereleaseLabel = 'alpha'
+        $currentVersion.PrereleaseNumber = ''
+    } else {
+        # 1.0.0 -> 1.1.0-alpha
+        $currentVersion.Minor++
+        $currentVersion.PrereleaseLabel = 'alpha'
+        $currentVersion.PrereleaseNumber = ''
+        $currentVersion.IsPrerelease = $true
+    }
+
+    $unreleased = $true
+    $replaceLatestEntryTitle = $false
+
+    $versionString = vscodeSemVerToString $currentVersion
+}
+
+setVersion $versionString
+
+. "$PSScriptRoot/../common/scripts/Update-ChangeLog.ps1" `
+    -Version $versionString `
+    -ChangeLogPath "$PSScriptRoot/../../ext/vscode/CHANGELOG.md" `
+    -Unreleased $unreleased `
+    -ReplaceLatestEntryTitle $replaceLatestEntryTitle

--- a/eng/scripts/tests/Update-CliVersion.constants.ps1
+++ b/eng/scripts/tests/Update-CliVersion.constants.ps1
@@ -1,0 +1,7 @@
+$CliVersionFile = "$PSScriptRoot../../../../cli/version.txt"
+$CliChangelogFile = "$PSScriptRoot../../../../cli/azd/CHANGELOG.md"
+
+function CheckoutChangedFiles {
+    git checkout $CliVersionFile
+    git checkout $CliChangelogFile
+}

--- a/eng/scripts/tests/Update-CliVersion.tests.ps1
+++ b/eng/scripts/tests/Update-CliVersion.tests.ps1
@@ -80,3 +80,22 @@ Describe 'Update-CliVersion with version 1.0.0' {
         $CliVersionFile | Should -FileContentMatchExactly '^1\.2\.3$'
     }
 }
+
+Describe 'Update-CliVersion with version 1.0.0-badPrereleaseLabel.2' {
+    BeforeEach {
+        ."$PSScriptRoot/Update-CliVersion.constants.ps1"
+        Set-Content -Path $CliVersionFile -Value "1.0.0-badPrereleaseLabel.2"
+    }
+
+    It "Increments minor and prerelease number" {
+        & $PSScriptRoot/../Update-CliVersion.ps1
+
+        $CliVersionFile | Should -FileContentMatchExactly '^1\.1\.0-beta\.1$'
+    }
+
+    It "Sets version when given -NewVersion" {
+        & $PSScriptRoot/../Update-CliVersion.ps1 -NewVersion 1.2.3
+
+        $CliVersionFile | Should -FileContentMatchExactly '^1\.2\.3$'
+    }
+}

--- a/eng/scripts/tests/Update-CliVersion.tests.ps1
+++ b/eng/scripts/tests/Update-CliVersion.tests.ps1
@@ -1,0 +1,82 @@
+Set-StrictMode -Version 3
+
+AfterAll {
+    ."$PSScriptRoot/Update-CliVersion.constants.ps1"
+    CheckoutChangedFiles
+}
+
+Describe 'Update-CliVersion with version 0.1.0-beta.1' {
+    BeforeEach {
+        ."$PSScriptRoot/Update-CliVersion.constants.ps1"
+        Set-Content -Path $CliVersionFile -Value "0.1.0-beta.1"
+    }
+
+    It "Increments prerelease number when no parameters are applied" {
+        & $PSScriptRoot/../Update-CliVersion.ps1
+
+        $CliVersionFile | Should -FileContentMatchExactly '^0\.1\.0-beta\.2$'
+    }
+
+    It "Sets version when given -NewVersion" {
+        & $PSScriptRoot/../Update-CliVersion.ps1 -NewVersion 1.2.3
+
+        $CliVersionFile | Should -FileContentMatchExactly '^1\.2\.3$'
+    }
+}
+
+Describe 'Update-CliVersion with version 0.1.0' {
+    BeforeEach {
+        ."$PSScriptRoot/Update-CliVersion.constants.ps1"
+        Set-Content -Path $CliVersionFile -Value "0.1.0"
+    }
+
+    It "Increments minor number and sets beta.1" {
+        & $PSScriptRoot/../Update-CliVersion.ps1
+
+        $CliVersionFile | Should -FileContentMatchExactly '^0\.2\.0-beta\.1$'
+    }
+
+    It "Sets version when given -NewVersion" {
+        & $PSScriptRoot/../Update-CliVersion.ps1 -NewVersion 1.2.3
+
+        $CliVersionFile | Should -FileContentMatchExactly '^1\.2\.3$'
+    }
+}
+
+Describe 'Update-CliVersion with version 1.0.0-beta.1' {
+    BeforeEach {
+        ."$PSScriptRoot/Update-CliVersion.constants.ps1"
+        Set-Content -Path $CliVersionFile -Value "1.0.0-beta.1"
+    }
+
+    It "Increments prerelease number" {
+        & $PSScriptRoot/../Update-CliVersion.ps1
+
+        $CliVersionFile | Should -FileContentMatchExactly '^1\.0\.0-beta\.2$'
+    }
+
+    It "Sets version when given -NewVersion" {
+        & $PSScriptRoot/../Update-CliVersion.ps1 -NewVersion 1.2.3
+
+        $CliVersionFile | Should -FileContentMatchExactly '^1\.2\.3$'
+    }
+}
+
+Describe 'Update-CliVersion with version 1.0.0' {
+    BeforeEach {
+        ."$PSScriptRoot/Update-CliVersion.constants.ps1"
+        Set-Content -Path $CliVersionFile -Value "1.0.0"
+    }
+
+    It "Increments minor and prerelease number" {
+        & $PSScriptRoot/../Update-CliVersion.ps1
+
+        $CliVersionFile | Should -FileContentMatchExactly '^1\.1\.0-beta\.1$'
+    }
+
+    It "Sets version when given -NewVersion" {
+        & $PSScriptRoot/../Update-CliVersion.ps1 -NewVersion 1.2.3
+
+        $CliVersionFile | Should -FileContentMatchExactly '^1\.2\.3$'
+    }
+}

--- a/ext/vscode/CHANGELOG.md
+++ b/ext/vscode/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Azure Dev CLI extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [0.3.0] 2022-09-14
+## 0.3.0 (2022-09-14)
 ### Added
 - [[#493]](https://github.com/Azure/azure-dev/pull/493)  Show README file after successful init/up.
 
@@ -12,7 +12,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - [[#498]](https://github.com/Azure/azure-dev/pull/498) Use `azd template list` to populate template list in VS Code (now always consistent with the CLI).
 - [[#556]](https://github.com/Azure/azure-dev/pull/556) Improve error message when no environments are found.
 
-## [0.2.0] 2022-08-02
+## 0.2.0 (2022-08-02)
 
 ### Changed
 - [[#189]](https://github.com/Azure/azure-dev/pull/189) Bump bicep minimum version to v0.8.9
@@ -24,6 +24,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - [[#159]](https://github.com/Azure/azure-dev/pull/159) Enable user feedback via surveys.
 - [[#170]](https://github.com/Azure/azure-dev/pull/170) Enable gradual rollout of new features.
 
-## [0.1.0] 2022-07-11
+## 0.1.0 (2022-07-11)
 
 - Initial release.


### PR DESCRIPTION
Opened a new PR against a branch in the main repo. Changes to scenarios involving branch pushes often necessitate using a branch from the main repo instead of from a fork. 

Example release scenarios: 

(links coming soon)

* CLI
  * Incremented version
  * New CHANGELOG entry 
* VSCode Extension
  * Incremented version 
  * New CHANGELOG entry