### PR TITLE
Explicitly require subscription id when `azd` config is not set

### DIFF
--- a/cli/azd/pkg/account/manager.go
+++ b/cli/azd/pkg/account/manager.go
@@ -65,7 +65,7 @@ func NewManager(configManager config.Manager, azCli azcli.AzCli) (*Manager, erro
 func (m *Manager) GetAccountDefaults(ctx context.Context) (*Account, error) {
 	subscription, err := m.getDefaultSubscription(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed retrieving default subscription: %w", err)
 	}
 
 	var location *Location
@@ -75,7 +75,7 @@ func (m *Manager) GetAccountDefaults(ctx context.Context) (*Account, error) {
 	} else {
 		location, err = m.getDefaultLocation(ctx, subscription.Id)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed retrieving default location: %w", err)
 		}
 	}
 

--- a/cli/azd/pkg/account/manager.go
+++ b/cli/azd/pkg/account/manager.go
@@ -232,7 +232,12 @@ func (m *Manager) getDefaultSubscription(ctx context.Context) (*Subscription, er
 	subscriptionId := fmt.Sprint(configSubscriptionId)
 	subscription, err := m.azCli.GetAccount(ctx, subscriptionId)
 	if err != nil {
-		return nil, fmt.Errorf("failed retrieving subscription with ID '%s'. %w", subscriptionId, err)
+		return nil, fmt.Errorf(
+			`the subscription id '%s' is either invalid or you no longer have access. 
+			Check your configuration with 'azd config list'. %w`,
+			subscriptionId,
+			err,
+		)
 	}
 
 	return &Subscription{
@@ -261,7 +266,7 @@ func (m *Manager) getDefaultLocation(ctx context.Context, subscriptionId string)
 	})
 
 	if index < 0 {
-		return nil, fmt.Errorf("The location '%s' specified in azd config is invalid", locationName)
+		return nil, fmt.Errorf("the location '%s' is invalid. Check your configuration with `azd config list`", locationName)
 	}
 
 	return &Location{

--- a/cli/azd/pkg/account/manager.go
+++ b/cli/azd/pkg/account/manager.go
@@ -25,7 +25,6 @@ var defaultLocation Location = Location{
 }
 
 // Manages azd account configuration
-// `az cli` is not required and will only be called `azd` default have not already been set.
 type Manager struct {
 	// Path to the local azd user configuration file
 	filePath      string
@@ -61,7 +60,7 @@ func NewManager(configManager config.Manager, azCli azcli.AzCli) (*Manager, erro
 
 // Gets the default subscription for the logged in account.
 // 1. Returns AZD config defaults if exists
-// 2. Returns AZ CLI defaults if exists
+// 2. Returns Coded location default if needed
 func (m *Manager) GetAccountDefaults(ctx context.Context) (*Account, error) {
 	subscription, err := m.getDefaultSubscription(ctx)
 	if err != nil {

--- a/cli/azd/pkg/account/manager.go
+++ b/cli/azd/pkg/account/manager.go
@@ -62,27 +62,27 @@ func NewManager(configManager config.Manager, azCli azcli.AzCli) (*Manager, erro
 // Gets the default subscription for the logged in account.
 // 1. Returns AZD config defaults if exists
 // 2. Returns AZ CLI defaults if exists
-func (m *Manager) GetAccountDefaults(ctx context.Context) *Account {
+func (m *Manager) GetAccountDefaults(ctx context.Context) (*Account, error) {
 	subscription, err := m.getDefaultSubscription(ctx)
-
-	// If we don't have a default subscription then the principal does not have any active
-	// subscriptions or the configured value is not valid.
 	if err != nil {
-		subscription = nil
+		return nil, err
 	}
 
-	location, err := m.getDefaultLocation(ctx, subscription.Id)
+	var location *Location
 
-	// If we don't have a default location then either this is the first run experience
-	// or the location specified in configuration is invalid.
-	if err != nil {
+	if subscription == nil {
 		location = &defaultLocation
+	} else {
+		location, err = m.getDefaultLocation(ctx, subscription.Id)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &Account{
 		DefaultSubscription: subscription,
 		DefaultLocation:     location,
-	}
+	}, nil
 }
 
 // Gets the available Azure subscriptions for the current logged in account.
@@ -98,9 +98,9 @@ func (m *Manager) GetSubscriptions(ctx context.Context) ([]*azcli.AzCliSubscript
 		return nil, err
 	}
 
-	// If there is only 1 account, set it as the default
-	if len(accounts) == 1 {
-		accounts[0].IsDefault = true
+	// If we don't have any default explicitly set return raw account list without and default set
+	if defaultSubscription == nil {
+		return accounts, nil
 	}
 
 	// If default subscription is set, set it in the results
@@ -225,39 +225,22 @@ func (m *Manager) getAllSubscriptions(ctx context.Context) ([]*azcli.AzCliSubscr
 func (m *Manager) getDefaultSubscription(ctx context.Context) (*Subscription, error) {
 	// Get the default subscription ID from azd configuration
 	configSubscriptionId, ok := m.config.Get(defaultSubscriptionKeyPath)
-	var defaultSubscription *Subscription
 
-	if ok {
-		subscriptionId := fmt.Sprint(configSubscriptionId)
-		subscription, err := m.azCli.GetAccount(ctx, subscriptionId)
-		if err != nil {
-			log.Printf("failed retrieving subscription with ID '%s'. %s", subscriptionId, err.Error())
-		}
-
-		defaultSubscription = &Subscription{
-			Id:       subscription.Id,
-			Name:     subscription.Name,
-			TenantId: subscription.TenantId,
-		}
-	} else {
-		// No defaults subscription has been set in azd config
-		allSubscriptions, err := m.getAllSubscriptions(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed retrieving subscriptions for current account. %w", err)
-		}
-
-		if len(allSubscriptions) == 0 {
-			return nil, errors.New("no subscriptions found for current account")
-		}
-
-		defaultSubscription = &Subscription{
-			Id:       allSubscriptions[0].Id,
-			Name:     allSubscriptions[0].Name,
-			TenantId: allSubscriptions[0].TenantId,
-		}
+	if !ok {
+		return nil, nil
 	}
 
-	return defaultSubscription, nil
+	subscriptionId := fmt.Sprint(configSubscriptionId)
+	subscription, err := m.azCli.GetAccount(ctx, subscriptionId)
+	if err != nil {
+		return nil, fmt.Errorf("failed retrieving subscription with ID '%s'. %w", subscriptionId, err)
+	}
+
+	return &Subscription{
+		Id:       subscription.Id,
+		Name:     subscription.Name,
+		TenantId: subscription.TenantId,
+	}, nil
 }
 
 // Gets the default Azure location for the specified subscription
@@ -278,12 +261,12 @@ func (m *Manager) getDefaultLocation(ctx context.Context, subscriptionId string)
 		return l.Name == locationName
 	})
 
-	if index > -1 {
-		return &Location{
-			Name:        allLocations[index].Name,
-			DisplayName: allLocations[index].RegionalDisplayName,
-		}, nil
+	if index < 0 {
+		return nil, fmt.Errorf("The location '%s' specified in azd config is invalid", locationName)
 	}
 
-	return &defaultLocation, nil
+	return &Location{
+		Name:        allLocations[index].Name,
+		DisplayName: allLocations[index].RegionalDisplayName,
+	}, nil
 }

--- a/cli/azd/pkg/azureutil/location.go
+++ b/cli/azd/pkg/azureutil/location.go
@@ -46,7 +46,11 @@ func PromptLocation(ctx context.Context, env *environment.Environment, message s
 
 	// If no location is set in the process environment, see what the azd config default is.
 	if defaultLocation == "" {
-		defaultConfig := accountManager.GetAccountDefaults(ctx)
+		defaultConfig, err := accountManager.GetAccountDefaults(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed retrieving azd defaults. %w", err)
+		}
+
 		defaultLocation = defaultConfig.DefaultLocation.Name
 	}
 

--- a/cli/azd/pkg/tools/azcli/account.go
+++ b/cli/azd/pkg/tools/azcli/account.go
@@ -2,7 +2,6 @@ package azcli
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
@@ -73,26 +72,6 @@ func (cli *azCli) ListAccounts(ctx context.Context) ([]*AzCliSubscriptionInfo, e
 	})
 
 	return subscriptions, nil
-}
-
-func (cli *azCli) GetDefaultAccount(ctx context.Context) (*AzCliSubscriptionInfo, error) {
-	result, err := cli.runAzCommand(
-		ctx,
-		"account", "show",
-		"--output", "json",
-	)
-
-	if err != nil {
-		return nil, fmt.Errorf("failed getting default account from az cli: %w", err)
-	}
-
-	var subscription AzCliSubscriptionInfo
-	err = json.Unmarshal([]byte(result.Stdout), &subscription)
-	if err != nil {
-		return nil, fmt.Errorf("failed unmarshalling result JSON: %w", err)
-	}
-
-	return &subscription, nil
 }
 
 func (cli *azCli) GetAccount(ctx context.Context, subscriptionId string) (*AzCliSubscriptionInfo, error) {

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -58,9 +58,7 @@ type AzCli interface {
 	LoginAcr(ctx context.Context, subscriptionId string, loginServer string) error
 	GetContainerRegistries(ctx context.Context, subscriptionId string) ([]*armcontainerregistry.Registry, error)
 	ListAccounts(ctx context.Context) ([]*AzCliSubscriptionInfo, error)
-	GetDefaultAccount(ctx context.Context) (*AzCliSubscriptionInfo, error)
 	GetAccount(ctx context.Context, subscriptionId string) (*AzCliSubscriptionInfo, error)
-	GetCliConfigValue(ctx context.Context, name string) (AzCliConfigValue, error)
 	GetSubscriptionDeployment(
 		ctx context.Context,
 		subscriptionId string,
@@ -434,22 +432,6 @@ func (cli *azCli) Login(ctx context.Context, useDeviceCode bool, deviceCodeWrite
 	}
 
 	return nil
-}
-
-func (cli *azCli) GetCliConfigValue(ctx context.Context, name string) (AzCliConfigValue, error) {
-	res, err := cli.runAzCommand(ctx, "config", "get", name, "--output", "json")
-	if isConfigurationIsNotSetMessage(res.Stderr) {
-		return AzCliConfigValue{}, ErrNoConfigurationValue
-	} else if err != nil {
-		return AzCliConfigValue{}, fmt.Errorf("failed running config get: %s: %w", res.String(), err)
-	}
-
-	var value AzCliConfigValue
-	if err := json.Unmarshal([]byte(res.Stdout), &value); err != nil {
-		return AzCliConfigValue{}, fmt.Errorf("could not unmarshal output %s as an AzCliConfigValue: %w", res.Stdout, err)
-	}
-
-	return value, nil
 }
 
 func (cli *azCli) runAzCommand(ctx context.Context, args ...string) (exec.RunResult, error) {

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -470,10 +470,7 @@ func (cli *azCli) createDefaultClientOptionsBuilder(ctx context.Context) *azsdk.
 // Additionally, https://learn.microsoft.com/azure/active-directory/develop/reference-aadsts-error-codes#aadsts-error-codes
 // is a helpful resource with a list of error codes and messages.
 
-var isConfigurationIsNotSetMessageRegex = regexp.MustCompile(`Configuration '.*' is not set\.`)
 
-func isConfigurationIsNotSetMessage(s string) bool {
-	return isConfigurationIsNotSetMessageRegex.MatchString(s)
 }
 
 type contextKey string

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"regexp"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -463,14 +462,6 @@ func (cli *azCli) createDefaultClientOptionsBuilder(ctx context.Context) *azsdk.
 	return azsdk.NewClientOptionsBuilder().
 		WithTransport(httputil.GetHttpClient(ctx)).
 		WithPerCallPolicy(azsdk.NewUserAgentPolicy(cli.UserAgent()))
-}
-
-// Azure Active Directory codes can be referenced via https://login.microsoftonline.com/error?code=<ERROR_CODE>,
-// where ERROR_CODE is the digits portion of an AAD error code. Example: AADSTS70043 has error code 70043
-// Additionally, https://learn.microsoft.com/azure/active-directory/develop/reference-aadsts-error-codes#aadsts-error-codes
-// is a helpful resource with a list of error codes and messages.
-
-
 }
 
 type contextKey string


### PR DESCRIPTION
If azure subscription id is not set in either azd config, env var, or flag then calling `azd init --no-prompt` should fail.