### PR TITLE
Reference doc copy updates

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -34,6 +34,9 @@ overrides:
       - puichan
       - devx
       - azdevcli
+      - azdeveloper
+      - hannahhunter
+      - hhunter
   - filename: pkg/tools/python/python.go
     words:
       - venv

--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -24,8 +24,8 @@ func configActions(root *actions.ActionDescriptor, rootOptions *internal.GlobalC
 		userConfigPath = heredoc.Doc(`the configuration path.
 
 		The default value of the config directory is:
-		* $HOME/.azd on Linux and MacOS
-		* %USERPROFILE%\.azd on Windows
+		* ` + output.WithBackticks(`$HOME/.azd`) + ` on Linux and macOS
+		* ` + output.WithBackticks(`%USERPROFILE%\.azd`) + ` on Windows
 
 		The configuration directory can be overridden by specifying a path in the AZD_CONFIG_DIR environment variable`)
 	} else if err != nil {
@@ -44,8 +44,12 @@ func configActions(root *actions.ActionDescriptor, rootOptions *internal.GlobalC
 	var helpConfigPaths string
 	if rootOptions.GenerateStaticHelp {
 		helpConfigPaths = heredoc.Doc(`
+		Available since ` + output.WithBackticks("azure-dev-cli_0.4.0-beta.1") + `.
+
+		The easiest way to configure ` + output.WithBackticks("azd") + ` for the first time is to run [` + output.WithBackticks("azd init") + `](#azd-init). The subscription and location you select will be stored in the ` + output.WithBackticks("config.json") + ` file located in the config directory. To configure ` + output.WithBackticks("azd") + ` anytime afterwards, you'll use [` + output.WithBackticks("azd config set") + `](#azd-config-set).
+
 		The default value of the config directory is: 
-		* $HOME/.azd on Linux and MacOS
+		* $HOME/.azd on Linux and macOS
 		* %USERPROFILE%\.azd on Windows
 		`)
 	} else {
@@ -68,7 +72,7 @@ func configActions(root *actions.ActionDescriptor, rootOptions *internal.GlobalC
 
 	groupCmd := &cobra.Command{
 		Use:   "config",
-		Short: "Manage Azure Developer CLI configuration",
+		Short: "Manage the Azure Developer CLI user configuration.",
 		Long:  longDescription,
 	}
 

--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -43,6 +43,7 @@ func configActions(root *actions.ActionDescriptor, rootOptions *internal.GlobalC
 
 	var helpConfigPaths string
 	if rootOptions.GenerateStaticHelp {
+		//nolint:lll
 		helpConfigPaths = heredoc.Doc(`
 		Available since ` + output.WithBackticks("azure-dev-cli_0.4.0-beta.1") + `.
 

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -67,9 +67,9 @@ func newDeployFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *
 func newDeployCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "deploy",
-		Short: "Deploy the application's code to Azure.",
+		Short: "Deploy the app's code to Azure.",
 		//nolint:lll
-		Long: `Deploy the application's code to Azure.
+		Long: `Deploy the app's code to Azure.
 When no ` + output.WithBackticks("--service") + ` value is specified, all services in the ` + output.WithBackticks("azure.yaml") + ` file (found in the root of your project) are deployed.
 
 Examples:

--- a/cli/azd/cmd/down.go
+++ b/cli/azd/cmd/down.go
@@ -23,7 +23,7 @@ func newDownFlags(cmd *cobra.Command, infraDeleteFlags *infraDeleteFlags, global
 func newDownCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "down",
-		Short: "Delete Azure resources for an application.",
+		Short: "Delete Azure resources for an app.",
 	}
 }
 

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -29,9 +29,9 @@ func envActions(root *actions.ActionDescriptor) *actions.ActionDescriptor {
 		//nolint:lll
 		Long: `Manage environments.
 
-With this command group, you can create a new environment or get, set, and list your application environments. An application can have multiple environments (for example, dev, test, prod), each with a different configuration (that is, connectivity information) for accessing Azure resources. 
+With this command group, you can create a new environment or get, set, and list your app environments. An app can have multiple environments (for example, dev, test, prod), each with a different configuration (that is, connectivity information) for accessing Azure resources.
 
-You can find all environment configurations under the *.azure\<environment-name>* folder. The environment name is stored as the AZURE_ENV_NAME environment variable in the *.azure\<environment-name>\folder\.env* file.`,
+You can find all environment configurations under the ` + output.WithBackticks(`.azure\<environment-name>`) + ` directories. The environment name is stored as the AZURE_ENV_NAME environment variable in the ` + output.WithBackticks(`.azure\<environment-name>\directory\.env`) + ` file.`,
 	}
 
 	group := root.Add("env", &actions.ActionDescriptorOptions{
@@ -182,7 +182,7 @@ func (e *envSelectAction) Run(ctx context.Context) (*actions.ActionResult, error
 func newEnvListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
-		Short:   "List environments",
+		Short:   "List environments.",
 		Aliases: []string{"ls"},
 	}
 }

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -57,7 +57,7 @@ func newInfraCreateFlags(cmd *cobra.Command, global *internal.GlobalCommandOptio
 func newInfraCreateCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "create",
-		Short:   "Create Azure resources for an application.",
+		Short:   "Create Azure resources for an app.",
 		Aliases: []string{"provision"},
 	}
 }

--- a/cli/azd/cmd/infra_delete.go
+++ b/cli/azd/cmd/infra_delete.go
@@ -46,7 +46,7 @@ func newInfraDeleteFlags(cmd *cobra.Command, global *internal.GlobalCommandOptio
 func newInfraDeleteCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete",
-		Short: "Delete Azure resources for an application.",
+		Short: "Delete Azure resources for an app.",
 	}
 }
 

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -40,9 +40,9 @@ func newInitFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *in
 func newInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: "Initialize a new application.",
+		Short: "Initialize a new app.",
 		//nolint:lll
-		Long: `Initialize a new application.
+		Long: `Initialize a new app.
 
 When no template is supplied, you can optionally select an Azure Developer CLI template for cloning. Otherwise, ` + output.WithBackticks("azd init") + ` initializes the current directory and creates resources so that your project is compatible with Azure Developer CLI.
 

--- a/cli/azd/cmd/monitor.go
+++ b/cli/azd/cmd/monitor.go
@@ -33,7 +33,7 @@ func (m *monitorFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommand
 		&m.monitorLive,
 		"live",
 		false,
-		"Open a browser to Application Insights Live Metrics. Live Metrics is currently not supported for Python applications.",
+		"Open a browser to Application Insights Live Metrics. Live Metrics is currently not supported for Python apps.",
 	)
 	local.BoolVar(&m.monitorLogs, "logs", false, "Open a browser to Application Insights Logs.")
 	local.BoolVar(&m.monitorOverview, "overview", false, "Open a browser to Application Insights Overview Dashboard.")
@@ -51,8 +51,8 @@ func newMonitorFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) 
 func newMonitorCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "monitor",
-		Short: "Monitor a deployed application.",
-		Long: `Monitor a deployed application.
+		Short: "Monitor a deployed app.",
+		Long: `Monitor a deployed app.
 
 Examples:
 

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -14,6 +14,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -54,11 +55,11 @@ func (pc *pipelineConfigFlags) Bind(local *pflag.FlagSet, global *internal.Globa
 func pipelineActions(root *actions.ActionDescriptor) *actions.ActionDescriptor {
 	infraCmd := &cobra.Command{
 		Use:   "pipeline",
-		Short: "Manage GitHub Actions pipelines.",
+		Short: "Manage GitHub Actions or Azure Pipelines.",
 		//nolint:lll
-		Long: `Manage GitHub Actions pipelines.
+		Long: `Manage GitHub Actions or Azure Pipelines.
 
-The Azure Developer CLI template includes a GitHub Actions pipeline configuration file (in the *.github/workflows* folder) that deploys your application whenever code is pushed to the main branch.
+The Azure Developer CLI template includes a GitHub Actions and an Azure Pipeline configuration file in the ` + output.WithBackticks(`.github/workflows`) + ` and ` + output.WithBackticks(`.azdo/pipelines`) + ` directories respectively. The configuration file deploys your app whenever code is pushed to the main branch.
 
 For more information, go to https://aka.ms/azure-dev/pipeline.`,
 	}

--- a/cli/azd/cmd/pipeline_test.go
+++ b/cli/azd/cmd/pipeline_test.go
@@ -16,7 +16,7 @@ func TestPipelineCmd(t *testing.T) {
 	root := actions.NewActionDescriptor("azd", &actions.ActionDescriptorOptions{})
 	group := pipelineActions(root)
 	assert.EqualValues(t, "pipeline", group.Options.Command.Use)
-	assert.EqualValues(t, "Manage GitHub Actions pipelines.", group.Options.Command.Short)
+	assert.EqualValues(t, "Manage GitHub Actions or Azure Pipelines.", group.Options.Command.Short)
 
 	childCommands := group.Children()
 	assert.EqualValues(t, 1, len(childCommands))

--- a/cli/azd/cmd/provision.go
+++ b/cli/azd/cmd/provision.go
@@ -15,11 +15,11 @@ func newProvisionFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions
 func newProvisionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "provision",
-		Short: "Provision the Azure resources for an application.",
+		Short: "Provision the Azure resources for an app.",
 		//nolint:lll
-		Long: `Provision the Azure resources for an application.
+		Long: `Provision the Azure resources for an app.
 
-The command prompts you for the following:
+The command prompts you for the following values:
 - Environment name: The name of your environment.
 - Azure location: The Azure location where your resources will be deployed.
 - Azure subscription: The Azure subscription where your resources will be deployed.

--- a/cli/azd/cmd/restore.go
+++ b/cli/azd/cmd/restore.go
@@ -48,11 +48,11 @@ func newRestoreFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) 
 func restoreCmdDesign() *cobra.Command {
 	return &cobra.Command{
 		Use:   "restore",
-		Short: "Restore application dependencies.",
+		Short: "Restore app dependencies.",
 		//nolint:lll
-		Long: `Restore application dependencies.
+		Long: `Restore app dependencies.
 
-Run this command to download and install all the required libraries so that you can build, run, and debug the application locally.
+Run this command to download and install all the required libraries so that you can build, run, and debug the app locally.
 
 For the best local run and debug experience, go to https://aka.ms/azure-dev/vscode to learn how to use the Visual Studio Code extension.`,
 	}

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -42,6 +42,7 @@ func NewRootCmd(staticHelp bool, middlewareChain []*actions.MiddlewareRegistrati
 	if opts.GenerateStaticHelp {
 		synopsisHeading = ""
 	}
+	//nolint:lll
 	longDescription := heredoc.Docf(`%sTo begin working with Azure Developer CLI, run the `+output.WithBackticks("azd up")+` command by supplying a sample template in an empty directory:
 
 		$ azd up –-template todo-nodejs-mongo

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/cmd/middleware"
 
@@ -30,25 +31,36 @@ func NewRootCmd(staticHelp bool, middlewareChain []*actions.MiddlewareRegistrati
 	opts := &internal.GlobalCommandOptions{GenerateStaticHelp: staticHelp}
 	opts.EnableTelemetry = telemetry.IsTelemetryEnabled()
 
+	productName := "Azure Developer CLI"
+	if opts.GenerateStaticHelp {
+		productName = "Azure Developer CLI (`azd`)"
+	}
+
+	shortDescription := heredoc.Docf(`%s is a command-line interface for developers who build Azure solutions.`, productName)
+
+	synopsisHeading := shortDescription + "\n\n"
+	if opts.GenerateStaticHelp {
+		synopsisHeading = ""
+	}
+	longDescription := heredoc.Docf(`%sTo begin working with Azure Developer CLI, run the `+output.WithBackticks("azd up")+` command by supplying a sample template in an empty directory:
+
+		$ azd up –-template todo-nodejs-mongo
+
+	You can pick a template by running `+output.WithBackticks("azd template list")+` and then supplying the repo name as a value to `+output.WithBackticks("--template")+`.
+
+	The most common next commands are:
+
+		$ azd pipeline config
+		$ azd deploy
+		$ azd monitor --overview
+
+	For more information, visit the Azure Developer CLI Dev Hub: https://aka.ms/azure-dev/devhub.`, synopsisHeading)
+
 	rootCmd := &cobra.Command{
 		Use:   "azd",
-		Short: "Azure Developer CLI is a command-line interface for developers who build Azure solutions.",
+		Short: shortDescription,
 		//nolint:lll
-		Long: `Azure Developer CLI is a command-line interface for developers who build Azure solutions.
-
-To begin working with Azure Developer CLI, run the ` + output.WithBackticks("azd up") + ` command by supplying a sample template in an empty directory:
-
-	$ azd up –-template todo-nodejs-mongo
-
-You can pick a template by running ` + output.WithBackticks("azd template list") + `and then supplying the repo name as a value to ` + output.WithBackticks("--template") + `.
-
-The most common next commands are:
-
-	$ azd pipeline config
-	$ azd deploy
-	$ azd monitor --overview
-
-For more information, visit the Azure Developer CLI Dev Hub: https://aka.ms/azure-dev/devhub.`,
+		Long: longDescription,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.Cwd != "" {
 				current, err := os.Getwd()

--- a/cli/azd/cmd/show.go
+++ b/cli/azd/cmd/show.go
@@ -42,7 +42,7 @@ func newShowFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *sh
 func newShowCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "show --output json",
-		Short:  "Display information about your application and its resources.",
+		Short:  "Display information about your app and its resources.",
 		Hidden: true,
 	}
 

--- a/cli/azd/cmd/testdata/TestUsage-azd-env.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env.snap
@@ -3,7 +3,7 @@ Usage:
 
 Available Commands:
   get-values  Get all environment values.
-  list        List environments
+  list        List environments.
   new         Create a new environment.
   refresh     Refresh environment settings by using information from a previous infrastructure provision.
   select      Set the default environment.

--- a/cli/azd/cmd/testdata/TestUsage-azd-infra.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-infra.snap
@@ -2,8 +2,8 @@ Usage:
   azd infra [command]
 
 Available Commands:
-  create      Create Azure resources for an application.
-  delete      Delete Azure resources for an application.
+  create      Create Azure resources for an app.
+  delete      Delete Azure resources for an app.
 
 Flags:
   -h, --help   Gets help for infra.

--- a/cli/azd/cmd/testdata/TestUsage-azd-login.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-login.snap
@@ -12,7 +12,7 @@ Flags:
   -o, --output string                          The output format (the supported formats are json, none). (default "none")
       --redirect-port int                      Choose the port to be used as part of the redirect URI during interactive login.
       --tenant-id string                       The tenant id for the service principal to authenticate with.
-      --use-device-code                        When true, log in by using a device code instead of a browser. (default true)
+      --use-device-code                        When true, log in by using a device code instead of a browser.
 
 Global Flags:
   -C, --cwd string   Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd-login.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-login.snap
@@ -12,7 +12,7 @@ Flags:
   -o, --output string                          The output format (the supported formats are json, none). (default "none")
       --redirect-port int                      Choose the port to be used as part of the redirect URI during interactive login.
       --tenant-id string                       The tenant id for the service principal to authenticate with.
-      --use-device-code                        When true, log in by using a device code instead of a browser.
+      --use-device-code                        When true, log in by using a device code instead of a browser. (default true)
 
 Global Flags:
   -C, --cwd string   Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd-monitor.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-monitor.snap
@@ -4,7 +4,7 @@ Usage:
 Flags:
   -e, --environment string   The name of the environment to use.
   -h, --help                 Gets help for monitor.
-      --live                 Open a browser to Application Insights Live Metrics. Live Metrics is currently not supported for Python applications.
+      --live                 Open a browser to Application Insights Live Metrics. Live Metrics is currently not supported for Python apps.
       --logs                 Open a browser to Application Insights Logs.
       --overview             Open a browser to Application Insights Overview Dashboard.
 

--- a/cli/azd/cmd/testdata/TestUsage-azd.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd.snap
@@ -2,20 +2,20 @@ Usage:
   azd [command]
 
 Available Commands:
-  config      Manage Azure Developer CLI configuration
-  deploy      Deploy the application's code to Azure.
-  down        Delete Azure resources for an application.
+  config      Manage the Azure Developer CLI user configuration.
+  deploy      Deploy the app's code to Azure.
+  down        Delete Azure resources for an app.
   env         Manage environments.
   infra       Manage Azure resources.
-  init        Initialize a new application.
+  init        Initialize a new app.
   login       Log in to Azure.
   logout      Log out of Azure
-  monitor     Monitor a deployed application.
-  pipeline    Manage GitHub Actions pipelines.
-  provision   Provision the Azure resources for an application.
-  restore     Restore application dependencies.
+  monitor     Monitor a deployed app.
+  pipeline    Manage GitHub Actions or Azure Pipelines.
+  provision   Provision the Azure resources for an app.
+  restore     Restore app dependencies.
   template    Manage templates.
-  up          Initialize application, provision Azure resources, and deploy your project with a single command.
+  up          Initialize the app, provision Azure resources, and deploy your project with a single command.
   version     Print the version number of Azure Developer CLI.
 
 Flags:

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -45,7 +45,7 @@ func newUpFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *upFl
 func newUpCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "up",
-		Short: "Initialize application, provision Azure resources, and deploy your project with a single command.",
+		Short: "Initialize the app, provision Azure resources, and deploy your project with a single command.",
 		//nolint:lll
 		Long: `Initialize the project (if the project folder has not been initialized or cloned from a template), provision Azure resources, and deploy your project with a single command.
 

--- a/cli/azd/docs/docgen.go
+++ b/cli/azd/docs/docgen.go
@@ -24,17 +24,17 @@ import (
 // generate. This string is formatted with a single value, the
 // current date in MM/DD/YY format.
 const fontMatterFormatString = `---
-title: Azure Developer CLI Preview reference
+title: Azure Developer CLI reference (preview)
 description: This article explains the syntax and parameters for the various Azure Developer CLI Preview commands.
-author: puichan
-ms.author: puichan
+author: hhunter-ms
+ms.author: hannahhunter
 ms.date: %v
+ms.service: azure-dev-cli
 ms.topic: conceptual
 ms.custom: devx-track-azdevcli
-ms.prod: azure
 ---
 
-# Azure Developer CLI Preview reference
+# Azure Developer CLI reference (preview)
 
 This article explains the syntax and parameters for the various Azure Developer CLI Preview commands.
 
@@ -98,7 +98,7 @@ func addCodeFencesToSampleCommands(s string) string {
 			} else if !inBlock && idx+1 < len(lines) && strings.HasPrefix(lines[idx+1], "\t$") {
 				inBlock = true
 				newLines = append(newLines, line)
-				newLines = append(newLines, "```")
+				newLines = append(newLines, "```azdeveloper")
 			} else {
 				newLines = append(newLines, line)
 			}
@@ -203,11 +203,11 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 	}
 
 	if cmd.Runnable() {
-		buf.WriteString(fmt.Sprintf("```\n%s\n```\n\n", cmd.UseLine()))
+		buf.WriteString(fmt.Sprintf("```azdeveloper\n%s\n```\n\n", cmd.UseLine()))
 	}
 
 	if len(cmd.Example) > 0 {
-		buf.WriteString("### Examples\n\n```\n")
+		buf.WriteString("### Examples\n\n```azdeveloper\n")
 		lines := strings.Split(cmd.Example, "\n")
 		for _, line := range lines {
 			buf.WriteString(formatCommandLine(line) + "\n")
@@ -275,7 +275,7 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
 	flags := cmd.NonInheritedFlags()
 	flags.SetOutput(buf)
 	if flags.HasAvailableFlags() {
-		buf.WriteString("### Options\n\n```\n")
+		buf.WriteString("### Options\n\n```azdeveloper\n")
 		flags.PrintDefaults()
 		buf.WriteString("```\n\n")
 	}
@@ -283,7 +283,7 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
 	parentFlags := cmd.InheritedFlags()
 	parentFlags.SetOutput(buf)
 	if parentFlags.HasAvailableFlags() {
-		buf.WriteString("### Options inherited from parent commands\n\n```\n")
+		buf.WriteString("### Options inherited from parent commands\n\n```azdeveloper\n")
 		parentFlags.PrintDefaults()
 		buf.WriteString("```\n\n")
 	}

--- a/cli/azd/docs/docgen.go
+++ b/cli/azd/docs/docgen.go
@@ -66,7 +66,7 @@ func main() {
 	defer docFile.Close()
 
 	// Write front-matter to the file:
-	if _, err := docFile.WriteString(fmt.Sprintf(fontMatterFormatString, time.Now().Format("01/02/06"))); err != nil {
+	if _, err := docFile.WriteString(fmt.Sprintf(fontMatterFormatString, time.Now().Format("01/02/2006"))); err != nil {
 		fmt.Printf("Error: %v", err)
 		os.Exit(1)
 	}

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -725,44 +725,15 @@ stages:
                     filePath: eng/scripts/Set-CliVersionVariable.ps1
                   displayName: Set CLI_VERSION
 
-                # - template: /eng/pipelines/templates/steps/publish-cli.yml
-                #   parameters:
-                #     CreateGitHubRelease: true
-                #     PublishUploadLocations: release/$(CLI_VERSION);release/latest
-                #     PublishShield: true
-                #     DockerImageTags: $(CLI_VERSION);latest
-                #     ReleaseSyndicatedDockerContainer: true
-                #     PublishUpdatedDocs: true
-                #     UploadMsi: true
-
-                - task: DownloadPipelineArtifact@2
-                  displayName: Download docs
-                  inputs:
-                    artifact: docs
-                    path: docs
-
-                - template: /eng/pipelines/templates/steps/set-git-credentials.yml
-
-                - pwsh: |
-                    git clone https://github.com/azure-sdk/azure-dev-docs-pr/
-                    Copy-Item docs/azd.md azure-dev-docs-pr/articles/azure-developer-cli/reference.md -Force
-                  displayName: Clone azure-dev-docs-pr and update reference.md
-
-                - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
+                - template: /eng/pipelines/templates/steps/publish-cli.yml
                   parameters:
-                    # Use a unique branch name per-build and per-attempt to prevent
-                    # collisions
-                    PRBranchName: azure-dev-cli/$(CLI_VERSION)-$(Build.BuildId).$(System.JobAttempt)
-                    CommitMsg: Update reference documents for Azure CLI @ $(CLI_VERSION)
-                    PRTitle: Update reference documents for Azure CLI @ $(CLI_VERSION)
-                    WorkingDirectory: $(System.DefaultWorkingDirectory)/azure-dev-docs-pr
-                    RepoOwner: MicrosoftDocs
-                    RepoName: azure-dev-docs-pr
-                    BaseBranchName: main
-                    # TODO: Remove before merge
-                    CloseAfterOpenForTesting: true
-                    OpenAsDraft: true
-
+                    CreateGitHubRelease: true
+                    PublishUploadLocations: release/$(CLI_VERSION);release/latest
+                    PublishShield: true
+                    DockerImageTags: $(CLI_VERSION);latest
+                    ReleaseSyndicatedDockerContainer: true
+                    PublishUpdatedDocs: true
+                    UploadMsi: true
 
       - deployment: Increment_Version
         condition: >-

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -725,15 +725,44 @@ stages:
                     filePath: eng/scripts/Set-CliVersionVariable.ps1
                   displayName: Set CLI_VERSION
 
-                - template: /eng/pipelines/templates/steps/publish-cli.yml
+                # - template: /eng/pipelines/templates/steps/publish-cli.yml
+                #   parameters:
+                #     CreateGitHubRelease: true
+                #     PublishUploadLocations: release/$(CLI_VERSION);release/latest
+                #     PublishShield: true
+                #     DockerImageTags: $(CLI_VERSION);latest
+                #     ReleaseSyndicatedDockerContainer: true
+                #     PublishUpdatedDocs: true
+                #     UploadMsi: true
+
+                - task: DownloadPipelineArtifact@2
+                  displayName: Download docs
+                  inputs:
+                    artifact: docs
+                    path: docs
+
+                - template: /eng/pipelines/templates/steps/set-git-credentials.yml
+
+                - pwsh: |
+                    git clone https://github.com/azure-sdk/azure-dev-docs-pr/
+                    Copy-Item docs/azd.md azure-dev-docs-pr/articles/azure-developer-cli/reference.md -Force
+                  displayName: Clone azure-dev-docs-pr and update reference.md
+
+                - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
                   parameters:
-                    CreateGitHubRelease: true
-                    PublishUploadLocations: release/$(CLI_VERSION);release/latest
-                    PublishShield: true
-                    DockerImageTags: $(CLI_VERSION);latest
-                    ReleaseSyndicatedDockerContainer: true
-                    PublishUpdatedDocs: true
-                    UploadMsi: true
+                    # Use a unique branch name per-build and per-attempt to prevent
+                    # collisions
+                    PRBranchName: azure-dev-cli/$(CLI_VERSION)-$(Build.BuildId).$(System.JobAttempt)
+                    CommitMsg: Update reference documents for Azure CLI @ $(CLI_VERSION)
+                    PRTitle: Update reference documents for Azure CLI @ $(CLI_VERSION)
+                    WorkingDirectory: $(System.DefaultWorkingDirectory)/azure-dev-docs-pr
+                    RepoOwner: MicrosoftDocs
+                    RepoName: azure-dev-docs-pr
+                    BaseBranchName: main
+                    # TODO: Remove before merge
+                    CloseAfterOpenForTesting: true
+                    OpenAsDraft: true
+
 
       - deployment: Increment_Version
         condition: >-

--- a/eng/pipelines/templates/steps/publish-cli.yml
+++ b/eng/pipelines/templates/steps/publish-cli.yml
@@ -192,11 +192,13 @@ steps:
         artifact: docs
         path: docs
 
+    - template: /eng/pipelines/templates/steps/set-git-credentials.yml
+
     - pwsh: |
-        git clone https://github.com/azure-sdk/azure-dev-docs/
-        Copy-Item docs/azd.md azure-dev-docs/articles/azure-developer-cli/reference.md -Force
-      displayName: Clone azure-dev-docs and update reference.md
-        
+        git clone https://github.com/azure-sdk/azure-dev-docs-pr/
+        Copy-Item docs/azd.md azure-dev-docs-pr/articles/azure-developer-cli/reference.md -Force
+      displayName: Clone azure-dev-docs-pr and update reference.md
+
     - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
       parameters:
         # Use a unique branch name per-build and per-attempt to prevent
@@ -204,7 +206,7 @@ steps:
         PRBranchName: azure-dev-cli/$(CLI_VERSION)-$(Build.BuildId).$(System.JobAttempt)
         CommitMsg: Update reference documents for Azure CLI @ $(CLI_VERSION)
         PRTitle: Update reference documents for Azure CLI @ $(CLI_VERSION)
-        WorkingDirectory: $(System.DefaultWorkingDirectory)/azure-dev-docs  
+        WorkingDirectory: $(System.DefaultWorkingDirectory)/azure-dev-docs-pr
         RepoOwner: MicrosoftDocs
-        RepoName: azure-dev-docs
+        RepoName: azure-dev-docs-pr
         BaseBranchName: main


### PR DESCRIPTION
Also fixes https://github.com/Azure/azure-dev/issues/1380 

Changes of note in both CLI and ref docs markdown: 
* "application" -> "app" in just about all mentions (except "Application Insights" which is a product name)

Documentation changes to match copy edits from the docs team up to this point and trivial changes are put back into the CLI help (like "application" -> "app").

Discussions here: 
* https://github.com/MicrosoftDocs/azure-dev-docs-pr/pull/4037
* https://github.com/MicrosoftDocs/azure-dev-docs/pull/993/files

<details><summary>CLI help generated by commands with the most changes:</summary>

`azd --help` 

```
Azure Developer CLI is a command-line interface for developers who build Azure solutions.

To begin working with Azure Developer CLI, run the `azd up` command by supplying a sample template in an empty directory:

        $ azd up –-template todo-nodejs-mongo

You can pick a template by running `azd template list` and then supplying the repo name as a value to `--template`.

The most common next commands are:

        $ azd pipeline config
        $ azd deploy
        $ azd monitor --overview

For more information, visit the Azure Developer CLI Dev Hub: https://aka.ms/azure-dev/devhub.

Usage:
  azd [command]

Available Commands:
  config      Manage the Azure Developer CLI user configuration.
  deploy      Deploy the app's code to Azure.
  down        Delete Azure resources for an app.
  env         Manage environments.
  help        Help about any command
  infra       Manage Azure resources.
  init        Initialize a new app.
  login       Log in to Azure.
  logout      Log out of Azure
  monitor     Monitor a deployed app.
  pipeline    Manage GitHub Actions or Azure Pipelines.
  provision   Provision the Azure resources for an app.
  restore     Restore app dependencies.
  template    Manage templates.
  up          Initialize the app, provision Azure resources, and deploy your project with a single command.
  version     Print the version number of Azure Developer CLI.

Flags:
  -C, --cwd string   Sets the current working directory.
      --debug        Enables debugging and diagnostics logging.
  -h, --help         Gets help for azd.
      --no-prompt    Accepts the default value instead of prompting, or it fails if there is no default.

Use "azd [command] --help" for more information about a command.

Please let us know how we are doing: https://aka.ms/azure-dev/hats
```

`azd config --help` 

```
Manage the Azure Developer CLI user configuration, which includes your default Azure subscription and location.

The easiest way to initially configure azd is to run `azd init`.
The subscription and location you select will be stored at `/home/vscode/.azd/config.json`.
The default configuration path is `$HOME/.azd`.

The configuration directory can be overridden by specifying a path in the AZD_CONFIG_DIR environment variable.

Usage:
  azd config [command]

Available Commands:
  get         Gets a configuration
  list        Lists all configuration values
  reset       Resets configuration to default
  set         Sets a configuration
  unset       Unsets a configuration

Flags:
  -h, --help   Gets help for config.

Global Flags:
  -C, --cwd string   Sets the current working directory.
      --debug        Enables debugging and diagnostics logging.
      --no-prompt    Accepts the default value instead of prompting, or it fails if there is no default.

Use "azd config [command] --help" for more information about a command.

Please let us know how we are doing: https://aka.ms/azure-dev/hats
```
</details>

### Addendum 

Also noticed on release that we were cloning from and pushing to the incorrect repo. This includes changes to fix that. The right repo is `azure-dev-docs-pr`. 

* Sample PR created with testing: https://github.com/MicrosoftDocs/azure-dev-docs-pr/pull/4055
* Build that created PR: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2115605&view=logs&j=493e9ff3-1332-590a-730c-4fca05f30c58&t=347bd482-f14a-5066-41a0-f4c562c123fc

Also, same fix already covered in this PR: https://github.com/Azure/azure-dev/pull/1288