### PR TITLE
Remove trailing whitespace in sqlserver.bicep

### DIFF
--- a/templates/common/infra/bicep/core/database/sqlserver/sqlserver.bicep
+++ b/templates/common/infra/bicep/core/database/sqlserver/sqlserver.bicep
@@ -33,7 +33,7 @@ resource sqlServer 'Microsoft.Sql/servers@2022-05-01-preview' = {
   resource firewall 'firewallRules' = {
     name: 'Azure Services'
     properties: {
-      // Allow all clients 
+      // Allow all clients
       // Note: range [0.0.0.0-0.0.0.0] means "allow all Azure-hosted clients only".
       // This is not sufficient, because we also want to allow direct access from developer machine, for debugging purposes.
       startIpAddress: '0.0.0.1'


### PR DESCRIPTION
Not a big deal, but my pre-commit hook keeps fixing it when I use core in my projects, so I figure might as well fix it in azure-dev.