### PR TITLE
Remove service calls for location and subscription defaults in UI prompt

### DIFF
--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -304,11 +304,7 @@ func getSubscriptionOptions(ctx context.Context, subscriptions account.Manager) 
 	// configured to use if the environment variable is unset.
 	defaultSubscriptionId := os.Getenv(environment.SubscriptionIdEnvVarName)
 	if defaultSubscriptionId == "" {
-		for _, info := range subscriptionInfos {
-			if info.IsDefault {
-				defaultSubscriptionId = info.Id
-			}
-		}
+		defaultSubscriptionId = subscriptions.GetDefaultSubscriptionID(ctx)
 	}
 
 	var subscriptionOptions = make([]string, len(subscriptionInfos)+1)

--- a/cli/azd/pkg/account/manager_test.go
+++ b/cli/azd/pkg/account/manager_test.go
@@ -150,7 +150,7 @@ func Test_GetAccountDefaults(t *testing.T) {
 	})
 }
 
-func Test_GetSubscriptions(t *testing.T) {
+func Test_GetSubscriptionsWithDefaultSet(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		mockConfig := mockconfig.NewMockConfigManager()
 		mockHttp := mockhttp.NewMockHttpUtil()
@@ -164,7 +164,7 @@ func Test_GetSubscriptions(t *testing.T) {
 			NewBypassSubscriptionsCache()))
 		require.NoError(t, err)
 
-		subscriptions, err := manager.GetSubscriptions(context.Background())
+		subscriptions, err := manager.GetSubscriptionsWithDefaultSet(context.Background())
 
 		require.NoError(t, err)
 		require.Len(t, subscriptions, 3)
@@ -201,7 +201,7 @@ func Test_GetSubscriptions(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		subscriptions, err := manager.GetSubscriptions(context.Background())
+		subscriptions, err := manager.GetSubscriptionsWithDefaultSet(context.Background())
 
 		defaultIndex := slices.IndexFunc(subscriptions, func(sub Subscription) bool {
 			return sub.IsDefault
@@ -229,7 +229,7 @@ func Test_GetSubscriptions(t *testing.T) {
 			))
 		require.NoError(t, err)
 
-		subscriptions, err := manager.GetSubscriptions(context.Background())
+		subscriptions, err := manager.GetSubscriptionsWithDefaultSet(context.Background())
 
 		require.Error(t, err)
 		require.Nil(t, subscriptions)

--- a/cli/azd/pkg/account/subscriptions_manager.go
+++ b/cli/azd/pkg/account/subscriptions_manager.go
@@ -223,6 +223,9 @@ func (m *SubscriptionsManager) ListSubscriptions(ctx context.Context) ([]Subscri
 }
 
 func (m *SubscriptionsManager) ListLocations(ctx context.Context, subscriptionId string) ([]azcli.AzCliLocation, error) {
+	stop := m.msg.ShowProgress(ctx, "Retrieving locations...")
+	defer stop()
+
 	tenantId, err := m.LookupTenant(ctx, subscriptionId)
 	if err != nil {
 		return nil, err

--- a/cli/azd/pkg/azureutil/location.go
+++ b/cli/azd/pkg/azureutil/location.go
@@ -63,12 +63,7 @@ func PromptLocationWithFilter(
 
 	// If no location is set in the process environment, see what the azd config default is.
 	if defaultLocation == "" {
-		defaultConfig, err := accountManager.GetAccountDefaults(ctx)
-		if err != nil {
-			return "", fmt.Errorf("failed retrieving azd defaults. %w", err)
-		}
-
-		defaultLocation = defaultConfig.DefaultLocation.Name
+		defaultLocation = accountManager.GetDefaultLocationName(ctx)
 	}
 
 	var defaultOption string

--- a/cli/azd/test/mocks/mockaccount/mock_manager.go
+++ b/cli/azd/test/mocks/mockaccount/mock_manager.go
@@ -37,8 +37,26 @@ func (a *MockAccountManager) GetAccountDefaults(ctx context.Context) (*account.A
 		DefaultLocation: &account.Location{},
 	}, nil
 }
+func (a *MockAccountManager) GetSubscriptionsWithDefaultSet(ctx context.Context) ([]account.Subscription, error) {
+	subscriptions := a.Subscriptions
+	for _, sub := range subscriptions {
+		if sub.Id == a.DefaultSubscription {
+			sub.IsDefault = true
+		}
+	}
+	return subscriptions, nil
+}
+
 func (a *MockAccountManager) GetSubscriptions(ctx context.Context) ([]account.Subscription, error) {
 	return a.Subscriptions, nil
+}
+
+func (a *MockAccountManager) GetDefaultLocationName(ctx context.Context) string {
+	return a.DefaultLocation
+}
+
+func (a *MockAccountManager) GetDefaultSubscriptionID(ctx context.Context) string {
+	return a.DefaultSubscription
 }
 
 func (a *MockAccountManager) GetLocations(ctx context.Context, subscriptionId string) ([]azcli.AzCliLocation, error) {


### PR DESCRIPTION
Currently, the concept of a `default.location` and `default.subscription` is tied to the UI selection. For the UI selection, it's not important to validate the default configuration's validity, and it is preferred that the UI simply chooses no default, or a hardcoded default, if the default configuration isn't valid.

This change removes the extra validation we're performing to validate account defaults. The API and implementation for validated defaults is still available in case we want better guarantees for other use-cases.