### PR TITLE
Bicep path not found fix - Check for AZURE_CONFIG_DIR

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -21,7 +21,12 @@ RUN export DEBIAN_FRONTEND=noninteractive \
      # az cli
      && curl -sSL https://aka.ms/InstallAzureCLIDeb | bash \
      # bicep
-     && az bicep install \
+     # Fetch the latest Bicep CLI binary
+     && curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64 \
+     # Mark it as executable
+     && chmod +x ./bicep \
+     # Add bicep to your PATH (requires admin)
+     && mv ./bicep /usr/local/bin/bicep \
      # nodejs
      && curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
      && apt-get install -y nodejs \

--- a/cli/azd/pkg/tools/bicep/bicep.go
+++ b/cli/azd/pkg/tools/bicep/bicep.go
@@ -18,8 +18,6 @@ import (
 	"github.com/blang/semver/v4"
 )
 
-const EnvNameAzureConfigDir = "AZURE_CONFIG_DIR"
-
 type BicepCli interface {
 	tools.ExternalTool
 	Build(ctx context.Context, file string) (string, error)
@@ -109,6 +107,7 @@ type contextKey string
 const (
 	bicepContextKey         contextKey = "bicepcli"
 	defaultBicepCommandPath string     = "bicep"
+	envNameAzureConfigDir   string     = "AZURE_CONFIG_DIR"
 )
 
 func GetBicepCli(ctx context.Context) BicepCli {
@@ -157,7 +156,7 @@ func findBicepPath() (*string, error) {
 	commonPaths := []string{}
 
 	// If AZURE_CONFIG_DIR is defined, check there first
-	azureConfigDir := os.Getenv(EnvNameAzureConfigDir)
+	azureConfigDir := os.Getenv(envNameAzureConfigDir)
 	if strings.TrimSpace(azureConfigDir) != "" {
 		commonPaths = append(commonPaths, filepath.Join(azureConfigDir, "bin", bicepFilename))
 	}

--- a/cli/azd/pkg/tools/bicep/bicep.go
+++ b/cli/azd/pkg/tools/bicep/bicep.go
@@ -6,6 +6,7 @@ package bicep
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -158,6 +159,7 @@ func findBicepPath() (*string, error) {
 	// If AZURE_CONFIG_DIR is defined, check there first
 	azureConfigDir := os.Getenv(envNameAzureConfigDir)
 	if strings.TrimSpace(azureConfigDir) != "" {
+		log.Printf("Found %s with path '%s'\n", envNameAzureConfigDir, azureConfigDir)
 		commonPaths = append(commonPaths, filepath.Join(azureConfigDir, "bin", bicepFilename))
 	}
 
@@ -176,6 +178,8 @@ func findBicepPath() (*string, error) {
 		if existsErr == nil {
 			return &installPath, nil
 		}
+
+		log.Printf("Bicep CLI not found at path '%s'\n", installPath)
 	}
 
 	return nil, fmt.Errorf("cannot find bicep path: %w", existsErr)

--- a/cli/azd/pkg/tools/bicep/bicep.go
+++ b/cli/azd/pkg/tools/bicep/bicep.go
@@ -159,7 +159,7 @@ func findBicepPath() (*string, error) {
 	// If AZURE_CONFIG_DIR is defined, check there first
 	azureConfigDir := os.Getenv(EnvNameAzureConfigDir)
 	if strings.TrimSpace(azureConfigDir) != "" {
-		commonPaths = append(commonPaths, filepath.Join(azureConfigDir, bicepFilename))
+		commonPaths = append(commonPaths, filepath.Join(azureConfigDir, "bin", bicepFilename))
 	}
 
 	// Check for standalone installation


### PR DESCRIPTION
Adds an additional check to see if the `AZURE_CONFIG_DIR` env var has been set.  We have found that Azdo pipelines set this variable for the installation path that is used for the default location for the Bicep exe.

This PR also moves away from an `az bicep install` approach to prefer a bicep standalone installation.

Resolves #1094 