### PR TITLE
Set subscription id env var for terraform login

### DIFF
--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -122,6 +122,7 @@ stages:
               ARM_CLIENT_ID: $(arm-client-id)
               ARM_CLIENT_SECRET: $(arm-client-secret)
               ARM_TENANT_ID: $(arm-tenant-id)
+              ARM_SUBSCRIPTION_ID: $(arm-subscription-id)
 
           - task: PublishTestResults@2
             inputs:

--- a/eng/pipelines/template-tests.yml
+++ b/eng/pipelines/template-tests.yml
@@ -51,7 +51,7 @@ jobs:
       - template: /eng/pipelines/templates/steps/install-bicep.yml
 
       - template: /eng/pipelines/templates/steps/install-terraform.yml
-      
+
       - template: /eng/pipelines/templates/steps/install-azd-live-sh.yml
 
       - template: /eng/pipelines/templates/steps/az-login.yml
@@ -84,7 +84,7 @@ jobs:
           if($useUpperCaseName -eq "true") {
             # Use upper case name for env prefix name
             $envPrefixName = "AZD-TEMPLATE-UPPER-TEST"
-          } 
+          }
           $resourceGroupName = "rg-$envPrefixName-$templateName-$(Build.BuildId)"
           Write-Host "Resource group name: $resourceGroupName"
           Write-Host "##vso[task.setvariable variable=ResourceGroupName]$resourceGroupName"
@@ -93,11 +93,12 @@ jobs:
 
       - task: Bash@3
         displayName: Test templates
-        env:             
+        env:
           # Required for Terraform service principal authentication
           ARM_CLIENT_ID: $(arm-client-id)
           ARM_CLIENT_SECRET: $(arm-client-secret)
           ARM_TENANT_ID: $(arm-tenant-id)
+          ARM_SUBSCRIPTION_ID: $(arm-subscription-id)
         inputs:
           targetType: filePath
           filePath: templates/tests/test-templates.sh
@@ -111,7 +112,7 @@ jobs:
           workingDirectory: templates/tests
 
       # First tag the resource group (if exists) so that it can get cleaned up
-      # by the cleanup pipeline. Then attempt to delete the resource group 
+      # by the cleanup pipeline. Then attempt to delete the resource group
       # directly. If the delete fails the cleanup pipeline will delete it.
       - pwsh: |
           $resourceGroupId = az group show `

--- a/eng/pipelines/templates/steps/az-login.yml
+++ b/eng/pipelines/templates/steps/az-login.yml
@@ -16,10 +16,11 @@ steps:
       az account set `
         --subscription "$($subscriptionConfiguration.SubscriptionId)"
 
-            # Export service principal auth information for terraform testing
-            Write-Host "##vso[task.setvariable variable=arm-client-id;issecret=true]$($subscriptionConfiguration.TestApplicationId)"
+      # Export service principal auth information for terraform testing
+      Write-Host "##vso[task.setvariable variable=arm-client-id;]$($subscriptionConfiguration.TestApplicationId)"
       Write-Host "##vso[task.setvariable variable=arm-client-secret;issecret=true]$($subscriptionConfiguration.TestApplicationSecret)"
-      Write-Host "##vso[task.setvariable variable=arm-tenant-id;issecret=true]$($subscriptionConfiguration.TenantId)"
+      Write-Host "##vso[task.setvariable variable=arm-tenant-id;]$($subscriptionConfiguration.TenantId)"
+      Write-Host "##vso[task.setvariable variable=arm-subscription-id;]$($subscriptionConfiguration.SubscriptionId)"
 
     condition: and(succeeded(), ne(variables['Skip.LiveTest'], 'true'))
     displayName: Azure Login


### PR DESCRIPTION
While the az login step sets the subscription id context on initial login, it doesn't seem to be extending that same behavior to the terraform login. This PR plumbs through the subscription id to terraform, otherwise the client will pick the first subscription in the list that the provided identity has access to.