### PR TITLE
Add `nil` check for container app endpoints fetch

### DIFF
--- a/cli/azd/pkg/tools/azcli/container_app.go
+++ b/cli/azd/pkg/tools/azcli/container_app.go
@@ -24,9 +24,19 @@ func (cli *azCli) GetContainerAppProperties(
 	if err != nil {
 		return nil, fmt.Errorf("failed retrieving container app properties: %w", err)
 	}
+	
+	var hostNames []string
+	if containerApp.Properties != nil
+		&& containerApp.Properties.Configuration != nil
+		&& containerApp.Properties.Configuration.Ingress != nil
+		&& containerApp.Properties.Configuration.Ingress.Fqdn != nil {
+		hostNames = []string{*containerApp.Properties.Configuration.Ingress.Fqdn }
+	} else {
+		hostNames = []string{}
+	}
 
 	return &AzCliContainerAppProperties{
-		HostNames: []string{*containerApp.Properties.Configuration.Ingress.Fqdn},
+		HostNames: hostNames,
 	}, nil
 }
 

--- a/cli/azd/pkg/tools/azcli/container_app.go
+++ b/cli/azd/pkg/tools/azcli/container_app.go
@@ -24,13 +24,13 @@ func (cli *azCli) GetContainerAppProperties(
 	if err != nil {
 		return nil, fmt.Errorf("failed retrieving container app properties: %w", err)
 	}
-	
+
 	var hostNames []string
-	if containerApp.Properties != nil
-		&& containerApp.Properties.Configuration != nil
-		&& containerApp.Properties.Configuration.Ingress != nil
-		&& containerApp.Properties.Configuration.Ingress.Fqdn != nil {
-		hostNames = []string{*containerApp.Properties.Configuration.Ingress.Fqdn }
+	if containerApp.Properties != nil &&
+		containerApp.Properties.Configuration != nil &&
+		containerApp.Properties.Configuration.Ingress != nil &&
+		containerApp.Properties.Configuration.Ingress.Fqdn != nil {
+		hostNames = []string{*containerApp.Properties.Configuration.Ingress.Fqdn}
 	} else {
 		hostNames = []string{}
 	}


### PR DESCRIPTION
`Ingress.Fqdn` properties may not be defined for container apps that only run in the background.

Fixes #1231