### PR TITLE
Add java templates

### DIFF
--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"sort"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
@@ -17,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 )
 
 func templatesCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
@@ -84,8 +84,8 @@ func (tl *templatesListAction) Run(ctx context.Context) error {
 	}
 
 	templateList := maps.Values(templateSet)
-	sort.Slice(templateList, func(i, j int) bool {
-		return templateList[i].Name < templateList[j].Name
+	slices.SortFunc(templateList, func(a, b templates.Template) bool {
+		return a.Name < b.Name
 	})
 
 	return formatTemplates(ctx, tl.formatter, tl.writer, templateList...)
@@ -104,7 +104,6 @@ func newTemplatesShowAction(
 		matchingTemplate, err := templateManager.GetTemplate(templateName)
 
 		log.Printf("Template Name: %s\n", templateName)
-		sort.Slice()
 
 		if err != nil {
 			return err

--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"sort"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
@@ -16,7 +17,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 func templatesCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
@@ -84,8 +84,8 @@ func (tl *templatesListAction) Run(ctx context.Context) error {
 	}
 
 	templateList := maps.Values(templateSet)
-	slices.SortFunc(templateList, func(a, b templates.Template) bool {
-		return a.Name < b.Name
+	sort.Slice(templateList, func(i, j int) bool {
+		return templateList[i].Name < templateList[j].Name
 	})
 
 	return formatTemplates(ctx, tl.formatter, tl.writer, templateList...)
@@ -104,6 +104,7 @@ func newTemplatesShowAction(
 		matchingTemplate, err := templateManager.GetTemplate(templateName)
 
 		log.Printf("Template Name: %s\n", templateName)
+		sort.Slice()
 
 		if err != nil {
 			return err

--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -15,6 +15,8 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/templates"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 )
 
 func templatesCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
@@ -81,10 +83,10 @@ func (tl *templatesListAction) Run(ctx context.Context) error {
 		return err
 	}
 
-	templateList := make([]templates.Template, 0, len(templateSet))
-	for _, template := range templateSet {
-		templateList = append(templateList, template)
-	}
+	templateList := maps.Values(templateSet)
+	slices.SortFunc(templateList, func(a, b templates.Template) bool {
+		return a.Name < b.Name
+	})
 
 	return formatTemplates(ctx, tl.formatter, tl.writer, templateList...)
 }

--- a/cli/azd/cmd/templates_test.go
+++ b/cli/azd/cmd/templates_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"sort"
+	"testing"
+	"text/template"
+
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/templates"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplateList(t *testing.T) {
+	var result bytes.Buffer
+	templateList := newTemplatesListAction(
+		templatesListFlags{
+			outputFormat: string(output.JsonFormat),
+			global:       &internal.GlobalCommandOptions{},
+		},
+		&output.JsonFormatter{},
+		&result,
+		templates.NewTemplateManager(),
+	)
+
+	err := templateList.Run(context.Background())
+	require.NoError(t, err)
+
+	templates := make([]template.Template, 0)
+	err = json.Unmarshal(result.Bytes(), &templates)
+	require.NoError(t, err)
+	assert.NotEmpty(t, templates)
+
+	names := make([]string, 0, len(templates))
+	for _, template := range templates {
+		names = append(names, template.Name())
+	}
+	sort.StringsAreSorted(names)
+}

--- a/cli/azd/pkg/templates/template_manager.go
+++ b/cli/azd/pkg/templates/template_manager.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"sort"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/resources"
+	"golang.org/x/exp/maps"
 )
 
 type TemplateManager struct {
@@ -61,10 +63,9 @@ func PromptTemplate(ctx context.Context, message string) (Template, error) {
 	}
 
 	templateNames := []string{"Empty Template"}
-
-	for name := range templatesSet {
-		templateNames = append(templateNames, name)
-	}
+	names := maps.Keys(templatesSet)
+	sort.Strings(names)
+	templateNames = append(templateNames, names...)
 
 	selectedIndex, err := console.Select(ctx, input.ConsoleOptions{
 		Message:      message,

--- a/cli/azd/resources/templates.json
+++ b/cli/azd/resources/templates.json
@@ -40,6 +40,16 @@
         "repositoryPath": "Azure-Samples/todo-csharp-sql"
     },
     {
+        "name": "Azure-Samples/todo-java-mongo",
+        "description": "ToDo Application with a Java API and Azure Cosmos DB API for MongoDB on Azure App Service",
+        "repositoryPath": "Azure-Samples/todo-java-mongo"
+    },
+    {
+        "name": "Azure-Samples/todo-java-mongo-aca",
+        "description": "ToDo Application with a Java API and Azure Cosmos DB API for MongoDB on Azure Container Apps",
+        "repositoryPath": "Azure-Samples/todo-java-mongo-aca"
+    },
+    {
         "name": "Azure-Samples/todo-nodejs-mongo-terraform",
         "description": "ToDo Application with a Node.js API and Azure Cosmos DB API for MongoDB on Azure App Service",
         "repositoryPath": "Azure-Samples/todo-nodejs-mongo-terraform"

--- a/eng/pipelines/template-tests.yml
+++ b/eng/pipelines/template-tests.yml
@@ -54,6 +54,8 @@ jobs:
       
       - template: /eng/pipelines/templates/steps/install-azd-live-sh.yml
 
+      - template: /eng/pipelines/templates/steps/install-ms-openjdk.yml
+
       - template: /eng/pipelines/templates/steps/az-login.yml
 
       # Required to clone repos that are not yet public

--- a/eng/pipelines/templates/steps/install-ms-openjdk.yml
+++ b/eng/pipelines/templates/steps/install-ms-openjdk.yml
@@ -1,11 +1,13 @@
 steps:
 - bash: |
-    # Valid values are only '18.04' and '20.04'
-    # For other versions of Ubuntu, please use the tar.gz package
     ubuntu_release=`lsb_release -rs`
     wget https://packages.microsoft.com/config/ubuntu/${ubuntu_release}/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
     sudo dpkg -i packages-microsoft-prod.deb
     sudo apt-get install apt-transport-https
     sudo apt-get update
     sudo apt-get install msopenjdk-17
+    sudo update-java-alternatives --set msopenjdk-17-amd64
+
+    # Set JAVA_HOME explicitly as an override since the build agent has existing JAVA_HOME defined
+    echo "##vso[task.setvariable variable=JAVA_HOME]/usr/lib/jvm/msopenjdk-17-amd64"
   displayName: Install msopenjdk-17

--- a/eng/pipelines/templates/steps/install-ms-openjdk.yml
+++ b/eng/pipelines/templates/steps/install-ms-openjdk.yml
@@ -1,0 +1,11 @@
+steps:
+- bash: |
+    # Valid values are only '18.04' and '20.04'
+    # For other versions of Ubuntu, please use the tar.gz package
+    ubuntu_release=`lsb_release -rs`
+    wget https://packages.microsoft.com/config/ubuntu/${ubuntu_release}/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+    sudo dpkg -i packages-microsoft-prod.deb
+    sudo apt-get install apt-transport-https
+    sudo apt-get update
+    sudo apt-get install msopenjdk-17
+  displayName: Install msopenjdk-17


### PR DESCRIPTION
Add java templates to `azd` templates list.

Display templates sorted by name. This groups languages together and provides better consistency:
![image](https://user-images.githubusercontent.com/2322434/198408947-d4cffdb3-1f03-4ea0-af9d-d6fea5bbe5ee.png)

![image](https://user-images.githubusercontent.com/2322434/198409097-da45497b-120c-4554-94a0-3e14f81a8a31.png)


Fixes #1016