### PR TITLE
Azd CLI: Parse ARM deployment errors from Go SDK response

### DIFF
--- a/cli/azd/pkg/tools/azcli/azcli_test.go
+++ b/cli/azd/pkg/tools/azcli/azcli_test.go
@@ -204,68 +204,6 @@ func runAndCaptureUserAgent(t *testing.T) string {
 	return matches[0][1]
 }
 
-func Test_extractDeploymentError(t *testing.T) {
-	type args struct {
-		stderr string
-	}
-	//nolint:lll
-	tests := []struct {
-		name     string
-		args     args
-		expected string
-	}{
-		{
-			name: "errorWithInner",
-			args: args{
-				`ERROR: {"code": "InvalidTemplateDeployment", "message": "See inner errors for details."}
-
-Inner Errors:
-{"code": "PreflightValidationCheckFailed", "message": "Preflight validation failed. Please refer to the details for the specific errors."}
-
-Inner Errors:
-{"code": "AccountNameInvalid", "target": "invalid-123", "message": "invalid-123 is not a valid storage account name. Storage account name must be between 3 and 24 characters in length and use numbers and lower-case letters only."}`},
-			expected: `Deployment Error Details:
-InvalidTemplateDeployment: See inner errors for details.
-
-Inner Error:
-PreflightValidationCheckFailed: Preflight validation failed. Please refer to the details for the specific errors.
-
-Inner Error:
-AccountNameInvalid: invalid-123 is not a valid storage account name. Storage account name must be between 3 and 24 characters in length and use numbers and lower-case letters only.
-`,
-		},
-		{
-			name: "errorWithInnerRaw",
-			args: args{
-				`ERROR: {"code": "InvalidTemplateDeployment", "message": "See inner errors for details."}
-
-Line1: additional detail happened
-Line2: additional detail happened`,
-			},
-			expected: `Deployment Error Details:
-InvalidTemplateDeployment: See inner errors for details.
-
-Line1: additional detail happened
-Line2: additional detail happened`,
-		},
-		{
-			name: "errorOnly",
-			args: args{
-				`ERROR: {"code": "InvalidTemplateDeployment", "message": "Invalid template deployment."}`,
-			},
-			expected: `Deployment Error Details:
-InvalidTemplateDeployment: Invalid template deployment.
-`,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := extractDeploymentError(tt.args.stderr)
-			assert.Equal(t, tt.expected, err.Error())
-		})
-	}
-}
-
 func TestAZCliGetAccessTokenTranslatesErrors(t *testing.T) {
 	//nolint:lll
 	tests := []struct {

--- a/cli/azd/pkg/tools/azcli/deployments.go
+++ b/cli/azd/pkg/tools/azcli/deployments.go
@@ -112,7 +112,10 @@ func (cli *azCli) DeployToSubscription(
 	deployResult, err := createFromTemplateOperation.PollUntilDone(ctx, nil)
 	if err != nil {
 		deploymentError := createDeploymentError(err)
-		return AzCliDeploymentResult{}, fmt.Errorf("deploying to subscription: %w", deploymentError)
+		return AzCliDeploymentResult{}, fmt.Errorf(
+			"deploying to subscription:\n\nDeployment Error Details:\n%w",
+			deploymentError,
+		)
 	}
 
 	return AzCliDeploymentResult{
@@ -157,7 +160,10 @@ func (cli *azCli) DeployToResourceGroup(
 	deployResult, err := createFromTemplateOperation.PollUntilDone(ctx, nil)
 	if err != nil {
 		deploymentError := createDeploymentError(err)
-		return AzCliDeploymentResult{}, fmt.Errorf("deploying to resource group: %w", deploymentError)
+		return AzCliDeploymentResult{}, fmt.Errorf(
+			"deploying to resource group:\n\nDeployment Error Details:\n%w",
+			deploymentError,
+		)
 	}
 
 	return AzCliDeploymentResult{

--- a/cli/azd/pkg/tools/azcli/deployments.go
+++ b/cli/azd/pkg/tools/azcli/deployments.go
@@ -8,12 +8,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/internal"
 )
 
 func (cli *azCli) GetSubscriptionDeployment(
@@ -109,7 +111,8 @@ func (cli *azCli) DeployToSubscription(
 	// wait for deployment creation
 	deployResult, err := createFromTemplateOperation.PollUntilDone(ctx, nil)
 	if err != nil {
-		return AzCliDeploymentResult{}, fmt.Errorf("deploying to subscription: %w", err)
+		deploymentError := createDeploymentError(err)
+		return AzCliDeploymentResult{}, fmt.Errorf("deploying to subscription: %w", deploymentError)
 	}
 
 	return AzCliDeploymentResult{
@@ -153,7 +156,8 @@ func (cli *azCli) DeployToResourceGroup(
 	// wait for deployment creation
 	deployResult, err := createFromTemplateOperation.PollUntilDone(ctx, nil)
 	if err != nil {
-		return AzCliDeploymentResult{}, fmt.Errorf("deploying to resource group: %w", err)
+		deploymentError := createDeploymentError(err)
+		return AzCliDeploymentResult{}, fmt.Errorf("deploying to resource group: %w", deploymentError)
 	}
 
 	return AzCliDeploymentResult{
@@ -218,4 +222,21 @@ func CreateDeploymentOutput(rawOutputs interface{}) (result map[string]AzCliDepl
 		}
 	}
 	return result
+}
+
+// Attempts to create an Azure Deployment error from the HTTP response error
+func createDeploymentError(err error) error {
+	var responseErr *azcore.ResponseError
+	if errors.As(err, &responseErr) {
+		var errorText string
+		rawBody, err := io.ReadAll(responseErr.RawResponse.Body)
+		if err != nil {
+			errorText = responseErr.Error()
+		} else {
+			errorText = string(rawBody)
+		}
+		return internal.NewAzureDeploymentError(errorText)
+	}
+
+	return err
 }


### PR DESCRIPTION
With the introduction of leveraging the Go SDK for ARM deployments we have regressed to no longer parsing the ARM error messages.  This re-introduces the `AzureDeploymentError` error parsing instead of getting a wall of JSON.

- [x] Removes code no longer in use
- [x] Create `AzureDeploymentError` from failed HTTP response.