### PR TITLE
Adds new config command category

### DIFF
--- a/.vscode/cspell.global.yaml
+++ b/.vscode/cspell.global.yaml
@@ -70,6 +70,7 @@ ignoreWords:
     - magefile
     - menuid
     - migr
+    - mockconfig
     - mockconsole
     - mockexec
     - mockhttp

--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -32,6 +32,7 @@ func configListCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command,
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Lists all configuration values",
+		Long:  "Lists all configuration values",
 	}
 
 	output.AddOutputParam(
@@ -47,6 +48,7 @@ func configGetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, 
 	cmd := &cobra.Command{
 		Use:   "get <key>",
 		Short: "Gets a configuration",
+		Long:  "Gets a configuration",
 	}
 
 	output.AddOutputParam(
@@ -63,6 +65,7 @@ func configSetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, 
 	cmd := &cobra.Command{
 		Use:   "set <key> <value>",
 		Short: "Sets a configuration",
+		Long:  "Sets a configuration",
 	}
 	cmd.Args = cobra.ExactArgs(2)
 	return cmd, &struct{}{}
@@ -72,6 +75,7 @@ func configUnsetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command
 	cmd := &cobra.Command{
 		Use:   "unset <key>",
 		Short: "Unsets a configuration",
+		Long:  "Unsets a configuration",
 	}
 	cmd.Args = cobra.ExactArgs(1)
 	return cmd, &struct{}{}
@@ -91,6 +95,7 @@ func newConfigListAction(config config.Config, formatter output.Formatter, write
 	}
 }
 
+// Executes the `azd config list` action
 func (a *configListAction) Run(ctx context.Context) error {
 	values := a.config.Raw()
 
@@ -120,6 +125,7 @@ func newConfigGetAction(config config.Config, formatter output.Formatter, writer
 	}
 }
 
+// Executes the `azd config get <key>` action
 func (a *configGetAction) Run(ctx context.Context) error {
 	key := a.args[0]
 	value, ok := a.config.Get(key)
@@ -150,6 +156,7 @@ func newConfigSetAction(config config.Config, args []string) *configSetAction {
 	}
 }
 
+// Executes the `azd config set <key> <value>` action
 func (a *configSetAction) Run(ctx context.Context) error {
 	path := a.args[0]
 	value := a.args[1]
@@ -179,6 +186,7 @@ func newConfigUnsetAction(config config.Config, args []string) *configUnsetActio
 	}
 }
 
+// Executes the `azd config unset <key>` action
 func (a *configUnsetAction) Run(ctx context.Context) error {
 	path := a.args[0]
 

--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -46,7 +46,7 @@ func configListCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command,
 
 func configGetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, *struct{}) {
 	cmd := &cobra.Command{
-		Use:   "get <key>",
+		Use:   "get <path>",
 		Short: "Gets a configuration",
 		Long:  "Gets a configuration",
 	}
@@ -63,7 +63,7 @@ func configGetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, 
 
 func configSetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, *struct{}) {
 	cmd := &cobra.Command{
-		Use:   "set <key> <value>",
+		Use:   "set <path> <value>",
 		Short: "Sets a configuration",
 		Long:  "Sets a configuration",
 	}
@@ -73,7 +73,7 @@ func configSetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, 
 
 func configUnsetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, *struct{}) {
 	cmd := &cobra.Command{
-		Use:   "unset <key>",
+		Use:   "unset <path>",
 		Short: "Unsets a configuration",
 		Long:  "Unsets a configuration",
 	}
@@ -125,7 +125,7 @@ func newConfigGetAction(config config.Config, formatter output.Formatter, writer
 	}
 }
 
-// Executes the `azd config get <key>` action
+// Executes the `azd config get <path>` action
 func (a *configGetAction) Run(ctx context.Context) error {
 	key := a.args[0]
 	value, ok := a.config.Get(key)
@@ -156,7 +156,7 @@ func newConfigSetAction(config config.Config, args []string) *configSetAction {
 	}
 }
 
-// Executes the `azd config set <key> <value>` action
+// Executes the `azd config set <path> <value>` action
 func (a *configSetAction) Run(ctx context.Context) error {
 	path := a.args[0]
 	value := a.args[1]
@@ -186,7 +186,7 @@ func newConfigUnsetAction(config config.Config, args []string) *configUnsetActio
 	}
 }
 
