### PR TITLE
Standardize naming for mock packages

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -15,6 +15,10 @@ words:
   - Retryable
   - Canonicalize
   - devcontainers
+languageSettings:
+  - languageId: go
+    ignoreRegExpList:
+      - /mock.*/
 dictionaryDefinitions:
   - name: azdProjectDictionary
     path: ./cspell-azd-dictionary.txt

--- a/cli/azd/pkg/commands/pipeline/azdo_provider_test.go
+++ b/cli/azd/pkg/commands/pipeline/azdo_provider_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
-	"github.com/azure/azure-dev/cli/azd/test/mocks/console"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
 	"github.com/azure/azure-dev/cli/azd/test/ostest"
 	"github.com/stretchr/testify/require"
 )
@@ -87,7 +87,7 @@ func Test_azdo_scm_provider_preConfigureCheck(t *testing.T) {
 		provider := getEmptyAzdoScmProviderTestHarness()
 		t.Setenv(azdo.AzDoEnvironmentOrgName, "testOrg")
 		t.Setenv(azdo.AzDoPatName, testPat)
-		testConsole := console.NewMockConsole()
+		testConsole := mockinput.NewMockConsole()
 		ctx := context.Background()
 
 		// act
@@ -102,7 +102,7 @@ func Test_azdo_scm_provider_preConfigureCheck(t *testing.T) {
 		ostest.Unsetenv(t, azdo.AzDoPatName)
 		ostest.Setenv(t, azdo.AzDoEnvironmentOrgName, "testOrg")
 		provider := getEmptyAzdoScmProviderTestHarness()
-		testConsole := console.NewMockConsole()
+		testConsole := mockinput.NewMockConsole()
 		testPat := "testPAT12345"
 		testConsole.WhenPrompt(func(options input.ConsoleOptions) bool {
 			return options.Message == "Personal Access Token (PAT):"
@@ -123,7 +123,7 @@ func Test_azdo_ci_provider_preConfigureCheck(t *testing.T) {
 	t.Run("success with default options", func(t *testing.T) {
 		ctx := context.Background()
 		provider := getAzdoCiProviderTestHarness()
-		testConsole := console.NewMockConsole()
+		testConsole := mockinput.NewMockConsole()
 		testPat := "testPAT12345"
 		testConsole.WhenPrompt(func(options input.ConsoleOptions) bool {
 			return options.Message == "Personal Access Token (PAT):"
@@ -140,7 +140,7 @@ func Test_azdo_ci_provider_preConfigureCheck(t *testing.T) {
 	t.Run("fails if auth type is set to federated", func(t *testing.T) {
 		ctx := context.Background()
 		provider := getAzdoCiProviderTestHarness()
-		testConsole := console.NewMockConsole()
+		testConsole := mockinput.NewMockConsole()
 
 		pipelineManagerArgs := PipelineManagerArgs{
 			PipelineAuthTypeName: string(AuthTypeFederated),

--- a/cli/azd/pkg/graphsdk/application_request_builders_test.go
+++ b/cli/azd/pkg/graphsdk/application_request_builders_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
-	graphsdk_mocks "github.com/azure/azure-dev/cli/azd/test/mocks/graphsdk"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockgraphsdk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,9 +34,9 @@ func TestGetApplicationList(t *testing.T) {
 		expected := append([]graphsdk.Application{}, applications...)
 
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationListMock(mockContext, http.StatusOK, expected)
+		mockgraphsdk.RegisterApplicationListMock(mockContext, http.StatusOK, expected)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		apps, err := client.Applications().Get(*mockContext.Context)
@@ -47,9 +47,9 @@ func TestGetApplicationList(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationListMock(mockContext, http.StatusUnauthorized, nil)
+		mockgraphsdk.RegisterApplicationListMock(mockContext, http.StatusUnauthorized, nil)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		res, err := client.
@@ -66,9 +66,9 @@ func TestGetApplicationById(t *testing.T) {
 		expected := applications[0]
 
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationGetItemMock(mockContext, http.StatusOK, *expected.Id, &expected)
+		mockgraphsdk.RegisterApplicationGetItemMock(mockContext, http.StatusOK, *expected.Id, &expected)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		actual, err := client.
@@ -84,9 +84,9 @@ func TestGetApplicationById(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationGetItemMock(mockContext, http.StatusNotFound, "bad-id", nil)
+		mockgraphsdk.RegisterApplicationGetItemMock(mockContext, http.StatusNotFound, "bad-id", nil)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		res, err := client.
@@ -103,9 +103,9 @@ func TestCreateApplication(t *testing.T) {
 		expected := applications[0]
 
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationCreateItemMock(mockContext, http.StatusCreated, &expected)
+		mockgraphsdk.RegisterApplicationCreateItemMock(mockContext, http.StatusCreated, &expected)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		actual, err := client.
@@ -121,9 +121,9 @@ func TestCreateApplication(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationCreateItemMock(mockContext, http.StatusBadRequest, nil)
+		mockgraphsdk.RegisterApplicationCreateItemMock(mockContext, http.StatusBadRequest, nil)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		res, err := client.
@@ -140,9 +140,9 @@ func TestDeleteApplication(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationDeleteItemMock(mockContext, applicationId, http.StatusNoContent)
+		mockgraphsdk.RegisterApplicationDeleteItemMock(mockContext, applicationId, http.StatusNoContent)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		err = client.
@@ -154,9 +154,9 @@ func TestDeleteApplication(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationDeleteItemMock(mockContext, applicationId, http.StatusNotFound)
+		mockgraphsdk.RegisterApplicationDeleteItemMock(mockContext, applicationId, http.StatusNotFound)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		err = client.
@@ -181,9 +181,9 @@ func TestApplicationAddPassword(t *testing.T) {
 		}
 
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationAddPasswordMock(mockContext, http.StatusOK, *application.Id, &mockCredential)
+		mockgraphsdk.RegisterApplicationAddPasswordMock(mockContext, http.StatusOK, *application.Id, &mockCredential)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		actual, err := client.
@@ -199,9 +199,9 @@ func TestApplicationAddPassword(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationAddPasswordMock(mockContext, http.StatusNotFound, "bad-app-id", nil)
+		mockgraphsdk.RegisterApplicationAddPasswordMock(mockContext, http.StatusNotFound, "bad-app-id", nil)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		actual, err := client.
@@ -218,9 +218,9 @@ func TestApplicationRemovePassword(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationRemovePasswordMock(mockContext, http.StatusNoContent, *application.Id)
+		mockgraphsdk.RegisterApplicationRemovePasswordMock(mockContext, http.StatusNoContent, *application.Id)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		err = client.
@@ -232,9 +232,9 @@ func TestApplicationRemovePassword(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationRemovePasswordMock(mockContext, http.StatusNotFound, *application.Id)
+		mockgraphsdk.RegisterApplicationRemovePasswordMock(mockContext, http.StatusNotFound, *application.Id)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		err = client.ApplicationById(*application.Id).RemovePassword(*mockContext.Context, "bad-key-id")

--- a/cli/azd/pkg/graphsdk/entity_list_request_builder_test.go
+++ b/cli/azd/pkg/graphsdk/entity_list_request_builder_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
-	graphsdk_mocks "github.com/azure/azure-dev/cli/azd/test/mocks/graphsdk"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockgraphsdk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,9 +28,9 @@ func TestEntityListRequestBuilder(t *testing.T) {
 
 	t.Run("WithProperties", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationListMock(mockContext, http.StatusOK, applications)
+		mockgraphsdk.RegisterApplicationListMock(mockContext, http.StatusOK, applications)
 
-		graphClient, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		graphClient, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		expectedFilter := "displayName eq 'APPLICATION'"
@@ -51,9 +51,9 @@ func TestEntityListRequestBuilder(t *testing.T) {
 
 	t.Run("NoProperties", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationListMock(mockContext, http.StatusOK, applications)
+		mockgraphsdk.RegisterApplicationListMock(mockContext, http.StatusOK, applications)
 
-		graphClient, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		graphClient, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		appRequestBuilder := graphsdk.NewApplicationListRequestBuilder(graphClient)

--- a/cli/azd/pkg/graphsdk/fic_request_builders_test.go
+++ b/cli/azd/pkg/graphsdk/fic_request_builders_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
-	graphsdk_mocks "github.com/azure/azure-dev/cli/azd/test/mocks/graphsdk"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockgraphsdk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,9 +45,9 @@ func TestGetFederatedCredentialList(t *testing.T) {
 		expected := append([]graphsdk.FederatedIdentityCredential{}, federatedCredentials...)
 
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterFederatedCredentialsListMock(mockContext, *application.Id, http.StatusOK, expected)
+		mockgraphsdk.RegisterFederatedCredentialsListMock(mockContext, *application.Id, http.StatusOK, expected)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		res, err := client.
@@ -62,9 +62,9 @@ func TestGetFederatedCredentialList(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterFederatedCredentialsListMock(mockContext, *application.Id, http.StatusUnauthorized, nil)
+		mockgraphsdk.RegisterFederatedCredentialsListMock(mockContext, *application.Id, http.StatusUnauthorized, nil)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		res, err := client.
@@ -82,7 +82,7 @@ func TestGetFederatedCredentialById(t *testing.T) {
 		expected := federatedCredentials[0]
 
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterFederatedCredentialGetItemMock(
+		mockgraphsdk.RegisterFederatedCredentialGetItemMock(
 			mockContext,
 			*application.Id,
 			*expected.Id,
@@ -90,7 +90,7 @@ func TestGetFederatedCredentialById(t *testing.T) {
 			&expected,
 		)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		actual, err := client.
@@ -107,7 +107,7 @@ func TestGetFederatedCredentialById(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterFederatedCredentialGetItemMock(
+		mockgraphsdk.RegisterFederatedCredentialGetItemMock(
 			mockContext,
 			*application.Id,
 			"bad-id",
@@ -115,7 +115,7 @@ func TestGetFederatedCredentialById(t *testing.T) {
 			nil,
 		)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		res, err := client.
@@ -133,9 +133,9 @@ func TestCreateFederatedCredential(t *testing.T) {
 		expected := federatedCredentials[0]
 
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterFederatedCredentialCreateItemMock(mockContext, *application.Id, http.StatusCreated, &expected)
+		mockgraphsdk.RegisterFederatedCredentialCreateItemMock(mockContext, *application.Id, http.StatusCreated, &expected)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		actual, err := client.ApplicationById(*application.Id).
@@ -150,9 +150,9 @@ func TestCreateFederatedCredential(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterFederatedCredentialCreateItemMock(mockContext, *application.Id, http.StatusBadRequest, nil)
+		mockgraphsdk.RegisterFederatedCredentialCreateItemMock(mockContext, *application.Id, http.StatusBadRequest, nil)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		res, err := client.
@@ -170,14 +170,14 @@ func TestPatchFederatedCredential(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterFederatedCredentialPatchItemMock(
+		mockgraphsdk.RegisterFederatedCredentialPatchItemMock(
 			mockContext,
 			*application.Id,
 			*expected.Id,
 			http.StatusNoContent,
 		)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		err = client.
@@ -190,14 +190,14 @@ func TestPatchFederatedCredential(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterFederatedCredentialPatchItemMock(
+		mockgraphsdk.RegisterFederatedCredentialPatchItemMock(
 			mockContext,
 			*application.Id,
 			*expected.Id,
 			http.StatusBadRequest,
 		)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		err = client.
@@ -214,14 +214,14 @@ func TestDeleteFederatedCredential(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterFederatedCredentialDeleteItemMock(
+		mockgraphsdk.RegisterFederatedCredentialDeleteItemMock(
 			mockContext,
 			*application.Id,
 			credentialId,
 			http.StatusNoContent,
 		)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		err = client.
@@ -234,14 +234,14 @@ func TestDeleteFederatedCredential(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterFederatedCredentialDeleteItemMock(
+		mockgraphsdk.RegisterFederatedCredentialDeleteItemMock(
 			mockContext,
 			*application.Id,
 			credentialId,
 			http.StatusNotFound,
 		)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		err = client.

--- a/cli/azd/pkg/graphsdk/graph_client_test.go
+++ b/cli/azd/pkg/graphsdk/graph_client_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
-	graphsdk_mocks "github.com/azure/azure-dev/cli/azd/test/mocks/graphsdk"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockgraphsdk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +15,7 @@ import (
 // acquiring token or DNS issues (host not found)
 func Test_GraphClientRequest_With_Preflight_Error(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
-	client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+	client, err := mockgraphsdk.CreateGraphClient(mockContext)
 	require.NoError(t, err)
 	require.NotNil(t, client)
 

--- a/cli/azd/pkg/graphsdk/me_request_builder_test.go
+++ b/cli/azd/pkg/graphsdk/me_request_builder_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
-	graphsdk_mocks "github.com/azure/azure-dev/cli/azd/test/mocks/graphsdk"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockgraphsdk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,9 +23,9 @@ func TestGetMe(t *testing.T) {
 		}
 
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterMeGetMock(mockContext, http.StatusOK, &expected)
+		mockgraphsdk.RegisterMeGetMock(mockContext, http.StatusOK, &expected)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		actual, err := client.Me().Get(*mockContext.Context)
@@ -36,9 +36,9 @@ func TestGetMe(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterMeGetMock(mockContext, http.StatusUnauthorized, nil)
+		mockgraphsdk.RegisterMeGetMock(mockContext, http.StatusUnauthorized, nil)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		actual, err := client.Me().Get(*mockContext.Context)

--- a/cli/azd/pkg/graphsdk/service_principal_request_builders_test.go
+++ b/cli/azd/pkg/graphsdk/service_principal_request_builders_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
-	graphsdk_mocks "github.com/azure/azure-dev/cli/azd/test/mocks/graphsdk"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockgraphsdk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,9 +32,9 @@ func TestGetServicePrincipalList(t *testing.T) {
 		expected := append([]graphsdk.ServicePrincipal{}, servicePrincipals...)
 
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterServicePrincipalListMock(mockContext, http.StatusOK, expected)
+		mockgraphsdk.RegisterServicePrincipalListMock(mockContext, http.StatusOK, expected)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		servicePrincipals, err := client.
@@ -48,9 +48,9 @@ func TestGetServicePrincipalList(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterServicePrincipalListMock(mockContext, http.StatusUnauthorized, nil)
+		mockgraphsdk.RegisterServicePrincipalListMock(mockContext, http.StatusUnauthorized, nil)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		res, err := client.
@@ -67,9 +67,9 @@ func TestGetServicePrincipalById(t *testing.T) {
 		expected := servicePrincipals[0]
 
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterServicePrincipalGetItemMock(mockContext, http.StatusOK, *expected.Id, &expected)
+		mockgraphsdk.RegisterServicePrincipalGetItemMock(mockContext, http.StatusOK, *expected.Id, &expected)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		actual, err := client.
@@ -85,9 +85,9 @@ func TestGetServicePrincipalById(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterServicePrincipalGetItemMock(mockContext, http.StatusNotFound, "bad-id", nil)
+		mockgraphsdk.RegisterServicePrincipalGetItemMock(mockContext, http.StatusNotFound, "bad-id", nil)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		res, err := client.
@@ -104,9 +104,9 @@ func TestCreateServicePrincipal(t *testing.T) {
 		expected := servicePrincipals[0]
 
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterServicePrincipalCreateItemMock(mockContext, http.StatusCreated, &expected)
+		mockgraphsdk.RegisterServicePrincipalCreateItemMock(mockContext, http.StatusCreated, &expected)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		actual, err := client.
@@ -122,9 +122,9 @@ func TestCreateServicePrincipal(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterServicePrincipalCreateItemMock(mockContext, http.StatusBadRequest, nil)
+		mockgraphsdk.RegisterServicePrincipalCreateItemMock(mockContext, http.StatusBadRequest, nil)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		res, err := client.
@@ -142,9 +142,9 @@ func TestDeleteServicePrincipal(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterServicePrincipalDeleteItemMock(mockContext, servicePrincipalId, http.StatusNoContent)
+		mockgraphsdk.RegisterServicePrincipalDeleteItemMock(mockContext, servicePrincipalId, http.StatusNoContent)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		err = client.
@@ -156,9 +156,9 @@ func TestDeleteServicePrincipal(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterServicePrincipalDeleteItemMock(mockContext, servicePrincipalId, http.StatusNotFound)
+		mockgraphsdk.RegisterServicePrincipalDeleteItemMock(mockContext, servicePrincipalId, http.StatusNotFound)
 
-		client, err := graphsdk_mocks.CreateGraphClient(mockContext)
+		client, err := mockgraphsdk.CreateGraphClient(mockContext)
 		require.NoError(t, err)
 
 		err = client.

--- a/cli/azd/pkg/graphsdk/util_test.go
+++ b/cli/azd/pkg/graphsdk/util_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
-	graphsdk_mocks "github.com/azure/azure-dev/cli/azd/test/mocks/graphsdk"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockgraphsdk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,7 +45,7 @@ func TestNewPipeline(t *testing.T) {
 		},
 	}
 
-	clientOptions := graphsdk_mocks.CreateDefaultClientOptions(mockContext)
+	clientOptions := mockgraphsdk.CreateDefaultClientOptions(mockContext)
 	pipeline := graphsdk.NewPipeline(&credential, graphsdk.ServiceConfig, clientOptions)
 	require.False(t, ran)
 	require.NotNil(t, pipeline)

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
-	execmock "github.com/azure/azure-dev/cli/azd/test/mocks/exec"
-	"github.com/azure/azure-dev/cli/azd/test/mocks/httputil"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazcli"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockexec"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockhttp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -339,7 +339,7 @@ func createBicepProvider(t *testing.T, mockContext *mocks.MockContext) *BicepPro
 	return provider
 }
 
-func prepareGenericMocks(commandRunner *execmock.MockCommandRunner) {
+func prepareGenericMocks(commandRunner *mockexec.MockCommandRunner) {
 	// Setup expected values for exec
 	commandRunner.When(func(args exec.RunArgs, command string) bool {
 		return strings.Contains(command, "az version")
@@ -350,7 +350,7 @@ func prepareGenericMocks(commandRunner *execmock.MockCommandRunner) {
 }
 
 // Sets up all the mocks required for the bicep plan & deploy operation
-func prepareDeployMocks(commandRunner *execmock.MockCommandRunner) {
+func prepareDeployMocks(commandRunner *mockexec.MockCommandRunner) {
 	// Gets deployment progress
 	commandRunner.When(
 		func(args exec.RunArgs, command string) bool {
@@ -417,7 +417,7 @@ func preparePlanningMocks(
 }
 
 func prepareDeployShowMocks(
-	httpClient *httputil.MockHttpClient) {
+	httpClient *mockhttp.MockHttpClient) {
 	expectedWebsiteUrl := "http://myapp.azurewebsites.net"
 
 	deployOutputs := make(map[string]interface{})

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
@@ -15,8 +15,8 @@ import (
 	. "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 
-	execmock "github.com/azure/azure-dev/cli/azd/test/mocks/exec"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazcli"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockexec"
 	"github.com/stretchr/testify/require"
 )
 
@@ -228,7 +228,7 @@ func createTerraformProvider(mockContext *mocks.MockContext) *TerraformProvider 
 	)
 }
 
-func prepareGenericMocks(commandRunner *execmock.MockCommandRunner) {
+func prepareGenericMocks(commandRunner *mockexec.MockCommandRunner) {
 	commandRunner.When(func(args exec.RunArgs, command string) bool {
 		return strings.Contains(command, "terraform version")
 	}).Respond(exec.RunResult{
@@ -238,7 +238,7 @@ func prepareGenericMocks(commandRunner *execmock.MockCommandRunner) {
 
 }
 
-func preparePlanningMocks(commandRunner *execmock.MockCommandRunner) {
+func preparePlanningMocks(commandRunner *mockexec.MockCommandRunner) {
 	commandRunner.When(func(args exec.RunArgs, command string) bool {
 		return args.Cmd == "terraform" && strings.Contains(command, "init")
 	}).Respond(exec.RunResult{
@@ -261,7 +261,7 @@ func preparePlanningMocks(commandRunner *execmock.MockCommandRunner) {
 	})
 }
 
-func prepareDeployMocks(commandRunner *execmock.MockCommandRunner) {
+func prepareDeployMocks(commandRunner *mockexec.MockCommandRunner) {
 	commandRunner.When(func(args exec.RunArgs, command string) bool {
 		return args.Cmd == "terraform" && strings.Contains(command, "validate")
 	}).Respond(exec.RunResult{
@@ -289,7 +289,7 @@ func prepareDeployMocks(commandRunner *execmock.MockCommandRunner) {
 //go:embed testdata/terraform_show_mock.json
 var terraformShowMockOutput string
 
-func prepareShowMocks(commandRunner *execmock.MockCommandRunner) {
+func prepareShowMocks(commandRunner *mockexec.MockCommandRunner) {
 	commandRunner.When(func(args exec.RunArgs, command string) bool {
 		return args.Cmd == "terraform" && strings.Contains(command, "show")
 	}).Respond(exec.RunResult{
@@ -298,7 +298,7 @@ func prepareShowMocks(commandRunner *execmock.MockCommandRunner) {
 	})
 }
 
-func prepareDestroyMocks(commandRunner *execmock.MockCommandRunner) {
+func prepareDestroyMocks(commandRunner *mockexec.MockCommandRunner) {
 	commandRunner.When(func(args exec.RunArgs, command string) bool {
 		return args.Cmd == "terraform" && strings.Contains(command, "init")
 	}).Respond(exec.RunResult{

--- a/cli/azd/pkg/tools/azcli/ad_test.go
+++ b/cli/azd/pkg/tools/azcli/ad_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
-	graphsdk_mocks "github.com/azure/azure-dev/cli/azd/test/mocks/graphsdk"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockgraphsdk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -92,13 +92,13 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 	// Tests the use case for a brand new service principal
 	t.Run("NewServicePrincipal", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationListMock(mockContext, http.StatusOK, []graphsdk.Application{})
-		graphsdk_mocks.RegisterServicePrincipalListMock(mockContext, http.StatusOK, []graphsdk.ServicePrincipal{})
-		graphsdk_mocks.RegisterApplicationCreateItemMock(mockContext, http.StatusCreated, &newApplication)
-		graphsdk_mocks.RegisterServicePrincipalCreateItemMock(mockContext, http.StatusCreated, &servicePrincipal)
-		graphsdk_mocks.RegisterApplicationAddPasswordMock(mockContext, http.StatusOK, *newApplication.Id, credential)
-		graphsdk_mocks.RegisterRoleDefinitionListMock(mockContext, http.StatusOK, roleDefinitions)
-		graphsdk_mocks.RegisterRoleAssignmentPutMock(mockContext, http.StatusCreated)
+		mockgraphsdk.RegisterApplicationListMock(mockContext, http.StatusOK, []graphsdk.Application{})
+		mockgraphsdk.RegisterServicePrincipalListMock(mockContext, http.StatusOK, []graphsdk.ServicePrincipal{})
+		mockgraphsdk.RegisterApplicationCreateItemMock(mockContext, http.StatusCreated, &newApplication)
+		mockgraphsdk.RegisterServicePrincipalCreateItemMock(mockContext, http.StatusCreated, &servicePrincipal)
+		mockgraphsdk.RegisterApplicationAddPasswordMock(mockContext, http.StatusOK, *newApplication.Id, credential)
+		mockgraphsdk.RegisterRoleDefinitionListMock(mockContext, http.StatusOK, roleDefinitions)
+		mockgraphsdk.RegisterRoleAssignmentPutMock(mockContext, http.StatusCreated)
 
 		azCli := newAzCliFromMockContext(mockContext)
 		rawMessage, err := azCli.CreateOrUpdateServicePrincipal(
@@ -116,16 +116,16 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 	// Tests the use case for updating an existing service principal
 	t.Run("ExistingServicePrincipal", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationListMock(mockContext, http.StatusOK, []graphsdk.Application{existingApplication})
-		graphsdk_mocks.RegisterServicePrincipalListMock(
+		mockgraphsdk.RegisterApplicationListMock(mockContext, http.StatusOK, []graphsdk.Application{existingApplication})
+		mockgraphsdk.RegisterServicePrincipalListMock(
 			mockContext,
 			http.StatusOK,
 			[]graphsdk.ServicePrincipal{servicePrincipal},
 		)
-		graphsdk_mocks.RegisterApplicationRemovePasswordMock(mockContext, http.StatusNoContent, *newApplication.Id)
-		graphsdk_mocks.RegisterApplicationAddPasswordMock(mockContext, http.StatusOK, *newApplication.Id, credential)
-		graphsdk_mocks.RegisterRoleDefinitionListMock(mockContext, http.StatusOK, roleDefinitions)
-		graphsdk_mocks.RegisterRoleAssignmentPutMock(mockContext, http.StatusCreated)
+		mockgraphsdk.RegisterApplicationRemovePasswordMock(mockContext, http.StatusNoContent, *newApplication.Id)
+		mockgraphsdk.RegisterApplicationAddPasswordMock(mockContext, http.StatusOK, *newApplication.Id, credential)
+		mockgraphsdk.RegisterRoleDefinitionListMock(mockContext, http.StatusOK, roleDefinitions)
+		mockgraphsdk.RegisterRoleAssignmentPutMock(mockContext, http.StatusCreated)
 
 		azCli := newAzCliFromMockContext(mockContext)
 		rawMessage, err := azCli.CreateOrUpdateServicePrincipal(
@@ -143,17 +143,17 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 	// Tests the use case for an existing service principal that already has the required role assignment.
 	t.Run("RoleAssignmentExists", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationListMock(mockContext, http.StatusOK, []graphsdk.Application{existingApplication})
-		graphsdk_mocks.RegisterServicePrincipalListMock(
+		mockgraphsdk.RegisterApplicationListMock(mockContext, http.StatusOK, []graphsdk.Application{existingApplication})
+		mockgraphsdk.RegisterServicePrincipalListMock(
 			mockContext,
 			http.StatusOK,
 			[]graphsdk.ServicePrincipal{servicePrincipal},
 		)
-		graphsdk_mocks.RegisterApplicationRemovePasswordMock(mockContext, http.StatusNoContent, *newApplication.Id)
-		graphsdk_mocks.RegisterApplicationAddPasswordMock(mockContext, http.StatusOK, *newApplication.Id, credential)
-		graphsdk_mocks.RegisterRoleDefinitionListMock(mockContext, http.StatusOK, roleDefinitions)
+		mockgraphsdk.RegisterApplicationRemovePasswordMock(mockContext, http.StatusNoContent, *newApplication.Id)
+		mockgraphsdk.RegisterApplicationAddPasswordMock(mockContext, http.StatusOK, *newApplication.Id, credential)
+		mockgraphsdk.RegisterRoleDefinitionListMock(mockContext, http.StatusOK, roleDefinitions)
 		// Note how role assignment returns a 409 conflict
-		graphsdk_mocks.RegisterRoleAssignmentPutMock(mockContext, http.StatusConflict)
+		mockgraphsdk.RegisterRoleAssignmentPutMock(mockContext, http.StatusConflict)
 
 		azCli := newAzCliFromMockContext(mockContext)
 		rawMessage, err := azCli.CreateOrUpdateServicePrincipal(
@@ -170,13 +170,13 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 
 	t.Run("InvalidRole", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationListMock(mockContext, http.StatusOK, []graphsdk.Application{})
-		graphsdk_mocks.RegisterServicePrincipalListMock(mockContext, http.StatusOK, []graphsdk.ServicePrincipal{})
-		graphsdk_mocks.RegisterApplicationCreateItemMock(mockContext, http.StatusCreated, &newApplication)
-		graphsdk_mocks.RegisterServicePrincipalCreateItemMock(mockContext, http.StatusCreated, &servicePrincipal)
-		graphsdk_mocks.RegisterApplicationAddPasswordMock(mockContext, http.StatusOK, *newApplication.Id, credential)
+		mockgraphsdk.RegisterApplicationListMock(mockContext, http.StatusOK, []graphsdk.Application{})
+		mockgraphsdk.RegisterServicePrincipalListMock(mockContext, http.StatusOK, []graphsdk.ServicePrincipal{})
+		mockgraphsdk.RegisterApplicationCreateItemMock(mockContext, http.StatusCreated, &newApplication)
+		mockgraphsdk.RegisterServicePrincipalCreateItemMock(mockContext, http.StatusCreated, &servicePrincipal)
+		mockgraphsdk.RegisterApplicationAddPasswordMock(mockContext, http.StatusOK, *newApplication.Id, credential)
 		// Note how retrieval of matching role assignments is empty
-		graphsdk_mocks.RegisterRoleDefinitionListMock(mockContext, http.StatusOK, []*armauthorization.RoleDefinition{})
+		mockgraphsdk.RegisterRoleDefinitionListMock(mockContext, http.StatusOK, []*armauthorization.RoleDefinition{})
 
 		azCli := newAzCliFromMockContext(mockContext)
 		rawMessage, err := azCli.CreateOrUpdateServicePrincipal(
@@ -191,10 +191,10 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 
 	t.Run("ErrorCreatingApplication", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		graphsdk_mocks.RegisterApplicationListMock(mockContext, http.StatusOK, []graphsdk.Application{})
-		graphsdk_mocks.RegisterServicePrincipalListMock(mockContext, http.StatusOK, []graphsdk.ServicePrincipal{})
+		mockgraphsdk.RegisterApplicationListMock(mockContext, http.StatusOK, []graphsdk.Application{})
+		mockgraphsdk.RegisterServicePrincipalListMock(mockContext, http.StatusOK, []graphsdk.ServicePrincipal{})
 		// Note that the application creation returns an unauthorized error
-		graphsdk_mocks.RegisterApplicationCreateItemMock(mockContext, http.StatusUnauthorized, nil)
+		mockgraphsdk.RegisterApplicationCreateItemMock(mockContext, http.StatusUnauthorized, nil)
 
 		azCli := newAzCliFromMockContext(mockContext)
 		rawMessage, err := azCli.CreateOrUpdateServicePrincipal(

--- a/cli/azd/pkg/tools/bicep/bicep_test.go
+++ b/cli/azd/pkg/tools/bicep/bicep_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
-	"github.com/azure/azure-dev/cli/azd/test/mocks/console"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,14 +48,14 @@ func TestNewBicepCli(t *testing.T) {
 
 	require.Equal(t, 2, len(mockContext.Console.SpinnerOps()))
 
-	require.Equal(t, console.SpinnerOp{
-		Op:      console.SpinnerOpShow,
+	require.Equal(t, mockinput.SpinnerOp{
+		Op:      mockinput.SpinnerOpShow,
 		Message: "Downloading Bicep",
 		Format:  input.Step,
 	}, mockContext.Console.SpinnerOps()[0])
 
-	require.Equal(t, console.SpinnerOp{
-		Op:      console.SpinnerOpStop,
+	require.Equal(t, mockinput.SpinnerOp{
+		Op:      mockinput.SpinnerOpStop,
 		Message: "Downloading Bicep",
 		Format:  input.StepDone,
 	}, mockContext.Console.SpinnerOps()[1])
@@ -120,14 +120,14 @@ func TestNewBicepCliWillUpgrade(t *testing.T) {
 
 	require.Equal(t, 2, len(mockContext.Console.SpinnerOps()))
 
-	require.Equal(t, console.SpinnerOp{
-		Op:      console.SpinnerOpShow,
+	require.Equal(t, mockinput.SpinnerOp{
+		Op:      mockinput.SpinnerOpShow,
 		Message: "Upgrading Bicep",
 		Format:  input.Step,
 	}, mockContext.Console.SpinnerOps()[0])
 
-	require.Equal(t, console.SpinnerOp{
-		Op:      console.SpinnerOpStop,
+	require.Equal(t, mockinput.SpinnerOp{
+		Op:      mockinput.SpinnerOpStop,
 		Message: "Upgrading Bicep",
 		Format:  input.StepDone,
 	}, mockContext.Console.SpinnerOps()[1])

--- a/cli/azd/pkg/tools/javac/javac_test.go
+++ b/cli/azd/pkg/tools/javac/javac_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	azdexec "github.com/azure/azure-dev/cli/azd/pkg/exec"
-	mockexec "github.com/azure/azure-dev/cli/azd/test/mocks/exec"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockexec"
 	"github.com/azure/azure-dev/cli/azd/test/ostest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/cli/azd/test/mocks/mock_context.go
+++ b/cli/azd/test/mocks/mock_context.go
@@ -5,23 +5,23 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
-	mockconfig "github.com/azure/azure-dev/cli/azd/test/mocks/config"
-	mockconsole "github.com/azure/azure-dev/cli/azd/test/mocks/console"
-	mockexec "github.com/azure/azure-dev/cli/azd/test/mocks/exec"
-	mockhttp "github.com/azure/azure-dev/cli/azd/test/mocks/httputil"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockconfig"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockexec"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockhttp"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
 )
 
 type MockContext struct {
 	Credentials   *MockCredentials
 	Context       *context.Context
-	Console       *mockconsole.MockConsole
+	Console       *mockinput.MockConsole
 	HttpClient    *mockhttp.MockHttpClient
 	CommandRunner *mockexec.MockCommandRunner
 	ConfigManager *mockconfig.MockConfigManager
 }
 
 func NewMockContext(ctx context.Context) *MockContext {
-	mockConsole := mockconsole.NewMockConsole()
+	mockConsole := mockinput.NewMockConsole()
 	commandRunner := mockexec.NewMockCommandRunner()
 	httpClient := mockhttp.NewMockHttpUtil()
 	credentials := MockCredentials{}

--- a/cli/azd/test/mocks/mockarmresources/mockarmresources.go
+++ b/cli/azd/test/mocks/mockarmresources/mockarmresources.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
-	"github.com/azure/azure-dev/cli/azd/test/mocks/httputil"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockhttp"
 )
 
 var tagFilterExpression = regexp.MustCompile("tagName eq '(.+)' and tagValue eq '(.*?)'")
@@ -19,7 +19,7 @@ var tagFilterExpression = regexp.MustCompile("tagName eq '(.+)' and tagValue eq 
 var nameFilterExpression = regexp.MustCompile("name eq '(.+)'")
 
 func AddAzResourceListMock(
-	c *httputil.MockHttpClient,
+	c *mockhttp.MockHttpClient,
 	matchResourceGroupName *string,
 	result []*armresources.GenericResourceExpanded,
 ) {

--- a/cli/azd/test/mocks/mockconfig/mock_config.go
+++ b/cli/azd/test/mocks/mockconfig/mock_config.go
@@ -1,4 +1,4 @@
-package config
+package mockconfig
 
 import "github.com/azure/azure-dev/cli/azd/pkg/config"
 

--- a/cli/azd/test/mocks/mockexec/mock_runner.go
+++ b/cli/azd/test/mocks/mockexec/mock_runner.go
@@ -1,4 +1,4 @@
-package exec
+package mockexec
 
 import (
 	"context"

--- a/cli/azd/test/mocks/mockgraphsdk/mocks.go
+++ b/cli/azd/test/mocks/mockgraphsdk/mocks.go
@@ -1,4 +1,4 @@
-package graphsdk
+package mockgraphsdk
 
 import (
 	"fmt"

--- a/cli/azd/test/mocks/mockhttp/mock_http_client.go
+++ b/cli/azd/test/mocks/mockhttp/mock_http_client.go
@@ -1,4 +1,4 @@
-package httputil
+package mockhttp
 
 import (
 	"fmt"

--- a/cli/azd/test/mocks/mockinput/mock_console.go
+++ b/cli/azd/test/mocks/mockinput/mock_console.go
@@ -1,4 +1,4 @@
-package console
+package mockinput
 
 import (
 	"bytes"


### PR DESCRIPTION
All mock packages now follow the naming: `mock<package name>`. This avoids package name clobbering and creates a pattern that is generalizable for all.