### PR TITLE
Re-assert executable bit

### DIFF
--- a/templates/todo/api/java/Dockerfile
+++ b/templates/todo/api/java/Dockerfile
@@ -5,10 +5,10 @@ EXPOSE 3100
 
 COPY mvnw .
 COPY .mvn .mvn
-COPY openapi.yaml openapi.yaml
 COPY pom.xml .
 COPY src src
 
+RUN chmod +x ./mvnw
 RUN ./mvnw package -DskipTests
 RUN mkdir -p target/dependency && (cd target/dependency; jar -xf ../*.jar)
 


### PR DESCRIPTION
From the manual test run, it seems that the Java template projects was failing to build due to executable bit on `mvnw` script not being set.

This is surprising, as the executable script is set correctly:
- In `azure-dev` repository
- In the replicated repoman template repository

Nevertheless, reasserting the executable bit doesn't harm anything and makes the docker image non-susceptible to the source environment.

Fixes #859