### PR TITLE
Fix codespaces setup issues

### DIFF
--- a/templates/common/.devcontainer/devcontainer.json/java/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/java/devcontainer.json
@@ -28,5 +28,8 @@
         3100
     ],
     "postCreateCommand": "",
-    "remoteUser": "vscode"
+    "remoteUser": "vscode",
+    "hostRequirements": {
+        "memory": "8gb"
+    }
 }

--- a/templates/common/.devcontainer/devcontainer.json/nodejs/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/nodejs/devcontainer.json
@@ -30,5 +30,8 @@
         3100
     ],
     "postCreateCommand": "",
-    "remoteUser": "vscode"
+    "remoteUser": "vscode",
+    "hostRequirements": {
+        "memory": "8gb"
+    }
 }

--- a/templates/common/.devcontainer/devcontainer.json/python/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/devcontainer.json
@@ -28,5 +28,8 @@
         3100
     ],
     "postCreateCommand": "",
-    "remoteUser": "vscode"
+    "remoteUser": "vscode",
+    "hostRequirements": {
+        "memory": "8gb"
+    }
 }

--- a/templates/common/.devcontainer/devcontainer.json/python/func/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/func/devcontainer.json
@@ -9,7 +9,7 @@
     "features": {
         "github-cli": "2",
         "azure-cli": "2.38",
-        "dotnet": "6.0",
+        "python": "os-provided",
         "docker-from-docker": "20.10",
         "node": {
             "version": "16",
@@ -21,8 +21,8 @@
         "ms-azuretools.vscode-bicep",
         "ms-azuretools.vscode-docker",
         "ms-vscode.vscode-node-azure-pack",
-        "ms-dotnettools.csharp",
-        "ms-dotnettools.vscode-dotnet-runtime"
+        "ms-python.python",
+        "ms-azuretools.vscode-azurefunctions"
     ],
     "forwardPorts": [
         3000,

--- a/templates/common/.devcontainer/devcontainer.json/python/terraform/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/terraform/devcontainer.json
@@ -28,5 +28,8 @@
   ],
   "forwardPorts": [3000, 3100],
   "postCreateCommand": "",
-  "remoteUser": "vscode"
+  "remoteUser": "vscode",
+  "hostRequirements": {
+      "memory": "8gb"
+  }
 }

--- a/templates/todo/projects/python-mongo-swa-func/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/python-mongo-swa-func/.repo/bicep/repo.yaml
@@ -125,7 +125,7 @@ repo:
       to: ./infra
 
     # .devcontainer common (devcontainer.json)
-    - from: ../../../../../common/.devcontainer/devcontainer.json/python
+    - from: ../../../../../common/.devcontainer/devcontainer.json/python/func
       to: ./.devcontainer
 
     # .devcontainer common (Dockerfile)


### PR DESCRIPTION
Picking up where @danieljurek left off. Cherry-picked changes from: #902

- Bump memory requirements to 8GB for devcontainers
- Fix python func template not installing `azurefunctions` extension