### PR TITLE
Fix AzureDeveloperCredential for Java

### DIFF
--- a/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
+++ b/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/AzureDeveloperCliCredential.java
@@ -143,6 +143,9 @@ public class AzureDeveloperCliCredential implements TokenCredential {
             }
             String processOutput = output.toString();
 
+            // wait until the process completes or the timeout (10 sec) is reached.
+            process.waitFor(10, TimeUnit.SECONDS);
+
             if (process.exitValue() != 0) {
                 if (processOutput.length() > 0) {
                     String redactedOutput = redactInfo(processOutput);
@@ -184,7 +187,7 @@ public class AzureDeveloperCliCredential implements TokenCredential {
                 .toOffsetDateTime()
                 .withOffsetSameInstant(ZoneOffset.UTC);
             token = new AccessToken(accessToken, expiresOn);
-        } catch (IOException e) {
+        } catch (IOException | InterruptedException e) {
             throw LOGGER.logExceptionAsError(new IllegalStateException(e));
         } catch (RuntimeException e) {
             return Mono.error(


### PR DESCRIPTION
There was a missing command to wait for the process to terminate before checking the return code.

fix: https://github.com/Azure/azure-dev/issues/1303