### PR TITLE
Installer container validation fixes

### DIFF
--- a/cli/installer/test-installer-containers.ps1
+++ b/cli/installer/test-installer-containers.ps1
@@ -36,6 +36,14 @@ docker build  . `
     }
 
     docker run -t azd-test
+    if ($LASTEXITCODE) {
+        Write-Error "Validation run failed for $dockerfile"
+        $exitCode = 1
+
+        # Build failed, don't execute the container becuase we'll be executing
+        # the last successfully built container with the name azd-test
+        continue
+    }
 }
 
 exit $exitCode

--- a/cli/installer/test-installer-containers.ps1
+++ b/cli/installer/test-installer-containers.ps1
@@ -2,7 +2,7 @@ param(
     [string] $BaseUrl='https://azure-dev.azureedge.net/azd/standalone/release',
     [string] $Version = 'latest',
     [string] $ContainerPrefix = '',
-    [string] $AdditionalArgs = '--no-cache',
+    [string] $AdditionalBuildArgs = '--no-cache',
     [string] $AdditionalRunArgs = ''
 )
 Write-Output "Docker version:"
@@ -18,7 +18,7 @@ docker build  . `
     --build-arg baseUrl="$BaseUrl" `
     --build-arg version="$Version" `
     --build-arg prefix="$ContainerPrefix" `
-    $AdditionalArgs
+    $AdditionalBuildArgs
 "@
     docker build  . `
         -f $dockerfile `
@@ -26,13 +26,13 @@ docker build  . `
         --build-arg baseUrl="$BaseUrl" `
         --build-arg version="$Version" `
         --build-arg prefix="$ContainerPrefix" `
-        $AdditionalArgs
+        $AdditionalBuildArgs
     if ($LASTEXITCODE) {
         Write-Error "Could not build for $dockerfile"
-        $exitCode = 1
 
-        # Build failed, don't execute the container becuase we'll be executing
-        # the last successfully built container with the name azd-test
+        # Build failed. Set exit code to error and move on to build the next
+        # test container
+        $exitCode = 1
         continue
     }
 
@@ -40,9 +40,6 @@ docker build  . `
     if ($LASTEXITCODE) {
         Write-Error "Validation run failed for $dockerfile"
         $exitCode = 1
-
-        # Build failed, don't execute the container becuase we'll be executing
-        # the last successfully built container with the name azd-test
         continue
     }
 }

--- a/cli/installer/test-installer-containers.ps1
+++ b/cli/installer/test-installer-containers.ps1
@@ -2,7 +2,8 @@ param(
     [string] $BaseUrl='https://azure-dev.azureedge.net/azd/standalone/release',
     [string] $Version = 'latest',
     [string] $ContainerPrefix = '',
-    [string] $AdditionalArgs = '--no-cache'
+    [string] $AdditionalArgs = '--no-cache',
+    [string] $AdditionalRunArgs = ''
 )
 Write-Output "Docker version:"
 docker -v
