### PR TITLE
Contractify `env refresh`'s JSON output

### DIFF
--- a/cli/azd/cmd/contracts/env_refresh.go
+++ b/cli/azd/cmd/contracts/env_refresh.go
@@ -1,0 +1,76 @@
+package contracts
+
+import (
+	"fmt"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
+)
+
+// LoginResult is the contract for the output of `azd env refresh`.
+type EnvRefreshResult struct {
+	Outputs   map[string]EnvRefreshOutputParameter `json:"outputs"`
+	Resources []EnvRefreshResource                 `json:"resources"`
+}
+
+// EvnRefreshOutputType are the values for the "type" property of an output.
+type EnvRefreshOutputType string
+
+const (
+	EnvRefreshOutputTypeBoolean EnvRefreshOutputType = "boolean"
+	EnvRefreshOutputTypeString  EnvRefreshOutputType = "string"
+	EnvRefreshOutputTypeNumber  EnvRefreshOutputType = "number"
+	EnvRefreshOutputTypeObject  EnvRefreshOutputType = "object"
+	EnvRefreshOutputTypeArray   EnvRefreshOutputType = "array"
+)
+
+// EnvRefreshOutputParameter is the contract for the value in the "outputs" map
+// of and EnvRefreshResult.
+type EnvRefreshOutputParameter struct {
+	Type  EnvRefreshOutputType `json:"type"`
+	Value any                  `json:"value"`
+}
+
+// EnvRefreshResource is the contract for a resource in the "resources" array
+type EnvRefreshResource struct {
+	Id string `json:"id"`
+}
+
+// NewEnvRefreshResultFromProvisioningState creates a EnvRefreshResult from a provisioning state object,
+// applying the required translations.
+func NewEnvRefreshResultFromProvisioningState(state *provisioning.State) EnvRefreshResult {
+	result := EnvRefreshResult{}
+	result.Outputs = make(map[string]EnvRefreshOutputParameter, len(state.Outputs))
+	result.Resources = make([]EnvRefreshResource, len(state.Resources))
+
+	mapType := func(p provisioning.ParameterType) EnvRefreshOutputType {
+		switch p {
+		case provisioning.ParameterTypeString:
+			return EnvRefreshOutputTypeString
+		case provisioning.ParameterTypeBoolean:
+			return EnvRefreshOutputTypeBoolean
+		case provisioning.ParameterTypeNumber:
+			return EnvRefreshOutputTypeNumber
+		case provisioning.ParameterTypeObject:
+			return EnvRefreshOutputTypeObject
+		case provisioning.ParameterTypeArray:
+			return EnvRefreshOutputTypeArray
+		default:
+			panic(fmt.Sprintf("unknown provisioning.ParameterType value: %v", p))
+		}
+	}
+
+	for k, v := range state.Outputs {
+		result.Outputs[k] = EnvRefreshOutputParameter{
+			Type:  mapType(v.Type),
+			Value: v.Value,
+		}
+	}
+
+	for idx, res := range state.Resources {
+		result.Resources[idx] = EnvRefreshResource{
+			Id: res.Id,
+		}
+	}
+
+	return result
+}

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/azure/azure-dev/cli/azd/cmd/contracts"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
@@ -257,19 +258,19 @@ func envRefreshCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 
 		scope := infra.NewSubscriptionScope(ctx, env.GetLocation(), env.GetSubscriptionId(), env.GetEnvName())
 
-		getDeploymentResult, err := infraManager.GetDeployment(ctx, scope)
+		getStateResult, err := infraManager.State(ctx, scope)
 		if err != nil {
 			return fmt.Errorf("getting deployment: %w", err)
 		}
 
