### PR TITLE
Fix `env new` to use positional argument

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## Upcoming (Unreleased)
+
+### Breaking Changes
+
+- [[#1105]](https://github.com/Azure/azure-dev/pull/1105) `azd env new` now accepts the name of the environment as the first argument, i.e. `azd env new <environment>`. Previously, this behavior was accomplished via the global environment flag `-e`, i.e. `azd env new -e <environment>`.
+
 ## 0.4.0-beta.1 (2022-11-02)
 
 ### Features Added

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -228,6 +228,7 @@ func envNewCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, *en
 	}
 	f := &envNewFlags{}
 	f.Bind(cmd.Flags(), global)
+	cmd.Args = cobra.MaximumNArgs(1)
 	return cmd, f
 }
 

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -235,6 +235,7 @@ type envNewAction struct {
 	azdCtx  *azdcontext.AzdContext
 	azCli   azcli.AzCli
 	flags   envNewFlags
+	args    []string
 	console input.Console
 }
 
@@ -242,12 +243,14 @@ func newEnvNewAction(
 	azdCtx *azdcontext.AzdContext,
 	azcli azcli.AzCli,
 	flags envNewFlags,
+	args []string,
 	console input.Console,
 ) *envNewAction {
 	return &envNewAction{
 		azdCtx:  azdCtx,
 		azCli:   azcli,
 		flags:   flags,
+		args:    args,
 		console: console,
 	}
 }
@@ -261,8 +264,13 @@ func (en *envNewAction) Run(ctx context.Context) error {
 		return err
 	}
 
+	environmentName := ""
+	if len(en.args) >= 1 {
+		environmentName = en.args[0]
+	}
+
 	envSpec := environmentSpec{
-		environmentName: en.flags.global.EnvironmentName,
+		environmentName: environmentName,
 		subscription:    en.flags.subscription,
 		location:        en.flags.location,
 	}

--- a/cli/azd/cmd/wire_gen.go
+++ b/cli/azd/cmd/wire_gen.go
@@ -281,7 +281,7 @@ func initEnvNewAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flag
 		return nil, err
 	}
 	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
-	cmdEnvNewAction := newEnvNewAction(azdContext, azCli, flags, console)
+	cmdEnvNewAction := newEnvNewAction(azdContext, azCli, flags, args, console)
 	return cmdEnvNewAction, nil
 }
 

--- a/cli/azd/pkg/contracts/env_list.go
+++ b/cli/azd/pkg/contracts/env_list.go
@@ -1,0 +1,7 @@
+package contracts
+
+type EnvListEnvironment struct {
+	Name       string `json:"name"`
+	IsDefault  bool   `json:"isDefault"`
+	DotEnvPath string `json:"dotEnvPath"`
+}

--- a/cli/azd/pkg/contracts/env_list.go
+++ b/cli/azd/pkg/contracts/env_list.go
@@ -1,7 +1,7 @@
 package contracts
 
 type EnvListEnvironment struct {
-	Name       string `json:"name"`
-	IsDefault  bool   `json:"isDefault"`
-	DotEnvPath string `json:"dotEnvPath"`
+	Name       string `json:"Name"`
+	IsDefault  bool   `json:"IsDefault"`
+	DotEnvPath string `json:"DotEnvPath"`
 }

--- a/cli/azd/pkg/environment/azdcontext/azdcontext.go
+++ b/cli/azd/pkg/environment/azdcontext/azdcontext.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 )
 
