### PR TITLE
Checks for container registration errors vs actual errors

### DIFF
--- a/cli/azd/cmd/cobra_builder.go
+++ b/cli/azd/cmd/cobra_builder.go
@@ -136,9 +136,8 @@ func (cb *CobraBuilder) configureActionResolver(cmd *cobra.Command, descriptor *
 
 		// TODO: Consider refactoring to move the UX writing to a middleware
 		invokeErr := ioc.Global.Invoke(func(console input.Console) {
-			// It is valid for a command to return a nil action result and error. If we have a result or an error, display
-			// it,
-			// otherwise don't print anything.
+			// It is valid for a command to return a nil action result and error.
+			// If we have a result or an error, display it, otherwise don't print anything.
 			if actionResult != nil || err != nil {
 				console.MessageUxItem(ctx, actions.ToUxItem(actionResult, err))
 			}

--- a/cli/azd/pkg/ioc/container.go
+++ b/cli/azd/pkg/ioc/container.go
@@ -5,14 +5,24 @@
 package ioc
 
 import (
+	"errors"
+	"fmt"
+	"regexp"
+
 	"github.com/golobby/container/v3"
 )
 
-// The global/root level container
-var Global *NestedContainer = &NestedContainer{
-	inner:  container.Global,
-	parent: nil,
-}
+var (
+	containerErrorRegex *regexp.Regexp = regexp.MustCompile("container:")
+
+	// The global/root level container
+	Global *NestedContainer = &NestedContainer{
+		inner:  container.Global,
+		parent: nil,
+	}
+
+	ErrResolveInstance error = errors.New("failed resolving instance from container")
+)
 
 // NestedContainer is an IoC container that support nested containers
 // Used for more complex registration scenarios such as scop based registration/resolution.
@@ -79,7 +89,7 @@ func (c *NestedContainer) Resolve(instance any) error {
 		}
 
 		if current.parent == nil {
-			return err
+			return inspectResolveError(err)
 		}
 		current = current.parent
 	}
@@ -96,7 +106,7 @@ func (c *NestedContainer) ResolveNamed(name string, instance any) error {
 		}
 
 		if current.parent == nil {
-			return err
+			return inspectResolveError(err)
 		}
 		current = current.parent
 	}
@@ -122,4 +132,15 @@ func RegisterNamedInstance[F any](c *NestedContainer, name string, instance F) {
 	container.MustNamedSingletonLazy(c.inner, name, func() F {
 		return instance
 	})
+}
+
+// Inspects the specified error to determine whether the error is a
+// developer container registration error or an error that was
+// returned while instantiating a dependency.
+func inspectResolveError(err error) error {
+	if containerErrorRegex.Match([]byte(err.Error())) {
+		return fmt.Errorf("%w: %s", ErrResolveInstance, err.Error())
+	}
+
+	return err
 }

--- a/cli/azd/pkg/ioc/container.go
+++ b/cli/azd/pkg/ioc/container.go
@@ -13,6 +13,8 @@ import (
 )
 
 var (
+	// The golobby project does not support types errors,
+	// but all the error messages are prefixed with `container:`
 	containerErrorRegex *regexp.Regexp = regexp.MustCompile("container:")
 
 	// The global/root level container

--- a/cli/azd/pkg/ioc/container_test.go
+++ b/cli/azd/pkg/ioc/container_test.go
@@ -31,8 +31,8 @@ func Test_Resolve(t *testing.T) {
 		err := container.Resolve(&instance)
 
 		require.Error(t, err)
-		require.False(t, errors.Is(err, ErrResolveInstance))
-		require.True(t, errors.Is(err, azdcontext.ErrNoProject))
+		require.True(t, errors.Is(err, ErrResolveInstance))
+		require.False(t, errors.Is(err, azdcontext.ErrNoProject))
 	})
 
 	t.Run("FailWithOtherError", func(t *testing.T) {

--- a/cli/azd/pkg/ioc/container_test.go
+++ b/cli/azd/pkg/ioc/container_test.go
@@ -1,0 +1,51 @@
+package ioc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Resolve(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		container := NewNestedContainer(nil)
+		container.RegisterSingleton(func() string {
+			return "Test"
+		})
+
+		var instance string
+		err := container.Resolve(&instance)
+
+		require.NoError(t, err)
+		require.Equal(t, "Test", instance)
+	})
+
+	t.Run("FailWithContainerError", func(t *testing.T) {
+		container := NewNestedContainer(nil)
+
+		var instance *azdcontext.AzdContext
+		// Since a resolver wasn't registered for AzdContext
+		// Expect a resolution container failure
+		err := container.Resolve(&instance)
+
+		require.Error(t, err)
+		require.False(t, errors.Is(err, ErrResolveInstance))
+		require.True(t, errors.Is(err, azdcontext.ErrNoProject))
+	})
+
+	t.Run("FailWithOtherError", func(t *testing.T) {
+		container := NewNestedContainer(nil)
+		container.RegisterSingleton(azdcontext.NewAzdContext)
+
+		var instance *azdcontext.AzdContext
+		// AzdContext resolver is registered above
+		// Expect failure from no project
+		err := container.Resolve(&instance)
+
+		require.Error(t, err)
+		require.False(t, errors.Is(err, ErrResolveInstance))
+		require.True(t, errors.Is(err, azdcontext.ErrNoProject))
+	})
+}


### PR DESCRIPTION
Fixes #1322 

Will verify if an error received during action instantiation is rooted from a developer container registration error vs an an actual error returned by a resolving dependency.