### PR TITLE
Remove VS Code extension dependency on `fs-extra`

### DIFF
--- a/ext/vscode/package-lock.json
+++ b/ext/vscode/package-lock.json
@@ -12,7 +12,6 @@
                 "@microsoft/vscode-azext-utils": "~0.3.15",
                 "dayjs": "~1.11",
                 "dotenv": "~16.0",
-                "fs-extra": "~10.1",
                 "glob": "~8.0",
                 "vscode-tas-client": "~0.1"
             },
@@ -2459,19 +2458,6 @@
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
             "dev": true
         },
-        "node_modules/fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2681,7 +2667,8 @@
         "node_modules/graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
         },
         "node_modules/grapheme-splitter": {
             "version": "1.0.4",
@@ -3149,17 +3136,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
             }
         },
         "node_modules/keytar": {
@@ -5101,14 +5077,6 @@
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
             "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==",
             "dev": true
-        },
-        "node_modules/universalify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-            "engines": {
-                "node": ">= 10.0.0"
-            }
         },
         "node_modules/unzipper": {
             "version": "0.10.11",
@@ -7507,16 +7475,6 @@
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
             "dev": true
         },
-        "fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-            "requires": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            }
-        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -7678,7 +7636,8 @@
         "graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
         },
         "grapheme-splitter": {
             "version": "1.0.4",
@@ -8002,15 +7961,6 @@
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
             "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
             "dev": true
-        },
-        "jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "requires": {
-                "graceful-fs": "^4.1.6",
-                "universalify": "^2.0.0"
-            }
         },
         "keytar": {
             "version": "7.9.0",
@@ -9421,11 +9371,6 @@
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
             "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==",
             "dev": true
-        },
-        "universalify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
         },
         "unzipper": {
             "version": "0.10.11",

--- a/ext/vscode/package.json
+++ b/ext/vscode/package.json
@@ -230,7 +230,6 @@
     "dependencies": {
       "@microsoft/vscode-azext-utils": "~0.3.15",
       "glob": "~8.0",
-      "fs-extra": "~10.1",
       "dotenv": "~16.0",
       "dayjs": "~1.11",
       "vscode-tas-client": "~0.1"

--- a/ext/vscode/src/commands/cmdUtil.ts
+++ b/ext/vscode/src/commands/cmdUtil.ts
@@ -8,16 +8,9 @@ import { IActionContext, IAzureQuickPickItem, UserCancelledError } from '@micros
 import { localize } from '../localize';
 import { createAzureDevCli } from "../utils/azureDevCli";
 import { execAsync } from "../utils/process";
+import { fileExists } from '../utils/fileUtils';
 
 const AzureYamlGlobPattern: vscode.GlobPattern = '**/[aA][zZ][uU][rR][eE].[yY][aA][mM][lL]';
-
-async function fileExists(path: vscode.Uri): Promise<boolean> {
-    try {
-        return (await vscode.workspace.fs.stat(path)).type === vscode.FileType.File;
-    } catch {
-        return false;
-    }
-}
 
 // If the command was invoked with a specific file context, use the file context as the working directory for running Azure dev CLI commands.
 // Otherwise search the workspace for "azure.yaml" files. If only one is found, use it (i.e. its folder). If more than one is found, ask the user which one to use.

--- a/ext/vscode/src/commands/cmdUtil.ts
+++ b/ext/vscode/src/commands/cmdUtil.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import * as vscode from 'vscode';
-import * as fse from 'fs-extra';
 import * as path from 'path';
 import { createHash } from 'crypto';
 import { IActionContext, IAzureQuickPickItem, UserCancelledError } from '@microsoft/vscode-azext-utils';
@@ -11,6 +10,14 @@ import { createAzureDevCli } from "../utils/azureDevCli";
 import { execAsync } from "../utils/process";
 
 const AzureYamlGlobPattern: vscode.GlobPattern = '**/[aA][zZ][uU][rR][eE].[yY][aA][mM][lL]';
+
+async function fileExists(path: vscode.Uri): Promise<boolean> {
+    try {
+        return (await vscode.workspace.fs.stat(path)).type === vscode.FileType.File;
+    } catch {
+        return false;
+    }
+}
 
 // If the command was invoked with a specific file context, use the file context as the working directory for running Azure dev CLI commands.
 // Otherwise search the workspace for "azure.yaml" files. If only one is found, use it (i.e. its folder). If more than one is found, ask the user which one to use.
@@ -37,13 +44,15 @@ export async function getWorkingFolder(context: IActionContext, selectedFile?: v
             throw new UserCancelledError();
         }
 
-        folderPath = localFolderUris[0].fsPath;
+        const folderUri = localFolderUris[0];
+        const azureYamlUri = vscode.Uri.joinPath(folderUri, 'azure.yaml');
 
-        const azureYamlPath = path.join(folderPath, 'azure.yaml');
-        if (!await fse.pathExists(azureYamlPath)) {
+        if (!await fileExists(azureYamlUri)) {
             context.errorHandling.suppressReportIssue = true;
             throw new Error(localize('azure-dev.commands.util.noAzureYamlFile', "The selected folder does not contain 'azure.yaml' file and cannot be used to run Azure Developer CLI commands"));
         }
+
+        folderPath = folderUri.fsPath;
     }
 
     return folderPath;
@@ -137,7 +146,7 @@ function sha256(s: string): string {
     return retval;
 }
 
-export async function showReadmeFile(folder: string | undefined): Promise<void> {
+export async function showReadmeFile(folder: vscode.Uri | undefined): Promise<void> {
     // The whole action is "best effort" -- if folder/file do not exist, just do nothing.
 
     if (!folder) {
@@ -147,9 +156,9 @@ export async function showReadmeFile(folder: string | undefined): Promise<void> 
     const candidates: string[] = ["README.md", "README.MD", "readme.md"];
 
     for (const fname of candidates) {
-        const fullPath = path.join(folder, fname);
-        if (await fse.pathExists(fullPath)) {
-            void vscode.commands.executeCommand('markdown.showPreview', vscode.Uri.file(fullPath), { 'sideBySide': false });
+        const fullPath = vscode.Uri.joinPath(folder, fname);
+        if (await fileExists(fullPath)) {
+            void vscode.commands.executeCommand('markdown.showPreview', fullPath, { 'sideBySide': false });
             return;
         }
     }

--- a/ext/vscode/src/commands/init.ts
+++ b/ext/vscode/src/commands/init.ts
@@ -22,12 +22,12 @@ export async function init(context: IActionContext, selectedFile?: vscode.Uri, a
     const command = azureCli.commandBuilder
         .withArg('init')
         .withNamedArg('-t', {value: templateUrl, quoting: vscode.ShellQuoting.Strong});
-    const workspacePath = folder?.uri.fsPath;
+    const workspacePath = folder?.uri;
 
     // Don't wait
     void executeAsTask(command.build(), getAzDevTerminalTitle(), {
         alwaysRunNew: true,
-        cwd: workspacePath,
+        cwd: workspacePath.fsPath,
         env: azureCli.env
     }, TelemetryId.InitCli).then(() => {
         void showReadmeFile(workspacePath);

--- a/ext/vscode/src/commands/up.ts
+++ b/ext/vscode/src/commands/up.ts
@@ -39,7 +39,7 @@ export async function up(context: IActionContext, selectedFile?: vscode.Uri): Pr
     }, TelemetryId.UpCli).then(() => {
         // Only show README if we are initializing a new workspace/application
         if (!azureYamlFile) {
-            void showReadmeFile(workingDir.fsPath);
+            void showReadmeFile(workingDir);
         }
     });
 }

--- a/ext/vscode/src/utils/fileUtils.ts
+++ b/ext/vscode/src/utils/fileUtils.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as vscode from 'vscode';
+
+export async function fileExists(path: vscode.Uri): Promise<boolean> {
+    try {
+        return (await vscode.workspace.fs.stat(path)).type === vscode.FileType.File;
+    } catch {
+        return false;
+    }
+}

--- a/ext/vscode/webpack.config.js
+++ b/ext/vscode/webpack.config.js
@@ -11,7 +11,7 @@
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
-const fse = require('fs-extra');
+const fs = require('fs/promises');
 const CopyPlugin = require('copy-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
@@ -70,7 +70,7 @@ const config = {
             // Webpack does not preserve the execute permission on the above xdg-open script, so apply it again within the bundle
             apply: (compiler) => {
                 compiler.hooks.afterEmit.tapPromise('AzCodeCopyWorkaround', async () => {
-                    await fse.chmod('./dist/node_modules/open/xdg-open', '755');
+                    await fs.chmod('./dist/node_modules/open/xdg-open', '755');
                 });
             },
         },


### PR DESCRIPTION
Removes the VS Code extension's dependency on `fs-extra` which is more or less supplanted by `fs/promises` in the runtime itself, or with equivalents in VS Code's virtualized file system API.

Resolves #675