### PR TITLE
adding Azure Developer CLI credential for Java

### DIFF
--- a/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
+++ b/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
@@ -158,7 +158,9 @@ public class AzureDeveloperCliCredential implements TokenCredential {
                     }
                     throw LOGGER.logExceptionAsError(new ClientAuthenticationException(redactedOutput, null));
                 } else {
-                    throw LOGGER.logExceptionAsError(new ClientAuthenticationException("Failed to invoke Azure Developer CLI ", null));
+                    throw LOGGER.logExceptionAsError(
+                        new ClientAuthenticationException("Failed to invoke Azure Developer CLI ", null)
+                    );
                 }
             }
 

--- a/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
+++ b/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
@@ -52,7 +52,7 @@ public class AzureDeveloperCliCredential implements TokenCredential {
     private static final String DEFAULT_MAC_LINUX_PATH = "/bin/";
     private static final String WINDOWS_PROCESS_ERROR_MESSAGE = "'azd' is not recognized";
     private static final Pattern LINUX_MAC_PROCESS_ERROR_MESSAGE = Pattern.compile("(.*)azd:(.*)not found");
-    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\": \"(.*?)(\"|$)");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"token\": \"(.*?)(\"|$)");
     private static final SerializerAdapter SERIALIZER_ADAPTER = JacksonAdapter.createDefaultSerializerAdapter();
 
     /**

--- a/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
+++ b/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
@@ -130,7 +130,7 @@ public class AzureDeveloperCliCredential implements TokenCredential {
                             LOGGER,
                             identityClientOptions,
                             new CredentialUnavailableException(
-                                "AzureCliCredential authentication unavailable. Azure CLI not installed." +
+                                "AzureDeveloperCliCredential authentication unavailable. Azure Developer CLI not installed." +
                                 "To mitigate this issue, please refer to the troubleshooting guidelines here at " +
                                 "https://aka.ms/azsdk/java/identity/azclicredential/troubleshoot"
                             )
@@ -151,19 +151,19 @@ public class AzureDeveloperCliCredential implements TokenCredential {
                             LOGGER,
                             identityClientOptions,
                             new CredentialUnavailableException(
-                                "AzureCliCredential authentication unavailable." +
+                                "AzureDeveloperCliCredential authentication unavailable." +
                                 " Please run 'azd login' to set up account."
                             )
                         );
                     }
                     throw LOGGER.logExceptionAsError(new ClientAuthenticationException(redactedOutput, null));
                 } else {
-                    throw LOGGER.logExceptionAsError(new ClientAuthenticationException("Failed to invoke Azure CLI ", null));
+                    throw LOGGER.logExceptionAsError(new ClientAuthenticationException("Failed to invoke Azure Developer CLI ", null));
                 }
             }
 
             LOGGER.verbose(
-                "Azure CLI Authentication => A token response was received from Azure Developer CLI, deserializing the" +
+                "Azure Developer CLI Authentication => A token response was received from Azure Developer CLI, deserializing the" +
                 " response into an Access Token."
             );
             Map<String, String> objectMap = SERIALIZER_ADAPTER.deserialize(

--- a/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
+++ b/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
@@ -64,12 +64,12 @@ public class AzureDeveloperCliCredential implements TokenCredential {
 
     @Override
     public Mono<AccessToken> getToken(TokenRequestContext request) {
-        return authenticateWithAzureCli(request)
+        return authenticateWithAzureDeveloperCli(request)
             .doOnNext(token -> LoggingUtil.logTokenSuccess(LOGGER, request))
             .doOnError(error -> LoggingUtil.logTokenError(LOGGER, identityClientOptions, request, error));
     }
 
-    private Mono<AccessToken> authenticateWithAzureCli(TokenRequestContext request) {
+    private Mono<AccessToken> authenticateWithAzureDeveloperCli(TokenRequestContext request) {
         StringBuilder azCommand = new StringBuilder("azd auth token --output json --scope ");
 
         var scopes = String.join(" --scope ", request.getScopes());

--- a/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
+++ b/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.simpletodo.configuration;
+
+import com.azure.core.annotation.Immutable;
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
+import com.azure.core.exception.ClientAuthenticationException;
+import com.azure.core.util.CoreUtils;
+import com.azure.core.util.logging.ClientLogger;
+import com.azure.core.util.serializer.JacksonAdapter;
+import com.azure.core.util.serializer.SerializerAdapter;
+import com.azure.core.util.serializer.SerializerEncoding;
+import com.azure.identity.CredentialUnavailableException;
+import com.azure.identity.implementation.IdentityClientOptions;
+import com.azure.identity.implementation.util.LoggingUtil;
+import com.azure.identity.implementation.util.ScopeUtil;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import reactor.core.publisher.Mono;
+
+/**
+ * A credential provider that provides token credentials based on
+ * Azure Developer CLI command.
+ */
+@Immutable
+public class AzureDeveloperCliCredential implements TokenCredential {
+
+    private static final ClientLogger LOGGER = new ClientLogger(AzureDeveloperCliCredential.class);
+    private IdentityClientOptions identityClientOptions;
+
+    private static final String WINDOWS_STARTER = "cmd.exe";
+    private static final String LINUX_MAC_STARTER = "/bin/sh";
+    private static final String WINDOWS_SWITCHER = "/c";
+    private static final String LINUX_MAC_SWITCHER = "-c";
+    private static final String DEFAULT_WINDOWS_SYSTEM_ROOT = System.getenv("SystemRoot");
+    private static final String DEFAULT_MAC_LINUX_PATH = "/bin/";
+    private static final String WINDOWS_PROCESS_ERROR_MESSAGE = "'azd' is not recognized";
+    private static final Pattern LINUX_MAC_PROCESS_ERROR_MESSAGE = Pattern.compile("(.*)azd:(.*)not found");
+    private static final Pattern ACCESS_TOKEN_PATTERN = Pattern.compile("\"accessToken\": \"(.*?)(\"|$)");
+    private static final SerializerAdapter SERIALIZER_ADAPTER = JacksonAdapter.createDefaultSerializerAdapter();
+
+    /**
+     * Creates an AzureDeveloperCliCredential with default identity client options.
+     */
+    public AzureDeveloperCliCredential() {
+        identityClientOptions = new IdentityClientOptions();
+    }
+
+    @Override
+    public Mono<AccessToken> getToken(TokenRequestContext request) {
+        return authenticateWithAzureCli(request)
+            .doOnNext(token -> LoggingUtil.logTokenSuccess(LOGGER, request))
+            .doOnError(error -> LoggingUtil.logTokenError(LOGGER, identityClientOptions, request, error));
+    }
+
+    private Mono<AccessToken> authenticateWithAzureCli(TokenRequestContext request) {
+        StringBuilder azCommand = new StringBuilder("azd auth token --output json --scope ");
+
+        String scopes = ScopeUtil.scopesToResource(request.getScopes());
+
+        try {
+            ScopeUtil.validateScope(scopes);
+        } catch (IllegalArgumentException ex) {
+            return Mono.error(LOGGER.logExceptionAsError(ex));
+        }
+
+        azCommand.append(scopes + "/.default");
+
+        AccessToken token;
+        try {
+            String starter;
+            String switcher;
+            if (isWindowsPlatform()) {
+                starter = WINDOWS_STARTER;
+                switcher = WINDOWS_SWITCHER;
+            } else {
+                starter = LINUX_MAC_STARTER;
+                switcher = LINUX_MAC_SWITCHER;
+            }
+
+            ProcessBuilder builder = new ProcessBuilder(starter, switcher, azCommand.toString());
+
+            String workingDirectory = getSafeWorkingDirectory();
+            if (workingDirectory != null) {
+                builder.directory(new File(workingDirectory));
+            } else {
+                throw LOGGER.logExceptionAsError(
+                    new IllegalStateException(
+                        "A Safe Working directory could not be" + " found to execute Azure Developer CLI command from."
+                    )
+                );
+            }
+            builder.redirectErrorStream(true);
+            Process process = builder.start();
+
+            StringBuilder output = new StringBuilder();
+            try (
+                BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8.name())
+                )
+            ) {
+                String line;
+                while (true) {
+                    line = reader.readLine();
+                    if (line == null) {
+                        break;
+                    }
+
+                    if (
+                        line.startsWith(WINDOWS_PROCESS_ERROR_MESSAGE) ||
+                        LINUX_MAC_PROCESS_ERROR_MESSAGE.matcher(line).matches()
+                    ) {
+                        throw LoggingUtil.logCredentialUnavailableException(
+                            LOGGER,
+                            identityClientOptions,
+                            new CredentialUnavailableException(
+                                "AzureCliCredential authentication unavailable. Azure CLI not installed." +
+                                "To mitigate this issue, please refer to the troubleshooting guidelines here at " +
+                                "https://aka.ms/azsdk/java/identity/azclicredential/troubleshoot"
+                            )
+                        );
+                    }
+                    output.append(line);
+                }
+            }
+            String processOutput = output.toString();
+
+            process.waitFor(10, TimeUnit.SECONDS);
+
+            if (process.exitValue() != 0) {
+                if (processOutput.length() > 0) {
+                    String redactedOutput = redactInfo(processOutput);
+                    if (redactedOutput.contains("azd login") || redactedOutput.contains("not logged in")) {
+                        throw LoggingUtil.logCredentialUnavailableException(
+                            LOGGER,
+                            identityClientOptions,
+                            new CredentialUnavailableException(
+                                "AzureCliCredential authentication unavailable." +
+                                " Please run 'azd login' to set up account."
+                            )
+                        );
+                    }
+                    throw LOGGER.logExceptionAsError(new ClientAuthenticationException(redactedOutput, null));
+                } else {
+                    throw LOGGER.logExceptionAsError(new ClientAuthenticationException("Failed to invoke Azure CLI ", null));
+                }
+            }
+
+            LOGGER.verbose(
+                "Azure CLI Authentication => A token response was received from Azure Developer CLI, deserializing the" +
+                " response into an Access Token."
+            );
+            Map<String, String> objectMap = SERIALIZER_ADAPTER.deserialize(
+                processOutput,
+                Map.class,
+                SerializerEncoding.JSON
+            );
+            String accessToken = objectMap.get("token");
+            String time = objectMap.get("expiresOn");
+            // az expiresOn format = "2022-11-30 02:38:42.000000" vs
+            // azd expiresOn format = "2022-11-30T02:05:08Z"
+            String standartTime = time.substring(0, time.indexOf("Z"));
+            OffsetDateTime expiresOn = LocalDateTime
+                .parse(standartTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                .atZone(ZoneId.systemDefault())
+                .toOffsetDateTime()
+                .withOffsetSameInstant(ZoneOffset.UTC);
+            token = new AccessToken(accessToken, expiresOn);
+        } catch (IOException | InterruptedException e) {
+            throw LOGGER.logExceptionAsError(new IllegalStateException(e));
+        } catch (RuntimeException e) {
+            return Mono.error(
+                e instanceof CredentialUnavailableException
+                    ? LoggingUtil.logCredentialUnavailableException(
+                        LOGGER,
+                        identityClientOptions,
+                        (CredentialUnavailableException) e
+                    )
+                    : LOGGER.logExceptionAsError(e)
+            );
+        }
+
+        return Mono.just(token);
+    }
+
+    private boolean isWindowsPlatform() {
+        return System.getProperty("os.name").contains("Windows");
+    }
+
+    private String getSafeWorkingDirectory() {
+        if (isWindowsPlatform()) {
+            if (CoreUtils.isNullOrEmpty(DEFAULT_WINDOWS_SYSTEM_ROOT)) {
+                return null;
+            }
+            return DEFAULT_WINDOWS_SYSTEM_ROOT + "\\system32";
+        } else {
+            return DEFAULT_MAC_LINUX_PATH;
+        }
+    }
+
+    private String redactInfo(String input) {
+        return ACCESS_TOKEN_PATTERN.matcher(input).replaceAll("****");
+    }
+}

