### PR TITLE
Adjust `settings.json` for `cil/azd`

### DIFF
--- a/cli/azd/.vscode/settings.json
+++ b/cli/azd/.vscode/settings.json
@@ -1,9 +1,10 @@
 {
     "go.testTimeout": "10m",
     "go.lintTool": "golangci-lint",
+    "go.lintFlags": ["--fast"],
     "go.lintOnSave": "package",
+    "editor.rulers": [ 125 ],
     "cSpell.import": [
         "${workspaceFolder}/.vscode/cspell.yaml"
     ]
 }
-


### PR DESCRIPTION
- Pass `--fast` to `golangci-lint` as described in https://golangci-lint.run/usage/integrations/. I had been hitting freezes from time to time so hopefully this helps.

- Add a line at 125 cols, now that wrap there.