### PR TITLE
Fix incorrect login failure

### DIFF
--- a/cli/azd/cmd/login.go
+++ b/cli/azd/cmd/login.go
@@ -213,7 +213,6 @@ func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		}
 	}
 
-	la.console.StopSpinner(ctx, "", input.StepDone)
 	if la.formatter.Kind() == output.NoneFormat {
 		if res.Status == contracts.LoginStatusSuccess {
 			fmt.Fprintln(la.console.Handles().Stdout, "Logged in to Azure.")

--- a/cli/azd/cmd/login.go
+++ b/cli/azd/cmd/login.go
@@ -128,7 +128,7 @@ func newLoginCmd() *cobra.Command {
 		Log in to Azure.
 
 		When run without any arguments, log in interactively using a browser. To log in using a device code, pass
-		--use-device-code. To log in under a particular tenant, pass --tenant-id.
+		--use-device-code.
 		
 		To log in as a service principal, pass --client-id and --tenant-id as well as one of: --client-secret, 
 		--client-certificate, --federated-credential, or --federated-credential-provider.

--- a/cli/azd/cmd/middleware/debug.go
+++ b/cli/azd/cmd/middleware/debug.go
@@ -35,9 +35,11 @@ func (m *DebugMiddleware) Run(ctx context.Context, next NextFn) (*actions.Action
 	}
 
 	envName := "AZD_DEBUG"
-	// Use a different flag for telemetry commands. This avoids stopping the background upload process
-	// unless set by this different flag.
+
 	if strings.Contains(m.options.CommandPath, "telemetry") {
+		// Use a different flag for telemetry commands. This avoids stopping the background upload process
+		// unintentionally by default when debugging interactive commands.
+		// AZD_DEBUG_TELEMETRY can be used instead to debug background upload process.
 		envName = "AZD_DEBUG_TELEMETRY"
 	}
 

--- a/cli/azd/cmd/middleware/debug.go
+++ b/cli/azd/cmd/middleware/debug.go
@@ -37,9 +37,9 @@ func (m *DebugMiddleware) Run(ctx context.Context, next NextFn) (*actions.Action
 	envName := "AZD_DEBUG"
 
 	if strings.Contains(m.options.CommandPath, "telemetry") {
-		// Use a different flag for telemetry commands. This avoids stopping the background upload process
+		// Use a different flag for telemetry commands. This avoids stopping telemetry background upload processes
 		// unintentionally by default when debugging interactive commands.
-		// AZD_DEBUG_TELEMETRY can be used instead to debug background upload process.
+		// AZD_DEBUG_TELEMETRY can be used instead to debug any background telemetry processes.
 		envName = "AZD_DEBUG_TELEMETRY"
 	}
 

--- a/cli/azd/cmd/middleware/debug.go
+++ b/cli/azd/cmd/middleware/debug.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -33,7 +34,14 @@ func (m *DebugMiddleware) Run(ctx context.Context, next NextFn) (*actions.Action
 		return next(ctx)
 	}
 
-	debugStr := os.Getenv("AZD_DEBUG")
+	envName := "AZD_DEBUG"
+	// Use a different flag for telemetry commands. This avoids stopping the background upload process
+	// unless set by this different flag.
+	if strings.Contains(m.options.CommandPath, "telemetry") {
+		envName = "AZD_DEBUG_TELEMETRY"
+	}
+
+	debugStr := os.Getenv(envName)
 	if debugStr == "" {
 		return next(ctx)
 	}

--- a/cli/azd/pkg/account/subscriptions_manager.go
+++ b/cli/azd/pkg/account/subscriptions_manager.go
@@ -152,6 +152,8 @@ func (m *SubscriptionsManager) ListSubscriptions(ctx context.Context) ([]Subscri
 		return nil, err
 	}
 
+	// If account is a service principal login,.we can skip listing subscriptions across tenants since a
+	// service principal is tied to a single tenant.
 	if principalTenantId != nil {
 		subscriptions, err := m.service.ListSubscriptions(ctx, *principalTenantId)
 		if err != nil {

--- a/cli/azd/pkg/account/subscriptions_manager.go
+++ b/cli/azd/pkg/account/subscriptions_manager.go
@@ -152,7 +152,7 @@ func (m *SubscriptionsManager) ListSubscriptions(ctx context.Context) ([]Subscri
 		return nil, err
 	}
 
-	// If account is a service principal login,.we can skip listing subscriptions across tenants since a
+	// If account is a service principal, we can speed up listing by skipping subscription listing across tenants since a
 	// service principal is tied to a single tenant.
 	if principalTenantId != nil {
 		subscriptions, err := m.service.ListSubscriptions(ctx, *principalTenantId)

--- a/cli/azd/pkg/auth/credential_providers.go
+++ b/cli/azd/pkg/auth/credential_providers.go
@@ -39,8 +39,7 @@ func (t *multiTenantCredentialProvider) GetTokenCredential(
 	}
 
 	credential, err := t.auth.CredentialForCurrentUser(ctx, &CredentialForCurrentUserOptions{
-		TenantID:             tenantId,
-		PreferFallbackTenant: true,
+		TenantID: tenantId,
 	})
 
 	if err != nil {

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -190,7 +190,7 @@ func (m *Manager) CredentialForCurrentUser(
 		// TenantID is non-empty and PreferFallbackTenant is not true.
 		tenantID := *currentUser.TenantID
 
-		if !options.PreferFallbackTenant && options.TenantID != "" {
+		if options.TenantID != "" {
 			tenantID = options.TenantID
 		}
 
@@ -593,10 +593,6 @@ func (m *Manager) saveSecret(tenantId, clientId string, ps *persistedSecret) err
 type CredentialForCurrentUserOptions struct {
 	// The tenant ID to use when constructing the credential, instead of the default tenant.
 	TenantID string
-
-	// If true, TenantID is only used if the tenant wasn't explicitly specified
-	// at the time of login.
-	PreferFallbackTenant bool
 }
 
 // persistedSecret is the model type for the value we store in the credential cache. It is logically a discriminated union


### PR DESCRIPTION
Fixes issue when user runs `azd login --tenant-id <X>`, but has MFA policy preventing access to home tenant. `azd login` currently reports an error.