### PR TITLE
Extensibility Spike: Add support for middleware

### DIFF
--- a/cli/azd/cmd/actions/action.go
+++ b/cli/azd/cmd/actions/action.go
@@ -32,6 +32,11 @@ type Action interface {
 	Run(ctx context.Context) (*ActionResult, error)
 }
 
+type ActionOptions struct {
+	Name             string
+	DisableTelemetry bool
+}
+
 func ShowActionResults(ctx context.Context, console input.Console, actionResult *ActionResult, err error) {
 	if err != nil {
 		console.MessageUx(ctx, err.Error(), input.ResultError)

--- a/cli/azd/cmd/actions/middleware.go
+++ b/cli/azd/cmd/actions/middleware.go
@@ -1,0 +1,46 @@
+package actions
+
+import (
+	"context"
+)
+
+var middlewares []MiddlewareFn = []MiddlewareFn{}
+
+// Executes the next middleware in the command chain
+type NextFn func(ctx context.Context) (*ActionResult, error)
+
+// An action middleware function to execute
+type MiddlewareFn func(ctx context.Context, buildOptions *ActionOptions, next NextFn) (*ActionResult, error)
+
+// Executes the middleware chain for the specified action
+func RunWithMiddleware(ctx context.Context, buildOptions *ActionOptions, action Action, chain []MiddlewareFn) (*ActionResult, error) {
+	chainLength := len(chain)
+	index := 0
+
+	var nextFn NextFn
+
+	nextFn = func(nextContext context.Context) (*ActionResult, error) {
+		if index < chainLength {
+			middlewareFn := chain[index]
+			index++
+			return middlewareFn(nextContext, buildOptions, nextFn)
+		} else {
+			return action.Run(ctx)
+		}
+	}
+
+	result, err := nextFn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func Use(middleware MiddlewareFn) {
+	middlewares = append(middlewares, middleware)
+}
+
+func GetMiddleware() []MiddlewareFn {
+	return middlewares
+}

--- a/cli/azd/cmd/middleware/debug.go
+++ b/cli/azd/cmd/middleware/debug.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/azure/azure-dev/cli/azd/cmd/actions"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+)
+
+func UseDebug() actions.MiddlewareFn {
+	return func(ctx context.Context, options *actions.ActionOptions, next actions.NextFn) (*actions.ActionResult, error) {
+		console := input.GetConsole(ctx)
+		console.Confirm(ctx, input.ConsoleOptions{
+			Message:      "Debugger Ready?",
+			DefaultValue: true,
+		})
+
+		return next(ctx)
+	}
+}

--- a/cli/azd/cmd/middleware/telemetry.go
+++ b/cli/azd/cmd/middleware/telemetry.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/azure/azure-dev/cli/azd/cmd/actions"
+	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
+	"github.com/azure/azure-dev/cli/azd/internal/telemetry/events"
+	"go.opentelemetry.io/otel/codes"
+)
+
+func UseTelemetry() actions.MiddlewareFn {
+	return func(ctx context.Context, options *actions.ActionOptions, next actions.NextFn) (*actions.ActionResult, error) {
+		if options != nil && options.DisableTelemetry {
+			return next(ctx)
+		}
+
+		// Note: CommandPath is constructed using the Use member on each command up to the root.
+		// It does not contain user input, and is safe for telemetry emission.
+		spanCtx, span := telemetry.GetTracer().Start(ctx, events.GetCommandEventName(options.Name))
+		defer span.End()
+
+		result, err := next(spanCtx)
+		if err != nil {
+			span.SetStatus(codes.Error, "UnknownError")
+		}
+
+		return result, err
+	}
+}

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -9,6 +9,8 @@ import (
 	"os"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
+	"github.com/azure/azure-dev/cli/azd/cmd/middleware"
+
 	// Importing for infrastructure provider plugin registrations
 	_ "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/bicep"
 	_ "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/terraform"
@@ -16,12 +18,10 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
-	"github.com/azure/azure-dev/cli/azd/internal/telemetry/events"
 	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/spf13/cobra"
-	"go.opentelemetry.io/otel/codes"
 )
 
 func NewRootCmd() *cobra.Command {
@@ -106,7 +106,7 @@ For more information, visit the Azure Developer CLI Dev Hub: https://aka.ms/azur
 	cmd.AddCommand(telemetryCmd(opts))
 	cmd.AddCommand(templatesCmd(opts))
 
-	cmd.AddCommand(BuildCmd(opts, versionCmdDesign, initVersionAction, &buildOptions{disableTelemetry: true}))
+	cmd.AddCommand(BuildCmd(opts, versionCmdDesign, initVersionAction, &actions.ActionOptions{DisableTelemetry: true}))
 	cmd.AddCommand(BuildCmd(opts, showCmdDesign, initShowAction, nil))
 	cmd.AddCommand(BuildCmd(opts, restoreCmdDesign, initRestoreAction, nil))
 	cmd.AddCommand(BuildCmd(opts, loginCmdDesign, initLoginAction, nil))
@@ -116,6 +116,9 @@ For more information, visit the Azure Developer CLI Dev Hub: https://aka.ms/azur
 	cmd.AddCommand(BuildCmd(opts, upCmdDesign, initUpAction, nil))
 	cmd.AddCommand(BuildCmd(opts, provisionCmdDesign, initInfraCreateAction, nil))
 	cmd.AddCommand(BuildCmd(opts, deployCmdDesign, initDeployAction, nil))
+
+	actions.Use(middleware.UseDebug())
+	actions.Use(middleware.UseTelemetry())
 
 	return cmd
 }
@@ -129,19 +132,23 @@ type actionBuilder[F any] func(
 	flags F,
 	args []string) (actions.Action, error)
 
-type buildOptions struct {
-	disableTelemetry bool
-}
-
 func BuildCmd[F any](
 	opts *internal.GlobalCommandOptions,
 	buildDesign designBuilder[F],
 	buildAction actionBuilder[F],
-	buildOptions *buildOptions) *cobra.Command {
+	actionOptions *actions.ActionOptions) *cobra.Command {
 	cmd, flags := buildDesign(opts)
 	cmd.Flags().BoolP("help", "h", false, fmt.Sprintf("Gets help for %s.", cmd.Name()))
 
-	runCmd := func(cmd *cobra.Command, ctx context.Context, args []string) error {
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		if actionOptions == nil {
+			actionOptions = &actions.ActionOptions{}
+		}
+
+		actionOptions.Name = cmd.CommandPath()
+
 		console, err := initConsole(cmd, opts)
 		if err != nil {
 			return err
@@ -159,7 +166,8 @@ func BuildCmd[F any](
 			return err
 		}
 
-		actionResult, err := action.Run(ctx)
+		middlewareChain := actions.GetMiddleware()
+		actionResult, err := actions.RunWithMiddleware(ctx, actionOptions, action, middlewareChain)
 		// At this point, we know that there might be an error, so we can silence cobra from showing it after us.
 		cmd.SilenceErrors = true
 		actions.ShowActionResults(ctx, console, actionResult, err)
@@ -167,30 +175,5 @@ func BuildCmd[F any](
 		return err
 	}
 
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if buildOptions != nil && buildOptions.disableTelemetry {
-			return runCmd(cmd, cmd.Context(), args)
-		} else {
-			// Bind cmd, args. Only a different context needs to be passed.
-			runWithContext := func(ctx context.Context) error { return runCmd(cmd, ctx, args) }
-			return runCmdWithTelemetry(cmd, runWithContext)
-		}
-	}
-
 	return cmd
-}
-
-func runCmdWithTelemetry(cmd *cobra.Command, runCmd func(ctx context.Context) error) error {
-	// Note: CommandPath is constructed using the Use member on each command up to the root.
-	// It does not contain user input, and is safe for telemetry emission.
-	spanCtx, span := telemetry.GetTracer().Start(cmd.Context(), events.GetCommandEventName(cmd.CommandPath()))
-	defer span.End()
-
-	err := runCmd(spanCtx)
-	if err != nil {
-		span.SetStatus(codes.Error, "UnknownError")
-	}
-
-	return err
-
 }


### PR DESCRIPTION
As we explore the path of extensibility introducing the concept of middleware within our commands will enable a more loose coupling of components and be a start to our extensibility journey.

For example - In order to add extensible script support for running custom scripts before/after commands within our pipeline we could simply introduce this as middleware component where we can pull registered scripts from azure.yml and execute them at the correct stage of any command in azd.

In this PR
- [x] Introduces concept of `MiddlwareFn` that can be registered for actions
- [x] Introduces a "debug" middleware that we can use for internal dev that allows an easy prompt to allow time to attach a debugger to the running azd process
- [x] Refactors telemetry tracing for all commands into a middleware component instead of directly coupling at the command/action layer.