### PR TITLE
Suppress offer to modify tasks.json

### DIFF
--- a/templates/todo/projects/csharp-sql-swa-func/.vscode/settings.json
+++ b/templates/todo/projects/csharp-sql-swa-func/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "azureFunctions.showProjectWarning": false
+}


### PR DESCRIPTION
The Azure Functions VS Code extension will offer to add Functions-specific tasks to tasks.json when the workspace is open in VS Code. The problem is, if the user agrees, the Azure Functions extension will overwrite the "API Functions Run" task that is necessary for local application run/debugging, rendering the local app run impossible.

See https://github.com/microsoft/vscode-azurefunctions/issues/3469 for more details about the issue.