### PR TITLE
Exclude appconfig/keyvault purge message if there's no appconfig/keyvault detected when running `azd down`

### DIFF
--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -430,11 +430,11 @@ func (p *BicepProvider) purgeItems(
 	items []itemToPurge,
 	options DestroyOptions,
 ) error {
-	if !options.Purge() {
+	if len(items) > 0 && !options.Purge() {
 		var itemString string
-		itemsWarning := "\n\nThis operation will delete:"
+		var itemsWarning string
 		for _, v := range items {
-			if v.count != 0 {
+			if v.count > 0 {
 				if itemString != "" {
 					itemString = itemString + "/" + v.resourceType
 				} else {
@@ -443,7 +443,12 @@ func (p *BicepProvider) purgeItems(
 				itemsWarning = itemsWarning + fmt.Sprintf("\n				%d %s", v.count, v.resourceType)
 			}
 		}
-		itemsWarning = itemsWarning + fmt.Sprintf("\nThese %s have soft delete enabled "+
+
+		if len(itemsWarning) < 1 {
+			return nil
+		}
+
+		itemsWarning = "\n\nThis operation will delete:" + itemsWarning + fmt.Sprintf("\nThese %s have soft delete enabled "+
 			"allowing them to be recovered for a period "+
 			"of time after deletion. During this period, their names may not be reused.\n"+
 			"You can use argument --purge to skip this confirmation.\n\n", itemString)


### PR DESCRIPTION
Message to ask for purge should not appear if key vaults and app configurations are empty. 