### PR TITLE
Allow configuration of service endpoint using `SERVICE_<service>_ENDPOINTS`

### DIFF
--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -178,7 +178,7 @@ func (d *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 		stepMessage := fmt.Sprintf("Deploying service %s", svc.Config.Name)
 		d.console.ShowSpinner(ctx, stepMessage, input.Step)
-		result, progress := svc.Deploy(ctx, d.azdCtx, env)
+		result, progress := svc.Deploy(ctx, d.azdCtx)
 
 		// Report any progress to logs only. Changes for the console are managed by the console object.
 		// This routine is required to drain all the string messages sent by the `progress`.

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -178,7 +178,7 @@ func (d *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 		stepMessage := fmt.Sprintf("Deploying service %s", svc.Config.Name)
 		d.console.ShowSpinner(ctx, stepMessage, input.Step)
-		result, progress := svc.Deploy(ctx, d.azdCtx)
+		result, progress := svc.Deploy(ctx, d.azdCtx, env)
 
 		// Report any progress to logs only. Changes for the console are managed by the console object.
 		// This routine is required to drain all the string messages sent by the `progress`.

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
@@ -201,4 +202,18 @@ func (e *Environment) SetPrincipalId(principalID string) {
 
 func (e *Environment) GetPrincipalId() string {
 	return e.Values[PrincipalIdEnvVarName]
+}
+
+func normalize(key string) string {
+	return strings.ReplaceAll(strings.ToUpper(key), "-", "_")
+}
+
+// Returns the value of a service-namespaced property in the environment.
+func (e *Environment) GetServiceProperty(serviceName string, propertyName string) string {
+	return e.Values[fmt.Sprintf("SERVICE_%s_%s", normalize(serviceName), propertyName)]
+}
+
+// Sets the value of a service-namespaced property in the environment.
+func (e *Environment) SetServiceProperty(serviceName string, propertyName string, value string) {
+	e.Values[fmt.Sprintf("SERVICE_%s_%s", normalize(serviceName), propertyName)] = value
 }

--- a/cli/azd/pkg/project/service.go
+++ b/cli/azd/pkg/project/service.go
@@ -19,6 +19,8 @@ type Service struct {
 	Project *Project
 	// The reference to the service configuration from the azure.yaml file
 	Config *ServiceConfig
+	// The environment the service is executing in
+	Environment *environment.Environment
 	// The framework/platform service used to build and package the service
 	Framework FrameworkService
 	// The application target service used to deploy the service to azure
@@ -45,7 +47,6 @@ func (svc *Service) RequiredExternalTools() []tools.ExternalTool {
 func (svc *Service) Deploy(
 	ctx context.Context,
 	azdCtx *azdcontext.AzdContext,
-	env *environment.Environment,
 ) (<-chan *ServiceDeploymentChannelResponse, <-chan string) {
 	result := make(chan *ServiceDeploymentChannelResponse, 1)
 	progress := make(chan string)
@@ -80,8 +81,8 @@ func (svc *Service) Deploy(
 
 		// Allow users to specify their own endpoints, in cases where they've configured their own front-end load balancers,
 		// reverse proxies or DNS host names outside of the service target (and prefer that to be used instead).
-		if endpointsOverride := env.GetServiceProperty(svc.Config.Name, "ENDPOINTS"); endpointsOverride != "" {
-			res.Endpoints = strings.Split(endpointsOverride, ",")
+		if overriddenEndpoints := svc.Environment.GetServiceProperty(svc.Config.Name, "ENDPOINTS"); overriddenEndpoints != "" {
+			res.Endpoints = strings.Split(overriddenEndpoints, ",")
 		}
 
 		log.Printf("deployed service %s", svc.Config.Name)

--- a/cli/azd/pkg/project/service.go
+++ b/cli/azd/pkg/project/service.go
@@ -5,9 +5,9 @@ package project
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
@@ -81,8 +81,9 @@ func (svc *Service) Deploy(
 
 		// Allow users to specify their own endpoints, in cases where they've configured their own front-end load balancers,
 		// reverse proxies or DNS host names outside of the service target (and prefer that to be used instead).
-		if overriddenEndpoints := svc.Environment.GetServiceProperty(svc.Config.Name, "ENDPOINTS"); overriddenEndpoints != "" {
-			res.Endpoints = strings.Split(overriddenEndpoints, ",")
+		overriddenEndpoints := svc.getOverriddenEndpoints()
+		if len(overriddenEndpoints) > 0 {
+			res.Endpoints = overriddenEndpoints
 		}
 
 		log.Printf("deployed service %s", svc.Config.Name)
@@ -94,4 +95,24 @@ func (svc *Service) Deploy(
 	}()
 
 	return result, progress
+}
+
+func (svc *Service) getOverriddenEndpoints() []string {
+	overriddenEndpoints := svc.Environment.GetServiceProperty(svc.Config.Name, "ENDPOINTS")
+	if overriddenEndpoints != "" {
+		var endpoints []string
+		err := json.Unmarshal([]byte(overriddenEndpoints), &endpoints)
+		if err != nil {
+			// This can only happen if the environment file is manually edited.
+			// For typical infra provider output passthrough, the infra provider would guarantee well-formed syntax
+			log.Printf(
+				"failed to unmarshal endpoints override for service '%s' as JSON: %v, skipping override",
+				svc.Config.Name,
+				err)
+		}
+
+		return endpoints
+	}
+
+	return nil
 }

--- a/cli/azd/pkg/project/service.go
+++ b/cli/azd/pkg/project/service.go
@@ -103,10 +103,10 @@ func (svc *Service) getOverriddenEndpoints() []string {
 		var endpoints []string
 		err := json.Unmarshal([]byte(overriddenEndpoints), &endpoints)
 		if err != nil {
-			// This can only happen if the environment file is manually edited.
-			// For typical infra provider output passthrough, the infra provider would guarantee well-formed syntax
+			// This can only happen if the environment output was not a valid JSON array, which would be due to an authoring
+			// error. For typical infra provider output passthrough, the infra provider would guarantee well-formed syntax
 			log.Printf(
-				"failed to unmarshal endpoints override for service '%s' as JSON: %v, skipping override",
+				"failed to unmarshal endpoints override for service '%s' as JSON array of strings: %v, skipping override",
 				svc.Config.Name,
 				err)
 		}

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -90,6 +90,7 @@ func (sc *ServiceConfig) GetService(
 	return &Service{
 		Project:        project,
 		Config:         sc,
+		Environment:    env,
 		Framework:      *framework,
 		Target:         *serviceTarget,
 		TargetResource: targetResource,

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -101,7 +101,7 @@ func (at *containerAppTarget) Deploy(
 	log.Printf("writing image name to environment")
 
 	// Save the name of the image we pushed into the environment with a well known key.
-	at.env.Values[fmt.Sprintf("SERVICE_%s_IMAGE_NAME", strings.ReplaceAll(strings.ToUpper(at.config.Name), "-", "_"))] = fullTag
+	at.env.SetServiceProperty(at.config.Name, "IMAGE_NAME", fullTag)
 
 	if err := at.env.Save(); err != nil {
 		return ServiceDeploymentResult{}, fmt.Errorf("saving image name to environment: %w", err)

--- a/cli/azd/pkg/project/service_test.go
+++ b/cli/azd/pkg/project/service_test.go
@@ -120,7 +120,7 @@ func TestDeployProgressMessages(t *testing.T) {
 		TargetResource: mockTarget,
 	}
 
-	result, progress := service.Deploy(*mockContext.Context, azdContext, env)
+	result, progress := service.Deploy(*mockContext.Context, azdContext)
 	progressMessages := []string{}
 
 	go func() {

--- a/cli/azd/pkg/project/service_test.go
+++ b/cli/azd/pkg/project/service_test.go
@@ -120,7 +120,7 @@ func TestDeployProgressMessages(t *testing.T) {
 		TargetResource: mockTarget,
 	}
 
-	result, progress := service.Deploy(*mockContext.Context, azdContext)
+	result, progress := service.Deploy(*mockContext.Context, azdContext, env)
 	progressMessages := []string{}
 
 	go func() {

--- a/cli/azd/pkg/project/service_test.go
+++ b/cli/azd/pkg/project/service_test.go
@@ -115,6 +115,7 @@ func TestDeployProgressMessages(t *testing.T) {
 	service := Service{
 		Project:        project,
 		Config:         project.Config.Services["api"],
+		Environment:    env,
 		Framework:      mockFramework,
 		Target:         mockServiceTarget,
 		TargetResource: mockTarget,

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -141,6 +142,8 @@ func Test_CLI_InfraCreateAndDelete(t *testing.T) {
 	require.True(t, ok)
 	require.Regexp(t, `st\S*`, accountName)
 
+	assertEnvValuesStored(t, env)
+
 	// GetResourceGroupsForEnvironment requires a credential since it is using the SDK now
 	cred, err := azidentity.NewAzureCLICredential(nil)
 	if err != nil {
@@ -194,6 +197,8 @@ func Test_CLI_InfraCreateAndDeleteUpperCase(t *testing.T) {
 	accountName, ok := env.Values["AZURE_STORAGE_ACCOUNT_NAME"]
 	require.True(t, ok)
 	require.Regexp(t, `st\S*`, accountName)
+
+	assertEnvValuesStored(t, env)
 
 	// GetResourceGroupsForEnvironment requires a credential since it is using the SDK now
 	cred, err := azidentity.NewAzureCLICredential(nil)
@@ -426,8 +431,10 @@ func Test_CLI_InfraCreateAndDeleteResourceTerraform(t *testing.T) {
 	_, err = cli.RunCommand(ctx, "infra", "create", "--cwd", dir)
 	require.NoError(t, err)
 
-	_, err = cli.RunCommand(ctx, "env", "get-values", "-o", "json", "--cwd", dir)
+	envPath := filepath.Join(dir, azdcontext.EnvironmentDirectoryName, envName)
+	env, err := environment.FromRoot(envPath)
 	require.NoError(t, err)
+	assertEnvValuesStored(t, env)
 
 	t.Logf("Starting infra delete\n")
 	_, err = cli.RunCommand(ctx, "infra", "delete", "--cwd", dir, "--force", "--purge")
@@ -609,4 +616,22 @@ func removeAllWithDiagnostics(t *testing.T, path string) error {
 			return retry.RetryableError(removeErr)
 		},
 	)
+}
+
+// Assert that all supported types from the infrastructure provider is marshalled and stored correctly in the environment.
+func assertEnvValuesStored(t *testing.T, env *environment.Environment) {
+	expectedEnv, err := environment.FromRoot("testdata/expected-output-types")
+	require.NoError(t, err)
+	primitives := []string{"STRING", "BOOL", "INT"}
+
+	for k, v := range expectedEnv.Values {
+		assert.Contains(t, env.Values, k)
+		actual := env.Values[k]
+
+		if slices.Contains(primitives, k) {
+			assert.Equal(t, v, actual)
+		} else {
+			assert.JSONEq(t, v, actual)
+		}
+	}
 }

--- a/cli/azd/test/functional/testdata/expected-output-types/typed-values.env
+++ b/cli/azd/test/functional/testdata/expected-output-types/typed-values.env
@@ -1,0 +1,5 @@
+STRING="abc"
+BOOL="true"
+INT=1234
+ARRAY="[true,\"abc\",1234]"
+OBJECT="{\"foo\":\"bar\",\"inner\":{\"foo\":\"bar\"},\"array\":[true, \"abc\", 1234]}"

--- a/cli/azd/test/functional/testdata/samples/resourcegroupterraform/infra/output.tf
+++ b/cli/azd/test/functional/testdata/samples/resourcegroupterraform/infra/output.tf
@@ -6,3 +6,30 @@ output "RG_NAME" {
   value = azurerm_resource_group.rg.name
 }
 
+
+// test cases for all supported types
+output "STRING" {
+  value = "abc"
+}
+
+output "BOOL" {
+  value = true
+}
+
+output "INT" {
+  value = 1234
+}
+
+output "ARRAY" {
+  value = [true, "abc", 1234]
+}
+
+output "OBJECT" {
+  value = {
+    foo : "bar"
+    inner: {
+      foo: "bar"
+    }
+    array: [true, "abc", 1234]
+  }
+}

--- a/cli/azd/test/functional/testdata/samples/storage/infra/main.bicep
+++ b/cli/azd/test/functional/testdata/samples/storage/infra/main.bicep
@@ -11,9 +11,6 @@ param location string
 @description('A time to mark on created resource groups, so they can be cleaned up via an automated process.')
 param deleteAfterTime string = dateTimeAdd(utcNow('o'), 'PT1H')
 
-@description('A simple sentinel that can be used to change behavior between PROD and non-PROD')
-param isProd string = 'false'
-
 var tags = { 'azd-env-name': environmentName, DeleteAfter: deleteAfterTime }
 var isProdBool = isProd == 'true' ? true : false
 
@@ -34,5 +31,16 @@ module resources 'resources.bicep' = {
 
 output AZURE_STORAGE_ACCOUNT_ID string = resources.outputs.AZURE_STORAGE_ACCOUNT_ID
 output AZURE_STORAGE_ACCOUNT_NAME string = resources.outputs.AZURE_STORAGE_ACCOUNT_NAME
-// test support for non string output
-output AZURE_STORAGE_IS_PROD bool = isProdBool
+
+// test cases for all supported types
+output STRING string = 'abc'
+output BOOL bool = true
+output INT int = 1234
+output ARRAY array = [true, 'abc', 1234]
+output OBJECT object = {
+  foo : 'bar'
+  inner: {
+    foo: 'bar'
+  }
+  array: [true, 'abc', 1234]
+}

--- a/cli/azd/test/functional/testdata/samples/storage/infra/main.bicep
+++ b/cli/azd/test/functional/testdata/samples/storage/infra/main.bicep
@@ -12,7 +12,6 @@ param location string
 param deleteAfterTime string = dateTimeAdd(utcNow('o'), 'PT1H')
 
 var tags = { 'azd-env-name': environmentName, DeleteAfter: deleteAfterTime }
-var isProdBool = isProd == 'true' ? true : false
 
 resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: 'rg-${environmentName}'

--- a/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/infra/main.bicep
@@ -201,5 +201,5 @@ output AZURE_TENANT_ID string = tenant().tenantId
 output REACT_APP_API_BASE_URL string = (useAPIM == 'true') ? apimApi.outputs.SERVICE_API_URI : api.outputs.SERVICE_API_URI
 output REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.applicationInsightsConnectionString
 output REACT_APP_WEB_BASE_URL string = web.outputs.SERVICE_WEB_URI
-output SERVICE_API_ENDPOINTS string = (useAPIM == 'true') ? apimApi.outputs.SERVICE_API_URI : ''
+output SERVICE_API_ENDPOINTS array = (useAPIM == 'true') ? [apimApi.outputs.SERVICE_API_URI ]: []
 output USE_APIM string = useAPIM

--- a/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/infra/main.bicep
@@ -201,4 +201,5 @@ output AZURE_TENANT_ID string = tenant().tenantId
 output REACT_APP_API_BASE_URL string = (useAPIM == 'true') ? apimApi.outputs.SERVICE_API_URI : api.outputs.SERVICE_API_URI
 output REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.applicationInsightsConnectionString
 output REACT_APP_WEB_BASE_URL string = web.outputs.SERVICE_WEB_URI
+output SERVICE_API_ENDPOINTS string = (useAPIM == 'true') ? apimApi.outputs.SERVICE_API_URI : ''
 output USE_APIM string = useAPIM


### PR DESCRIPTION
Allow users to specify their own endpoints for a given service, in cases where they've configured their own front-end load balancers, reverse proxies or DNS host names outside of the service target (and prefer that to be used instead).

With this change, manually tested that the CSharp cosmos template with APIM enabled prints the APIM endpoint:
```
  (✓) Done: Deploying service api
  - Endpoint: https://apim-tktoainmj6iyu.azure-api.net/todo
```

And also works correctly when APIM is not enabled.

Fixes #1192 