### PR TITLE
Add CDN to resource types

### DIFF
--- a/cli/azd/pkg/infra/azure_resource_types.go
+++ b/cli/azd/pkg/infra/azure_resource_types.go
@@ -26,6 +26,7 @@ const (
 	AzureResourceTypeApim                    AzureResourceType = "Microsoft.ApiManagement/service"
 	AzureResourceTypeCacheForRedis           AzureResourceType = "Microsoft.Cache/redis"
 	AzureResourceTypePostgreSqlServer        AzureResourceType = "Microsoft.DBforPostgreSQL/flexibleServers"
+	AzureResourceTypeCDNProfile              AzureResourceType = "Microsoft.Cdn/profiles"
 )
 
 const resourceLevelSeparator = "/"
@@ -69,6 +70,8 @@ func GetResourceTypeDisplayName(resourceType AzureResourceType) string {
 		return "Azure SQL Server"
 	case AzureResourceTypePostgreSqlServer:
 		return "Azure Database for PostgreSQL flexible server"
+	case AzureResourceTypeCDNProfile:
+		return "Azure Front Door / CDN profile"
 	}
 
 	return ""


### PR DESCRIPTION
I'm making some templates with CDNs in front, and I realized it doesn't display when the CDN is created. Making a CDN involves both a CDN Profile and a CDN endpoint, but endpoints require a profile, so probably okay to just show the profile created? I'm not sure how to reason about what resources should be displayed other than my surprise at not seeing something listed.

The labeling is tricky - the Portal calls it "Front Door and CDN profiles", but the "and" feels a bit ambiguous, so I went for a slash here. Let me know your preference.