### PR TITLE
Consider command when matching expression in MockConsole

### DIFF
--- a/cli/azd/test/mocks/console/mock_console.go
+++ b/cli/azd/test/mocks/console/mock_console.go
@@ -66,7 +66,7 @@ func (c *MockConsole) respond(command string, options input.ConsoleOptions) (any
 	var match *MockConsoleExpression
 
 	for _, expr := range c.expressions {
-		if expr.predicateFn(options) {
+		if command == expr.command && expr.predicateFn(options) {
 			match = expr
 			break
 		}


### PR DESCRIPTION
Without this, a handler for a "Confirm" action may be used for a "Prompt" or "Select" action if the predicates match, which is not what would be expected.