### PR TITLE
Improve `azd login` behavior when logged out

### DIFF
--- a/cli/azd/cmd/contracts/doc.go
+++ b/cli/azd/cmd/contracts/doc.go
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Package contracts contains API contracts that azd CLI communicates externally in commands via stdout.
+// Currently, all contracts support JSON output.
+package contracts

--- a/cli/azd/cmd/contracts/login.go
+++ b/cli/azd/cmd/contracts/login.go
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package contracts
+
+import "time"
+
+// LoginStatus are the values of the "status" property of a LoginResult
+type LoginStatus string
+
+const (
+	// The user is logged in and we were able to obtain an access token for them.
+	// The "ExpiresOn" property of the result will contain information on when the
+	// access token expires.
+	LoginStatusSuccess LoginStatus = "success"
+	// The user is not logged in.
+	LoginStatusUnauthenticated LoginStatus = "unauthenticated"
+)
+
+// LoginResult is the contract for the output of `azd login`.
+type LoginResult struct {
+	// The result of checking for a valid access token.
+	Status LoginStatus `json:"status"`
+	// When status is `LoginStatusSuccess`, the time at which the access token
+	// expires.
+	ExpiresOn *time.Time `json:"expiresOn,omitempty"`
+}

--- a/cli/azd/cmd/contracts/show.go
+++ b/cli/azd/cmd/contracts/show.go
@@ -1,16 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
-// Package contracts contains API contracts that azd CLI communicates externally in commands via stdout.
-// Currently, all contracts support JSON output.
 package contracts
 
-// showResult is the model type that represents the JSON output of `azd show`
+// ShowType are the values for the language property of a ShowServiceProject
+type ShowType string
+
+const (
+	ShowTypeDotNet ShowType = "dotnet"
+	ShowTypePython ShowType = "python"
+	ShowTypeNode   ShowType = "node"
+)
+
+// ShowResult is the contract for the output of `azd show`
 type ShowResult struct {
 	Name     string                 `json:"name"`
 	Services map[string]ShowService `json:"services"`
 }
 
+// ShowService is the contract for a service returned by `azd show`
 type ShowService struct {
 	// Project contains information about the project that backs this service.
 	Project ShowServiceProject `json:"project"`
@@ -19,14 +26,17 @@ type ShowService struct {
 	Target *ShowTargetArm `json:"target,omitempty"`
 }
 
+// ShowServiceProject is the contract for a service's project as returned by `azd show`
 type ShowServiceProject struct {
 	// Path contains the path to the project for this service.
 	// When 'type' is 'dotnet', this includes the project file (i.e. Todo.Api.csproj).
 	Path string `json:"path"`
-	// The type of this project. One of "dotnet", "python", or "node"
-	Type string `json:"language"`
+	// The type of this project.
+	Type ShowType `json:"language"`
 }
 
+// ShowTargetArm is the contract for information about the resources that a given service
+// is deployed to.
 type ShowTargetArm struct {
 	ResourceIds []string `json:"resourceIds"`
 }

--- a/cli/azd/cmd/show.go
+++ b/cli/azd/cmd/show.go
@@ -107,14 +107,14 @@ func showCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 	return cmd
 }
 
-func showTypeFromLanguage(language string) string {
+func showTypeFromLanguage(language string) contracts.ShowType {
 	switch language {
 	case "dotnet":
-		return "dotnet"
+		return contracts.ShowTypeDotNet
 	case "py", "python":
-		return "python"
+		return contracts.ShowTypePython
 	case "ts", "js":
-		return "node"
+		return contracts.ShowTypeNode
 	default:
 		panic(fmt.Sprintf("unknown language %s", language))
 	}

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -979,11 +979,16 @@ func (cli *azCli) runAzCommandWithArgs(ctx context.Context, args exec.RunArgs) (
 
 // Azure Active Directory codes can be referenced via https://login.microsoftonline.com/error?code=<ERROR_CODE>,
 // where ERROR_CODE is the digits portion of an AAD error code. Example: AADSTS70043 has error code 70043
+// Additionally, https://learn.microsoft.com/azure/active-directory/develop/reference-aadsts-error-codes#aadsts-error-codes
+// is a helpful resource with a list of error codes and messages.
 
 var isNotLoggedInMessageRegex = regexp.MustCompile(`Please run ('|")az login('|") to (setup account|access your accounts)\.`)
 
-// Regex for "AADSTS70043: The refresh token has expired or is invalid due to sign-in frequency checks by conditional access."
-var isRefreshTokenExpiredMessageRegex = regexp.MustCompile(`AADSTS70043`)
+// Regex for the following errors related to refresh tokens:
+// - "AADSTS70043: The refresh token has expired or is invalid due to sign-in frequency checks by conditional access.""
+// - "AADSTS700082: The refresh token has expired due to inactivity."
+var isRefreshTokenExpiredMessageRegex = regexp.MustCompile(`AADSTS(70043|700082)`)
+
 var isResourceSegmentMeNotFoundMessageRegex = regexp.MustCompile(`Resource not found for the segment 'me'.`)
 
 // Regex for "(DeploymentNotFound) Deployment '<name>' could not be found."


### PR DESCRIPTION
- Extend the set of STS codes we map to `ErrRefreshTokenExpired` based on new codes seen in the wild.

- If the user is not logged in, have `azd login --check-status` say so, and return success, instead of behaving as if the command had failed with some internal error. This also means when using `--output=json` we print an object that shows this unauthenticated state, which is helpful to folks consuming us (see #738).

- Move the types that model the JSON output of `azd login` into the contracts package.

- Improve documentation for some contracts.

Fixes #738