### PR TITLE
Mark more commands as not requiring login

### DIFF
--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
@@ -111,6 +112,9 @@ func envSelectCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, 
 	cmd := &cobra.Command{
 		Use:   "select <environment>",
 		Short: "Set the default environment.",
+		Annotations: map[string]string{
+			commands.RequireNoLoginAnnotation: "true",
+		},
 	}
 	cmd.Args = cobra.ExactArgs(1)
 	return cmd, &struct{}{}
@@ -145,6 +149,9 @@ func envListCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Command, *s
 		Use:     "list",
 		Short:   "List environments",
 		Aliases: []string{"ls"},
+		Annotations: map[string]string{
+			commands.RequireNoLoginAnnotation: "true",
+		},
 	}
 	output.AddOutputParam(
 		cmd,

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/commands/pipeline"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -69,6 +70,9 @@ func pipelineConfigCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Comm
 		Long: `Create and configure your deployment pipeline by using GitHub Actions.
 
 For more information, go to https://aka.ms/azure-dev/pipeline.`,
+		Annotations: map[string]string{
+			commands.RequireNoLoginAnnotation: "true",
+		},
 	}
 
 	flags := &pipelineConfigFlags{}

--- a/cli/azd/cmd/telemetry.go
+++ b/cli/azd/cmd/telemetry.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
+	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/spf13/cobra"
 )
 
@@ -37,6 +38,9 @@ func uploadCmd(rootOptions *internal.GlobalCommandOptions) *cobra.Command {
 			}
 
 			return telemetrySystem.RunBackgroundUpload(cmd.Context(), rootOptions.EnableDebugLogging)
+		},
+		Annotations: map[string]string{
+			commands.RequireNoLoginAnnotation: "true",
 		},
 	}
 	return cmd

--- a/cli/azd/pkg/config/manager.go
+++ b/cli/azd/pkg/config/manager.go
@@ -95,14 +95,17 @@ func Parse(configJson []byte) (Config, error) {
 //
 // The config directory is guaranteed to exist, otherwise an error is returned.
 func GetUserConfigDir() (string, error) {
-	user, err := user.Current()
-	if err != nil {
-		return "", fmt.Errorf("could not determine current user: %w", err)
+	configDirPath := os.Getenv("AZD_CONFIG_DIR")
+	if configDirPath == "" {
+		user, err := user.Current()
+		if err != nil {
+			return "", fmt.Errorf("could not determine current user: %w", err)
+		}
+
+		configDirPath = filepath.Join(user.HomeDir, configDir)
 	}
 
-	configDirPath := filepath.Join(user.HomeDir, configDir)
-	err = os.MkdirAll(configDirPath, osutil.PermissionDirectory)
-
+	err := os.MkdirAll(configDirPath, osutil.PermissionDirectory)
 	return configDirPath, err
 }
 


### PR DESCRIPTION
As fallout of #1022 we ended up requiring authentication for some commands that did not need it. This change ads annotations to these commands such that they do not require authentication.

We should be able to remove these annotations and have everything be correct by construction when we stop putting a credential and azcli on the context but instead just inject these into the commands that need them (and only the commands that need them).

Fixes #1135