### PR TITLE
Use webpack watch as default build task for extension

### DIFF
--- a/ext/vscode/.vscode/extensions.json
+++ b/ext/vscode/.vscode/extensions.json
@@ -3,6 +3,7 @@
     // for the documentation about the extensions.json format
     "recommendations": [
         "dbaeumer.vscode-eslint",
+        "amodio.tsl-problem-matcher",
         "streetsidesoftware.code-spell-checker"
     ]
 }

--- a/ext/vscode/.vscode/tasks.json
+++ b/ext/vscode/.vscode/tasks.json
@@ -14,7 +14,8 @@
                 "reveal": "never"
             },
             "group": {
-                "kind": "build"
+                "kind": "build",
+                "isDefault": true
             }
         },
 
@@ -30,8 +31,7 @@
                 "reveal": "never"
             },
             "group": {
-                "kind": "build",
-                "isDefault": true
+                "kind": "build"
             }
         }
     ]


### PR DESCRIPTION
Webpack watch takes about the same amount of time on the first build, but drastically less on subsequent builds, speeding up inner loop.