### PR TITLE
Support login to specific realm

### DIFF
--- a/cli/azd/cmd/login.go
+++ b/cli/azd/cmd/login.go
@@ -205,8 +205,8 @@ func countTrue(elms ...bool) int {
 }
 
 func (la *loginAction) login(ctx context.Context) error {
-	if la.flags.clientID != "" || la.flags.tenantID != "" {
-		if la.flags.clientID == "" || la.flags.tenantID == "" {
+	if la.flags.clientID != "" {
+		if la.flags.tenantID == "" {
 			return errors.New("must set both `client-id` and `tenant-id` for service principal login")
 		}
 
@@ -291,7 +291,10 @@ func (la *loginAction) login(ctx context.Context) error {
 			return fmt.Errorf("logging in: %w", err)
 		}
 	} else {
-		if _, err := la.authManager.LoginInteractive(ctx, la.flags.redirectPort); err != nil {
+		if _, err := la.authManager.LoginInteractive(ctx, &auth.LoginInteractiveOptions{
+			RedirectPort: la.flags.redirectPort,
+			TenantId:     la.flags.tenantID,
+		}); err != nil {
 			return fmt.Errorf("logging in: %w", err)
 		}
 	}

--- a/cli/azd/pkg/auth/manager_test.go
+++ b/cli/azd/pkg/auth/manager_test.go
@@ -218,7 +218,9 @@ func TestLoginInteractive(t *testing.T) {
 		publicClient:  &mockPublicClient{},
 	}
 
-	cred, err := m.LoginInteractive(context.Background(), 0)
+	cred, err := m.LoginInteractive(context.Background(), &LoginInteractiveOptions{
+		RedirectPort: 0,
+	})
 
 	require.NoError(t, err)
 	require.IsType(t, new(azdCredential), cred)


### PR DESCRIPTION
Provides workaround for: https://github.com/Azure/azure-dev/issues/1430, https://github.com/Azure/azure-dev/issues/1409 and https://github.com/Azure/azure-dev/issues/1398

Adding support to azd to select an specific tenant during `log in`.  By doing `azd login --tenant-id XXXX-XXXX-XXX`, the interactive flow won't try `tenant-discovery` for the login account. Instead, only accounts within the specific tenant are allowed.

The downside is the process for users to discover what's the `tenant-id`, which can be seen from the Azure portal or by calling `Az cli`.

This is not a final solution to the issues, as the right fix is to fully support `multi-tenant` for live accounts, with the same experience as using Office365 accounts (work/school account). 