### PR TITLE
Updating features in devcontainers to not use deprecated syntax

### DIFF
--- a/templates/common/.devcontainer/devcontainer.json/csharp/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/csharp/devcontainer.json
@@ -7,9 +7,6 @@
         }
     },
     "features": {
-        "ghcr.io/devcontainers/features/github-cli:1": {
-            "version": "2"
-        },
         "ghcr.io/devcontainers/features/azure-cli:1": {
             "version": "2.38"
         },
@@ -18,6 +15,9 @@
         },
         "ghcr.io/devcontainers/features/dotnet:1": {
             "version": "6.0"
+        },
+        "ghcr.io/devcontainers/features/github-cli:1": {
+            "version": "2"
         },
         "ghcr.io/devcontainers/features/node:1": {
             "version": "16",

--- a/templates/common/.devcontainer/devcontainer.json/csharp/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/csharp/devcontainer.json
@@ -7,11 +7,19 @@
         }
     },
     "features": {
-        "github-cli": "2",
-        "azure-cli": "2.38",
-        "dotnet": "6.0",
-        "docker-from-docker": "20.10",
-        "node": {
+        "ghcr.io/devcontainers/features/github-cli:1": {
+            "version": "2"
+        },
+        "ghcr.io/devcontainers/features/azure-cli:1": {
+            "version": "2.38"
+        },
+        "ghcr.io/devcontainers/features/docker-from-docker:1": {
+            "version": "20.10"
+        },
+        "ghcr.io/devcontainers/features/dotnet:1": {
+            "version": "6.0"
+        },
+        "ghcr.io/devcontainers/features/node:1": {
             "version": "16",
             "nodeGypDependencies": false
         }

--- a/templates/common/.devcontainer/devcontainer.json/java/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/java/devcontainer.json
@@ -7,11 +7,19 @@
         }
     },
     "features": {
-        "github-cli": "2",
-        "azure-cli": "2.38",
-        "docker-from-docker": "20.10",
-        "java": "17.0",
-        "node": {
+        "ghcr.io/devcontainers/features/github-cli:1": {
+            "version": "2"
+        },
+        "ghcr.io/devcontainers/features/azure-cli:1": {
+            "version": "2.38"
+        },
+        "ghcr.io/devcontainers/features/docker-from-docker:1": {
+            "version": "20.10"
+        },
+        "ghcr.io/devcontainers/features/java:1": {
+            "version": "17.0"
+        },
+        "ghcr.io/devcontainers/features/node:1": {
             "version": "16",
             "nodeGypDependencies": false
         }

--- a/templates/common/.devcontainer/devcontainer.json/java/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/java/devcontainer.json
@@ -7,14 +7,14 @@
         }
     },
     "features": {
-        "ghcr.io/devcontainers/features/github-cli:1": {
-            "version": "2"
-        },
         "ghcr.io/devcontainers/features/azure-cli:1": {
             "version": "2.38"
         },
         "ghcr.io/devcontainers/features/docker-from-docker:1": {
             "version": "20.10"
+        },
+        "ghcr.io/devcontainers/features/github-cli:1": {
+            "version": "2"
         },
         "ghcr.io/devcontainers/features/java:1": {
             "version": "17.0"

--- a/templates/common/.devcontainer/devcontainer.json/nodejs/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/nodejs/devcontainer.json
@@ -7,10 +7,19 @@
         }
     },
     "features": {
-        "github-cli": "2",
-        "azure-cli": "2.38",
-        "docker-from-docker": "20.10",
-        "node": {
+        "ghcr.io/devcontainers/features/github-cli:1": {
+            "version": "2"
+        },
+        "ghcr.io/devcontainers/features/azure-cli:1": {
+            "version": "2.38"
+        },
+        "ghcr.io/devcontainers/features/docker-from-docker:1": {
+            "version": "20.10"
+        },
+        "ghcr.io/devcontainers/features/python:1": {
+            "version": "os-provided"
+        },
+        "ghcr.io/devcontainers/features/node:1": {
             "version": "16",
             "nodeGypDependencies": false
         }

--- a/templates/common/.devcontainer/devcontainer.json/nodejs/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/nodejs/devcontainer.json
@@ -7,21 +7,21 @@
         }
     },
     "features": {
-        "ghcr.io/devcontainers/features/github-cli:1": {
-            "version": "2"
-        },
         "ghcr.io/devcontainers/features/azure-cli:1": {
             "version": "2.38"
         },
         "ghcr.io/devcontainers/features/docker-from-docker:1": {
             "version": "20.10"
         },
-        "ghcr.io/devcontainers/features/python:1": {
-            "version": "os-provided"
+        "ghcr.io/devcontainers/features/github-cli:1": {
+            "version": "2"
         },
         "ghcr.io/devcontainers/features/node:1": {
             "version": "16",
             "nodeGypDependencies": false
+        },
+        "ghcr.io/devcontainers/features/python:1": {
+            "version": "os-provided"
         }
     },
     "extensions": [

--- a/templates/common/.devcontainer/devcontainer.json/python/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/devcontainer.json
@@ -7,11 +7,19 @@
         }
     },
     "features": {
-        "github-cli": "2",
-        "azure-cli": "2.38",
-        "python": "os-provided",
-        "docker-from-docker": "20.10",
-        "node": {
+        "ghcr.io/devcontainers/features/github-cli:1": {
+            "version": "2"
+        },
+        "ghcr.io/devcontainers/features/azure-cli:1": {
+            "version": "2.38"
+        },
+        "ghcr.io/devcontainers/features/docker-from-docker:1": {
+            "version": "20.10"
+        },
+        "ghcr.io/devcontainers/features/python:1": {
+            "version": "os-provided"
+        },
+        "ghcr.io/devcontainers/features/node:1": {
             "version": "16",
             "nodeGypDependencies": false
         }

--- a/templates/common/.devcontainer/devcontainer.json/python/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/devcontainer.json
@@ -7,21 +7,21 @@
         }
     },
     "features": {
-        "ghcr.io/devcontainers/features/github-cli:1": {
-            "version": "2"
-        },
         "ghcr.io/devcontainers/features/azure-cli:1": {
             "version": "2.38"
         },
         "ghcr.io/devcontainers/features/docker-from-docker:1": {
             "version": "20.10"
         },
-        "ghcr.io/devcontainers/features/python:1": {
-            "version": "os-provided"
+        "ghcr.io/devcontainers/features/github-cli:1": {
+            "version": "2"
         },
         "ghcr.io/devcontainers/features/node:1": {
             "version": "16",
             "nodeGypDependencies": false
+        },
+        "ghcr.io/devcontainers/features/python:1": {
+            "version": "os-provided"
         }
     },
     "extensions": [

--- a/templates/common/.devcontainer/devcontainer.json/python/func/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/func/devcontainer.json
@@ -7,11 +7,19 @@
         }
     },
     "features": {
-        "github-cli": "2",
-        "azure-cli": "2.38",
-        "python": "os-provided",
-        "docker-from-docker": "20.10",
-        "node": {
+        "ghcr.io/devcontainers/features/github-cli:1": {
+            "version": "2"
+        },
+        "ghcr.io/devcontainers/features/azure-cli:1": {
+            "version": "2.38"
+        },
+        "ghcr.io/devcontainers/features/docker-from-docker:1": {
+            "version": "20.10"
+        },
+        "ghcr.io/devcontainers/features/python:1": {
+            "version": "os-provided"
+        },
+        "ghcr.io/devcontainers/features/node:1": {
             "version": "16",
             "nodeGypDependencies": false
         }

--- a/templates/common/.devcontainer/devcontainer.json/python/func/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/func/devcontainer.json
@@ -7,21 +7,21 @@
         }
     },
     "features": {
-        "ghcr.io/devcontainers/features/github-cli:1": {
-            "version": "2"
-        },
         "ghcr.io/devcontainers/features/azure-cli:1": {
             "version": "2.38"
         },
         "ghcr.io/devcontainers/features/docker-from-docker:1": {
             "version": "20.10"
         },
-        "ghcr.io/devcontainers/features/python:1": {
-            "version": "os-provided"
+        "ghcr.io/devcontainers/features/github-cli:1": {
+            "version": "2"
         },
         "ghcr.io/devcontainers/features/node:1": {
             "version": "16",
             "nodeGypDependencies": false
+        },
+        "ghcr.io/devcontainers/features/python:1": {
+            "version": "os-provided"
         }
     },
     "extensions": [

--- a/templates/common/.devcontainer/devcontainer.json/python/terraform/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/terraform/devcontainer.json
@@ -1,43 +1,43 @@
 {
-  "name": "Azure Developer CLI",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "args": {
-      "VARIANT": "bullseye"
+    "name": "Azure Developer CLI",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "args": {
+            "VARIANT": "bullseye"
+        }
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/azure-cli:1": {
+            "version": "2.38"
+        },
+        "ghcr.io/devcontainers/features/docker-from-docker:1": {
+            "version": "20.10"
+        },
+        "ghcr.io/devcontainers/features/github-cli:1": {
+            "version": "2"
+        },
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "16",
+            "nodeGypDependencies": false
+        },
+        "ghcr.io/devcontainers/features/python:1": {
+            "version": "os-provided"
+        },
+        "ghcr.io/devcontainers/features/terraform:1": {
+            "version": "latest"
+        }
+    },
+    "extensions": [
+        "ms-azuretools.azure-dev",
+        "ms-azuretools.vscode-bicep",
+        "ms-azuretools.vscode-docker",
+        "ms-vscode.vscode-node-azure-pack",
+        "ms-python.python"
+    ],
+    "forwardPorts": [3000, 3100],
+    "postCreateCommand": "",
+    "remoteUser": "vscode",
+    "hostRequirements": {
+        "memory": "8gb"
     }
-  },
-  "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {
-        "version": "2"
-    },
-    "ghcr.io/devcontainers/features/azure-cli:1": {
-        "version": "2.38"
-    },
-    "ghcr.io/devcontainers/features/docker-from-docker:1": {
-        "version": "20.10"
-    },
-    "ghcr.io/devcontainers/features/python:1": {
-        "version": "os-provided"
-    },
-    "ghcr.io/devcontainers/features/node:1": {
-        "version": "16",
-        "nodeGypDependencies": false
-    },
-    "ghcr.io/devcontainers/features/terraform:1": {
-        "version": "latest"
-    }
-  },
-  "extensions": [
-    "ms-azuretools.azure-dev",
-    "ms-azuretools.vscode-bicep",
-    "ms-azuretools.vscode-docker",
-    "ms-vscode.vscode-node-azure-pack",
-    "ms-python.python"
-  ],
-  "forwardPorts": [3000, 3100],
-  "postCreateCommand": "",
-  "remoteUser": "vscode",
-  "hostRequirements": {
-      "memory": "8gb"
-  }
 }

