### PR TITLE
Fix infinite recursion

### DIFF
--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -119,7 +119,8 @@ func (c *AskerConsole) Message(ctx context.Context, message string) {
 		// these objects be written on a single line.
 		jsonMessage, err := json.Marshal(output.EventForMessage(message))
 		if err != nil {
-			panic(fmt.Sprintf("Message: unexpected error during marshaling for a valid object: %v", err))
+			log.Printf("failed to marshal message into JSON output: %v\n", err)
+			return
 		}
 		fmt.Fprintln(c.writer, string(jsonMessage))
 	} else if c.formatter == nil || c.formatter.Kind() == output.NoneFormat {
@@ -133,8 +134,13 @@ func (c *AskerConsole) MessageUxItem(ctx context.Context, item ux.UxItem) {
 	if c.formatter != nil && c.formatter.Kind() == output.JsonFormat {
 		// no need to check the spinner for json format, as the spinner won't start when using json format
 		// instead, there would be a message about starting spinner
-		json, _ := json.Marshal(item)
-		fmt.Fprintln(c.writer, string(json))
+		envelope := item.Envelope()
+		text, err := json.Marshal(envelope)
+		if err != nil {
+			log.Printf("failed to marshal event into JSON output: %v\n", err)
+			return
+		}
+		fmt.Fprintln(c.writer, string(text))
 		return
 	}
 

--- a/cli/azd/pkg/output/ux/action_result.go
+++ b/cli/azd/pkg/output/ux/action_result.go
@@ -4,9 +4,9 @@
 package ux
 
 import (
-	"encoding/json"
 	"fmt"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
@@ -29,9 +29,9 @@ func (ar *ActionResult) ToString(currentIndentation string) (result string) {
 	return result
 }
 
-func (ar *ActionResult) MarshalJSON() ([]byte, error) {
+func (ar *ActionResult) Envelope() contracts.EventEnvelope {
 	if ar.Err != nil {
-		return json.Marshal(output.EventForMessage(ar.Err.Error()))
+		return output.EventForMessage(ar.Err.Error())
 	}
 	result := ""
 	if ar.SuccessMessage != "" {
@@ -40,5 +40,5 @@ func (ar *ActionResult) MarshalJSON() ([]byte, error) {
 	if ar.FollowUp != "" {
 		result += fmt.Sprintf(". FOLLOW UP: %s", ar.FollowUp)
 	}
-	return json.Marshal(output.EventForMessage(result))
+	return output.EventForMessage(result)
 }

--- a/cli/azd/pkg/output/ux/created_repo_secret.go
+++ b/cli/azd/pkg/output/ux/created_repo_secret.go
@@ -4,9 +4,9 @@
 package ux
 
 import (
-	"encoding/json"
 	"fmt"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
@@ -18,8 +18,7 @@ func (cr *CreatedRepoSecret) ToString(currentIndentation string) string {
 	return fmt.Sprintf("%s%s Setting %s repo secret", currentIndentation, donePrefix, cr.Name)
 }
 
-func (cr *CreatedRepoSecret) MarshalJSON() ([]byte, error) {
+func (cr *CreatedRepoSecret) Envelope() contracts.EventEnvelope {
 	// reusing the same envelope from console messages
-	return json.Marshal(output.EventForMessage(
-		fmt.Sprintf("%s Setting %s repo secret", donePrefix, cr.Name)))
+	return output.EventForMessage(fmt.Sprintf("%s Setting %s repo secret", donePrefix, cr.Name))
 }

--- a/cli/azd/pkg/output/ux/created_resource.go
+++ b/cli/azd/pkg/output/ux/created_resource.go
@@ -4,9 +4,9 @@
 package ux
 
 import (
-	"encoding/json"
 	"fmt"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
@@ -19,8 +19,7 @@ func (cr *CreatedResource) ToString(currentIndentation string) string {
 	return fmt.Sprintf("%s%s %s: %s", currentIndentation, donePrefix, cr.Type, cr.Name)
 }
 
-func (cr *CreatedResource) MarshalJSON() ([]byte, error) {
+func (cr *CreatedResource) Envelope() contracts.EventEnvelope {
 	// reusing the same envelope from console messages
-	return json.Marshal(output.EventForMessage(
-		fmt.Sprintf("%s Creating %s: %s", donePrefix, cr.Type, cr.Name)))
+	return output.EventForMessage(fmt.Sprintf("%s Creating %s: %s", donePrefix, cr.Type, cr.Name))
 }

--- a/cli/azd/pkg/output/ux/done.go
+++ b/cli/azd/pkg/output/ux/done.go
@@ -4,9 +4,9 @@
 package ux
 
 import (
-	"encoding/json"
 	"fmt"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
@@ -21,8 +21,7 @@ func (d *DoneMessage) ToString(currentIndentation string) string {
 	return fmt.Sprintf("%s%s %s", currentIndentation, donePrefix, d.Message)
 }
 
-func (d *DoneMessage) MarshalJSON() ([]byte, error) {
+func (d *DoneMessage) Envelope() contracts.EventEnvelope {
 	// reusing the same envelope from console messages
-	return json.Marshal(output.EventForMessage(
-		fmt.Sprintf("%s %s", donePrefix, d.Message)))
+	return output.EventForMessage(fmt.Sprintf("%s %s", donePrefix, d.Message))
 }

--- a/cli/azd/pkg/output/ux/endpoint.go
+++ b/cli/azd/pkg/output/ux/endpoint.go
@@ -4,7 +4,6 @@
 package ux
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -20,13 +19,11 @@ func (e *Endpoint) ToString(currentIndentation string) string {
 	return fmt.Sprintf("%s- Endpoint: %s", currentIndentation, output.WithLinkFormat(e.Endpoint))
 }
 
-func (e *Endpoint) MarshalJSON() ([]byte, error) {
+func (e *Endpoint) Envelope() contracts.EventEnvelope {
 	// reusing the same envelope from console messages
-	return json.Marshal(
-		contracts.EventEnvelope{
-			Type:      contracts.Endpoint,
-			Timestamp: time.Now(),
-			Data:      e,
-		},
-	)
+	return contracts.EventEnvelope{
+		Type:      contracts.Endpoint,
+		Timestamp: time.Now(),
+		Data:      e,
+	}
 }

--- a/cli/azd/pkg/output/ux/multiline_message.go
+++ b/cli/azd/pkg/output/ux/multiline_message.go
@@ -4,9 +4,9 @@
 package ux
 
 import (
-	"encoding/json"
 	"strings"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
@@ -24,7 +24,7 @@ func (mm *MultilineMessage) ToString(currentIndentation string) string {
 	return strings.Join(updatedLines, "\n")
 }
 
-func (mm *MultilineMessage) MarshalJSON() ([]byte, error) {
+func (mm *MultilineMessage) Envelope() contracts.EventEnvelope {
 	// reusing the same envelope from console messages
-	return json.Marshal(output.EventForMessage(strings.Join(mm.Lines, ",")))
+	return output.EventForMessage(strings.Join(mm.Lines, ","))
 }

--- a/cli/azd/pkg/output/ux/title.go
+++ b/cli/azd/pkg/output/ux/title.go
@@ -4,7 +4,6 @@
 package ux
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -26,13 +25,11 @@ func (t *MessageTitle) ToString(currentIndentation string) string {
 	return fmt.Sprintf("\n%s\n", output.WithBold(t.Title))
 }
 
-func (t *MessageTitle) MarshalJSON() ([]byte, error) {
+func (t *MessageTitle) Envelope() contracts.EventEnvelope {
 	// reusing the same envelope from console messages
-	return json.Marshal(
-		contracts.EventEnvelope{
-			Type:      contracts.OperationStart,
-			Timestamp: time.Now(),
-			Data:      t,
-		},
-	)
+	return contracts.EventEnvelope{
+		Type:      contracts.OperationStart,
+		Timestamp: time.Now(),
+		Data:      t,
+	}
 }

--- a/cli/azd/pkg/output/ux/uxitem.go
+++ b/cli/azd/pkg/output/ux/uxitem.go
@@ -4,8 +4,7 @@
 package ux
 
 import (
-	"encoding/json"
-
+	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
@@ -13,7 +12,9 @@ type UxItem interface {
 	// Defines how the object is transformed into a printable string.
 	// The current indentation can be used to make the string to be aligned to the previous lines.
 	ToString(currentIndentation string) string
-	json.Marshaler
+
+	// Envelope returns the UX message as an event envelope suitable for machine parsing.
+	Envelope() contracts.EventEnvelope
 }
 
 var donePrefix string = output.WithSuccessFormat("(✓) Done:")

--- a/cli/azd/pkg/output/ux/warning.go
+++ b/cli/azd/pkg/output/ux/warning.go
@@ -4,7 +4,6 @@
 package ux
 
 import (
-	"encoding/json"
 	"time"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
@@ -24,13 +23,11 @@ func (t *WarningMessage) ToString(currentIndentation string) string {
 	return output.WithWarningFormat("%s%s%s", currentIndentation, prefix, t.Description)
 }
 
-func (t *WarningMessage) MarshalJSON() ([]byte, error) {
+func (t *WarningMessage) Envelope() contracts.EventEnvelope {
 	// reusing the same envelope from console messages
-	return json.Marshal(
-		contracts.EventEnvelope{
-			Type:      contracts.Warning,
-			Timestamp: time.Now(),
-			Data:      t,
-		},
-	)
+	return contracts.EventEnvelope{
+		Type:      contracts.Warning,
+		Timestamp: time.Now(),
+		Data:      t,
+	}
 }

--- a/cli/azd/test/functional/up_test.go
+++ b/cli/azd/test/functional/up_test.go
@@ -250,10 +250,10 @@ func Test_CLI_Up_Down_ContainerApp(t *testing.T) {
 			_, err = cli.RunCommandWithStdIn(ctx, stdinForTests(envName), "init")
 			require.NoError(t, err)
 
-			_, err = cli.RunCommand(ctx, "infra", "create")
+			_, err = cli.RunCommand(ctx, "infra", "create", "--output", "json")
 			require.NoError(t, err)
 
-			_, err = cli.RunCommand(ctx, "deploy")
+			_, err = cli.RunCommand(ctx, "deploy", "--output", "json")
 			require.NoError(t, err)
 
 			// The sample hosts a small application that just responds with a 200 OK with a body of "Hello, `azd`."
@@ -267,7 +267,7 @@ func Test_CLI_Up_Down_ContainerApp(t *testing.T) {
 			err = probeServiceHealth(t, ctx, url, expectedTestAppResponse)
 			require.NoError(t, err)
 
-			_, err = cli.RunCommand(ctx, "infra", "delete", "--force", "--purge")
+			_, err = cli.RunCommand(ctx, "infra", "delete", "--force", "--purge", "--output", "json")
 			require.NoError(t, err)
 		})
 	}


### PR DESCRIPTION
This change fixes infinite recursion when `--output json` is specified.

`ux.UxItem` implemented `json.Unmarshaler`, and called `json.Marshal` with an envelope struct. The struct has `Data` set to itself. Thus, `json.Marshal` will then call `json.Marshal` on the same instance, calling an infinite recursion and resulting in stack overflow.

Fix #1437