### PR TITLE
Undo the merging of `writer` and `handles.Stdout`

### DIFF
--- a/cli/azd/pkg/commands/builder.go
+++ b/cli/azd/pkg/commands/builder.go
@@ -173,7 +173,7 @@ func createRootContext(
 	isTerminal := cmd.OutOrStdout() == os.Stdout &&
 		cmd.InOrStdin() == os.Stdin && isatty.IsTerminal(os.Stdin.Fd()) &&
 		isatty.IsTerminal(os.Stdout.Fd())
-	console := input.NewConsole(!rootOptions.NoPrompt, isTerminal, input.ConsoleHandles{
+	console := input.NewConsole(!rootOptions.NoPrompt, isTerminal, writer, input.ConsoleHandles{
 		Stdin:  cmd.InOrStdin(),
 		Stdout: cmd.OutOrStdout(),
 		Stderr: cmd.ErrOrStderr(),

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -139,14 +139,14 @@ func (c *AskerConsole) Handles() ConsoleHandles {
 }
 
 // Creates a new console with the specified handles and formatter
-func NewConsole(interactive bool, isTerminal bool, handles ConsoleHandles, formatter output.Formatter) Console {
+func NewConsole(interactive bool, isTerminal bool, w io.Writer, handles ConsoleHandles, formatter output.Formatter) Console {
 	asker := NewAsker(!interactive, isTerminal, handles.Stdout, handles.Stdin)
 
 	return &AskerConsole{
 		interactive: interactive,
 		asker:       asker,
 		handles:     handles,
-		writer:      handles.Stdout,
+		writer:      w,
 		formatter:   formatter,
 	}
 }


### PR DESCRIPTION
In #879 we incorrectly refactored things such that we would lose writing via the colorable writer when calling `Message` and friends. This change separates things such that we can have to same behavior as we had as before.