### PR TITLE
Fix issues so `todo-csharp-cosmos-sql` can be run locally

### DIFF
--- a/eng/scripts/Set-TemplateTestMatrixVariable.ps1
+++ b/eng/scripts/Set-TemplateTestMatrixVariable.ps1
@@ -72,6 +72,12 @@ if ($TemplateListFilter -ne '.*') {
     $templateNames = $templateNames -match $TemplateListFilter
 }
 
+# If we only had a single template name, templateNames may be a string at this point
+# but we really want it to be an array, for the rest of the script.
+if ($templateNames -is [string]) {
+    $templateNames = @($templateNames)
+}
+
 $matrix = @{}
 foreach ($template in $templateNames) {
     $jobName = $template.Replace('/', '_')

--- a/eng/scripts/Set-TemplateTestMatrixVariable.ps1
+++ b/eng/scripts/Set-TemplateTestMatrixVariable.ps1
@@ -52,10 +52,12 @@ function Get-JobVariables() {
 
 $jobVariables = Get-JobVariables -JobVariablesDefinition $JobVariablesDefinition
 
+$templateNames = @()
+
 if ($TemplateList -eq '(azd template list)') {
     Write-Host "Using results of (azd template list --output json)"
     
-    $templateNames = (azd template list --output json | ConvertFrom-Json).name
+    $templateNames += (azd template list --output json | ConvertFrom-Json).name
     if ($LASTEXITCODE -ne 0) {
         Write-Error "azd template list failed"
         exit 1
@@ -63,19 +65,13 @@ if ($TemplateList -eq '(azd template list)') {
 } else {
     Write-Host "Using provided TemplateList value: $TemplateList"
 
-    $templateNames = ($TemplateList -split ",").Trim()
+    $templateNames += ($TemplateList -split ",").Trim()
 }
 
 if ($TemplateListFilter -ne '.*') {
     Write-Host "Filtering with TemplateListFilter regex: $TemplateListFilter"
 
     $templateNames = $templateNames -match $TemplateListFilter
-}
-
-# If we only had a single template name, templateNames may be a string at this point
-# but we really want it to be an array, for the rest of the script.
-if ($templateNames -is [string]) {
-    $templateNames = @($templateNames)
 }
 
 $matrix = @{}

--- a/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/infra/main.bicep
@@ -92,6 +92,17 @@ module apiCosmosSqlRoleAssign '../../../../../../common/infra/bicep/core/databas
   }
 }
 
+// Give the API the role to access Cosmos
+module userComsosSqlRoleAssign '../../../../../../common/infra/bicep/core/database/cosmos/sql/cosmos-sql-role-assign.bicep' = if (principalId != '') {
+  name: 'user-cosmos-access'
+  scope: rg
+  params: {
+    accountName: cosmos.outputs.accountName
+    roleDefinitionId: cosmos.outputs.roleDefinitionId
+    principalId: principalId
+  }
+}
+
 // The application database
 module cosmos '../../../../../common/infra/bicep/app/cosmos-sql-db.bicep' = {
   name: 'cosmos'
@@ -145,6 +156,7 @@ module monitoring '../../../../../../common/infra/bicep/core/monitor/monitoring.
 }
 
 // Data outputs
+output AZURE_COSMOS_ENDPOINT string = cosmos.outputs.endpoint
 output AZURE_COSMOS_CONNECTION_STRING_KEY string = cosmos.outputs.connectionStringKey
 output AZURE_COSMOS_DATABASE_NAME string = cosmos.outputs.databaseName
 


### PR DESCRIPTION
The `todo-csharp-cosmos-sql` template had two issues that prevented it from being used locally:

1. It did not set `AZURE_COSMOS_ENDPOINT` as an output of the infrastructure - but this value was used by the application to at runtime to connect to the cosmos database. When run in App Service we correctly defined the environment variaible, but since we didn't export it from the infrastructure, it was not added to the `.env` file and hence not avaiaible for the app to use when running locally.

2. It did not grant RBAC access to the local user, so once (1) was fixed, the local user could not access the database.

This change fixes both of these issues.

Fixes #1101