### PR TITLE
update golangci-lint to version 3 with golang 1.20

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "^1.20.0"      
+          go-version: "^1.19.0"
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20.0"      
+          go-version: "^1.20.0"      
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -20,9 +20,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/setup-go@v3
-      - uses: actions/checkout@v3
         with:
-          go-version: "1.20.0"
+          go-version: "1.20.0"      
+      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -19,12 +19,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
         with:
-          go-version: "1.19.0"
+          go-version: "1.20.0"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           args: -v --timeout 5m0s
           working-directory: cli/azd


### PR DESCRIPTION
Updating golangci-version to fix these warnings:

![image](https://user-images.githubusercontent.com/24213737/216438808-96aee20c-7a6e-4965-a369-1d48bf37a580.png)
