### PR TITLE
Enable check enforcer for mixed github actions + azure pipelines CI

### DIFF
--- a/.github/workflows/event.yml
+++ b/.github/workflows/event.yml
@@ -8,6 +8,11 @@ on:
     types: [completed]
   issue_comment:
     types: [created]
+  # Trigger off other github actions, because otherwise a check_suite completed event consisting
+  # entirely of github actions won't trigger this action.
+  workflow_run:
+    types: [completed]
+    workflows: ["cli-ci", "templates-ci", "vscode-ci"]
 
 permissions: {}
 


### PR DESCRIPTION
**Requires https://github.com/Azure/azure-sdk-actions/pull/7 to merge first (currently reverted), which adds support for workflow_run action types and enforcing multiple check suites**

This updates the check enforcer github action to run on completion of other github actions, namely template-ci, cli-ci and vscode-ci (by default, events from github actions do not trigger other github actions to prevent loops).

With this update, we will be able to de-commission check enforcer v1. Once it goes in, we will need to update the branch protection settings to require `https://aka.ms/azsdk/checkenforcer` and remove the `check-enforcer` github app from this repository.

I think these changes are pretty well tested, but regardless should be monitored for a while after they go in.