### PR TITLE
Don't print an extra newline after (most) commands

### DIFF
--- a/cli/azd/cmd/actions/action.go
+++ b/cli/azd/cmd/actions/action.go
@@ -32,7 +32,7 @@ type Action interface {
 	Run(ctx context.Context) (*ActionResult, error)
 }
 
-func ToActionResult(actionResult *ActionResult, err error) ux.UxItem {
+func ToUxItem(actionResult *ActionResult, err error) ux.UxItem {
 	if err != nil {
 		return &ux.ActionResult{
 			SuccessMessage: "",

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -153,7 +153,12 @@ func BuildCmd[F any](
 		actionResult, err := action.Run(ctx)
 		// At this point, we know that there might be an error, so we can silence cobra from showing it after us.
 		cmd.SilenceErrors = true
-		console.MessageUxItem(ctx, actions.ToActionResult(actionResult, err))
+
+		// It is valid for a command to return a nil action result and error. If we have a result or an error, display it,
+		// otherwise don't print anything.
+		if actionResult != nil || err != nil {
+			console.MessageUxItem(ctx, actions.ToUxItem(actionResult, err))
+		}
 
 		return err
 	}

--- a/cli/azd/test/functional/version_test.go
+++ b/cli/azd/test/functional/version_test.go
@@ -61,3 +61,14 @@ func Test_CLI_Version_Json(t *testing.T) {
 	expected := getExpectedVersion(t)
 	require.Equal(t, expected, versionJson.Azd.Version)
 }
+
+func Test_CLI_Version_NoExtraConsoleMessages(t *testing.T) {
+	ctx, cancel := newTestContext(t)
+	defer cancel()
+
+	cli := azdcli.NewCLI(t)
+	result, err := cli.RunCommand(ctx, "version", "--output", "json")
+	require.NoError(t, err)
+
+	require.Empty(t, result.Stderr)
+}


### PR DESCRIPTION
If a command returned a nil ActionResult (as most commands do), we would still try to create a MessageUxItem for it and render that. This would end up with an empty message being printed to the console and then another newline. When using JSON output this was very obvious (when running at the terminal, it's a little easy to not notice the extra blank line that is at the end of the command).