### PR TITLE
Display PostgreSQL server created in resource

### DIFF
--- a/cli/azd/pkg/infra/azure_resource_types.go
+++ b/cli/azd/pkg/infra/azure_resource_types.go
@@ -68,7 +68,7 @@ func GetResourceTypeDisplayName(resourceType AzureResourceType) string {
 	case AzureResourceTypeSqlServer:
 		return "Azure SQL Server"
 	case AzureResourceTypePostgreSqlServer:
-		return "Azure PostgreSQL Server"
+		return "Azure Database for PostgreSQL flexible server"
 	}
 
 	return ""

--- a/cli/azd/pkg/infra/azure_resource_types.go
+++ b/cli/azd/pkg/infra/azure_resource_types.go
@@ -70,6 +70,7 @@ func GetResourceTypeDisplayName(resourceType AzureResourceType) string {
 	case AzureResourceTypePostgreSqlServer:
 		return "Azure PostgreSQL Server"
 	}
+
 	return ""
 }
 

--- a/cli/azd/pkg/infra/azure_resource_types.go
+++ b/cli/azd/pkg/infra/azure_resource_types.go
@@ -19,12 +19,13 @@ const (
 	AzureResourceTypeWebSite                 AzureResourceType = "Microsoft.Web/sites"
 	AzureResourceTypeStaticWebSite           AzureResourceType = "Microsoft.Web/staticSites"
 	AzureResourceTypeServicePlan             AzureResourceType = "Microsoft.Web/serverfarms"
-	AzureResourceTypeSqlDatabase             AzureResourceType = "Microsoft.Sql/servers"
+	AzureResourceTypeSqlServer               AzureResourceType = "Microsoft.Sql/servers"
 	AzureResourceTypeCosmosDb                AzureResourceType = "Microsoft.DocumentDB/databaseAccounts"
 	AzureResourceTypeContainerApp            AzureResourceType = "Microsoft.App/containerApps"
 	AzureResourceTypeContainerAppEnvironment AzureResourceType = "Microsoft.App/managedEnvironments"
 	AzureResourceTypeApim                    AzureResourceType = "Microsoft.ApiManagement/service"
 	AzureResourceTypeCacheForRedis           AzureResourceType = "Microsoft.Cache/redis"
+	AzureResourceTypePostgreSqlServer        AzureResourceType = "Microsoft.DBforPostgreSQL/flexibleServers"
 )
 
 const resourceLevelSeparator = "/"
@@ -64,10 +65,11 @@ func GetResourceTypeDisplayName(resourceType AzureResourceType) string {
 		return "Azure API Management"
 	case AzureResourceTypeCacheForRedis:
 		return "Cache for Redis"
-	case AzureResourceTypeSqlDatabase:
-		return "Azure SQL DB"
+	case AzureResourceTypeSqlServer:
+		return "Azure SQL Server"
+	case AzureResourceTypePostgreSqlServer:
+		return "Azure PostgreSQL Server"
 	}
-
 	return ""
 }
 


### PR DESCRIPTION
Currently, azd doesn't display when it creates a PostgreSQL flexible server, but it should, since it displays SQL server creations.

I based this PR off https://github.com/Azure/azure-dev/pull/1320/files
