### PR TITLE
Use case insensitive match for resource types

### DIFF
--- a/cli/azd/pkg/project/service_target_appservice.go
+++ b/cli/azd/pkg/project/service_target_appservice.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
@@ -105,7 +106,7 @@ func NewAppServiceTarget(
 	resource *environment.TargetResource,
 	azCli azcli.AzCli,
 ) (ServiceTarget, error) {
-	if resource.ResourceType() != string(infra.AzureResourceTypeWebSite) {
+	if !strings.EqualFold(resource.ResourceType(), string(infra.AzureResourceTypeWebSite)) {
 		return nil, resourceTypeMismatchError(
 			resource.ResourceName(),
 			resource.ResourceType(),

--- a/cli/azd/pkg/project/service_target_appservice_test.go
+++ b/cli/azd/pkg/project/service_target_appservice_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAppServiceTargetTypeValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ValidateTypeSuccess", func(t *testing.T) {
+		_, err := NewAppServiceTarget(
+			nil,
+			nil,
+			environment.NewTargetResource("SUB_ID", "RG_ID", "res", string(infra.AzureResourceTypeWebSite)),
+			nil,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("ValidateTypeLowerCaseSuccess", func(t *testing.T) {
+		_, err := NewAppServiceTarget(
+			nil,
+			nil,
+			environment.NewTargetResource(
+				"SUB_ID", "RG_ID", "res", strings.ToLower(string(infra.AzureResourceTypeWebSite)),
+			),
+			nil,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("ValidateTypeFail", func(t *testing.T) {
+		_, err := NewAppServiceTarget(
+			nil,
+			nil,
+			environment.NewTargetResource("SUB_ID", "RG_ID", "res", "BadType"),
+			nil,
+		)
+
+		require.Error(t, err)
+	})
+}

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -183,7 +183,7 @@ func NewContainerAppTarget(
 	console input.Console,
 	commandRunner exec.CommandRunner,
 ) (ServiceTarget, error) {
-	if resource.ResourceType() != string(infra.AzureResourceTypeContainerApp) {
+	if !strings.EqualFold(resource.ResourceType(), string(infra.AzureResourceTypeContainerApp)) {
 		return nil, resourceTypeMismatchError(
 			resource.ResourceName(),
 			resource.ResourceType(),

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewContainerAppTargetTypeValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ValidateTypeSuccess", func(t *testing.T) {
+		_, err := NewContainerAppTarget(
+			nil,
+			nil,
+			environment.NewTargetResource("SUB_ID", "RG_ID", "res", string(infra.AzureResourceTypeContainerApp)),
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("ValidateTypeLowerCaseSuccess", func(t *testing.T) {
+		_, err := NewContainerAppTarget(
+			nil,
+			nil,
+			environment.NewTargetResource(
+				"SUB_ID", "RG_ID", "res", strings.ToLower(string(infra.AzureResourceTypeContainerApp)),
+			),
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("ValidateTypeFail", func(t *testing.T) {
+		_, err := NewContainerAppTarget(
+			nil,
+			nil,
+			environment.NewTargetResource("SUB_ID", "RG_ID", "res", "BadType"),
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		require.Error(t, err)
+	})
+}

--- a/cli/azd/pkg/project/service_target_functionapp.go
+++ b/cli/azd/pkg/project/service_target_functionapp.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
@@ -103,7 +104,7 @@ func NewFunctionAppTarget(
 	resource *environment.TargetResource,
 	azCli azcli.AzCli,
 ) (ServiceTarget, error) {
-	if resource.ResourceType() != string(infra.AzureResourceTypeWebSite) {
+	if !strings.EqualFold(resource.ResourceType(), string(infra.AzureResourceTypeWebSite)) {
 		return nil, resourceTypeMismatchError(
 			resource.ResourceName(),
 			resource.ResourceType(),

--- a/cli/azd/pkg/project/service_target_functionapp_test.go
+++ b/cli/azd/pkg/project/service_target_functionapp_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFunctionAppTargetTypeValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ValidateTypeSuccess", func(t *testing.T) {
+		_, err := NewFunctionAppTarget(
+			nil,
+			nil,
+			environment.NewTargetResource("SUB_ID", "RG_ID", "res", string(infra.AzureResourceTypeWebSite)),
+			nil,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("ValidateTypeLowerCaseSuccess", func(t *testing.T) {
+		_, err := NewFunctionAppTarget(
+			nil,
+			nil,
+			environment.NewTargetResource(
+				"SUB_ID", "RG_ID", "res", strings.ToLower(string(infra.AzureResourceTypeWebSite)),
+			),
+			nil,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("ValidateTypeFail", func(t *testing.T) {
+		_, err := NewFunctionAppTarget(
+			nil,
+			nil,
+			environment.NewTargetResource("SUB_ID", "RG_ID", "res", "BadType"),
+			nil,
+		)
+
+		require.Error(t, err)
+	})
+}

--- a/cli/azd/pkg/project/service_target_staticwebapp.go
+++ b/cli/azd/pkg/project/service_target_staticwebapp.go
@@ -158,7 +158,7 @@ func NewStaticWebAppTarget(
 	azCli azcli.AzCli,
 	swaCli swa.SwaCli,
 ) (ServiceTarget, error) {
-	if resource.ResourceType() != string(infra.AzureResourceTypeStaticWebSite) {
+	if !strings.EqualFold(resource.ResourceType(), string(infra.AzureResourceTypeStaticWebSite)) {
 		return nil, resourceTypeMismatchError(
 			resource.ResourceName(),
 			resource.ResourceType(),

--- a/cli/azd/pkg/project/service_target_staticwebapp_test.go
+++ b/cli/azd/pkg/project/service_target_staticwebapp_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStaticWebAppTargetTypeValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ValidateTypeSuccess", func(t *testing.T) {
+		_, err := NewStaticWebAppTarget(
+			nil,
+			nil,
+			environment.NewTargetResource("SUB_ID", "RG_ID", "res", string(infra.AzureResourceTypeStaticWebSite)),
+			nil,
+			nil,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("ValidateTypeLowerCaseSuccess", func(t *testing.T) {
+		_, err := NewStaticWebAppTarget(
+			nil,
+			nil,
+			environment.NewTargetResource(
+				"SUB_ID", "RG_ID", "res", strings.ToLower(string(infra.AzureResourceTypeStaticWebSite)),
+			),
+			nil,
+			nil,
+		)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("ValidateTypeFail", func(t *testing.T) {
+		_, err := NewStaticWebAppTarget(
+			nil,
+			nil,
+			environment.NewTargetResource("SUB_ID", "RG_ID", "res", "BadType"),
+			nil,
+			nil,
+		)
+
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
CI informs me there are cases where Azure will return the all lower-case form, as I'm seeing errors like this in the template tests:

```
ERROR: creating project: creating service web: creating service target: failed validation for host 'appservice': resource 'app-web-xxmeesgcaossw' with type 'microsoft.web/sites' does not match expected resource type 'Microsoft.Web/sites'
```

Ignore case differences in these comparisons.

Fixes #1203