### PR TITLE
Support redirect port for azd login

### DIFF
--- a/cli/azd/cmd/login.go
+++ b/cli/azd/cmd/login.go
@@ -32,6 +32,7 @@ type loginFlags struct {
 	clientCertificate      string
 	federatedToken         stringPtr
 	federatedTokenProvider string
+	redirectPort           int
 	global                 *internal.GlobalCommandOptions
 }
 
@@ -95,6 +96,7 @@ func (lf *loginFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandO
 		"",
 		"The provider to use to acquire a federated token to authenticate with.")
 	local.StringVar(&lf.tenantID, "tenant-id", "", "The tenant id for the service principal to authenticate with.")
+	local.IntVar(&lf.redirectPort, "redirect-port", 0, "Choose the port to use when doing interactive login.")
 
 	output.AddOutputFlag(
 		local,
@@ -285,7 +287,7 @@ func (la *loginAction) login(ctx context.Context) error {
 			return fmt.Errorf("logging in: %w", err)
 		}
 	} else {
-		if _, err := la.authManager.LoginInteractive(ctx); err != nil {
+		if _, err := la.authManager.LoginInteractive(ctx, la.flags.redirectPort); err != nil {
 			return fmt.Errorf("logging in: %w", err)
 		}
 	}

--- a/cli/azd/cmd/login.go
+++ b/cli/azd/cmd/login.go
@@ -96,7 +96,7 @@ func (lf *loginFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandO
 		"",
 		"The provider to use to acquire a federated token to authenticate with.")
 	local.StringVar(&lf.tenantID, "tenant-id", "", "The tenant id for the service principal to authenticate with.")
-	local.IntVar(&lf.redirectPort, "redirect-port", 0, "Choose the port to use when doing interactive login.")
+	local.IntVar(&lf.redirectPort, "redirect-port", 0, "Choose the port to be used as part of the redirect URI during interactive login.")
 
 	output.AddOutputFlag(
 		local,

--- a/cli/azd/cmd/login.go
+++ b/cli/azd/cmd/login.go
@@ -96,7 +96,11 @@ func (lf *loginFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandO
 		"",
 		"The provider to use to acquire a federated token to authenticate with.")
 	local.StringVar(&lf.tenantID, "tenant-id", "", "The tenant id for the service principal to authenticate with.")
-	local.IntVar(&lf.redirectPort, "redirect-port", 0, "Choose the port to be used as part of the redirect URI during interactive login.")
+	local.IntVar(
+		&lf.redirectPort,
+		"redirect-port",
+		0,
+		"Choose the port to be used as part of the redirect URI during interactive login.")
 
 	output.AddOutputFlag(
 		local,

--- a/cli/azd/cmd/testdata/TestUsage-azd-login.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-login.snap
@@ -10,7 +10,7 @@ Flags:
       --federated-credential-provider string   The provider to use to acquire a federated token to authenticate with.
   -h, --help                                   Gets help for login.
   -o, --output string                          The output format (the supported formats are json, none). (default "none")
-      --redirect-port int                      Choose the port to use when doing interactive login.
+      --redirect-port int                      Choose the port to be used as part of the redirect URI during interactive login.
       --tenant-id string                       The tenant id for the service principal to authenticate with.
       --use-device-code                        When true, log in by using a device code instead of a browser.
 

--- a/cli/azd/cmd/testdata/TestUsage-azd-login.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-login.snap
@@ -10,6 +10,7 @@ Flags:
       --federated-credential-provider string   The provider to use to acquire a federated token to authenticate with.
   -h, --help                                   Gets help for login.
   -o, --output string                          The output format (the supported formats are json, none). (default "none")
+      --redirect-port int                      Choose the port to use when doing interactive login.
       --tenant-id string                       The tenant id for the service principal to authenticate with.
       --use-device-code                        When true, log in by using a device code instead of a browser.
 

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -197,8 +197,12 @@ func (m *Manager) CredentialForCurrentUser(ctx context.Context) (azcore.TokenCre
 	return nil, ErrNoCurrentUser
 }
 
-func (m *Manager) LoginInteractive(ctx context.Context) (azcore.TokenCredential, error) {
-	res, err := m.publicClient.AcquireTokenInteractive(ctx, cLoginScopes)
+func (m *Manager) LoginInteractive(ctx context.Context, redirectPort int) (azcore.TokenCredential, error) {
+	options := []public.InteractiveAuthOption{}
+	if redirectPort > 0 {
+		options = append(options, public.WithRedirectURI(fmt.Sprintf("http://localhost:%d", redirectPort)))
+	}
+	res, err := m.publicClient.AcquireTokenInteractive(ctx, cLoginScopes, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/pkg/auth/manager_test.go
+++ b/cli/azd/pkg/auth/manager_test.go
@@ -218,7 +218,7 @@ func TestLoginInteractive(t *testing.T) {
 		publicClient:  &mockPublicClient{},
 	}
 
-	cred, err := m.LoginInteractive(context.Background())
+	cred, err := m.LoginInteractive(context.Background(), 0)
 
 	require.NoError(t, err)
 	require.IsType(t, new(azdCredential), cred)


### PR DESCRIPTION
This PR adds a new parameter `redirect-port` for `azd login` which can be used to define the port to use after doing an interactive web browser authentication.

The default behavior (when this new arg is not set, or is set to 0) is to let `azd` to automatically select an available port.
 
But, in some cases, customers might want to define the port to be used for convenience. For example:
- When using codespaces, customers can create a `port redirect` before calling `azd login`.
- When using remote-ssh connection, similarly, customers don't need to wait for the url redirect from `azd login` to discover the port that azd is using.
- When using a `dev-tunnel`, each new `port redirect` requires approving the connections thru the tunnel (the first time it is used). This approval ends up as an invalid response to the `MSAL client` on azd waiting for the token response and `azd` fails to complete login.  So, if the port is known in advance, customer can approve the connection before calling `azd login` and use the already approved tunnel to complete the login