### PR TITLE
Update cwd in tasks.json to be workspace-based

### DIFF
--- a/templates/todo/projects/python-mongo-swa-func/.vscode/tasks.json
+++ b/templates/todo/projects/python-mongo-swa-func/.vscode/tasks.json
@@ -53,7 +53,7 @@
 			"isBackground": true,
 			"dependsOn": "Restore API",
             "options": {
-                "cwd": "./src/api"
+                "cwd": "${workspaceFolder}/src/api"
             }
 		},
         {


### PR DESCRIPTION
I got an error about directory not found when I tried to run "Start Functions" from Github Codespaces on the Python Mongo function sample. I changed the "cwd" to use "${workspaceFolder}" and that seemed to work well. I'm not an expert in VS Code JSON config yet, so do let me know if there's some good reason not to reference `workspaceFolder` here.
