### PR TITLE
Update `CODEOWNERS` paths: fix invalid paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,18 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
-* @jongio @ellismg
-/cli/ @ellismg @wbreza @vhvb1989 @hemarina @jongio @weikanglim
-/cli/installer @ellismg @danieljurek
-/ext/ @karolz-ms @ellismg @jongio
+/**               @jongio @ellismg
+
+/cli/             @ellismg @wbreza @vhvb1989 @hemarina @jongio @weikanglim
+/cli/installer/   @ellismg @danieljurek
+
+/ext/             @karolz-ms @ellismg @jongio
+
 /generators/repo/ @wbreza @ellismg @danieljurek
-/.github/ @danieljurek @ellismg
-/eng/ @danieljurek @ellismg
-/schemas/ @jongio @karolz-ms @ellismg @wbreza
-/templates/ @jongio @wbreza
+
+/.github/         @danieljurek @ellismg
+
+/eng/             @danieljurek @ellismg
+
+/schemas/         @jongio @karolz-ms @ellismg @wbreza
+
+/templates/       @jongio @wbreza


### PR DESCRIPTION
As part of ongoing work of enabling wildcard support for `CODEOWNERS`:
- https://github.com/Azure/azure-sdk-tools/issues/2770
- https://github.com/Azure/azure-sdk-tools/pull/5088

and enabling stricter validation:
- https://github.com/Azure/azure-sdk-tools/issues/4859

this PR:
- fixes invalid paths, to match rules explained [here](https://github.com/Azure/azure-sdk/blob/main/docs/policies/opensource.md#codeowners);
- removes `/**/tests.yml` and `/**/ci.yml`, to avoid all build failure notifications being routed to it once we enable the new regex-based, wildcard-supporting `CODEOWNERS` matcher, per: https://github.com/Azure/azure-sdk-tools/pull/5088#issuecomment-1397330147

Once this PR is merged, I will enable the new `CODEOWNERS` matcher, similar to how it was done for `net` repo by these two PRs:
- https://github.com/Azure/azure-sdk-tools/pull/5241
- https://github.com/Azure/azure-sdk-tools/pull/5240