### PR TITLE
SetWriter should restore to original writer

### DIFF
--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -32,6 +32,8 @@ type AskerConsole struct {
 	interactive bool
 	asker       Asker
 	handles     ConsoleHandles
+	// the writer the console was constructed with, and what we reset to when SetWriter(nil) is called.
+	defaultWriter io.Writer
 	// the current writer, may differ from handles.Stdout when SetWriter has been
 	// called.
 	writer    io.Writer
@@ -54,7 +56,7 @@ type ConsoleHandles struct {
 // if writer is nil, sets it back to the default writer.
 func (c *AskerConsole) SetWriter(writer io.Writer) {
 	if writer == nil {
-		writer = c.handles.Stdout
+		writer = c.defaultWriter
 	}
 
 	c.writer = writer
@@ -138,16 +140,17 @@ func (c *AskerConsole) Handles() ConsoleHandles {
 	return c.handles
 }
 
-// Creates a new console with the specified handles and formatter
+// Creates a new console with the specified writer, handles and formatter.
 func NewConsole(interactive bool, isTerminal bool, w io.Writer, handles ConsoleHandles, formatter output.Formatter) Console {
 	asker := NewAsker(!interactive, isTerminal, handles.Stdout, handles.Stdin)
 
 	return &AskerConsole{
-		interactive: interactive,
-		asker:       asker,
-		handles:     handles,
-		writer:      w,
-		formatter:   formatter,
+		interactive:   interactive,
+		asker:         asker,
+		handles:       handles,
+		defaultWriter: w,
+		writer:        w,
+		formatter:     formatter,
 	}
 }
 

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -34,8 +34,7 @@ type AskerConsole struct {
 	handles     ConsoleHandles
 	// the writer the console was constructed with, and what we reset to when SetWriter(nil) is called.
 	defaultWriter io.Writer
-	// the current writer, may differ from handles.Stdout when SetWriter has been
-	// called.
+	// the writer which output is written to. 
 	writer    io.Writer
 	formatter output.Formatter
 }

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -34,7 +34,7 @@ type AskerConsole struct {
 	handles     ConsoleHandles
 	// the writer the console was constructed with, and what we reset to when SetWriter(nil) is called.
 	defaultWriter io.Writer
-	// the writer which output is written to. 
+	// the writer which output is written to.
 	writer    io.Writer
 	formatter output.Formatter
 }


### PR DESCRIPTION
I had intended this to be part of #891 but forgot to commit before pushing the PR. Originally, when SetWriter(nil) was called, we would use `GetDefaultWriter()` (which has since been removed) to re-fetch the same value that was passed in to `writer` when the object was created.

So store the originial writer for now and restore to it. We could otherwise run into issues when NO_COLOR was set where we'd not restore the stream that striped the ANSI color codes.