### PR TITLE
Default to deviceCode on Codespaces

### DIFF
--- a/cli/azd/cmd/login.go
+++ b/cli/azd/cmd/login.go
@@ -70,7 +70,10 @@ func (lf *loginFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandO
 	local.BoolVar(
 		&lf.useDeviceCode,
 		"use-device-code",
-		false,
+		// For Codespaces in VSCode Browser, interactive browser login will 404 when attempting to redirect to localhost
+		// (since azd cannot launch a localhost server when running remotely).
+		// Hence, we default to device-code. See https://github.com/Azure/azure-dev/issues/1006
+		os.Getenv("CODESPACES") == "true",
 		"When true, log in by using a device code instead of a browser.",
 	)
 	local.StringVar(&lf.clientID, "client-id", "", "The client id for the service principal to authenticate with.")


### PR DESCRIPTION
For users running Codespaces in browsers, interactive login does not work due to the localhost server being launched remotely with no forwarding. See #1006.

This switches the default login on Codespaces to device-code based which circumvents the need for the login redirect. User can still opt-out of decide-code via `azd login --use-device-code=false`.