@@ -35,7 +36,7 @@ docker build  . `
         continue
     }
 
-    docker run -t azd-test
+    docker run $AdditionalRunArgs -t azd-test
     if ($LASTEXITCODE) {
         Write-Error "Validation run failed for $dockerfile"
         $exitCode = 1

--- a/cli/installer/test-pwsh-xplat-install.ps1
+++ b/cli/installer/test-pwsh-xplat-install.ps1
@@ -17,6 +17,10 @@ function assertSuccessfulExecution($errorMessage) {
 assertSuccessfulExecution "Install failed"
 
 try {
+    $azdCommand = Get-Command 'azd'
+    Write-Host "File info for $($azdCommand.Source)"
+    ls -lah $azdCommand.Source
+
     & azd version
     assertSuccessfulExecution "Could not execute azd"
 } catch {

--- a/cli/installer/test/telemetry/alpine.pwsh.telemetry.json
+++ b/cli/installer/test/telemetry/alpine.pwsh.telemetry.json
@@ -1,6 +1,6 @@
 {
     "os": "alpine",
-    "osVersion": "3.15.4",
+    "osVersion": "3.15.6",
     "isWsl": "false",
     "terminal": "pwsh"
 }

--- a/cli/installer/test/telemetry/alpine.pwsh.telemetry.json
+++ b/cli/installer/test/telemetry/alpine.pwsh.telemetry.json
@@ -1,6 +1,6 @@
 {
     "os": "alpine",
     "osVersion": "3.15.4",
-    "isWsl": true,
+    "isWsl": "false",
     "terminal": "pwsh"
 }

--- a/cli/installer/test/telemetry/alpine.sh.telemetry.csv
+++ b/cli/installer/test/telemetry/alpine.sh.telemetry.csv
@@ -1,4 +1,4 @@
 os,alpine
-osVersion,3.15.4
+osVersion,3.15.6
 isWsl,false
 terminal,bash

--- a/cli/installer/test/telemetry/alpine.sh.telemetry.csv
+++ b/cli/installer/test/telemetry/alpine.sh.telemetry.csv
@@ -1,4 +1,4 @@
 os,alpine
 osVersion,3.15.4
-isWsl,true
+isWsl,false
 terminal,bash

--- a/cli/installer/test/telemetry/centos.sh.telemetry.csv
+++ b/cli/installer/test/telemetry/centos.sh.telemetry.csv
@@ -1,4 +1,4 @@
-os,INVALID
-osVersion,INVALID
+os,centos
+osVersion,7
 isWsl,true
 terminal,bash

--- a/cli/installer/test/telemetry/centos.sh.telemetry.csv
+++ b/cli/installer/test/telemetry/centos.sh.telemetry.csv
@@ -1,4 +1,4 @@
 os,centos
 osVersion,7
-isWsl,true
+isWsl,false
 terminal,bash

--- a/cli/installer/test/telemetry/debian.pwsh.telemetry.json
+++ b/cli/installer/test/telemetry/debian.pwsh.telemetry.json
@@ -1,6 +1,6 @@
 {
     "os": "debian",
     "osVersion": "11",
-    "isWsl": true,
+    "isWsl": "false",
     "terminal": "pwsh"
 }

--- a/cli/installer/test/telemetry/debian.sh.telemetry.csv
+++ b/cli/installer/test/telemetry/debian.sh.telemetry.csv
@@ -1,4 +1,4 @@
 os,debian
 osVersion,11
-isWsl,true
+isWsl,false
 terminal,bash

--- a/cli/installer/test/telemetry/fedora.sh.telemetry.csv
+++ b/cli/installer/test/telemetry/fedora.sh.telemetry.csv
@@ -1,4 +1,4 @@
 os,fedora
 osVersion,37
-isWsl,true
+isWsl,false
 terminal,bash

--- a/cli/installer/test/telemetry/ubuntu.pwsh.telemetry.json
+++ b/cli/installer/test/telemetry/ubuntu.pwsh.telemetry.json
@@ -1,6 +1,6 @@
 {
     "os": "ubuntu",
     "osVersion": "20.04",
-    "isWsl": "true",
+    "isWsl": "false",
     "terminal": "pwsh"
 }

--- a/cli/installer/test/telemetry/ubuntu.sh.telemetry.csv
+++ b/cli/installer/test/telemetry/ubuntu.sh.telemetry.csv
@@ -1,4 +1,4 @@
 os,ubuntu
 osVersion,20.04
-isWsl,true
+isWsl,false
 terminal,bash

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -273,7 +273,11 @@ stages:
 
               Write-Host "Compressing artifacts as if publishing"
               zip hosting/azd-windows-amd64.zip -j azd-windows-amd64.exe/azd-windows-amd64.exe
+
+              chmod +x azd-darwin-amd64/azd-darwin-amd64
               zip hosting/azd-darwin-amd64.zip -j azd-darwin-amd64/azd-darwin-amd64
+
+              chmod +x azd-linux-amd64/azd-linux-amd64
               tar -C azd-linux-amd64 -cvzf hosting/azd-linux-amd64.tar.gz azd-linux-amd64
 
               Get-ChildItem hosting/ -Recurse | Select-Object -Property Name,Size

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -397,7 +397,7 @@ stages:
                 -BaseUrl "http://localhost:8080"
                 -Version ''
                 -ContainerPrefix '$(docker-mirror-tag-prefix)/'
-                --add-host=host.docker.internal:host-gateway--add-host=host.docker.internal:host-gateway
+                --add-host=host.docker.internal:host-gateway
             LinuxSh:
               Pool: azsdk-pool-mms-ubuntu-2004-general
               OSVmImage:  MMSUbuntu20.04

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -394,10 +394,10 @@ stages:
               TestShell: pwsh
               TestInstallCommand: >
                 ./test-installer-containers.ps1
-                -BaseUrl "http://localhost:8080"
+                -BaseUrl "http://host.docker.internal:8080"
                 -Version ''
                 -ContainerPrefix '$(docker-mirror-tag-prefix)/'
-                --add-host=host.docker.internal:host-gateway
+                -AdditionalRunArgs '--add-host=host.docker.internal:host-gateway'
             LinuxSh:
               Pool: azsdk-pool-mms-ubuntu-2004-general
               OSVmImage:  MMSUbuntu20.04

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -397,6 +397,7 @@ stages:
                 -BaseUrl "http://localhost:8080"
                 -Version ''
                 -ContainerPrefix '$(docker-mirror-tag-prefix)/'
+                --add-host=host.docker.internal:host-gateway--add-host=host.docker.internal:host-gateway
             LinuxSh:
               Pool: azsdk-pool-mms-ubuntu-2004-general
               OSVmImage:  MMSUbuntu20.04


### PR DESCRIPTION
Container validation works locally in Docker running in WSL, fails silently in DevOps pipelines. The installer scripts _do_ work correctly but the pipeline tests don't currently prove that. 