### PR TITLE
Mark `pipeline config` as requiring login

### DIFF
--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
-	"github.com/azure/azure-dev/cli/azd/pkg/commands"
 	"github.com/azure/azure-dev/cli/azd/pkg/commands/pipeline"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -70,9 +70,6 @@ func pipelineConfigCmdDesign(global *internal.GlobalCommandOptions) (*cobra.Comm
 		Long: `Create and configure your deployment pipeline by using GitHub Actions.
 
 For more information, go to https://aka.ms/azure-dev/pipeline.`,
-		Annotations: map[string]string{
-			commands.RequireNoLoginAnnotation: "true",
-		},
 	}
 
 	flags := &pipelineConfigFlags{}
@@ -87,18 +84,21 @@ type pipelineConfigAction struct {
 	manager *pipeline.PipelineManager
 	azdCtx  *azdcontext.AzdContext
 	console input.Console
+	azCli   azcli.AzCli
 }
 
 func newPipelineConfigAction(
 	azdCtx *azdcontext.AzdContext,
 	console input.Console,
 	flags pipelineConfigFlags,
+	azCli azcli.AzCli,
 ) *pipelineConfigAction {
 	pca := &pipelineConfigAction{
 		flags:   flags,
 		manager: pipeline.NewPipelineManager(azdCtx, flags.global, flags.PipelineManagerArgs),
 		azdCtx:  azdCtx,
 		console: console,
+		azCli:   azCli,
 	}
 
 	return pca

--- a/cli/azd/cmd/wire_gen.go
+++ b/cli/azd/cmd/wire_gen.go
@@ -319,7 +319,18 @@ func initPipelineConfigAction(console input.Console, ctx context.Context, o *int
 	if err != nil {
 		return nil, err
 	}
-	cmdPipelineConfigAction := newPipelineConfigAction(azdContext, console, flags)
+	commandRunner := newCommandRunnerFromConsole(console)
+	userConfigManager := config.NewUserConfigManager()
+	manager, err := auth.NewManager(userConfigManager)
+	if err != nil {
+		return nil, err
+	}
+	tokenCredential, err := newCredential(ctx, manager)
+	if err != nil {
+		return nil, err
+	}
+	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
+	cmdPipelineConfigAction := newPipelineConfigAction(azdContext, console, flags, azCli)
 	return cmdPipelineConfigAction, nil
 }
 


### PR DESCRIPTION
This command requries that you are logged into Azure to work, but in

I removed the incorrect annotation, and I also added a `azcli.AzCli` parameter to the type that represents the action itself and used wire to ensure it is injected. This is work we'd do any way as part of remvoing `commands.RequireNoLoginAnnotation` (see #1145) so might as well lock it is now.

Fixes #1147