### PR TITLE
Require a `azcore.TokenCredential` when constructing an `AzCli`

### DIFF
--- a/cli/azd/cmd/wire_gen.go
+++ b/cli/azd/cmd/wire_gen.go
@@ -34,7 +34,11 @@ func initDeployAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flag
 	writer := newWriter(cmd)
 	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
-	azCli := newAzCliFromOptions(o, commandRunner)
+	tokenCredential, err := newCredential()
+	if err != nil {
+		return nil, err
+	}
+	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
 	cmdDeployAction, err := newDeployAction(flags, azdContext, azCli, console, formatter, writer)
 	if err != nil {
 		return nil, err
@@ -54,7 +58,11 @@ func initInitAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags 
 	writer := newWriter(cmd)
 	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
-	azCli := newAzCliFromOptions(o, commandRunner)
+	tokenCredential, err := newCredential()
+	if err != nil {
+		return nil, err
+	}
+	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
 	gitCli := git.NewGitCliFromRunner(commandRunner)
 	cmdInitAction, err := newInitAction(azdContext, commandRunner, console, azCli, gitCli, flags)
 	if err != nil {
@@ -71,7 +79,11 @@ func initLoginAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags
 	writer := newWriter(cmd)
 	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
-	azCli := newAzCliFromOptions(o, commandRunner)
+	tokenCredential, err := newCredential()
+	if err != nil {
+		return nil, err
+	}
+	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
 	cmdLoginAction := newLoginAction(formatter, writer, azCli, flags, console)
 	return cmdLoginAction, nil
 }
@@ -88,7 +100,11 @@ func initUpAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags up
 	writer := newWriter(cmd)
 	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
-	azCli := newAzCliFromOptions(o, commandRunner)
+	tokenCredential, err := newCredential()
+	if err != nil {
+		return nil, err
+	}
+	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
 	gitCli := git.NewGitCliFromRunner(commandRunner)
 	cmdInitFlags := flags.initFlags
 	cmdInitAction, err := newInitAction(azdContext, commandRunner, console, azCli, gitCli, cmdInitFlags)
@@ -118,7 +134,11 @@ func initMonitorAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, fla
 	writer := newWriter(cmd)
 	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
-	azCli := newAzCliFromOptions(o, commandRunner)
+	tokenCredential, err := newCredential()
+	if err != nil {
+		return nil, err
+	}
+	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
 	cmdMonitorAction := newMonitorAction(azdContext, azCli, console, flags)
 	return cmdMonitorAction, nil
 }
@@ -176,7 +196,11 @@ func initInfraCreateAction(cmd *cobra.Command, o *internal.GlobalCommandOptions,
 	writer := newWriter(cmd)
 	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
-	azCli := newAzCliFromOptions(o, commandRunner)
+	tokenCredential, err := newCredential()
+	if err != nil {
+		return nil, err
+	}
+	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
 	cmdInfraCreateAction := newInfraCreateAction(flags, azdContext, azCli, console, formatter, writer)
 	return cmdInfraCreateAction, nil
 }
@@ -193,7 +217,11 @@ func initInfraDeleteAction(cmd *cobra.Command, o *internal.GlobalCommandOptions,
 	writer := newWriter(cmd)
 	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
-	azCli := newAzCliFromOptions(o, commandRunner)
+	tokenCredential, err := newCredential()
+	if err != nil {
+		return nil, err
+	}
+	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
 	cmdInfraDeleteAction := newInfraDeleteAction(flags, azdContext, azCli, console)
 	return cmdInfraDeleteAction, nil
 }
@@ -210,7 +238,11 @@ func initEnvSetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flag
 	writer := newWriter(cmd)
 	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
-	azCli := newAzCliFromOptions(o, commandRunner)
+	tokenCredential, err := newCredential()
+	if err != nil {
+		return nil, err
+	}
+	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
 	cmdEnvSetAction := newEnvSetAction(azdContext, azCli, console, o, args)
 	return cmdEnvSetAction, nil
 }
@@ -250,7 +282,11 @@ func initEnvNewAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flag
 	writer := newWriter(cmd)
 	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
-	azCli := newAzCliFromOptions(o, commandRunner)
+	tokenCredential, err := newCredential()
+	if err != nil {
+		return nil, err
+	}
+	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
 	cmdEnvNewAction := newEnvNewAction(azdContext, azCli, flags, console)
 	return cmdEnvNewAction, nil
 }
@@ -267,7 +303,11 @@ func initEnvRefreshAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, 
 	writer := newWriter(cmd)
 	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
-	azCli := newAzCliFromOptions(o, commandRunner)
+	tokenCredential, err := newCredential()
+	if err != nil {
+		return nil, err
+	}
+	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
 	cmdEnvRefreshAction := newEnvRefreshAction(azdContext, azCli, o, console, formatter, writer)
 	return cmdEnvRefreshAction, nil
 }
