### PR TITLE
Add azure-sdk logs in debug mode

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -6,6 +6,7 @@ appinsightsstorage
 appservice
 armappconfiguration
 AZCLI
+azcorelog
 azdcli
 azdcontext
 azddeploy

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	azcorelog "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
 	"github.com/azure/azure-dev/cli/azd/cmd"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
@@ -39,7 +40,11 @@ func main() {
 
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
-	if !isDebugEnabled() {
+	if isDebugEnabled() {
+		azcorelog.SetListener(func(event azcorelog.Event, msg string) {
+			log.Printf("%s: %s\n", event, msg)
+		})
+	} else {
 		log.SetOutput(io.Discard)
 	}
 


### PR DESCRIPTION
- Add logging for Azure requests in `--debug` mode. This allows us to debug HTTP requests if needed. It is less noisy than `az` and has proper redaction for all logged outputs.

Example output:

```
2022/10/31 13:37:24 main.go:47: Retry: 
=====> Try=1 PUT https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/weilim-log-test-1?api-version=2021-04-01
2022/10/31 13:37:26 main.go:47: Authentication: *azidentity.AzureCLICredential.GetToken() acquired a token for scope https://management.core.windows.net//.default

2022/10/31 13:37:26 main.go:47: Request: ==> OUTGOING REQUEST (Try=1)
   PUT https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/weilim-log-test-1?api-version=2021-04-01
   Accept: application/json
   Authorization: REDACTED
   Content-Length: 108260
   Content-Type: application/json
   User-Agent: azsdk-go-armresources/v1.0.0 (go1.19; Windows_NT),azdev/0.0.0-dev.0 (Go go1.19; windows/amd64)

2022/10/31 13:37:27 main.go:47: Retry: 
=====> Try=1 GET https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/weilim-log-test-1?api-version=2021-04-01
2022/10/31 13:37:29 main.go:47: Authentication: *azidentity.AzureCLICredential.GetToken() acquired a token for scope https://management.core.windows.net//.default

2022/10/31 13:37:29 main.go:47: Request: ==> OUTGOING REQUEST (Try=1)
   GET https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/weilim-log-test-1?api-version=2021-04-01
   Accept: application/json
   Authorization: REDACTED
   User-Agent: azsdk-go-armresources/v1.0.0 (go1.19; Windows_NT),azdev/0.0.0-dev.0 (Go go1.19; windows/amd64)

2022/10/31 13:37:29 main.go:47: Response: ==> REQUEST/RESPONSE (Try=1/81.917ms, OpTime=81.917ms) -- RESPONSE RECEIVED
   GET https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/weilim-log-test-1?api-version=2021-04-01
   Accept: application/json
   Authorization: REDACTED
   User-Agent: azsdk-go-armresources/v1.0.0 (go1.19; Windows_NT),azdev/0.0.0-dev.0 (Go go1.19; windows/amd64)
   --------------------------------------------------------------------------------
   RESPONSE Status: 404 Not Found
   Cache-Control: no-cache
   Content-Length: 102
   Content-Type: application/json; charset=utf-8
   Date: Mon, 31 Oct 2022 20:37:29 GMT
   Expires: -1
   Pragma: no-cache
   Strict-Transport-Security: REDACTED
   X-Content-Type-Options: REDACTED
   X-Ms-Correlation-Request-Id: REDACTED
   X-Ms-Failure-Cause: REDACTED
   X-Ms-Ratelimit-Remaining-Subscription-Reads: REDACTED
   X-Ms-Request-Id: a440718a-2082-40ac-b101-3d9cabd63a6f
   X-Ms-Routing-Request-Id: REDACTED

2022/10/31 13:37:29 main.go:47: Retry: response 404
```