--- a/templates/common/.devcontainer/devcontainer.json/python/terraform/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/terraform/devcontainer.json
@@ -8,7 +8,7 @@
   },
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {
-      "version": "2"
+        "version": "2"
     },
     "ghcr.io/devcontainers/features/azure-cli:1": {
         "version": "2.38"
@@ -24,7 +24,7 @@
         "nodeGypDependencies": false
     },
     "ghcr.io/devcontainers/features/terraform:1": {
-      "version": "latest"
+        "version": "latest"
     }
   },
   "extensions": [

--- a/templates/common/.devcontainer/devcontainer.json/python/terraform/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/terraform/devcontainer.json
@@ -7,13 +7,21 @@
     }
   },
   "features": {
-    "github-cli": "2",
-    "azure-cli": "2.38",
-    "python": "os-provided",
-    "docker-from-docker": "20.10",
-    "node": {
-      "version": "16",
-      "nodeGypDependencies": false
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "2"
+    },
+    "ghcr.io/devcontainers/features/azure-cli:1": {
+        "version": "2.38"
+    },
+    "ghcr.io/devcontainers/features/docker-from-docker:1": {
+        "version": "20.10"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+        "version": "os-provided"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+        "version": "16",
+        "nodeGypDependencies": false
     },
     "ghcr.io/devcontainers/features/terraform:1": {
       "version": "latest"


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-dev/issues/946

This PR updates the devcontainer.json files for Python samples to use the new deprecated features syntax. I tested by using the same features in my fork of the todo-mongo-python app, and confirmed no warnings about deprecation in the logs.

I retained the version numbers used in the previous JSON files, but let me know if you think we should un-pin and use latest instead. I don't know the thinking there. (One concern with pinning is that people will copy these templates and never-ever update their versions. But of course using latest subjects the repos to regression issues).

I can update the features for other languages once this PR is approved. I just want to make sure this one looks good first.