### PR TITLE
Make `azdcli` in functional tests return explicit result

### DIFF
--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -249,7 +249,7 @@ func Test_CLI_InfraCreateAndDeleteWebApp(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Running show\n")
-	out, err := cli.RunCommand(ctx, "show", "-o", "json", "--cwd", dir)
+	result, err := cli.RunCommand(ctx, "show", "-o", "json", "--cwd", dir)
 	require.NoError(t, err)
 
 	var showRes struct {
@@ -263,7 +263,7 @@ func Test_CLI_InfraCreateAndDeleteWebApp(t *testing.T) {
 			} `json:"target"`
 		} `json:"services"`
 	}
-	err = json.Unmarshal([]byte(out), &showRes)
+	err = json.Unmarshal([]byte(result.Stdout), &showRes)
 	require.NoError(t, err)
 
 	service, has := showRes.Services["web"]
@@ -335,10 +335,10 @@ func Test_CLI_InfraCreateAndDeleteWebApp(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Running show (again)\n")
-	out, err = cli.RunCommand(ctx, "show", "-o", "json", "--cwd", dir)
+	result, err = cli.RunCommand(ctx, "show", "-o", "json", "--cwd", dir)
 	require.NoError(t, err)
 
-	err = json.Unmarshal([]byte(out), &showRes)
+	err = json.Unmarshal([]byte(result.Stdout), &showRes)
 	require.NoError(t, err)
 
 	// Project information should be present, but since we have run infra delete, there shouldn't
@@ -437,13 +437,13 @@ func Test_CLI_InfraCreateAndDeleteFuncApp(t *testing.T) {
 	_, err = cli.RunCommand(ctx, "deploy", "--cwd", dir)
 	require.NoError(t, err)
 
-	out, err := cli.RunCommand(ctx, "env", "get-values", "-o", "json", "--cwd", dir)
+	result, err := cli.RunCommand(ctx, "env", "get-values", "-o", "json", "--cwd", dir)
 	require.NoError(t, err)
 
-	t.Logf("env get-values command output: %s\n", out)
+	t.Logf("env get-values command output: %s\n", result.Stdout)
 
 	var envValues map[string]interface{}
-	err = json.Unmarshal([]byte(out), &envValues)
+	err = json.Unmarshal([]byte(result.Stdout), &envValues)
 	require.NoError(t, err)
 
 	url := fmt.Sprintf("%s/api/httptrigger", envValues["AZURE_FUNCTION_URI"])

--- a/cli/azd/test/functional/env_test.go
+++ b/cli/azd/test/functional/env_test.go
@@ -116,11 +116,11 @@ func envNew(ctx context.Context, t *testing.T, cli *azdcli.CLI, envName string, 
 }
 
 func envList(ctx context.Context, t *testing.T, cli *azdcli.CLI) []contracts.EnvListEnvironment {
-	jsonOutput, err := cli.RunCommand(ctx, "env", "list", "--output", "json")
+	result, err := cli.RunCommand(ctx, "env", "list", "--output", "json")
 	require.NoError(t, err)
 
 	env := []contracts.EnvListEnvironment{}
-	err = json.Unmarshal([]byte(jsonOutput), &env)
+	err = json.Unmarshal([]byte(result.Stdout), &env)
 	require.NoError(t, err)
 
 	return env
@@ -137,11 +137,11 @@ func envSetValue(ctx context.Context, t *testing.T, cli *azdcli.CLI, key string,
 }
 
 func envGetValues(ctx context.Context, t *testing.T, cli *azdcli.CLI) map[string]string {
-	jsonOutput, err := cli.RunCommand(ctx, "env", "get-values", "--output", "json")
+	result, err := cli.RunCommand(ctx, "env", "get-values", "--output", "json")
 	require.NoError(t, err)
 
 	var envValues map[string]string
-	err = json.Unmarshal([]byte(jsonOutput), &envValues)
+	err = json.Unmarshal([]byte(result.Stdout), &envValues)
 	require.NoError(t, err)
 
 	return envValues

--- a/cli/azd/test/functional/version_test.go
+++ b/cli/azd/test/functional/version_test.go
@@ -48,11 +48,11 @@ func Test_CLI_Version_Json(t *testing.T) {
 	defer cancel()
 
 	cli := azdcli.NewCLI(t)
-	jsonOutput, err := cli.RunCommand(ctx, "version", "--output", "json")
+	result, err := cli.RunCommand(ctx, "version", "--output", "json")
 	require.NoError(t, err)
 
 	versionJson := &internal.VersionSpec{}
-	err = json.Unmarshal([]byte(jsonOutput), versionJson)
+	err = json.Unmarshal([]byte(result.Stdout), versionJson)
 	require.NoError(t, err)
 
 	_, err = semver.Parse(versionJson.Azd.Version)


### PR DESCRIPTION
As we start adding additional tests that verify the functional output of `azd`, it becomes more important to distinguish between `stdout` and `stderr` output.

This change refactors the `azdcli` used in end-to-end functional tests to result `stdout` and `stderr` output separately, in preparation for future testing.