### PR TITLE
Move **DEPRECATED** to a place where it won't be removed in changelog automation

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -120,7 +120,7 @@ We plan to improve this behavior with [[#1126]](https://github.com/Azure/azure-d
 
 - [[#979]](https://github.com/Azure/azure-dev/pull/979) Fix provisioning template with non string outputs.
 
-## 0.3.0-beta.4 (2022-10-25) **DEPRECATED**
+## 0.3.0-beta.4 **DEPRECATED** (2022-10-25)
 
 ### Bugs Fixed
 

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -120,7 +120,7 @@ We plan to improve this behavior with [[#1126]](https://github.com/Azure/azure-d
 
 - [[#979]](https://github.com/Azure/azure-dev/pull/979) Fix provisioning template with non string outputs.
 
-## 0.3.0-beta.4 **DEPRECATED** (2022-10-25)
+## 0.3.0-beta.4 (2022-10-25 **DEPRECATED**)
 
 ### Bugs Fixed
 


### PR DESCRIPTION
This would fail change log entry validation for release but that validation doesn't apply to already released packages.