-		if err := provisioning.UpdateEnvironment(env, &getDeploymentResult.Deployment.Outputs); err != nil {
+		if err := provisioning.UpdateEnvironment(env, getStateResult.State.Outputs); err != nil {
 			return err
 		}
 
 		console.Message(ctx, "Environments setting refresh completed")
 
 		if formatter.Kind() == output.JsonFormat {
-			err = formatter.Format(getDeploymentResult.Deployment, writer, nil)
+			err = formatter.Format(contracts.NewEnvRefreshResultFromProvisioningState(getStateResult.State), writer, nil)
 			if err != nil {
 				return fmt.Errorf("writing deployment result in JSON format: %w", err)
 			}

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/azure/azure-dev/cli/azd/cmd/contracts"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
@@ -97,12 +98,12 @@ func (ica *infraCreateAction) Run(ctx context.Context, cmd *cobra.Command, args 
 
 	if err != nil {
 		if formatter.Kind() == output.JsonFormat {
-			deployment, err := infraManager.GetDeployment(ctx, provisioningScope)
+			stateResult, err := infraManager.State(ctx, provisioningScope)
 			if err != nil {
 				return fmt.Errorf("deployment failed and the deployment result is unavailable: %w", multierr.Combine(err, err))
 			}
 
-			if err := formatter.Format(deployment, writer, nil); err != nil {
+			if err := formatter.Format(contracts.NewEnvRefreshResultFromProvisioningState(stateResult.State), writer, nil); err != nil {
 				return fmt.Errorf("deployment failed and the deployment result could not be displayed: %w", multierr.Combine(err, err))
 			}
 		}

--- a/cli/azd/pkg/async/task_context.go
+++ b/cli/azd/pkg/async/task_context.go
@@ -85,7 +85,7 @@ func NewInteractiveTaskContextWithProgress[R comparable, P comparable](task *Int
 	}
 }
 
-// Sends a signal to the CLI that the task wants to interact with the terminal
+// Sends a signal to the CLI that the task wants to interact with the terminal.
 // This will pause any special console spinners, etc.
 func (c *InteractiveTaskContextWithProgress[R, P]) Interact(interactFn func() error) error {
 	c.task.interactiveChannel <- true

--- a/cli/azd/pkg/infra/provisioning/deployment.go
+++ b/cli/azd/pkg/infra/provisioning/deployment.go
@@ -8,6 +8,16 @@ type Deployment struct {
 	Outputs    map[string]OutputParameter
 }
 
+type ParameterType string
+
+const (
+	ParameterTypeString  ParameterType = "string"
+	ParameterTypeNumber  ParameterType = "number"
+	ParameterTypeBoolean ParameterType = "bool"
+	ParameterTypeObject  ParameterType = "object"
+	ParameterTypeArray   ParameterType = "array"
+)
+
 type InputParameter struct {
 	Type         string
 	DefaultValue interface{}
@@ -15,8 +25,22 @@ type InputParameter struct {
 }
 
 type OutputParameter struct {
-	Type  string
+	Type  ParameterType
 	Value interface{}
+}
+
+// State represents the "current state" of the infrastructure, which is the result of the most recent deployment. For ARM
+// this corresponds to information from the most recent deployment object. For Terraform, it's information from the state
+// file.
+type State struct {
+	// Outputs from the most recent deployment.
+	Outputs map[string]OutputParameter
+	// The resources that make up the application.
+	Resources []Resource
+}
+
+type Resource struct {
+	Id string
 }
 
 func (p *InputParameter) HasValue() bool {

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -42,11 +42,11 @@ func (m *Manager) Plan(ctx context.Context) (*DeploymentPlan, error) {
 }
 
 // Gets the latest deployment details for the specified scope
-func (m *Manager) GetDeployment(ctx context.Context, scope infra.Scope) (*DeployResult, error) {
-	var deployResult *DeployResult
+func (m *Manager) State(ctx context.Context, scope infra.Scope) (*StateResult, error) {
+	var stateResult *StateResult
 
-	err := m.runAction(ctx, "Retrieving Azure Deployment", m.interactive, func(ctx context.Context, spinner *spin.Spinner) error {
-		queryTask := m.provider.GetDeployment(ctx, scope)
+	err := m.runAction(ctx, "Retrieving Infrastructure State", m.interactive, func(ctx context.Context, spinner *spin.Spinner) error {
+		queryTask := m.provider.State(ctx, scope)
 
 		go func() {
 			for progress := range queryTask.Progress() {
@@ -61,16 +61,16 @@ func (m *Manager) GetDeployment(ctx context.Context, scope infra.Scope) (*Deploy
 			return err
 		}
 
-		deployResult = result
+		stateResult = result
 
 		return nil
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving deployment: %w", err)
+		return nil, fmt.Errorf("error retrieving state: %w", err)
 	}
 
-	return deployResult, nil
+	return stateResult, nil
 }
 
 // Deploys the Azure infrastructure for the specified project
@@ -87,7 +87,7 @@ func (m *Manager) Deploy(ctx context.Context, plan *DeploymentPlan, scope infra.
 		return nil, err
 	}
 
-	if err := UpdateEnvironment(m.env, &deployResult.Deployment.Outputs); err != nil {
+	if err := UpdateEnvironment(m.env, deployResult.Deployment.Outputs); err != nil {
 		return nil, fmt.Errorf("updating environment with deployment outputs: %w", err)
 	}
 

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -35,7 +35,7 @@ func TestManagerPlan(t *testing.T) {
 	require.Equal(t, deploymentPlan.Deployment.Parameters["location"].Value, env.Values["AZURE_LOCATION"])
 }
 
-func TestManagerGetDeployment(t *testing.T) {
+func TestManagerGetState(t *testing.T) {
 	env := environment.EphemeralWithValues("test-env", map[string]string{
 		"AZURE_LOCATION": "eastus2",
 	})
@@ -47,7 +47,7 @@ func TestManagerGetDeployment(t *testing.T) {
 	mgr, _ := NewManager(*mockContext.Context, env, "", options, interactive)
 
 	provisioningScope := infra.NewSubscriptionScope(*mockContext.Context, "eastus2", env.GetSubscriptionId(), env.GetEnvName())
-	getResult, err := mgr.GetDeployment(*mockContext.Context, provisioningScope)
+	getResult, err := mgr.State(*mockContext.Context, provisioningScope)
 
 	require.NotNil(t, getResult)
 	require.Nil(t, err)

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -74,10 +74,20 @@ type DestroyProgress struct {
 	Timestamp time.Time
 }
 
+type StateResult struct {
+	State *State
+}
+
+type StateProgress struct {
+	Message   string
+	Timestamp time.Time
+}
+
 type Provider interface {
 	Name() string
 	RequiredExternalTools() []tools.ExternalTool
-	GetDeployment(ctx context.Context, scope infra.Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress]
+	// State gets the current state of the infrastructure, this contains both the provisioned resources and any outputs from the module.
+	State(ctx context.Context, scope infra.Scope) *async.InteractiveTaskWithProgress[*StateResult, *StateProgress]
 	Plan(ctx context.Context) *async.InteractiveTaskWithProgress[*DeploymentPlan, *DeploymentPlanningProgress]
 	Deploy(ctx context.Context, plan *DeploymentPlan, scope infra.Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress]
 	Destroy(ctx context.Context, deployment *Deployment, options DestroyOptions) *async.InteractiveTaskWithProgress[*DestroyResult, *DestroyProgress]

--- a/cli/azd/pkg/infra/provisioning/provisioning.go
+++ b/cli/azd/pkg/infra/provisioning/provisioning.go
@@ -14,9 +14,9 @@ import (
 	"github.com/drone/envsubst"
 )
 
-func UpdateEnvironment(env *environment.Environment, outputs *map[string]OutputParameter) error {
-	if len(*outputs) > 0 {
-		for key, param := range *outputs {
+func UpdateEnvironment(env *environment.Environment, outputs map[string]OutputParameter) error {
+	if len(outputs) > 0 {
+		for key, param := range outputs {
 			env.Values[key] = fmt.Sprintf("%v", param.Value)
 		}
 

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -257,52 +257,34 @@ func (t *TerraformProvider) Destroy(ctx context.Context, deployment *Deployment,
 		})
 }
 
-// Gets the latest deployment details
-func (t *TerraformProvider) GetDeployment(ctx context.Context, scope infra.Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress] {
+func (t *TerraformProvider) State(ctx context.Context, _ infra.Scope) *async.InteractiveTaskWithProgress[*StateResult, *StateProgress] {
 	return async.RunInteractiveTaskWithProgress(
-		func(asyncContext *async.InteractiveTaskContextWithProgress[*DeployResult, *DeployProgress]) {
-			t.console.Message(ctx, "Loading terraform module...")
-
+		func(asyncContext *async.InteractiveTaskContextWithProgress[*StateResult, *StateProgress]) {
 			isRemoteBackendConfig, err := t.isRemoteBackendConfig()
 			if err != nil {
 				asyncContext.SetError(fmt.Errorf("reading backend config: %w", err))
 				return
 			}
 
-			err = asyncContext.Interact(func() error {
-				initRes, err := t.init(ctx, isRemoteBackendConfig)
-				if err != nil {
-					return fmt.Errorf("terraform init failed: %s , err: %w", initRes, err)
-				}
-
-				return nil
-			})
-
-			if err != nil {
-				asyncContext.SetError(err)
-				return
-			}
-
-			t.console.Message(ctx, "Retrieving deployment output...")
+			t.console.Message(ctx, "Retrieving terraform state...")
 			modulePath := t.modulePath()
-			deployment, err := t.createDeployment(ctx, modulePath)
+
+			terraformState, err := t.showCurrentState(ctx, modulePath, isRemoteBackendConfig)
 			if err != nil {
-				asyncContext.SetError(fmt.Errorf("compiling terraform deployment: %w", err))
+				asyncContext.SetError(fmt.Errorf("fetching terraform state failed: %w", err))
 				return
 			}
 
-			outputs, err := t.createOutputParameters(ctx, modulePath, isRemoteBackendConfig)
-			if err != nil {
-				asyncContext.SetError(fmt.Errorf("create terraform output failed: %w", err))
-				return
+			state := State{}
+
+			state.Outputs = t.convertOutputs(terraformState.Values.Outputs)
+			state.Resources = t.collectAzureResources(terraformState.Values.RootModule)
+
+			result := StateResult{
+				State: &state,
 			}
 
-			deployment.Outputs = outputs
-			result := &DeployResult{
-				Deployment: deployment,
-			}
-
-			asyncContext.SetResult(result)
+			asyncContext.SetResult(&result)
 		})
 }
 
@@ -400,19 +382,75 @@ func (t *TerraformProvider) createOutputParameters(ctx context.Context, modulePa
 		return nil, fmt.Errorf("reading deployment output failed: %s, err:%w", runResult, err)
 	}
 
-	var outputMap map[string]map[string]interface{}
+	var outputMap map[string]terraformOutput
 	if err := json.Unmarshal([]byte(runResult), &outputMap); err != nil {
 		return nil, err
 	}
 
+	return t.convertOutputs(outputMap), nil
+}
+
+func (t *TerraformProvider) mapTerraformTypeToInterfaceType(typ any) ParameterType {
+	// in the JSON output, the type property maps to either a string (for a primitive type) or an
+	// array of things which describe a complex type.
+	switch v := typ.(type) {
+	case string:
+		switch v {
+		case "string":
+			return ParameterTypeString
+		case "bool":
+			return ParameterTypeBoolean
+		case "number":
+			return ParameterTypeNumber
+		default:
+			panic(fmt.Sprintf("unknown primitive type: %s", v))
+		}
+	case []any:
+		// in this case we have a complex type, which in json looked like ["type", <schema parts>...], just pull out the
+		// first part and map to either and object or array.
+		switch v[0].(string) {
+		case "tuple":
+			return ParameterTypeArray
+		case "object":
+			return ParameterTypeObject
+		default:
+			panic(fmt.Sprintf("unknown primitive complex type tag: %s (full type: %+v)", v, typ))
+		}
+	}
+
+	return ParameterTypeString
+}
+
+// convertOutputs converts a terraform output map to the canonical format shared by all provider implementations.
+func (t *TerraformProvider) convertOutputs(outputMap map[string]terraformOutput) map[string]OutputParameter {
 	outputParameters := make(map[string]OutputParameter)
 	for k, v := range outputMap {
 		outputParameters[k] = OutputParameter{
-			Type:  fmt.Sprint(v["type"]),
-			Value: v["value"],
+			Type:  t.mapTerraformTypeToInterfaceType(v.Type),
+			Value: v.Value,
 		}
 	}
-	return outputParameters, nil
+	return outputParameters
+}
+
+func (t *TerraformProvider) showCurrentState(ctx context.Context, modulePath string, isRemoteBackend bool) (*terraformShowOutput, error) {
+	cmd := []string{}
+
+	if !isRemoteBackend {
+		cmd = append(cmd, t.localStateFilePath())
+	}
+
+	runResult, err := t.cli.Show(ctx, modulePath, cmd...)
+	if err != nil {
+		return nil, fmt.Errorf("showing current state failed: %s, err:%w", runResult, err)
+	}
+
+	var showOutput terraformShowOutput
+	if err := json.Unmarshal([]byte(runResult), &showOutput); err != nil {
+		return nil, err
+	}
+
+	return &showOutput, nil
 }
 
 // Creates the deployment object from the specified module path
@@ -450,6 +488,75 @@ func (t *TerraformProvider) createDeployment(ctx context.Context, modulePath str
 	}
 
 	return &template, nil
+}
+
+// collectAzureResources collects the set of resources from the root module of a terraform state file, including
+// resources from all child modules. Only resources managed by azure providers are considered (today, that's
+// just resources from the `registry.terraform.io/hashicorp/azurerm` provider). Only "managed" resources are
+// considered.
+func (t *TerraformProvider) collectAzureResources(rootModule terraformRootModule) []Resource {
+	// the set of resources we've seen (keyed by their id)
+	azureResources := make(map[string]struct{})
+
+	// Walk over all the modules (starting at the root) and mark each resource we see from the azure
+	// provider.
+	visitResource := func(r terraformResource) {
+		if r.Mode == terraformModeManaged && r.ProviderName == "registry.terraform.io/hashicorp/azurerm" {
+			if id, err := t.getIdForManagedResource(r); err != nil {
+				log.Printf("error determining id for resource: %v, ignoring...", err)
+			} else {
+				azureResources[id] = struct{}{}
+			}
+		}
+	}
+
+	var visitChildModule func(c terraformChildModule)
+	visitChildModule = func(c terraformChildModule) {
+		for _, r := range c.Resources {
+			visitResource(r)
+		}
+
+		for _, c := range c.ChildModules {
+			visitChildModule(c)
+		}
+	}
+
+	for _, r := range rootModule.Resources {
+		visitResource(r)
+	}
+
+	for _, c := range rootModule.ChildModules {
+		visitChildModule(c)
+	}
+
+	// At this point, allResources contains the ids of all the resources we discovered.
+	resources := make([]Resource, 0, len(azureResources))
+	for id := range azureResources {
+		resources = append(resources, Resource{
+			Id: id,
+		})
+	}
+
+	return resources
+}
+
+func (t *TerraformProvider) getIdForManagedResource(r terraformResource) (string, error) {
+	// Most azure resources use "id" as the key in the values bag that holds the resource id. However, some
+	// resources are special and use a different key for the Azure Resource Id.
+	idKey := "id"
+
+	switch r.Type {
+	case "azurerm_key_vault_secret":
+		idKey = "resource_id"
+	}
+
+	if val, has := r.Values[idKey]; !has {
+		return "", fmt.Errorf("resource %s has no %s property", r.Address, idKey)
+	} else if id, ok := val.(string); !ok {
+		return "", fmt.Errorf("resource %s has %s property with type %T not string", r.Address, idKey, val)
+	} else {
+		return id, nil
+	}
 }
 
 // Gets the path to the project parameters file path
@@ -546,4 +653,55 @@ func Register() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+// terraformShowOutput is a model type for the output of `terraform show` for a tfstate file.
+// see https://www.terraform.io/internals/json-format#state-representation for more information on the shape
+// of the JSON data
+type terraformShowOutput struct {
+	FormatVersion string          `json:"format_version"`
+	Values        terraformValues `json:"values"`
+}
+
+// terraformValues is a model type for the `values-representation` object in a JSON output from terraform.
+// see https://www.terraform.io/internals/json-format#values-representation for more information on the shape
+// of the JSON data.
+type terraformValues struct {
+	Outputs    map[string]terraformOutput `json:"outputs"`
+	RootModule terraformRootModule        `json:"root_module"`
+}
+
+// terraformOutput is a model type for the value in the output map.
+type terraformOutput struct {
+	Value any `json:"value"`
+	// This is either a string or an array objects for a complex type
+	Type      any  `json:"type"`
+	Sensitive bool `json:"sensitive"`
+}
+
+// terraformRootModule is a model type for the "root_module" property the JSON output of a state file.
+type terraformRootModule struct {
+	Resources    []terraformResource    `json:"resources"`
+	ChildModules []terraformChildModule `json:"child_modules"`
+}
+
+const terraformModeManaged = "managed"
+
+// terraformResource is the model type for a resource in a terraform state file. The "values"
+// array contains provider specific values (for azurerm, this includes "id" which is the resource id).
+type terraformResource struct {
+	Address      string `json:"address"`
+	ProviderName string `json:"provider_name"`
+	// "mode" can be "managed", for resources, or "data", for data resources
+	Mode   string         `json:"mode"`
+	Type   string         `json:"type"`
+	Values map[string]any `json:"values"`
+}
+
+// terraformChildModule is the model type for a child module in the state file. It may contain
+// further child modules which contain additional resources.
+type terraformChildModule struct {
+	Address      string                 `json:"address"`
+	Resources    []terraformResource    `json:"resources"`
+	ChildModules []terraformChildModule `json:"child_modules"`
 }

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -156,42 +157,42 @@ func TestTerraformDestroy(t *testing.T) {
 	require.Equal(t, destroyResult.Outputs["RG_NAME"].Value, fmt.Sprintf("rg-%s", infraProvider.env.GetEnvName()))
 }
 
-func TestTerraformGetDeployment(t *testing.T) {
+func TestTerraformState(t *testing.T) {
 	progressLog := []string{}
 	interactiveLog := []bool{}
 	progressDone := make(chan bool)
 
 	mockContext := mocks.NewMockContext(context.Background())
 	prepareGenericMocks(mockContext.CommandRunner)
-	preparePlanningMocks(mockContext.CommandRunner)
-	prepareDeployMocks(mockContext.CommandRunner)
+	prepareShowMocks(mockContext.CommandRunner)
 
 	infraProvider := createTerraformProvider(*mockContext.Context)
 	scope := infra.NewSubscriptionScope(*mockContext.Context, infraProvider.env.Values["AZURE_LOCATION"], infraProvider.env.GetSubscriptionId(), infraProvider.env.GetEnvName())
-	getDeploymentTask := infraProvider.GetDeployment(*mockContext.Context, scope)
+	getStateTask := infraProvider.State(*mockContext.Context, scope)
 
 	go func() {
-		for progressReport := range getDeploymentTask.Progress() {
+		for progressReport := range getStateTask.Progress() {
 			progressLog = append(progressLog, progressReport.Message)
 		}
 		progressDone <- true
 	}()
 
 	go func() {
-		for deploymentInteractive := range getDeploymentTask.Interactive() {
+		for deploymentInteractive := range getStateTask.Interactive() {
 			interactiveLog = append(interactiveLog, deploymentInteractive)
 		}
 	}()
 
-	getDeploymentResult, err := getDeploymentTask.Await()
+	getStateResult, err := getStateTask.Await()
 	<-progressDone
 
 	require.Nil(t, err)
-	require.NotNil(t, getDeploymentResult.Deployment)
+	require.NotNil(t, getStateResult.State)
 
-	require.Equal(t, getDeploymentResult.Deployment.Outputs["AZURE_LOCATION"].Value, infraProvider.env.Values["AZURE_LOCATION"])
-	require.Equal(t, getDeploymentResult.Deployment.Outputs["RG_NAME"].Value, fmt.Sprintf("rg-%s", infraProvider.env.GetEnvName()))
-
+	require.Equal(t, infraProvider.env.Values["AZURE_LOCATION"], getStateResult.State.Outputs["AZURE_LOCATION"].Value)
+	require.Equal(t, fmt.Sprintf("rg-%s", infraProvider.env.GetEnvName()), getStateResult.State.Outputs["RG_NAME"].Value)
+	require.Len(t, getStateResult.State.Resources, 1)
+	require.Regexp(t, regexp.MustCompile(`^/subscriptions/[^/]*/resourceGroups/[^/]*$`), getStateResult.State.Resources[0].Id)
 }
 
 func createTerraformProvider(ctx context.Context) *TerraformProvider {
@@ -221,21 +222,21 @@ func preparePlanningMocks(commandRunner *execmock.MockCommandRunner) {
 	commandRunner.When(func(args exec.RunArgs, command string) bool {
 		return args.Cmd == "terraform" && strings.Contains(command, "init")
 	}).Respond(exec.RunResult{
-		Stdout: string("Terraform has been successfully initialized!"),
+		Stdout: "Terraform has been successfully initialized!",
 		Stderr: "",
 	})
 
 	commandRunner.When(func(args exec.RunArgs, command string) bool {
 		return args.Cmd == "terraform" && strings.Contains(command, "validate")
 	}).Respond(exec.RunResult{
-		Stdout: string("Success! The configuration is valid."),
+		Stdout: "Success! The configuration is valid.",
 		Stderr: "",
 	})
 
 	commandRunner.When(func(args exec.RunArgs, command string) bool {
 		return args.Cmd == "terraform" && strings.Contains(command, "plan")
 	}).Respond(exec.RunResult{
-		Stdout: string("To perform exactly these actions, run the following command to apply:terraform apply"),
+		Stdout: "To perform exactly these actions, run the following command to apply:terraform apply",
 		Stderr: "",
 	})
 }
@@ -244,20 +245,31 @@ func prepareDeployMocks(commandRunner *execmock.MockCommandRunner) {
 	commandRunner.When(func(args exec.RunArgs, command string) bool {
 		return args.Cmd == "terraform" && strings.Contains(command, "validate")
 	}).Respond(exec.RunResult{
-		Stdout: string("Success! The configuration is valid."),
+		Stdout: "Success! The configuration is valid.",
 		Stderr: "",
 	})
 
 	commandRunner.When(func(args exec.RunArgs, command string) bool {
 		return args.Cmd == "terraform" && strings.Contains(command, "apply")
 	}).Respond(exec.RunResult{
-		Stdout: string(""),
+		Stdout: "",
 		Stderr: "",
 	})
 
-	output := "{\"AZURE_LOCATION\": {\"sensitive\": false,\"type\": \"string\",\"value\": \"westus2\"},\"RG_NAME\":{\"sensitive\": false,\"type\": \"string\",\"value\": \"rg-test-env\"}}"
+	output := `{"AZURE_LOCATION":{"sensitive": false,"type": "string","value": "westus2"},"RG_NAME":{"sensitive": false,"type": "string","value": "rg-test-env"}}`
 	commandRunner.When(func(args exec.RunArgs, command string) bool {
 		return args.Cmd == "terraform" && strings.Contains(command, "output")
+	}).Respond(exec.RunResult{
+		Stdout: output,
+		Stderr: "",
+	})
+}
+
+func prepareShowMocks(commandRunner *execmock.MockCommandRunner) {
+	output := `{"format_version":"1.0","terraform_version":"1.3.1","values":{"outputs":{"AZURE_LOCATION":{"sensitive":false,"value":"westus2","type":"string"},"RG_NAME":{"sensitive":false,"value":"rg-test-env","type":"string"}},"root_module":{"resources":[{"address":"azurecaf_name.rg_name","mode":"managed","type":"azurecaf_name","name":"rg_name","provider_name":"registry.terraform.io/aztfmod/azurecaf","schema_version":3,"values":{"clean_input":true,"id":"ufeuqcdmnpcnbwum","name":"test-env","passthrough":false,"prefixes":null,"random_length":0,"random_seed":null,"resource_type":"azurerm_resource_group","resource_types":null,"result":"rg-test-env","results":{},"separator":"-","suffixes":null,"use_slug":true},"sensitive_values":{"results":{}}},{"address":"azurerm_resource_group.rg","mode":"managed","type":"azurerm_resource_group","name":"rg","provider_name":"registry.terraform.io/hashicorp/azurerm","schema_version":0,"values":{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-test-env","location":"westus2","name":"rg-test-env","tags":{"azd-env-name":"test-env"},"timeouts":null},"sensitive_values":{"tags":{}},"depends_on":["azurecaf_name.rg_name"]}]}}}`
+
+	commandRunner.When(func(args exec.RunArgs, command string) bool {
+		return args.Cmd == "terraform" && strings.Contains(command, "show")
 	}).Respond(exec.RunResult{
 		Stdout: output,
 		Stderr: "",
@@ -268,11 +280,11 @@ func prepareDestroyMocks(commandRunner *execmock.MockCommandRunner) {
 	commandRunner.When(func(args exec.RunArgs, command string) bool {
 		return args.Cmd == "terraform" && strings.Contains(command, "init")
 	}).Respond(exec.RunResult{
-		Stdout: string("Terraform has been successfully initialized!"),
+		Stdout: "Terraform has been successfully initialized!",
 		Stderr: "",
 	})
 
-	output := "{\"AZURE_LOCATION\": {\"sensitive\": false,\"type\": \"string\",\"value\": \"westus2\"},\"RG_NAME\":{\"sensitive\": false,\"type\": \"string\",\"value\": \"rg-test-env\"}}"
+	output := `{"AZURE_LOCATION":{"sensitive": false,"type": "string","value": "westus2"},"RG_NAME":{"sensitive": false,"type": "string","value": "rg-test-env"}}`
 	commandRunner.When(func(args exec.RunArgs, command string) bool {
 		return args.Cmd == "terraform" && strings.Contains(command, "output")
 	}).Respond(exec.RunResult{
@@ -283,7 +295,7 @@ func prepareDestroyMocks(commandRunner *execmock.MockCommandRunner) {
 	commandRunner.When(func(args exec.RunArgs, command string) bool {
 		return args.Cmd == "terraform" && strings.Contains(command, "destroy")
 	}).Respond(exec.RunResult{
-		Stdout: string(""),
+		Stdout: "",
 		Stderr: "",
 	})
 }

--- a/cli/azd/pkg/infra/provisioning/test/test_provider.go
+++ b/cli/azd/pkg/infra/provisioning/test/test_provider.go
@@ -53,6 +53,27 @@ func (p *TestProvider) Plan(ctx context.Context) *async.InteractiveTaskWithProgr
 		})
 }
 
+func (p *TestProvider) State(ctx context.Context, scope infra.Scope) *async.InteractiveTaskWithProgress[*StateResult, *StateProgress] {
+	return async.RunInteractiveTaskWithProgress(
+		func(asyncContext *async.InteractiveTaskContextWithProgress[*StateResult, *StateProgress]) {
+			asyncContext.SetProgress(&StateProgress{
+				Message:   "Looking up deployment",
+				Timestamp: time.Now(),
+			})
+
+			state := State{
+				Outputs:   make(map[string]OutputParameter),
+				Resources: make([]Resource, 0),
+			}
+
+			stateResult := StateResult{
+				State: &state,
+			}
+
+			asyncContext.SetResult(&stateResult)
+		})
+}
+
 func (p *TestProvider) GetDeployment(ctx context.Context, scope infra.Scope) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress] {
 	return async.RunInteractiveTaskWithProgress(
 		func(asyncContext *async.InteractiveTaskContextWithProgress[*DeployResult, *DeployProgress]) {

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -106,7 +106,7 @@ func (at *containerAppTarget) Deploy(ctx context.Context, azdCtx *azdcontext.Azd
 
 	if len(deployResult.Deployment.Outputs) > 0 {
 		log.Printf("saving %d deployment outputs", len(deployResult.Deployment.Outputs))
-		if err := provisioning.UpdateEnvironment(at.env, &deployResult.Deployment.Outputs); err != nil {
+		if err := provisioning.UpdateEnvironment(at.env, deployResult.Deployment.Outputs); err != nil {
 			return ServiceDeploymentResult{}, fmt.Errorf("saving outputs to environment: %w", err)
 		}
 	}

--- a/cli/azd/pkg/tools/terraform/terraform.go
+++ b/cli/azd/pkg/tools/terraform/terraform.go
@@ -27,6 +27,8 @@ type TerraformCli interface {
 	Apply(ctx context.Context, modulePath string, additionalArgs ...string) (string, error)
 	// Retrieves the output variables from the most recent deployment state
 	Output(ctx context.Context, modulePath string, additionalArgs ...string) (string, error)
+	// Retrieves information about the infrastructure from the current deployment state
+	Show(ctx context.Context, modulePath string, additionalArgs ...string) (string, error)
 	// Destroys all resources referenced in the terraform module
 	Destroy(ctx context.Context, modulePath string, additionalArgs ...string) (string, error)
 }
@@ -203,6 +205,22 @@ func (cli *terraformCli) Apply(ctx context.Context, modulePath string, additiona
 func (cli *terraformCli) Output(ctx context.Context, modulePath string, additionalArgs ...string) (string, error) {
 	args := []string{
 		fmt.Sprintf("-chdir=%s", modulePath), "output", "-json"}
+
+	args = append(args, additionalArgs...)
+	cmdRes, err := cli.runCommand(ctx, args...)
+	if err != nil {
+		return "", fmt.Errorf(
+			"failed running terraform output: %s (%w)",
+			cmdRes.Stderr,
+			err,
+		)
+	}
+	return cmdRes.Stdout, nil
+}
+
+func (cli *terraformCli) Show(ctx context.Context, modulePath string, additionalArgs ...string) (string, error) {
+	args := []string{
+		fmt.Sprintf("-chdir=%s", modulePath), "show", "-json"}
 
 	args = append(args, additionalArgs...)
 	cmdRes, err := cli.runCommand(ctx, args...)

--- a/go.mod
+++ b/go.mod
@@ -40,14 +40,12 @@ require (
 )
 
 require (
-	code.cloudfoundry.org/clock v0.0.0-20180518195852-02e53af36e6c // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/gofrs/uuid v3.3.0+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,7 +45,6 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
-code.cloudfoundry.org/clock v0.0.0-20180518195852-02e53af36e6c h1:5eeuG0BHx1+DHeT3AP+ISKZ2ht1UjGhm581ljqYpVeQ=
 code.cloudfoundry.org/clock v0.0.0-20180518195852-02e53af36e6c/go.mod h1:QD9Lzhd/ux6eNQVUDVRJX/RKTigpewimNYBi7ivZKY8=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/AlecAivazis/survey/v2 v2.3.2 h1:TqTB+aDDCLYhf9/bD2TwSO8u8jDSmMUd2SUVO4gCnU8=
@@ -58,10 +57,10 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.1 h1:XUNQ4mw+zJmaA2KXzP9JlQi
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.1/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.10.1 h1:AhZnZn4kUKz36bHJ8AK/FH2tH/q3CAkG+Gme+2ibuak=
 github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.10.1/go.mod h1:S78i9yTr4o/nXlH76bKjGUye9Z2wSxO5Tz7GoDr4vfI=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v0.6.0 h1:Z5/bDxQL2Zc9t6ZDwdRU60bpLHZvoKOeuaM7XVbf2z0=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v0.6.0/go.mod h1:0FPu3oDRGPvuX1H8TtHJ5XGA0KrXLunomcixR+PQGGA=
 github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.0 h1:Lg6BW0VPmCwcMlvOviL3ruHFO+H9tZNqscK0AeuFjGM=
 github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.0/go.mod h1:9V2j0jn9jDEkCkv8w/bKTNppX/d0FVA1ud77xCIP4KA=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v0.6.0 h1:Z5/bDxQL2Zc9t6ZDwdRU60bpLHZvoKOeuaM7XVbf2z0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v0.6.0/go.mod h1:0FPu3oDRGPvuX1H8TtHJ5XGA0KrXLunomcixR+PQGGA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.0.0 h1:lMW1lD/17LUA5z1XTURo7LcVG2ICBPlyMHjIUrcFZNQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.0.0 h1:Jc2KcpCDMu7wJfkrzn7fs/53QMDXH78GuqnH4HOd7zs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.0.0/go.mod h1:PFVgFsclKzPqYRT/BiwpfUN22cab0C7FlgXR3iWpwMo=
@@ -157,7 +156,6 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
-github.com/gofrs/uuid v3.3.0+incompatible h1:8K4tyRfvU1CYPgJsveYFQMhpFd/wXNM7iK6rR7UHz84=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=


### PR DESCRIPTION
When we added support for terraform, we changed the JSON output from `azd env refresh` somewhat unintentionally. Previously, it had been the full deployment object, from ARM, but since there is no deployment object when using Terraform, we could not long return that complete value. What we ended up returning was what the provider interface calls a `Deployment` which is a set of parameters and outputs, with no resources.

This change moves the output of `env refresh` to be a type we have a specific contract for and right now contains just the outputs and resources from the most recent infrastructure update. For ARM based deployments, this information is sources from the most recent deployment object and for terraform it is discovered by reading the current state file (via `terraform show`)

Contributes To: #742