### PR TITLE
az login uses device token in codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+ARG VARIANT=bullseye
+FROM mcr.microsoft.com/devcontainers/go

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+    "name": "Azure Developer CLI",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "args": {
+            "VARIANT": "bullseye"
+        }
+    },
+    "features": {
+        // Prerequisites for running azd
+        // https://github.com/Azure/azure-dev/wiki/Install
+        "github-cli": "2.3",
+        "azure-cli": "2.38"
+    }, 
+    "extensions": [
+        "redhat.vscode-yaml",
+        "streetsidesoftware.code-spell-checker"
+    ]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,7 @@
     }, 
     "extensions": [
         "redhat.vscode-yaml",
-        "streetsidesoftware.code-spell-checker"
+        "streetsidesoftware.code-spell-checker",
+        "golang.go"
     ]
 }

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -279,13 +279,3 @@ func (i *initAction) Run(ctx context.Context, cmd *cobra.Command, args []string,
 
 	return nil
 }
-
-const (
-	// CodespacesEnvVarName is the name of the env variable set when you're in a Github codespace. It's
-	// just set to 'true'.
-	CodespacesEnvVarName = "CODESPACES"
-
-	// RemoteContainersEnvVarName is the name of the env variable set when you're in a remote container. It's
-	// just set to 'true'.
-	RemoteContainersEnvVarName = "REMOTE_CONTAINERS"
-)

