### PR TITLE
Add provision command to the Azure Resources "create resources" menu.

### DIFF
--- a/ext/vscode/package.json
+++ b/ext/vscode/package.json
@@ -42,8 +42,8 @@
           "commands": [
               {
                   "command": "azure-dev.commands.cli.provision",
-                  "title": "Create with the Azure Developer CLI (azd)...",
-                  "detail": "Use the Azure Developer CLI to set up all application resources."
+                  "title": "Create application infrastructure using azd...",
+                  "detail": "Use the Azure Developer CLI to set up application infrastructure resources (azd provision)."
               }
           ]
         },

--- a/ext/vscode/package.json
+++ b/ext/vscode/package.json
@@ -38,7 +38,16 @@
     ],
     "main": "./main.js",
     "contributes": {
-      "commands": [
+        "x-azResources": {
+          "commands": [
+              {
+                  "command": "azure-dev.commands.cli.provision",
+                  "title": "Create with the Azure Developer CLI (azd)...",
+                  "detail": "Use the Azure Developer CLI to set up all application resources."
+              }
+          ]
+        },
+        "commands": [
         {
           "category": "%azure-dev.commands_category%",
           "command": "azure-dev.commands.cli.init",


### PR DESCRIPTION
Add the `azd provision` command to the "create resources" menu of the Azure Resources view.

<img width="1397" alt="Screenshot 2022-10-21 at 10 10 41" src="https://user-images.githubusercontent.com/6402946/197251853-91f7bd0e-832e-481b-8637-622232b02664.png">

Resolves #924