### PR TITLE
Support `--tenant-id` parameter on `azd auth token`

### DIFF
--- a/cli/azd/cmd/auth_token.go
+++ b/cli/azd/cmd/auth_token.go
@@ -53,20 +53,6 @@ type authTokenAction struct {
 }
 
 func newAuthTokenAction(
-	authManager *auth.Manager,
-	formatter output.Formatter,
-	writer io.Writer,
-	flags authTokenFlags,
-) *authTokenAction {
-	return &authTokenAction{
-		credentialProvider: authManager.CredentialForCurrentUser,
-		formatter:          formatter,
-		writer:             writer,
-		flags:              flags,
-	}
-}
-
-func newAuthTokenActionWithCredentialProvider(
 	credentialProvider func(context.Context, *auth.CredentialForCurrentUserOptions) (azcore.TokenCredential, error),
 	formatter output.Formatter,
 	writer io.Writer,

--- a/cli/azd/cmd/auth_token.go
+++ b/cli/azd/cmd/auth_token.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -21,6 +22,7 @@ import (
 
 type authTokenFlags struct {
 	outputFormat string
+	tenantID     string
 	scopes       []string
 	global       *internal.GlobalCommandOptions
 }
@@ -40,26 +42,41 @@ func (f *authTokenFlags) Bind(local *pflag.FlagSet, global *internal.GlobalComma
 	f.global = global
 	output.AddOutputFlag(local, &f.outputFormat, []output.Format{output.JsonFormat}, output.NoneFormat)
 	local.StringArrayVar(&f.scopes, "scope", nil, "The scope to use when requesting an access token")
+	local.StringVar(&f.tenantID, "tenant-id", "", "The tenant id to use when requesting an access token.")
 }
 
 type authTokenAction struct {
-	credential azcore.TokenCredential
-	formatter  output.Formatter
-	writer     io.Writer
-	flags      authTokenFlags
+	credentialProvider func(context.Context, *auth.CredentialForCurrentUserOptions) (azcore.TokenCredential, error)
+	formatter          output.Formatter
+	writer             io.Writer
+	flags              authTokenFlags
 }
 
 func newAuthTokenAction(
-	credential azcore.TokenCredential,
+	authManager *auth.Manager,
 	formatter output.Formatter,
 	writer io.Writer,
 	flags authTokenFlags,
 ) *authTokenAction {
 	return &authTokenAction{
-		credential: credential,
-		formatter:  formatter,
-		writer:     writer,
-		flags:      flags,
+		credentialProvider: authManager.CredentialForCurrentUser,
+		formatter:          formatter,
+		writer:             writer,
+		flags:              flags,
+	}
+}
+
+func newAuthTokenActionWithCredentialProvider(
+	credentialProvider func(context.Context, *auth.CredentialForCurrentUserOptions) (azcore.TokenCredential, error),
+	formatter output.Formatter,
+	writer io.Writer,
+	flags authTokenFlags,
+) *authTokenAction {
+	return &authTokenAction{
+		credentialProvider: credentialProvider,
+		formatter:          formatter,
+		writer:             writer,
+		flags:              flags,
 	}
 }
 
@@ -68,7 +85,16 @@ func (a *authTokenAction) Run(ctx context.Context) (*actions.ActionResult, error
 		a.flags.scopes = []string{azure.ManagementScope}
 	}
 
-	token, err := a.credential.GetToken(ctx, policy.TokenRequestOptions{
+	var cred azcore.TokenCredential
+
+	cred, err := a.credentialProvider(ctx, &auth.CredentialForCurrentUserOptions{
+		TenantID: a.flags.tenantID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := cred.GetToken(ctx, policy.TokenRequestOptions{
 		Scopes: a.flags.scopes,
 	})
 	if err != nil {

--- a/cli/azd/cmd/auth_token_test.go
+++ b/cli/azd/cmd/auth_token_test.go
@@ -37,7 +37,7 @@ func TestAuthToken(t *testing.T) {
 		}, nil
 	})
 
-	a := newAuthTokenActionWithCredentialProvider(
+	a := newAuthTokenAction(
 		credentialProviderForTokenFn(token),
 		&output.JsonFormatter{},
 		buf,
@@ -70,7 +70,7 @@ func TestAuthTokenCustomScopes(t *testing.T) {
 		return azcore.AccessToken{}, nil
 	})
 
-	a := newAuthTokenActionWithCredentialProvider(
+	a := newAuthTokenAction(
 		credentialProviderForTokenFn(token),
 		&output.JsonFormatter{},
 		io.Discard,
@@ -90,7 +90,7 @@ func TestAuthTokenFailure(t *testing.T) {
 		return azcore.AccessToken{}, errors.New("could not fetch token")
 	})
 
-	a := newAuthTokenActionWithCredentialProvider(
+	a := newAuthTokenAction(
 		credentialProviderForTokenFn(token),
 		&output.JsonFormatter{},
 		io.Discard,

--- a/cli/azd/cmd/auth_token_test.go
+++ b/cli/azd/cmd/auth_token_test.go
@@ -38,7 +38,7 @@ func TestAuthToken(t *testing.T) {
 	})
 
 	a := newAuthTokenActionWithCredentialProvider(
-		token.GetCredentialForCurrentUser,
+		credentialProviderForTokenFn(token),
 		&output.JsonFormatter{},
 		buf,
 		authTokenFlags{
@@ -71,7 +71,7 @@ func TestAuthTokenCustomScopes(t *testing.T) {
 	})
 
 	a := newAuthTokenActionWithCredentialProvider(
-		token.GetCredentialForCurrentUser,
+		credentialProviderForTokenFn(token),
 		&output.JsonFormatter{},
 		io.Discard,
 		authTokenFlags{
@@ -91,7 +91,7 @@ func TestAuthTokenFailure(t *testing.T) {
 	})
 
 	a := newAuthTokenActionWithCredentialProvider(
-		token.GetCredentialForCurrentUser,
+		credentialProviderForTokenFn(token),
 		&output.JsonFormatter{},
 		io.Discard,
 		authTokenFlags{
@@ -110,8 +110,12 @@ func (f authTokenFn) GetToken(ctx context.Context, options policy.TokenRequestOp
 	return f(ctx, options)
 }
 
-func (f authTokenFn) GetCredentialForCurrentUser(
-	_ context.Context, _ *auth.CredentialForCurrentUserOptions,
-) (azcore.TokenCredential, error) {
-	return f, nil
+// credentialProviderForTokenFn creates a provider that returns the given token, regardless of what options are set.
+func credentialProviderForTokenFn(
+	fn authTokenFn,
+) func(context.Context, *auth.CredentialForCurrentUserOptions) (azcore.TokenCredential, error) {
+	return func(_ context.Context, _ *auth.CredentialForCurrentUserOptions) (azcore.TokenCredential, error) {
+		return fn, nil
+	}
+
 }

--- a/cli/azd/cmd/auth_token_test.go
+++ b/cli/azd/cmd/auth_token_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -36,9 +37,14 @@ func TestAuthToken(t *testing.T) {
 		}, nil
 	})
 
-	a := newAuthTokenAction(token, &output.JsonFormatter{}, buf, authTokenFlags{
-		outputFormat: string(output.JsonFormat),
-	})
+	a := newAuthTokenActionWithCredentialProvider(
+		token.GetCredentialForCurrentUser,
+		&output.JsonFormatter{},
+		buf,
+		authTokenFlags{
+			outputFormat: string(output.JsonFormat),
+		},
+	)
 
 	_, err := a.Run(context.Background())
 	require.NoError(t, err)
@@ -64,10 +70,15 @@ func TestAuthTokenCustomScopes(t *testing.T) {
 		return azcore.AccessToken{}, nil
 	})
 
-	a := newAuthTokenAction(token, &output.JsonFormatter{}, io.Discard, authTokenFlags{
-		outputFormat: string(output.JsonFormat),
-		scopes:       scopes,
-	})
+	a := newAuthTokenActionWithCredentialProvider(
+		token.GetCredentialForCurrentUser,
+		&output.JsonFormatter{},
+		io.Discard,
+		authTokenFlags{
+			outputFormat: string(output.JsonFormat),
+			scopes:       scopes,
+		},
+	)
 
 	_, err := a.Run(context.Background())
 	require.NoError(t, err)
@@ -79,9 +90,14 @@ func TestAuthTokenFailure(t *testing.T) {
 		return azcore.AccessToken{}, errors.New("could not fetch token")
 	})
 
-	a := newAuthTokenAction(token, &output.JsonFormatter{}, io.Discard, authTokenFlags{
-		outputFormat: string(output.JsonFormat),
-	})
+	a := newAuthTokenActionWithCredentialProvider(
+		token.GetCredentialForCurrentUser,
+		&output.JsonFormatter{},
+		io.Discard,
+		authTokenFlags{
+			outputFormat: string(output.JsonFormat),
+		},
+	)
 
 	_, err := a.Run(context.Background())
 	require.ErrorContains(t, err, "could not fetch token")
@@ -92,4 +108,10 @@ type authTokenFn func(ctx context.Context, options policy.TokenRequestOptions) (
 
 func (f authTokenFn) GetToken(ctx context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
 	return f(ctx, options)
+}
+
+func (f authTokenFn) GetCredentialForCurrentUser(
+	_ context.Context, _ *auth.CredentialForCurrentUserOptions,
+) (azcore.TokenCredential, error) {
+	return f, nil
 }

--- a/cli/azd/cmd/login.go
+++ b/cli/azd/cmd/login.go
@@ -167,7 +167,7 @@ func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 	res := contracts.LoginResult{}
 
-	if cred, err := la.authManager.CredentialForCurrentUser(ctx); errors.Is(err, auth.ErrNoCurrentUser) {
+	if cred, err := la.authManager.CredentialForCurrentUser(ctx, nil); errors.Is(err, auth.ErrNoCurrentUser) {
 		res.Status = contracts.LoginStatusUnauthenticated
 	} else if err != nil {
 		return nil, fmt.Errorf("checking auth status: %w", err)

--- a/cli/azd/cmd/sets.go
+++ b/cli/azd/cmd/sets.go
@@ -108,6 +108,12 @@ func newCredential(ctx context.Context, authManager *auth.Manager) (azcore.Token
 	return credential, nil
 }
 
+func newCredentialProviderFromManager(
+	mgr *auth.Manager,
+) func(context.Context, *auth.CredentialForCurrentUserOptions) (azcore.TokenCredential, error) {
+	return mgr.CredentialForCurrentUser
+}
+
 var FormattedConsoleSet = wire.NewSet(
 	output.GetCommandFormatter,
 	newConsoleFromOptions,
@@ -280,5 +286,6 @@ var ConfigResetCmdSet = wire.NewSet(
 var AuthTokenCmdSet = wire.NewSet(
 	CommonSet,
 	auth.NewManager,
+	newCredentialProviderFromManager,
 	newAuthTokenAction,
 	wire.Bind(new(actions.Action), new(*authTokenAction)))

--- a/cli/azd/cmd/sets.go
+++ b/cli/azd/cmd/sets.go
@@ -96,7 +96,7 @@ func newAzdContext() (*azdcontext.AzdContext, error) {
 }
 
 func newCredential(ctx context.Context, authManager *auth.Manager) (azcore.TokenCredential, error) {
-	credential, err := authManager.CredentialForCurrentUser(ctx)
+	credential, err := authManager.CredentialForCurrentUser(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -280,6 +280,5 @@ var ConfigResetCmdSet = wire.NewSet(
 var AuthTokenCmdSet = wire.NewSet(
 	CommonSet,
 	auth.NewManager,
-	newCredential,
 	newAuthTokenAction,
 	wire.Bind(new(actions.Action), new(*authTokenAction)))

--- a/cli/azd/cmd/wire_gen.go
+++ b/cli/azd/cmd/wire_gen.go
@@ -227,9 +227,10 @@ func initAuthTokenAction(console input.Console, ctx context.Context, o *internal
 	if err != nil {
 		return nil, err
 	}
+	v := newCredentialProviderFromManager(manager)
 	formatter := newFormatterFromConsole(console)
 	writer := newOutputWriter(console)
-	cmdAuthTokenAction := newAuthTokenAction(manager, formatter, writer, flags)
+	cmdAuthTokenAction := newAuthTokenAction(v, formatter, writer, flags)
 	return cmdAuthTokenAction, nil
 }
 

--- a/cli/azd/cmd/wire_gen.go
+++ b/cli/azd/cmd/wire_gen.go
@@ -227,13 +227,9 @@ func initAuthTokenAction(console input.Console, ctx context.Context, o *internal
 	if err != nil {
 		return nil, err
 	}
-	tokenCredential, err := newCredential(ctx, manager)
-	if err != nil {
-		return nil, err
-	}
 	formatter := newFormatterFromConsole(console)
 	writer := newOutputWriter(console)
-	cmdAuthTokenAction := newAuthTokenAction(tokenCredential, formatter, writer, flags)
+	cmdAuthTokenAction := newAuthTokenAction(manager, formatter, writer, flags)
 	return cmdAuthTokenAction, nil
 }
 

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -58,10 +58,11 @@ var cLoginScopes = []string{azure.ManagementScope}
 // You can configure azd to ignore its native credential system and instead delegate to AZ CLI (useful for cases where azd
 // does not yet support your preferred method of authentication by setting [cUseLegacyAzCliAuthKey] in config to true.
 type Manager struct {
-	publicClient    publicClient
-	configManager   config.UserConfigManager
-	credentialCache Cache
-	ghClient        *github.FederatedTokenClient
+	publicClient        publicClient
+	publicClientOptions []public.Option
+	configManager       config.UserConfigManager
+	credentialCache     Cache
+	ghClient            *github.FederatedTokenClient
 }
 
 func NewManager(configManager config.UserConfigManager) (*Manager, error) {
@@ -80,7 +81,11 @@ func NewManager(configManager config.UserConfigManager) (*Manager, error) {
 		return nil, fmt.Errorf("creating msal cache root: %w", err)
 	}
 
-	publicClientApp, err := public.New(cAZD_CLIENT_ID, public.WithCache(newCache(cacheRoot)))
+	options := []public.Option{
+		public.WithCache(newCache(cacheRoot)),
+	}
+
+	publicClientApp, err := public.New(cAZD_CLIENT_ID, options...)
 	if err != nil {
 		return nil, fmt.Errorf("creating msal client: %w", err)
 	}
@@ -88,10 +93,11 @@ func NewManager(configManager config.UserConfigManager) (*Manager, error) {
 	ghClient := github.NewFederatedTokenClient(nil)
 
 	return &Manager{
-		publicClient:    &msalPublicClientAdapter{client: &publicClientApp},
-		configManager:   configManager,
-		credentialCache: newCredentialCache(authRoot),
-		ghClient:        ghClient,
+		publicClient:        &msalPublicClientAdapter{client: &publicClientApp},
+		publicClientOptions: options,
+		configManager:       configManager,
+		credentialCache:     newCredentialCache(authRoot),
+		ghClient:            ghClient,
 	}, nil
 }
 
@@ -111,8 +117,17 @@ func EnsureLoggedInCredential(ctx context.Context, credential azcore.TokenCreden
 }
 
 // CredentialForCurrentUser returns a TokenCredential instance for the current user. If `auth.useLegacyAzCliAuth` is set to
-// a truthy value in config, an instance of azidentity.AzureCLICredential is returned instead.
-func (m *Manager) CredentialForCurrentUser(ctx context.Context) (azcore.TokenCredential, error) {
+// a truthy value in config, an instance of azidentity.AzureCLICredential is returned instead. To accept the default options,
+// pass nil.
+func (m *Manager) CredentialForCurrentUser(
+	ctx context.Context,
+	options *CredentialForCurrentUserOptions,
+) (azcore.TokenCredential, error) {
+
+	if options == nil {
+		options = &CredentialForCurrentUserOptions{}
+	}
+
 	cfg, err := m.configManager.Load()
 	if err != nil {
 		return nil, fmt.Errorf("fetching current user: %w", err)
@@ -121,7 +136,9 @@ func (m *Manager) CredentialForCurrentUser(ctx context.Context) (azcore.TokenCre
 	if useLegacyAuth, has := cfg.Get(cUseAzCliAuthKey); has {
 		if use, err := strconv.ParseBool(useLegacyAuth.(string)); err == nil && use {
 			log.Printf("delegating auth to az since %s is set to true", cUseAzCliAuthKey)
-			cred, err := azidentity.NewAzureCLICredential(nil)
+			cred, err := azidentity.NewAzureCLICredential(&azidentity.AzureCLICredentialOptions{
+				TenantID: options.TenantID,
+			})
 			if err != nil {
 				return nil, fmt.Errorf("failed to create credential: %v: %w", err, ErrNoCurrentUser)
 			}
@@ -137,7 +154,22 @@ func (m *Manager) CredentialForCurrentUser(ctx context.Context) (azcore.TokenCre
 	if currentUser.HomeAccountID != nil {
 		for _, account := range m.publicClient.Accounts() {
 			if account.HomeAccountID == *currentUser.HomeAccountID {
-				return newAzdCredential(m.publicClient, &account), nil
+				if options.TenantID == "" {
+					return newAzdCredential(m.publicClient, &account), nil
+				} else {
+					newAuthority := "https://login.microsoftonline.com/" + options.TenantID
+
+					newOptions := make([]public.Option, 0, len(m.publicClientOptions)+1)
+					newOptions = append(newOptions, m.publicClientOptions...)
+					newOptions = append(newOptions, public.WithAuthority(newAuthority))
+
+					clientWithNewTenant, err := public.New(cAZD_CLIENT_ID, newOptions...)
+					if err != nil {
+						return nil, err
+					}
+
+					return newAzdCredential(&msalPublicClientAdapter{client: &clientWithNewTenant}, &account), nil
+				}
 			}
 		}
 	} else if currentUser.TenantID != nil && currentUser.ClientID != nil {
@@ -146,9 +178,15 @@ func (m *Manager) CredentialForCurrentUser(ctx context.Context) (azcore.TokenCre
 			return nil, fmt.Errorf("loading secret: %v: %w", err, ErrNoCurrentUser)
 		}
 
+		tenantID := *currentUser.TenantID
+
+		if options.TenantID != "" {
+			tenantID = options.TenantID
+		}
+
 		if ps.ClientSecret != nil {
 			cred, err := azidentity.NewClientSecretCredential(
-				*currentUser.TenantID, *currentUser.ClientID, *ps.ClientSecret, nil,
+				tenantID, *currentUser.ClientID, *ps.ClientSecret, nil,
 			)
 
 			if err != nil {
@@ -169,7 +207,7 @@ func (m *Manager) CredentialForCurrentUser(ctx context.Context) (azcore.TokenCre
 			}
 
 			cred, err := azidentity.NewClientCertificateCredential(
-				*currentUser.TenantID, *currentUser.ClientID, certs, key, nil,
+				tenantID, *currentUser.ClientID, certs, key, nil,
 			)
 
 			if err != nil {
@@ -179,7 +217,7 @@ func (m *Manager) CredentialForCurrentUser(ctx context.Context) (azcore.TokenCre
 			return cred, nil
 		} else if ps.FederatedToken != nil {
 			cred, err := azidentity.NewClientAssertionCredential(
-				*currentUser.TenantID,
+				tenantID,
 				*currentUser.ClientID,
 				func(_ context.Context) (string, error) {
 					return *ps.FederatedToken, nil
@@ -479,6 +517,11 @@ func (m *Manager) saveSecret(tenantId, clientId string, ps *persistedSecret) err
 	}
 
 	return m.credentialCache.Set(persistedSecretLookupKey(tenantId, clientId), data)
+}
+
+type CredentialForCurrentUserOptions struct {
+	// The tenant ID to use when constructing the credential, instead of the default tenant.
+	TenantID string
 }
 
 // persistedSecret is the model type for the value we store in the credential cache. It is logically a discriminated union

--- a/cli/azd/pkg/auth/manager_test.go
+++ b/cli/azd/pkg/auth/manager_test.go
@@ -66,7 +66,7 @@ func TestServicePrincipalLoginClientSecret(t *testing.T) {
 	require.NoError(t, err)
 	require.IsType(t, new(azidentity.ClientSecretCredential), cred)
 
-	cred, err = m.CredentialForCurrentUser(context.Background())
+	cred, err = m.CredentialForCurrentUser(context.Background(), nil)
 
 	require.NoError(t, err)
 	require.IsType(t, new(azidentity.ClientSecretCredential), cred)
@@ -75,7 +75,7 @@ func TestServicePrincipalLoginClientSecret(t *testing.T) {
 
 	require.NoError(t, err)
 
-	_, err = m.CredentialForCurrentUser(context.Background())
+	_, err = m.CredentialForCurrentUser(context.Background(), nil)
 
 	require.True(t, errors.Is(err, ErrNoCurrentUser))
 }
@@ -100,7 +100,7 @@ func TestServicePrincipalLoginClientCertificate(t *testing.T) {
 	require.NoError(t, err)
 	require.IsType(t, new(azidentity.ClientCertificateCredential), cred)
 
-	cred, err = m.CredentialForCurrentUser(context.Background())
+	cred, err = m.CredentialForCurrentUser(context.Background(), nil)
 
 	require.NoError(t, err)
 	require.IsType(t, new(azidentity.ClientCertificateCredential), cred)
@@ -109,7 +109,7 @@ func TestServicePrincipalLoginClientCertificate(t *testing.T) {
 
 	require.NoError(t, err)
 
-	_, err = m.CredentialForCurrentUser(context.Background())
+	_, err = m.CredentialForCurrentUser(context.Background(), nil)
 
 	require.True(t, errors.Is(err, ErrNoCurrentUser))
 }
@@ -131,7 +131,7 @@ func TestServicePrincipalLoginFederatedToken(t *testing.T) {
 	require.NoError(t, err)
 	require.IsType(t, new(azidentity.ClientAssertionCredential), cred)
 
-	cred, err = m.CredentialForCurrentUser(context.Background())
+	cred, err = m.CredentialForCurrentUser(context.Background(), nil)
 
 	require.NoError(t, err)
 	require.IsType(t, new(azidentity.ClientAssertionCredential), cred)
@@ -140,7 +140,7 @@ func TestServicePrincipalLoginFederatedToken(t *testing.T) {
 
 	require.NoError(t, err)
 
-	_, err = m.CredentialForCurrentUser(context.Background())
+	_, err = m.CredentialForCurrentUser(context.Background(), nil)
 
 	require.True(t, errors.Is(err, ErrNoCurrentUser))
 }
@@ -176,7 +176,7 @@ func TestServicePrincipalLoginFederatedTokenProvider(t *testing.T) {
 	require.NoError(t, err)
 	require.IsType(t, new(azidentity.ClientAssertionCredential), cred)
 
-	cred, err = m.CredentialForCurrentUser(context.Background())
+	cred, err = m.CredentialForCurrentUser(context.Background(), nil)
 
 	require.NoError(t, err)
 	require.IsType(t, new(azidentity.ClientAssertionCredential), cred)
@@ -185,7 +185,7 @@ func TestServicePrincipalLoginFederatedTokenProvider(t *testing.T) {
 
 	require.NoError(t, err)
 
-	_, err = m.CredentialForCurrentUser(context.Background())
+	_, err = m.CredentialForCurrentUser(context.Background(), nil)
 
 	require.True(t, errors.Is(err, ErrNoCurrentUser))
 }
@@ -206,7 +206,7 @@ func TestLegacyAzCliCredentialSupport(t *testing.T) {
 		configManager: mgr,
 	}
 
-	cred, err := m.CredentialForCurrentUser(context.Background())
+	cred, err := m.CredentialForCurrentUser(context.Background(), nil)
 
 	require.NoError(t, err)
 	require.IsType(t, new(azidentity.AzureCLICredential), cred)
@@ -223,7 +223,7 @@ func TestLoginInteractive(t *testing.T) {
 	require.NoError(t, err)
 	require.IsType(t, new(azdCredential), cred)
 
-	cred, err = m.CredentialForCurrentUser(context.Background())
+	cred, err = m.CredentialForCurrentUser(context.Background(), nil)
 
 	require.NoError(t, err)
 	require.IsType(t, new(azdCredential), cred)
@@ -232,7 +232,7 @@ func TestLoginInteractive(t *testing.T) {
 
 	require.NoError(t, err)
 
-	_, err = m.CredentialForCurrentUser(context.Background())
+	_, err = m.CredentialForCurrentUser(context.Background(), nil)
 
 	require.True(t, errors.Is(err, ErrNoCurrentUser))
 }
@@ -252,7 +252,7 @@ func TestLoginDeviceCode(t *testing.T) {
 	require.NoError(t, err)
 	require.IsType(t, new(azdCredential), cred)
 
-	cred, err = m.CredentialForCurrentUser(context.Background())
+	cred, err = m.CredentialForCurrentUser(context.Background(), nil)
 
 	require.NoError(t, err)
 	require.IsType(t, new(azdCredential), cred)
@@ -261,7 +261,7 @@ func TestLoginDeviceCode(t *testing.T) {
 
 	require.NoError(t, err)
 
-	_, err = m.CredentialForCurrentUser(context.Background())
+	_, err = m.CredentialForCurrentUser(context.Background(), nil)
 
 	require.True(t, errors.Is(err, ErrNoCurrentUser))
 }

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,10 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.0.0
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0
+	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/benbjohnson/clock v1.3.0
 	github.com/blang/semver/v4 v4.0.0
+	github.com/bradleyjkemp/cupaloy/v2 v2.8.0
 	github.com/drone/envsubst v1.0.3
 	github.com/fatih/color v1.13.0
 	github.com/gofrs/flock v0.8.1
@@ -42,14 +44,8 @@ require (
 	golang.org/x/exp v0.0.0-20220428152302-39d4317da171
 	golang.org/x/sys v0.2.0
 	gopkg.in/yaml.v3 v3.0.0
-)
 
-require (
-	github.com/MakeNowJust/heredoc/v2 v2.0.1
-	github.com/bradleyjkemp/cupaloy/v2 v2.8.0
 )
-
-require github.com/kr/text v0.2.0 // indirect
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.1 // indirect
@@ -63,6 +59,7 @@ require (
 	github.com/google/subcommands v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect


### PR DESCRIPTION
This allows fetching a token from a different tenant than the user's default tenant.