### PR TITLE
Update featured syntax

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,8 +9,12 @@
     "features": {
         // Prerequisites for running azd
         // https://github.com/Azure/azure-dev/wiki/Install
-        "github-cli": "2.3",
-        "azure-cli": "2.38"
+        "ghcr.io/devcontainers/features/github-cli:1": {
+            "version": "2.3"
+        },
+        "ghcr.io/devcontainers/features/azure-cli:1": {
+            "version": "2.38"
+        }
     }, 
     "extensions": [
         "redhat.vscode-yaml",


### PR DESCRIPTION
As I started work on https://github.com/Azure/azure-dev/issues/946, I noticed the devcontainer.json for this repository also uses the deprecated syntax. 

I updated the syntax and kept the same version numbers, but I notice its using an older version of azure-cli (2.38) than latest (2.41), and I wonder if the pinning is intentional.