--- a/cli/azd/cmd/login.go
+++ b/cli/azd/cmd/login.go
@@ -108,6 +108,16 @@ func ensureLoggedIn(ctx context.Context) error {
 // runLogin runs an interactive login. When running in a Codespace or Remote Container, a device code based is
 // preformed since the default browser login needs UI. A device code login can be forced with `forceDeviceCode`.
 func runLogin(ctx context.Context, forceDeviceCode bool) error {
+	const (
+		// CodespacesEnvVarName is the name of the env variable set when you're in a Github codespace. It's
+		// just set to 'true'.
+		CodespacesEnvVarName = "CODESPACES"
+
+		// RemoteContainersEnvVarName is the name of the env variable set when you're in a remote container. It's
+		// just set to 'true'.
+		RemoteContainersEnvVarName = "REMOTE_CONTAINERS"
+	)
+
 	azCli := azcli.GetAzCli(ctx)
 	useDeviceCode := forceDeviceCode || os.Getenv(CodespacesEnvVarName) == "true" || os.Getenv(RemoteContainersEnvVarName) == "true"
 

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -479,6 +479,7 @@ func (cli *azCli) Login(ctx context.Context, useDeviceCode bool, deviceCodeWrite
 	var writer io.Writer
 	if useDeviceCode {
 		writer = deviceCodeWriter
+		args = append(args, "--use-device-code")
 	}
 
 	res, err := cli.runAzCommandWithArgs(ctx, exec.RunArgs{

--- a/cli/azd/pkg/tools/azcli/azcli_test.go
+++ b/cli/azd/pkg/tools/azcli/azcli_test.go
@@ -110,43 +110,6 @@ func TestAZCLIWithUserAgent(t *testing.T) {
 	require.Contains(t, userAgent, "azdev")
 }
 
-func Test_AzCli_Login_Appends_useDeviceCode(t *testing.T) {
-	var commandArgs []string
-	var writer io.Writer
-
-	mockContext := mocks.NewMockContext(context.Background())
-	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.Contains(command, "--use-device-code")
-	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-		commandArgs = args.Args
-		return exec.NewRunResult(0, "", ""), nil
-	})
-
-	azCli := GetAzCli(*mockContext.Context)
-	err := azCli.Login(*mockContext.Context, true, writer)
-	require.NoError(t, err)
-	require.Contains(t, commandArgs, "--use-device-code")
-}
-
-func Test_AzCli_Login_DoesNotAppend_useDeviceCode(t *testing.T) {
-	var commandArgs []string
-	var writer io.Writer
-
-	mockContext := mocks.NewMockContext(context.Background())
-	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return !strings.Contains(command, "--use-device-code")
-	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-		commandArgs = args.Args
-		return exec.NewRunResult(0, "", ""), nil
-	})
-
-	azCli := GetAzCli(*mockContext.Context)
-	err := azCli.Login(*mockContext.Context, false, writer)
-
-	require.NoError(t, err)
-	require.NotContains(t, commandArgs, "--use-device-code")
-}
-
 func mustGetDefaultAccount(t *testing.T, azCli AzCli) AzCliSubscriptionInfo {
 	accounts, err := azCli.ListAccounts(context.Background())
 	require.NoError(t, err)

--- a/cli/azd/pkg/tools/azcli/azcli_test.go
+++ b/cli/azd/pkg/tools/azcli/azcli_test.go
@@ -110,6 +110,43 @@ func TestAZCLIWithUserAgent(t *testing.T) {
 	require.Contains(t, userAgent, "azdev")
 }
 
+func Test_AzCli_Login_Appends_useDeviceCode(t *testing.T) {
+	var commandArgs []string
+	var writer io.Writer
+
+	mockContext := mocks.NewMockContext(context.Background())
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "--use-device-code")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		commandArgs = args.Args
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	azCli := GetAzCli(*mockContext.Context)
+	err := azCli.Login(*mockContext.Context, true, writer)
+	require.NoError(t, err)
+	require.Contains(t, commandArgs, "--use-device-code")
+}
+
+func Test_AzCli_Login_DoesNotAppend_useDeviceCode(t *testing.T) {
+	var commandArgs []string
+	var writer io.Writer
+
+	mockContext := mocks.NewMockContext(context.Background())
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return !strings.Contains(command, "--use-device-code")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		commandArgs = args.Args
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	azCli := GetAzCli(*mockContext.Context)
+	err := azCli.Login(*mockContext.Context, false, writer)
+
+	require.NoError(t, err)
+	require.NotContains(t, commandArgs, "--use-device-code")
+}
+
 func mustGetDefaultAccount(t *testing.T, azCli AzCli) AzCliSubscriptionInfo {
 	accounts, err := azCli.ListAccounts(context.Background())
 	require.NoError(t, err)

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -69,6 +69,8 @@ func Test_CLI_Login_UsesDeviceCodeInDevContainer(t *testing.T) {
 	cli.Env = append(filterEnviron("CODESPACES"), "CODESPACES=true")
 
 	out, err := cli.RunCommand(ctx, "", "login")
+	// Error is expected because the az CLI waits for user response and the
+	// test times out execution instead of waiting for the process to complete
 	require.Error(t, err)
 	require.Contains(t, out, "WARNING: To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code")
 }
@@ -85,6 +87,8 @@ func Test_CLI_Login_UsesDeviceCodeInRemoteContainer(t *testing.T) {
 
 	out, err := cli.RunCommand(ctx, "", "login")
 	require.Error(t, err)
+	// Error is expected because the az CLI waits for user response and the
+	// test times out execution instead of waiting for the process to complete
 	require.Contains(t, out, "WARNING: To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code")
 }
 
@@ -96,9 +100,11 @@ func Test_CLI_Login_DoesNotUseDeviceCodeByDefault(t *testing.T) {
 
 	cli := azdcli.NewCLI(t)
 	cli.WorkingDirectory = dir
-	cli.Env = append(filterEnviron("REMOTE_CONTAINERS", "CODESPACES"))
+	cli.Env = filterEnviron("REMOTE_CONTAINERS", "CODESPACES")
 
 	out, err := cli.RunCommand(ctx, "", "login")
+	// Error is expected because the az CLI waits for user response and the
+	// test times out execution instead of waiting for the process to complete
 	require.Error(t, err)
 	require.NotContains(t, out, "WARNING: To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code")
 }

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -58,6 +58,51 @@ func Test_CLI_Login_FailsIfNoAzCliIsMissing(t *testing.T) {
 	require.Contains(t, out, "Azure CLI is not installed, please see https://aka.ms/azure-dev/azure-cli-install to install")
 }
 
+func Test_CLI_Login_UsesDeviceCodeInDevContainer(t *testing.T) {
+	ctx, cancel := newTimeoutTestContext(t, time.Second*2)
+	defer cancel()
+
+	dir := ostest.TempDirWithDiagnostics(t)
+
+	cli := azdcli.NewCLI(t)
+	cli.WorkingDirectory = dir
+	cli.Env = append(filterEnviron("CODESPACES"), "CODESPACES=true")
+
+	out, err := cli.RunCommand(ctx, "", "login")
+	require.Error(t, err)
+	require.Contains(t, out, "WARNING: To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code")
+}
+
+func Test_CLI_Login_UsesDeviceCodeInRemoteContainer(t *testing.T) {
+	ctx, cancel := newTimeoutTestContext(t, time.Second*2)
+	defer cancel()
+
+	dir := ostest.TempDirWithDiagnostics(t)
+
+	cli := azdcli.NewCLI(t)
+	cli.WorkingDirectory = dir
+	cli.Env = append(filterEnviron("REMOTE_CONTAINERS"), "REMOTE_CONTAINERS=true")
+
+	out, err := cli.RunCommand(ctx, "", "login")
+	require.Error(t, err)
+	require.Contains(t, out, "WARNING: To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code")
+}
+
+func Test_CLI_Login_DoesNotUseDeviceCodeByDefault(t *testing.T) {
+	ctx, cancel := newTimeoutTestContext(t, time.Second*5)
+	defer cancel()
+
+	dir := ostest.TempDirWithDiagnostics(t)
+
+	cli := azdcli.NewCLI(t)
+	cli.WorkingDirectory = dir
+	cli.Env = append(filterEnviron("REMOTE_CONTAINERS", "CODESPACES"))
+
+	out, err := cli.RunCommand(ctx, "", "login")
+	require.Error(t, err)
+	require.NotContains(t, out, "WARNING: To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code")
+}
+
 func Test_CLI_Version_PrintsVersion(t *testing.T) {
 	ctx, cancel := newTestContext(t)
 	defer cancel()
@@ -739,6 +784,17 @@ func newTestContext(t *testing.T) (context.Context, context.CancelFunc) {
 	}
 
 	return context.WithCancel(ctx)
+}
+
+func newTimeoutTestContext(t *testing.T, timeout time.Duration) (context.Context, context.CancelFunc) {
+	container.RegisterDependencies()
+
+	ctx := context.Background()
+	ctx = internal.WithCommandOptions(ctx, internal.GlobalCommandOptions{})
+
+	// TODO: Should this also incorporate checking whether a Deadline or
+	// timeout is closer and then selecting for the one that's closer?
+	return context.WithTimeout(ctx, timeout)
 }
 
 func Test_CLI_InfraCreateAndDeleteResourceTerraform(t *testing.T) {


### PR DESCRIPTION
First time writing Go. Please have a look and let me know where I can write more correctly. 

Since this is related to Codespaces, I added some codespaces configs for the azure-dev repo. 

A couple of things I noticed: 

* `CodespacesEnvVarName` and `RemoteContainersEnvVarName` are defined in `init.go` but only referenced in `login.go`... should those definitions be moved into `login.go` ... If so, what's the correct scope? The function in which they're used or further up?
* Was `newTimeoutTestContext` the way to go here? Do we want to look at timeout vs. deadline so as not to let tests run over on a long timeout? 