### PR TITLE
Enable `jdk.attach.allowAttachSelf`

### DIFF
--- a/templates/todo/common/infra/bicep/app/api-appservice-java.bicep
+++ b/templates/todo/common/infra/bicep/app/api-appservice-java.bicep
@@ -10,6 +10,14 @@ param appSettings object = {}
 param keyVaultName string
 param serviceName string = 'api'
 
+@description('JVM runtime options. Use this instead of defining JAVA_OPTS manually on appSettings.')
+param javaRuntimeOptions array = []
+
+// applicationinsights-runtime-attach (and other plugins) requires runtime attach
+// require allowAttachSelf to be enabled on App Service. Otherwise, it fails 
+// writing to the temp directory.
+var defaultJavaRuntimeOptions = ['-Djdk.attach.allowAttachSelf=true']
+
 module api '../../../../../common/infra/bicep/core/host/appservice.bicep' = {
   name: '${name}-app-module'
   params: {
@@ -20,7 +28,13 @@ module api '../../../../../common/infra/bicep/core/host/appservice.bicep' = {
     appCommandLine: appCommandLine
     applicationInsightsName: applicationInsightsName
     appServicePlanId: appServicePlanId
-    appSettings: appSettings
+    appSettings: union(appSettings, {
+      JAVA_OPTS: join(
+        concat(
+            javaRuntimeOptions,
+            defaultJavaRuntimeOptions),
+          ' ')
+     })
     keyVaultName: keyVaultName
     runtimeName: 'java'
     runtimeVersion: '17-java17'

--- a/templates/todo/common/infra/bicep/app/api-appservice-java.bicep
+++ b/templates/todo/common/infra/bicep/app/api-appservice-java.bicep
@@ -14,8 +14,8 @@ param serviceName string = 'api'
 param javaRuntimeOptions array = []
 
 // applicationinsights-runtime-attach (and other plugins) that uses runtime attach
-// require allowAttachSelf to be enabled on App Service. Otherwise, the plugin fails to load
-// when writing to the temp directory on App Service.
+// require allowAttachSelf to be enabled on App Service. Otherwise, plugins will fail to attach
+// on App Service.
 var defaultJavaRuntimeOptions = ['-Djdk.attach.allowAttachSelf=true']
 
 module api '../../../../../common/infra/bicep/core/host/appservice.bicep' = {

--- a/templates/todo/common/infra/bicep/app/api-appservice-java.bicep
+++ b/templates/todo/common/infra/bicep/app/api-appservice-java.bicep
@@ -13,9 +13,9 @@ param serviceName string = 'api'
 @description('JVM runtime options. Use this instead of defining JAVA_OPTS manually on appSettings.')
 param javaRuntimeOptions array = []
 
-// applicationinsights-runtime-attach (and other plugins) requires runtime attach
-// require allowAttachSelf to be enabled on App Service. Otherwise, it fails 
-// writing to the temp directory.
+// applicationinsights-runtime-attach (and other plugins) that uses runtime attach
+// require allowAttachSelf to be enabled on App Service. Otherwise, the plugin fails to load
+// when writing to the temp directory on App Service.
 var defaultJavaRuntimeOptions = ['-Djdk.attach.allowAttachSelf=true']
 
 module api '../../../../../common/infra/bicep/core/host/appservice.bicep' = {


### PR DESCRIPTION
There seems to be a recent change in App Service that prevents `applicationinsights-runtime-attach` from loading correctly. The root cause is that the plugin attempts to write to tempDir as a workaround when  `jdk.attach.allowAttachSelf` is `false` which times out after awhile.

With `jdk.attach.allowAttachSelf` specified to `true`, the app service works as normal.

Confirmed with the Application Insights team that this is a safe workaround. Still root causing how this has started happening.

Addresses #1214