### PR TITLE
Improve performance of multi-tenant subscription listing

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -44,6 +44,7 @@ eastus
 endregion
 envname
 errcheck
+errorinfo
 errorlint
 executil
 funcapp

--- a/cli/azd/internal/telemetry/events/events.go
+++ b/cli/azd/internal/telemetry/events/events.go
@@ -14,3 +14,7 @@ const CommandEventPrefix = "cmd."
 
 // BicepInstallEvent is the name of the event which tracks the overall bicep install operation.
 const BicepInstallEvent = "tools.bicep.install"
+
+// AccountSubscriptionsListEvent is the name of the event which tracks listing of account subscriptions .
+// See fields.AccountSubscriptionsListTenantsFound for additional event fields.
+const AccountSubscriptionsListEvent = "account.subscriptions.list"

--- a/cli/azd/internal/telemetry/fields/fields.go
+++ b/cli/azd/internal/telemetry/fields/fields.go
@@ -55,6 +55,8 @@ const (
 	ObjectIdKey = attribute.Key(contracts.UserAuthUserId) // user_AuthenticatedId
 	// Tenant ID of the principal.
 	TenantIdKey = attribute.Key("ad.tenant.id")
+	// The type of account. See AccountTypeUser for all possible options.
+	AccountTypeKey = attribute.Key("ad.account.type")
 	// Currently selected Subscription ID.
 	SubscriptionIdKey = attribute.Key("ad.subscription.id")
 	// Currently selected Project Template ID.
@@ -88,5 +90,21 @@ const (
 	EnvCodespaces         = "GitHub Codespaces"
 )
 
+// All possible enumerations of AccountTypeKey
+const (
+	// A user.
+	AccountTypeUser = "User"
+	// A service principal, typically an application.
+	AccountTypeServicePrincipal = "Service Principal"
+)
+
 // The value used for ServiceNameKey
 const ServiceNameAzd = "azd"
+
+// Additional fields of events.AccountSubscriptionsListEvent
+const (
+	// Number of tenants found
+	AccountSubscriptionsListTenantsFound = attribute.Key("tenants.found")
+	// Number of tenants where listing of subscriptions failed
+	AccountSubscriptionsListTenantsFailed = attribute.Key("tenants.failed")
+)

--- a/cli/azd/internal/telemetry/tracer.go
+++ b/cli/azd/internal/telemetry/tracer.go
@@ -112,7 +112,7 @@ func (s *wrapperSpan) EndWithStatus(err error, options ...trace.SpanEndOption) {
 		s.span.SetStatus(codes.Ok, "")
 	}
 
-	s.End(options)
+	s.End(options...)
 }
 
 // IsRecording returns the recording state of the Span. It will return

