### PR TITLE
Add github actions check enforcer

### DIFF
--- a/.github/workflows/event.yml
+++ b/.github/workflows/event.yml
@@ -1,0 +1,25 @@
+# NOTE: currently azure-sdk-actions only hosts check enforcer code.
+# If further functionality is added, this name should be updated to reflect
+# the more generic behavior
+name: Check Enforcer
+
+on:
+  check_suite:
+    types: [completed]
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  event-handler:
+    permissions:
+      statuses: write # to set status (azure/azure-sdk-actions)
+      pull-requests: read # to read pull requests (azure/azure-sdk-actions)
+      checks: read # to read check status (azure/azure-sdk-actions)
+    name: Handle ${{ github.event_name }} ${{ github.event.action }} event
+    runs-on: ubuntu-latest
+    steps:
+      - uses: azure/azure-sdk-actions@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adding check enforcer v2 action to repository. See https://github.com/Azure/azure-sdk-tools/pull/3287 for details.

The naming of the file is a little generic because for the other sdk repos we had in mind to make "one handler to rule them all." In this repo there are more actions defined, so I can change the yaml filename if people like.