### PR TITLE
Delay resolving `${var}` references when loading azure.yaml

### DIFF
--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -136,7 +136,7 @@ func (d *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		return nil, fmt.Errorf("loading environment: %w", err)
 	}
 
-	projConfig, err := project.LoadProjectConfig(d.azdCtx.ProjectPath(), env)
+	projConfig, err := project.LoadProjectConfig(d.azdCtx.ProjectPath())
 	if err != nil {
 		return nil, fmt.Errorf("loading project: %w", err)
 	}

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -359,7 +359,7 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 		return nil, fmt.Errorf("loading environment: %w", err)
 	}
 
-	prj, err := project.LoadProjectConfig(ef.azdCtx.ProjectPath(), env)
+	prj, err := project.LoadProjectConfig(ef.azdCtx.ProjectPath())
 	if err != nil {
 		return nil, fmt.Errorf("loading project: %w", err)
 	}

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -118,7 +118,7 @@ func (i *infraCreateAction) Run(ctx context.Context) (*actions.ActionResult, err
 		return nil, fmt.Errorf("loading environment: %w", err)
 	}
 
-	prj, err := project.LoadProjectConfig(i.azdCtx.ProjectPath(), env)
+	prj, err := project.LoadProjectConfig(i.azdCtx.ProjectPath())
 	if err != nil {
 		return nil, fmt.Errorf("loading project: %w", err)
 	}

--- a/cli/azd/cmd/infra_delete.go
+++ b/cli/azd/cmd/infra_delete.go
@@ -82,7 +82,7 @@ func (a *infraDeleteAction) Run(ctx context.Context) (*actions.ActionResult, err
 		return nil, fmt.Errorf("loading environment: %w", err)
 	}
 
-	prj, err := project.LoadProjectConfig(a.azdCtx.ProjectPath(), env)
+	prj, err := project.LoadProjectConfig(a.azdCtx.ProjectPath())
 	if err != nil {
 		return nil, fmt.Errorf("loading project: %w", err)
 	}

--- a/cli/azd/cmd/restore.go
+++ b/cli/azd/cmd/restore.go
@@ -89,7 +89,7 @@ func (r *restoreAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 		return nil, fmt.Errorf("loading environment: %w", err)
 	}
 
-	proj, err := project.LoadProjectConfig(r.azdCtx.ProjectPath(), env)
+	proj, err := project.LoadProjectConfig(r.azdCtx.ProjectPath())
 
 	if err != nil {
 		return nil, fmt.Errorf("loading project: %w", err)

--- a/cli/azd/cmd/show.go
+++ b/cli/azd/cmd/show.go
@@ -83,7 +83,7 @@ func (s *showAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		return nil, fmt.Errorf("loading environment: %w", err)
 	}
 
-	prj, err := project.LoadProjectConfig(s.azdCtx.ProjectPath(), env)
+	prj, err := project.LoadProjectConfig(s.azdCtx.ProjectPath())
 	if err != nil {
 		return nil, fmt.Errorf("loading project: %w", err)
 	}

--- a/cli/azd/pkg/commands/pipeline/pipeline.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline.go
@@ -169,7 +169,7 @@ func DetectProviders(
 			overrideWith = lastUsedProvider
 		}
 		// Figure out what is the expected provider to use for provisioning
-		prj, err := project.LoadProjectConfig(azdContext.ProjectPath(), env)
+		prj, err := project.LoadProjectConfig(azdContext.ProjectPath())
 		if err != nil {
 			return nil, nil, fmt.Errorf("finding pipeline provider: %w", err)
 		}

--- a/cli/azd/pkg/commands/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline_manager.go
@@ -241,7 +241,7 @@ func (manager *PipelineManager) Configure(ctx context.Context) error {
 	}
 
 	// Figure out what is the expected provider to use for provisioning
-	prj, err := project.LoadProjectConfig(manager.AzdCtx.ProjectPath(), manager.Environment)
+	prj, err := project.LoadProjectConfig(manager.AzdCtx.ProjectPath())
 	if err != nil {
 		return fmt.Errorf("finding provisioning provider: %w", err)
 	}

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -131,6 +131,15 @@ func EphemeralWithValues(name string, values map[string]string) *Environment {
 	return env
 }
 
+// Getenv fetches a key from e.Values, falling back to os.Getenv if it is not present.
+func (e *Environment) Getenv(key string) string {
+	if v, has := e.Values[key]; has {
+		return v
+	}
+
+	return os.Getenv(key)
+}
+
 // If `Root` is set, Save writes the current contents of the environment to
 // the given directory, creating it and any intermediate directories as needed.
 func (e *Environment) Save() error {

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -68,7 +68,7 @@ services:
 		}, nil
 	})
 
