### PR TITLE
Improve Azure Functions config

### DIFF
--- a/templates/todo/projects/csharp-sql-swa-func/.vscode/settings.json
+++ b/templates/todo/projects/csharp-sql-swa-func/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "azureFunctions.showProjectWarning": false
+    "azureFunctions.projectLanguage": "C#",
+    "azureFunctions.projectRuntime": "~4"
 }


### PR DESCRIPTION
An improvement over https://github.com/Azure/azure-dev/pull/1254 where we tell Azure Functions extension what the project's language and Functions runtime are, instead of just suppressing their (unnecessary) offer to re-configure project tasks.