### PR TITLE
Azd Hook bug fixes

### DIFF
--- a/cli/azd/cmd/down.go
+++ b/cli/azd/cmd/down.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
-	"github.com/azure/azure-dev/cli/azd/cmd/middleware"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/spf13/cobra"
 )
@@ -29,12 +28,10 @@ func newDownCmd() *cobra.Command {
 }
 
 type downAction struct {
-	runner      middleware.MiddlewareContext
 	infraDelete *infraDeleteAction
 }
 
 func newDownAction(
-	runner middleware.MiddlewareContext,
 	downFlags *downFlags,
 	infraDelete *infraDeleteAction,
 ) actions.Action {
@@ -43,11 +40,9 @@ func newDownAction(
 
 	return &downAction{
 		infraDelete: infraDelete,
-		runner:      runner,
 	}
 }
 
 func (a *downAction) Run(ctx context.Context) (*actions.ActionResult, error) {
-	runOptions := &middleware.Options{Name: "infradelete"}
-	return a.runner.RunChildAction(ctx, runOptions, a.infraDelete)
+	return a.infraDelete.Run(ctx)
 }

--- a/cli/azd/cmd/middleware/hooks.go
+++ b/cli/azd/cmd/middleware/hooks.go
@@ -67,7 +67,7 @@ func (m *HooksMiddleware) registerCommandHooks(ctx context.Context, next NextFn)
 
 	var actionResult *actions.ActionResult
 
-	commandNames := []string{m.options.Name}
+	commandNames := []string{m.options.CommandPath}
 	commandNames = append(commandNames, m.options.Aliases...)
 
 	err := hooksRunner.Invoke(ctx, commandNames, func() error {
@@ -90,6 +90,11 @@ func (m *HooksMiddleware) registerCommandHooks(ctx context.Context, next NextFn)
 // Registers event handlers for all services within the project configuration
 // Runs hooks for each matching event handler
 func (m *HooksMiddleware) registerServiceHooks(ctx context.Context) error {
+	// Service level hooks have already been registered at the root command
+	if m.options.IsChildAction() {
+		return nil
+	}
+
 	for serviceName, service := range m.projectConfig.Services {
 		// If the service hasn't configured any hooks we can continue on.
 		if service.Hooks == nil || len(service.Hooks) == 0 {

--- a/cli/azd/cmd/middleware/hooks.go
+++ b/cli/azd/cmd/middleware/hooks.go
@@ -40,6 +40,11 @@ func NewHooksMiddleware(
 
 // Runs the Hooks middleware
 func (m *HooksMiddleware) Run(ctx context.Context, next NextFn) (*actions.ActionResult, error) {
+	if m.env == nil {
+		log.Println("azd environment is not available, skipping all hook registrations.")
+		return next(ctx)
+	}
+
 	if err := m.registerServiceHooks(ctx); err != nil {
 		return nil, fmt.Errorf("failed registering service hooks, %w", err)
 	}
@@ -50,8 +55,9 @@ func (m *HooksMiddleware) Run(ctx context.Context, next NextFn) (*actions.Action
 // Register command level hooks for the executing cobra command & action
 // Invokes the middleware next function
 func (m *HooksMiddleware) registerCommandHooks(ctx context.Context, next NextFn) (*actions.ActionResult, error) {
-	if m.projectConfig.Hooks == nil || len(m.projectConfig.Hooks) == 0 {
-		log.Println("project does not contain any command hooks.")
+	if m.projectConfig == nil || m.projectConfig.Hooks == nil || len(m.projectConfig.Hooks) == 0 {
+		//nolint:lll
+		log.Println("azd project is not available or does not contain any command hooks, skipping command hook registrations.")
 		return next(ctx)
 	}
 

--- a/cli/azd/cmd/middleware/hooks_test.go
+++ b/cli/azd/cmd/middleware/hooks_test.go
@@ -21,7 +21,7 @@ func Test_CommandHooks_Middleware_WithValidProjectAndMatchingCommand(t *testing.
 	azdContext := createAzdContext(t)
 
 	envName := "test"
-	runOptions := Options{Name: "command"}
+	runOptions := Options{CommandPath: "command"}
 
 	projectConfig := project.ProjectConfig{
 		Name: envName,
@@ -53,7 +53,7 @@ func Test_CommandHooks_Middleware_ValidProjectWithDifferentCommand(t *testing.T)
 	azdContext := createAzdContext(t)
 
 	envName := "test"
-	runOptions := Options{Name: "another command"}
+	runOptions := Options{CommandPath: "another command"}
 
 	projectConfig := project.ProjectConfig{
 		Name: envName,
@@ -85,7 +85,7 @@ func Test_CommandHooks_Middleware_ValidProjectWithNoHooks(t *testing.T) {
 	azdContext := createAzdContext(t)
 
 	envName := "test"
-	runOptions := Options{Name: "another command"}
+	runOptions := Options{CommandPath: "another command"}
 
 	projectConfig := project.ProjectConfig{
 		Name: envName,
@@ -111,7 +111,7 @@ func Test_CommandHooks_Middleware_PreHookWithError(t *testing.T) {
 	azdContext := createAzdContext(t)
 
 	envName := "test"
-	runOptions := Options{Name: "command"}
+	runOptions := Options{CommandPath: "command"}
 
 	projectConfig := project.ProjectConfig{
 		Name: envName,
@@ -146,7 +146,7 @@ func Test_CommandHooks_Middleware_PreHookWithErrorAndContinue(t *testing.T) {
 	azdContext := createAzdContext(t)
 
 	envName := "test"
-	runOptions := Options{Name: "command"}
+	runOptions := Options{CommandPath: "command"}
 
 	projectConfig := project.ProjectConfig{
 		Name: envName,
@@ -182,7 +182,7 @@ func Test_CommandHooks_Middleware_WithCmdAlias(t *testing.T) {
 	azdContext := createAzdContext(t)
 
 	envName := "test"
-	runOptions := Options{Name: "command", Aliases: []string{"alias"}}
+	runOptions := Options{CommandPath: "command", Aliases: []string{"alias"}}
 
 	projectConfig := project.ProjectConfig{
 		Name: envName,

--- a/cli/azd/cmd/provision.go
+++ b/cli/azd/cmd/provision.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
-	"github.com/azure/azure-dev/cli/azd/cmd/middleware"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/spf13/cobra"
 )
@@ -38,12 +37,10 @@ Depending on what Azure resources are created, running this command might take a
 }
 
 type provisionAction struct {
-	runner      middleware.MiddlewareContext
 	infraCreate *infraCreateAction
 }
 
 func newProvisionAction(
-	runner middleware.MiddlewareContext,
 	provisionFlags *provisionFlags,
 	infraCreate *infraCreateAction,
 ) actions.Action {
@@ -51,12 +48,10 @@ func newProvisionAction(
 	infraCreate.flags = &provisionFlags.infraCreateFlags
 
 	return &provisionAction{
-		runner:      runner,
 		infraCreate: infraCreate,
 	}
 }
 
 func (a *provisionAction) Run(ctx context.Context) (*actions.ActionResult, error) {
-	runOptions := &middleware.Options{Name: "infracreate"}
-	return a.runner.RunChildAction(ctx, runOptions, a.infraCreate)
+	return a.infraCreate.Run(ctx)
 }

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -102,7 +102,7 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	}
 
 	infraCreateAction.flags = &u.flags.infraCreateFlags
-	provisionOptions := &middleware.Options{Name: "infracreate", Aliases: []string{"provision"}}
+	provisionOptions := &middleware.Options{CommandPath: "infra create", Aliases: []string{"provision"}}
 	_, err = u.runner.RunChildAction(ctx, provisionOptions, infraCreateAction)
 	if err != nil {
 		return nil, err
@@ -117,7 +117,7 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	}
 
 	deployAction.flags = &u.flags.deployFlags
-	deployOptions := &middleware.Options{Name: "deploy"}
+	deployOptions := &middleware.Options{CommandPath: "deploy"}
 	deployResult, err := u.runner.RunChildAction(ctx, deployOptions, deployAction)
 	if err != nil {
 		return nil, err
@@ -133,7 +133,7 @@ func (u *upAction) runInit(ctx context.Context) error {
 	}
 
 	initAction.flags = &u.flags.initFlags
-	initOptions := &middleware.Options{Name: "init"}
+	initOptions := &middleware.Options{CommandPath: "init"}
 	_, err = u.runner.RunChildAction(ctx, initOptions, initAction)
 	var envInitError *environment.EnvironmentInitError
 	if errors.As(err, &envInitError) {

--- a/cli/azd/pkg/ext/hooks_runner.go
+++ b/cli/azd/pkg/ext/hooks_runner.go
@@ -113,11 +113,6 @@ func (h *HooksRunner) GetScript(hookConfig *HookConfig) (tools.Script, error) {
 }
 
 func (h *HooksRunner) execHook(ctx context.Context, hookConfig *HookConfig) error {
-	// Delete any temporary inline scripts after execution
-	if hookConfig.location == ScriptLocationInline {
-		defer os.Remove(hookConfig.path)
-	}
-
 	script, err := h.GetScript(hookConfig)
 	if err != nil {
 		return err
@@ -163,6 +158,12 @@ func (h *HooksRunner) execHook(ctx context.Context, hookConfig *HookConfig) erro
 		} else {
 			return execErr
 		}
+	}
+
+	// Delete any temporary inline scripts after execution
+	// Removing temp scripts only on success to support better debugging with failing scripts.
+	if hookConfig.location == ScriptLocationInline {
+		defer os.Remove(hookConfig.path)
 	}
 
 	return nil

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -158,13 +158,8 @@ func createTempScript(hookConfig *HookConfig) (string, error) {
 		ext = "ps1"
 	}
 
-	directory, err := os.MkdirTemp(os.TempDir(), "azd-*")
-	if err != nil {
-		return "", fmt.Errorf("failed creating temp directory, %w", err)
-	}
-
-	// Write the temporary script file to .azure/hooks folder
-	file, err := os.CreateTemp(directory, fmt.Sprintf("%s-*.%s", hookConfig.Name, ext))
+	// Write the temporary script file to OS temp dir
+	file, err := os.CreateTemp(os.TempDir(), fmt.Sprintf("azd-%s-*.%s", hookConfig.Name, ext))
 	if err != nil {
 		return "", fmt.Errorf("failed creating hook file: %w", err)
 	}

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 )
 
 type ShellType string
@@ -178,6 +180,11 @@ func createTempScript(hookConfig *HookConfig) (string, error) {
 	_, err = file.WriteString(scriptBuilder.String())
 	if err != nil {
 		return "", fmt.Errorf("failed writing hook file, %w", err)
+	}
+
+	// Update file permissions to grant exec permissions
+	if err := file.Chmod(osutil.PermissionExecutableFile); err != nil {
+		return "", fmt.Errorf("failed setting executable file permissions, %w", err)
 	}
 
 	return file.Name(), nil


### PR DESCRIPTION
Fixes #1481 the following azd hook issues

- [x] Issue executing alias hooks (provision => infra create, down => infra delete)
- [x] Fixed issue where service hooks where being double registered
- [x] Fixes file exec permissions on temp generated inline scripts
- [x] Updates temp file path used for temp generated inline scripts 