-// Executes the `azd config unset <key>` action
+// Executes the `azd config unset <path>` action
 func (a *configUnsetAction) Run(ctx context.Context) error {
 	path := a.args[0]
 

--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -109,7 +109,12 @@ type configGetAction struct {
 	args          []string
 }
 
-func newConfigGetAction(configManager config.Manager, formatter output.Formatter, writer io.Writer, args []string) *configGetAction {
+func newConfigGetAction(
+	configManager config.Manager,
+	formatter output.Formatter,
+	writer io.Writer,
+	args []string,
+) *configGetAction {
 	return &configGetAction{
 		configManager: configManager,
 		formatter:     formatter,

--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
+	"os"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
@@ -23,6 +25,7 @@ func configCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 	root.AddCommand(BuildCmd(rootOptions, configGetCmdDesign, initConfigGetAction, nil))
 	root.AddCommand(BuildCmd(rootOptions, configSetCmdDesign, initConfigSetAction, nil))
 	root.AddCommand(BuildCmd(rootOptions, configUnsetCmdDesign, initConfigUnsetAction, nil))
+	root.AddCommand(BuildCmd(rootOptions, configResetCmdDesign, initConfigResetAction, nil))
 
 	root.Flags().BoolP("help", "h", false, fmt.Sprintf("Gets help for %s.", root.Name()))
 
@@ -63,7 +66,11 @@ func newConfigListAction(configManager config.Manager, formatter output.Formatte
 
 // Executes the `azd config list` action
 func (a *configListAction) Run(ctx context.Context) error {
-	azdConfig := getUserConfig(a.configManager)
+	azdConfig, err := getUserConfig(a.configManager)
+	if err != nil {
+		return err
+	}
+
 	values := azdConfig.Raw()
 
 	if a.formatter.Kind() == output.JsonFormat {
@@ -113,7 +120,11 @@ func newConfigGetAction(configManager config.Manager, formatter output.Formatter
 
 // Executes the `azd config get <path>` action
 func (a *configGetAction) Run(ctx context.Context) error {
-	azdConfig := getUserConfig(a.configManager)
+	azdConfig, err := getUserConfig(a.configManager)
+	if err != nil {
+		return err
+	}
+
 	key := a.args[0]
 	value, ok := azdConfig.Get(key)
 
@@ -157,21 +168,25 @@ func newConfigSetAction(configManager config.Manager, args []string) *configSetA
 
 // Executes the `azd config set <path> <value>` action
 func (a *configSetAction) Run(ctx context.Context) error {
-	azdConfig := getUserConfig(a.configManager)
+	azdConfig, err := getUserConfig(a.configManager)
+	if err != nil {
+		return err
+	}
+
 	path := a.args[0]
 	value := a.args[1]
 
-	err := azdConfig.Set(path, value)
+	err = azdConfig.Set(path, value)
 	if err != nil {
 		return fmt.Errorf("failed setting configuration value '%s' to '%s'. %w", path, value, err)
 	}
 
-	userFilePath, err := config.GetUserConfigFilePath()
+	userConfigFilePath, err := config.GetUserConfigFilePath()
 	if err != nil {
 		return fmt.Errorf("failed getting user config file path. %w", err)
 	}
 
-	err = a.configManager.Save(azdConfig, userFilePath)
+	err = a.configManager.Save(azdConfig, userConfigFilePath)
 	if err != nil {
 		return fmt.Errorf("failed saving configuration. %w", err)
 	}
@@ -205,20 +220,24 @@ func newConfigUnsetAction(configManager config.Manager, args []string) *configUn
 
 // Executes the `azd config unset <path>` action
 func (a *configUnsetAction) Run(ctx context.Context) error {
-	azdConfig := getUserConfig(a.configManager)
+	azdConfig, err := getUserConfig(a.configManager)
+	if err != nil {
+		return err
+	}
+
 	path := a.args[0]
 
-	err := azdConfig.Unset(path)
+	err = azdConfig.Unset(path)
 	if err != nil {
 		return fmt.Errorf("failed removing configuration with path '%s'. %w", path, err)
 	}
 
-	userFilePath, err := config.GetUserConfigFilePath()
+	userConfigFilePath, err := config.GetUserConfigFilePath()
 	if err != nil {
 		return fmt.Errorf("failed getting user config file path. %w", err)
 	}
 
-	err = a.configManager.Save(azdConfig, userFilePath)
+	err = a.configManager.Save(azdConfig, userConfigFilePath)
 	if err != nil {
 		return fmt.Errorf("failed saving configuration. %w", err)
 	}
@@ -226,22 +245,66 @@ func (a *configUnsetAction) Run(ctx context.Context) error {
 	return nil
 }
 
-func getUserConfig(configManager config.Manager) config.Config {
+// azd config reset
+
+func configResetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, *struct{}) {
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Resets configuration to default",
+		Long:  "Resets configuration to default",
+	}
+
+	return cmd, &struct{}{}
+}
+
+type configResetAction struct {
+	configManager config.Manager
+	args          []string
+}
+
+func newConfigResetAction(configManager config.Manager, args []string) *configResetAction {
+	return &configResetAction{
+		configManager: configManager,
+		args:          args,
+	}
+}
+
+// Executes the `azd config reset` action
+func (a *configResetAction) Run(ctx context.Context) error {
+	userConfigFilePath, err := config.GetUserConfigFilePath()
+	if err != nil {
+		return fmt.Errorf("failed getting user config file path. %w", err)
+	}
+
+	emptyConfig := config.NewConfig(nil)
+
+	err = a.configManager.Save(emptyConfig, userConfigFilePath)
+	if err != nil {
+		return fmt.Errorf("failed saving configuration. %w", err)
+	}
+
+	return nil
+}
+
+func getUserConfig(configManager config.Manager) (config.Config, error) {
 	var azdConfig config.Config
 
 	configFilePath, err := config.GetUserConfigFilePath()
 	if err != nil {
-		log.Printf("failed retrieving azd user config file path. %s\n", err.Error())
+		return nil, err
 	}
 
 	azdConfig, err = configManager.Load(configFilePath)
 	if err != nil {
-		log.Printf("failed loading azd user config. %s\n", err.Error())
+		// Ignore missing file errors
+		// File will automatically be created on first `set` operation
+		if errors.Is(err, os.ErrNotExist) {
+			log.Printf("failed loading azd user config from '%s'. %s\n", configFilePath, err.Error())
+			return config.NewConfig(nil), nil
+		}
+
+		return nil, fmt.Errorf("failed loading azd user config from '%s'. %w", configFilePath, err)
 	}
 
-	if azdConfig == nil {
-		azdConfig = config.NewConfig(nil)
-	}
-
-	return azdConfig
+	return azdConfig, nil
 }

--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/spf13/cobra"
+)
+
+// Setup account command category
+func configCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
+	root := &cobra.Command{
+		Use:   "config",
+		Short: "Manage Azure Developer CLI configuration",
+	}
+
+	root.AddCommand(BuildCmd(rootOptions, configListCmdDesign, initConfigListAction, nil))
+	root.AddCommand(BuildCmd(rootOptions, configGetCmdDesign, initConfigGetAction, nil))
+	root.AddCommand(BuildCmd(rootOptions, configSetCmdDesign, initConfigSetAction, nil))
+	root.AddCommand(BuildCmd(rootOptions, configUnsetCmdDesign, initConfigUnsetAction, nil))
+
+	root.Flags().BoolP("help", "h", false, fmt.Sprintf("Gets help for %s.", root.Name()))
+
+	return root
+}
+
+func configListCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, *struct{}) {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Lists all configuration values",
+	}
+
+	output.AddOutputParam(
+		cmd,
+		[]output.Format{output.JsonFormat},
+		output.JsonFormat,
+	)
+
+	return cmd, &struct{}{}
+}
+
+func configGetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, *struct{}) {
+	cmd := &cobra.Command{
+		Use:   "get <key>",
+		Short: "Gets a configuration",
+	}
+
+	output.AddOutputParam(
+		cmd,
+		[]output.Format{output.JsonFormat},
+		output.JsonFormat,
+	)
+
+	cmd.Args = cobra.ExactArgs(1)
+	return cmd, &struct{}{}
+}
+
+func configSetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, *struct{}) {
+	cmd := &cobra.Command{
+		Use:   "set <key> <value>",
+		Short: "Sets a configuration",
+	}
+	cmd.Args = cobra.ExactArgs(2)
+	return cmd, &struct{}{}
+}
+
+func configUnsetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, *struct{}) {
+	cmd := &cobra.Command{
+		Use:   "unset <key>",
+		Short: "Unsets a configuration",
+	}
+	cmd.Args = cobra.ExactArgs(1)
+	return cmd, &struct{}{}
+}
+
+type configListAction struct {
+	config    config.Config
+	formatter output.Formatter
+	writer    io.Writer
+}
+
+func newConfigListAction(config config.Config, formatter output.Formatter, writer io.Writer) *configListAction {
+	return &configListAction{
+		config:    config,
+		formatter: formatter,
+		writer:    writer,
+	}
+}
+
+func (a *configListAction) Run(ctx context.Context) error {
+	values := a.config.Raw()
+
+	if a.formatter.Kind() == output.JsonFormat {
+		err := a.formatter.Format(values, a.writer, nil)
+		if err != nil {
+			return fmt.Errorf("failing formatting config values: %w", err)
+		}
+	}
+
+	return nil
+}
+
+type configGetAction struct {
+	config    config.Config
+	formatter output.Formatter
+	writer    io.Writer
+	args      []string
+}
+
+func newConfigGetAction(config config.Config, formatter output.Formatter, writer io.Writer, args []string) *configGetAction {
+	return &configGetAction{
+		config:    config,
+		formatter: formatter,
+		writer:    writer,
+		args:      args,
+	}
+}
+
+func (a *configGetAction) Run(ctx context.Context) error {
+	key := a.args[0]
+	value, ok := a.config.Get(key)
+
+	if !ok {
+		return fmt.Errorf("no value stored at path '%s'", key)
+	}
+
+	if a.formatter.Kind() == output.JsonFormat {
+		err := a.formatter.Format(value, a.writer, nil)
+		if err != nil {
+			return fmt.Errorf("failing formatting config values: %w", err)
+		}
+	}
+
+	return nil
+}
+
+type configSetAction struct {
+	config config.Config
+	args   []string
+}
+
+func newConfigSetAction(config config.Config, args []string) *configSetAction {
+	return &configSetAction{
+		config: config,
+		args:   args,
+	}
+}
+
+func (a *configSetAction) Run(ctx context.Context) error {
+	path := a.args[0]
+	value := a.args[1]
+
+	err := a.config.Set(path, value)
+	if err != nil {
+		return fmt.Errorf("failed setting configuration value '%s' to '%s'. %w", path, value, err)
+	}
+
+	err = a.config.Save()
+	if err != nil {
+		return fmt.Errorf("failed saving configuration. %w", err)
+	}
+
+	return nil
+}
+
+type configUnsetAction struct {
+	config config.Config
+	args   []string
+}
+
+func newConfigUnsetAction(config config.Config, args []string) *configUnsetAction {
+	return &configUnsetAction{
+		config: config,
+		args:   args,
+	}
+}
+
+func (a *configUnsetAction) Run(ctx context.Context) error {
+	path := a.args[0]
+
+	err := a.config.Unset(path)
+	if err != nil {
+		return fmt.Errorf("failed removing configuration with path '%s'. %w", path, err)
+	}
+
+	err = a.config.Save()
+	if err != nil {
+		return fmt.Errorf("failed saving configuration. %w", err)
+	}
+
+	return nil
+}

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
-	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
@@ -83,7 +82,6 @@ func (i *initFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOpt
 
 type initAction struct {
 	azdCtx         *azdcontext.AzdContext
-	config         config.Config
 	accountManager *account.Manager
 	console        input.Console
 	cmdRun         exec.CommandRunner
@@ -94,7 +92,6 @@ type initAction struct {
 
 func newInitAction(
 	azdCtx *azdcontext.AzdContext,
-	config config.Config,
 	accountManager *account.Manager,
 	cmdRun exec.CommandRunner,
 	console input.Console,
@@ -103,7 +100,6 @@ func newInitAction(
 	flags initFlags) (*initAction, error) {
 	return &initAction{
 		azdCtx:         azdCtx,
-		config:         config,
 		accountManager: accountManager,
 		console:        console,
 		cmdRun:         cmdRun,
@@ -334,14 +330,14 @@ func (i *initAction) Run(ctx context.Context) error {
 
 	// If the configuration is empty, set default subscription & location
 	// This will be the case for first run experience
-	if i.config.IsEmpty() {
+	if !i.accountManager.HasDefaults() {
 		_, err = i.accountManager.SetDefaultSubscription(ctx, env.GetSubscriptionId())
 		if err != nil {
-			return fmt.Errorf("failed setting default subscription. %w", err)
+			log.Printf("failed setting default subscription. %s\n", err.Error())
 		}
 		_, err = i.accountManager.SetDefaultLocation(ctx, env.GetSubscriptionId(), env.GetLocation())
 		if err != nil {
-			return fmt.Errorf("failed setting default location. %w", err)
+			log.Printf("failed setting default location. %s\n", err.Error())
 		}
 	}
 

--- a/cli/azd/cmd/monitor.go
+++ b/cli/azd/cmd/monitor.go
@@ -151,7 +151,11 @@ func (m *monitorAction) Run(ctx context.Context) error {
 
 		if envBrowser := os.Getenv(BrowserEnvVarName); len(envBrowser) > 0 {
 			if err := exec.Command(envBrowser, url).Run(); err != nil {
-				fmt.Fprintf(m.console.Handles().Stderr, "warning: failed to open browser configured by $BROWSER: %s\n", err.Error())
+				fmt.Fprintf(
+					m.console.Handles().Stderr,
+					"warning: failed to open browser configured by $BROWSER: %s\n",
+					err.Error(),
+				)
 			}
 			return
 		}

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -98,6 +98,7 @@ For more information, visit the Azure Developer CLI Dev Hub: https://aka.ms/azur
 
 	opts.EnableTelemetry = telemetry.IsTelemetryEnabled()
 
+	cmd.AddCommand(configCmd(opts))
 	cmd.AddCommand(envCmd(opts))
 	cmd.AddCommand(infraCmd(opts))
 	cmd.AddCommand(pipelineCmd(opts))

--- a/cli/azd/cmd/sets.go
+++ b/cli/azd/cmd/sets.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
@@ -108,15 +109,6 @@ func newCredential() (azcore.TokenCredential, error) {
 	return credential, nil
 }
 
-func newConfig() config.Config {
-	cfg, err := config.Load()
-	if err != nil {
-		cfg = config.NewConfig(nil)
-	}
-
-	return cfg
-}
-
 var FormattedConsoleSet = wire.NewSet(
 	output.GetCommandFormatter,
 	newWriter,
@@ -124,7 +116,8 @@ var FormattedConsoleSet = wire.NewSet(
 )
 
 var CommonSet = wire.NewSet(
-	newConfig,
+	config.GetConfig,
+	account.NewManager,
 	newAzdContext,
 	FormattedConsoleSet,
 	newCommandRunnerFromConsole,

--- a/cli/azd/cmd/sets.go
+++ b/cli/azd/cmd/sets.go
@@ -262,3 +262,8 @@ var ConfigUnsetCmdSet = wire.NewSet(
 	CommonSet,
 	newConfigUnsetAction,
 	wire.Bind(new(actions.Action), new(*configUnsetAction)))
+
+var ConfigResetCmdSet = wire.NewSet(
+	CommonSet,
+	newConfigResetAction,
+	wire.Bind(new(actions.Action), new(*configResetAction)))

--- a/cli/azd/cmd/sets.go
+++ b/cli/azd/cmd/sets.go
@@ -116,7 +116,7 @@ var FormattedConsoleSet = wire.NewSet(
 )
 
 var CommonSet = wire.NewSet(
-	config.GetConfig,
+	config.NewManager,
 	account.NewManager,
 	newAzdContext,
 	FormattedConsoleSet,

--- a/cli/azd/cmd/sets.go
+++ b/cli/azd/cmd/sets.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -107,6 +108,15 @@ func newCredential() (azcore.TokenCredential, error) {
 	return credential, nil
 }
 
+func newConfig() config.Config {
+	cfg, err := config.Load()
+	if err != nil {
+		cfg = config.NewConfig(nil)
+	}
+
+	return cfg
+}
+
 var FormattedConsoleSet = wire.NewSet(
 	output.GetCommandFormatter,
 	newWriter,
@@ -114,6 +124,7 @@ var FormattedConsoleSet = wire.NewSet(
 )
 
 var CommonSet = wire.NewSet(
+	newConfig,
 	newAzdContext,
 	FormattedConsoleSet,
 	newCommandRunnerFromConsole,
@@ -238,3 +249,23 @@ var VersionCmdSet = wire.NewSet(
 	CommonSet,
 	newVersionAction,
 	wire.Bind(new(actions.Action), new(*versionAction)))
+
+var ConfigListCmdSet = wire.NewSet(
+	CommonSet,
+	newConfigListAction,
+	wire.Bind(new(actions.Action), new(*configListAction)))
+
+var ConfigGetCmdSet = wire.NewSet(
+	CommonSet,
+	newConfigGetAction,
+	wire.Bind(new(actions.Action), new(*configGetAction)))
+
+var ConfigSetCmdSet = wire.NewSet(
+	CommonSet,
+	newConfigSetAction,
+	wire.Bind(new(actions.Action), new(*configSetAction)))
+
+var ConfigUnsetCmdSet = wire.NewSet(
+	CommonSet,
+	newConfigUnsetAction,
+	wire.Bind(new(actions.Action), new(*configUnsetAction)))

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -285,7 +285,11 @@ func ensureEnvironmentInitialized(
 }
 
 func getSubscriptionOptions(ctx context.Context) ([]string, string, error) {
-	accountManager := account.NewManager(config.GetConfig(), azcli.GetAzCli(ctx))
+	accountManager, err := account.NewManager(config.NewManager(), azcli.GetAzCli(ctx))
+	if err != nil {
+		return nil, "", fmt.Errorf("failed creating account manager: %w", err)
+	}
+
 	subscriptionInfos, err := accountManager.GetSubscriptions(ctx)
 	if err != nil {
 		return nil, "", fmt.Errorf("listing accounts: %w", err)

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -14,9 +14,11 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/azureutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 )
 
 type Asker func(p survey.Prompt, response interface{}) error
@@ -260,7 +262,7 @@ func ensureEnvironmentInitialized(
 	if !hasLocation && envSpec.location != "" {
 		env.SetLocation(envSpec.location)
 	} else {
-		location, err := azureutil.PromptLocation(ctx, "Please select an Azure location to use:")
+		location, err := azureutil.PromptLocation(ctx, env, "Please select an Azure location to use:")
 		if err != nil {
 			return fmt.Errorf("prompting for location: %w", err)
 		}
@@ -283,7 +285,7 @@ func ensureEnvironmentInitialized(
 }
 
 func getSubscriptionOptions(ctx context.Context) ([]string, string, error) {
-	accountManager := account.NewManager(ctx)
+	accountManager := account.NewManager(config.GetConfig(), azcli.GetAzCli(ctx))
 	subscriptionInfos, err := accountManager.GetSubscriptions(ctx)
 	if err != nil {
 		return nil, "", fmt.Errorf("listing accounts: %w", err)

--- a/cli/azd/cmd/wire.go
+++ b/cli/azd/cmd/wire.go
@@ -202,3 +202,43 @@ func initTemplatesShowAction(
 }
 
 //#endregion Templates
+
+//#region Config
+
+func initConfigListAction(
+	cmd *cobra.Command,
+	o *internal.GlobalCommandOptions,
+	flags struct{},
+	args []string,
+) (actions.Action, error) {
+	panic(wire.Build(ConfigListCmdSet))
+}
+
+func initConfigGetAction(
+	cmd *cobra.Command,
+	o *internal.GlobalCommandOptions,
+	flags struct{},
+	args []string,
+) (actions.Action, error) {
+	panic(wire.Build(ConfigGetCmdSet))
+}
+
+func initConfigSetAction(
+	cmd *cobra.Command,
+	o *internal.GlobalCommandOptions,
+	flags struct{},
+	args []string,
+) (actions.Action, error) {
+	panic(wire.Build(ConfigSetCmdSet))
+}
+
+func initConfigUnsetAction(
+	cmd *cobra.Command,
+	o *internal.GlobalCommandOptions,
+	flags struct{},
+	args []string,
+) (actions.Action, error) {
+	panic(wire.Build(ConfigUnsetCmdSet))
+}
+
+//#endregion Config

--- a/cli/azd/cmd/wire.go
+++ b/cli/azd/cmd/wire.go
@@ -241,4 +241,13 @@ func initConfigUnsetAction(
 	panic(wire.Build(ConfigUnsetCmdSet))
 }
 
+func initConfigResetAction(
+	cmd *cobra.Command,
+	o *internal.GlobalCommandOptions,
+	flags struct{},
+	args []string,
+) (actions.Action, error) {
+	panic(wire.Build(ConfigResetCmdSet))
+}
+
 //#endregion Config

--- a/cli/azd/cmd/wire_gen.go
+++ b/cli/azd/cmd/wire_gen.go
@@ -53,7 +53,7 @@ func initInitAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags 
 	if err != nil {
 		return nil, err
 	}
-	configConfig := config.GetConfig()
+	manager := config.NewManager()
 	formatter, err := output.GetCommandFormatter(cmd)
 	if err != nil {
 		return nil, err
@@ -66,9 +66,12 @@ func initInitAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags 
 		return nil, err
 	}
 	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
-	manager := account.NewManager(configConfig, azCli)
+	accountManager, err := account.NewManager(manager, azCli)
+	if err != nil {
+		return nil, err
+	}
 	gitCli := git.NewGitCliFromRunner(commandRunner)
-	cmdInitAction, err := newInitAction(azdContext, manager, commandRunner, console, azCli, gitCli, flags)
+	cmdInitAction, err := newInitAction(azdContext, accountManager, commandRunner, console, azCli, gitCli, flags)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +100,7 @@ func initUpAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags up
 	if err != nil {
 		return nil, err
 	}
-	configConfig := config.GetConfig()
+	manager := config.NewManager()
 	formatter, err := output.GetCommandFormatter(cmd)
 	if err != nil {
 		return nil, err
@@ -110,10 +113,13 @@ func initUpAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags up
 		return nil, err
 	}
 	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
-	manager := account.NewManager(configConfig, azCli)
+	accountManager, err := account.NewManager(manager, azCli)
+	if err != nil {
+		return nil, err
+	}
 	gitCli := git.NewGitCliFromRunner(commandRunner)
 	cmdInitFlags := flags.initFlags
-	cmdInitAction, err := newInitAction(azdContext, manager, commandRunner, console, azCli, gitCli, cmdInitFlags)
+	cmdInitAction, err := newInitAction(azdContext, accountManager, commandRunner, console, azCli, gitCli, cmdInitFlags)
 	if err != nil {
 		return nil, err
 	}
@@ -377,35 +383,35 @@ func initTemplatesShowAction(cmd *cobra.Command, o *internal.GlobalCommandOption
 }
 
 func initConfigListAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
-	configConfig := config.GetConfig()
+	manager := config.NewManager()
 	formatter, err := output.GetCommandFormatter(cmd)
 	if err != nil {
 		return nil, err
 	}
 	writer := newWriter(cmd)
-	cmdConfigListAction := newConfigListAction(configConfig, formatter, writer)
+	cmdConfigListAction := newConfigListAction(manager, formatter, writer)
 	return cmdConfigListAction, nil
 }
 
 func initConfigGetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
-	configConfig := config.GetConfig()
+	manager := config.NewManager()
 	formatter, err := output.GetCommandFormatter(cmd)
 	if err != nil {
 		return nil, err
 	}
 	writer := newWriter(cmd)
-	cmdConfigGetAction := newConfigGetAction(configConfig, formatter, writer, args)
+	cmdConfigGetAction := newConfigGetAction(manager, formatter, writer, args)
 	return cmdConfigGetAction, nil
 }
 
 func initConfigSetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
-	configConfig := config.GetConfig()
-	cmdConfigSetAction := newConfigSetAction(configConfig, args)
+	manager := config.NewManager()
+	cmdConfigSetAction := newConfigSetAction(manager, args)
 	return cmdConfigSetAction, nil
 }
 
 func initConfigUnsetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
-	configConfig := config.GetConfig()
-	cmdConfigUnsetAction := newConfigUnsetAction(configConfig, args)
+	manager := config.NewManager()
+	cmdConfigUnsetAction := newConfigUnsetAction(manager, args)
 	return cmdConfigUnsetAction, nil
 }

--- a/cli/azd/cmd/wire_gen.go
+++ b/cli/azd/cmd/wire_gen.go
@@ -369,3 +369,37 @@ func initTemplatesShowAction(cmd *cobra.Command, o *internal.GlobalCommandOption
 	cmdTemplatesShowAction := newTemplatesShowAction(formatter, writer, templateManager, args)
 	return cmdTemplatesShowAction, nil
 }
+
+func initConfigListAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
+	config := newConfig()
+	formatter, err := output.GetCommandFormatter(cmd)
+	if err != nil {
+		return nil, err
+	}
+	writer := newWriter(cmd)
+	cmdConfigListAction := newConfigListAction(config, formatter, writer)
+	return cmdConfigListAction, nil
+}
+
+func initConfigGetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
+	config := newConfig()
+	formatter, err := output.GetCommandFormatter(cmd)
+	if err != nil {
+		return nil, err
+	}
+	writer := newWriter(cmd)
+	cmdConfigGetAction := newConfigGetAction(config, formatter, writer, args)
+	return cmdConfigGetAction, nil
+}
+
+func initConfigSetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
+	config := newConfig()
+	cmdConfigSetAction := newConfigSetAction(config, args)
+	return cmdConfigSetAction, nil
+}
+
+func initConfigUnsetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
+	config := newConfig()
+	cmdConfigUnsetAction := newConfigUnsetAction(config, args)
+	return cmdConfigUnsetAction, nil
+}

--- a/cli/azd/cmd/wire_gen.go
+++ b/cli/azd/cmd/wire_gen.go
@@ -415,3 +415,9 @@ func initConfigUnsetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions,
 	cmdConfigUnsetAction := newConfigUnsetAction(manager, args)
 	return cmdConfigUnsetAction, nil
 }
+
+func initConfigResetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
+	manager := config.NewManager()
+	cmdConfigResetAction := newConfigResetAction(manager, args)
+	return cmdConfigResetAction, nil
+}

--- a/cli/azd/cmd/wire_gen.go
+++ b/cli/azd/cmd/wire_gen.go
@@ -9,6 +9,8 @@ package cmd
 import (
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/account"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/templates"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/git"
@@ -51,6 +53,7 @@ func initInitAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags 
 	if err != nil {
 		return nil, err
 	}
+	configConfig := config.GetConfig()
 	formatter, err := output.GetCommandFormatter(cmd)
 	if err != nil {
 		return nil, err
@@ -63,8 +66,9 @@ func initInitAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags 
 		return nil, err
 	}
 	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
+	manager := account.NewManager(configConfig, azCli)
 	gitCli := git.NewGitCliFromRunner(commandRunner)
-	cmdInitAction, err := newInitAction(azdContext, commandRunner, console, azCli, gitCli, flags)
+	cmdInitAction, err := newInitAction(azdContext, configConfig, manager, commandRunner, console, azCli, gitCli, flags)
 	if err != nil {
 		return nil, err
 	}
@@ -93,6 +97,7 @@ func initUpAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags up
 	if err != nil {
 		return nil, err
 	}
+	configConfig := config.GetConfig()
 	formatter, err := output.GetCommandFormatter(cmd)
 	if err != nil {
 		return nil, err
@@ -105,9 +110,10 @@ func initUpAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags up
 		return nil, err
 	}
 	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
+	manager := account.NewManager(configConfig, azCli)
 	gitCli := git.NewGitCliFromRunner(commandRunner)
 	cmdInitFlags := flags.initFlags
-	cmdInitAction, err := newInitAction(azdContext, commandRunner, console, azCli, gitCli, cmdInitFlags)
+	cmdInitAction, err := newInitAction(azdContext, configConfig, manager, commandRunner, console, azCli, gitCli, cmdInitFlags)
 	if err != nil {
 		return nil, err
 	}
@@ -371,35 +377,35 @@ func initTemplatesShowAction(cmd *cobra.Command, o *internal.GlobalCommandOption
 }
 
 func initConfigListAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
-	config := newConfig()
+	configConfig := config.GetConfig()
 	formatter, err := output.GetCommandFormatter(cmd)
 	if err != nil {
 		return nil, err
 	}
 	writer := newWriter(cmd)
-	cmdConfigListAction := newConfigListAction(config, formatter, writer)
+	cmdConfigListAction := newConfigListAction(configConfig, formatter, writer)
 	return cmdConfigListAction, nil
 }
 
 func initConfigGetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
-	config := newConfig()
+	configConfig := config.GetConfig()
 	formatter, err := output.GetCommandFormatter(cmd)
 	if err != nil {
 		return nil, err
 	}
 	writer := newWriter(cmd)
-	cmdConfigGetAction := newConfigGetAction(config, formatter, writer, args)
+	cmdConfigGetAction := newConfigGetAction(configConfig, formatter, writer, args)
 	return cmdConfigGetAction, nil
 }
 
 func initConfigSetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
-	config := newConfig()
-	cmdConfigSetAction := newConfigSetAction(config, args)
+	configConfig := config.GetConfig()
+	cmdConfigSetAction := newConfigSetAction(configConfig, args)
 	return cmdConfigSetAction, nil
 }
 
 func initConfigUnsetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
-	config := newConfig()
-	cmdConfigUnsetAction := newConfigUnsetAction(config, args)
+	configConfig := config.GetConfig()
+	cmdConfigUnsetAction := newConfigUnsetAction(configConfig, args)
 	return cmdConfigUnsetAction, nil
 }

--- a/cli/azd/cmd/wire_gen.go
+++ b/cli/azd/cmd/wire_gen.go
@@ -68,7 +68,7 @@ func initInitAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags 
 	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
 	manager := account.NewManager(configConfig, azCli)
 	gitCli := git.NewGitCliFromRunner(commandRunner)
-	cmdInitAction, err := newInitAction(azdContext, configConfig, manager, commandRunner, console, azCli, gitCli, flags)
+	cmdInitAction, err := newInitAction(azdContext, manager, commandRunner, console, azCli, gitCli, flags)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func initUpAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags up
 	manager := account.NewManager(configConfig, azCli)
 	gitCli := git.NewGitCliFromRunner(commandRunner)
 	cmdInitFlags := flags.initFlags
-	cmdInitAction, err := newInitAction(azdContext, configConfig, manager, commandRunner, console, azCli, gitCli, cmdInitFlags)
+	cmdInitAction, err := newInitAction(azdContext, manager, commandRunner, console, azCli, gitCli, cmdInitFlags)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/pkg/account/manager.go
+++ b/cli/azd/pkg/account/manager.go
@@ -161,6 +161,14 @@ func (m *Manager) SetDefaultLocation(ctx context.Context, subscriptionId string,
 	}, nil
 }
 
+// Checks whether account related defaults of subscription and location have previously been set
+func (m *Manager) HasDefaults() bool {
+	_, hasDefaultSubscription := m.config.Get(defaultSubscriptionKeyPath)
+	_, hasDefaultLocation := m.config.Get(defaultLocationKeyPath)
+
+	return hasDefaultSubscription && hasDefaultLocation
+}
+
 // Clears any persisted defaults in the AZD config
 func (m *Manager) Clear(ctx context.Context) error {
 	err := m.config.Unset("defaults")

--- a/cli/azd/pkg/account/manager.go
+++ b/cli/azd/pkg/account/manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
@@ -40,16 +41,21 @@ func NewManager(configManager config.Manager, azCli azcli.AzCli) (*Manager, erro
 		return nil, err
 	}
 
-	config, err := configManager.Load(filePath)
+	azdConfig, err := configManager.Load(filePath)
 	if err != nil {
-		return nil, err
+		if errors.Is(err, os.ErrNotExist) {
+			log.Println(err.Error())
+			azdConfig = config.NewConfig(nil)
+		} else {
+			return nil, err
+		}
 	}
 
 	return &Manager{
 		filePath:      filePath,
 		azCli:         azCli,
 		configManager: configManager,
-		config:        config,
+		config:        azdConfig,
 	}, nil
 }
 

--- a/cli/azd/pkg/account/manager.go
+++ b/cli/azd/pkg/account/manager.go
@@ -41,7 +41,7 @@ func NewManager(config config.Config, azCli azcli.AzCli) *Manager {
 // Gets the default subscription for the logged in account.
 // 1. Returns AZD config defaults if exists
 // 2. Returns AZ CLI defaults if exists
-func (m *Manager) GetAccountDefaults(ctx context.Context) (*Account, error) {
+func (m *Manager) GetAccountDefaults(ctx context.Context) *Account {
 	subscription, err := m.getDefaultSubscription(ctx)
 
 	// If we don't have a default subscription then the principal does not have any active
@@ -61,7 +61,7 @@ func (m *Manager) GetAccountDefaults(ctx context.Context) (*Account, error) {
 	return &Account{
 		DefaultSubscription: subscription,
 		DefaultLocation:     location,
-	}, nil
+	}
 }
 
 // Gets the available Azure subscriptions for the current logged in account.

--- a/cli/azd/pkg/account/manager.go
+++ b/cli/azd/pkg/account/manager.go
@@ -44,7 +44,7 @@ func NewManager(configManager config.Manager, azCli azcli.AzCli) (*Manager, erro
 	azdConfig, err := configManager.Load(filePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			log.Println(err.Error())
+			log.Printf("configuration file '%s' does not exist. Creating new empty config.\n", filePath)
 			azdConfig = config.NewConfig(nil)
 		} else {
 			return nil, err

--- a/cli/azd/pkg/account/manager_test.go
+++ b/cli/azd/pkg/account/manager_test.go
@@ -39,7 +39,9 @@ func Test_GetAccountDefaults(t *testing.T) {
 		setupAccountMocks(mockContext)
 		setupGetSubscriptionMock(mockContext, &subscription, nil)
 
-		manager := NewManager(expectedConfig, azcli.GetAzCli(*mockContext.Context))
+		manager, err := NewManager(mockContext.ConfigManager.WithConfig(expectedConfig), azcli.GetAzCli(*mockContext.Context))
+		require.NoError(t, err)
+
 		accountDefaults := manager.GetAccountDefaults(*mockContext.Context)
 
 		require.Equal(t, "SUBSCRIPTION_01", accountDefaults.DefaultSubscription.Id)
@@ -52,7 +54,9 @@ func Test_GetAccountDefaults(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		setupAccountMocks(mockContext)
 
-		manager := NewManager(emptyConfig, azcli.GetAzCli(*mockContext.Context))
+		manager, err := NewManager(mockContext.ConfigManager.WithConfig(emptyConfig), azcli.GetAzCli(*mockContext.Context))
+		require.NoError(t, err)
+
 		accountDefaults := manager.GetAccountDefaults(*mockContext.Context)
 
 		require.Equal(t, *allTestSubscriptions[0].SubscriptionID, accountDefaults.DefaultSubscription.Id)
@@ -65,7 +69,9 @@ func Test_GetSubscriptions(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		setupAccountMocks(mockContext)
 
-		manager := NewManager(config.NewConfig(nil), azcli.GetAzCli(*mockContext.Context))
+		manager, err := NewManager(mockContext.ConfigManager, azcli.GetAzCli(*mockContext.Context))
+		require.NoError(t, err)
+
 		subscriptions, err := manager.GetSubscriptions(*mockContext.Context)
 
 		require.NoError(t, err)
@@ -90,7 +96,9 @@ func Test_GetSubscriptions(t *testing.T) {
 		setupAccountMocks(mockContext)
 		setupGetSubscriptionMock(mockContext, &subscription, nil)
 
-		manager := NewManager(defaultConfig, azcli.GetAzCli(*mockContext.Context))
+		manager, err := NewManager(mockContext.ConfigManager.WithConfig(defaultConfig), azcli.GetAzCli(*mockContext.Context))
+		require.NoError(t, err)
+
 		subscriptions, err := manager.GetSubscriptions(*mockContext.Context)
 
 		defaultIndex := slices.IndexFunc(subscriptions, func(sub *azcli.AzCliSubscriptionInfo) bool {
@@ -107,7 +115,9 @@ func Test_GetSubscriptions(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		setupAccountErrorMocks(mockContext)
 
-		manager := NewManager(config.NewConfig(nil), azcli.GetAzCli(*mockContext.Context))
+		manager, err := NewManager(config.NewManager(), azcli.GetAzCli(*mockContext.Context))
+		require.NoError(t, err)
+
 		subscriptions, err := manager.GetSubscriptions(*mockContext.Context)
 
 		require.Error(t, err)
@@ -134,7 +144,9 @@ func Test_GetLocations(t *testing.T) {
 		setupAccountMocks(mockContext)
 		setupGetSubscriptionMock(mockContext, &subscription, nil)
 
-		manager := NewManager(defaultConfig, azcli.GetAzCli(*mockContext.Context))
+		manager, err := NewManager(config.NewManager(), azcli.GetAzCli(*mockContext.Context))
+		require.NoError(t, err)
+
 		locations, err := manager.GetLocations(*mockContext.Context, subscription.Id)
 
 		require.NoError(t, err)
@@ -145,7 +157,9 @@ func Test_GetLocations(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		setupAccountErrorMocks(mockContext)
 
-		manager := NewManager(config.NewConfig(nil), azcli.GetAzCli(*mockContext.Context))
+		manager, err := NewManager(config.NewManager(), azcli.GetAzCli(*mockContext.Context))
+		require.NoError(t, err)
+
 		locations, err := manager.GetLocations(*mockContext.Context, subscription.Id)
 
 		require.Error(t, err)
@@ -157,7 +171,9 @@ func Test_GetLocations(t *testing.T) {
 		setupAccountErrorMocks(mockContext)
 		setupGetSubscriptionMock(mockContext, &subscription, nil)
 
-		manager := NewManager(defaultConfig, azcli.GetAzCli(*mockContext.Context))
+		manager, err := NewManager(config.NewManager(), azcli.GetAzCli(*mockContext.Context))
+		require.NoError(t, err)
+
 		locations, err := manager.GetLocations(*mockContext.Context, subscription.Id)
 
 		require.Error(t, err)
@@ -177,7 +193,9 @@ func Test_SetDefaultSubscription(t *testing.T) {
 		setupAccountMocks(mockContext)
 		setupGetSubscriptionMock(mockContext, &expectedSubscription, nil)
 
-		manager := NewManager(config.NewConfig(nil), azcli.GetAzCli(*mockContext.Context))
+		manager, err := NewManager(config.NewManager(), azcli.GetAzCli(*mockContext.Context))
+		require.NoError(t, err)
+
 		actualSubscription, err := manager.SetDefaultSubscription(*mockContext.Context, expectedSubscription.Id)
 
 		require.NoError(t, err)
@@ -195,7 +213,9 @@ func Test_SetDefaultSubscription(t *testing.T) {
 		setupAccountMocks(mockContext)
 		setupGetSubscriptionMock(mockContext, &expectedSubscription, errors.New("Not found"))
 
-		manager := NewManager(config.NewConfig(nil), azcli.GetAzCli(*mockContext.Context))
+		manager, err := NewManager(config.NewManager(), azcli.GetAzCli(*mockContext.Context))
+		require.NoError(t, err)
+
 		actualSubscription, err := manager.SetDefaultSubscription(*mockContext.Context, expectedSubscription.Id)
 
 		require.Error(t, err)
@@ -224,7 +244,9 @@ func Test_SetDefaultLocation(t *testing.T) {
 		setupAccountMocks(mockContext)
 		setupGetSubscriptionMock(mockContext, &subscription, nil)
 
-		manager := NewManager(defaultConfig, azcli.GetAzCli(*mockContext.Context))
+		manager, err := NewManager(config.NewManager(), azcli.GetAzCli(*mockContext.Context))
+		require.NoError(t, err)
+
 		location, err := manager.SetDefaultLocation(*mockContext.Context, subscription.Id, expectedLocation)
 
 		require.NoError(t, err)
@@ -238,7 +260,9 @@ func Test_SetDefaultLocation(t *testing.T) {
 		setupAccountMocks(mockContext)
 		setupGetSubscriptionMock(mockContext, &subscription, nil)
 
-		manager := NewManager(defaultConfig, azcli.GetAzCli(*mockContext.Context))
+		manager, err := NewManager(config.NewManager(), azcli.GetAzCli(*mockContext.Context))
+		require.NoError(t, err)
+
 		location, err := manager.SetDefaultLocation(*mockContext.Context, subscription.Id, expectedLocation)
 
 		require.Error(t, err)
@@ -257,7 +281,9 @@ func Test_Clear(t *testing.T) {
 	setupAccountMocks(mockContext)
 	setupGetSubscriptionMock(mockContext, &expectedSubscription, nil)
 
-	manager := NewManager(config.NewConfig(nil), azcli.GetAzCli(*mockContext.Context))
+	manager, err := NewManager(config.NewManager(), azcli.GetAzCli(*mockContext.Context))
+	require.NoError(t, err)
+
 	subscription, err := manager.SetDefaultSubscription(*mockContext.Context, expectedSubscription.Id)
 	require.NoError(t, err)
 

--- a/cli/azd/pkg/account/manager_test.go
+++ b/cli/azd/pkg/account/manager_test.go
@@ -40,9 +40,8 @@ func Test_GetAccountDefaults(t *testing.T) {
 		setupGetSubscriptionMock(mockContext, &subscription, nil)
 
 		manager := NewManager(expectedConfig, azcli.GetAzCli(*mockContext.Context))
-		accountDefaults, err := manager.GetAccountDefaults(*mockContext.Context)
+		accountDefaults := manager.GetAccountDefaults(*mockContext.Context)
 
-		require.NoError(t, err)
 		require.Equal(t, "SUBSCRIPTION_01", accountDefaults.DefaultSubscription.Id)
 		require.Equal(t, "westus", accountDefaults.DefaultLocation.Name)
 	})
@@ -54,9 +53,8 @@ func Test_GetAccountDefaults(t *testing.T) {
 		setupAccountMocks(mockContext)
 
 		manager := NewManager(emptyConfig, azcli.GetAzCli(*mockContext.Context))
-		accountDefaults, err := manager.GetAccountDefaults(*mockContext.Context)
+		accountDefaults := manager.GetAccountDefaults(*mockContext.Context)
 
-		require.NoError(t, err)
 		require.Equal(t, *allTestSubscriptions[0].SubscriptionID, accountDefaults.DefaultSubscription.Id)
 		require.Equal(t, "eastus2", accountDefaults.DefaultLocation.Name)
 	})

--- a/cli/azd/pkg/account/manager_test.go
+++ b/cli/azd/pkg/account/manager_test.go
@@ -144,7 +144,7 @@ func Test_GetLocations(t *testing.T) {
 		setupAccountMocks(mockContext)
 		setupGetSubscriptionMock(mockContext, &subscription, nil)
 
-		manager, err := NewManager(config.NewManager(), azcli.GetAzCli(*mockContext.Context))
+		manager, err := NewManager(mockContext.ConfigManager.WithConfig(defaultConfig), azcli.GetAzCli(*mockContext.Context))
 		require.NoError(t, err)
 
 		locations, err := manager.GetLocations(*mockContext.Context, subscription.Id)
@@ -157,7 +157,7 @@ func Test_GetLocations(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		setupAccountErrorMocks(mockContext)
 
-		manager, err := NewManager(config.NewManager(), azcli.GetAzCli(*mockContext.Context))
+		manager, err := NewManager(mockContext.ConfigManager, azcli.GetAzCli(*mockContext.Context))
 		require.NoError(t, err)
 
 		locations, err := manager.GetLocations(*mockContext.Context, subscription.Id)
@@ -244,7 +244,7 @@ func Test_SetDefaultLocation(t *testing.T) {
 		setupAccountMocks(mockContext)
 		setupGetSubscriptionMock(mockContext, &subscription, nil)
 
-		manager, err := NewManager(config.NewManager(), azcli.GetAzCli(*mockContext.Context))
+		manager, err := NewManager(mockContext.ConfigManager.WithConfig(defaultConfig), azcli.GetAzCli(*mockContext.Context))
 		require.NoError(t, err)
 
 		location, err := manager.SetDefaultLocation(*mockContext.Context, subscription.Id, expectedLocation)
@@ -290,7 +290,7 @@ func Test_Clear(t *testing.T) {
 	location, err := manager.SetDefaultLocation(*mockContext.Context, subscription.Id, "westus2")
 	require.NoError(t, err)
 
-	updatedConfig, err := config.Load()
+	updatedConfig, err := mockContext.ConfigManager.Load("PATH")
 	require.NoError(t, err)
 
 	configSubscription, _ := updatedConfig.Get(defaultSubscriptionKeyPath)
@@ -302,7 +302,7 @@ func Test_Clear(t *testing.T) {
 	err = manager.Clear(*mockContext.Context)
 	require.NoError(t, err)
 
-	clearedConfig, err := config.Load()
+	clearedConfig, err := mockContext.ConfigManager.Load("PATH")
 	require.NotNil(t, clearedConfig)
 	require.NoError(t, err)
 

--- a/cli/azd/pkg/account/manager_test.go
+++ b/cli/azd/pkg/account/manager_test.go
@@ -39,7 +39,10 @@ func Test_GetAccountDefaults(t *testing.T) {
 		setupAccountMocks(mockContext)
 		setupGetSubscriptionMock(mockContext, &subscription, nil)
 
-		manager, err := NewManager(mockContext.ConfigManager.WithConfig(expectedConfig), azcli.GetAzCli(*mockContext.Context))
+		manager, err := NewManager(
+			mockContext.ConfigManager.WithConfig(expectedConfig),
+			azcli.GetAzCli(*mockContext.Context),
+		)
 		require.NoError(t, err)
 
 		accountDefaults := manager.GetAccountDefaults(*mockContext.Context)

--- a/cli/azd/pkg/account/models.go
+++ b/cli/azd/pkg/account/models.go
@@ -1,0 +1,18 @@
+package account
+
+// AZD Account configuration
+type Account struct {
+	DefaultSubscription *Subscription `json:"defaultSubscription"`
+	DefaultLocation     *Location     `json:"defaultLocation"`
+}
+
+type Subscription struct {
+	Id       string `json:"id"`
+	Name     string `json:"name"`
+	TenantId string `json:"tenantId"`
+}
+
+type Location struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+}

--- a/cli/azd/pkg/azureutil/location.go
+++ b/cli/azd/pkg/azureutil/location.go
@@ -41,13 +41,9 @@ func PromptLocation(ctx context.Context, env *environment.Environment, message s
 	// selection.
 	defaultLocation := os.Getenv(environment.LocationEnvVarName)
 
-	// If no location is set in the process environment, see what the CLI default is.
+	// If no location is set in the process environment, see what the azd config default is.
 	if defaultLocation == "" {
-		defaultConfig, err := accountManager.GetAccountDefaults(ctx)
-		if err != nil {
-			return "", fmt.Errorf("failed retrieving account defaults: %w", err)
-		}
-
+		defaultConfig := accountManager.GetAccountDefaults(ctx)
 		defaultLocation = defaultConfig.DefaultLocation.Name
 	}
 

--- a/cli/azd/pkg/azureutil/location.go
+++ b/cli/azd/pkg/azureutil/location.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
@@ -25,11 +26,11 @@ func (s Locs) Less(i, j int) bool {
 func (s Locs) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
 // PromptLocation asks the user to select a location from a list of supported azure location
-func PromptLocation(ctx context.Context, message string) (string, error) {
-	accountManager := account.NewManager(ctx)
+func PromptLocation(ctx context.Context, env *environment.Environment, message string) (string, error) {
+	accountManager := account.NewManager(config.GetConfig(), azcli.GetAzCli(ctx))
 	console := input.GetConsole(ctx)
 
-	locations, err := accountManager.GetLocations(ctx)
+	locations, err := accountManager.GetLocations(ctx, env.GetSubscriptionId())
 	if err != nil {
 		return "", fmt.Errorf("listing locations: %w", err)
 	}

--- a/cli/azd/pkg/azureutil/location.go
+++ b/cli/azd/pkg/azureutil/location.go
@@ -27,7 +27,10 @@ func (s Locs) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
 // PromptLocation asks the user to select a location from a list of supported azure location
 func PromptLocation(ctx context.Context, env *environment.Environment, message string) (string, error) {
-	accountManager := account.NewManager(config.GetConfig(), azcli.GetAzCli(ctx))
+	accountManager, err := account.NewManager(config.NewManager(), azcli.GetAzCli(ctx))
+	if err != nil {
+		return "", fmt.Errorf("failed creating account manager: %w", err)
+	}
 	console := input.GetConsole(ctx)
 
 	locations, err := accountManager.GetLocations(ctx, env.GetSubscriptionId())

--- a/cli/azd/pkg/commands/builder.go
+++ b/cli/azd/pkg/commands/builder.go
@@ -90,10 +90,5 @@ func RegisterDependenciesInCtx(
 	}, formatter)
 	ctx = input.WithConsole(ctx, console)
 
-	console.Confirm(ctx, input.ConsoleOptions{
-		Message:      "Ready?",
-		DefaultValue: true,
-	})
-
 	return ctx, nil
 }

--- a/cli/azd/pkg/commands/builder.go
+++ b/cli/azd/pkg/commands/builder.go
@@ -90,5 +90,10 @@ func RegisterDependenciesInCtx(
 	}, formatter)
 	ctx = input.WithConsole(ctx, console)
 
+	console.Confirm(ctx, input.ConsoleOptions{
+		Message:      "Ready?",
+		DefaultValue: true,
+	})
+
 	return ctx, nil
 }

--- a/cli/azd/pkg/config/config.go
+++ b/cli/azd/pkg/config/config.go
@@ -7,7 +7,6 @@
 package config
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -26,6 +25,7 @@ type Config interface {
 	Set(path string, value any) error
 	Unset(path string) error
 	Save() error
+	IsEmpty() bool
 }
 
 // Creates a new empty configuration
@@ -57,6 +57,11 @@ func GetUserConfigDir() (string, error) {
 // Top level AZD configuration
 type config struct {
 	data map[string]any
+}
+
+// Returns a value indicating whether the configuration is empty
+func (c *config) IsEmpty() bool {
+	return len(c.data) == 0
 }
 
 // Gets the raw values stored in the configuration as a Go map
@@ -210,26 +215,13 @@ func getConfigFilePath() (string, error) {
 	return filepath.Join(configPath, "config.json"), nil
 }
 
-type contextKey string
-
-const configContextKey contextKey = "config"
-
 // Gets the AZD config from current context
 // If it does not exist will return a new empty AZD config
-func GetConfig(ctx context.Context) Config {
-	existingConfig, ok := ctx.Value(configContextKey).(Config)
-	if !ok {
-		loadedConfig, err := Load()
-		if err != nil {
-			loadedConfig = NewConfig(nil)
-		}
-		existingConfig = loadedConfig
+func GetConfig() Config {
+	azdConfig, err := Load()
+	if err != nil {
+		azdConfig = NewConfig(nil)
 	}
 
-	return existingConfig
-}
-
-// Sets the AZD config in the Go context and returns the new context
-func WithConfig(ctx context.Context, config Config) context.Context {
-	return context.WithValue(ctx, configContextKey, config)
+	return azdConfig
 }

--- a/cli/azd/pkg/config/config.go
+++ b/cli/azd/pkg/config/config.go
@@ -19,6 +19,8 @@ import (
 
 const configDir = ".azd"
 
+// Azd configuration for the current user
+// Configuration data is stored in user's home directory @ ~/.azd/config.json
 type Config interface {
 	Raw() map[string]any
 	Get(path string) (any, bool)
@@ -135,6 +137,9 @@ func (c *config) Set(path string, value any) error {
 	return nil
 }
 
+// Removes any values stored at the specified path
+// When the path location is an object will remove the whole node
+// When the path does not exist, will return a `nil` value
 func (c *config) Unset(path string) error {
 	depth := 1
 	currentNode := c.data
@@ -206,15 +211,6 @@ func Parse(configJson []byte) (Config, error) {
 	return NewConfig(data), nil
 }
 
-func getConfigFilePath() (string, error) {
-	configPath, err := GetUserConfigDir()
-	if err != nil {
-		return "", fmt.Errorf("failed locating config dir")
-	}
-
-	return filepath.Join(configPath, "config.json"), nil
-}
-
 // Gets the AZD config from current context
 // If it does not exist will return a new empty AZD config
 func GetConfig() Config {
@@ -224,4 +220,13 @@ func GetConfig() Config {
 	}
 
 	return azdConfig
+}
+
+func getConfigFilePath() (string, error) {
+	configPath, err := GetUserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("failed locating config dir")
+	}
+
+	return filepath.Join(configPath, "config.json"), nil
 }

--- a/cli/azd/pkg/config/config_test.go
+++ b/cli/azd/pkg/config/config_test.go
@@ -76,7 +76,7 @@ func Test_SetGetUnsetRootNodeWithChildren(t *testing.T) {
 	require.Equal(t, expectedEmail, email)
 }
 
-func Test_IsEmtpy(t *testing.T) {
+func Test_IsEmpty(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
 		azdConfig := NewConfig(nil)
 		require.True(t, azdConfig.IsEmpty())

--- a/cli/azd/pkg/config/config_test.go
+++ b/cli/azd/pkg/config/config_test.go
@@ -10,39 +10,104 @@ import (
 func Test_SaveAndLoadConfig(t *testing.T) {
 	defer deleteExistingConfig()
 
-	newConfig := &Config{
-		Account: &Account{
-			DefaultSubscription: &Subscription{
-				Id:   "SUBSCRIPTION_ID",
-				Name: "Test Subscription",
-			},
-			DefaultLocation: &Location{
-				Name:        "eastus2",
-				DisplayName: "East US 2",
+	var azdConfig Config = NewConfig(
+		map[string]any{
+			"defaults": map[string]any{
+				"location":     "eastus2",
+				"subscription": "SUBSCRIPTION_ID",
 			},
 		},
-	}
+	)
 
-	err := newConfig.Save()
+	err := azdConfig.Save()
 	require.NoError(t, err)
 
 	existingConfig, err := Load()
 	require.NoError(t, err)
 	require.NotNil(t, existingConfig)
-	require.Equal(t, newConfig, existingConfig)
+	require.Equal(t, azdConfig, existingConfig)
 }
 
 func Test_SaveAndLoadEmptyConfig(t *testing.T) {
 	defer deleteExistingConfig()
 
-	newConfig := &Config{}
-	err := newConfig.Save()
+	azdConfig := NewConfig(nil)
+	err := azdConfig.Save()
 	require.NoError(t, err)
 
 	existingConfig, err := Load()
 	require.NoError(t, err)
 	require.NotNil(t, existingConfig)
-	require.Nil(t, existingConfig.Account)
+}
+
+func Test_SetGetUnsetWithValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		path  string
+		value any
+	}{
+		{
+			name:  "RootValue",
+			path:  "a",
+			value: "apple",
+		},
+		{
+			name:  "NestedValue",
+			path:  "defaults.location",
+			value: "westus",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			azdConfig := NewConfig(nil)
+			err := azdConfig.Set(test.path, test.value)
+			require.NoError(t, err)
+
+			value, ok := azdConfig.Get(test.path)
+			require.True(t, ok)
+			require.Equal(t, test.value, value)
+
+			err = azdConfig.Unset(test.path)
+			require.NoError(t, err)
+
+			value, ok = azdConfig.Get(test.path)
+			require.Nil(t, value)
+			require.False(t, ok)
+		})
+	}
+}
+
+func Test_SetGetUnsetRootNodeWithChildren(t *testing.T) {
+	expectedLocation := "westus2"
+	expectedEmail := "john.doe@contoso.com"
+
+	azdConfig := NewConfig(nil)
+	_ = azdConfig.Set("defaults.location", expectedLocation)
+	_ = azdConfig.Set("defaults.subscription", "SUBSCRIPTION_ID")
+	_ = azdConfig.Set("user.email", expectedEmail)
+
+	location, ok := azdConfig.Get("defaults.location")
+	require.True(t, ok)
+	require.Equal(t, expectedLocation, location)
+
+	email, ok := azdConfig.Get("user.email")
+	require.True(t, ok)
+	require.Equal(t, expectedEmail, email)
+
+	// Remove the whole defaults object
+	err := azdConfig.Unset("defaults")
+	require.NoError(t, err)
+
+	// Location should not exist
+	location, ok = azdConfig.Get("defaults.location")
+	require.False(t, ok)
+	require.Nil(t, location)
+
+	// user.email should still exist
+	email, ok = azdConfig.Get("user.email")
+	require.True(t, ok)
+	require.Equal(t, expectedEmail, email)
 }
 
 func deleteExistingConfig() {

--- a/cli/azd/pkg/config/config_test.go
+++ b/cli/azd/pkg/config/config_test.go
@@ -75,3 +75,22 @@ func Test_SetGetUnsetRootNodeWithChildren(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, expectedEmail, email)
 }
+
+func Test_IsEmtpy(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		azdConfig := NewConfig(nil)
+		require.True(t, azdConfig.IsEmpty())
+	})
+
+	t.Run("EmptyWithEmptyMap", func(t *testing.T) {
+		azdConfig := NewConfig(map[string]any{})
+		require.True(t, azdConfig.IsEmpty())
+	})
+
+	t.Run("NotEmpty", func(t *testing.T) {
+		azdConfig := NewConfig(map[string]any{
+			"a": "apple",
+		})
+		require.False(t, azdConfig.IsEmpty())
+	})
+}

--- a/cli/azd/pkg/config/config_test.go
+++ b/cli/azd/pkg/config/config_test.go
@@ -1,44 +1,10 @@
 package config
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-func Test_SaveAndLoadConfig(t *testing.T) {
-	defer deleteExistingConfig()
-
-	var azdConfig Config = NewConfig(
-		map[string]any{
-			"defaults": map[string]any{
-				"location":     "eastus2",
-				"subscription": "SUBSCRIPTION_ID",
-			},
-		},
-	)
-
-	err := azdConfig.Save()
-	require.NoError(t, err)
-
-	existingConfig, err := Load()
-	require.NoError(t, err)
-	require.NotNil(t, existingConfig)
-	require.Equal(t, azdConfig, existingConfig)
-}
-
-func Test_SaveAndLoadEmptyConfig(t *testing.T) {
-	defer deleteExistingConfig()
-
-	azdConfig := NewConfig(nil)
-	err := azdConfig.Save()
-	require.NoError(t, err)
-
-	existingConfig, err := Load()
-	require.NoError(t, err)
-	require.NotNil(t, existingConfig)
-}
 
 func Test_SetGetUnsetWithValue(t *testing.T) {
 	tests := []struct {
@@ -108,10 +74,4 @@ func Test_SetGetUnsetRootNodeWithChildren(t *testing.T) {
 	email, ok = azdConfig.Get("user.email")
 	require.True(t, ok)
 	require.Equal(t, expectedEmail, email)
-}
-
-func deleteExistingConfig() {
-	configFilePath, _ := getConfigFilePath()
-	// Remove file if it exists
-	_ = os.Remove(configFilePath)
 }

--- a/cli/azd/pkg/config/manager.go
+++ b/cli/azd/pkg/config/manager.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+)
+
+const configDir = ".azd"
+
+// Config Manager provides the ability to load, parse and save azd configuration files
+type manager struct {
+}
+
+type Manager interface {
+	Save(config Config, filePath string) error
+	Load(filePath string) (Config, error)
+	Parse(configJson []byte) (Config, error)
+}
+
+// Creates a new Configuration Manager
+func NewManager() Manager {
+	return &manager{}
+}
+
+// Saves the azd configuration to the specified file path
+func (c *manager) Save(config Config, filePath string) error {
+	configJson, err := json.MarshalIndent(config.Raw(), "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed marshalling config JSON: %w", err)
+	}
+
+	err = os.WriteFile(filePath, configJson, osutil.PermissionFile)
+	if err != nil {
+		return fmt.Errorf("failed writing configuration data")
+	}
+
+	return nil
+}
+
+// Loads azd configuration from the specified file path
+func (c *manager) Load(filePath string) (Config, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed opening azd configuration file: %w", err)
+	}
+
+	defer file.Close()
+
+	jsonBytes, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading azd configuration file")
+	}
+
+	return c.Parse(jsonBytes)
+}
+
+// Parses azd configuration JSON and returns a Config instance
+func (c *manager) Parse(configJson []byte) (Config, error) {
+	var data map[string]any
+	err := json.Unmarshal(configJson, &data)
+	if err != nil {
+		return nil, fmt.Errorf("failed unmarshalling configuration JSON: %w", err)
+	}
+
+	return NewConfig(data), nil
+}
+
+// GetUserConfigDir returns the config directory for storing user wide configuration data.
+//
+// The config directory is guaranteed to exist, otherwise an error is returned.
+func GetUserConfigDir() (string, error) {
+	user, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("could not determine current user: %w", err)
+	}
+
+	configDirPath := filepath.Join(user.HomeDir, configDir)
+	err = os.MkdirAll(configDirPath, osutil.PermissionDirectory)
+
+	return configDirPath, err
+}
+
+// Gets the local file system path to the Azd configuration file
+func GetUserConfigFilePath() (string, error) {
+	configPath, err := GetUserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("failed locating config dir")
+	}
+
+	return filepath.Join(configPath, "config.json"), nil
+}

--- a/cli/azd/pkg/config/manager.go
+++ b/cli/azd/pkg/config/manager.go
@@ -90,7 +90,7 @@ func GetUserConfigDir() (string, error) {
 func GetUserConfigFilePath() (string, error) {
 	configPath, err := GetUserConfigDir()
 	if err != nil {
-		return "", fmt.Errorf("failed locating config dir")
+		return "", fmt.Errorf("failed getting user config file path '%s'. %w", configPath, err)
 	}
 
 	return filepath.Join(configPath, "config.json"), nil

--- a/cli/azd/pkg/config/manager_test.go
+++ b/cli/azd/pkg/config/manager_test.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_SaveAndLoadConfig(t *testing.T) {
+	defer deleteExistingConfig()
+
+	var azdConfig Config = NewConfig(
+		map[string]any{
+			"defaults": map[string]any{
+				"location":     "eastus2",
+				"subscription": "SUBSCRIPTION_ID",
+			},
+		},
+	)
+
+	configFilePath, _ := GetUserConfigFilePath()
+	configManager := NewManager()
+	err := configManager.Save(azdConfig, configFilePath)
+	require.NoError(t, err)
+
+	existingConfig, err := configManager.Load(configFilePath)
+	require.NoError(t, err)
+	require.NotNil(t, existingConfig)
+	require.Equal(t, azdConfig, existingConfig)
+}
+
+func Test_SaveAndLoadEmptyConfig(t *testing.T) {
+	defer deleteExistingConfig()
+
+	configFilePath, _ := GetUserConfigFilePath()
+	configManager := NewManager()
+	azdConfig := NewConfig(nil)
+	err := configManager.Save(azdConfig, configFilePath)
+	require.NoError(t, err)
+
+	existingConfig, err := configManager.Load(configFilePath)
+	require.NoError(t, err)
+	require.NotNil(t, existingConfig)
+}
+
+func deleteExistingConfig() {
+	configFilePath, _ := GetUserConfigFilePath()
+	// Remove file if it exists
+	_ = os.Remove(configFilePath)
+}

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -262,6 +262,7 @@ func (m *Manager) ensureLocation(ctx context.Context, deployment *Deployment) (s
 		// project.
 		selected, err := azureutil.PromptLocation(
 			ctx,
+			m.env,
 			"Please select an Azure location to use to store deployment metadata:",
 		)
 		if err != nil {

--- a/cli/azd/pkg/tools/azcli/account.go
+++ b/cli/azd/pkg/tools/azcli/account.go
@@ -43,13 +43,13 @@ type AzCliAccessToken struct {
 	ExpiresOn   *time.Time
 }
 
-func (cli *azCli) ListAccounts(ctx context.Context) ([]AzCliSubscriptionInfo, error) {
+func (cli *azCli) ListAccounts(ctx context.Context) ([]*AzCliSubscriptionInfo, error) {
 	client, err := cli.createSubscriptionsClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	subscriptions := []AzCliSubscriptionInfo{}
+	subscriptions := []*AzCliSubscriptionInfo{}
 	pager := client.NewListPager(nil)
 
 	for pager.More() {
@@ -59,11 +59,12 @@ func (cli *azCli) ListAccounts(ctx context.Context) ([]AzCliSubscriptionInfo, er
 		}
 
 		for _, subscription := range page.SubscriptionListResult.Value {
-			subscriptions = append(subscriptions, AzCliSubscriptionInfo{
-				Id:       *subscription.SubscriptionID,
-				Name:     *subscription.DisplayName,
-				TenantId: *subscription.TenantID,
-			})
+			subscriptions = append(subscriptions,
+				&AzCliSubscriptionInfo{
+					Id:       *subscription.SubscriptionID,
+					Name:     *subscription.DisplayName,
+					TenantId: *subscription.TenantID,
+				})
 		}
 	}
 

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -60,7 +60,7 @@ type AzCli interface {
 	Login(ctx context.Context, useDeviceCode bool, deviceCodeWriter io.Writer) error
 	LoginAcr(ctx context.Context, subscriptionId string, loginServer string) error
 	GetContainerRegistries(ctx context.Context, subscriptionId string) ([]*armcontainerregistry.Registry, error)
-	ListAccounts(ctx context.Context) ([]AzCliSubscriptionInfo, error)
+	ListAccounts(ctx context.Context) ([]*AzCliSubscriptionInfo, error)
 	GetDefaultAccount(ctx context.Context) (*AzCliSubscriptionInfo, error)
 	GetAccount(ctx context.Context, subscriptionId string) (*AzCliSubscriptionInfo, error)
 	GetCliConfigValue(ctx context.Context, name string) (AzCliConfigValue, error)

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -108,7 +108,11 @@ func Test_CLI_Init_AsksForSubscriptionIdAndCreatesEnvAndProjectFile(t *testing.T
 	cli.WorkingDirectory = dir
 	cli.Env = append(os.Environ(), "AZURE_LOCATION=eastus2")
 
-	_, err := cli.RunCommandWithStdIn(ctx, fmt.Sprintf("Empty Template\nTESTENV\nOther (enter manually)\n%s\n\n", testSubscriptionId), "init")
+	_, err := cli.RunCommandWithStdIn(
+		ctx,
+		fmt.Sprintf("Empty Template\nTESTENV\nOther (enter manually)\n%s\n\n", testSubscriptionId),
+		"init",
+	)
 	require.NoError(t, err)
 
 	file, err := os.ReadFile(getTestEnvPath(dir, "TESTENV"))

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -44,6 +44,10 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
+const (
+	testSubscriptionId = "2cd617ea-1866-46b1-90e3-fffb087ebf9b"
+)
+
 func Test_CLI_Login_FailsIfNoAzCliIsMissing(t *testing.T) {
 	ctx, cancel := newTestContext(t)
 	defer cancel()
@@ -99,10 +103,6 @@ func Test_CLI_Init_AsksForSubscriptionIdAndCreatesEnvAndProjectFile(t *testing.T
 	defer cancel()
 
 	dir := tempDirWithDiagnostics(t)
-	testSubscriptionId := os.Getenv("TEST_SUBSCRIPTION_ID")
-	if strings.TrimSpace(testSubscriptionId) == "" {
-		testSubscriptionId = "faa080af-c1d8-40ad-9cce-e1a450ca5b57"
-	}
 
 	cli := azdcli.NewCLI(t)
 	cli.WorkingDirectory = dir

--- a/cli/azd/test/mocks/config/mock_config.go
+++ b/cli/azd/test/mocks/config/mock_config.go
@@ -1,0 +1,28 @@
+package config
+
+import "github.com/azure/azure-dev/cli/azd/pkg/config"
+
+type MockConfigManager struct {
+	config config.Config
+}
+
+func NewMockConfigManager() *MockConfigManager {
+	return &MockConfigManager{}
+}
+
+func (m *MockConfigManager) WithConfig(config config.Config) *MockConfigManager {
+	m.config = config
+	return m
+}
+
+func (m *MockConfigManager) Save(config config.Config, filePath string) error {
+	return nil
+}
+
+func (m *MockConfigManager) Load(filePath string) (config.Config, error) {
+	return m.config, nil
+}
+
+func (m *MockConfigManager) Parse(configJson []byte) (config.Config, error) {
+	return m.config, nil
+}

--- a/cli/azd/test/mocks/config/mock_config.go
+++ b/cli/azd/test/mocks/config/mock_config.go
@@ -7,7 +7,9 @@ type MockConfigManager struct {
 }
 
 func NewMockConfigManager() *MockConfigManager {
-	return &MockConfigManager{}
+	return &MockConfigManager{
+		config: config.NewConfig(nil),
+	}
 }
 
 func (m *MockConfigManager) WithConfig(config config.Config) *MockConfigManager {

--- a/cli/azd/test/mocks/mock_context.go
+++ b/cli/azd/test/mocks/mock_context.go
@@ -10,6 +10,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/identity"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	mockconfig "github.com/azure/azure-dev/cli/azd/test/mocks/config"
 	mockconsole "github.com/azure/azure-dev/cli/azd/test/mocks/console"
 	mockexec "github.com/azure/azure-dev/cli/azd/test/mocks/exec"
 	mockhttp "github.com/azure/azure-dev/cli/azd/test/mocks/httputil"
@@ -20,6 +21,7 @@ type MockContext struct {
 	Console       *mockconsole.MockConsole
 	HttpClient    *mockhttp.MockHttpClient
 	CommandRunner *mockexec.MockCommandRunner
+	ConfigManager *mockconfig.MockConfigManager
 }
 
 func NewMockContext(ctx context.Context) *MockContext {
@@ -27,6 +29,7 @@ func NewMockContext(ctx context.Context) *MockContext {
 	commandRunner := mockexec.NewMockCommandRunner()
 	httpClient := mockhttp.NewMockHttpUtil()
 	credentials := MockCredentials{}
+	configManager := mockconfig.NewMockConfigManager()
 
 	mockexec.AddAzLoginMocks(commandRunner)
 	httpClient.AddDefaultMocks()
@@ -43,6 +46,7 @@ func NewMockContext(ctx context.Context) *MockContext {
 		Console:       mockConsole,
 		CommandRunner: commandRunner,
 		HttpClient:    httpClient,
+		ConfigManager: configManager,
 	}
 
 	return mockContext

--- a/cli/azd/test/mocks/mock_context.go
+++ b/cli/azd/test/mocks/mock_context.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/azure/azure-dev/cli/azd/pkg/identity"
@@ -27,6 +28,7 @@ func NewMockContext(ctx context.Context) *MockContext {
 	commandRunner := mockexec.NewMockCommandRunner()
 	httpClient := mockhttp.NewMockHttpUtil()
 	credentials := MockCredentials{}
+	azdConfig := config.NewConfig(nil)
 
 	mockexec.AddAzLoginMocks(commandRunner)
 	httpClient.AddDefaultMocks()
@@ -37,6 +39,7 @@ func NewMockContext(ctx context.Context) *MockContext {
 	ctx = httputil.WithHttpClient(ctx, httpClient)
 	ctx = identity.WithCredentials(ctx, &credentials)
 	ctx = output.WithWriter(ctx, os.Stdout)
+	ctx = config.WithConfig(ctx, azdConfig)
 
 	mockContext := &MockContext{
 		Context:       &ctx,

--- a/cli/azd/test/mocks/mock_context.go
+++ b/cli/azd/test/mocks/mock_context.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
-	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/azure/azure-dev/cli/azd/pkg/identity"
@@ -28,7 +27,6 @@ func NewMockContext(ctx context.Context) *MockContext {
 	commandRunner := mockexec.NewMockCommandRunner()
 	httpClient := mockhttp.NewMockHttpUtil()
 	credentials := MockCredentials{}
-	azdConfig := config.NewConfig(nil)
 
 	mockexec.AddAzLoginMocks(commandRunner)
 	httpClient.AddDefaultMocks()
@@ -39,7 +37,6 @@ func NewMockContext(ctx context.Context) *MockContext {
 	ctx = httputil.WithHttpClient(ctx, httpClient)
 	ctx = identity.WithCredentials(ctx, &credentials)
 	ctx = output.WithWriter(ctx, os.Stdout)
-	ctx = config.WithConfig(ctx, azdConfig)
 
 	mockContext := &MockContext{
 		Context:       &ctx,

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -122,7 +122,6 @@ stages:
               ARM_CLIENT_ID: $(arm-client-id)
               ARM_CLIENT_SECRET: $(arm-client-secret)
               ARM_TENANT_ID: $(arm-tenant-id)
-              TEST_SUBSCRIPTION_ID: $(sub-config-azure-cloud-test-resources.SubscriptionId)
 
           - task: PublishTestResults@2
             inputs:

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -122,6 +122,7 @@ stages:
               ARM_CLIENT_ID: $(arm-client-id)
               ARM_CLIENT_SECRET: $(arm-client-secret)
               ARM_TENANT_ID: $(arm-tenant-id)
+              TEST_SUBSCRIPTION_ID: $(sub-config-azure-cloud-test-resources.SubscriptionId)
 
           - task: PublishTestResults@2
             inputs:


### PR DESCRIPTION
Adds new `azd config` command category with the following commands.

- `azd config list` => List all configurations
- `azd config get` => Gets the values stored at the specified path
- `azd config set` => Sets a value stored at the specified path
- `azd config unset` => Removes/unsets the value at the specified path
- `azd config reset` => Clears out any configuration values that were previously set

Updates the `config` package to support above commands.

**First run experience**
Updates  `azd init` to store default values for subscription & location when not previously set.