### PR TITLE
Write final JSON output from `azd` to `stdout`

### DIFF
--- a/cli/azd/cmd/sets.go
+++ b/cli/azd/cmd/sets.go
@@ -27,8 +27,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newWriterFromConsole(console input.Console) io.Writer {
-	return console.GetWriter()
+func newOutputWriter(console input.Console) io.Writer {
+	writer := console.Handles().Stdout
+
+	if os.Getenv("NO_COLOR") != "" {
+		writer = colorable.NewNonColorable(writer)
+	}
+
+	return writer
 }
 
 func newFormatterFromConsole(console input.Console) output.Formatter {
@@ -116,7 +122,7 @@ var CommonSet = wire.NewSet(
 	newAzdContext,
 	newCommandRunnerFromConsole,
 	newFormatterFromConsole,
-	newWriterFromConsole,
+	newOutputWriter,
 )
 
 var AzCliSet = wire.NewSet(

--- a/cli/azd/cmd/wire_gen.go
+++ b/cli/azd/cmd/wire_gen.go
@@ -42,7 +42,7 @@ func initDeployAction(console input.Console, ctx context.Context, o *internal.Gl
 		return nil, err
 	}
 	formatter := newFormatterFromConsole(console)
-	writer := newWriterFromConsole(console)
+	writer := newOutputWriter(console)
 	cmdDeployAction, err := newDeployAction(flags, azdContext, console, formatter, writer)
 	if err != nil {
 		return nil, err
@@ -81,7 +81,7 @@ func initInitAction(console input.Console, ctx context.Context, o *internal.Glob
 
 func initLoginAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags loginFlags, args []string) (actions.Action, error) {
 	formatter := newFormatterFromConsole(console)
-	writer := newWriterFromConsole(console)
+	writer := newOutputWriter(console)
 	userConfigManager := config.NewUserConfigManager()
 	manager, err := auth.NewManager(userConfigManager)
 	if err != nil {
@@ -98,7 +98,7 @@ func initLogoutAction(console input.Console, ctx context.Context, o *internal.Gl
 		return nil, err
 	}
 	formatter := newFormatterFromConsole(console)
-	writer := newWriterFromConsole(console)
+	writer := newOutputWriter(console)
 	cmdLogoutAction := newLogoutAction(manager, formatter, writer)
 	return cmdLogoutAction, nil
 }
@@ -132,7 +132,7 @@ func initUpAction(console input.Console, ctx context.Context, o *internal.Global
 	}
 	cmdInfraCreateFlags := flags.infraCreateFlags
 	formatter := newFormatterFromConsole(console)
-	writer := newWriterFromConsole(console)
+	writer := newOutputWriter(console)
 	cmdInfraCreateAction := newInfraCreateAction(cmdInfraCreateFlags, azdContext, console, formatter, writer)
 	cmdDeployFlags := flags.deployFlags
 	cmdDeployAction, err := newDeployAction(cmdDeployFlags, azdContext, console, formatter, writer)
@@ -174,7 +174,7 @@ func initRestoreAction(console input.Console, ctx context.Context, o *internal.G
 
 func initShowAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags showFlags, args []string) (actions.Action, error) {
 	formatter := newFormatterFromConsole(console)
-	writer := newWriterFromConsole(console)
+	writer := newOutputWriter(console)
 	azdContext, err := newAzdContext()
 	if err != nil {
 		return nil, err
@@ -185,7 +185,7 @@ func initShowAction(console input.Console, ctx context.Context, o *internal.Glob
 
 func initVersionAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags versionFlags, args []string) (actions.Action, error) {
 	formatter := newFormatterFromConsole(console)
-	writer := newWriterFromConsole(console)
+	writer := newOutputWriter(console)
 	cmdVersionAction := newVersionAction(flags, formatter, writer, console)
 	return cmdVersionAction, nil
 }
@@ -196,7 +196,7 @@ func initInfraCreateAction(console input.Console, ctx context.Context, o *intern
 		return nil, err
 	}
 	formatter := newFormatterFromConsole(console)
-	writer := newWriterFromConsole(console)
+	writer := newOutputWriter(console)
 	cmdInfraCreateAction := newInfraCreateAction(flags, azdContext, console, formatter, writer)
 	return cmdInfraCreateAction, nil
 }
@@ -245,7 +245,7 @@ func initEnvListAction(console input.Console, ctx context.Context, o *internal.G
 		return nil, err
 	}
 	formatter := newFormatterFromConsole(console)
-	writer := newWriterFromConsole(console)
+	writer := newOutputWriter(console)
 	cmdEnvListAction := newEnvListAction(azdContext, formatter, writer)
 	return cmdEnvListAction, nil
 }
@@ -287,7 +287,7 @@ func initEnvRefreshAction(console input.Console, ctx context.Context, o *interna
 	}
 	azCli := newAzCliFromOptions(o, commandRunner, tokenCredential)
 	formatter := newFormatterFromConsole(console)
-	writer := newWriterFromConsole(console)
+	writer := newOutputWriter(console)
 	cmdEnvRefreshAction := newEnvRefreshAction(azdContext, azCli, o, console, formatter, writer)
 	return cmdEnvRefreshAction, nil
 }
@@ -298,7 +298,7 @@ func initEnvGetValuesAction(console input.Console, ctx context.Context, o *inter
 		return nil, err
 	}
 	formatter := newFormatterFromConsole(console)
-	writer := newWriterFromConsole(console)
+	writer := newOutputWriter(console)
 	commandRunner := newCommandRunnerFromConsole(console)
 	userConfigManager := config.NewUserConfigManager()
 	manager, err := auth.NewManager(userConfigManager)
@@ -325,7 +325,7 @@ func initPipelineConfigAction(console input.Console, ctx context.Context, o *int
 
 func initTemplatesListAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags templatesListFlags, args []string) (actions.Action, error) {
 	formatter := newFormatterFromConsole(console)
-	writer := newWriterFromConsole(console)
+	writer := newOutputWriter(console)
 	templateManager := templates.NewTemplateManager()
 	cmdTemplatesListAction := newTemplatesListAction(flags, formatter, writer, templateManager)
 	return cmdTemplatesListAction, nil
@@ -333,7 +333,7 @@ func initTemplatesListAction(console input.Console, ctx context.Context, o *inte
 
 func initTemplatesShowAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
 	formatter := newFormatterFromConsole(console)
-	writer := newWriterFromConsole(console)
+	writer := newOutputWriter(console)
 	templateManager := templates.NewTemplateManager()
 	cmdTemplatesShowAction := newTemplatesShowAction(formatter, writer, templateManager, args)
 	return cmdTemplatesShowAction, nil
@@ -342,7 +342,7 @@ func initTemplatesShowAction(console input.Console, ctx context.Context, o *inte
 func initConfigListAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
 	userConfigManager := config.NewUserConfigManager()
 	formatter := newFormatterFromConsole(console)
-	writer := newWriterFromConsole(console)
+	writer := newOutputWriter(console)
 	cmdConfigListAction := newConfigListAction(userConfigManager, formatter, writer)
 	return cmdConfigListAction, nil
 }
@@ -350,7 +350,7 @@ func initConfigListAction(console input.Console, ctx context.Context, o *interna
 func initConfigGetAction(console input.Console, ctx context.Context, o *internal.GlobalCommandOptions, flags struct{}, args []string) (actions.Action, error) {
 	userConfigManager := config.NewUserConfigManager()
 	formatter := newFormatterFromConsole(console)
-	writer := newWriterFromConsole(console)
+	writer := newOutputWriter(console)
 	cmdConfigGetAction := newConfigGetAction(userConfigManager, formatter, writer, args)
 	return cmdConfigGetAction, nil
 }

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -249,7 +249,7 @@ func Test_CLI_InfraCreateAndDeleteWebApp(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Running show\n")
-	out, err := cli.RunCommand(ctx, "show", "-o", "json", "--cwd", dir)
+	result, err := cli.RunCommand(ctx, "show", "-o", "json", "--cwd", dir)
 	require.NoError(t, err)
 
 	var showRes struct {
@@ -263,7 +263,7 @@ func Test_CLI_InfraCreateAndDeleteWebApp(t *testing.T) {
 			} `json:"target"`
 		} `json:"services"`
 	}
-	err = json.Unmarshal([]byte(out), &showRes)
+	err = json.Unmarshal([]byte(result.Stdout), &showRes)
 	require.NoError(t, err)
 
 	service, has := showRes.Services["web"]
@@ -347,10 +347,10 @@ func Test_CLI_InfraCreateAndDeleteWebApp(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Running show (again)\n")
-	out, err = cli.RunCommand(ctx, "show", "-o", "json", "--cwd", dir)
+	result, err = cli.RunCommand(ctx, "show", "-o", "json", "--cwd", dir)
 	require.NoError(t, err)
 
-	err = json.Unmarshal([]byte(out), &showRes)
+	err = json.Unmarshal([]byte(result.Stdout), &showRes)
 	require.NoError(t, err)
 
 	// Project information should be present, but since we have run infra delete, there shouldn't
@@ -449,13 +449,13 @@ func Test_CLI_InfraCreateAndDeleteFuncApp(t *testing.T) {
 	_, err = cli.RunCommand(ctx, "deploy", "--cwd", dir)
 	require.NoError(t, err)
 
-	out, err := cli.RunCommand(ctx, "env", "get-values", "-o", "json", "--cwd", dir)
+	result, err := cli.RunCommand(ctx, "env", "get-values", "-o", "json", "--cwd", dir)
 	require.NoError(t, err)
 
-	t.Logf("env get-values command output: %s\n", out)
+	t.Logf("env get-values command output: %s\n", result.Stdout)
 
 	var envValues map[string]interface{}
-	err = json.Unmarshal([]byte(out), &envValues)
+	err = json.Unmarshal([]byte(result.Stdout), &envValues)
 	require.NoError(t, err)
 
 	url := fmt.Sprintf("%s/api/httptrigger", envValues["AZURE_FUNCTION_URI"])

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -525,9 +525,9 @@ func Test_CLI_ProjectIsNeeded(t *testing.T) {
 		}
 
 		t.Run(test.command, func(t *testing.T) {
-			out, err := cli.RunCommand(ctx, args...)
+			result, err := cli.RunCommand(ctx, args...)
 			assert.Error(t, err)
-			assert.Regexp(t, "no project exists; to create a new project, run `azd init`", out)
+			assert.Regexp(t, "no project exists; to create a new project, run `azd init`", result.Stdout)
 		})
 	}
 }
@@ -644,9 +644,8 @@ func Test_CLI_InfraCreateAndDeleteResourceTerraform(t *testing.T) {
 	_, err = cli.RunCommand(ctx, "infra", "create", "--cwd", dir)
 	require.NoError(t, err)
 
-	out, err := cli.RunCommand(ctx, "env", "get-values", "-o", "json", "--cwd", dir)
+	_, err = cli.RunCommand(ctx, "env", "get-values", "-o", "json", "--cwd", dir)
 	require.NoError(t, err)
-	_ = out
 
 	t.Logf("Starting infra delete\n")
 	_, err = cli.RunCommand(ctx, "infra", "delete", "--cwd", dir, "--force", "--purge")

--- a/cli/azd/test/functional/env_test.go
+++ b/cli/azd/test/functional/env_test.go
@@ -41,7 +41,7 @@ func Test_CLI_EnvCommandsWorkWhenLoggedOut(t *testing.T) {
 	require.NoError(t, err)
 
 	var lr contracts.LoginResult
-	err = json.Unmarshal([]byte(res), &lr)
+	err = json.Unmarshal([]byte(res.Stdout), &lr)
 	require.NoError(t, err)
 
 	require.Equal(t, contracts.LoginStatusUnauthenticated, lr.Status)
@@ -50,7 +50,7 @@ func Test_CLI_EnvCommandsWorkWhenLoggedOut(t *testing.T) {
 	require.NoError(t, err)
 
 	var envs []contracts.EnvListEnvironment
-	err = json.Unmarshal([]byte(res), &envs)
+	err = json.Unmarshal([]byte(res.Stdout), &envs)
 	require.NoError(t, err)
 
 	// We should see the two environments.

--- a/cli/azd/test/functional/env_test.go
+++ b/cli/azd/test/functional/env_test.go
@@ -160,11 +160,11 @@ func envNew(ctx context.Context, t *testing.T, cli *azdcli.CLI, envName string, 
 }
 
 func envList(ctx context.Context, t *testing.T, cli *azdcli.CLI) []contracts.EnvListEnvironment {
-	jsonOutput, err := cli.RunCommand(ctx, "env", "list", "--output", "json")
+	result, err := cli.RunCommand(ctx, "env", "list", "--output", "json")
 	require.NoError(t, err)
 
 	env := []contracts.EnvListEnvironment{}
-	err = json.Unmarshal([]byte(jsonOutput), &env)
+	err = json.Unmarshal([]byte(result.Stdout), &env)
 	require.NoError(t, err)
 
 	return env
@@ -181,11 +181,11 @@ func envSetValue(ctx context.Context, t *testing.T, cli *azdcli.CLI, key string,
 }
 
 func envGetValues(ctx context.Context, t *testing.T, cli *azdcli.CLI) map[string]string {
-	jsonOutput, err := cli.RunCommand(ctx, "env", "get-values", "--output", "json")
+	result, err := cli.RunCommand(ctx, "env", "get-values", "--output", "json")
 	require.NoError(t, err)
 
 	var envValues map[string]string
-	err = json.Unmarshal([]byte(jsonOutput), &envValues)
+	err = json.Unmarshal([]byte(result.Stdout), &envValues)
 	require.NoError(t, err)
 
 	return envValues

--- a/cli/azd/test/functional/version_test.go
+++ b/cli/azd/test/functional/version_test.go
@@ -36,11 +36,11 @@ func Test_CLI_Version_Text(t *testing.T) {
 	defer cancel()
 
 	cli := azdcli.NewCLI(t)
-	textOutput, err := cli.RunCommand(ctx, "version")
+	result, err := cli.RunCommand(ctx, "version")
 	require.NoError(t, err)
 
 	expected := getExpectedVersion(t)
-	require.Contains(t, textOutput, fmt.Sprintf("azd version %s", expected))
+	require.Contains(t, result.Stdout, fmt.Sprintf("azd version %s", expected))
 }
 
 func Test_CLI_Version_Json(t *testing.T) {

--- a/cli/azd/test/functional/version_test.go
+++ b/cli/azd/test/functional/version_test.go
@@ -20,7 +20,7 @@ import (
 //   - When running in CI, the version specified by the CI pipeline.
 //   - When running locally, the version specified in source.
 func getExpectedVersion(t *testing.T) string {
-	expected := internal.Version
+	expected := internal.GetVersionNumber()
 
 	if os.Getenv("GITHUB_RUN_NUMBER") != "" {
 		// By using CLI_VERSION, we validate that azd was built with the correct version.

--- a/cli/azd/test/functional/version_test.go
+++ b/cli/azd/test/functional/version_test.go
@@ -48,11 +48,11 @@ func Test_CLI_Version_Json(t *testing.T) {
 	defer cancel()
 
 	cli := azdcli.NewCLI(t)
-	jsonOutput, err := cli.RunCommand(ctx, "version", "--output", "json")
+	result, err := cli.RunCommand(ctx, "version", "--output", "json")
 	require.NoError(t, err)
 
 	versionJson := &internal.VersionSpec{}
-	err = json.Unmarshal([]byte(jsonOutput), versionJson)
+	err = json.Unmarshal([]byte(result.Stdout), versionJson)
 	require.NoError(t, err)
 
 	_, err = semver.Parse(versionJson.Azd.Version)


### PR DESCRIPTION
It is intended that the final JSON output of `azd` to be written to `stdout` instead of `stderr`. This change restores that behavior (unintended behavioral change caused by #1108), and updates existing tests to explicitly verify `stdout` output instead of `stdout` or `stderr`.