### PR TITLE
Updates inline help docs for `azd config` commands

### DIFF
--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -19,20 +19,19 @@ func configCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 	root := &cobra.Command{
 		Use:   "config",
 		Short: "Manage Azure Developer CLI configuration",
-		Long: `Manage the Azure Developer CLI user configuration, which includes your default Azure subscription and location. 
+		Long: `Manage the Azure Developer CLI user configuration, which includes your default Azure subscription and location.
 
-		The easiest way to configure azd is to run ` + output.WithBackticks("azd init") + `. 
-		The subscription and location you select will be stored in the config.json file located at $AZURE_CONFIG_DIR. 
-		The default value of AZURE_CONFIG_DIR is $HOME/.azd on Linux and macOS, and %USERPROFILE%\.azd on Windows.`,
+The easiest way to initially configure azd is to run ` + output.WithBackticks("azd init") + `.
+The subscription and location you select will be stored in the config.json file located at $AZURE_CONFIG_DIR.
+The default value of AZURE_CONFIG_DIR is $HOME/.azd on Linux and macOS, and %USERPROFILE%\.azd on Windows.`,
 	}
 
+	root.Flags().BoolP("help", "h", false, fmt.Sprintf("Gets help for %s.", root.Name()))
 	root.AddCommand(BuildCmd(rootOptions, configListCmdDesign, initConfigListAction, nil))
 	root.AddCommand(BuildCmd(rootOptions, configGetCmdDesign, initConfigGetAction, nil))
 	root.AddCommand(BuildCmd(rootOptions, configSetCmdDesign, initConfigSetAction, nil))
 	root.AddCommand(BuildCmd(rootOptions, configUnsetCmdDesign, initConfigUnsetAction, nil))
 	root.AddCommand(BuildCmd(rootOptions, configResetCmdDesign, initConfigResetAction, nil))
-
-	root.Flags().BoolP("help", "h", false, fmt.Sprintf("Gets help for %s.", root.Name()))
 
 	return root
 }
@@ -94,7 +93,7 @@ func configGetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, 
 	cmd := &cobra.Command{
 		Use:   "get <path>",
 		Short: "Gets a configuration",
-		Long:  `Gets a configuration in $AZURE_CONFIG_DIR/config.json. `,
+		Long:  `Gets a configuration in $AZURE_CONFIG_DIR/config.json.`,
 	}
 
 	output.AddOutputParam(
@@ -159,8 +158,8 @@ func configSetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, 
 		Use:   "set <path> <value>",
 		Short: "Sets a configuration",
 		Long:  `Sets a configuration in $AZURE_CONFIG_DIR/config.json.`,
-		Example: `$ azd config set defaults.subscription <yourSubscriptionID> 
-		$ azd config set defaults.location eastus`,
+		Example: `$ azd config set defaults.subscription <yourSubscriptionID>
+$ azd config set defaults.location eastus`,
 	}
 	cmd.Args = cobra.ExactArgs(2)
 	return cmd, &struct{}{}

--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
+	"runtime"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
@@ -14,16 +16,32 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var userConfigPath string
+
 // Setup account command category
 func configCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
