### PR TITLE
Correctly show function app resources in provision log

### DIFF
--- a/cli/azd/pkg/infra/azure_resource_manager.go
+++ b/cli/azd/pkg/infra/azure_resource_manager.go
@@ -251,12 +251,15 @@ func (rm *AzureResourceManager) GetResourceTypeDisplayName(
 	}
 }
 
+// cWebAppApiVersion is the API Version we use when querying information about Web App resources
+const cWebAppApiVersion = "2021-03-01"
+
 func (rm *AzureResourceManager) GetWebAppResourceTypeDisplayName(
 	ctx context.Context,
 	subscriptionId string,
 	resourceId string,
 ) (string, error) {
-	resource, err := rm.azCli.GetResource(ctx, subscriptionId, resourceId)
+	resource, err := rm.azCli.GetResource(ctx, subscriptionId, resourceId, cWebAppApiVersion)
 
 	if err != nil {
 		return "", fmt.Errorf("getting web app resource type display names: %w", err)

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -52,7 +52,12 @@ type AzCli interface {
 		resourceGroupName string,
 		deploymentName string,
 	) (*armresources.DeploymentExtended, error)
-	GetResource(ctx context.Context, subscriptionId string, resourceId string) (AzCliResourceExtended, error)
+	GetResource(
+		ctx context.Context,
+		subscriptionId string,
+		resourceId string,
+		apiVersion string,
+	) (AzCliResourceExtended, error)
 	GetKeyVault(
 		ctx context.Context,
 		subscriptionId string,

--- a/cli/azd/pkg/tools/azcli/azcli_test.go
+++ b/cli/azd/pkg/tools/azcli/azcli_test.go
@@ -43,7 +43,7 @@ func TestAZCLIWithUserAgent(t *testing.T) {
 	azCli := newAzCliFromMockContext(mockContext)
 	// We don't care about the actual response or if an error occurred
 	// Any API call that leverages the Go SDK is fine
-	_, _ = azCli.GetResource(ctx, "SUBSCRIPTION_ID", "RESOURCE_ID")
+	_, _ = azCli.GetResource(ctx, "SUBSCRIPTION_ID", "RESOURCE_ID", "API_VERSION")
 
 	userAgent, ok := rawResponse.Request.Header["User-Agent"]
 	if !ok {
@@ -142,7 +142,7 @@ func Test_AzSdk_User_Agent_Policy(t *testing.T) {
 	azCli := newAzCliFromMockContext(mockContext)
 	// We don't care about the actual response or if an error occurred
 	// Any API call that leverages the Go SDK is fine
-	_, _ = azCli.GetResource(ctx, "SUBSCRIPTION_ID", "RESOURCE_ID")
+	_, _ = azCli.GetResource(ctx, "SUBSCRIPTION_ID", "RESOURCE_ID", "API_VERSION")
 
 	userAgent, ok := rawResponse.Request.Header["User-Agent"]
 	if !ok {

--- a/cli/azd/pkg/tools/azcli/resources.go
+++ b/cli/azd/pkg/tools/azcli/resources.go
@@ -8,13 +8,13 @@ import (
 )
 
 func (cli *azCli) GetResource(
-	ctx context.Context, subscriptionId string, resourceId string) (AzCliResourceExtended, error) {
+	ctx context.Context, subscriptionId string, resourceId string, apiVersion string) (AzCliResourceExtended, error) {
 	client, err := cli.createResourcesClient(ctx, subscriptionId)
 	if err != nil {
 		return AzCliResourceExtended{}, err
 	}
 
-	res, err := client.GetByID(ctx, resourceId, "", nil)
+	res, err := client.GetByID(ctx, resourceId, apiVersion, nil)
 	if err != nil {
 		return AzCliResourceExtended{}, fmt.Errorf("getting resource by id: %w", err)
 	}


### PR DESCRIPTION
Function Apps and App Service apps use the same Azure resource types, so our display logic needs to query information about the provisioned resource to understand if a provisioned resource is an app service or a function app.

Our existing logic to do this was broken when we moved away from using `az` to get information about a resource, since we were not passing an API version on our query. This caused our REST call to fail, and we just ignored the error (under the assumption it was a transient issue and we were okay displaying slightly wrong output for progress in this case).

This change addresses the issue by forcing callers (who in theory understand what API version is valid for the resource they want to fetch information about) to provide an API verison and updates the one call site we have to pass a valid API version.

Without this change, when deploying a template like `todo-nodejs-mongo-swa-func` you'd see this in the provision log:

```
(✓) Done: Web App: func-api-trxnle2vswr24
```

Whereas with this change, we now correctly report that this is a function app:

```
(✓) Done: Function App: func-api-trxnle2vswr24
```

Fixes #1484