### PR TITLE
Fix `azd up --template` so it can initialize a new project

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 0.5.0-beta.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 0.5.0-beta.3 (2023-01-13)
 
 ### Bugs Fixed
 
-### Other Changes
+- [[#1392]](https://github.com/Azure/azure-dev/issues/1392) Bug when running azd up with a template.
 
 ## 0.5.0-beta.2 (2023-01-12)
 

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs Fixed
 
-- [[#1392]](https://github.com/Azure/azure-dev/issues/1392) Bug when running azd up with a template.
+- [[#1394]](https://github.com/Azure/azure-dev/issues/1394) Bug when running azd up with a template.
 
 ## 0.5.0-beta.2 (2023-01-12)
 

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs Fixed
 
-- [[#1394]](https://github.com/Azure/azure-dev/issues/1394) Bug when running azd up with a template.
+- [[#1394]](https://github.com/Azure/azure-dev/pull/1394) Bug when running azd up with a template.
 
 ## 0.5.0-beta.2 (2023-01-12)
 

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -85,7 +85,6 @@ After the deployment is complete, the endpoint is printed. To start the service,
 type deployAction struct {
 	flags         *deployFlags
 	azCli         azcli.AzCli
-	azdCtx        *azdcontext.AzdContext
 	formatter     output.Formatter
 	writer        io.Writer
 	console       input.Console
@@ -96,7 +95,6 @@ func newDeployAction(
 	flags *deployFlags,
 	azCli azcli.AzCli,
 	commandRunner exec.CommandRunner,
-	azdCtx *azdcontext.AzdContext,
 	console input.Console,
 	formatter output.Formatter,
 	writer io.Writer,
@@ -104,7 +102,6 @@ func newDeployAction(
 	return &deployAction{
 		flags:         flags,
 		azCli:         azCli,
-		azdCtx:        azdCtx,
 		formatter:     formatter,
 		writer:        writer,
 		console:       console,
@@ -118,12 +115,21 @@ type DeploymentResult struct {
 }
 
 func (d *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) {
-	env, err := loadOrInitEnvironment(ctx, &d.flags.environmentName, d.azdCtx, d.console, d.azCli)
+	// We call `NewAzdContext` here instead of having the value injected because we want to delay the
+	// walk for the context until this command has started to execute (for example, in the case of `up`,
+	// the context is not created until the init action actually runs, which is after the infraCreateAction
+	// object is created.
+	azdCtx, err := azdcontext.NewAzdContext()
+	if err != nil {
+		return nil, err
+	}
+
+	env, err := loadOrInitEnvironment(ctx, &d.flags.environmentName, azdCtx, d.console, d.azCli)
 	if err != nil {
 		return nil, fmt.Errorf("loading environment: %w", err)
 	}
 
-	projConfig, err := project.LoadProjectConfig(d.azdCtx.ProjectPath())
+	projConfig, err := project.LoadProjectConfig(azdCtx.ProjectPath())
 	if err != nil {
 		return nil, fmt.Errorf("loading project: %w", err)
 	}
@@ -169,7 +175,7 @@ func (d *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 		stepMessage := fmt.Sprintf("Deploying service %s", svc.Config.Name)
 		d.console.ShowSpinner(ctx, stepMessage, input.Step)
-		result, progress := svc.Deploy(ctx, d.azdCtx)
+		result, progress := svc.Deploy(ctx, azdCtx)
 
 		// Report any progress to logs only. Changes for the console are managed by the console object.
 		// This routine is required to drain all the string messages sent by the `progress`.


### PR DESCRIPTION
In #1296 we changed our logic such that we would inject `AzdContext` as a depenecy of our actions, and expect our IoC container to wire things up.

This had the side effect of breaking `azd up --template` to initilize (and then provison and deploy) a new project.

The break comes from the fact that the IoC container will call `NewAzdContext` as part of building the `deploy` and `infraCreate` actions, which need to be created because they are dependencies of the `up` composite action.  However, `NewAzdContext` should not be called before the project has actually been created (which will happen when the `up` composite action calls the `init` action), because it looks for an existing project and if it doesn't find one it fails.

To work around this issue - I've made the infra create and deploy actions explicitly call `NewAzdContext` so the calls can happen at the right time.

A regression test has been added (it's a little hacky because we don't actually care about running the `infra create` or `deploy` parts of `up` in this test, we just want to ensure that we correctly initialized via a template.

Fixes #1392 