### PR TITLE
Fix environment flag not respected

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -163,9 +163,9 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	})
 
 	container.RegisterSingleton(func(cmd *cobra.Command) envFlag {
-		// Get the current cmd flags for the executing command
 		envValue, err := cmd.Flags().GetString(environmentNameFlag)
 		if err != nil {
+			// This is probably an error
 			return envFlag{}
 		}
 

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -326,6 +326,8 @@ func getSubscriptionOptions(ctx context.Context, subscriptions account.Manager) 
 	return subscriptionOptions, defaultSubscription, nil
 }
 
+const environmentNameFlag string = "environment"
+
 type envFlag struct {
 	environmentName string
 }
@@ -333,7 +335,7 @@ type envFlag struct {
 func (e *envFlag) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	local.StringVarP(
 		&e.environmentName,
-		"environment",
+		environmentNameFlag,
 		"e",
 		// Set the default value to AZURE_ENV_NAME value if available
 		os.Getenv(environment.EnvNameEnvVarName),
@@ -357,18 +359,4 @@ func getResourceGroupFollowUp(
 		}
 	}
 	return followUp
-}
-
-func (e *envFlag) EnvironmentName() string {
-	return e.environmentName
-}
-
-// Represent command flags that accept an environment name argument
-type flagsWithEnv interface {
-	EnvironmentName() string
-}
-
-// Represents and command flags
-type flags interface {
-	Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions)
 }

--- a/cli/azd/test/functional/env_test.go
+++ b/cli/azd/test/functional/env_test.go
@@ -99,7 +99,7 @@ func Test_CLI_Env_Management(t *testing.T) {
 }
 
 // Verifies azd env commands that manage environment values.
-func Test_CLI_Env_Values_Management(t *testing.T) {
+func Test_CLI_Env_Values_SingleEnvironment(t *testing.T) {
 	ctx, cancel := newTestContext(t)
 	defer cancel()
 
@@ -115,7 +115,6 @@ func Test_CLI_Env_Values_Management(t *testing.T) {
 	// Create one environment
 	envName := randomEnvName()
 	envNew(ctx, t, cli, envName, false)
-	t.Logf("DIR: %s", dir)
 
 	// Add key1
 	envSetValue(ctx, t, cli, "key1", "value1")
@@ -136,6 +135,45 @@ func Test_CLI_Env_Values_Management(t *testing.T) {
 	require.Equal(t, values["key1"], "modified1")
 	require.Contains(t, values, "key2")
 	require.Equal(t, values["key2"], "value2")
+}
+
+// Verifies azd env commands that manage values across different environments.
+func Test_CLI_Env_Values_MultipleEnvironments(t *testing.T) {
+	ctx, cancel := newTestContext(t)
+	defer cancel()
+
+	dir := tempDirWithDiagnostics(t)
+	t.Logf("DIR: %s", dir)
+
+	cli := azdcli.NewCLI(t)
+	cli.WorkingDirectory = dir
+
+	err := copySample(dir, "storage")
+	require.NoError(t, err, "failed expanding sample")
+
+	// Create one environment
+	envName1 := randomEnvName()
+	envNew(ctx, t, cli, envName1, false)
+
+	// Create another environment
+	envName2 := randomEnvName()
+	envNew(ctx, t, cli, envName2, false)
+
+	// Get and set values via -e flag for first environment
+	envSetValue(ctx, t, cli, "envName1", envName1, "--environment", envName1)
+	values := envGetValues(ctx, t, cli, "--environment", envName1)
+	require.Contains(t, values, "AZURE_ENV_NAME")
+	require.Equal(t, values["AZURE_ENV_NAME"], envName1)
+	require.Contains(t, values, "envName1")
+	require.Equal(t, values["envName1"], envName1)
+
+	// Get and set values via -e flag for the second environment
+	envSetValue(ctx, t, cli, "envName2", envName2, "--environment", envName2)
+	values = envGetValues(ctx, t, cli, "--environment", envName2)
+	require.Contains(t, values, "AZURE_ENV_NAME")
+	require.Equal(t, values["AZURE_ENV_NAME"], envName2)
+	require.Contains(t, values, "envName2")
+	require.Equal(t, values["envName2"], envName2)
 }
 
 func requireIsDefault(t *testing.T, list []contracts.EnvListEnvironment, envName string) {
@@ -175,13 +213,19 @@ func envSelect(ctx context.Context, t *testing.T, cli *azdcli.CLI, envName strin
 	require.NoError(t, err)
 }
 
-func envSetValue(ctx context.Context, t *testing.T, cli *azdcli.CLI, key string, value string) {
-	_, err := cli.RunCommand(ctx, "env", "set", key, value)
+func envSetValue(ctx context.Context, t *testing.T, cli *azdcli.CLI, key string, value string, args ...string) {
+	defaultArgs := []string{"env", "set", key, value}
+	args = append(defaultArgs, args...)
+
+	_, err := cli.RunCommand(ctx, args...)
 	require.NoError(t, err)
 }
 
-func envGetValues(ctx context.Context, t *testing.T, cli *azdcli.CLI) map[string]string {
-	result, err := cli.RunCommand(ctx, "env", "get-values", "--output", "json")
+func envGetValues(ctx context.Context, t *testing.T, cli *azdcli.CLI, args ...string) map[string]string {
+	defaultArgs := []string{"env", "get-values", "--output", "json"}
+	args = append(defaultArgs, args...)
+
+	result, err := cli.RunCommand(ctx, args...)
 	require.NoError(t, err)
 
 	var envValues map[string]string


### PR DESCRIPTION
This changes the resolution of environment flag to bypass IoC registration and use the hardcoded `environmentName` flag. A test has been added to verify that `-e` is respected in the CLI.

With the switch to `golobby`, there isn't an ability to specify bindings between concrete and interfaces except through the resolver function's return type. A concrete flag instance is being registered, and thus in the existing code, only the concrete type is resolved, and `flags` is never resolved. Switching to named registration is also not an option, since: we need a single unique name, and actions end up sharing the same container. Thus, the second time a `flagResolver` is registered, it will fail.