### PR TITLE
Enhance core templates with Key Vault secret

### DIFF
--- a/templates/common/infra/bicep/core/security/keyvault-secret.bicep
+++ b/templates/common/infra/bicep/core/security/keyvault-secret.bicep
@@ -1,0 +1,30 @@
+param name string
+param tags object = {}
+param keyVaultName string
+param contentType string = 'string'
+@description('The value of the secret. Provide only derived values like blob storage access, but do not hard code any secrets in your templates')
+@secure()
+param secretValue string
+
+param enabled bool = true
+param exp int = 0
+param nbf int = 0
+
+resource keyVaultSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: name
+  tags: tags
+  parent: keyVault
+  properties: {
+    attributes: {
+      enabled: enabled
+      exp: exp
+      nbf: nbf
+    }
+    contentType: contentType
+    value: secretValue
+  }
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
+  name: keyVaultName
+}


### PR DESCRIPTION
 This PR add an additional template to the `core` folder for `.bicep`. The template allows the creation of an Azure Key Vault secret as a further building block in the `security` folder

 CC @jongio 