### PR TITLE
Clean up VSCode extension activation events

### DIFF
--- a/ext/vscode/package-lock.json
+++ b/ext/vscode/package-lock.json
@@ -18,7 +18,7 @@
                 "@types/glob": "~7",
                 "@types/mocha": "~9",
                 "@types/node": "~16",
-                "@types/vscode": "~1.64",
+                "@types/vscode": "~1.74",
                 "@typescript-eslint/eslint-plugin": "~5",
                 "@typescript-eslint/parser": "~5",
                 "@vscode/test-electron": "~2.1",
@@ -36,7 +36,7 @@
                 "webpack-cli": "~4.10"
             },
             "engines": {
-                "vscode": "^1.66.0"
+                "vscode": "^1.74.0"
             }
         },
         "node_modules/@discoveryjs/json-ext": {
@@ -358,9 +358,9 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.64.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.64.0.tgz",
-            "integrity": "sha512-bSlAWz5WtcSL3cO9tAT/KpEH9rv5OBnm93OIIFwdCshaAiqr2bp1AUyEwW9MWeCvZBHEXc3V0fTYVdVyzDNwHA==",
+            "version": "1.74.1",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.1.tgz",
+            "integrity": "sha512-/4bwu5Lz2tQIhCDfGyEho36jEBHfEGgbuajgFZgRIfsfK/U0vv8diYIvQRiz8cc9tGlzd7m/NJscEJ7gFExJ4g==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -5923,9 +5923,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.64.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.64.0.tgz",
-            "integrity": "sha512-bSlAWz5WtcSL3cO9tAT/KpEH9rv5OBnm93OIIFwdCshaAiqr2bp1AUyEwW9MWeCvZBHEXc3V0fTYVdVyzDNwHA==",
+            "version": "1.74.1",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.1.tgz",
+            "integrity": "sha512-/4bwu5Lz2tQIhCDfGyEho36jEBHfEGgbuajgFZgRIfsfK/U0vv8diYIvQRiz8cc9tGlzd7m/NJscEJ7gFExJ4g==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {

--- a/ext/vscode/package.json
+++ b/ext/vscode/package.json
@@ -9,7 +9,7 @@
     "publisher": "ms-azuretools",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "engines": {
-        "vscode": "^1.66.0"
+        "vscode": "^1.74.0"
     },
     "categories": [
         "Other"
@@ -22,18 +22,6 @@
         "url": "https://github.com/azure/azure-dev"
     },
     "activationEvents": [
-        "onCommand:azure-dev.commands.cli.init",
-        "onCommand:azure-dev.commands.cli.provision",
-        "onCommand:azure-dev.commands.cli.deploy",
-        "onCommand:azure-dev.commands.cli.restore",
-        "onCommand:azure-dev.commands.cli.infra-delete",
-        "onCommand:azure-dev.commands.cli.up",
-        "onCommand:azure-dev.commands.cli.monitor",
-        "onCommand:azure-dev.commands.cli.env-select",
-        "onCommand:azure-dev.commands.cli.env-new",
-        "onCommand:azure-dev.commands.cli.env-refresh",
-        "onCommand:azure-dev.commands.cli.pipeline-config",
-        "onCommand:azure-dev.commands.getDotEnvFilePath",
         "onTaskType:dotenv"
     ],
     "main": "./main.js",
@@ -220,7 +208,7 @@
         "@types/glob": "~7",
         "@types/mocha": "~9",
         "@types/node": "~16",
-        "@types/vscode": "~1.64",
+        "@types/vscode": "~1.74",
         "@typescript-eslint/eslint-plugin": "~5",
         "@typescript-eslint/parser": "~5",
         "@vscode/test-electron": "~2.1",


### PR DESCRIPTION
Fixes #1509. VSCode has gotten pretty pushy about removing these--showing warnings even when `package.json` isn't open--so I'm just going to deal with it now. VSCode 1.74.0 has been out for about two months now and by the time we release this version of the extension, it'll have been closer to three months.