### PR TITLE
Fix java version check for major-only release

### DIFF
--- a/cli/azd/pkg/tools/bicep/bicep.go
+++ b/cli/azd/pkg/tools/bicep/bicep.go
@@ -59,7 +59,7 @@ func (cli *bicepCli) CheckInstalled(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("checking %s version: %w", cli.Name(), err)
 	}
 
-	bicepSemver, err := tools.ExtractSemver(bicepRes.Stdout)
+	bicepSemver, err := tools.ExtractVersion(bicepRes.Stdout)
 	if err != nil {
 		return false, fmt.Errorf("converting to semver version fails: %w", err)
 	}

--- a/cli/azd/pkg/tools/dotnet/dotnet.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet.go
@@ -51,7 +51,7 @@ func (cli *dotNetCli) CheckInstalled(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("checking %s version: %w", cli.Name(), err)
 	}
-	dotnetSemver, err := tools.ExtractSemver(dotnetRes)
+	dotnetSemver, err := tools.ExtractVersion(dotnetRes)
 	if err != nil {
 		return false, fmt.Errorf("converting to semver version fails: %w", err)
 	}

--- a/cli/azd/pkg/tools/git/git.go
+++ b/cli/azd/pkg/tools/git/git.go
@@ -68,7 +68,7 @@ func (cli *gitCli) CheckInstalled(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("checking %s version: %w", cli.Name(), err)
 	}
-	gitSemver, err := tools.ExtractSemver(gitRes)
+	gitSemver, err := tools.ExtractVersion(gitRes)
 	if err != nil {
 		return false, fmt.Errorf("converting to semver version fails: %w", err)
 	}

--- a/cli/azd/pkg/tools/github/github.go
+++ b/cli/azd/pkg/tools/github/github.go
@@ -81,7 +81,7 @@ func (cli *ghCli) CheckInstalled(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("checking %s version: %w", cli.Name(), err)
 	}
-	ghSemver, err := tools.ExtractSemver(ghRes)
+	ghSemver, err := tools.ExtractVersion(ghRes)
 	if err != nil {
 		return false, fmt.Errorf("converting to semver version fails: %w", err)
 	}

--- a/cli/azd/pkg/tools/javac/javac_test.go
+++ b/cli/azd/pkg/tools/javac/javac_test.go
@@ -2,6 +2,7 @@ package javac
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -67,7 +68,9 @@ func TestCheckInstalled_OlderJavaVersion(t *testing.T) {
 	// error when --version
 	execMock := mockexec.NewMockCommandRunner().
 		When(func(a azdexec.RunArgs, command string) bool { return a.Args[0] == "--version" }).
-		Respond(azdexec.NewRunResult(2, "", ""))
+		RespondFn(func(args azdexec.RunArgs) (azdexec.RunResult, error) {
+			return azdexec.NewRunResult(2, "", ""), errors.New("--version not recognized")
+		})
 
 	// non-zero exit code on -version
 	execMock = execMock.
@@ -78,7 +81,7 @@ func TestCheckInstalled_OlderJavaVersion(t *testing.T) {
 	ok, err := cli.CheckInstalled(context.Background())
 
 	assert.False(t, ok)
-	assert.NoError(t, err)
+	assert.ErrorContains(t, err, "need at least version")
 }
 
 func Test_getInstalledPath(t *testing.T) {

--- a/cli/azd/pkg/tools/javac/javac_test.go
+++ b/cli/azd/pkg/tools/javac/javac_test.go
@@ -31,7 +31,9 @@ func TestCheckInstalledVersion(t *testing.T) {
 	}{
 		{name: "MetExact", stdOut: "javac 17.0.0.0", want: true},
 		{name: "Met", stdOut: "javac 18.0.2.1", want: true},
+		{name: "MetMajorOnly", stdOut: "javac 19", want: true},
 		{name: "NotMet", stdOut: "javac 15.0.0.0", wantErr: true},
+		{name: "NotMetMajorOnly", stdOut: "javac 11", wantErr: true},
 		{name: "InvalidSemVer", stdOut: "javac NoVer", wantErr: true},
 	}
 
@@ -44,14 +46,39 @@ func TestCheckInstalledVersion(t *testing.T) {
 			cli := NewCli(execMock)
 			ok, err := cli.CheckInstalled(context.Background())
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			assert.Equal(t, tt.want, ok)
 		})
 	}
