### PR TITLE
Add `array` types to lists

### DIFF
--- a/templates/todo/api/common/openapi.yaml
+++ b/templates/todo/api/common/openapi.yaml
@@ -115,6 +115,7 @@ components:
       content:
         application/json:
           schema:
+            type: array
             items:
               $ref: "#/components/schemas/TodoList"
     TodoItem:
@@ -128,6 +129,7 @@ components:
       content:
         application/json:
           schema:
+            type: array
             items:
               $ref: "#/components/schemas/TodoItem"
 


### PR DESCRIPTION
The `TodoListArray` and the `TodoItemArray` are missing, `type: array`, which causes client code generation to fail.