### PR TITLE
Fix nil ref in deploy

### DIFF
--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -109,12 +109,13 @@ func newDeployAction(
 	writer io.Writer,
 ) (*deployAction, error) {
 	da := &deployAction{
-		flags:     flags,
-		azCli:     azCli,
-		azdCtx:    azdCtx,
-		formatter: formatter,
-		writer:    writer,
-		console:   console,
+		flags:         flags,
+		azCli:         azCli,
+		azdCtx:        azdCtx,
+		formatter:     formatter,
+		writer:        writer,
+		console:       console,
+		commandRunner: commandRunner,
 	}
 
 	return da, nil


### PR DESCRIPTION
We did not set the `commandRunner` state in the object constructor, leading to a nil ref later when trying to use it.