### PR TITLE
Remove Azure Account extension dependency

### DIFF
--- a/ext/vscode/package.json
+++ b/ext/vscode/package.json
@@ -241,8 +241,5 @@
         "@microsoft/vscode-azext-utils": "~0.3.15",
         "dayjs": "~1.11",
         "dotenv": "~16.0"
-    },
-    "extensionDependencies": [
-        "ms-vscode.azure-account"
-    ]
+    }
 }


### PR DESCRIPTION
Since `VisualStudioCodeCredential` / `DefaultAzureCredential` are no longer able to use the tokens created by the Azure Account extension, IMO we should just remove the extension dependency. Relates also to the bigger auth questions in #1157 / #1101 / etc.

As an aside, the long term plan for the Azure Account extension is deprecation in favor of VSCode's authentication provider API.