### PR TITLE
Azure App Service - Enhancement to specify health check endpoint

### DIFF
--- a/templates/common/infra/bicep/core/host/appservice.bicep
+++ b/templates/common/infra/bicep/core/host/appservice.bicep
@@ -33,6 +33,7 @@ param numberOfWorkers int = -1
 param scmDoBuildDuringDeployment bool = false
 param use32BitWorkerProcess bool = false
 param ftpsState string = 'FtpsOnly'
+param healthCheckPath string = ''
 
 resource appService 'Microsoft.Web/sites@2022-03-01' = {
   name: name
@@ -50,6 +51,7 @@ resource appService 'Microsoft.Web/sites@2022-03-01' = {
       minimumElasticInstanceCount: minimumElasticInstanceCount != -1 ? minimumElasticInstanceCount : null
       use32BitWorkerProcess: use32BitWorkerProcess
       functionAppScaleLimit: functionAppScaleLimit != -1 ? functionAppScaleLimit : null
+      healthCheckPath: healthCheckPath
       cors: {
         allowedOrigins: union([ 'https://portal.azure.com', 'https://ms.portal.azure.com' ], allowedOrigins)
       }

--- a/templates/common/infra/terraform/core/host/appservice/appservicenode/appservicenode.tf
+++ b/templates/common/infra/terraform/core/host/appservice/appservicenode/appservicenode.tf
@@ -35,6 +35,7 @@ resource "azurerm_linux_web_app" "web" {
     application_stack {
       node_version = var.node_version
     }
+    health_check_path = var.health_check_path
   }
 
   app_settings = var.app_settings

--- a/templates/common/infra/terraform/core/host/appservice/appservicenode/appservicenode_variables.tf
+++ b/templates/common/infra/terraform/core/host/appservice/appservicenode/appservicenode_variables.tf
@@ -49,3 +49,9 @@ variable "node_version" {
   type        = string
   default     = "16-lts"
 }
+
+variable "health_check_path" {
+  description = "The path to the health check endpoint"
+  type        = string
+  default     = ""
+}

--- a/templates/common/infra/terraform/core/host/appservice/appservicepython/appservicepython.tf
+++ b/templates/common/infra/terraform/core/host/appservice/appservicepython/appservicepython.tf
@@ -35,6 +35,7 @@ resource "azurerm_linux_web_app" "web" {
     application_stack {
       python_version = var.python_version
     }
+    health_check_path = var.health_check_path
   }
 
   app_settings = var.app_settings

--- a/templates/common/infra/terraform/core/host/appservice/appservicepython/appservicepython_variables.tf
+++ b/templates/common/infra/terraform/core/host/appservice/appservicepython/appservicepython_variables.tf
@@ -49,3 +49,9 @@ variable "python_version" {
   type        = string
   default     = "3.8"
 }
+
+variable "health_check_path" {
+  description = "The path to the health check endpoint"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Content

This PR contains the changes necessary for a user to configure the health check endpoint when suing the Azure App Service.
The PR adds the corresponding parameter to both IaC variants i.e., Bicep and Terraform. The parameter is defaulted to an empty string. 

The change is a *non*-breaking change as the new parameters are optional and the default value causes the same behavior as the current templates do.

## Reason

Real-life setups can have a dedicated health endpoint that should be used in the app service.

## Additional information

n/a