### PR TITLE
Fix trigger on global cspell check

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -29,16 +29,5 @@ jobs:
           args: -v --timeout 5m0s
           working-directory: cli/azd
 
-  cspell-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        name: Run spell check for project and for azd
-        with:
-          node-version: "16"
-      - run: npm install -g cspell
-      - run: cspell lint '**/*.go' --config ./cli/azd/.vscode/cspell.yaml --root ./cli/azd --no-progress
-
   bicep-lint:
     uses: ./.github/workflows/lint-bicep.yml

--- a/.github/workflows/cspell.yml
+++ b/.github/workflows/cspell.yml
@@ -1,18 +1,10 @@
 name: global-cspell
 
 on:
-  workflow_dispatch:
   pull_request:
     branches: [main]
     paths-ignore:
-      - 'cli/**' # Covered by CLI-specific spell
-      - 'ext/**' # Covered by VSCode-specific cspell
       - 'eng/**' # Not required
-
-
-permissions:
-  contents: read
-  pull-requests: write
 
 jobs:
   cspell-lint:
@@ -24,4 +16,6 @@ jobs:
         with:
           node-version: "16"
       - run: npm install -g cspell
+      - run: cspell lint '**/*.go' --config ./cli/azd/.vscode/cspell.yaml --root ./cli/azd --no-progress
+      - run: cspell lint '**/*.ts' --config ./ext/vscode/.vscode/cspell.yaml --root ./ext/vscode --no-progress
       - run: cspell lint '**/*' --config ./.vscode/cspell.yaml --relative --no-progress

--- a/.github/workflows/global-cspell.yml
+++ b/.github/workflows/global-cspell.yml
@@ -1,0 +1,27 @@
+name: global-cspell
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - 'cli/**' # Covered by CLI-specific spell
+      - 'ext/**' # Covered by VSCode-specific cspell
+      - ".github/workflows/global-cspell.yml"
+
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  cspell-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        name: Run spell check for templates
+        with:
+          node-version: "16"
+      - run: npm install -g cspell
+      - run: cspell lint '**/*' --config ./.vscode/cspell.yaml --relative --no-progress

--- a/.github/workflows/global-cspell.yml
+++ b/.github/workflows/global-cspell.yml
@@ -7,7 +7,7 @@ on:
     paths-ignore:
       - 'cli/**' # Covered by CLI-specific spell
       - 'ext/**' # Covered by VSCode-specific cspell
-      - ".github/workflows/global-cspell.yml"
+      - 'eng/**' # Not required
 
 
 permissions:

--- a/.github/workflows/templates-ci.yml
+++ b/.github/workflows/templates-ci.yml
@@ -17,13 +17,4 @@ jobs:
   bicep-lint:
     uses: ./.github/workflows/lint-bicep.yml
   
-  cspell-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        name: Run spell check for templates
-        with:
-          node-version: "16"
-      - run: npm install -g cspell
-      - run: cspell lint '**/*' --config ./.vscode/cspell.yaml --relative --no-progress
+  # cspell-lint : runs as part of global-cspell.

--- a/.github/workflows/templates-ci.yml
+++ b/.github/workflows/templates-ci.yml
@@ -16,5 +16,3 @@ permissions:
 jobs:
   bicep-lint:
     uses: ./.github/workflows/lint-bicep.yml
-  
-  # cspell-lint : runs as part of global-cspell.

--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -13,17 +13,6 @@ permissions:
   id-token: write
 
 jobs:
-  cspell-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        name: Run spell check azd vscode extension
-        with:
-          node-version: "16"
-      - run: npm install -g cspell
-      - run: cspell lint '**/*.ts' --config ./ext/vscode/.vscode/cspell.yaml --root ./ext/vscode --no-progress
-
   build-test:
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Previously, the global cspell check was running under the `templates-ci` trigger which triggers on `templates/*` path modifications.