### PR TITLE
Shell completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ powershell -ex AllSigned -c "Invoke-RestMethod 'https://aka.ms/install-azd.ps1' 
 curl -fsSL https://aka.ms/install-azd.sh | bash
 ```
 
+## Set Up Shell Completion
+
+The CLI supports shell completion for `bash`, `zsh`, `fish` and `powershell`.
+
+To learn how to install shell completion for the CLI for your shell, run `azd completion [bash | zsh | fish | powershell] --help`.
+For example, to get the instructions for `bash` run `azd completion bash --help`
+
 ## Uninstall Azure Developer CLI
 
 ### Windows

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -47,6 +47,8 @@ When a template is provided, the sample code is cloned to the current directory.
 	f := &initFlags{}
 	f.Bind(cmd.Flags(), rootOptions)
 
+	cmd.RegisterFlagCompletionFunc("template", templateNameCompletion)
+
 	return cmd, f
 }
 

--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -19,6 +19,26 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+func templateNameCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	templateManager := templates.NewTemplateManager()
+	templateSet, err := templateManager.ListTemplates()
+
+	if err != nil {
+		cobra.CompError(fmt.Sprintf("Error listing templates: %s", err))
+		return []string{}, cobra.ShellCompDirectiveError
+	}
+
+	templateList := maps.Values(templateSet)
+	slices.SortFunc(templateList, func(a, b templates.Template) bool {
+		return a.Name < b.Name
+	})
+	templateNames := make([]string, len(templateList))
+	for i, v := range templateList {
+		templateNames[i] = v.Name
+	}
+	return templateNames, cobra.ShellCompDirectiveDefault
+}
+
 func templatesCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 	root := &cobra.Command{
 		Use:   "template",

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -58,6 +58,8 @@ When no template is supplied, you can optionally select an Azure Developer CLI t
 	uf := &upFlags{}
 	uf.Bind(cmd.Flags(), global)
 
+	cmd.RegisterFlagCompletionFunc("template", templateNameCompletion)
+
 	return cmd, uf
 }
 


### PR DESCRIPTION
Resolves #846

- Add section on shell completion to README to guide to enabling existing shell completion in `azd`
- Add completion for template names (`--template` parameters)