@@ -284,7 +324,11 @@ func initEnvGetValuesAction(cmd *cobra.Command, o *internal.GlobalCommandOptions
 	writer := newWriter(cmd)
 	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
-	azCli := newAzCliFromOptions(o, commandRunner)
+	tokenCredential, err := newCredential()
+	if err != nil {
+		return nil, err
+	}
+	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
 	cmdEnvGetValuesAction := newEnvGetValuesAction(azdContext, console, formatter, writer, azCli, o)
 	return cmdEnvGetValuesAction, nil
 }

--- a/cli/azd/pkg/commands/builder.go
+++ b/cli/azd/pkg/commands/builder.go
@@ -32,12 +32,6 @@ func RegisterDependenciesInCtx(
 	runner := exec.NewCommandRunner(cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr())
 	ctx = exec.WithCommandRunner(ctx, runner)
 
-	azCliArgs := azcli.NewAzCliArgs{
-		EnableDebug:     rootOptions.EnableDebugLogging,
-		EnableTelemetry: rootOptions.EnableTelemetry,
-		CommandRunner:   runner,
-	}
-
 	// Set default credentials used for operations against azure data/control planes
 	credentials, err := azidentity.NewAzureCLICredential(nil)
 	if err != nil {
@@ -45,8 +39,14 @@ func RegisterDependenciesInCtx(
 	}
 	ctx = identity.WithCredentials(ctx, credentials)
 
+	azCliArgs := azcli.NewAzCliArgs{
+		EnableDebug:     rootOptions.EnableDebugLogging,
+		EnableTelemetry: rootOptions.EnableTelemetry,
+		CommandRunner:   runner,
+	}
+
 	// Create and set the AzCli that will be used for the command
-	azCli := azcli.NewAzCli(azCliArgs)
+	azCli := azcli.NewAzCli(credentials, azCliArgs)
 	ctx = azcli.WithAzCli(ctx, azCli)
 
 	// Attempt to get the user specified formatter from the command args

--- a/cli/azd/pkg/identity/credentials.go
+++ b/cli/azd/pkg/identity/credentials.go
@@ -2,31 +2,23 @@ package identity
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 )
 
 type contextKey string
 
 const credentialsContextKey contextKey = "azure_credentials"
 
-// Gets credentials for Azure from current context
-// If not found returns DefaultAzureCredential
-func GetCredentials(ctx context.Context) (azcore.TokenCredential, error) {
+// Gets credentials for Azure from current context or panics if none are present.
+func GetCredentials(ctx context.Context) azcore.TokenCredential {
 	cred, ok := ctx.Value(credentialsContextKey).(azcore.TokenCredential)
 
 	if !ok {
-		defaultCreds, err := azidentity.NewAzureCLICredential(nil)
-		if err != nil {
-			return nil, fmt.Errorf("getting azure credentials: %w", err)
-		}
-
-		cred = defaultCreds
+		panic("GetCredentials: no credentials in context")
 	}
 
-	return cred, nil
+	return cred
 }
 
 // Sets the specified Azure token credential in context and returns new context

--- a/cli/azd/pkg/tools/azcli/account.go
+++ b/cli/azd/pkg/tools/azcli/account.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
-	"github.com/azure/azure-dev/cli/azd/pkg/identity"
 )
 
 type AzCliSubscriptionInfo struct {
@@ -133,13 +132,8 @@ func (cli *azCli) ListAccountLocations(ctx context.Context, subscriptionId strin
 }
 
 func (cli *azCli) createSubscriptionsClient(ctx context.Context) (*armsubscriptions.Client, error) {
-	cred, err := identity.GetCredentials(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
-	client, err := armsubscriptions.NewClient(cred, options)
+	client, err := armsubscriptions.NewClient(cli.credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Subscriptions client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/azcli_test.go
+++ b/cli/azd/pkg/tools/azcli/azcli_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/identity"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,7 +30,7 @@ func TestAzCli(t *testing.T) {
 	t.Run("DebugAndTelemetryEnabled", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 
-		tempCli := NewAzCli(NewAzCliArgs{
+		tempCli := NewAzCli(identity.GetCredentials(*mockContext.Context), NewAzCliArgs{
 			EnableDebug:     true,
 			EnableTelemetry: true,
 			CommandRunner:   mockContext.CommandRunner,
@@ -66,7 +67,7 @@ func TestAzCli(t *testing.T) {
 	t.Run("DebugAndTelemetryDisabled", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 
-		tempCli := NewAzCli(NewAzCliArgs{
+		tempCli := NewAzCli(identity.GetCredentials(*mockContext.Context), NewAzCliArgs{
 			EnableDebug:     false,
 			EnableTelemetry: false,
 			CommandRunner:   mockContext.CommandRunner,
@@ -151,7 +152,7 @@ func runAndCaptureUserAgent(t *testing.T) string {
 	defaultRunner := exec.NewCommandRunner(os.Stdin, os.Stdout, os.Stderr)
 	mockContext := mocks.NewMockContext(context.Background())
 
-	azCli := NewAzCli(NewAzCliArgs{
+	azCli := NewAzCli(identity.GetCredentials(*mockContext.Context), NewAzCliArgs{
 		EnableDebug:     true,
 		EnableTelemetry: true,
 		CommandRunner:   mockContext.CommandRunner,
@@ -294,7 +295,7 @@ func TestAZCliGetAccessTokenTranslatesErrors(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			mockContext := mocks.NewMockContext(context.Background())
-			azCli := NewAzCli(NewAzCliArgs{
+			azCli := NewAzCli(identity.GetCredentials(*mockContext.Context), NewAzCliArgs{
 				EnableDebug:     true,
 				EnableTelemetry: true,
 				CommandRunner:   mockContext.CommandRunner,

--- a/cli/azd/pkg/tools/azcli/container_app.go
+++ b/cli/azd/pkg/tools/azcli/container_app.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers"
-	"github.com/azure/azure-dev/cli/azd/pkg/identity"
 )
 
 type AzCliContainerAppProperties struct {
@@ -35,13 +34,8 @@ func (cli *azCli) createContainerAppsClient(
 	ctx context.Context,
 	subscriptionId string,
 ) (*armappcontainers.ContainerAppsClient, error) {
-	cred, err := identity.GetCredentials(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
-	client, err := armappcontainers.NewContainerAppsClient(subscriptionId, cred, options)
+	client, err := armappcontainers.NewContainerAppsClient(subscriptionId, cli.credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating ContainerApps client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/container_registry.go
+++ b/cli/azd/pkg/tools/azcli/container_registry.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
-	"github.com/azure/azure-dev/cli/azd/pkg/identity"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
 	"golang.org/x/exp/slices"
 )
@@ -104,13 +103,8 @@ func (cli *azCli) createRegistriesClient(
 	ctx context.Context,
 	subscriptionId string,
 ) (*armcontainerregistry.RegistriesClient, error) {
-	cred, err := identity.GetCredentials(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
-	client, err := armcontainerregistry.NewRegistriesClient(subscriptionId, cred, options)
+	client, err := armcontainerregistry.NewRegistriesClient(subscriptionId, cli.credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating registries client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/deployments.go
+++ b/cli/azd/pkg/tools/azcli/deployments.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	"github.com/azure/azure-dev/cli/azd/pkg/identity"
 )
 
 func (cli *azCli) GetSubscriptionDeployment(
@@ -62,13 +61,8 @@ func (cli *azCli) createDeploymentsClient(
 	ctx context.Context,
 	subscriptionId string,
 ) (*armresources.DeploymentsClient, error) {
-	cred, err := identity.GetCredentials(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
-	client, err := armresources.NewDeploymentsClient(subscriptionId, cred, options)
+	client, err := armresources.NewDeploymentsClient(subscriptionId, cli.credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating deployments client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/keyvault.go
+++ b/cli/azd/pkg/tools/azcli/keyvault.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
-	"github.com/azure/azure-dev/cli/azd/pkg/identity"
 )
 
 type AzCliKeyVault struct {
@@ -112,13 +111,8 @@ func (cli *azCli) PurgeKeyVault(ctx context.Context, subscriptionId string, vaul
 
 // Creates a KeyVault client for ARM control plane operations
 func (cli *azCli) createKeyVaultClient(ctx context.Context, subscriptionId string) (*armkeyvault.VaultsClient, error) {
-	cred, err := identity.GetCredentials(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
-	client, err := armkeyvault.NewVaultsClient(subscriptionId, cred, options)
+	client, err := armkeyvault.NewVaultsClient(subscriptionId, cli.credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
 	}
@@ -129,16 +123,11 @@ func (cli *azCli) createKeyVaultClient(ctx context.Context, subscriptionId strin
 // Creates a KeyVault client for data plan operations
 // Data plane client is able to fetch secret values. ARM control plane client never returns secret values.
 func (cli *azCli) createSecretsDataClient(ctx context.Context, vaultUrl string) (*azsecrets.Client, error) {
-	cred, err := identity.GetCredentials(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	coreOptions := cli.createDefaultClientOptionsBuilder(ctx).BuildCoreClientOptions()
 	options := &azsecrets.ClientOptions{
 		ClientOptions:                        *coreOptions,
 		DisableChallengeResourceVerification: false,
 	}
 
-	return azsecrets.NewClient(vaultUrl, cred, options), nil
+	return azsecrets.NewClient(vaultUrl, cli.credential, options), nil
 }

--- a/cli/azd/pkg/tools/azcli/resources.go
+++ b/cli/azd/pkg/tools/azcli/resources.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	"github.com/azure/azure-dev/cli/azd/pkg/identity"
 )
 
 func (cli *azCli) GetResource(
@@ -138,13 +137,8 @@ func (cli *azCli) DeleteResourceGroup(ctx context.Context, subscriptionId string
 }
 
 func (cli *azCli) createResourcesClient(ctx context.Context, subscriptionId string) (*armresources.Client, error) {
-	cred, err := identity.GetCredentials(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
-	client, err := armresources.NewClient(subscriptionId, cred, options)
+	client, err := armresources.NewClient(subscriptionId, cli.credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
 	}
@@ -156,13 +150,8 @@ func (cli *azCli) createResourceGroupClient(
 	ctx context.Context,
 	subscriptionId string,
 ) (*armresources.ResourceGroupsClient, error) {
-	cred, err := identity.GetCredentials(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
-	client, err := armresources.NewResourceGroupsClient(subscriptionId, cred, options)
+	client, err := armresources.NewResourceGroupsClient(subscriptionId, cli.credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating ResourceGroup client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/static_webapp.go
+++ b/cli/azd/pkg/tools/azcli/static_webapp.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice"
-	"github.com/azure/azure-dev/cli/azd/pkg/identity"
 )
 
 type AzCliStaticWebAppProperties struct {
@@ -90,13 +89,8 @@ func (cli *azCli) createStaticSitesClient(
 	ctx context.Context,
 	subscriptionId string,
 ) (*armappservice.StaticSitesClient, error) {
-	cred, err := identity.GetCredentials(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
-	client, err := armappservice.NewStaticSitesClient(subscriptionId, cred, options)
+	client, err := armappservice.NewStaticSitesClient(subscriptionId, cli.credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Static Sites client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/webapp.go
+++ b/cli/azd/pkg/tools/azcli/webapp.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice"
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
-	"github.com/azure/azure-dev/cli/azd/pkg/identity"
 )
 
 type AzCliAppServiceProperties struct {
@@ -57,13 +56,8 @@ func (cli *azCli) DeployAppServiceZip(
 }
 
 func (cli *azCli) createWebAppsClient(ctx context.Context, subscriptionId string) (*armappservice.WebAppsClient, error) {
-	cred, err := identity.GetCredentials(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
-	client, err := armappservice.NewWebAppsClient(subscriptionId, cred, options)
+	client, err := armappservice.NewWebAppsClient(subscriptionId, cli.credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating WebApps client: %w", err)
 	}
@@ -72,13 +66,9 @@ func (cli *azCli) createWebAppsClient(ctx context.Context, subscriptionId string
 }
 
 func (cli *azCli) createZipDeployClient(ctx context.Context, subscriptionId string) (*azsdk.ZipDeployClient, error) {
-	cred, err := identity.GetCredentials(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
-	client, err := azsdk.NewZipDeployClient(subscriptionId, cred, options)
+	client, err := azsdk.NewZipDeployClient(subscriptionId, cli.credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating WebApps client: %w", err)
 	}

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -26,11 +26,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/identity"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
@@ -186,6 +188,13 @@ func Test_CLI_InfraCreateAndDelete(t *testing.T) {
 	// NewAzureResourceManager needs a command runner right now (since it can call the AZ CLI)
 	ctx = exec.WithCommandRunner(ctx, exec.NewCommandRunner(os.Stdin, os.Stdout, os.Stderr))
 
+	// GetResourceGroupsForEnvironment requires a credential since it is using the SDK now
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		t.Fatal("could not create credential")
+	}
+	ctx = identity.WithCredentials(ctx, cred)
+
 	// Verify that resource groups are created with tag
 	resourceManager := infra.NewAzureResourceManager(ctx)
 	rgs, err := resourceManager.GetResourceGroupsForEnvironment(ctx, env)
@@ -234,6 +243,13 @@ func Test_CLI_InfraCreateAndDeleteUpperCase(t *testing.T) {
 
 	// NewAzureResourceManager needs a command runner right now (since it can call the AZ CLI)
 	ctx = exec.WithCommandRunner(ctx, exec.NewCommandRunner(os.Stdin, os.Stdout, os.Stderr))
+
+	// GetResourceGroupsForEnvironment requires a credential since it is using the SDK now
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		t.Fatal("could not create credential")
+	}
+	ctx = identity.WithCredentials(ctx, cred)
 
 	// Verify that resource groups are created with tag
 	resourceManager := infra.NewAzureResourceManager(ctx)


### PR DESCRIPTION
As part of this change, I adjusted `identity.GetCredentials` to panic if one was not found in the context.