### PR TITLE
Fix `errors.As` usage

### DIFF
--- a/cli/azd/pkg/tools/azcli/deployments.go
+++ b/cli/azd/pkg/tools/azcli/deployments.go
@@ -32,8 +32,7 @@ func (cli *azCli) GetSubscriptionDeployment(
 	deployment, err := deploymentClient.GetAtSubscriptionScope(ctx, deploymentName, nil)
 	if err != nil {
 		var errDetails *azcore.ResponseError
-		errors.As(err, &errDetails)
-		if errDetails.StatusCode == 404 {
+		if errors.As(err, &errDetails) && errDetails.StatusCode == 404 {
 			return nil, ErrDeploymentNotFound
 		}
 		return nil, fmt.Errorf("getting deployment from subscription: %w", err)
@@ -62,8 +61,7 @@ func (cli *azCli) GetResourceGroupDeployment(
 	deployment, err := deploymentClient.Get(ctx, resourceGroupName, deploymentName, nil)
 	if err != nil {
 		var errDetails *azcore.ResponseError
-		errors.As(err, &errDetails)
-		if errDetails.StatusCode == 404 {
+		if errors.As(err, &errDetails) && errDetails.StatusCode == 404 {
 			return nil, ErrDeploymentNotFound
 		}
 		return nil, fmt.Errorf("getting deployment from resource group: %w", err)


### PR DESCRIPTION
I saw a panic in one of our end to end test runs recently:

```
 panic: runtime error: invalid memory address or nil pointer dereference
 [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x43fd3a6]

 goroutine 57 [running]:
 github.com/azure/azure-dev/cli/azd/pkg/tools/azcli.(*azCli).GetSubscriptionDeployment(0xc00016bf00, {0x477ccd8, 0xc000025680}, {0xc00002ecc0, 0x24}, {0xc00002c390, 0xf})
 	/Users/runner/work/1/s/cli/azd/pkg/tools/azcli/deployments.go:36 +0x3e6
 github.com/azure/azure-dev/cli/azd/pkg/infra.(*SubscriptionScope).GetDeployment(0xc0001e7e68?, {0x477ccd8?, 0xc000025680?})
 	/Users/runner/work/1/s/cli/azd/pkg/infra/scope.go:116 +0x42
 github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning.(*ProvisioningProgressDisplay).ReportProgress(0xc0001e7f90, {0x477ccd8, 0xc000025680})
 	/Users/runner/work/1/s/cli/azd/pkg/infra/provisioning/provisioning_progress_display.go:58 +0x15d
 github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/bicep.(*BicepProvider).Deploy.func1.2()
 	/Users/runner/work/1/s/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go:230 +0x232
 created by github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/bicep.(*BicepProvider).Deploy.func1
 	/Users/runner/work/1/s/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go:216 +0x1dd
 ```

Inspecting the code made me realize we were not checking the return
value of `errors.As` so in some cases we would try to access a
property on a nil pointer. This fixes this issue (and I looked at
other `errors.As` usage in the tool to check we didn't have this
elsewhere).