### PR TITLE
Add pid to debug attach printout

### DIFF
--- a/cli/azd/cmd/middleware/debug.go
+++ b/cli/azd/cmd/middleware/debug.go
@@ -44,7 +44,7 @@ func (m *DebugMiddleware) Run(ctx context.Context, next NextFn) (*actions.Action
 
 	for {
 		isReady, err := m.console.Confirm(ctx, input.ConsoleOptions{
-			Message:      "Debugger Ready?",
+			Message:      fmt.Sprintf("Debugger Ready? (pid: %d)", os.Getpid()),
 			DefaultValue: true,
 		})
 


### PR DESCRIPTION
Add pid to debug attach printout. Since attaching debugger to the process requires the PID, having it displayed saves an extra step and avoids confusion when multiple instances of `azd` is running.