### PR TITLE
Parse inner deployment errors

### DIFF
--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -21,6 +21,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/internal"
 	"github.com/blang/semver/v4"
@@ -666,15 +667,43 @@ func (cli *azCli) GetStaticWebAppApiKey(ctx context.Context, subscriptionID stri
 	return strings.TrimSpace(res.Stdout), nil
 }
 
+func extractDeploymentError(stderr string) error {
+	if start, end := findDeploymentErrorJsonIndex(stderr); start != -1 && end != -1 {
+		deploymentError := internal.NewAzureDeploymentError(stderr[start:end])
+		var innerErrorDetails string
+		if len(stderr) >= end+1 {
+			innerErrorDetails = extractInnerDeploymentErrors(stderr[end+1:])
+		}
+
+		return fmt.Errorf("%s\n%w%s", output.WithErrorFormat("Deployment Error Details:"), deploymentError, innerErrorDetails)
+	}
+
+	return nil
+}
+
+func extractInnerDeploymentErrors(stderr string) string {
+	innerErrors := getInnerDeploymentErrorsJson(stderr)
+
+	if len(innerErrors) == 0 {
+		// Return raw text to be displayed
+		return stderr
+	} else {
+		var sb strings.Builder
+		for _, innerErrorJson := range innerErrors {
+			innerError := internal.NewAzureDeploymentError(innerErrorJson)
+			sb.WriteString(output.WithErrorFormat(fmt.Sprintf("\nInner Error:\n%s", innerError.Error())))
+		}
+		return sb.String()
+	}
+}
+
 func (cli *azCli) DeployToSubscription(ctx context.Context, subscriptionId string, deploymentName string, templateFile string, parametersFile string, location string) (AzCliDeploymentResult, error) {
 	res, err := cli.runAzCommand(ctx, "deployment", "sub", "create", "--subscription", subscriptionId, "--name", deploymentName, "--location", location, "--template-file", templateFile, "--parameters", fmt.Sprintf("@%s", parametersFile), "--output", "json")
 	if isNotLoggedInMessage(res.Stderr) {
 		return AzCliDeploymentResult{}, ErrAzCliNotLoggedIn
 	} else if err != nil {
-		if isDeploymentError(res.Stderr) {
-			deploymentErrorJson := getDeploymentErrorJson(res.Stderr)
-			deploymentError := internal.NewAzureDeploymentError(deploymentErrorJson)
-			return AzCliDeploymentResult{}, fmt.Errorf("failed running az deployment sub create: \n%w", deploymentError)
+		if deploymentError := extractDeploymentError(res.Stderr); deploymentError != nil {
+			return AzCliDeploymentResult{}, fmt.Errorf("failed running az deployment sub create:\n\n%w", deploymentError)
 		}
 
 		return AzCliDeploymentResult{}, fmt.Errorf("failed running az deployment sub create: %s: %w", res.String(), err)
@@ -692,10 +721,8 @@ func (cli *azCli) DeployToResourceGroup(ctx context.Context, subscriptionId stri
 	if isNotLoggedInMessage(res.Stderr) {
 		return AzCliDeploymentResult{}, ErrAzCliNotLoggedIn
 	} else if err != nil {
-		if isDeploymentError(res.Stderr) {
-			deploymentErrorJson := getDeploymentErrorJson(res.Stderr)
-			deploymentError := internal.NewAzureDeploymentError(deploymentErrorJson)
-			return AzCliDeploymentResult{}, fmt.Errorf("failed running az deployment group create: \n%w", deploymentError)
+		if deploymentError := extractDeploymentError(res.Stderr); deploymentError != nil {
+			return AzCliDeploymentResult{}, fmt.Errorf("failed running az deployment group create:\n\n%w", deploymentError)
 		}
 
 		return AzCliDeploymentResult{}, fmt.Errorf("failed running az deployment group create: %s: %w", res.String(), err)
@@ -993,6 +1020,7 @@ var isDeploymentNotFoundMessageRegex = regexp.MustCompile(`\(DeploymentNotFound\
 var isClientAssertionInvalidMessagedRegex = regexp.MustCompile(`AADSTS700024`)
 var isConfigurationIsNotSetMessageRegex = regexp.MustCompile(`Configuration '.*' is not set\.`)
 var isDeploymentErrorRegex = regexp.MustCompile(`ERROR: ({.+})`)
+var isInnerDeploymentErrorRegex = regexp.MustCompile(`Inner Errors:\s+({.+})`)
 
 func isNotLoggedInMessage(s string) bool {
 	return isNotLoggedInMessageRegex.MatchString(s)
@@ -1018,20 +1046,32 @@ func isConfigurationIsNotSetMessage(s string) bool {
 	return isConfigurationIsNotSetMessageRegex.MatchString(s)
 }
 
-func isDeploymentError(s string) bool {
-	return isDeploymentErrorRegex.MatchString(s)
-}
+func findDeploymentErrorJsonIndex(s string) (int, int) {
+	index := isDeploymentErrorRegex.FindStringSubmatchIndex(s)
 
-func getDeploymentErrorJson(s string) string {
-	matches := isDeploymentErrorRegex.FindStringSubmatch(s)
-
-	if matches == nil {
-		return ""
-	} else if len(matches) > 1 {
-		return matches[1]
+	if index == nil {
+		return -1, -1
+	} else if len(index) >= 4 { // [matchStart, matchEnd, submatchStart, submatchEnd]
+		return index[2], index[3]
 	}
 
-	return s
+	return -1, -1
+}
+
+func getInnerDeploymentErrorsJson(s string) []string {
+	results := []string{}
+	matches := isInnerDeploymentErrorRegex.FindAllStringSubmatch(s, -1)
+	if matches == nil {
+		return results
+	}
+
+	for _, match := range matches {
+		if len(match) > 1 {
+			results = append(results, match[1])
+		}
+	}
+
+	return results
 }
 
 type contextKey string

--- a/cli/azd/pkg/tools/azcli/azcli_test.go
+++ b/cli/azd/pkg/tools/azcli/azcli_test.go
@@ -163,3 +163,64 @@ func runAndCaptureUserAgent(t *testing.T, subscriptionID string) string {
 
 	return matches[0][1]
 }
+
+func Test_extractDeploymentError(t *testing.T) {
+	type args struct {
+		stderr string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected string
+	}{
+		{
+			name: "errorWithInner",
+			args: args{
+				`ERROR: {"code": "InvalidTemplateDeployment", "message": "See inner errors for details."}
+
+Inner Errors:
+{"code": "PreflightValidationCheckFailed", "message": "Preflight validation failed. Please refer to the details for the specific errors."}
+
+Inner Errors:
+{"code": "AccountNameInvalid", "target": "invalid-123", "message": "invalid-123 is not a valid storage account name. Storage account name must be between 3 and 24 characters in length and use numbers and lower-case letters only."}`},
+			expected: `Deployment Error Details:
+InvalidTemplateDeployment: See inner errors for details.
+
+Inner Error:
+PreflightValidationCheckFailed: Preflight validation failed. Please refer to the details for the specific errors.
+
+Inner Error:
+AccountNameInvalid: invalid-123 is not a valid storage account name. Storage account name must be between 3 and 24 characters in length and use numbers and lower-case letters only.
+`,
+		},
+		{
+			name: "errorWithInnerRaw",
+			args: args{
+				`ERROR: {"code": "InvalidTemplateDeployment", "message": "See inner errors for details."}
+
+Line1: additional detail happened
+Line2: additional detail happened`,
+			},
+			expected: `Deployment Error Details:
+InvalidTemplateDeployment: See inner errors for details.
+
+Line1: additional detail happened
+Line2: additional detail happened`,
+		},
+		{
+			name: "errorOnly",
+			args: args{
+				`ERROR: {"code": "InvalidTemplateDeployment", "message": "Invalid template deployment."}`,
+			},
+			expected: `Deployment Error Details:
+InvalidTemplateDeployment: Invalid template deployment.
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := extractDeploymentError(tt.args.stderr)
+			assert.Equal(t, tt.expected, err.Error())
+		})
+	}
+}

--- a/cli/azd/pkg/tools/internal/azure_deployment_error.go
+++ b/cli/azd/pkg/tools/internal/azure_deployment_error.go
@@ -41,8 +41,6 @@ func (e *AzureDeploymentError) Error() string {
 	lines := generateErrorOutput(errors)
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintln())
-	sb.WriteString(fmt.Sprintln(output.WithErrorFormat("Deployment Error Details:")))
 
 	for _, line := range lines {
 		sb.WriteString(fmt.Sprintln(output.WithErrorFormat(line)))

--- a/cli/azd/pkg/tools/internal/samples/arm_sample_error_01.txt
+++ b/cli/azd/pkg/tools/internal/samples/arm_sample_error_01.txt
@@ -1,5 +1,3 @@
-
-Deployment Error Details:
 Conflict: Website with given name devapi already exists.
 - Website with given name devapi already exists.
 Conflict: Website with given name devweb already exists.

--- a/cli/azd/pkg/tools/internal/samples/arm_sample_error_02.txt
+++ b/cli/azd/pkg/tools/internal/samples/arm_sample_error_02.txt
@@ -1,3 +1,1 @@
-
-Deployment Error Details:
 ResourceNameInvalid: Invalid resource name: 'matell-azdacaacr'. Resource names may contain alpha numeric characters only and must be between 5 and 50 characters.. For more information, please refer resource name requirements at: https://docs.microsoft.com/en-us/rest/api/containerregistry/

--- a/cli/azd/pkg/tools/internal/samples/arm_sample_error_03.txt
+++ b/cli/azd/pkg/tools/internal/samples/arm_sample_error_03.txt
@@ -1,5 +1,3 @@
-
-Deployment Error Details:
 ResourceNotFound: The Resource 'Microsoft.Insights/components/matell-azdacainsights' under resource group 'matell-azdacarg' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix
 ResourceNotFound: The Resource 'Microsoft.App/containerApps/matell-azdacaapi' under resource group 'matell-azdacarg' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix
 ResourceNotFound: The Resource 'Microsoft.Insights/components/matell-azdacainsights' under resource group 'matell-azdacarg' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix

--- a/cli/azd/pkg/tools/internal/samples/arm_sample_error_04.txt
+++ b/cli/azd/pkg/tools/internal/samples/arm_sample_error_04.txt
@@ -1,3 +1,1 @@
-
-Deployment Error Details:
 InternalServerError: There was an unexpected InternalServerError.  Please try again later.  x-ms-correlation-request-id: 89ea695c-9786-402b-8d4e-48ce04127a0b


### PR DESCRIPTION
Fixes #786 

Add logic to parse remainder of `az cli`'s stderr output as inner errors.

Example output text:
```
Deployment Error Details:
InvalidTemplateDeployment: The template deployment 'weilim-todo-java-mongo' is not valid according to the validation procedure. The tracking id is '96acda23-5fa4-4439-a9c3-6aad0cd7733d'. See inner errors for details.

Inner Error:
PreflightValidationCheckFailed: Preflight validation failed. Please refer to the details for the specific errors.

Inner Error:
AccountNameInvalid: invalid-123 is not a valid storage account name. Storage account name must be between 3 and 24 characters in length and use numbers and lower-case letters only.
```

Once we switch to ARM APIs, parsing the `az cli` output will no longer be necessary so this is really a temporary fix.