### PR TITLE
Do not disable output when `noPrompt` is specified

### DIFF
--- a/cli/azd/cmd/sets.go
+++ b/cli/azd/cmd/sets.go
@@ -49,7 +49,7 @@ func newConsoleFromOptions(
 		cmd.InOrStdin() == os.Stdin && isatty.IsTerminal(os.Stdin.Fd()) &&
 		isatty.IsTerminal(os.Stdout.Fd())
 
-	return input.NewConsole(!rootOptions.NoPrompt, isTerminal, writer, input.ConsoleHandles{
+	return input.NewConsole(rootOptions.NoPrompt, isTerminal, writer, input.ConsoleHandles{
 		Stdin:  cmd.InOrStdin(),
 		Stdout: cmd.OutOrStdout(),
 		Stderr: cmd.ErrOrStderr(),

--- a/cli/azd/pkg/commands/builder.go
+++ b/cli/azd/pkg/commands/builder.go
@@ -77,7 +77,7 @@ func RegisterDependenciesInCtx(
 	isTerminal := cmd.OutOrStdout() == os.Stdout &&
 		cmd.InOrStdin() == os.Stdin && isatty.IsTerminal(os.Stdin.Fd()) &&
 		isatty.IsTerminal(os.Stdout.Fd())
-	console := input.NewConsole(!rootOptions.NoPrompt, isTerminal, writer, input.ConsoleHandles{
+	console := input.NewConsole(rootOptions.NoPrompt, isTerminal, writer, input.ConsoleHandles{
 		Stdin:  cmd.InOrStdin(),
 		Stdout: cmd.OutOrStdout(),
 		Stderr: cmd.ErrOrStderr(),

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -29,9 +29,8 @@ type Console interface {
 }
 
 type AskerConsole struct {
-	interactive bool
-	asker       Asker
-	handles     ConsoleHandles
+	asker   Asker
+	handles ConsoleHandles
 	// the writer the console was constructed with, and what we reset to when SetWriter(nil) is called.
 	defaultWriter io.Writer
 	// the writer which output is written to.
@@ -63,8 +62,8 @@ func (c *AskerConsole) SetWriter(writer io.Writer) {
 
 // Prints out a message to the underlying console write
 func (c *AskerConsole) Message(ctx context.Context, message string) {
-	// Only write to the console during interactive & non-formatted responses.
-	if c.interactive && (c.formatter == nil || c.formatter.Kind() == output.NoneFormat) {
+	// Disable output when formatting is enabled
+	if c.formatter == nil || c.formatter.Kind() == output.NoneFormat {
 		fmt.Fprintln(c.writer, message)
 	} else {
 		log.Println(message)
@@ -140,11 +139,10 @@ func (c *AskerConsole) Handles() ConsoleHandles {
 }
 
 // Creates a new console with the specified writer, handles and formatter.
-func NewConsole(interactive bool, isTerminal bool, w io.Writer, handles ConsoleHandles, formatter output.Formatter) Console {
-	asker := NewAsker(!interactive, isTerminal, handles.Stdout, handles.Stdin)
+func NewConsole(noPrompt bool, isTerminal bool, w io.Writer, handles ConsoleHandles, formatter output.Formatter) Console {
+	asker := NewAsker(noPrompt, isTerminal, handles.Stdout, handles.Stdin)
 
 	return &AskerConsole{
-		interactive:   interactive,
 		asker:         asker,
 		handles:       handles,
 		defaultWriter: w,


### PR DESCRIPTION
`azd` used to produce output when --no-prompt is specified. However, this behavior was changed in a console refactor. 

Here's the current description of `--no-prompt`:
```
     --no-prompt            Accepts the default value instead of prompting, or it fails if there is no default.
```

This is currently causing pipelines generated by `azd pipeline config` to have no output for `azd provision`. In `azd deploy`, some output escapes as we don't consistently use `console.Message`.