+}
+
+func TestCheckInstalled_OlderJavaVersion(t *testing.T) {
+	javaHome := t.TempDir()
+	javaHomeBin := filepath.Join(javaHome, "bin")
+	require.NoError(t, os.Mkdir(javaHomeBin, 0755))
+
+	placeJavac(t, javaHomeBin)
+	t.Setenv("JAVA_HOME", javaHome)
+
+	// error when --version
+	execMock := mockexec.NewMockCommandRunner().
+		When(func(a azdexec.RunArgs, command string) bool { return a.Args[0] == "--version" }).
+		Respond(azdexec.NewRunResult(2, "", ""))
+
+	// non-zero exit code on -version
+	execMock = execMock.
+		When(func(a azdexec.RunArgs, command string) bool { return a.Args[0] == "-version" }).
+		Respond(azdexec.NewRunResult(0, "", "javac 1.8_353"))
+
+	cli := NewCli(execMock)
+	ok, err := cli.CheckInstalled(context.Background())
+
+	assert.False(t, ok)
+	assert.NoError(t, err)
 }
 
 func Test_getInstalledPath(t *testing.T) {

--- a/cli/azd/pkg/tools/npm/npm.go
+++ b/cli/azd/pkg/tools/npm/npm.go
@@ -49,7 +49,7 @@ func (cli *npmCli) CheckInstalled(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("checking %s version: %w", cli.Name(), err)
 	}
-	nodeSemver, err := tools.ExtractSemver(nodeRes)
+	nodeSemver, err := tools.ExtractVersion(nodeRes)
 	if err != nil {
 		return false, fmt.Errorf("converting to semver version fails: %w", err)
 	}

--- a/cli/azd/pkg/tools/python/python.go
+++ b/cli/azd/pkg/tools/python/python.go
@@ -44,7 +44,7 @@ func (cli *PythonCli) CheckInstalled(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("checking %s version: %w", cli.Name(), err)
 	}
-	pythonSemver, err := tools.ExtractSemver(pythonRes)
+	pythonSemver, err := tools.ExtractVersion(pythonRes)
 	if err != nil {
 		return false, fmt.Errorf("converting to semver version fails: %w", err)
 	}

--- a/cli/azd/pkg/tools/tool.go
+++ b/cli/azd/pkg/tools/tool.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	osexec "os/exec"
 	"regexp"
+	"strconv"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/blang/semver/v4"
@@ -60,11 +61,36 @@ func ExecuteCommand(ctx context.Context, cmd string, args ...string) (string, er
 	return runResult.Stdout, err
 }
 
-func ExtractSemver(cliOutput string) (semver.Version, error) {
-	ver := regexp.MustCompile(`\d+\.\d+\.\d+`).FindString(cliOutput)
-	semver, err := semver.Parse(ver)
-	if err != nil {
-		return semver, err
+// ExtractVersion extracts a major.minor.patch version number from a typical CLI version flag output.
+//
+// minor and patch version numbers are both optional, treated as 0 if not found.
+func ExtractVersion(cliOutput string) (semver.Version, error) {
+	majorMinorPatch := regexp.MustCompile(`\d+\.\d+\.\d+`).FindString(cliOutput)
+	ver, err := semver.Parse(majorMinorPatch)
+	if err == nil {
+		return ver, nil
 	}
-	return semver, nil
+
+	majorMinor := regexp.MustCompile(`(\d+)\.(\d+)`).FindStringSubmatch(cliOutput)
+	if len(majorMinor) >= 3 {
+		return semver.Version{
+			Major: parseUint(majorMinor[1]),
+			Minor: parseUint(majorMinor[2]),
+		}, nil
+	}
+
+	major := regexp.MustCompile(`\d+`).FindString(cliOutput)
+	if major != "" {
+		return semver.Version{Major: parseUint(major)}, nil
+	}
+
+	return semver.Version{}, fmt.Errorf("no valid version number found in %s", cliOutput)
+}
+
+func parseUint(s string) uint64 {
+	res, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	return res
 }


### PR DESCRIPTION
- For major release of Java, the version reported by `javac` is a major only version. Example output: `javac 19`. This change fixes our CLI version extraction logic to be more flexible in parsing, allowing: `major`, `major.minor` only formats as well.
- On extremely old versions of Java, (Java 8 and below) `javac --version` is not recognized. This change fixes the error output to be the version check validation failure.

Fixes #1077