-	projectConfig, err := ParseProjectConfig(testProj, env)
+	projectConfig, err := ParseProjectConfig(testProj)
 	require.NoError(t, err)
 	prj, err := projectConfig.GetProject(*mockContext.Context, env, mockContext.Console, azCli, mockContext.CommandRunner)
 	require.NoError(t, err)
@@ -158,7 +158,7 @@ services:
 
 	docker := docker.NewDocker(mockContext.CommandRunner)
 
-	projectConfig, err := ParseProjectConfig(testProj, env)
+	projectConfig, err := ParseProjectConfig(testProj)
 	require.NoError(t, err)
 
 	prj, err := projectConfig.GetProject(*mockContext.Context, env, mockContext.Console, azCli, mockContext.CommandRunner)

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -17,6 +17,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
+	"github.com/drone/envsubst"
 	"gopkg.in/yaml.v3"
 )
 
@@ -47,7 +48,7 @@ func ReadProject(
 	projectRootDir := filepath.Dir(projectPath)
 
 	// Load Project configuration
-	projectConfig, err := LoadProjectConfig(projectRootDir, env)
+	projectConfig, err := LoadProjectConfig(projectRootDir)
 	if err != nil {
 		return nil, fmt.Errorf("reading project config: %w", err)
 	}
@@ -101,8 +102,9 @@ func GetResourceGroupName(
 	azCli azcli.AzCli,
 	projectConfig *ProjectConfig,
 	env *environment.Environment) (string, error) {
+
 	if strings.TrimSpace(projectConfig.ResourceGroupName) != "" {
-		return projectConfig.ResourceGroupName, nil
+		return envsubst.Eval(projectConfig.ResourceGroupName, env.Getenv)
 	}
 
 	envResourceGroupName := environment.GetResourceGroupNameFromEnvVar(env)

--- a/cli/azd/pkg/project/project_config.go
+++ b/cli/azd/pkg/project/project_config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
-	"github.com/drone/envsubst"
 	"gopkg.in/yaml.v3"
 )
 
@@ -211,27 +210,10 @@ func (pc *ProjectConfig) RaiseEvent(ctx context.Context, name Event, args map[st
 }
 
 // ParseProjectConfig will parse a project from a yaml string and return the project configuration
-func ParseProjectConfig(yamlContent string, env *environment.Environment) (*ProjectConfig, error) {
-	log.Printf("Parsing file contents, %s\n", yamlContent)
-	rawFile, err := envsubst.Parse(yamlContent)
-	if err != nil {
-		return nil, fmt.Errorf("parsing environment references in project file: %w", err)
-	}
-
-	file, err := rawFile.Execute(func(name string) string {
-		if val, has := env.Values[name]; has {
-			return val
-		}
-		return os.Getenv(name)
-	})
-
-	if err != nil {
-		return nil, fmt.Errorf("replacing environment references: %w", err)
-	}
-
+func ParseProjectConfig(yamlContent string) (*ProjectConfig, error) {
 	var projectFile ProjectConfig
 
-	if err = yaml.Unmarshal([]byte(file), &projectFile); err != nil {
+	if err := yaml.Unmarshal([]byte(yamlContent), &projectFile); err != nil {
 		return nil, fmt.Errorf(
 			"unable to parse azure.yaml file. Please check the format of the file, "+
 				"and also verify you have the latest version of the CLI: %w",
@@ -286,7 +268,7 @@ func (p *ProjectConfig) Initialize(
 
 // LoadProjectConfig loads the azure.yaml configuring into an viewable structure
 // This does not evaluate any tooling
-func LoadProjectConfig(projectPath string, env *environment.Environment) (*ProjectConfig, error) {
+func LoadProjectConfig(projectPath string) (*ProjectConfig, error) {
 	log.Printf("Reading project from file '%s'\n", projectPath)
 	bytes, err := os.ReadFile(projectPath)
 	if err != nil {
@@ -295,7 +277,7 @@ func LoadProjectConfig(projectPath string, env *environment.Environment) (*Proje
 
 	yaml := string(bytes)
 
-	projectConfig, err := ParseProjectConfig(yaml, env)
+	projectConfig, err := ParseProjectConfig(yaml)
 	if err != nil {
 		return nil, fmt.Errorf("parsing project file: %w", err)
 	}

--- a/cli/azd/pkg/project/project_config_test.go
+++ b/cli/azd/pkg/project/project_config_test.go
@@ -37,7 +37,7 @@ services:
 		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
 	})
 
-	projectConfig, err := ParseProjectConfig(testProj, e)
+	projectConfig, err := ParseProjectConfig(testProj)
 	require.Nil(t, err)
 	require.NotNil(t, projectConfig)
 
@@ -70,11 +70,7 @@ services:
     host: appservice
 `
 
-	e := environment.EphemeralWithValues("test-env", map[string]string{
-		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
-	})
-
-	projectConfig, err := ParseProjectConfig(testProj, e)
+	projectConfig, err := ParseProjectConfig(testProj)
 	require.Nil(t, err)
 
 	require.True(t, projectConfig.HasService("web"))
@@ -129,7 +125,7 @@ services:
 		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
 	})
 
-	projectConfig, err := ParseProjectConfig(testProj, e)
+	projectConfig, err := ParseProjectConfig(testProj)
 	require.Nil(t, err)
 
 	project, err := projectConfig.GetProject(*mockContext.Context, e, mockContext.Console, azCli, mockContext.CommandRunner)
@@ -162,11 +158,8 @@ services:
       path: ./Dockerfile.dev
       context: ../
 `
-	e := environment.EphemeralWithValues("test-env", map[string]string{
-		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
-	})
 
-	projectConfig, err := ParseProjectConfig(testProj, e)
+	projectConfig, err := ParseProjectConfig(testProj)
 
 	require.NotNil(t, projectConfig)
 	require.Nil(t, err)
@@ -191,11 +184,7 @@ services:
     module: ./api/api
 `
 
-	e := environment.EphemeralWithValues("test-env", map[string]string{
-		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
-	})
-
-	projectConfig, err := ParseProjectConfig(testProj, e)
+	projectConfig, err := ParseProjectConfig(testProj)
 
 	require.NotNil(t, projectConfig)
 	require.Nil(t, err)
@@ -356,11 +345,7 @@ services:
     module: ./api/api
 `
 
-	e := environment.EphemeralWithValues("test-env", map[string]string{
-		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
-	})
-
-	projectConfig, _ := ParseProjectConfig(testProj, e)
+	projectConfig, _ := ParseProjectConfig(testProj)
 
 	return projectConfig
 }

--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -50,7 +50,7 @@ services:
 	e := environment.EphemeralWithValues("envA", map[string]string{
 		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
 	})
-	projectConfig, err := ParseProjectConfig(testProj, e)
+	projectConfig, err := ParseProjectConfig(testProj)
 	require.NoError(t, err)
 
 	project, err := projectConfig.GetProject(*mockContext.Context, e, mockContext.Console, azCli, mockContext.CommandRunner)
@@ -97,7 +97,7 @@ services:
 	e := environment.EphemeralWithValues("envA", map[string]string{
 		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
 	})
-	projectConfig, err := ParseProjectConfig(testProj, e)
+	projectConfig, err := ParseProjectConfig(testProj)
 	require.NoError(t, err)
 
 	project, err := projectConfig.GetProject(*mockContext.Context, e, mockContext.Console, azCli, mockContext.CommandRunner)
@@ -155,7 +155,7 @@ services:
 	e := environment.EphemeralWithValues("envA", map[string]string{
 		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
 	})
-	projectConfig, err := ParseProjectConfig(testProj, e)
+	projectConfig, err := ParseProjectConfig(testProj)
 	require.NoError(t, err)
 
 	project, err := projectConfig.GetProject(*mockContext.Context, e, mockContext.Console, azCli, mockContext.CommandRunner)
@@ -221,7 +221,7 @@ services:
 		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
 	})
 
-	projectConfig, err := ParseProjectConfig(testProj, e)
+	projectConfig, err := ParseProjectConfig(testProj)
 	require.NoError(t, err)
 
 	project, err := projectConfig.GetProject(*mockContext.Context, e, mockContext.Console, azCli, mockContext.CommandRunner)

--- a/cli/azd/pkg/project/service_config_test.go
+++ b/cli/azd/pkg/project/service_config_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/stretchr/testify/require"
 )
 
@@ -162,9 +161,7 @@ services:
     module: ./api/api
 `
 
-	e := environment.EphemeralWithValues("test-env", nil)
-
-	projectConfig, _ := ParseProjectConfig(testProj, e)
+	projectConfig, _ := ParseProjectConfig(testProj)
 
 	return projectConfig.Services["api"]
 }

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -96,7 +96,8 @@ func Test_containerAppTarget_generateImageTag(t *testing.T) {
 					Docker: tt.dockerConfig,
 				},
 				clock: mockClock}
-			tag := containerAppTarget.generateImageTag()
+			tag, err := containerAppTarget.generateImageTag()
+			assert.NoError(t, err)
 			assert.Equal(t, tt.want, tag)
 		})
 	}

--- a/cli/azd/pkg/project/service_test.go
+++ b/cli/azd/pkg/project/service_test.go
@@ -105,7 +105,7 @@ func TestDeployProgressMessages(t *testing.T) {
 	env := environment.Ephemeral()
 	env.SetSubscriptionId("SUBSCRIPTION_ID")
 
-	projectConfig, _ := ParseProjectConfig(projectYaml, env)
+	projectConfig, _ := ParseProjectConfig(projectYaml)
 	project, _ := projectConfig.GetProject(*mockContext.Context, env, mockContext.Console, azCli, mockContext.CommandRunner)
 	azdContext, _ := azdcontext.NewAzdContext()
 

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -70,7 +70,7 @@ func Test_CLI_Init_AsksForSubscriptionIdAndCreatesEnvAndProjectFile(t *testing.T
 	require.Regexp(t, regexp.MustCompile(fmt.Sprintf(`AZURE_SUBSCRIPTION_ID="%s"`, testSubscriptionId)+"\n"), string(file))
 	require.Regexp(t, regexp.MustCompile(`AZURE_ENV_NAME="TESTENV"`+"\n"), string(file))
 
-	proj, err := project.LoadProjectConfig(filepath.Join(dir, azdcontext.ProjectFileName), environment.Ephemeral())
+	proj, err := project.LoadProjectConfig(filepath.Join(dir, azdcontext.ProjectFileName))
 	require.NoError(t, err)
 
 	require.Equal(t, filepath.Base(dir), proj.Name)

--- a/cli/azd/test/functional/up_test.go
+++ b/cli/azd/test/functional/up_test.go
@@ -225,6 +225,7 @@ func Test_CLI_Up_Down_ContainerApp(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tc := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -241,7 +242,7 @@ func Test_CLI_Up_Down_ContainerApp(t *testing.T) {
 			cli.WorkingDirectory = dir
 			cli.Env = append(os.Environ(),
 				"AZURE_LOCATION=eastus2",
-				fmt.Sprintf("AZURE_PROVISION_CONTAINER_APP=%t", tt.provisionContainerApp))
+				fmt.Sprintf("AZURE_PROVISION_CONTAINER_APP=%t", tc.provisionContainerApp))
 
 			err := copySample(dir, "containerapp")
 			require.NoError(t, err, "failed expanding sample")


### PR DESCRIPTION
We support using `${var}` style substitutions in `azure.yaml` today, but the current implementation is very simple: we do a single substitution pass before attempting to prase the YAML that makes up the file.

This means to get a `ProjectConfig` instance, you need an `*Environment` and that's something we can't fix with the given design because the yaml file may not even be valid until we do substituitions (and hence we couldn't parse it to form the ProjectConfig).

After chatting about this with Wei, We'd like the remove the dependency of ProjectConfig on `*Environment` and at the same time be more restrctive around where these references could appear (for example, in the case of the inline script work Wallace is prototyping, the current behavior would cause references in lines scripts that look like `${var}` to be replaced while the file is being loaded, which is not correct).

This change pushes this idea into the codebase.  Looking at the existing fields of `ProjectConfig` it seemed like we should really only allow substituitons for the name of the primary resource group and in the tag parameter for docker containers (where we documented that we support substituitons). We can always add more stuff later but this seemed like a reasonable place to start.