### PR TITLE
Avoid multiple instances of `console`

### DIFF
--- a/cli/azd/cmd/actions/action.go
+++ b/cli/azd/cmd/actions/action.go
@@ -3,7 +3,6 @@ package actions
 
 import (
 	"context"
-	"log"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 )
@@ -33,11 +32,7 @@ type Action interface {
 	Run(ctx context.Context) (*ActionResult, error)
 }
 
-func ShowActionResults(ctx context.Context, actionResult *ActionResult, err error) {
-	console := input.GetConsole(ctx)
-	if console == nil {
-		log.Panicln("showing actions results: console was not attached to the context")
-	}
+func ShowActionResults(ctx context.Context, console input.Console, actionResult *ActionResult, err error) {
 	if err != nil {
 		console.MessageUx(ctx, err.Error(), input.ResultError)
 		return

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -351,9 +351,6 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 		return nil, fmt.Errorf("loading project: %w", err)
 	}
 
-	formatter := output.GetFormatter(ctx)
-	writer := output.GetWriter(ctx)
-
 	infraManager, err := provisioning.NewManager(ctx, env, prj.Path, prj.Infra, !ef.global.NoPrompt)
 	if err != nil {
 		return nil, fmt.Errorf("creating provisioning manager: %w", err)
@@ -372,8 +369,8 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 
 	ef.console.Message(ctx, "Environments setting refresh completed")
 
-	if formatter.Kind() == output.JsonFormat {
-		err = formatter.Format(provisioning.NewEnvRefreshResultFromState(getStateResult.State), writer, nil)
+	if ef.formatter.Kind() == output.JsonFormat {
+		err = ef.formatter.Format(provisioning.NewEnvRefreshResultFromState(getStateResult.State), ef.writer, nil)
 		if err != nil {
 			return nil, fmt.Errorf("writing deployment result in JSON format: %w", err)
 		}

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -106,7 +106,7 @@ func (i *infraCreateAction) Run(ctx context.Context) (*actions.ActionResult, err
 		return nil, err
 	}
 
-	infraManager, err := provisioning.NewManager(ctx, env, prj.Path, prj.Infra, !i.flags.global.NoPrompt)
+	infraManager, err := provisioning.NewManager(ctx, env, prj.Path, prj.Infra, i.console.IsUnformatted())
 	if err != nil {
 		return nil, fmt.Errorf("creating provisioning manager: %w", err)
 	}

--- a/cli/azd/cmd/infra_delete.go
+++ b/cli/azd/cmd/infra_delete.go
@@ -81,7 +81,7 @@ func (a *infraDeleteAction) Run(ctx context.Context) (*actions.ActionResult, err
 		return nil, fmt.Errorf("loading project: %w", err)
 	}
 
-	infraManager, err := provisioning.NewManager(ctx, env, prj.Path, prj.Infra, !a.flags.global.NoPrompt)
+	infraManager, err := provisioning.NewManager(ctx, env, prj.Path, prj.Infra, a.console.IsUnformatted())
 	if err != nil {
 		return nil, fmt.Errorf("creating provisioning manager: %w", err)
 	}

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	// Importing for infrastructure provider plugin registrations
 	_ "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/bicep"
 	_ "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/terraform"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
@@ -122,7 +123,8 @@ For more information, visit the Azure Developer CLI Dev Hub: https://aka.ms/azur
 type designBuilder[F any] func(opts *internal.GlobalCommandOptions) (*cobra.Command, *F)
 
 type actionBuilder[F any] func(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags F,
 	args []string) (actions.Action, error)
@@ -140,14 +142,19 @@ func BuildCmd[F any](
 	cmd.Flags().BoolP("help", "h", false, fmt.Sprintf("Gets help for %s.", cmd.Name()))
 
 	runCmd := func(cmd *cobra.Command, ctx context.Context, args []string) error {
-		action, err := buildAction(cmd, opts, *flags, args)
+		console, err := initConsole(cmd, opts)
+		if err != nil {
+			return err
+		}
+
+		action, err := buildAction(console, ctx, opts, *flags, args)
 		if err != nil {
 			return err
 		}
 
 		// shim to register dependencies in context to maintain backwards compatibility
 		// to be removed long term
-		ctx, err = commands.RegisterDependenciesInCtx(ctx, cmd, opts)
+		ctx, err = commands.RegisterDependenciesInCtx(ctx, cmd, console, opts)
 		if err != nil {
 			return err
 		}
@@ -155,7 +162,7 @@ func BuildCmd[F any](
 		actionResult, err := action.Run(ctx)
 		// At this point, we know that there might be an error, so we can silence cobra from showing it after us.
 		cmd.SilenceErrors = true
-		actions.ShowActionResults(ctx, actionResult, err)
+		actions.ShowActionResults(ctx, console, actionResult, err)
 
 		return err
 	}

--- a/cli/azd/cmd/sets.go
+++ b/cli/azd/cmd/sets.go
@@ -26,35 +26,32 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newWriter(cmd *cobra.Command) io.Writer {
-	writer := cmd.OutOrStdout()
+func newWriterFromConsole(console input.Console) io.Writer {
+	return console.GetWriter()
+}
 
-	if os.Getenv("NO_COLOR") != "" {
-		writer = colorable.NewNonColorable(writer)
-	}
-
-	return writer
+func newFormatterFromConsole(console input.Console) output.Formatter {
+	return console.GetFormatter()
 }
 
 func newConsoleFromOptions(
 	rootOptions *internal.GlobalCommandOptions,
 	formatter output.Formatter,
-	writer io.Writer,
 	cmd *cobra.Command,
 ) input.Console {
-	// NOTE: There is a similar version of this code in pkg/commands/builder.go that exists while we transition
-	// from the old plan of passing everything via a context to the new plan of wiring everything up explicitly.
-	//
-	// If you make changes to this logic here, also take a look over there to make the same changes.
-
-	isTerminal := cmd.OutOrStdout() == os.Stdout &&
-		cmd.InOrStdin() == os.Stdin && isatty.IsTerminal(os.Stdin.Fd()) &&
-		isatty.IsTerminal(os.Stdout.Fd())
-
+	writer := cmd.OutOrStdout()
 	// When using JSON formatting, we want to ensure we always write messages from the console to stderr.
 	if formatter != nil && formatter.Kind() == output.JsonFormat {
 		writer = cmd.ErrOrStderr()
 	}
+
+	if os.Getenv("NO_COLOR") != "" {
+		writer = colorable.NewNonColorable(writer)
+	}
+
+	isTerminal := cmd.OutOrStdout() == os.Stdout &&
+		cmd.InOrStdin() == os.Stdin && isatty.IsTerminal(os.Stdin.Fd()) &&
+		isatty.IsTerminal(os.Stdout.Fd())
 
 	return input.NewConsole(rootOptions.NoPrompt, isTerminal, writer, input.ConsoleHandles{
 		Stdin:  cmd.InOrStdin(),
@@ -104,7 +101,6 @@ func newCredential() (azcore.TokenCredential, error) {
 
 var FormattedConsoleSet = wire.NewSet(
 	output.GetCommandFormatter,
-	newWriter,
 	newConsoleFromOptions,
 )
 
@@ -112,8 +108,9 @@ var CommonSet = wire.NewSet(
 	config.NewManager,
 	account.NewManager,
 	newAzdContext,
-	FormattedConsoleSet,
 	newCommandRunnerFromConsole,
+	newFormatterFromConsole,
+	newWriterFromConsole,
 )
 
 var AzCliSet = wire.NewSet(

--- a/cli/azd/cmd/wire.go
+++ b/cli/azd/cmd/wire.go
@@ -6,16 +6,26 @@ package cmd
 // Run `go generate ./cmd` or `wire ./cmd` after modifying this file to regenerate `wire_gen.go`.
 
 import (
+	"context"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/google/wire"
 	"github.com/spf13/cobra"
 )
 
+func initConsole(
+	cmd *cobra.Command,
+	o *internal.GlobalCommandOptions,
+) (input.Console, error) {
+	panic(wire.Build(FormattedConsoleSet))
+}
+
 //#region Root
 
 func initDeployAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags deployFlags,
 	args []string,
@@ -24,7 +34,8 @@ func initDeployAction(
 }
 
 func initInitAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags initFlags,
 	args []string,
@@ -33,7 +44,8 @@ func initInitAction(
 }
 
 func initLoginAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags loginFlags,
 	args []string,
@@ -42,7 +54,8 @@ func initLoginAction(
 }
 
 func initUpAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags upFlags,
 	args []string,
@@ -51,7 +64,8 @@ func initUpAction(
 }
 
 func initMonitorAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags monitorFlags,
 	args []string,
@@ -60,7 +74,8 @@ func initMonitorAction(
 }
 
 func initRestoreAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags restoreFlags,
 	args []string,
@@ -69,7 +84,8 @@ func initRestoreAction(
 }
 
 func initShowAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags showFlags,
 	args []string,
@@ -78,7 +94,8 @@ func initShowAction(
 }
 
 func initVersionAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags versionFlags,
 	args []string,
@@ -91,7 +108,8 @@ func initVersionAction(
 //#region Infra
 
 func initInfraCreateAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags infraCreateFlags,
 	args []string,
@@ -100,7 +118,8 @@ func initInfraCreateAction(
 }
 
 func initInfraDeleteAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags infraDeleteFlags,
 	args []string,
@@ -113,7 +132,8 @@ func initInfraDeleteAction(
 //#region Env
 
 func initEnvSetAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags struct{},
 	args []string,
@@ -122,7 +142,8 @@ func initEnvSetAction(
 }
 
 func initEnvSelectAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags struct{},
 	args []string,
@@ -131,7 +152,8 @@ func initEnvSelectAction(
 }
 
 func initEnvListAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags struct{},
 	args []string,
@@ -140,7 +162,8 @@ func initEnvListAction(
 }
 
 func initEnvNewAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags envNewFlags,
 	args []string,
@@ -149,7 +172,8 @@ func initEnvNewAction(
 }
 
 func initEnvRefreshAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags struct{},
 	args []string,
@@ -158,7 +182,8 @@ func initEnvRefreshAction(
 }
 
 func initEnvGetValuesAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags struct{},
 	args []string,
@@ -171,7 +196,8 @@ func initEnvGetValuesAction(
 //#region Pipeline
 
 func initPipelineConfigAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags pipelineConfigFlags,
 	args []string,
@@ -184,7 +210,8 @@ func initPipelineConfigAction(
 //#region Templates
 
 func initTemplatesListAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags templatesListFlags,
 	args []string,
@@ -193,7 +220,8 @@ func initTemplatesListAction(
 }
 
 func initTemplatesShowAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags struct{},
 	args []string,
@@ -206,7 +234,8 @@ func initTemplatesShowAction(
 //#region Config
 
 func initConfigListAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags struct{},
 	args []string,
@@ -215,7 +244,8 @@ func initConfigListAction(
 }
 
 func initConfigGetAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags struct{},
 	args []string,
@@ -224,7 +254,8 @@ func initConfigGetAction(
 }
 
 func initConfigSetAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags struct{},
 	args []string,
@@ -233,7 +264,8 @@ func initConfigSetAction(
 }
 
 func initConfigUnsetAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags struct{},
 	args []string,
@@ -242,7 +274,8 @@ func initConfigUnsetAction(
 }
 
 func initConfigResetAction(
-	cmd *cobra.Command,
+	console input.Console,
+	ctx context.Context,
 	o *internal.GlobalCommandOptions,
 	flags struct{},
 	args []string,

--- a/cli/azd/cmd/wire_gen.go
+++ b/cli/azd/cmd/wire_gen.go
@@ -7,10 +7,12 @@
 package cmd
 
 import (
+	"context"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/templates"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/git"
@@ -24,17 +26,22 @@ import (
 
 // Injectors from wire.go:
 
-func initDeployAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags deployFlags, args []string) (actions.Action, error) {
-	azdContext, err := newAzdContext()
-	if err != nil {
-		return nil, err
-	}
+func initConsole(cmd *cobra.Command, o *internal.GlobalCommandOptions) (input.Console, error) {
 	formatter, err := output.GetCommandFormatter(cmd)
 	if err != nil {
 		return nil, err
 	}
-	writer := newWriter(cmd)
-	console := newConsoleFromOptions(o, formatter, writer, cmd)
+	console := newConsoleFromOptions(o, formatter, cmd)
+	return console, nil
+}
+
+func initDeployAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags deployFlags, args []string) (actions.Action, error) {
+	azdContext, err := newAzdContext()
+	if err != nil {
+		return nil, err
+	}
+	formatter := newFormatterFromConsole(console)
+	writer := newWriterFromConsole(console)
 	cmdDeployAction, err := newDeployAction(flags, azdContext, console, formatter, writer)
 	if err != nil {
 		return nil, err
@@ -42,18 +49,12 @@ func initDeployAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flag
 	return cmdDeployAction, nil
 }
 
-func initInitAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags initFlags, args []string) (actions.Action, error) {
+func initInitAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags initFlags, args []string) (actions.Action, error) {
 	azdContext, err := newAzdContext()
 	if err != nil {
 		return nil, err
 	}
 	manager := config.NewManager()
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
-	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
 	tokenCredential, err := newCredential()
 	if err != nil {
@@ -72,13 +73,9 @@ func initInitAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags 
 	return cmdInitAction, nil
 }
 
-func initLoginAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags loginFlags, args []string) (actions.Action, error) {
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
-	console := newConsoleFromOptions(o, formatter, writer, cmd)
+func initLoginAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags loginFlags, args []string) (actions.Action, error) {
+	formatter := newFormatterFromConsole(console)
+	writer := newWriterFromConsole(console)
 	commandRunner := newCommandRunnerFromConsole(console)
 	tokenCredential, err := newCredential()
 	if err != nil {
@@ -89,18 +86,12 @@ func initLoginAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags
 	return cmdLoginAction, nil
 }
 
-func initUpAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags upFlags, args []string) (actions.Action, error) {
+func initUpAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags upFlags, args []string) (actions.Action, error) {
 	azdContext, err := newAzdContext()
 	if err != nil {
 		return nil, err
 	}
 	manager := config.NewManager()
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
-	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
 	tokenCredential, err := newCredential()
 	if err != nil {
@@ -118,6 +109,8 @@ func initUpAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags up
 		return nil, err
 	}
 	cmdInfraCreateFlags := flags.infraCreateFlags
+	formatter := newFormatterFromConsole(console)
+	writer := newWriterFromConsole(console)
 	cmdInfraCreateAction := newInfraCreateAction(cmdInfraCreateFlags, azdContext, console, formatter, writer)
 	cmdDeployFlags := flags.deployFlags
 	cmdDeployAction, err := newDeployAction(cmdDeployFlags, azdContext, console, formatter, writer)
@@ -128,17 +121,11 @@ func initUpAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags up
 	return cmdUpAction, nil
 }
 
-func initMonitorAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags monitorFlags, args []string) (actions.Action, error) {
+func initMonitorAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags monitorFlags, args []string) (actions.Action, error) {
 	azdContext, err := newAzdContext()
 	if err != nil {
 		return nil, err
 	}
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
-	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
 	tokenCredential, err := newCredential()
 	if err != nil {
@@ -149,13 +136,7 @@ func initMonitorAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, fla
 	return cmdMonitorAction, nil
 }
 
-func initRestoreAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags restoreFlags, args []string) (actions.Action, error) {
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
-	console := newConsoleFromOptions(o, formatter, writer, cmd)
+func initRestoreAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags restoreFlags, args []string) (actions.Action, error) {
 	azdContext, err := newAzdContext()
 	if err != nil {
 		return nil, err
@@ -164,13 +145,9 @@ func initRestoreAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, fla
 	return cmdRestoreAction, nil
 }
 
-func initShowAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags showFlags, args []string) (actions.Action, error) {
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
-	console := newConsoleFromOptions(o, formatter, writer, cmd)
+func initShowAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags showFlags, args []string) (actions.Action, error) {
+	formatter := newFormatterFromConsole(console)
+	writer := newWriterFromConsole(console)
 	azdContext, err := newAzdContext()
 	if err != nil {
 		return nil, err
@@ -179,58 +156,38 @@ func initShowAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags 
 	return cmdShowAction, nil
 }
 
-func initVersionAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags versionFlags, args []string) (actions.Action, error) {
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
-	console := newConsoleFromOptions(o, formatter, writer, cmd)
+func initVersionAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags versionFlags, args []string) (actions.Action, error) {
+	formatter := newFormatterFromConsole(console)
+	writer := newWriterFromConsole(console)
 	cmdVersionAction := newVersionAction(flags, formatter, writer, console)
 	return cmdVersionAction, nil
 }
 
-func initInfraCreateAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags infraCreateFlags, args []string) (actions.Action, error) {
+func initInfraCreateAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags infraCreateFlags, args []string) (actions.Action, error) {
 	azdContext, err := newAzdContext()
 	if err != nil {
 		return nil, err
 	}
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
-	console := newConsoleFromOptions(o, formatter, writer, cmd)
+	formatter := newFormatterFromConsole(console)
+	writer := newWriterFromConsole(console)
 	cmdInfraCreateAction := newInfraCreateAction(flags, azdContext, console, formatter, writer)
 	return cmdInfraCreateAction, nil
 }
 
-func initInfraDeleteAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags infraDeleteFlags, args []string) (actions.Action, error) {
+func initInfraDeleteAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags infraDeleteFlags, args []string) (actions.Action, error) {
 	azdContext, err := newAzdContext()
 	if err != nil {
 		return nil, err
 	}
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
-	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	cmdInfraDeleteAction := newInfraDeleteAction(flags, azdContext, console)
 	return cmdInfraDeleteAction, nil
 }
 
-func initEnvSetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
+func initEnvSetAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
 	azdContext, err := newAzdContext()
 	if err != nil {
 		return nil, err
 	}
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
-	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
 	tokenCredential, err := newCredential()
 	if err != nil {
@@ -241,7 +198,7 @@ func initEnvSetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flag
 	return cmdEnvSetAction, nil
 }
 
-func initEnvSelectAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
+func initEnvSelectAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
 	azdContext, err := newAzdContext()
 	if err != nil {
 		return nil, err
@@ -250,31 +207,22 @@ func initEnvSelectAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, f
 	return cmdEnvSelectAction, nil
 }
 
-func initEnvListAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
+func initEnvListAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
 	azdContext, err := newAzdContext()
 	if err != nil {
 		return nil, err
 	}
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
+	formatter := newFormatterFromConsole(console)
+	writer := newWriterFromConsole(console)
 	cmdEnvListAction := newEnvListAction(azdContext, formatter, writer)
 	return cmdEnvListAction, nil
 }
 
-func initEnvNewAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags envNewFlags, args []string) (actions.Action, error) {
+func initEnvNewAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags envNewFlags, args []string) (actions.Action, error) {
 	azdContext, err := newAzdContext()
 	if err != nil {
 		return nil, err
 	}
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
-	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
 	tokenCredential, err := newCredential()
 	if err != nil {
@@ -285,38 +233,30 @@ func initEnvNewAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flag
 	return cmdEnvNewAction, nil
 }
 
-func initEnvRefreshAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
+func initEnvRefreshAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
 	azdContext, err := newAzdContext()
 	if err != nil {
 		return nil, err
 	}
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
-	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	commandRunner := newCommandRunnerFromConsole(console)
 	tokenCredential, err := newCredential()
 	if err != nil {
 		return nil, err
 	}
 	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
+	formatter := newFormatterFromConsole(console)
+	writer := newWriterFromConsole(console)
 	cmdEnvRefreshAction := newEnvRefreshAction(azdContext, azCli, o, console, formatter, writer)
 	return cmdEnvRefreshAction, nil
 }
 
-func initEnvGetValuesAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
+func initEnvGetValuesAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
 	azdContext, err := newAzdContext()
 	if err != nil {
 		return nil, err
 	}
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
-	console := newConsoleFromOptions(o, formatter, writer, cmd)
+	formatter := newFormatterFromConsole(console)
+	writer := newWriterFromConsole(console)
 	commandRunner := newCommandRunnerFromConsole(console)
 	tokenCredential, err := newCredential()
 	if err != nil {
@@ -327,78 +267,60 @@ func initEnvGetValuesAction(cmd *cobra.Command, o *internal.GlobalCommandOptions
 	return cmdEnvGetValuesAction, nil
 }
 
-func initPipelineConfigAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags pipelineConfigFlags, args []string) (actions.Action, error) {
+func initPipelineConfigAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags pipelineConfigFlags, args []string) (actions.Action, error) {
 	azdContext, err := newAzdContext()
 	if err != nil {
 		return nil, err
 	}
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
-	console := newConsoleFromOptions(o, formatter, writer, cmd)
 	cmdPipelineConfigAction := newPipelineConfigAction(azdContext, console, flags)
 	return cmdPipelineConfigAction, nil
 }
 
-func initTemplatesListAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags templatesListFlags, args []string) (actions.Action, error) {
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
+func initTemplatesListAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags templatesListFlags, args []string) (actions.Action, error) {
+	formatter := newFormatterFromConsole(console)
+	writer := newWriterFromConsole(console)
 	templateManager := templates.NewTemplateManager()
 	cmdTemplatesListAction := newTemplatesListAction(flags, formatter, writer, templateManager)
 	return cmdTemplatesListAction, nil
 }
 
-func initTemplatesShowAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
+func initTemplatesShowAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
+	formatter := newFormatterFromConsole(console)
+	writer := newWriterFromConsole(console)
 	templateManager := templates.NewTemplateManager()
 	cmdTemplatesShowAction := newTemplatesShowAction(formatter, writer, templateManager, args)
 	return cmdTemplatesShowAction, nil
 }
 
-func initConfigListAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
+func initConfigListAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
 	manager := config.NewManager()
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
+	formatter := newFormatterFromConsole(console)
+	writer := newWriterFromConsole(console)
 	cmdConfigListAction := newConfigListAction(manager, formatter, writer)
 	return cmdConfigListAction, nil
 }
 
-func initConfigGetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
+func initConfigGetAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
 	manager := config.NewManager()
-	formatter, err := output.GetCommandFormatter(cmd)
-	if err != nil {
-		return nil, err
-	}
-	writer := newWriter(cmd)
+	formatter := newFormatterFromConsole(console)
+	writer := newWriterFromConsole(console)
 	cmdConfigGetAction := newConfigGetAction(manager, formatter, writer, args)
 	return cmdConfigGetAction, nil
 }
 
-func initConfigSetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
+func initConfigSetAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
 	manager := config.NewManager()
 	cmdConfigSetAction := newConfigSetAction(manager, args)
 	return cmdConfigSetAction, nil
 }
 
-func initConfigUnsetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
+func initConfigUnsetAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
 	manager := config.NewManager()
 	cmdConfigUnsetAction := newConfigUnsetAction(manager, args)
 	return cmdConfigUnsetAction, nil
 }
 
-func initConfigResetAction(cmd *cobra.Command, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
+func initConfigResetAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
 	manager := config.NewManager()
 	cmdConfigResetAction := newConfigResetAction(manager, args)
 	return cmdConfigResetAction, nil

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -24,7 +24,6 @@ type Manager struct {
 	azCli       azcli.AzCli
 	env         *environment.Environment
 	provider    Provider
-	formatter   output.Formatter
 	writer      io.Writer
 	console     input.Console
 	interactive bool
@@ -283,7 +282,7 @@ func (m *Manager) runAction(
 ) error {
 	var spinner *spin.Spinner
 
-	if interactive && (m.formatter == nil || m.formatter.Kind() != output.JsonFormat) {
+	if interactive {
 		spinner, ctx = spin.GetOrCreateSpinner(ctx, m.console.Handles().Stdout, title)
 		defer spinner.Stop()
 		defer m.console.SetWriter(nil)
@@ -339,16 +338,12 @@ func NewManager(
 
 	azCli := azcli.GetAzCli(ctx)
 	console := input.GetConsole(ctx)
-	formatter := output.GetFormatter(ctx)
-	writer := output.GetWriter(ctx)
-	interactive = interactive && formatter.Kind() == output.NoneFormat
 
 	return &Manager{
 		azCli:       azCli,
 		env:         env,
 		provider:    infraProvider,
-		formatter:   formatter,
-		writer:      writer,
+		writer:      console.GetWriter(),
 		console:     console,
 		interactive: interactive,
 	}, nil

--- a/cli/azd/pkg/output/formatter.go
+++ b/cli/azd/pkg/output/formatter.go
@@ -4,7 +4,6 @@
 package output
 
 import (
-	"context"
 	"fmt"
 	"io"
 )
@@ -36,43 +35,4 @@ func NewFormatter(format string) (Formatter, error) {
 	default:
 		return nil, fmt.Errorf("unsupported format %v", format)
 	}
-}
-
-type contextKey string
-
-const (
-	formatterContextKey contextKey = "formatter"
-	writerContextKey    contextKey = "writer"
-)
-
-// Sets the output formatter that will be used to format data back to std out
-func WithFormatter(ctx context.Context, formatter Formatter) context.Context {
-	return context.WithValue(ctx, formatterContextKey, formatter)
-}
-
-// Gets the formatter that had been previously specified.
-// If not found will default to `None` formatter.
-func GetFormatter(ctx context.Context) Formatter {
-	formatter, ok := ctx.Value(formatterContextKey).(Formatter)
-	if !ok {
-		return &NoneFormatter{}
-	}
-
-	return formatter
-}
-
-// Sets the io.Writer implementation used for printing to std out
-func WithWriter(ctx context.Context, writer io.Writer) context.Context {
-	return context.WithValue(ctx, writerContextKey, writer)
-}
-
-// Gets the io.Writer implementation previously specified or panics
-// if one can not be found
-func GetWriter(ctx context.Context) io.Writer {
-	writer, ok := ctx.Value(writerContextKey).(io.Writer)
-	if !ok {
-		panic("no writer")
-	}
-
-	return writer
 }

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
@@ -97,13 +96,12 @@ func (at *containerAppTarget) Deploy(
 		return ServiceDeploymentResult{}, fmt.Errorf("saving image name to environment: %w", err)
 	}
 
-	commandOptions := internal.GetCommandOptions(ctx)
 	infraManager, err := provisioning.NewManager(
 		ctx,
 		at.env,
 		at.config.Project.Path,
 		at.config.Infra,
-		!commandOptions.NoPrompt,
+		at.console.IsUnformatted(),
 	)
 	if err != nil {
 		return ServiceDeploymentResult{}, fmt.Errorf("creating provisioning manager: %w", err)

--- a/cli/azd/test/mocks/console/mock_console.go
+++ b/cli/azd/test/mocks/console/mock_console.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
 // A predicate function definition for registering expressions
@@ -22,6 +23,18 @@ func NewMockConsole() *MockConsole {
 	return &MockConsole{
 		expressions: []*MockConsoleExpression{},
 	}
+}
+
+func (c *MockConsole) IsUnformatted() bool {
+	return true
+}
+
+func (c *MockConsole) GetFormatter() output.Formatter {
+	return nil
+}
+
+func (c *MockConsole) GetWriter() io.Writer {
+	return nil
 }
 
 func (c *MockConsole) SetWriter(writer io.Writer) {

--- a/cli/azd/test/mocks/mock_context.go
+++ b/cli/azd/test/mocks/mock_context.go
@@ -2,7 +2,6 @@ package mocks
 
 import (
 	"context"
-	"os"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
@@ -10,7 +9,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/azure/azure-dev/cli/azd/pkg/identity"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
-	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	mockconfig "github.com/azure/azure-dev/cli/azd/test/mocks/config"
 	mockconsole "github.com/azure/azure-dev/cli/azd/test/mocks/console"
 	mockexec "github.com/azure/azure-dev/cli/azd/test/mocks/exec"
@@ -40,7 +38,6 @@ func NewMockContext(ctx context.Context) *MockContext {
 	ctx = exec.WithCommandRunner(ctx, commandRunner)
 	ctx = httputil.WithHttpClient(ctx, httpClient)
 	ctx = identity.WithCredentials(ctx, &credentials)
-	ctx = output.WithWriter(ctx, os.Stdout)
 	ctx = config.WithConfigManager(ctx, configManager)
 
 	mockContext := &MockContext{


### PR DESCRIPTION
With the introduction of spinner in #965, we want to avoid creating multiple instances of console since the spinner state is now on console.

To fix this, first notice that `console` shouldn't be constructed within the `action` itself, as we also want to format and print additional output in `root.go` when we're formatting the output result.

Thus, the right change is to move `console` to be constructed outside of the `action`. We then pass this to be registered in `ctx` for existing code that depends on `ctx`. This will again be removed when we start removing all `ctx` dependencies.

What we gained:
- No more `formatter` and `writer` in `ctx`
- Single `console` instance. No duplication of logic.
- The `actionBuilder` is more inline with long-term thinking -- action doesn't depend on `cobra.Command`, it depends on stdin/stdout/stderr (which is abstracted by `console`)

What we lost:
- `console` leaking internals. A temporary shim had to be introduced in `console` to expose `formatter` and `writer` until we reconsolidate

Intentional changes were made outside of refactoring:
- Print provisioning messages when `--no-prompt` is specified. (Missed change from #905)
- Reorder writer construction for console so that `NO_COLOR` applies to json output