--- a/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
+++ b/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
@@ -175,9 +175,9 @@ public class AzureDeveloperCliCredential implements TokenCredential {
             String time = objectMap.get("expiresOn");
             // az expiresOn format = "2022-11-30 02:38:42.000000" vs
             // azd expiresOn format = "2022-11-30T02:05:08Z"
-            String standartTime = time.substring(0, time.indexOf("Z"));
+            String standardTime = time.substring(0, time.indexOf("Z"));
             OffsetDateTime expiresOn = LocalDateTime
-                .parse(standartTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                .parse(standardTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
                 .atZone(ZoneId.systemDefault())
                 .toOffsetDateTime()
                 .withOffsetSameInstant(ZoneOffset.UTC);

--- a/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
+++ b/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
@@ -70,7 +70,7 @@ public class AzureDeveloperCliCredential implements TokenCredential {
     }
 
     private Mono<AccessToken> authenticateWithAzureDeveloperCli(TokenRequestContext request) {
-        StringBuilder azCommand = new StringBuilder("azd auth token --output json --scope ");
+        StringBuilder azdCommand = new StringBuilder("azd auth token --output json --scope ");
 
         var scopes = request.getScopes();
 
@@ -96,7 +96,7 @@ public class AzureDeveloperCliCredential implements TokenCredential {
                 switcher = LINUX_MAC_SWITCHER;
             }
 
-            ProcessBuilder builder = new ProcessBuilder(starter, switcher, azCommand.toString());
+            ProcessBuilder builder = new ProcessBuilder(starter, switcher, azdCommand.toString());
 
             String workingDirectory = getSafeWorkingDirectory();
             if (workingDirectory != null) {
@@ -143,8 +143,6 @@ public class AzureDeveloperCliCredential implements TokenCredential {
             }
             String processOutput = output.toString();
 
-            process.waitFor(10, TimeUnit.SECONDS);
-
             if (process.exitValue() != 0) {
                 if (processOutput.length() > 0) {
                     String redactedOutput = redactInfo(processOutput);
@@ -184,7 +182,7 @@ public class AzureDeveloperCliCredential implements TokenCredential {
                 .toOffsetDateTime()
                 .withOffsetSameInstant(ZoneOffset.UTC);
             token = new AccessToken(accessToken, expiresOn);
-        } catch (IOException | InterruptedException e) {
+        } catch (IOException e) {
             throw LOGGER.logExceptionAsError(new IllegalStateException(e));
         } catch (RuntimeException e) {
             return Mono.error(

--- a/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
+++ b/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
@@ -72,7 +72,7 @@ public class AzureDeveloperCliCredential implements TokenCredential {
     private Mono<AccessToken> authenticateWithAzureCli(TokenRequestContext request) {
         StringBuilder azCommand = new StringBuilder("azd auth token --output json --scope ");
 
-        String scopes = ScopeUtil.scopesToResource(request.getScopes());
+        var scopes = String.join(" ", request.getScopes());
 
         try {
             ScopeUtil.validateScope(scopes);
@@ -80,7 +80,7 @@ public class AzureDeveloperCliCredential implements TokenCredential {
             return Mono.error(LOGGER.logExceptionAsError(ex));
         }
 
-        azCommand.append(scopes + "/.default");
+        azCommand.append(scopes);
 
         AccessToken token;
         try {

--- a/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
+++ b/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
@@ -72,7 +72,7 @@ public class AzureDeveloperCliCredential implements TokenCredential {
     private Mono<AccessToken> authenticateWithAzureCli(TokenRequestContext request) {
         StringBuilder azCommand = new StringBuilder("azd auth token --output json --scope ");
 
-        var scopes = String.join(" ", request.getScopes());
+        var scopes = String.join(" --scope ", request.getScopes());
 
         try {
             ScopeUtil.validateScope(scopes);

--- a/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/ConfigurationSources.java
+++ b/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/ConfigurationSources.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+package com.microsoft.azure.simpletodo.configuration;
+
+import com.azure.core.annotation.Immutable;
+import com.azure.identity.ChainedTokenCredentialBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.security.keyvault.secrets.SecretClientBuilder;
+
+/**
+ * A wrapper accessing configuration from external sources like Azure Key Vault.
+ */
+@Immutable
+public class ConfigurationSources {
+
+    /**
+     * A source for getting configuration from Azure Key Vault Secrets
+     */
+    public class KeyVaultSecrets {
+
+        // Create a key vault secret client to fetch the secret
+        // Set azdTokenCredential as the first credential
+        public static String get(String keyVaultUrl, String configName) {
+            var credential = new ChainedTokenCredentialBuilder()
+                .addFirst(new AzureDeveloperCliCredential())
+                .addLast(new DefaultAzureCredentialBuilder().build())
+                .build();
+            var secretClient = new SecretClientBuilder().vaultUrl(keyVaultUrl).credential(credential).buildClient();
+            var secret = secretClient.getSecret(configName);
+            return secret.getValue();
+        }
+    }
+}

--- a/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/MongoDBConfiguration.java
+++ b/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/MongoDBConfiguration.java
@@ -29,7 +29,7 @@ public class MongoDBConfiguration {
 
     @Bean
     public MongoClientSettingsBuilderCustomizer customizer(
-        @Value("${custom.azure.keyvault.secret.endpoint}") String keyVaultSettings
+        @Value("${custom.azure.keyvault.secret.mongodb}") String keyVaultSettings
     ) {
         var config = keyVaultSettings.split(",", 0);
         var connString = ConfigurationSources.KeyVaultSecrets.get(config[0], config[1]);

--- a/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/MongoDBConfiguration.java
+++ b/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/MongoDBConfiguration.java
@@ -1,9 +1,17 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
 package com.microsoft.azure.simpletodo.configuration;
 
+import com.mongodb.ConnectionString;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.mongo.MongoClientSettingsBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
@@ -17,6 +25,16 @@ public class MongoDBConfiguration {
         return new MongoCustomConversions(
             Arrays.asList(new OffsetDateTimeReadConverter(), new OffsetDateTimeWriteConverter())
         );
+    }
+
+    @Bean
+    public MongoClientSettingsBuilderCustomizer customizer(
+        @Value("${custom.azure.keyvault.secret.endpoint}") String keyVaultSettings
+    ) {
+        var config = keyVaultSettings.split(",", 0);
+        var connString = ConfigurationSources.KeyVaultSecrets.get(config[0], config[1]);
+        ConnectionString connection = new ConnectionString(connString);
+        return settings -> settings.applyConnectionString(connection);
     }
 
     static class OffsetDateTimeWriteConverter implements Converter<OffsetDateTime, Date> {

--- a/templates/todo/api/java/src/main/resources/application.properties
+++ b/templates/todo/api/java/src/main/resources/application.properties
@@ -3,11 +3,13 @@ server.port=3100
 spring.jackson.date-format=com.microsoft.azure.simpletodo.configuration.RFC3339DateFormat
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false
 
+# Temporally disabling auto-configuration for key vault
 # Import KeyVault secrets as properties
-spring.cloud.azure.keyvault.secret.property-sources[0].enabled=true
-spring.cloud.azure.keyvault.secret.property-sources[0].endpoint=${AZURE_KEY_VAULT_ENDPOINT}
+# spring.cloud.azure.keyvault.secret.property-sources[0].enabled=true
+# spring.cloud.azure.keyvault.secret.property-sources[0].endpoint=${AZURE_KEY_VAULT_ENDPOINT}
+custom.azure.keyvault.secret.endpoint=${AZURE_KEY_VAULT_ENDPOINT},AZURE-COSMOS-CONNECTION-STRING
 
-spring.data.mongodb.uri=${AZURE_COSMOS_CONNECTION_STRING:#{null}}
+#spring.data.mongodb.uri=${AZURE_COSMOS_CONNECTION_STRING:#{null}}
 spring.data.mongodb.database=todo
 
 springdoc.swagger-ui.use-root-path=true

--- a/templates/todo/api/java/src/main/resources/application.properties
+++ b/templates/todo/api/java/src/main/resources/application.properties
@@ -7,7 +7,7 @@ spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false
 # Import KeyVault secrets as properties
 # spring.cloud.azure.keyvault.secret.property-sources[0].enabled=true
 # spring.cloud.azure.keyvault.secret.property-sources[0].endpoint=${AZURE_KEY_VAULT_ENDPOINT}
-custom.azure.keyvault.secret.endpoint=${AZURE_KEY_VAULT_ENDPOINT},AZURE-COSMOS-CONNECTION-STRING
+custom.azure.keyvault.secret.mongodb=${AZURE_KEY_VAULT_ENDPOINT},AZURE-COSMOS-CONNECTION-STRING
 
 #spring.data.mongodb.uri=${AZURE_COSMOS_CONNECTION_STRING:#{null}}
 spring.data.mongodb.database=todo


### PR DESCRIPTION
Updates Java template to:
- Disable auto-configuration from Key Vault to pull secrets as application properties during spring boot initialization.
- Disable auto-configuration for mongodb url
- Adds a customizer `@bean` for setting the mongodb url
  - Creates Key Vault secrets client manually using the Azure Developer CLI Token Credential