### PR TITLE
Templates: Update managed identity value due to change in Bicep 0.12.1

### DIFF
--- a/templates/common/infra/bicep/core/host/appservice.bicep
+++ b/templates/common/infra/bicep/core/host/appservice.bicep
@@ -57,7 +57,7 @@ resource appService 'Microsoft.Web/sites@2022-03-01' = {
     httpsOnly: true
   }
 
-  identity: managedIdentity ? { type: 'SystemAssigned' } : null
+  identity: { type: managedIdentity ? 'SystemAssigned' : 'None' }
 
   resource configAppSettings 'config' = {
     name: 'appsettings'

--- a/templates/common/infra/bicep/core/host/container-app.bicep
+++ b/templates/common/infra/bicep/core/host/container-app.bicep
@@ -21,7 +21,7 @@ resource app 'Microsoft.App/containerApps@2022-03-01' = {
   name: name
   location: location
   tags: tags
-  identity: managedIdentity ? { type: 'SystemAssigned' } : null
+  identity: { type: managedIdentity ? 'SystemAssigned' : 'None' }
   properties: {
     managedEnvironmentId: containerAppsEnvironment.id
     configuration: {


### PR DESCRIPTION
In Bicep version 0.12.1 release today (11/3/2022) our app service and container app templates are throwing an error:

<img width="732" alt="image" src="https://user-images.githubusercontent.com/6540159/199839231-847c8ac7-028e-4a4e-ac45-4d80535c07a0.png">

This resolves the issue by setting managed identity type to `None` instead of a null value.

Bicep 0.12.1 Release Notes
https://github.com/Azure/bicep/releases/tag/v0.12.1

- [x] Verify if this is a breaking change and require bicep upgrade

Confirmed this is NOT a breaking change and will NOT require users to upgrade to latest bicep version.