### PR TITLE
stringify default value in github prompt

### DIFF
--- a/cli/azd/pkg/commands/pipeline/github_provider.go
+++ b/cli/azd/pkg/commands/pipeline/github_provider.go
@@ -258,7 +258,7 @@ func notifyWhenGitHubActionsAreDisabled(
 				manualChoice.String(),
 				cancelChoice.String(),
 			},
-			DefaultValue: manualChoice,
+			DefaultValue: manualChoice.String(),
 		})
 
 		if err != nil {


### PR DESCRIPTION
Quick fix for a broken UI prompt.

User reported error:
```
? What would you like to do now?  [Use arrows to move, type to filter]
> I have manually enabled GitHub Actions. Continue with pushing my changes.
  Exit without pushing my changes. I don't need to run GitHub actions right now.
Error: check git push prevent: prompting to enable github actions: default value of select must be an int or string
```

I could reproduce this locally in a unit test.