### PR TITLE
Fixes service event hooks firing correctly in azd up

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -170,30 +170,32 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	})
 
 	// Environment
-	container.RegisterSingleton(func(azdContext *azdcontext.AzdContext, envFlags flagsWithEnv) (*environment.Environment, error) {
-		if azdContext == nil {
-			return nil, azdcontext.ErrNoProject
-		}
+	container.RegisterSingleton(
+		func(azdContext *azdcontext.AzdContext, envFlags flagsWithEnv) (*environment.Environment, error) {
+			if azdContext == nil {
+				return nil, azdcontext.ErrNoProject
+			}
 
-		environmentName := envFlags.EnvironmentName()
-		var err error
+			environmentName := envFlags.EnvironmentName()
+			var err error
 
-		if environmentName == "" {
-			defaultEnvName, err := azdContext.GetDefaultEnvironmentName()
+			if environmentName == "" {
+				defaultEnvName, err := azdContext.GetDefaultEnvironmentName()
+				if err != nil {
+					return nil, err
+				}
+
+				environmentName = defaultEnvName
+			}
+
+			env, err := environment.GetEnvironment(azdContext, environmentName)
 			if err != nil {
 				return nil, err
 			}
 
-			environmentName = defaultEnvName
-		}
-
-		env, err := environment.GetEnvironment(azdContext, environmentName)
-		if err != nil {
-			return nil, err
-		}
-
-		return env, nil
-	})
+			return env, nil
+		},
+	)
 
 	// Lazy loads the environment from the Azd Context when it becomes available
 	container.RegisterSingleton(

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -173,19 +173,21 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.RegisterSingleton(initEnvironment)
 
 	// Lazy loads the environment from the Azd Context when it becomes available
-	container.RegisterSingleton(func(lazyAzdContext *lazy.Lazy[*azdcontext.AzdContext], envFlags flagsWithEnv) *lazy.Lazy[*environment.Environment] {
-		return lazy.NewLazy(func() (*environment.Environment, error) {
-			_, err := lazyAzdContext.GetValue()
-			if err != nil {
-				return nil, err
-			}
+	container.RegisterSingleton(
+		func(lazyAzdContext *lazy.Lazy[*azdcontext.AzdContext], envFlags flagsWithEnv) *lazy.Lazy[*environment.Environment] {
+			return lazy.NewLazy(func() (*environment.Environment, error) {
+				_, err := lazyAzdContext.GetValue()
+				if err != nil {
+					return nil, err
+				}
 
-			var env *environment.Environment
-			err = container.Resolve(&env)
+				var env *environment.Environment
+				err = container.Resolve(&env)
 
-			return env, err
-		})
-	})
+				return env, err
+			})
+		},
+	)
 
 	// Project Config
 	container.RegisterSingleton(initProjectConfig)

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -378,7 +378,14 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 	}
 
 	infraManager, err := provisioning.NewManager(
-		ctx, env, ef.projectConfig.Path, ef.projectConfig.Infra, !ef.flags.global.NoPrompt, ef.azCli, ef.console, ef.commandRunner,
+		ctx,
+		env,
+		ef.projectConfig.Path,
+		ef.projectConfig.Infra,
+		!ef.flags.global.NoPrompt,
+		ef.azCli,
+		ef.console,
+		ef.commandRunner,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating provisioning manager: %w", err)

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -340,6 +340,7 @@ func newEnvRefreshCmd() *cobra.Command {
 
 type envRefreshAction struct {
 	azdCtx        *azdcontext.AzdContext
+	projectConfig *project.ProjectConfig
 	azCli         azcli.AzCli
 	flags         *envRefreshFlags
 	console       input.Console
@@ -350,6 +351,7 @@ type envRefreshAction struct {
 
 func newEnvRefreshAction(
 	azdCtx *azdcontext.AzdContext,
+	projectConfig *project.ProjectConfig,
 	azCli azcli.AzCli,
 	commandRunner exec.CommandRunner,
 	flags *envRefreshFlags,
@@ -359,6 +361,7 @@ func newEnvRefreshAction(
 ) actions.Action {
 	return &envRefreshAction{
 		azdCtx:        azdCtx,
+		projectConfig: projectConfig,
 		azCli:         azCli,
 		flags:         flags,
 		console:       console,
@@ -374,13 +377,8 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 		return nil, fmt.Errorf("loading environment: %w", err)
 	}
 
-	prj, err := project.GetCurrent()
-	if err != nil {
-		return nil, fmt.Errorf("loading project: %w", err)
-	}
-
 	infraManager, err := provisioning.NewManager(
-		ctx, env, prj.Path, prj.Infra, !ef.flags.global.NoPrompt, ef.azCli, ef.console, ef.commandRunner,
+		ctx, env, ef.projectConfig.Path, ef.projectConfig.Infra, !ef.flags.global.NoPrompt, ef.azCli, ef.console, ef.commandRunner,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating provisioning manager: %w", err)
@@ -406,13 +404,13 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 		}
 	}
 
-	if err = prj.Initialize(ctx, env, ef.commandRunner); err != nil {
+	if err = ef.projectConfig.Initialize(ctx, env, ef.commandRunner); err != nil {
 		return nil, err
 	}
 
-	for _, svc := range prj.Services {
+	for _, svc := range ef.projectConfig.Services {
 		eventArgs := project.ServiceLifecycleEventArgs{
-			Project: prj,
+			Project: ef.projectConfig,
 			Service: svc,
 			Args: map[string]any{
 				"bicepOutput": getStateResult.State.Outputs,

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -121,7 +121,14 @@ func (i *infraCreateAction) Run(ctx context.Context) (*actions.ActionResult, err
 	}
 
 	infraManager, err := provisioning.NewManager(
-		ctx, env, i.projectConfig.Path, i.projectConfig.Infra, i.console.IsUnformatted(), i.azCli, i.console, i.commandRunner,
+		ctx,
+		env,
+		i.projectConfig.Path,
+		i.projectConfig.Infra,
+		i.console.IsUnformatted(),
+		i.azCli,
+		i.console,
+		i.commandRunner,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating provisioning manager: %w", err)

--- a/cli/azd/cmd/infra_delete.go
+++ b/cli/azd/cmd/infra_delete.go
@@ -85,7 +85,14 @@ func (a *infraDeleteAction) Run(ctx context.Context) (*actions.ActionResult, err
 	}
 
 	infraManager, err := provisioning.NewManager(
-		ctx, env, a.projectConfig.Path, a.projectConfig.Infra, a.console.IsUnformatted(), a.azCli, a.console, a.commandRunner,
+		ctx,
+		env,
+		a.projectConfig.Path,
+		a.projectConfig.Infra,
+		a.console.IsUnformatted(),
+		a.azCli,
+		a.console,
+		a.commandRunner,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating provisioning manager: %w", err)

--- a/cli/azd/cmd/infra_delete.go
+++ b/cli/azd/cmd/infra_delete.go
@@ -55,6 +55,7 @@ type infraDeleteAction struct {
 	flags         *infraDeleteFlags
 	azCli         azcli.AzCli
 	azdCtx        *azdcontext.AzdContext
+	projectConfig *project.ProjectConfig
 	console       input.Console
 	commandRunner exec.CommandRunner
 }
@@ -63,6 +64,7 @@ func newInfraDeleteAction(
 	flags *infraDeleteFlags,
 	azCli azcli.AzCli,
 	azdCtx *azdcontext.AzdContext,
+	projectConfig *project.ProjectConfig,
 	console input.Console,
 	commandRunner exec.CommandRunner,
 ) actions.Action {
@@ -70,6 +72,7 @@ func newInfraDeleteAction(
 		flags:         flags,
 		azCli:         azCli,
 		azdCtx:        azdCtx,
+		projectConfig: projectConfig,
 		console:       console,
 		commandRunner: commandRunner,
 	}
@@ -81,13 +84,8 @@ func (a *infraDeleteAction) Run(ctx context.Context) (*actions.ActionResult, err
 		return nil, fmt.Errorf("loading environment: %w", err)
 	}
 
-	prj, err := project.GetCurrent()
-	if err != nil {
-		return nil, fmt.Errorf("loading project: %w", err)
-	}
-
 	infraManager, err := provisioning.NewManager(
-		ctx, env, prj.Path, prj.Infra, a.console.IsUnformatted(), a.azCli, a.console, a.commandRunner,
+		ctx, env, a.projectConfig.Path, a.projectConfig.Infra, a.console.IsUnformatted(), a.azCli, a.console, a.commandRunner,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating provisioning manager: %w", err)

--- a/cli/azd/cmd/middleware/hooks_test.go
+++ b/cli/azd/cmd/middleware/hooks_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
+	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/ostest"
@@ -260,9 +261,17 @@ func runMiddleware(
 ) (*actions.ActionResult, error) {
 	env := environment.EphemeralWithValues(envName, nil)
 
+	lazyEnv := lazy.NewLazy(func() (*environment.Environment, error) {
+		return env, nil
+	})
+
+	lazyProjectConfig := lazy.NewLazy(func() (*project.ProjectConfig, error) {
+		return projectConfig, nil
+	})
+
 	middleware := NewHooksMiddleware(
-		env,
-		projectConfig,
+		lazyEnv,
+		lazyProjectConfig,
 		mockContext.CommandRunner,
 		mockContext.Console,
 		runOptions,

--- a/cli/azd/cmd/middleware/hooks_test.go
+++ b/cli/azd/cmd/middleware/hooks_test.go
@@ -241,7 +241,7 @@ func Test_ServiceHooks_Registered(t *testing.T) {
 	preDeployCount := 0
 
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.Contains(command, "bash") && strings.Contains(command, "predeploy")
+		return strings.Contains(command, "predeploy")
 	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
 		preDeployCount++
 		return exec.NewRunResult(0, "", ""), nil

--- a/cli/azd/pkg/ext/event_dispatcher.go
+++ b/cli/azd/pkg/ext/event_dispatcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 )
 
@@ -47,7 +48,8 @@ func (ed *EventDispatcher[T]) AddHandler(name Event, handler EventHandlerFn[T]) 
 		existingHandler := fmt.Sprintf("%v", ref)
 
 		if newHandler == existingHandler {
-			return fmt.Errorf("event handler has already been registered for %s event", name)
+			log.Printf("event handler '%s' has already been registered for '%s' event\n", existingHandler, name)
+			continue
 		}
 	}
 

--- a/cli/azd/pkg/ext/event_dispatcher.go
+++ b/cli/azd/pkg/ext/event_dispatcher.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 )
 
@@ -48,8 +47,7 @@ func (ed *EventDispatcher[T]) AddHandler(name Event, handler EventHandlerFn[T]) 
 		existingHandler := fmt.Sprintf("%v", ref)
 
 		if newHandler == existingHandler {
-			log.Printf("event handler '%s' has already been registered for '%s' event\n", existingHandler, name)
-			continue
+			return fmt.Errorf("event handler has already been registered for %s event", name)
 		}
 	}
 

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -66,7 +66,7 @@ type HookConfig struct {
 	// When running on windows use this override config
 	Windows *HookConfig `yaml:"windows,omitempty"`
 	// When running on linux/macos use this override config
-	Posix *HookConfig `yaml:"linux,omitempty"`
+	Posix *HookConfig `yaml:"posix,omitempty"`
 }
 
 // Validates and normalizes the hook configuration

--- a/cli/azd/pkg/project/project_config.go
+++ b/cli/azd/pkg/project/project_config.go
@@ -15,7 +15,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
-	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
@@ -235,18 +234,5 @@ func LoadProjectConfig(projectPath string) (*ProjectConfig, error) {
 	}
 
 	projectConfig.Path = filepath.Dir(projectPath)
-	return projectConfig, nil
-}
-
-// Gets the current project config from the IoC container
-// This method ensures the same instance is returned that can be referenced from any component
-// ex) Can be referenced from within middleware as well as command actions
-// Returns and error when the project is not found
-func GetCurrent() (*ProjectConfig, error) {
-	var projectConfig *ProjectConfig
-	if err := ioc.Global.Resolve(&projectConfig); err != nil {
-		return nil, err
-	}
-
 	return projectConfig, nil
 }


### PR DESCRIPTION
Fixes service event hooks to fire correctly in the case of nested actions where azd env / project are lazily loaded.

- [x] Lazily evaluates azd env & project config
- [x] Sets go context value to protect against multiple service event registrations
- [x] Updates commands to inject `project.ProjectConfig` in actions.  
- [x] Also fixes issue running hooks in POSIX environments 