### PR TITLE
Avoid loading entire user profile for `homeDir`

### DIFF
--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -17,7 +17,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strconv"

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -143,13 +143,13 @@ func fetchLatestVersion(version chan<- semver.Version) {
 
 	// To avoid fetching the latest version of the CLI on every invocation, we cache the result for a period
 	// of time, in the user's home directory.
-	user, err := user.Current()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		log.Printf("could not determine current user: %v, skipping update check", err)
+		log.Printf("could not determine current home directory: %v, skipping update check", err)
 		return
 	}
 
-	cacheFilePath := filepath.Join(user.HomeDir, azdConfigDir, updateCheckCacheFileName)
+	cacheFilePath := filepath.Join(homeDir, azdConfigDir, updateCheckCacheFileName)
 	cacheFile, err := os.ReadFile(cacheFilePath)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		log.Printf("error reading update cache file: %v, skipping update check", err)

--- a/cli/azd/pkg/config/manager.go
+++ b/cli/azd/pkg/config/manager.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"os/user"
 	"path/filepath"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"

--- a/cli/azd/pkg/config/manager.go
+++ b/cli/azd/pkg/config/manager.go
@@ -97,12 +97,12 @@ func Parse(configJson []byte) (Config, error) {
 func GetUserConfigDir() (string, error) {
 	configDirPath := os.Getenv("AZD_CONFIG_DIR")
 	if configDirPath == "" {
-		user, err := user.Current()
+		homeDir, err := os.UserHomeDir()
 		if err != nil {
-			return "", fmt.Errorf("could not determine current user: %w", err)
+			return "", fmt.Errorf("could not determine current home directory: %w", err)
 		}
 
-		configDirPath = filepath.Join(user.HomeDir, configDir)
+		configDirPath = filepath.Join(homeDir, configDir)
 	}
 
 	err := os.MkdirAll(configDirPath, osutil.PermissionDirectory)


### PR DESCRIPTION
This switches `user.Current().HomeDir` to `os.UserHomeDir`, avoids loading entire user profile when only the home directory is needed, and improves `azd` (including `--help` only) performance by ~100ms to seconds on certain Windows machines.

`user.Current` fetches the entire user profile (this is loaded once and then cached). On *Nix, it simply reads pwd through a single syscall. However, on Windows, it requires talking to the domain controller for a domain-joined account. This is on magnitude of ~100ms to seconds slow which is noticeable, and also impacts the `--help` experience (since we currently have logic that runs in `main` irrespective of flags).

This changes the underlying implementation to use %HOMEPROFILE% or $HOME env variables instead of looking the system user. This should not be a problem and now matches how `azd config` is documented, where %HOMEPROFILE% or $HOME is stated explicitly.

Thanks to @bwateratmsft for reporting this.