### PR TITLE
Use `bicep` directly instead of via `az bicep`

### DIFF
--- a/cli/azd/pkg/tools/bicep/bicep.go
+++ b/cli/azd/pkg/tools/bicep/bicep.go
@@ -11,7 +11,6 @@ import (
 	osexec "os/exec"
 	"os/user"
 	"path/filepath"
-	"regexp"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
@@ -32,12 +31,6 @@ func NewBicepCli(ctx context.Context) BicepCli {
 type bicepCli struct {
 	bicepPath     string
 	commandRunner exec.CommandRunner
-}
-
-var isBicepNotFoundRegex = regexp.MustCompile(`Bicep CLI not found\.`)
-
-func isBicepNotFoundMessage(s string) bool {
-	return isBicepNotFoundRegex.MatchString(s)
 }
 
 func (cli *bicepCli) Name() string {

--- a/cli/azd/pkg/tools/bicep/unix.go
+++ b/cli/azd/pkg/tools/bicep/unix.go
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build unix
+// +build unix
+
+package bicep
+
+const cBicepCommandName = "bicep"

--- a/cli/azd/pkg/tools/bicep/windows.go
+++ b/cli/azd/pkg/tools/bicep/windows.go
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build windows
+// +build windows
+
+package bicep
+
+const cBicepCommandName = "bicep.exe"


### PR DESCRIPTION
If `bicep` is on the user's path, use that version. Otherwise, look in `~/.azure/bin` which is the location that `az` installs bicep to when using `az bicep install`.

This should give us a nice little speed-boost as we no longer need to boot python just to discover and launch the bicep compiler (and we don't have to do a version check to work around an issue with the AZ CLI and how it called bicep in some cases).
