### PR TITLE
introduce terraform azdo workflow

### DIFF
--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -159,7 +159,7 @@ func getDefinitionVariables(
 		variables["ARM_CLIENT_ID"] = createBuildDefinitionVariable(credentials.ClientId, true, false)
 		variables["ARM_CLIENT_SECRET"] = createBuildDefinitionVariable(credentials.ClientSecret, true, false)
 
-		// Sets the terraform remote state environment variables in github
+		// Sets the terraform remote state environment variables in azure devops
 		remoteStateKeys := []string{"RS_RESOURCE_GROUP", "RS_STORAGE_ACCOUNT", "RS_CONTAINER_NAME"}
 		for _, key := range remoteStateKeys {
 			value, ok := env.Values[key]

--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -164,8 +164,9 @@ func getDefinitionVariables(
 		for _, key := range remoteStateKeys {
 			value, ok := env.Values[key]
 			if !ok || strings.TrimSpace(value) == "" {
-				message := `terraform remote state is not correctly configured, Visit %s for more information on configuring Terraform remote state`
-				return nil, fmt.Errorf(fmt.Sprintf(message, output.WithLinkFormat("https://aka.ms/azure-dev/terraform")))
+				return nil, fmt.Errorf(fmt.Sprintf(`terraform remote state is not correctly configured,
+Visit %s for more information on configuring Terraform remote state`,
+					output.WithLinkFormat("https://aka.ms/azure-dev/terraform")))
 			}
 			variables[key] = createBuildDefinitionVariable(value, false, true)
 		}

--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -164,7 +164,9 @@ func getDefinitionVariables(
 		for _, key := range remoteStateKeys {
 			value, ok := env.Values[key]
 			if !ok || strings.TrimSpace(value) == "" {
-				return nil, fmt.Errorf(fmt.Sprintf("terraform remote state is not correctly configured, Visit %s for more information on configuring Terraform remote state", output.WithLinkFormat("https://aka.ms/azure-dev/terraform")))
+				return nil, fmt.Errorf(fmt.Sprintf(`terraform remote state is not correctly configured,
+				Visit %s for more information on configuring Terraform remote state`,
+					output.WithLinkFormat("https://aka.ms/azure-dev/terraform")))
 			}
 			variables[key] = createBuildDefinitionVariable(value, false, true)
 		}

--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -6,10 +6,12 @@ package azdo
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/build"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/taskagent"
@@ -106,7 +108,11 @@ func CreatePipeline(
 		// Pipeline is already created. It uses the same connection but
 		// we need to update the variables and secrets as they
 		// might have been updated
-		definition.Variables = getDefinitionVariables(env, credentials, provisioningProvider)
+		buildDefinitionVariables, err := getDefinitionVariables(env, credentials, provisioningProvider)
+		if err != nil {
+			return nil, err
+		}
+		definition.Variables = buildDefinitionVariables
 		definition, err := client.UpdateDefinition(ctx, build.UpdateDefinitionArgs{
 			Definition:   definition,
 			Project:      &projectId,
@@ -140,7 +146,7 @@ func CreatePipeline(
 func getDefinitionVariables(
 	env *environment.Environment,
 	credentials AzureServicePrincipalCredentials,
-	provisioningProvider provisioning.Options) *map[string]build.BuildDefinitionVariable {
+	provisioningProvider provisioning.Options) (*map[string]build.BuildDefinitionVariable, error) {
 	variables := map[string]build.BuildDefinitionVariable{
 		"AZURE_LOCATION":           createBuildDefinitionVariable(env.GetLocation(), false, false),
 		"AZURE_ENV_NAME":           createBuildDefinitionVariable(env.GetEnvName(), false, false),
@@ -152,8 +158,18 @@ func getDefinitionVariables(
 		variables["ARM_TENANT_ID"] = createBuildDefinitionVariable(credentials.TenantId, false, false)
 		variables["ARM_CLIENT_ID"] = createBuildDefinitionVariable(credentials.ClientId, true, false)
 		variables["ARM_CLIENT_SECRET"] = createBuildDefinitionVariable(credentials.ClientSecret, true, false)
+
+		// Sets the terraform remote state environment variables in github
+		remoteStateKeys := []string{"RS_RESOURCE_GROUP", "RS_STORAGE_ACCOUNT", "RS_CONTAINER_NAME"}
+		for _, key := range remoteStateKeys {
+			value, ok := env.Values[key]
+			if !ok || strings.TrimSpace(value) == "" {
+				return nil, fmt.Errorf(fmt.Sprintf("terraform remote state is not correctly configured, Visit %s for more information on configuring Terraform remote state", output.WithLinkFormat("https://aka.ms/azure-dev/terraform")))
+			}
+			variables[key] = createBuildDefinitionVariable(value, false, true)
+		}
 	}
-	return &variables
+	return &variables, nil
 }
 
 // create Azure Deploy Pipeline parameters
@@ -202,6 +218,10 @@ func createAzureDevPipelineArgs(
 		trigger,
 	}
 
+	buildDefinitionVariables, err := getDefinitionVariables(env, credentials, provisioningProvider)
+	if err != nil {
+		return nil, err
+	}
 	buildDefinition := &build.BuildDefinition{
 		Name:        &name,
 		Type:        &buildDefinitionType,
@@ -209,7 +229,7 @@ func createAzureDevPipelineArgs(
 		Repository:  buildRepository,
 		Process:     process,
 		Queue:       agentPoolQueue,
-		Variables:   getDefinitionVariables(env, credentials, provisioningProvider),
+		Variables:   buildDefinitionVariables,
 		Triggers:    &triggers,
 	}
 

--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -164,9 +164,8 @@ func getDefinitionVariables(
 		for _, key := range remoteStateKeys {
 			value, ok := env.Values[key]
 			if !ok || strings.TrimSpace(value) == "" {
-				return nil, fmt.Errorf(fmt.Sprintf(`terraform remote state is not correctly configured,
-				Visit %s for more information on configuring Terraform remote state`,
-					output.WithLinkFormat("https://aka.ms/azure-dev/terraform")))
+				message := `terraform remote state is not correctly configured, Visit %s for more information on configuring Terraform remote state`
+				return nil, fmt.Errorf(fmt.Sprintf(message, output.WithLinkFormat("https://aka.ms/azure-dev/terraform")))
 			}
 			variables[key] = createBuildDefinitionVariable(value, false, true)
 		}

--- a/templates/common/.azdo/pipelines/bicep/azure-dev.yml
+++ b/templates/common/.azdo/pipelines/bicep/azure-dev.yml
@@ -1,0 +1,35 @@
+trigger:
+  - main
+  - master
+
+pool:
+  vmImage: ubuntu-latest
+
+container: mcr.microsoft.com/azure-dev-cli-apps:latest
+
+steps:
+  - task: AzureCLI@2
+    displayName: Azure Dev Provision
+    inputs:
+      azureSubscription: azconnection
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        azd provision --no-prompt
+    env:
+      AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
+      AZURE_ENV_NAME: $(AZURE_ENV_NAME)
+      AZURE_LOCATION: $(AZURE_LOCATION)
+      
+  - task: AzureCLI@2
+    displayName: Azure Dev Deploy
+    inputs:
+      azureSubscription: azconnection
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        azd deploy --no-prompt
+    env:
+      AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
+      AZURE_ENV_NAME: $(AZURE_ENV_NAME)
+      AZURE_LOCATION: $(AZURE_LOCATION)

--- a/templates/common/.azdo/pipelines/terraform/azure-dev.yml
+++ b/templates/common/.azdo/pipelines/terraform/azure-dev.yml
@@ -23,6 +23,9 @@ steps:
       ARM_TENANT_ID: $(ARM_TENANT_ID)
       ARM_CLIENT_ID: $(ARM_CLIENT_ID)
       ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
+      RS_RESOURCE_GROUP: $(RS_RESOURCE_GROUP)
+      RS_STORAGE_ACCOUNT: $(RS_STORAGE_ACCOUNT)
+      RS_CONTAINER_NAME: $(RS_CONTAINER_NAME)
   - task: AzureCLI@2
     displayName: Azure Dev Deploy
     inputs:

--- a/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/repo.yaml
@@ -115,14 +115,11 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
-        - .azdo/**/*
+        - .azdo/pipelines/*/azure-dev.yml
 
     # AzDo workflows for bicep
     - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
       to: ./.azdo/pipelines/azure-dev.yml
-
-    - from: ../../../../../common/.azdo/pipelines/README.md
-      to: ./.azdo/pipelines/README.md
 
     # Github pipeline for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/repo.yaml
@@ -115,8 +115,16 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
+        - .azdo/**/*
 
-    # Github workflows for bicep
+    # AzDo workflows for bicep
+    - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
+      to: ./.azdo/pipelines/azure-dev.yml
+
+    - from: ../../../../../common/.azdo/pipelines/README.md
+      to: ./.azdo/pipelines/README.md
+
+    # Github pipeline for bicep
     - from: ../../../../../common/.github/workflows/bicep
       to: ./.github/workflows
 

--- a/templates/todo/projects/csharp-sql-swa-func/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/csharp-sql-swa-func/.repo/bicep/repo.yaml
@@ -115,14 +115,11 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
-        - .azdo/**/*
+        - .azdo/pipelines/*/azure-dev.yml
 
     # AzDo workflows for bicep
     - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
       to: ./.azdo/pipelines/azure-dev.yml
-
-    - from: ../../../../../common/.azdo/pipelines/README.md
-      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/csharp-sql-swa-func/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/csharp-sql-swa-func/.repo/bicep/repo.yaml
@@ -115,6 +115,14 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
+        - .azdo/**/*
+
+    # AzDo workflows for bicep
+    - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
+      to: ./.azdo/pipelines/azure-dev.yml
+
+    - from: ../../../../../common/.azdo/pipelines/README.md
+      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/csharp-sql/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/csharp-sql/.repo/bicep/repo.yaml
@@ -116,14 +116,11 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
-        - .azdo/**/*
+        - .azdo/pipelines/*/azure-dev.yml
 
     # AzDo workflows for bicep
     - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
       to: ./.azdo/pipelines/azure-dev.yml
-
-    - from: ../../../../../common/.azdo/pipelines/README.md
-      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/csharp-sql/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/csharp-sql/.repo/bicep/repo.yaml
@@ -116,6 +116,14 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
+        - .azdo/**/*
+
+    # AzDo workflows for bicep
+    - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
+      to: ./.azdo/pipelines/azure-dev.yml
+
+    - from: ../../../../../common/.azdo/pipelines/README.md
+      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/java-mongo-aca/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/java-mongo-aca/.repo/bicep/repo.yaml
@@ -125,6 +125,14 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
+        - .azdo/**/*
+
+    # AzDo workflows for bicep
+    - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
+      to: ./.azdo/pipelines/azure-dev.yml
+
+    - from: ../../../../../common/.azdo/pipelines/README.md
+      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/java-mongo-aca/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/java-mongo-aca/.repo/bicep/repo.yaml
@@ -125,14 +125,11 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
-        - .azdo/**/*
+        - .azdo/pipelines/*/azure-dev.yml
 
     # AzDo workflows for bicep
     - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
       to: ./.azdo/pipelines/azure-dev.yml
-
-    - from: ../../../../../common/.azdo/pipelines/README.md
-      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/java-mongo/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/java-mongo/.repo/bicep/repo.yaml
@@ -112,6 +112,14 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
+        - .azdo/**/*
+
+    # AzDo workflows for bicep
+    - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
+      to: ./.azdo/pipelines/azure-dev.yml
+
+    - from: ../../../../../common/.azdo/pipelines/README.md
+      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/java-mongo/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/java-mongo/.repo/bicep/repo.yaml
@@ -112,14 +112,11 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
-        - .azdo/**/*
+        - .azdo/pipelines/*/azure-dev.yml
 
     # AzDo workflows for bicep
     - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
       to: ./.azdo/pipelines/azure-dev.yml
-
-    - from: ../../../../../common/.azdo/pipelines/README.md
-      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/repo.yaml
@@ -128,14 +128,11 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
-        - .azdo/**/*
+        - .azdo/pipelines/*/azure-dev.yml
 
     # AzDo workflows for bicep
     - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
       to: ./.azdo/pipelines/azure-dev.yml
-
-    - from: ../../../../../common/.azdo/pipelines/README.md
-      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/repo.yaml
@@ -128,6 +128,14 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
+        - .azdo/**/*
+
+    # AzDo workflows for bicep
+    - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
+      to: ./.azdo/pipelines/azure-dev.yml
+
+    - from: ../../../../../common/.azdo/pipelines/README.md
+      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/nodejs-mongo-swa-func/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/nodejs-mongo-swa-func/.repo/bicep/repo.yaml
@@ -115,14 +115,11 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
-        - .azdo/**/*
+        - .azdo/pipelines/*/azure-dev.yml
 
     # AzDo workflows for bicep
     - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
       to: ./.azdo/pipelines/azure-dev.yml
-
-    - from: ../../../../../common/.azdo/pipelines/README.md
-      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/nodejs-mongo-swa-func/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/nodejs-mongo-swa-func/.repo/bicep/repo.yaml
@@ -115,6 +115,14 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
+        - .azdo/**/*
+
+    # AzDo workflows for bicep
+    - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
+      to: ./.azdo/pipelines/azure-dev.yml
+
+    - from: ../../../../../common/.azdo/pipelines/README.md
+      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/nodejs-mongo/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/nodejs-mongo/.repo/bicep/repo.yaml
@@ -127,14 +127,11 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
-        - .azdo/**/*
+        - .azdo/pipelines/*/azure-dev.yml
 
     # AzDo workflows for bicep
     - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
       to: ./.azdo/pipelines/azure-dev.yml
-
-    - from: ../../../../../common/.azdo/pipelines/README.md
-      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/nodejs-mongo/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/nodejs-mongo/.repo/bicep/repo.yaml
@@ -127,6 +127,14 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
+        - .azdo/**/*
+
+    # AzDo workflows for bicep
+    - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
+      to: ./.azdo/pipelines/azure-dev.yml
+
+    - from: ../../../../../common/.azdo/pipelines/README.md
+      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/nodejs-mongo/.repo/terraform/repo.yaml
+++ b/templates/todo/projects/nodejs-mongo/.repo/terraform/repo.yaml
@@ -105,6 +105,14 @@ repo:
       - .devcontainer/**/*
       - "infra/**/*"
       - .github/**/*
+      - .azdo/**/*
+
+    # AzDo workflows for bicep
+    - from: ../../../../../common/.azdo/pipelines/terraform/azure-dev.yml
+      to: ./.azdo/pipelines/azure-dev.yml
+
+    - from: ../../../../../common/.azdo/pipelines/README.md
+      to: ./.azdo/pipelines/README.md
     
     # Github workflows for terraform
     - from: ../../../../../common/.github/workflows/terraform

--- a/templates/todo/projects/nodejs-mongo/.repo/terraform/repo.yaml
+++ b/templates/todo/projects/nodejs-mongo/.repo/terraform/repo.yaml
@@ -105,14 +105,11 @@ repo:
       - .devcontainer/**/*
       - "infra/**/*"
       - .github/**/*
-      - .azdo/**/*
+      - .azdo/pipelines/*/azure-dev.yml
 
     # AzDo workflows for bicep
     - from: ../../../../../common/.azdo/pipelines/terraform/azure-dev.yml
       to: ./.azdo/pipelines/azure-dev.yml
-
-    - from: ../../../../../common/.azdo/pipelines/README.md
-      to: ./.azdo/pipelines/README.md
     
     # Github workflows for terraform
     - from: ../../../../../common/.github/workflows/terraform

--- a/templates/todo/projects/python-mongo-aca/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/python-mongo-aca/.repo/bicep/repo.yaml
@@ -128,14 +128,11 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
-        - .azdo/**/*
+        - .azdo/pipelines/*/azure-dev.yml
 
     # AzDo workflows for bicep
     - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
       to: ./.azdo/pipelines/azure-dev.yml
-
-    - from: ../../../../../common/.azdo/pipelines/README.md
-      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/python-mongo-aca/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/python-mongo-aca/.repo/bicep/repo.yaml
@@ -128,6 +128,14 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
+        - .azdo/**/*
+
+    # AzDo workflows for bicep
+    - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
+      to: ./.azdo/pipelines/azure-dev.yml
+
+    - from: ../../../../../common/.azdo/pipelines/README.md
+      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/python-mongo-swa-func/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/python-mongo-swa-func/.repo/bicep/repo.yaml
@@ -115,14 +115,11 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
-        - .azdo/**/*
+        - .azdo/pipelines/*/azure-dev.yml
 
     # AzDo workflows for bicep
     - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
       to: ./.azdo/pipelines/azure-dev.yml
-
-    - from: ../../../../../common/.azdo/pipelines/README.md
-      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/python-mongo-swa-func/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/python-mongo-swa-func/.repo/bicep/repo.yaml
@@ -115,6 +115,14 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
+        - .azdo/**/*
+
+    # AzDo workflows for bicep
+    - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
+      to: ./.azdo/pipelines/azure-dev.yml
+
+    - from: ../../../../../common/.azdo/pipelines/README.md
+      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/python-mongo/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/python-mongo/.repo/bicep/repo.yaml
@@ -140,14 +140,11 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
-        - .azdo/**/*
+        - .azdo/pipelines/*/azure-dev.yml
 
     # AzDo workflows for bicep
     - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
       to: ./.azdo/pipelines/azure-dev.yml
-
-    - from: ../../../../../common/.azdo/pipelines/README.md
-      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/python-mongo/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/python-mongo/.repo/bicep/repo.yaml
@@ -140,6 +140,14 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
+        - .azdo/**/*
+
+    # AzDo workflows for bicep
+    - from: ../../../../../common/.azdo/pipelines/bicep/azure-dev.yml
+      to: ./.azdo/pipelines/azure-dev.yml
+
+    - from: ../../../../../common/.azdo/pipelines/README.md
+      to: ./.azdo/pipelines/README.md
 
     # Github workflows for bicep
     - from: ../../../../../common/.github/workflows/bicep

--- a/templates/todo/projects/python-mongo/.repo/terraform/repo.yaml
+++ b/templates/todo/projects/python-mongo/.repo/terraform/repo.yaml
@@ -109,14 +109,11 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
-        - .azdo/**/*
+        - .azdo/pipelines/*/azure-dev.yml
 
     # AzDo workflows for bicep
     - from: ../../../../../common/.azdo/pipelines/terraform/azure-dev.yml
       to: ./.azdo/pipelines/azure-dev.yml
-
-    - from: ../../../../../common/.azdo/pipelines/README.md
-      to: ./.azdo/pipelines/README.md
 
     # Github workflows for terraform
     - from: ../../../../../common/.github/workflows/terraform

--- a/templates/todo/projects/python-mongo/.repo/terraform/repo.yaml
+++ b/templates/todo/projects/python-mongo/.repo/terraform/repo.yaml
@@ -109,6 +109,14 @@ repo:
         - .github/**/*
         - .devcontainer/**/*
         - "infra/**/*"
+        - .azdo/**/*
+
+    # AzDo workflows for bicep
+    - from: ../../../../../common/.azdo/pipelines/terraform/azure-dev.yml
+      to: ./.azdo/pipelines/azure-dev.yml
+
+    - from: ../../../../../common/.azdo/pipelines/README.md
+      to: ./.azdo/pipelines/README.md
 
     # Github workflows for terraform
     - from: ../../../../../common/.github/workflows/terraform


### PR DESCRIPTION
This PR addresses #658 by:

- Updates azdo provider to set the needed terraform remote state variables as part of azd pipeline config --provider azdo cmd.
- Introduces an additional azdo pipeline for terraform, and update the existing azdo pipeline to remove the terraform related variables.
- Updates all templates todo/repoman.yaml files to use the right azdo pipeline based on the infra selection.



![image](https://user-images.githubusercontent.com/34171319/198741702-947982dc-7322-46fa-aeb6-6f9035cb5207.png)


Co-authored-by: Hattan Shobokshi <hattan.shobokshi@microsoft.com>