@@ -19,12 +20,6 @@ const InfraDirectoryName = "infra"
 
 type AzdContext struct {
 	projectDirectory string
-}
-
-type EnvironmentView struct {
-	Name       string
-	IsDefault  bool
-	DotEnvPath string
 }
 
 func (c *AzdContext) ProjectDirectory() string {
@@ -63,7 +58,7 @@ func (c *AzdContext) GetInfrastructurePath() string {
 	return filepath.Join(c.ProjectDirectory(), InfraDirectoryName)
 }
 
-func (c *AzdContext) ListEnvironments() ([]EnvironmentView, error) {
+func (c *AzdContext) ListEnvironments() ([]contracts.EnvListEnvironment, error) {
 	defaultEnv, err := c.GetDefaultEnvironmentName()
 	if err != nil {
 		return nil, err
@@ -74,10 +69,10 @@ func (c *AzdContext) ListEnvironments() ([]EnvironmentView, error) {
 		return nil, fmt.Errorf("listing entries: %w", err)
 	}
 
-	var envs []EnvironmentView
+	var envs []contracts.EnvListEnvironment
 	for _, ent := range ents {
 		if ent.IsDir() {
-			ev := EnvironmentView{
+			ev := contracts.EnvListEnvironment{
 				Name:       ent.Name(),
 				IsDefault:  ent.Name() == defaultEnv,
 				DotEnvPath: c.GetEnvironmentFilePath(ent.Name()),

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -47,6 +47,7 @@ import (
 
 const (
 	testSubscriptionId = "2cd617ea-1866-46b1-90e3-fffb087ebf9b"
+	defaultLocation    = "eastus2"
 )
 
 func Test_CLI_Login_FailsIfNoAzCliIsMissing(t *testing.T) {
@@ -507,7 +508,7 @@ func Test_CLI_ProjectIsNeeded(t *testing.T) {
 		{command: "down"},
 		{command: "env get-values"},
 		{command: "env list"},
-		{command: "env new"},
+		{command: "env new", args: []string{"testEnvironmentName"}},
 		{command: "env refresh"},
 		{command: "env select", args: []string{"testEnvironmentName"}},
 		{command: "env set", args: []string{"testKey", "testValue"}},

--- a/cli/azd/test/functional/env_test.go
+++ b/cli/azd/test/functional/env_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cli_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
+	"github.com/azure/azure-dev/cli/azd/test/azdcli"
+	"github.com/stretchr/testify/require"
+)
+
+// Verifies that azd env commands work together to manage environments.
+func Test_CLI_Env_Management(t *testing.T) {
+	ctx, cancel := newTestContext(t)
+	defer cancel()
+
+	dir := tempDirWithDiagnostics(t)
+	t.Logf("DIR: %s", dir)
+
+	cli := azdcli.NewCLI(t)
+	cli.WorkingDirectory = dir
+
+	err := copySample(dir, "storage")
+	require.NoError(t, err, "failed expanding sample")
+
+	// Create one environment via interactive prompt
+	envName := randomEnvName()
+	envNew(ctx, t, cli, envName, true)
+
+	// Verify env list is updated
+	environmentList := envList(ctx, t, cli)
+	require.Len(t, environmentList, 1)
+	requireIsDefault(t, environmentList, envName)
+
+	// Create one environment via flags
+	envName2 := randomEnvName()
+	envNew(ctx, t, cli, envName2, false)
+
+	// Verify env list is updated, and with new default set
+	environmentList = envList(ctx, t, cli)
+	require.Len(t, environmentList, 2)
+	requireIsDefault(t, environmentList, envName2)
+
+	// Select old environment
+	envSelect(ctx, t, cli, envName)
+
+	// Verify env list has new default set
+	environmentList = envList(ctx, t, cli)
+	require.Len(t, environmentList, 2)
+	requireIsDefault(t, environmentList, envName)
+}
+
+func Test_CLI_Env_Values_Management(t *testing.T) {
+	ctx, cancel := newTestContext(t)
+	defer cancel()
+
+	dir := tempDirWithDiagnostics(t)
+	t.Logf("DIR: %s", dir)
+
+	cli := azdcli.NewCLI(t)
+	cli.WorkingDirectory = dir
+
+	err := copySample(dir, "storage")
+	require.NoError(t, err, "failed expanding sample")
+
+	// Create one environment
+	envName := randomEnvName()
+	envNew(ctx, t, cli, envName, false)
+	t.Logf("DIR: %s", dir)
+
+	// Add key1
+	envSetValue(ctx, t, cli, "key1", "value1")
+	values := envGetValues(ctx, t, cli)
+	require.Contains(t, values, "key1")
+	require.Equal(t, values["key1"], "value1")
+
+	// Add key2
+	envSetValue(ctx, t, cli, "key2", "value2")
+	values = envGetValues(ctx, t, cli)
+	require.Contains(t, values, "key2")
+	require.Equal(t, values["key2"], "value2")
+
+	// Modify key1
+	envSetValue(ctx, t, cli, "key1", "modified1")
+	values = envGetValues(ctx, t, cli)
+	require.Contains(t, values, "key1")
+	require.Equal(t, values["key1"], "modified1")
+	require.Contains(t, values, "key2")
+	require.Equal(t, values["key2"], "value2")
+}
+
+func requireIsDefault(t *testing.T, list []contracts.EnvListEnvironment, envName string) {
+	for _, env := range list {
+		if env.Name == envName {
+			require.True(t, env.IsDefault)
+			return
+		}
+	}
+
+	require.Fail(t, "%#v does not contain env with name %#v", list, envName)
+}
+
+func envNew(ctx context.Context, t *testing.T, cli *azdcli.CLI, envName string, usePrompt bool) {
+	if usePrompt {
+		_, err := cli.RunCommandWithStdIn(ctx, stdinForTests(envName), "env", "new")
+		require.NoError(t, err)
+	} else {
+		_, err := cli.RunCommand(ctx, "env", "new", envName, "--subscription", testSubscriptionId, "-l", defaultLocation)
+		require.NoError(t, err)
+	}
+}
+
+func envList(ctx context.Context, t *testing.T, cli *azdcli.CLI) []contracts.EnvListEnvironment {
+	jsonOutput, err := cli.RunCommand(ctx, "env", "list", "--output", "json")
+	require.NoError(t, err)
+
+	env := []contracts.EnvListEnvironment{}
+	err = json.Unmarshal([]byte(jsonOutput), &env)
+	require.NoError(t, err)
+
+	return env
+}
+
+func envSelect(ctx context.Context, t *testing.T, cli *azdcli.CLI, envName string) {
+	_, err := cli.RunCommand(ctx, "env", "select", envName)
+	require.NoError(t, err)
+}
+
+func envSetValue(ctx context.Context, t *testing.T, cli *azdcli.CLI, key string, value string) {
+	_, err := cli.RunCommand(ctx, "env", "set", key, value)
+	require.NoError(t, err)
+}
+
+func envGetValues(ctx context.Context, t *testing.T, cli *azdcli.CLI) map[string]string {
+	jsonOutput, err := cli.RunCommand(ctx, "env", "get-values", "--output", "json")
+	require.NoError(t, err)
+
+	var envValues map[string]string
+	err = json.Unmarshal([]byte(jsonOutput), &envValues)
+	require.NoError(t, err)
+
+	return envValues
+}

--- a/cli/azd/test/functional/env_test.go
+++ b/cli/azd/test/functional/env_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Verifies that azd env commands work together to manage environments.
+// Verifies azd env commands that manage environments.
 func Test_CLI_Env_Management(t *testing.T) {
 	ctx, cancel := newTestContext(t)
 	defer cancel()
@@ -54,6 +54,7 @@ func Test_CLI_Env_Management(t *testing.T) {
 	requireIsDefault(t, environmentList, envName)
 }
 
+// Verifies azd env commands that manage environment values.
 func Test_CLI_Env_Values_Management(t *testing.T) {
 	ctx, cancel := newTestContext(t)
 	defer cancel()


### PR DESCRIPTION
- Address #502 as a breaking change: `azd env new` now reads from arg instead of the `-e` flag (which means the environment to execute the command under, i.e: ` azd env new <environment>` instead of ` azd env new -e <environment>`
- Add functional end-to-end tests for `azd env *` commands