### PR TITLE
Improve bicep and terraform input/output type-handling

### DIFF
--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -1031,10 +1031,6 @@ func armParameterFileValue(paramType ParameterType, value any) any {
 			if intVal, err := strconv.ParseInt(val, 10, 64); err == nil {
 				return intVal
 			}
-
-			if floatVal, err := strconv.ParseFloat(val, 64); err == nil {
-				return floatVal
-			}
 		}
 	}
 

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -941,7 +942,9 @@ func (p *BicepProvider) ensureParameters(
 
 		// If a value is explicitly configured via a parameters file, use it.
 		if v, has := parameters[key]; has {
-			configuredParameters[key] = v
+			configuredParameters[key] = azure.ArmParameterValue{
+				Value: armParameterFileValue(p.mapBicepTypeToInterfaceType(param.Type), v.Value),
+			}
 			continue
 		}
 
@@ -1011,6 +1014,31 @@ func (p *BicepProvider) ensureParameters(
 	}
 
 	return configuredParameters, nil
+}
+
+// Convert the ARM parameters file value into a value suitable for deployment
+func armParameterFileValue(paramType ParameterType, value any) any {
+	// Relax the handling of bool and number types to accept convertible strings
+	switch paramType {
+	case ParameterTypeBoolean:
+		if val, ok := value.(string); ok {
+			if boolVal, err := strconv.ParseBool(val); err == nil {
+				return boolVal
+			}
+		}
+	case ParameterTypeNumber:
+		if val, ok := value.(string); ok {
+			if intVal, err := strconv.ParseInt(val, 10, 64); err == nil {
+				return intVal
+			}
+
+			if floatVal, err := strconv.ParseFloat(val, 64); err == nil {
+				return floatVal
+			}
+		}
+	}
+
+	return value
 }
 
 func isValueAssignableToParameterType(paramType ParameterType, value any) bool {

--- a/cli/azd/pkg/infra/provisioning/bicep/prompt.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt.go
@@ -154,7 +154,7 @@ func convertString(s string) string {
 }
 
 func convertInt(s string) int {
-	if i, err := strconv.ParseInt(s, 10, 0); err != nil {
+	if i, err := strconv.ParseInt(s, 10, 64); err != nil {
 		panic(fmt.Sprintf("convertInt: %v", err))
 	} else {
 		return int(i)

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -423,12 +423,14 @@ func (t *TerraformProvider) mapTerraformTypeToInterfaceType(typ any) ParameterTy
 		// in this case we have a complex type, which in json looked like ["type", <schema parts>...], just pull out the
 		// first part and map to either and object or array.
 		switch v[0].(string) {
+		case "list":
 		case "tuple":
 			return ParameterTypeArray
 		case "object":
+		case "map":
 			return ParameterTypeObject
 		default:
-			panic(fmt.Sprintf("unknown primitive complex type tag: %s (full type: %+v)", v, typ))
+			panic(fmt.Sprintf("unknown complex type tag: %s (full type: %+v)", v, typ))
 		}
 	}
 
@@ -439,6 +441,10 @@ func (t *TerraformProvider) mapTerraformTypeToInterfaceType(typ any) ParameterTy
 func (t *TerraformProvider) convertOutputs(outputMap map[string]terraformOutput) map[string]OutputParameter {
 	outputParameters := make(map[string]OutputParameter)
 	for k, v := range outputMap {
+		if v.Type == "null" {
+			continue
+		}
+
 		outputParameters[k] = OutputParameter{
 			Type:  t.mapTerraformTypeToInterfaceType(v.Type),
 			Value: v.Value,

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -423,11 +423,9 @@ func (t *TerraformProvider) mapTerraformTypeToInterfaceType(typ any) ParameterTy
 		// in this case we have a complex type, which in json looked like ["type", <schema parts>...], just pull out the
 		// first part and map to either and object or array.
 		switch v[0].(string) {
-		case "list":
-		case "tuple":
+		case "list", "tuple", "set":
 			return ParameterTypeArray
-		case "object":
-		case "map":
+		case "object", "map":
 			return ParameterTypeObject
 		default:
 			panic(fmt.Sprintf("unknown complex type tag: %s (full type: %+v)", v, typ))
@@ -441,7 +439,8 @@ func (t *TerraformProvider) mapTerraformTypeToInterfaceType(typ any) ParameterTy
 func (t *TerraformProvider) convertOutputs(outputMap map[string]terraformOutput) map[string]OutputParameter {
 	outputParameters := make(map[string]OutputParameter)
 	for k, v := range outputMap {
-		if v.Type == "null" {
+		if val, ok := v.Value.(string); ok && val == "null" {
+			// omit null
 			continue
 		}
 

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/test/azdcli"
+	"github.com/joho/godotenv"
 	"github.com/sethvargo/go-retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -620,11 +621,11 @@ func removeAllWithDiagnostics(t *testing.T, path string) error {
 
 // Assert that all supported types from the infrastructure provider is marshalled and stored correctly in the environment.
 func assertEnvValuesStored(t *testing.T, env *environment.Environment) {
-	expectedEnv, err := environment.FromRoot("testdata/expected-output-types")
+	expectedEnv, err := godotenv.Read(filepath.Join("testdata", "expected-output-types", "typed-values.env"))
 	require.NoError(t, err)
 	primitives := []string{"STRING", "BOOL", "INT"}
 
-	for k, v := range expectedEnv.Values {
+	for k, v := range expectedEnv {
 		assert.Contains(t, env.Values, k)
 		actual := env.Values[k]
 

--- a/cli/azd/test/functional/testdata/expected-output-types/typed-values.env
+++ b/cli/azd/test/functional/testdata/expected-output-types/typed-values.env
@@ -2,4 +2,6 @@ STRING="abc"
 BOOL="true"
 INT=1234
 ARRAY="[true,\"abc\",1234]"
+ARRAY_INT="[1,2,3]"
+ARRAY_STRING="[\"elem1\",\"elem2\",\"elem3\"]"
 OBJECT="{\"foo\":\"bar\",\"inner\":{\"foo\":\"bar\"},\"array\":[true, \"abc\", 1234]}"

--- a/cli/azd/test/functional/testdata/expected-output-types/typed-values.env
+++ b/cli/azd/test/functional/testdata/expected-output-types/typed-values.env
@@ -4,4 +4,4 @@ INT=1234
 ARRAY="[true,\"abc\",1234]"
 ARRAY_INT="[1,2,3]"
 ARRAY_STRING="[\"elem1\",\"elem2\",\"elem3\"]"
-OBJECT="{\"foo\":\"bar\",\"inner\":{\"foo\":\"bar\"},\"array\":[true, \"abc\", 1234]}"
+OBJECT="{\"foo\":\"bar\",\"inner\":{\"foo\":\"bar\"},\"array\":[true,\"abc\",1234]}"

--- a/cli/azd/test/functional/testdata/samples/resourcegroupterraform/infra/output.tf
+++ b/cli/azd/test/functional/testdata/samples/resourcegroupterraform/infra/output.tf
@@ -21,15 +21,25 @@ output "INT" {
 }
 
 output "ARRAY" {
-  value = [true, "abc", 1234]
+  value = var.dummy_tuple
+}
+
+output "ARRAY_INT" {
+  value = var.dummy_set_numbers
+}
+
+output "ARRAY_STRING" {
+  value = var.dummy_list_string
+}
+
+output "NULL" {
+  value = null
 }
 
 output "OBJECT" {
   value = {
     foo : "bar"
-    inner: {
-      foo: "bar"
-    }
-    array: [true, "abc", 1234]
+    inner: var.dummy_map
+    array: var.dummy_tuple
   }
 }

--- a/cli/azd/test/functional/testdata/samples/resourcegroupterraform/infra/variables.tf
+++ b/cli/azd/test/functional/testdata/samples/resourcegroupterraform/infra/variables.tf
@@ -7,3 +7,30 @@ variable "environment_name" {
   description = "The name of the azd environment to be deployed"
   type        = string
 }
+
+variable "dummy_tuple" {
+  description = "Dummy tuple-typed value."
+  type = tuple([bool, string, number])
+  default = [true, "abc", 1234]
+}
+
+
+variable "dummy_list_string" {
+  description = "Dummy list-typed value."
+  type = list(string)
+  default = ["elem1", "elem2", "elem3"]
+}
+
+variable "dummy_map" {
+  description = "Dummy map-typed value."
+  type = map(string)
+  default = {
+    foo: "bar"
+  }
+}
+
+variable "dummy_set_numbers" {
+  description = "Dummy set-typed value."
+  type = set(number)
+  default = [1, 2,3, "1", 1]
+}

--- a/cli/azd/test/functional/testdata/samples/storage/infra/main.bicep
+++ b/cli/azd/test/functional/testdata/samples/storage/infra/main.bicep
@@ -11,7 +11,18 @@ param location string
 @description('A time to mark on created resource groups, so they can be cleaned up via an automated process.')
 param deleteAfterTime string = dateTimeAdd(utcNow('o'), 'PT1H')
 
-var tags = { 'azd-env-name': environmentName, DeleteAfter: deleteAfterTime }
+@description('Test parameter for int-typed values.')
+param intTagValue int
+
+@description('Test parameter for bool-typed values.')
+param boolTagValue bool
+
+var tags = {
+  'azd-env-name': environmentName
+  DeleteAfter: deleteAfterTime
+  IntTag: string(intTagValue)
+  BoolTag: string(boolTagValue)
+}
 
 resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: 'rg-${environmentName}'
@@ -36,6 +47,8 @@ output STRING string = 'abc'
 output BOOL bool = true
 output INT int = 1234
 output ARRAY array = [true, 'abc', 1234]
+output ARRAY_INT array = [1,2,3]
+output ARRAY_STRING array = ['elem1', 'elem2', 'elem3']
 output OBJECT object = {
   foo : 'bar'
   inner: {

--- a/cli/azd/test/functional/testdata/samples/storage/infra/main.parameters.json
+++ b/cli/azd/test/functional/testdata/samples/storage/infra/main.parameters.json
@@ -7,6 +7,12 @@
     },
     "location": {
       "value": "${AZURE_LOCATION}"
+    },
+    "intTagValue": {
+      "value": "${INT_TAG_VALUE=678}" 
+    },
+    "boolTagValue": {
+      "value": "${BOOL_TAG_VALUE=false}"
     }
   }
 }


### PR DESCRIPTION
For Bicep parameters, allow for stringly-typed conversions for `bool` and `number`, i.e.: `"true"` to `true` and `"123"` to `123`. This allows us to write JSON that is both valid and suitable for `envsubt` substitutions, i.e. `"useApim": "${USE_APIM:false}"`. Terraform does this by-default.

For Terraform, provide support for converting `list`, `set` and `map` complex-type outputs. Also, handle `null` values.

Pre-req for #1323