### PR TITLE
Store installed check cache in Context

### DIFF
--- a/cli/azd/pkg/commands/builder.go
+++ b/cli/azd/pkg/commands/builder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/identity"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel/codes"
@@ -104,6 +105,7 @@ func createRootContext(ctx context.Context, cmd *cobra.Command, rootOptions *int
 	// Set the global options in the go context
 	ctx = azdcontext.WithAzdContext(ctx, azdCtx)
 	ctx = internal.WithCommandOptions(ctx, *rootOptions)
+	ctx = tools.WithInstalledCheckCache(ctx)
 
 	azCliArgs := azcli.NewAzCliArgs{
 		EnableDebug:     rootOptions.EnableDebugLogging,

--- a/cli/azd/pkg/tools/ensure_test.go
+++ b/cli/azd/pkg/tools/ensure_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_EnsureInstalledOnlyOnce(t *testing.T) {
-	ctx := context.Background()
+func Test_EnsureInstalledOnlyOnceWhenCached(t *testing.T) {
+	ctx := WithInstalledCheckCache(context.Background())
 	tool := TestTool{}
 
 	_ = EnsureInstalled(ctx, &tool)

--- a/cli/azd/pkg/tools/tool_test.go
+++ b/cli/azd/pkg/tools/tool_test.go
@@ -71,15 +71,11 @@ func Test_EnsureInstalled(t *testing.T) {
 	}
 
 	t.Run("HaveAll", func(t *testing.T) {
-		resetConfirmedTools()
-
 		err := EnsureInstalled(context.Background(), installedToolOne, installedToolTwo)
 		assert.NoError(t, err)
 	})
 
 	t.Run("MissingOne", func(t *testing.T) {
-		resetConfirmedTools()
-
 		err := EnsureInstalled(context.Background(), installedToolOne, missingToolOne)
 		assert.Error(t, err)
 		assert.Regexp(t, regexp.MustCompile(regexp.QuoteMeta(missingToolOne.Name())), err.Error())
@@ -87,8 +83,6 @@ func Test_EnsureInstalled(t *testing.T) {
 	})
 
 	t.Run("MissingMany", func(t *testing.T) {
-		resetConfirmedTools()
-
 		err := EnsureInstalled(context.Background(), installedToolOne, missingToolOne, missingToolTwo)
 		assert.Error(t, err)
 		assert.Regexp(t, regexp.MustCompile(regexp.QuoteMeta(missingToolOne.Name())), err.Error())
@@ -116,8 +110,4 @@ func (m *mockTool) InstallUrl() string {
 
 func (m *mockTool) Name() string {
 	return m.name
-}
-
-func resetConfirmedTools() {
-	confirmedTools = map[string]bool{}
 }


### PR DESCRIPTION
Instead of using a package level variable and having an internal method for testing to reset the cache, store the cache on the Context object and pull it when we need it.