### PR TITLE
[check enforcer] Bump minimum check runs to 2

### DIFF
--- a/eng/CHECKENFORCER
+++ b/eng/CHECKENFORCER
@@ -1,5 +1,5 @@
 format: v0.1-alpha
-minimumCheckRuns: 1
+minimumCheckRuns: 2
 timeout: 10
 message: >
   This pull request is protected by [Check Enforcer](https://aka.ms/azsdk/check-enforcer).


### PR DESCRIPTION
Temporary fix for legacy check enforcer given that the new license/cla check now posts a check_run instead of a status.