### PR TITLE
Install script sign artifacts

### DIFF
--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -994,6 +994,6 @@ stages:
                       --account-key '$(azdev-storage-account-key-test)' `
                       --auth-mode key `
                       -s script-release/ `
-                      -d "azd/standalone/installer" `
+                      -d "azd/standalone/installer-testing" `
                       --overwrite
                   displayName: Upload installer to storage location

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -111,6 +111,8 @@ stages:
               version: 6.0.x
 
           - template: /eng/pipelines/templates/steps/az-login.yml
+            parameters:
+              Condition: and(succeeded(), ne(variables['Skip.LiveTest'], 'true'))
 
           - template: /eng/pipelines/templates/steps/azd-login.yml
             parameters:

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -686,86 +686,86 @@ stages:
               workingDirectory: cli/installer/
             displayName: Test install script (cmd)
 
-  - stage: PublishCLI
-    dependsOn: Sign
-    condition: >-
-      and(
-        succeeded(),
-        ne(variables['Skip.Release'], 'true'),
-        or(
-          eq('Manual', variables['BuildReasonOverride']),
-          and(
-            eq('', variables['BuildReasonOverride']),
-            eq('Manual', variables['Build.Reason'])
-          )
-        )
-      )
-    jobs:
-      - deployment: Publish_Release
-        condition: >-
-          and(
-            succeeded(),
-            ne('true', variables['Skip.Publish'])
-          )
-        environment: azure-dev
+  # - stage: PublishCLI
+  #   dependsOn: Sign
+  #   condition: >-
+  #     and(
+  #       succeeded(),
+  #       ne(variables['Skip.Release'], 'true'),
+  #       or(
+  #         eq('Manual', variables['BuildReasonOverride']),
+  #         and(
+  #           eq('', variables['BuildReasonOverride']),
+  #           eq('Manual', variables['Build.Reason'])
+  #         )
+  #       )
+  #     )
+  #   jobs:
+      # - deployment: Publish_Release
+      #   condition: >-
+      #     and(
+      #       succeeded(),
+      #       ne('true', variables['Skip.Publish'])
+      #     )
+      #   environment: azure-dev
 
-        pool:
-          name: azsdk-pool-mms-ubuntu-2004-general
-          OSVmImage: MMSUbuntu20.04
+      #   pool:
+      #     name: azsdk-pool-mms-ubuntu-2004-general
+      #     OSVmImage: MMSUbuntu20.04
 
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - checkout: self
-                - task: PowerShell@2
-                  inputs:
-                    pwsh: true
-                    targetType: filePath
-                    filePath: eng/scripts/Set-CliVersionVariable.ps1
-                  displayName: Set CLI_VERSION
+      #   strategy:
+      #     runOnce:
+      #       deploy:
+      #         steps:
+      #           - checkout: self
+      #           - task: PowerShell@2
+      #             inputs:
+      #               pwsh: true
+      #               targetType: filePath
+      #               filePath: eng/scripts/Set-CliVersionVariable.ps1
+      #             displayName: Set CLI_VERSION
 
-                - template: /eng/pipelines/templates/steps/publish-cli.yml
-                  parameters:
-                    CreateGitHubRelease: true
-                    PublishUploadLocations: release/$(CLI_VERSION);release/latest
-                    PublishShield: true
-                    DockerImageTags: $(CLI_VERSION);latest
-                    ReleaseSyndicatedDockerContainer: true
-                    PublishUpdatedDocs: true
-                    UploadMsi: true
+      #           - template: /eng/pipelines/templates/steps/publish-cli.yml
+      #             parameters:
+      #               CreateGitHubRelease: true
+      #               PublishUploadLocations: release/$(CLI_VERSION);release/latest
+      #               PublishShield: true
+      #               DockerImageTags: $(CLI_VERSION);latest
+      #               ReleaseSyndicatedDockerContainer: true
+      #               PublishUpdatedDocs: true
+      #               UploadMsi: true
 
-      - deployment: Increment_Version
-        condition: >-
-          and(
-            succeeded(),
-            ne('true', variables['Skip.IncrementVersion'])
-          )
-        dependsOn: Publish_Release
-        environment: azure-dev
+      # - deployment: Increment_Version
+      #   condition: >-
+      #     and(
+      #       succeeded(),
+      #       ne('true', variables['Skip.IncrementVersion'])
+      #     )
+      #   dependsOn: Publish_Release
+      #   environment: azure-dev
 
-        pool:
-          name: azsdk-pool-mms-ubuntu-2004-general
-          OSVmImage: MMSUbuntu20.04
+      #   pool:
+      #     name: azsdk-pool-mms-ubuntu-2004-general
+      #     OSVmImage: MMSUbuntu20.04
 
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - checkout: self
+      #   strategy:
+      #     runOnce:
+      #       deploy:
+      #         steps:
+      #           - checkout: self
 
-                - task: PowerShell@2
-                  inputs:
-                    pwsh: true
-                    targetType: filePath
-                    filePath: eng/scripts/Update-CliVersion.ps1
-                  displayName: Increment CLI version
+      #           - task: PowerShell@2
+      #             inputs:
+      #               pwsh: true
+      #               targetType: filePath
+      #               filePath: eng/scripts/Update-CliVersion.ps1
+      #             displayName: Increment CLI version
 
-                - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
-                  parameters:
-                    PRBranchName: cli-version-increment-$(Build.BuildId)
-                    CommitMsg: Increment CLI version after release
-                    PRTitle: Increment CLI version after release
+      #           - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
+      #             parameters:
+      #               PRBranchName: cli-version-increment-$(Build.BuildId)
+      #               CommitMsg: Increment CLI version after release
+      #               PRTitle: Increment CLI version after release
 
   - stage: PublishIntegration
     dependsOn: Sign
@@ -950,7 +950,7 @@ stages:
             env:
               GH_TOKEN: $(azuresdk-github-pat)
 
-  - stage: Publish_Installers
+  - stage: PublishInstallers
     dependsOn: Sign
     condition: >-
       and(
@@ -965,7 +965,7 @@ stages:
         )
       )
     jobs:
-      - deployment: Publish_Installers
+      - deployment: PublishInstallers
         environment: azure-dev
         pool:
           name: azsdk-pool-mms-ubuntu-2004-general

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -688,86 +688,86 @@ stages:
               workingDirectory: cli/installer/
             displayName: Test install script (cmd)
 
-  # - stage: PublishCLI
-  #   dependsOn: Sign
-  #   condition: >-
-  #     and(
-  #       succeeded(),
-  #       ne(variables['Skip.Release'], 'true'),
-  #       or(
-  #         eq('Manual', variables['BuildReasonOverride']),
-  #         and(
-  #           eq('', variables['BuildReasonOverride']),
-  #           eq('Manual', variables['Build.Reason'])
-  #         )
-  #       )
-  #     )
-  #   jobs:
-      # - deployment: Publish_Release
-      #   condition: >-
-      #     and(
-      #       succeeded(),
-      #       ne('true', variables['Skip.Publish'])
-      #     )
-      #   environment: azure-dev
+  - stage: PublishCLI
+    dependsOn: Sign
+    condition: >-
+      and(
+        succeeded(),
+        ne(variables['Skip.Release'], 'true'),
+        or(
+          eq('Manual', variables['BuildReasonOverride']),
+          and(
+            eq('', variables['BuildReasonOverride']),
+            eq('Manual', variables['Build.Reason'])
+          )
+        )
+      )
+    jobs:
+      - deployment: Publish_Release
+        condition: >-
+          and(
+            succeeded(),
+            ne('true', variables['Skip.Publish'])
+          )
+        environment: azure-dev
 
-      #   pool:
-      #     name: azsdk-pool-mms-ubuntu-2004-general
-      #     OSVmImage: MMSUbuntu20.04
+        pool:
+          name: azsdk-pool-mms-ubuntu-2004-general
+          OSVmImage: MMSUbuntu20.04
 
-      #   strategy:
-      #     runOnce:
-      #       deploy:
-      #         steps:
-      #           - checkout: self
-      #           - task: PowerShell@2
-      #             inputs:
-      #               pwsh: true
-      #               targetType: filePath
-      #               filePath: eng/scripts/Set-CliVersionVariable.ps1
-      #             displayName: Set CLI_VERSION
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: self
+                - task: PowerShell@2
+                  inputs:
+                    pwsh: true
+                    targetType: filePath
+                    filePath: eng/scripts/Set-CliVersionVariable.ps1
+                  displayName: Set CLI_VERSION
 
-      #           - template: /eng/pipelines/templates/steps/publish-cli.yml
-      #             parameters:
-      #               CreateGitHubRelease: true
-      #               PublishUploadLocations: release/$(CLI_VERSION);release/latest
-      #               PublishShield: true
-      #               DockerImageTags: $(CLI_VERSION);latest
-      #               ReleaseSyndicatedDockerContainer: true
-      #               PublishUpdatedDocs: true
-      #               UploadMsi: true
+                - template: /eng/pipelines/templates/steps/publish-cli.yml
+                  parameters:
+                    CreateGitHubRelease: true
+                    PublishUploadLocations: release/$(CLI_VERSION);release/latest
+                    PublishShield: true
+                    DockerImageTags: $(CLI_VERSION);latest
+                    ReleaseSyndicatedDockerContainer: true
+                    PublishUpdatedDocs: true
+                    UploadMsi: true
 
-      # - deployment: Increment_Version
-      #   condition: >-
-      #     and(
-      #       succeeded(),
-      #       ne('true', variables['Skip.IncrementVersion'])
-      #     )
-      #   dependsOn: Publish_Release
-      #   environment: azure-dev
+      - deployment: Increment_Version
+        condition: >-
+          and(
+            succeeded(),
+            ne('true', variables['Skip.IncrementVersion'])
+          )
+        dependsOn: Publish_Release
+        environment: azure-dev
 
-      #   pool:
-      #     name: azsdk-pool-mms-ubuntu-2004-general
-      #     OSVmImage: MMSUbuntu20.04
+        pool:
+          name: azsdk-pool-mms-ubuntu-2004-general
+          OSVmImage: MMSUbuntu20.04
 
-      #   strategy:
-      #     runOnce:
-      #       deploy:
-      #         steps:
-      #           - checkout: self
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: self
 
-      #           - task: PowerShell@2
-      #             inputs:
-      #               pwsh: true
-      #               targetType: filePath
-      #               filePath: eng/scripts/Update-CliVersion.ps1
-      #             displayName: Increment CLI version
+                - task: PowerShell@2
+                  inputs:
+                    pwsh: true
+                    targetType: filePath
+                    filePath: eng/scripts/Update-CliVersion.ps1
+                  displayName: Increment CLI version
 
-      #           - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
-      #             parameters:
-      #               PRBranchName: cli-version-increment-$(Build.BuildId)
-      #               CommitMsg: Increment CLI version after release
-      #               PRTitle: Increment CLI version after release
+                - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
+                  parameters:
+                    PRBranchName: cli-version-increment-$(Build.BuildId)
+                    CommitMsg: Increment CLI version after release
+                    PRTitle: Increment CLI version after release
 
   - stage: PublishIntegration
     dependsOn: Sign
@@ -992,10 +992,10 @@ stages:
 
                 - pwsh: |
                     az storage blob upload-batch `
