### PR TITLE
Simplify color processing on Windows

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.0-beta.6 (Unreleased)
 
+- [[#1060]](https://github.com/Azure/azure-dev/pull/1060) Fix color rendering on Windows.
+
 ## 0.3.0-beta.5 (2022-10-26)
 
 ### Bugs Fixed

--- a/cli/azd/cmd/sets.go
+++ b/cli/azd/cmd/sets.go
@@ -33,13 +33,6 @@ func newWriter(cmd *cobra.Command) io.Writer {
 		writer = colorable.NewNonColorable(writer)
 	}
 
-	// To support color on windows platforms which don't natively support rendering ANSI codes
-	// we use colorable.NewColorableStdout() which creates a stream that uses the Win32 APIs to
-	// change colors as it interprets the ANSI escape codes in the string it is writing.
-	if writer == os.Stdout {
-		writer = colorable.NewColorableStdout()
-	}
-
 	return writer
 }
 

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -29,11 +29,15 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/blang/semver/v4"
+	"github.com/mattn/go-colorable"
 	"github.com/spf13/pflag"
 )
 
 func main() {
 	ctx := context.Background()
+
+	restoreColorMode := colorable.EnableColorsStdout(nil)
+	defer restoreColorMode()
 
 	// Ensure random numbers from default random number generator are unpredictable
 	rand.Seed(time.Now().UTC().UnixNano())

--- a/cli/azd/pkg/commands/builder.go
+++ b/cli/azd/pkg/commands/builder.go
@@ -65,13 +65,6 @@ func RegisterDependenciesInCtx(
 		writer = colorable.NewNonColorable(writer)
 	}
 
-	// To support color on windows platforms which don't natively support rendering ANSI codes
-	// we use colorable.NewColorableStdout() which creates a stream that uses the Win32 APIs to
-	// change colors as it interprets the ANSI escape codes in the string it is writing.
-	if writer == os.Stdout {
-		writer = colorable.NewColorableStdout()
-	}
-
 	ctx = output.WithWriter(ctx, writer)
 
 	isTerminal := cmd.OutOrStdout() == os.Stdout &&


### PR DESCRIPTION
Historically, the Windows console has used out of band signaling for control color information, unlike *nix where control characters are added to the text to control what color it is printed in and other formatting information.

For a long time, Windows could not cope with the *nix strategy, leading to things like `colorable.NewColorableStdout()` and friends which tried to provide streams which would interpret ANSI escape sequences and call the corresponding Win32 methods to change colors as it rendered the text.

This process was very fragile and would lead to cases where we'd end up not using `colorable.NewColorableStdout()` and then when run on windows in the legacy console host we'd see these escape codes get printed.

Windows now supports processing these escape sequences. Enable that behavior and get out of the `colorable.NewColorableStdout()` game.

Fixes #1058