### PR TITLE
Support `secureObject` and `secureString` ARM parameter types

### DIFF
--- a/cli/azd/pkg/azure/arm_template.go
+++ b/cli/azd/pkg/azure/arm_template.go
@@ -35,6 +35,10 @@ type ArmTemplateParameterDefinition struct {
 	Metadata      map[string]json.RawMessage `json:"metadata"`
 }
 
+func (d *ArmTemplateParameterDefinition) Secure() bool {
+	return d.Type == "secureObject" || d.Type == "secureString"
+}
+
 type AzdMetadata struct {
 	Type *string `json:"type,omitempty"`
 }

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -655,13 +655,13 @@ func (p *BicepProvider) deleteDeployment(
 
 func (p *BicepProvider) mapBicepTypeToInterfaceType(s string) ParameterType {
 	switch s {
-	case "String", "string":
+	case "String", "string", "secureString":
 		return ParameterTypeString
 	case "Bool", "bool":
 		return ParameterTypeBoolean
 	case "Int", "int":
 		return ParameterTypeNumber
-	case "Object", "object":
+	case "Object", "object", "secureObject":
 		return ParameterTypeObject
 	case "Array", "array":
 		return ParameterTypeArray
@@ -901,19 +901,21 @@ func (p *BicepProvider) ensureParameters(
 				return fmt.Errorf("prompting for value: %w", err)
 			}
 
-			saveParameter, err := p.console.Confirm(ctx, input.ConsoleOptions{
-				Message: "Save the value in the environment for future use",
-			})
+			if !param.Secure() {
+				saveParameter, err := p.console.Confirm(ctx, input.ConsoleOptions{
+					Message: "Save the value in the environment for future use",
+				})
 
-			if err != nil {
-				return fmt.Errorf("prompting to save deployment parameter: %w", err)
-			}
+				if err != nil {
+					return fmt.Errorf("prompting to save deployment parameter: %w", err)
+				}
 
-			if saveParameter {
-				if err := p.env.Config.Set(configKey, value); err == nil {
-					configModified = true
-				} else {
-					p.console.Message(ctx, fmt.Sprintf("warning: failed to set value: %v", err))
+				if saveParameter {
+					if err := p.env.Config.Set(configKey, value); err == nil {
+						configModified = true
+					} else {
+						p.console.Message(ctx, fmt.Sprintf("warning: failed to set value: %v", err))
+					}
 				}
 			}
 

--- a/cli/azd/pkg/infra/provisioning/bicep/prompt_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt_test.go
@@ -34,6 +34,8 @@ func TestPromptForParameter(t *testing.T) {
 		{"boolFalse", "bool", 1, true},
 		{"arrayParam", "array", `["hello", "world"]`, []any{"hello", "world"}},
 		{"objectParam", "object", `{"hello": "world"}`, map[string]any{"hello": "world"}},
+		{"secureObject", "secureObject", `{"hello": "world"}`, map[string]any{"hello": "world"}},
+		{"secureString", "secureString", "value", "value"},
 	} {
 		tc := cc
 


### PR DESCRIPTION
From the user's point of view, these behave the same ways as their insecure counterparts. During a deployment, ARM will not retain information about secure parameters.

When prompting for un-configured parameters, we do not offer to save the value of a secure parameter in the environment.

Fixes #1289