-                      --account-name '$(azdev-storage-account-name-test)' `
-                      --account-key '$(azdev-storage-account-key-test)' `
+                      --account-name '$(azdev-storage-account-name)' `
+                      --account-key '$(azdev-storage-account-key)' `
                       --auth-mode key `
                       -s script-release/ `
-                      -d "azd/standalone/installer-testing" `
+                      -d "azd/standalone/installer" `
                       --overwrite
                   displayName: Upload installer to storage location

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -979,19 +979,19 @@ stages:
 
                 - task: DownloadPipelineArtifact@2
                   inputs:
-                    artifact: signed
-                    path: signed
+                    artifact: signed-win
+                    path: signed-win
 
                 - pwsh: |
                     New-Item -ItemType Directory -Path script-release
-                    Copy-Item signed/win/*.ps1 script-release/
+                    Copy-Item signed-win/*.ps1 script-release/
                     Copy-Item cli/installer/*.sh script-release/
                   displayName: Copy scripts for release upload
 
                 - pwsh: |
                     az storage blob upload-batch `
-                      --account-name '$(azdev-storage-account-name)' `
-                      --account-key '$(azdev-storage-account-key)' `
+                      --account-name '$(azdev-storage-account-name-test)' `
+                      --account-key '$(azdev-storage-account-key-test)' `
                       --auth-mode key `
                       -s script-release/ `
                       -d "azd/standalone/installer" `


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-dev/issues/1379

Since splitting up signing into separate jobs the signed PowerShell artifacts download sources and locations need to be updated. 

Test run showing success in a test storage account: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2115773&view=logs&j=550e6a3f-0691-5d18-3071-14c14b608781&t=550e6a3f-0691-5d18-3071-14c14b608781

@rajeshkamal5050 -- This fixes the issue we saw on installer release on Wednesday. 