### PR TITLE
Fix template test not cleaning up when test fails

### DIFF
--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -98,6 +98,8 @@ stages:
             inputs:
               version: 6.0.x
 
+          - template: /eng/pipelines/templates/steps/az-login.yml
+
           - template: /eng/pipelines/templates/steps/azd-login.yml
             parameters:
               AzdDirectory: cli/azd

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -98,8 +98,6 @@ stages:
             inputs:
               version: 6.0.x
 
-          - template: /eng/pipelines/templates/steps/az-login.yml
-
           - template: /eng/pipelines/templates/steps/azd-login.yml
             parameters:
               AzdDirectory: cli/azd

--- a/eng/pipelines/templates/steps/az-login.yml
+++ b/eng/pipelines/templates/steps/az-login.yml
@@ -1,5 +1,6 @@
 parameters:
   SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+  Condition: succeeded()
 
 steps:
   - pwsh: |
@@ -24,5 +25,5 @@ steps:
       Write-Host "##vso[task.setvariable variable=arm-client-secret;issecret=true]$($subscriptionConfiguration.TestApplicationSecret)"
       Write-Host "##vso[task.setvariable variable=arm-tenant-id;issecret=false]$($subscriptionConfiguration.TenantId)"
 
-    condition: and(succeeded(), ne(variables['Skip.LiveTest'], 'true'))
+    condition: ${{ parameters.Condition }}
     displayName: Azure Login

--- a/eng/pipelines/templates/steps/template-test-run-job.yml
+++ b/eng/pipelines/templates/steps/template-test-run-job.yml
@@ -77,11 +77,11 @@ steps:
     if ($LASTEXITCODE) {
       if ($errOutput -match "ResourceGroupNotFound") {
         Write-Host "Resource group $(ResourceGroupName) has already been deleted."
-        return
+        exit 0
       }
 
       Write-Error "Error querying for resource group. Exit code: $LASTEXITCODE, $errOutput"
-      return
+      exit 1
     }
 
     $resourceGroupId = $output

--- a/eng/pipelines/templates/steps/template-test-run-job.yml
+++ b/eng/pipelines/templates/steps/template-test-run-job.yml
@@ -66,19 +66,25 @@ steps:
     workingDirectory: templates/tests
 
 - template: /eng/pipelines/templates/steps/az-login.yml
+  parameters:
+    Condition: always()
 
 # First tag the resource group (if exists) so that it can get cleaned up
 # by the cleanup pipeline. Then attempt to delete the resource group 
 # directly. If the delete fails the cleanup pipeline will delete it.
 - pwsh: |
-    $resourceGroupId = az group show `
-      --resource-group '$(ResourceGroupName)' `
-      --query id
-
+    $errOutput = ($( $output = & az group show --resource-group '$(ResourceGroupName)' --query id ) 2>&1) -join [System.Environment]::NewLine
     if ($LASTEXITCODE) {
-      Write-Host "Could not get information for resource group: $(ResourceGroupName)"
-      exit 0
+      if ($errOutput -match "ResourceGroupNotFound") {
+        Write-Host "Resource group $(ResourceGroupName) has already been deleted."
+        return
+      }
+
+      Write-Error "Error querying for resource group. Exit code: $LASTEXITCODE, $errOutput"
+      return
     }
+
+    $resourceGroupId = $output
 
     if ('$(CleanupImmediate)' -eq 'true') {
       # Tag the resource group so it gets cleaned up later if delete fails


### PR DESCRIPTION
- Always run `az login` for post-cleanup
- Avoid silent errors if `az group show` fails unexpectedly.