### PR TITLE
Add `xdg-open` to our Dev Containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,6 @@
 ARG VARIANT=bullseye
 FROM mcr.microsoft.com/devcontainers/go
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+     apt-get update && apt-get install -y xdg-utils \
+     && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -46,6 +46,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
           https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
           tee /etc/apt/sources.list.d/hashicorp.list \
      && apt update && apt-get install terraform \
+     # xdg-open
+     && apt update && apt-get install -y xdg-utils \
      # Cleanup
      && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 

--- a/templates/common/.devcontainer/Dockerfile/base/Dockerfile
+++ b/templates/common/.devcontainer/Dockerfile/base/Dockerfile
@@ -1,4 +1,6 @@
 ARG VARIANT=bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
-RUN curl -fsSL https://aka.ms/install-azd.sh | bash \
-    && apt-get update && rm -rf /var/lib/apt/lists/*
+RUN export DEBIAN_FRONTEND=noninteractive \
+     apt-get update && apt-get install -y xdg-utils \
+     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://aka.ms/install-azd.sh | bash

--- a/templates/common/.devcontainer/Dockerfile/func/Dockerfile
+++ b/templates/common/.devcontainer/Dockerfile/func/Dockerfile
@@ -1,7 +1,9 @@
 ARG VARIANT=bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
-RUN curl -fsSL https://aka.ms/install-azd.sh | bash \
-    && curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
     && mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg \
     && sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/debian/$(lsb_release -rs | cut -d'.' -f 1)/prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list' \
-    && apt-get update && apt-get install -y azure-functions-core-tools-4 && rm -rf /var/lib/apt/lists/*
+    && apt-get update && apt-get install -y xdg-utils \
+    && apt-get update && apt-get install -y azure-functions-core-tools-4 \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://aka.ms/install-azd.sh | bash


### PR DESCRIPTION
`azd login` uses this to launch a browser when running on Linux. Ensure it is installed in our containers.