--- a/cli/azd/internal/telemetry/tracer.go
+++ b/cli/azd/internal/telemetry/tracer.go
@@ -87,6 +87,9 @@ type redefinedSpan interface {
 // properly end the Span when the operation itself ends.
 type Span interface {
 	redefinedSpan
+
+	// EndWithStatus calls End, but also sets Status based on the value of err (nil mean success).
+	EndWithStatus(err error, options ...trace.SpanEndOption)
 }
 
 type wrapperSpan struct {
@@ -100,6 +103,16 @@ type wrapperSpan struct {
 func (s *wrapperSpan) End(options ...trace.SpanEndOption) {
 	s.span.SetAttributes(GetGlobalAttributes()...)
 	s.span.End(options...)
+}
+
+func (s *wrapperSpan) EndWithStatus(err error, options ...trace.SpanEndOption) {
+	if err != nil {
+		s.span.SetStatus(codes.Error, "UnknownError")
+	} else {
+		s.span.SetStatus(codes.Ok, "")
+	}
+
+	s.End(options)
 }
 
 // IsRecording returns the recording state of the Span. It will return

--- a/cli/azd/pkg/account/manager_test.go
+++ b/cli/azd/pkg/account/manager_test.go
@@ -550,7 +550,7 @@ func setupGetSubscriptionMock(mockHttp *mockhttp.MockHttpClient, subscription *S
 		isSub := func(request *http.Request) bool {
 			return mockarmresources.IsGetSubscription(request, subscription.Id)
 		}
-		mockHttp.When(isSub).SetError(err)
+		mockHttp.When(isSub).SetNonRetriableError(err)
 		return
 	}
 

--- a/cli/azd/pkg/account/subscriptions_manager_test.go
+++ b/cli/azd/pkg/account/subscriptions_manager_test.go
@@ -1,0 +1,241 @@
+package account
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockarmresources"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockhttp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscriptionsManager_ListSubscriptions(t *testing.T) {
+	type args struct {
+		principalInfo      *principalInfoProviderMock
+		tenants            []*armsubscriptions.TenantIDDescription
+		subscriptions      map[string][]*armsubscriptions.Subscription
+		subscriptionErrors map[string]error
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []Subscription
+		wantErr bool
+	}{
+		{
+			name: "WhenServicePrincipal",
+			args: args{
+				principalInfo: &principalInfoProviderMock{
+					GetLoggedInServicePrincipalTenantIDFunc: func() (*string, error) {
+						return convert.RefOf("TENANT_ID_1"), nil
+					},
+				},
+				tenants:       generateTenants(1),
+				subscriptions: generateSubscriptions(5, "TENANT_ID_1"),
+			},
+			want:    toExpectedSubscriptions(generateSubscriptions(5, "TENANT_ID_1")),
+			wantErr: false,
+		},
+		{
+			name: "SingleTenant",
+			args: args{
+				tenants:       generateTenants(1),
+				subscriptions: generateSubscriptions(5, "TENANT_ID_1"),
+			},
+			want:    toExpectedSubscriptions(generateSubscriptions(5, "TENANT_ID_1")),
+			wantErr: false,
+		},
+		{
+			name: "LotsOfTenants",
+			args: args{
+				tenants:       generateTenants(100),
+				subscriptions: generateSubscriptionsForTenants(10, 100),
+			},
+			want:    toExpectedSubscriptions(generateSubscriptionsForTenants(10, 100)),
+			wantErr: false,
+		},
+		{
+			name: "NoTenants",
+			args: args{
+				tenants:       generateTenants(0),
+				subscriptions: generateSubscriptions(0, ""),
+			},
+			want:    []Subscription{},
+			wantErr: false,
+		},
+		{
+			name: "NoSubscriptions",
+			args: args{
+				tenants:       generateTenants(1),
+				subscriptions: generateSubscriptions(0, "TENANT_ID_1"),
+			},
+			want:    []Subscription{},
+			wantErr: false,
+		},
+		{
+			name: "SomeTenantErrors",
+			args: args{
+				tenants:       generateTenants(5),
+				subscriptions: generateSubscriptionsForTenants(1, 5),
+				subscriptionErrors: map[string]error{
+					"TENANT_ID_2": fmt.Errorf("invalid"),
+					"TENANT_ID_3": fmt.Errorf("AADSTS50076"),
+				},
+			},
+			want:    toExpectedSubscriptions(generateSubscriptions(1, "TENANT_ID_1", "TENANT_ID_4", "TENANT_ID_5")),
+			wantErr: false,
+		},
+		{
+			name: "AllTenantErrors",
+			args: args{
+				tenants:       generateTenants(3),
+				subscriptions: generateSubscriptionsForTenants(1, 3),
+				subscriptionErrors: map[string]error{
+					"TENANT_ID_1": fmt.Errorf("unknownError"),
+					"TENANT_ID_2": fmt.Errorf("invalid"),
+					"TENANT_ID_3": fmt.Errorf("AADSTS50076"),
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			mockHttp := mockhttp.NewMockHttpUtil()
+			mockarmresources.MockListTenants(mockHttp, armsubscriptions.TenantListResult{
+				Value: tt.args.tenants,
+			})
+
+			for tenant, subs := range tt.args.subscriptions {
+				tenantID := tenant
+				subs := subs
+				whenTenantRequest := mockHttp.When(func(request *http.Request) bool {
+					return mockarmresources.IsListSubscriptions(request) && mockhttp.HasBearerToken(request, tenantID)
+				})
+
+				// If error is registered, use the error
+				if err, ok := tt.args.subscriptionErrors[tenant]; ok {
+					whenTenantRequest.SetError(err)
+					continue
+				}
+
+				mockHttp.When(func(request *http.Request) bool {
+					return mockarmresources.IsListSubscriptions(request) && mockhttp.HasBearerToken(request, tenantID)
+				}).RespondFn(func(request *http.Request) (*http.Response, error) {
+					res := armsubscriptions.ClientListResponse{
+						SubscriptionListResult: armsubscriptions.SubscriptionListResult{
+							Value: subs,
+						},
+					}
+
+					jsonBytes, _ := json.Marshal(res)
+
+					return &http.Response{
+						Request:    request,
+						StatusCode: http.StatusOK,
+						Header:     http.Header{},
+						Body:       io.NopCloser(bytes.NewBuffer(jsonBytes)),
+					}, nil
+				})
+			}
+
+			principalInfo := &principalInfoProviderMock{}
+			if tt.args.principalInfo != nil {
+				principalInfo = tt.args.principalInfo
+			}
+
+			subManager := &SubscriptionsManager{
+				service: azcli.NewSubscriptionsService(
+					&mocks.MockMultiTenantCredentialProvider{},
+					mockHttp,
+				),
+				cache:         NewBypassSubscriptionsCache(),
+				principalInfo: principalInfo,
+				msg:           &mockMessaging{},
+			}
+
+			got, err := subManager.ListSubscriptions(ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+			}
+
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func generateTenants(total int) []*armsubscriptions.TenantIDDescription {
+	results := make([]*armsubscriptions.TenantIDDescription, 0, total)
+	for i := 1; i <= total; i++ {
+		results = append(results, &armsubscriptions.TenantIDDescription{
+			DisplayName:   convert.RefOf(fmt.Sprintf("TENANT_%d", i)),
+			TenantID:      convert.RefOf(fmt.Sprintf("TENANT_ID_%d", i)),
+			DefaultDomain: convert.RefOf(fmt.Sprintf("TENANT_DOMAIN_%d", i)),
+		})
+	}
+	return results
+}
+
+func generateSubscriptionsForTenants(total int, totalTenants int) map[string][]*armsubscriptions.Subscription {
+	results := make(map[string][]*armsubscriptions.Subscription, totalTenants)
+	for i := 1; i <= totalTenants; i++ {
+		tenantID := fmt.Sprintf("TENANT_ID_%d", i)
+		results[tenantID] = generateSubscriptions(total, tenantID)[tenantID]
+	}
+	return results
+}
+
+func generateSubscriptions(total int, tenantIDs ...string) map[string][]*armsubscriptions.Subscription {
+	results := make(map[string][]*armsubscriptions.Subscription, len(tenantIDs))
+
+	for _, tenantID := range tenantIDs {
+		tenantID := tenantID
+		subs := make([]*armsubscriptions.Subscription, 0, total)
+		for i := 1; i <= total; i++ {
+			subs = append(subs, &armsubscriptions.Subscription{
+				ID:             convert.RefOf(fmt.Sprintf("subscriptions/SUBSCRIPTION_%d", i)),
+				SubscriptionID: convert.RefOf(fmt.Sprintf("SUBSCRIPTION_%d_%s", i, tenantID)),
+				DisplayName:    convert.RefOf(fmt.Sprintf("Subscription %d (%s)", i, tenantID)),
+				TenantID:       &tenantID,
+			})
+		}
+		results[tenantID] = subs
+	}
+
+	return results
+}
+
+// Converts the raw ARM subscription response object into an account subscription.
+// Also sorts names since this is the expected behavior.
+func toExpectedSubscriptions(armTenantSubs map[string][]*armsubscriptions.Subscription) []Subscription {
+	results := []Subscription{}
+	for _, tenantSubs := range armTenantSubs {
+		for _, armSub := range tenantSubs {
+			results = append(results, Subscription{
+				Id:                 *armSub.SubscriptionID,
+				Name:               *armSub.DisplayName,
+				TenantId:           *armSub.TenantID,
+				UserAccessTenantId: *armSub.TenantID,
+				IsDefault:          false,
+			})
+		}
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Name < results[j].Name
+	})
+
+	return results
+}

--- a/cli/azd/pkg/account/subscriptions_manager_test.go
+++ b/cli/azd/pkg/account/subscriptions_manager_test.go
@@ -111,7 +111,9 @@ func TestSubscriptionsManager_ListSubscriptions(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx := context.Background()
 			mockHttp := mockhttp.NewMockHttpUtil()
 			mockarmresources.MockListTenants(mockHttp, armsubscriptions.TenantListResult{
@@ -127,13 +129,11 @@ func TestSubscriptionsManager_ListSubscriptions(t *testing.T) {
 
 				// If error is registered, use the error
 				if err, ok := tt.args.subscriptionErrors[tenant]; ok {
-					whenTenantRequest.SetError(err)
+					whenTenantRequest.SetNonRetriableError(err)
 					continue
 				}
 
-				mockHttp.When(func(request *http.Request) bool {
-					return mockarmresources.IsListSubscriptions(request) && mockhttp.HasBearerToken(request, tenantID)
-				}).RespondFn(func(request *http.Request) (*http.Response, error) {
+				whenTenantRequest.RespondFn(func(request *http.Request) (*http.Response, error) {
 					res := armsubscriptions.ClientListResponse{
 						SubscriptionListResult: armsubscriptions.SubscriptionListResult{
 							Value: subs,

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -19,6 +19,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
+	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
+	"github.com/azure/azure-dev/cli/azd/internal/telemetry/fields"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/github"
@@ -235,6 +237,15 @@ func (m *Manager) GetLoggedInServicePrincipalTenantID() (*string, error) {
 	currentUser, err := readUserProperties(cfg)
 	if err != nil {
 		return nil, ErrNoCurrentUser
+	}
+
+	// Record type of account found
+	if currentUser.TenantID != nil {
+		telemetry.SetGlobalAttributes(fields.AccountTypeKey.String(fields.AccountTypeServicePrincipal))
+	}
+
+	if currentUser.HomeAccountID != nil {
+		telemetry.SetGlobalAttributes(fields.AccountTypeKey.String(fields.AccountTypeUser))
 	}
 
 	return currentUser.TenantID, nil

--- a/cli/azd/pkg/tools/bicep/bicep.go
+++ b/cli/azd/pkg/tools/bicep/bicep.go
@@ -165,8 +165,9 @@ func downloadBicep(ctx context.Context, transporter policy.Transporter, bicepVer
 
 	log.Printf("downloading bicep release %s -> %s", bicepReleaseUrl, name)
 
+	var err error
 	spanCtx, span := telemetry.GetTracer().Start(ctx, events.BicepInstallEvent)
-	defer span.End()
+	defer span.EndWithStatus(err)
 
 	req, err := http.NewRequestWithContext(spanCtx, "GET", bicepReleaseUrl, nil)
 	if err != nil {

--- a/cli/azd/test/mocks/mock_credentials.go
+++ b/cli/azd/test/mocks/mock_credentials.go
@@ -34,5 +34,12 @@ func (c *MockMultiTenantCredentialProvider) GetTokenCredential(
 		return &tokenCred, nil
 	}
 
-	return &MockCredentials{}, nil
+	return &MockCredentials{
+		GetTokenFn: func(ctx context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
+			return azcore.AccessToken{
+				Token:     tenantId,
+				ExpiresOn: time.Now().Add(time.Hour * 1),
+			}, nil
+		},
+	}, nil
 }

--- a/cli/azd/test/mocks/mockarmresources/subscriptions.go
+++ b/cli/azd/test/mocks/mockarmresources/subscriptions.go
@@ -1,0 +1,111 @@
+package mockarmresources
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockhttp"
+)
+
+func IsListSubscriptions(request *http.Request) bool {
+	return request.Method == http.MethodGet && request.URL.Path == "/subscriptions"
+}
+
+func MockListSubscriptions(mockHttp *mockhttp.MockHttpClient, response armsubscriptions.SubscriptionListResult) {
+	mockHttp.When(IsListSubscriptions).RespondFn(func(request *http.Request) (*http.Response, error) {
+		res := armsubscriptions.ClientListResponse{
+			SubscriptionListResult: response,
+		}
+
+		jsonBytes, _ := json.Marshal(res)
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewBuffer(jsonBytes)),
+		}, nil
+	})
+}
+
+func IsGetSubscription(request *http.Request, subscription string) bool {
+	return request.Method == http.MethodGet && request.URL.Path == fmt.Sprintf("/subscriptions/%s", subscription)
+}
+
+func MockGetSubscription(mockHttp *mockhttp.MockHttpClient, subscription string, response armsubscriptions.Subscription) {
+	mockHttp.When(func(request *http.Request) bool {
+		return IsGetSubscription(request, subscription)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		res := armsubscriptions.ClientGetResponse{
+			Subscription: response,
+		}
+
+		jsonBytes, _ := json.Marshal(res)
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewBuffer(jsonBytes)),
+		}, nil
+	})
+}
+
+func IsListTenants(request *http.Request) bool {
+	return request.Method == http.MethodGet && request.URL.Path == "/tenants"
+}
+
+func MockListTenants(mockHttp *mockhttp.MockHttpClient, response armsubscriptions.TenantListResult) {
+	mockHttp.When(IsListTenants).RespondFn(func(request *http.Request) (*http.Response, error) {
+		res := armsubscriptions.TenantsClientListResponse{
+			TenantListResult: response,
+		}
+
+		jsonBytes, _ := json.Marshal(res)
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewBuffer(jsonBytes)),
+		}, nil
+	})
+}
+
+func IsListLocations(request *http.Request, subscription string) bool {
+	if subscription == "" {
+		return request.Method == http.MethodGet &&
+			strings.HasPrefix(request.URL.Path, "/subscriptions/") &&
+			strings.HasSuffix(request.URL.Path, "/locations")
+	}
+
+	return request.Method == http.MethodGet &&
+		request.URL.Path == fmt.Sprintf("/subscriptions/%s/locations", subscription)
+}
+
+func MockListLocations(
+	mockHttp *mockhttp.MockHttpClient,
+	subscription string,
+	response armsubscriptions.LocationListResult) {
+	mockHttp.When(func(request *http.Request) bool {
+		return IsListLocations(request, subscription)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		res := armsubscriptions.ClientListLocationsResponse{
+			LocationListResult: response,
+		}
+
+		jsonBytes, _ := json.Marshal(res)
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewBuffer(jsonBytes)),
+		}, nil
+	})
+}

--- a/cli/azd/test/mocks/mockhttp/mock_http_client.go
+++ b/cli/azd/test/mocks/mockhttp/mock_http_client.go
@@ -2,6 +2,7 @@ package mockhttp
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 )
 
@@ -75,4 +76,11 @@ func (e *HttpExpression) RespondFn(responseFn RespondFn) *MockHttpClient {
 func (e *HttpExpression) SetError(err error) *MockHttpClient {
 	e.error = err
 	return e.http
+}
+
+func HasBearerToken(request *http.Request, bearerToken string) bool {
+	authHeader := request.Header["Authorization"]
+	isTrue := authHeader != nil && len(authHeader) == 1 && authHeader[0] == fmt.Sprintf("Bearer %s", bearerToken)
+	log.Printf("HasBearerToken(%s, %s) = %v\n", authHeader[0], bearerToken, isTrue)
+	return isTrue
 }

--- a/cli/azd/test/mocks/mockhttp/mock_http_client.go
+++ b/cli/azd/test/mocks/mockhttp/mock_http_client.go
@@ -2,7 +2,6 @@ package mockhttp
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 )
 
@@ -80,7 +79,5 @@ func (e *HttpExpression) SetError(err error) *MockHttpClient {
 
 func HasBearerToken(request *http.Request, bearerToken string) bool {
 	authHeader := request.Header["Authorization"]
-	isTrue := authHeader != nil && len(authHeader) == 1 && authHeader[0] == fmt.Sprintf("Bearer %s", bearerToken)
-	log.Printf("HasBearerToken(%s, %s) = %v\n", authHeader[0], bearerToken, isTrue)
-	return isTrue
+	return len(authHeader) == 1 && authHeader[0] == fmt.Sprintf("Bearer %s", bearerToken)
 }


### PR DESCRIPTION
Improve performance of multi-tenant subscription listing by fanning out subscription listing across tenants. Listing subscriptions for a given tenant can incur 200ms - seconds worth of delay. If a user has 5 tenants, this can be noticeably slow. Fanning out subscription listing per tenant alleviates this problem.

Tests, specifically `TestSubscriptionsManager_ListSubscriptions_LotsOfTenants` verifies the behavior when listing across 100 tenants. This test does not cover the full extent of application due to specific mocked dependencies. The dependencies that are not verified are: `multiTenantCredentialProvider`, `azdCredential`. I inspected these two types and verified that they are safe for parallel use.

Additionally, with this change, I've added usage telemetry for tracking multitenancy as described in #1501

