### PR TITLE
Fix azure devops CI detection in telemetry

### DIFF
--- a/cli/azd/internal/telemetry/fields/fields.go
+++ b/cli/azd/internal/telemetry/fields/fields.go
@@ -71,18 +71,20 @@ const (
 
 	// Continuous Integration environments
 
-	EnvUnknownCI        = "UnknownCI"
-	EnvAzurePipelines   = "Azure Pipelines"
-	EnvGitHubActions    = "GitHub Actions"
-	EnvAppVeyor         = "AppVeyor"
-	EnvTravisCI         = "Travis CI"
-	EnvCircleCI         = "Circle CI"
-	EnvGitLabCI         = "GitLab CI"
-	EnvJenkins          = "Jenkins"
-	EnvAwsCodeBuild     = "AWS CodeBuild"
-	EnvGoogleCloudBuild = "Google Cloud Build"
-	EnvTeamCity         = "TeamCity"
-	EnvJetBrainsSpace   = "JetBrains Space"
+	EnvUnknownCI          = "UnknownCI"
+	EnvAzurePipelines     = "Azure Pipelines"
+	EnvGitHubActions      = "GitHub Actions"
+	EnvAppVeyor           = "AppVeyor"
+	EnvBamboo             = "Bamboo"
+	EnvBitBucketPipelines = "BitBucket Pipelines"
+	EnvTravisCI           = "Travis CI"
+	EnvCircleCI           = "Circle CI"
+	EnvGitLabCI           = "GitLab CI"
+	EnvJenkins            = "Jenkins"
+	EnvAwsCodeBuild       = "AWS CodeBuild"
+	EnvGoogleCloudBuild   = "Google Cloud Build"
+	EnvTeamCity           = "TeamCity"
+	EnvJetBrainsSpace     = "JetBrains Space"
 )
 
 // The value used for ServiceNameKey

--- a/cli/azd/internal/telemetry/resource/exec_environment.go
+++ b/cli/azd/internal/telemetry/resource/exec_environment.go
@@ -11,6 +11,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry/fields"
 )
 
+// Rules that apply when the specified environment variable is set to "true" (case-insensitive)
 var booleanEnvVarRules = []struct {
 	envVar      string
 	environment string
@@ -31,23 +32,26 @@ var booleanEnvVarRules = []struct {
 	{"GITLAB_CI", fields.EnvGitLabCI},
 }
 
+// Rules that apply when the specified environment variable is set to any value
 var nonNullEnvVarRules = []struct {
 	envVar      string
 	environment string
 }{
 	// AWS CodeBuild - https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
 	{"CODEBUILD_BUILD_ID", fields.EnvAwsCodeBuild},
-	// Jenkins -
 	//nolint:lll
-	// https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
+	// Jenkins - https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
 	{"JENKINS_URL", fields.EnvJenkins},
 	//nolint:lll
 	// TeamCity - https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html#Predefined+Server+Build+Parameters
 	{"TEAMCITY_VERSION", fields.EnvTeamCity},
 	//nolint:lll
-	// https://www.jetbrains.com/help/space/automation-environment-variables.html#when-does-automation-resolve-its-environment-variables
+	// JetBrains Space - https://www.jetbrains.com/help/space/automation-environment-variables.html#when-does-automation-resolve-its-environment-variables
 	{"JB_SPACE_API_URL", fields.EnvJetBrainsSpace},
-
+	// Bamboo - https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html#Bamboovariables-Build-specificvariables
+	{"bamboo.buildKey", fields.EnvBamboo},
+	// BitBucket - https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
+	{"BITBUCKET_BUILD_NUMBER", fields.EnvBitBucketPipelines},
 	// Unknown CI cases
 	{"CI", fields.EnvUnknownCI},
 	{"BUILD_ID", fields.EnvUnknownCI},
@@ -64,7 +68,9 @@ func getExecutionEnvironment() string {
 
 func getExecutionEnvironmentForCI() (string, bool) {
 	for _, rule := range booleanEnvVarRules {
-		if os.Getenv(rule.envVar) == "true" {
+		// Some CI providers specify 'True' on Windows vs 'true' on Linux, while others use `True` always
+		// Thus, it's better to err on the side of being generous and be case-insensitive
+		if strings.ToLower(os.Getenv(rule.envVar)) == "true" {
 			return rule.environment, true
 		}
 	}


### PR DESCRIPTION
Use case-insensitive match of `true` to detect Azure DevOps correctly. Also, adding BitBucket Pipelines and Bamboo specific CI detection.