+	userConfigDir, err := config.GetUserConfigDir()
+	if err != nil {
+		userConfigPath = output.WithBackticks(filepath.Join("$AZURE_CONFIG_DIR", "config.json"))
+	} else {
+		userConfigPath = output.WithBackticks(filepath.Join(userConfigDir, "config.json"))
+	}
+
+	var defaultConfigPath string
+	if runtime.GOOS == "windows" {
+		defaultConfigPath = filepath.Join("%USERPROFILE%", ".azd")
+	} else {
+		defaultConfigPath = filepath.Join("$HOME", ".azd")
+	}
+
 	root := &cobra.Command{
 		Use:   "config",
 		Short: "Manage Azure Developer CLI configuration",
 		Long: `Manage the Azure Developer CLI user configuration, which includes your default Azure subscription and location.
 
 The easiest way to initially configure azd is to run ` + output.WithBackticks("azd init") + `.
-The subscription and location you select will be stored in the config.json file located at $AZURE_CONFIG_DIR.
-The default value of AZURE_CONFIG_DIR is $HOME/.azd on Linux and macOS, and %USERPROFILE%\.azd on Windows.`,
+The subscription and location you select will be stored at ` + userConfigPath + `.
+The default configuration path is ` + output.WithBackticks(defaultConfigPath) + `.`,
 	}
 
 	root.Flags().BoolP("help", "h", false, fmt.Sprintf("Gets help for %s.", root.Name()))
@@ -42,7 +60,7 @@ func configListCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command,
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Lists all configuration values",
-		Long:  `Lists all configuration values in $AZURE_CONFIG_DIR/config.json.`,
+		Long:  `Lists all configuration values in ` + userConfigPath + `.`,
 	}
 
 	output.AddOutputParam(
@@ -93,7 +111,7 @@ func configGetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, 
 	cmd := &cobra.Command{
 		Use:   "get <path>",
 		Short: "Gets a configuration",
-		Long:  `Gets a configuration in $AZURE_CONFIG_DIR/config.json.`,
+		Long:  `Gets a configuration in ` + userConfigPath + `.`,
 	}
 
 	output.AddOutputParam(
@@ -157,7 +175,7 @@ func configSetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, 
 	cmd := &cobra.Command{
 		Use:   "set <path> <value>",
 		Short: "Sets a configuration",
-		Long:  `Sets a configuration in $AZURE_CONFIG_DIR/config.json.`,
+		Long:  `Sets a configuration in ` + userConfigPath + `.`,
 		Example: `$ azd config set defaults.subscription <yourSubscriptionID>
 $ azd config set defaults.location eastus`,
 	}
@@ -211,7 +229,7 @@ func configUnsetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command
 	cmd := &cobra.Command{
 		Use:     "unset <path>",
 		Short:   "Unsets a configuration",
-		Long:    `Removes a configuration in $AZURE_CONFIG_DIR/config.json.`,
+		Long:    `Removes a configuration in ` + userConfigPath + `.`,
 		Example: `$ azd config unset defaults.location`,
 	}
 	cmd.Args = cobra.ExactArgs(1)
@@ -263,7 +281,7 @@ func configResetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command
 	cmd := &cobra.Command{
 		Use:   "reset",
 		Short: "Resets configuration to default",
-		Long:  `Resets all configuration in $AZURE_CONFIG_DIR/config.json to the default.`,
+		Long:  `Resets all configuration in ` + userConfigPath + ` to the default.`,
 	}
 
 	return cmd, &struct{}{}

--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -19,6 +19,11 @@ func configCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 	root := &cobra.Command{
 		Use:   "config",
 		Short: "Manage Azure Developer CLI configuration",
+		Long: `Manage the Azure Developer CLI user configuration, which includes your default Azure subscription and location. 
+
+		The easiest way to configure azd is to run ` + output.WithBackticks("azd init") + `. 
+		The subscription and location you select will be stored in the config.json file located at $AZURE_CONFIG_DIR. 
+		The default value of AZURE_CONFIG_DIR is $HOME/.azd on Linux and macOS, and %USERPROFILE%\.azd on Windows.`,
 	}
 
 	root.AddCommand(BuildCmd(rootOptions, configListCmdDesign, initConfigListAction, nil))
@@ -38,7 +43,7 @@ func configListCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command,
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Lists all configuration values",
-		Long:  "Lists all configuration values",
+		Long:  `Lists all configuration values in $AZURE_CONFIG_DIR/config.json.`,
 	}
 
 	output.AddOutputParam(
@@ -89,7 +94,7 @@ func configGetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, 
 	cmd := &cobra.Command{
 		Use:   "get <path>",
 		Short: "Gets a configuration",
-		Long:  "Gets a configuration",
+		Long:  `Gets a configuration in $AZURE_CONFIG_DIR/config.json. `,
 	}
 
 	output.AddOutputParam(
@@ -153,7 +158,9 @@ func configSetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, 
 	cmd := &cobra.Command{
 		Use:   "set <path> <value>",
 		Short: "Sets a configuration",
-		Long:  "Sets a configuration",
+		Long:  `Sets a configuration in $AZURE_CONFIG_DIR/config.json.`,
+		Example: `$ azd config set defaults.subscription <yourSubscriptionID> 
+		$ azd config set defaults.location eastus`,
 	}
 	cmd.Args = cobra.ExactArgs(2)
 	return cmd, &struct{}{}
@@ -203,9 +210,10 @@ func (a *configSetAction) Run(ctx context.Context) error {
 
 func configUnsetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, *struct{}) {
 	cmd := &cobra.Command{
-		Use:   "unset <path>",
-		Short: "Unsets a configuration",
-		Long:  "Unsets a configuration",
+		Use:     "unset <path>",
+		Short:   "Unsets a configuration",
+		Long:    `Removes a configuration in $AZURE_CONFIG_DIR/config.json.`,
+		Example: `$ azd config unset defaults.location`,
 	}
 	cmd.Args = cobra.ExactArgs(1)
 	return cmd, &struct{}{}
@@ -256,7 +264,7 @@ func configResetCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command
 	cmd := &cobra.Command{
 		Use:   "reset",
 		Short: "Resets configuration to default",
-		Long:  "Resets configuration to default",
+		Long:  `Resets all configuration in $AZURE_CONFIG_DIR/config.json to the default.`,
 	}
 
 	return cmd, &struct{}{}

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -279,7 +279,7 @@ func isDebugEnabled() bool {
 	// Parse when `--help` is on the command line. Add an explicit help parameter (which we ignore)
 	// so pflag doesn't fail in this case.  If `--help` is passed, the help for `azd` will be shown later
 	// when `cmd.Execute` is run
-	flags.BoolVar(&help, "help", false, "")
+	flags.BoolVarP(&help, "help", "h", false, "")
 
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		log.Printf("could not parse flags: %v", err)


### PR DESCRIPTION
- [x] Update help docs for `azd config` commands
- [x] Fixes issue where `-h` flag was throwing help parsing error 

<img width="688" alt="image" src="https://user-images.githubusercontent.com/6540159/199310840-c196c0b8-a18d-4733-8441-5b2847ebfb2c.png">
