### PR TITLE
Flow context around in more places

### DIFF
--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -99,9 +99,3 @@ For more information, visit the Azure Developer CLI Dev Hub: https://aka.ms/azur
 
 	return cmd
 }
-
-func Execute(args []string) error {
-	tempRootCmd := NewRootCmd()
-	tempRootCmd.SetArgs(args)
-	return tempRootCmd.Execute()
-}

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -33,6 +33,8 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
+
 	// Ensure random numbers from default random number generator are unpredictable
 	rand.Seed(time.Now().UTC().UnixNano())
 
@@ -48,7 +50,7 @@ func main() {
 	latest := make(chan semver.Version)
 	go fetchLatestVersion(latest)
 
-	cmdErr := cmd.Execute(os.Args[1:])
+	cmdErr := cmd.NewRootCmd().ExecuteContext(ctx)
 	latestVersion, ok := <-latest
 
 	// If we were able to fetch a latest version, check to see if we are up to date and
@@ -76,7 +78,7 @@ func main() {
 	}
 
 	if ts != nil {
-		err := ts.Shutdown(context.Background())
+		err := ts.Shutdown(ctx)
 		if err != nil {
 			log.Printf("non-graceful telemetry shutdown: %v\n", err)
 		}

--- a/cli/azd/pkg/commands/builder.go
+++ b/cli/azd/pkg/commands/builder.go
@@ -55,7 +55,7 @@ func Build(action Action, rootOptions *internal.GlobalCommandOptions, use string
 		Long:    buildOptions.Long,
 		Aliases: buildOptions.Aliases,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, azdCtx, err := createRootContext(context.Background(), cmd, rootOptions)
+			ctx, azdCtx, err := createRootContext(cmd.Context(), cmd, rootOptions)
 			if err != nil {
 				return err
 			}

--- a/cli/azd/pkg/commands/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/commands/pipeline/azdo_provider.go
@@ -51,7 +51,7 @@ type AzdoRepositoryDetails struct {
 
 // requiredTools return the list of external tools required by
 // Azure DevOps provider during its execution.
-func (p *AzdoScmProvider) requiredTools() []tools.ExternalTool {
+func (p *AzdoScmProvider) requiredTools(_ context.Context) []tools.ExternalTool {
 	return []tools.ExternalTool{}
 }
 
@@ -542,7 +542,7 @@ type AzdoCiProvider struct {
 // ***  subareaProvider implementation ******
 
 // requiredTools defines the requires tools for GitHub to be used as CI manager
-func (p *AzdoCiProvider) requiredTools() []tools.ExternalTool {
+func (p *AzdoCiProvider) requiredTools(_ context.Context) []tools.ExternalTool {
 	return []tools.ExternalTool{}
 }
 

--- a/cli/azd/pkg/commands/pipeline/github_provider.go
+++ b/cli/azd/pkg/commands/pipeline/github_provider.go
@@ -33,9 +33,9 @@ type GitHubScmProvider struct {
 
 // requiredTools return the list of external tools required by
 // GitHub provider during its execution.
-func (p *GitHubScmProvider) requiredTools() []tools.ExternalTool {
+func (p *GitHubScmProvider) requiredTools(ctx context.Context) []tools.ExternalTool {
 	return []tools.ExternalTool{
-		github.NewGitHubCli(context.Background()),
+		github.NewGitHubCli(ctx),
 	}
 }
 
@@ -281,9 +281,9 @@ type GitHubCiProvider struct {
 // ***  subareaProvider implementation ******
 
 // requiredTools defines the requires tools for GitHub to be used as CI manager
-func (p *GitHubCiProvider) requiredTools() []tools.ExternalTool {
+func (p *GitHubCiProvider) requiredTools(ctx context.Context) []tools.ExternalTool {
 	return []tools.ExternalTool{
-		github.NewGitHubCli(context.Background()),
+		github.NewGitHubCli(ctx),
 	}
 }
 

--- a/cli/azd/pkg/commands/pipeline/pipeline.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline.go
@@ -22,7 +22,7 @@ import (
 // subareaProvider defines the base behavior from any pipeline provider
 type subareaProvider interface {
 	// requiredTools return the list of requires external tools required by the provider.
-	requiredTools() []tools.ExternalTool
+	requiredTools(ctx context.Context) []tools.ExternalTool
 	// preConfigureCheck validates that the provider's state is ready to be used.
 	// a provider would typically use this method for checking if tools are logged in
 	// of checking if all expected input data is found.

--- a/cli/azd/pkg/commands/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline_manager.go
@@ -36,9 +36,9 @@ type PipelineManager struct {
 }
 
 // requiredTools get all the provider's required tools.
-func (i *PipelineManager) requiredTools() []tools.ExternalTool {
-	reqTools := i.ScmProvider.requiredTools()
-	reqTools = append(reqTools, i.CiProvider.requiredTools()...)
+func (i *PipelineManager) requiredTools(ctx context.Context) []tools.ExternalTool {
+	reqTools := i.ScmProvider.requiredTools(ctx)
+	reqTools = append(reqTools, i.CiProvider.requiredTools(ctx)...)
 	return reqTools
 }
 
@@ -189,7 +189,7 @@ func (manager *PipelineManager) Configure(ctx context.Context) error {
 
 	// check all required tools are installed
 	azCli := azcli.GetAzCli(ctx)
-	requiredTools := manager.requiredTools()
+	requiredTools := manager.requiredTools(ctx)
 	requiredTools = append(requiredTools, azCli)
 	if err := tools.EnsureInstalled(ctx, requiredTools...); err != nil {
 		return err

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -523,7 +523,7 @@ func (cli *azCli) DeployAppServiceZip(ctx context.Context, subscriptionId string
 
 func (cli *azCli) DeployFunctionAppUsingZipFile(ctx context.Context, subscriptionID string, resourceGroup string, funcName string, deployZipPath string) (string, error) {
 	// eg: az functionapp deployment source config-zip -g <resource_group> -n <app_name> --src <zip_file_path>
-	res, err := cli.runAzCommandWithArgs(context.Background(), exec.RunArgs{
+	res, err := cli.runAzCommandWithArgs(ctx, exec.RunArgs{
 		Args: []string{
 			"functionapp", "deployment", "source", "config-zip",
 			"--subscription", subscriptionID,
@@ -576,7 +576,7 @@ func (cli *azCli) GetContainerAppProperties(ctx context.Context, subscriptionId,
 }
 
 func (cli *azCli) GetFunctionAppProperties(ctx context.Context, subscriptionID string, resourceGroup string, funcName string) (AzCliFunctionAppProperties, error) {
-	res, err := cli.runAzCommandWithArgs(context.Background(), exec.RunArgs{
+	res, err := cli.runAzCommandWithArgs(ctx, exec.RunArgs{
 		Args: []string{
 			"functionapp", "show",
 			"--subscription", subscriptionID,
@@ -600,7 +600,7 @@ func (cli *azCli) GetFunctionAppProperties(ctx context.Context, subscriptionID s
 }
 
 func (cli *azCli) GetStaticWebAppProperties(ctx context.Context, subscriptionID string, resourceGroup string, appName string) (AzCliStaticWebAppProperties, error) {
-	res, err := cli.runAzCommandWithArgs(context.Background(), exec.RunArgs{
+	res, err := cli.runAzCommandWithArgs(ctx, exec.RunArgs{
 		Args: []string{
 			"staticwebapp", "show",
 			"--subscription", subscriptionID,
@@ -624,7 +624,7 @@ func (cli *azCli) GetStaticWebAppProperties(ctx context.Context, subscriptionID 
 }
 
 func (cli *azCli) GetStaticWebAppEnvironmentProperties(ctx context.Context, subscriptionID string, resourceGroup string, appName string, environmentName string) (AzCliStaticWebAppEnvironmentProperties, error) {
-	res, err := cli.runAzCommandWithArgs(context.Background(), exec.RunArgs{
+	res, err := cli.runAzCommandWithArgs(ctx, exec.RunArgs{
 		Args: []string{
 			"staticwebapp", "environment", "show",
 			"--subscription", subscriptionID,
@@ -649,7 +649,7 @@ func (cli *azCli) GetStaticWebAppEnvironmentProperties(ctx context.Context, subs
 }
 
 func (cli *azCli) GetStaticWebAppApiKey(ctx context.Context, subscriptionID string, resourceGroup string, appName string) (string, error) {
-	res, err := cli.runAzCommandWithArgs(context.Background(), exec.RunArgs{
+	res, err := cli.runAzCommandWithArgs(ctx, exec.RunArgs{
 		Args: []string{
 			"staticwebapp", "secrets", "list",
 			"--subscription", subscriptionID,

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/azure/azure-dev/cli/azd/cmd"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
 	"github.com/azure/azure-dev/cli/azd/pkg/container"
@@ -549,11 +548,11 @@ func Test_CLI_InfraCreateAndDeleteFuncApp(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Starting infra create\n")
-	err = cmd.Execute([]string{"infra", "create", "--cwd", dir})
+	_, err = cli.RunCommand(ctx, "infra", "create", "--cwd", dir)
 	require.NoError(t, err)
 
 	t.Logf("Starting deploy\n")
-	err = cmd.Execute([]string{"deploy", "--cwd", dir})
+	_, err = cli.RunCommand(ctx, "deploy", "--cwd", dir)
 	require.NoError(t, err)
 
 	out, err := cli.RunCommand(ctx, "env", "get-values", "-o", "json", "--cwd", dir)
@@ -585,7 +584,7 @@ func Test_CLI_InfraCreateAndDeleteFuncApp(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Starting infra delete\n")
-	err = cmd.Execute([]string{"infra", "delete", "--cwd", dir, "--force", "--purge"})
+	_, err = cli.RunCommand(ctx, "infra", "delete", "--cwd", dir, "--force", "--purge")
 	require.NoError(t, err)
 
 	t.Logf("Done\n")


### PR DESCRIPTION
We had a few places which were using `context.Background()` instead of flowing a context value around.  I did an audit of all calls to `context.Background()` in non test files and cleaned up everything except for a single call at the start of `main()`.