### PR TITLE
Fix `azd pipeline config` in codespaces

### DIFF
--- a/cli/azd/pkg/commands/pipeline/github_provider.go
+++ b/cli/azd/pkg/commands/pipeline/github_provider.go
@@ -307,7 +307,11 @@ func (p *GitHubCiProvider) name() string {
 
 // ensureAuthorizedForRepoSecrets ensures the user is authorized for modifying repository-level secrets.
 // If not, the user is prompted for login.
-func (p *GitHubCiProvider) ensureAuthorizedForRepoSecrets(ctx context.Context, ghCli github.GitHubCli, console input.Console, repoSlug string) error {
+func (p *GitHubCiProvider) ensureAuthorizedForRepoSecrets(
+	ctx context.Context,
+	ghCli github.GitHubCli,
+	console input.Console,
+	repoSlug string) error {
 	// The actual scope for repository-level secrets is simply the `repo` scope in GitHub.
 	// Thus, listing secrets has the same access level permissions as writing secrets
 	// and can be used for probing secrets authorization.

--- a/cli/azd/pkg/commands/pipeline/github_provider.go
+++ b/cli/azd/pkg/commands/pipeline/github_provider.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -328,6 +329,7 @@ func (p *GitHubCiProvider) ensureAuthorizedForRepoSecrets(
 		}
 
 		if authResult.TokenSource == github.TokenSourceEnvVar {
+			log.Println("Switching gh to file authentication mode")
 			// Force file-based auth so that we can re-prompt for login.
 			// Otherwise, `gh auth` commands will simply report that we are authenticated.
 			ghCli.ForceConfigureAuth(github.TokenSourceFile)
@@ -338,7 +340,10 @@ func (p *GitHubCiProvider) ensureAuthorizedForRepoSecrets(
 			if err != nil {
 				return fmt.Errorf("logging in: %w", err)
 			}
+
+			return nil
 		}
+
 	}
 
 	return fmt.Errorf("listing secrets: %w", err)

--- a/cli/azd/pkg/commands/pipeline/github_provider.go
+++ b/cli/azd/pkg/commands/pipeline/github_provider.go
@@ -42,7 +42,7 @@ func (p *GitHubScmProvider) requiredTools(ctx context.Context) []tools.ExternalT
 // preConfigureCheck check the current state of external tools and any
 // other dependency to be as expected for execution.
 func (p *GitHubScmProvider) preConfigureCheck(ctx context.Context, console input.Console) error {
-	return ensureGitHubLogin(ctx, github.GitHubHostName, console)
+	return ensureGitHubLogin(ctx, github.NewGitHubCli(ctx), github.GitHubHostName, console)
 }
 
 // name returns the name of the provider
@@ -295,7 +295,7 @@ func (p *GitHubCiProvider) requiredTools(ctx context.Context) []tools.ExternalTo
 // preConfigureCheck validates that current state of tools and GitHub is as expected to
 // execute.
 func (p *GitHubCiProvider) preConfigureCheck(ctx context.Context, console input.Console) error {
-	return ensureGitHubLogin(ctx, github.GitHubHostName, console)
+	return ensureGitHubLogin(ctx, github.NewGitHubCli(ctx), github.GitHubHostName, console)
 }
 
 // name returns the name of the provider.
@@ -304,6 +304,39 @@ func (p *GitHubCiProvider) name() string {
 }
 
 // ***  ciProvider implementation ******
+
+// ensureAuthorizedForRepoSecrets ensures the user is authorized for modifying repository-level secrets.
+// If not, the user is prompted for login.
+func (p *GitHubCiProvider) ensureAuthorizedForRepoSecrets(ctx context.Context, ghCli github.GitHubCli, console input.Console, repoSlug string) error {
+	// The actual scope for repository-level secrets is simply the `repo` scope in GitHub.
+	// Thus, listing secrets has the same access level permissions as writing secrets
+	// and can be used for probing secrets authorization.
+	err := ghCli.ListSecrets(ctx, repoSlug)
+
+	if err != nil {
+		return fmt.Errorf("listing secrets: %w", err)
+	} else if errors.Is(err, github.ErrUserNotAuthorized) {
+		authResult, err := ghCli.CheckAuth(ctx, github.GitHubHostName)
+		if err != nil {
+			return fmt.Errorf("checking auth: %w", err)
+		}
+
+		if authResult.TokenSource == github.TokenSourceEnvVar {
+			// Force file-based auth so that we can re-prompt for login.
+			// Otherwise, `gh auth` commands will simply report that we are authenticated.
+			ghCli.ForceConfigureAuth(github.TokenSourceFile)
+
+			// Since repository-level secrets only requires `repo` scope, and `gh auth login` always grants `repo` scope,
+			//  we can run `gh auth login`` without needing `gh auth refresh` with additional scopes
+			err = ensureGitHubLogin(ctx, ghCli, github.GitHubHostName, console)
+			if err != nil {
+				return fmt.Errorf("logging in: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
 
 // configureConnection set up GitHub account with Azure Credentials for
 // GitHub actions to use a service principal account to log in to Azure
@@ -321,6 +354,10 @@ func (p *GitHubCiProvider) configureConnection(
 	console.Message(ctx, "Setting AZURE_CREDENTIALS GitHub repo secret.\n")
 
 	ghCli := github.NewGitHubCli(ctx)
+	if err := p.ensureAuthorizedForRepoSecrets(ctx, ghCli, console, repoSlug); err != nil {
+		return fmt.Errorf("ensuring authorization: %w", err)
+	}
+
 	// set azure credential for pipelines can log in to Azure
 	if err := ghCli.SetSecret(ctx, repoSlug, "AZURE_CREDENTIALS", string(credentials)); err != nil {
 		return fmt.Errorf("failed setting AZURE_CREDENTIALS secret: %w", err)
@@ -403,14 +440,13 @@ func (p *GitHubCiProvider) configurePipeline(
 
 // ensureGitHubLogin ensures the user is logged into the GitHub CLI. If not, it prompt the user
 // if they would like to log in and if so runs `gh auth login` interactively.
-func ensureGitHubLogin(ctx context.Context, hostname string, console input.Console) error {
-	ghCli := github.NewGitHubCli(ctx)
-	loggedIn, err := ghCli.CheckAuth(ctx, hostname)
+func ensureGitHubLogin(ctx context.Context, ghCli github.GitHubCli, hostname string, console input.Console) error {
+	authResult, err := ghCli.CheckAuth(ctx, hostname)
 	if err != nil {
 		return err
 	}
 
-	if loggedIn {
+	if authResult.LoggedIn {
 		return nil
 	}
 

--- a/cli/azd/pkg/tools/github/github.go
+++ b/cli/azd/pkg/tools/github/github.go
@@ -258,14 +258,18 @@ func (cli *ghCli) GitHubActionsExists(ctx context.Context, repoSlug string) (boo
 }
 
 func (cli *ghCli) ForceConfigureAuth(authMode AuthTokenSource) {
-	if authMode == TokenSourceFile {
+	switch authMode {
+	case TokenSourceFile:
+		// Unset token environment variables to force file-base auth.
 		for _, tokenEnvVarName := range TokenEnvVars {
 			cli.overrideTokenEnv = append(cli.overrideTokenEnv, fmt.Sprintf("%v=", tokenEnvVarName))
 		}
-	} else { // authMode == TokenSourceEnvVar
+	case TokenSourceEnvVar:
 		// GitHub CLI will always use environment variables first.
-		// Therefore, we simply need to clear our environment context override to force environment variable usage.
+		// Therefore, we simply need to clear our environment context override (if any) to force environment variable usage.
 		cli.overrideTokenEnv = nil
+	default:
+		panic(fmt.Sprintf("Unsupported auth mode: %d", authMode))
 	}
 }
 

--- a/cli/azd/pkg/tools/github/github.go
+++ b/cli/azd/pkg/tools/github/github.go
@@ -41,8 +41,9 @@ func NewGitHubCli(ctx context.Context) GitHubCli {
 
 var (
 	ErrGitHubCliNotLoggedIn = errors.New("gh cli is not logged in")
-	ErrUserNotAuthorized    = errors.New("user is not authorized. Try running gh auth refresh with the required scopes to request additional authorization")
-	ErrRepositoryNameInUse  = errors.New("repository name already in use")
+	ErrUserNotAuthorized    = errors.New("user is not authorized. " +
+		"Try running gh auth refresh with the required scopes to request additional authorization")
+	ErrRepositoryNameInUse = errors.New("repository name already in use")
 
 	// The hostname of the public GitHub service.
 	GitHubHostName = "github.com"


### PR DESCRIPTION
Problem: When `GITHUB_TOKEN` variable is set in codespaces, GitHub CLI will always attempt to use `GITHUB_TOKEN`, which fails to set repository-level secrets. This is due to tokens generated in codespaces not having the ability to manage repository secrets (this is a technical limitation of codespaces).

As a holistic fix that is not specific to codespaces, we simply detect if GitHub CLI is using an environment variable token source (`GITHUB_TOKEN` or `GH_TOKEN`), and if we fail setting secrets due to authorization errors, we simply configure GitHub CLI to ignore the environment variables (by hiding these environment variables when invoking the command) and proceed with logging in.

This type of authorization failure detection + forcing auth mode can be extended to other types of API calls for GitHub CLI in the future.

With this change, running `azd pipeline config` prompts the user to login if credentials are not yet stored on disk in the codespaces container, or otherwise it simply uses the user's oauth token instead of the limited scope PAT token to perform repo-level secrets modifications.

Fixes #948