### PR TITLE
Update changelog entry for `0.6.0-beta.2`

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bugs Fixed
 
 - [[#1527]](https://github.com/Azure/azure-dev/pull/1527) Fix running specific commands with `--output json`  causing stack overflow errors to occur.
-- [[#1534]](https://github.com/Azure/azure-dev/pull/1534) Fix running commands with `-e <environment name>` flags or `AZURE_ENV_NAME` not being respected. When running in CI environments, this caused prompting to occur, and failing if `--no-prompt` is specified.
+- [[#1534]](https://github.com/Azure/azure-dev/pull/1534) Fix running commands with `-e <environment name>` flag or with `AZURE_ENV_NAME` set not being respected. When running in CI environments, this caused prompting to occur, and failing if `--no-prompt` is specified.
 
 ### Other Changes
 

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -1,13 +1,11 @@
 # Release History
 
-## 0.6.0-beta.2 (Unreleased)
+## 0.6.0-beta.2 (2023-02-10)
 
 ### Bugs Fixed
 
 - [[#1527]](https://github.com/Azure/azure-dev/pull/1527) Fix running specific commands with `--output json`  causing stack overflow errors to occur.
 - [[#1534]](https://github.com/Azure/azure-dev/pull/1534) Fix running commands with `-e <environment name>` flag or with `AZURE_ENV_NAME` set not being respected. When running in CI environments, this caused prompting to occur, and failing if `--no-prompt` is specified.
-
-### Other Changes
 
 ## 0.6.0-beta.1 (2023-02-08)
 

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 ## 0.6.0-beta.2 (Unreleased)
 
-### Features Added
-
-### Breaking Changes
-
 ### Bugs Fixed
+
+- [[#1527]](https://github.com/Azure/azure-dev/pull/1527) Fix running specific `--output json` commands causing stack overflow errors to occur.
+- [[#1534]](https://github.com/Azure/azure-dev/pull/1534) Fix `-e <environment name>` flags or `AZURE_ENV_NAME` not being respected, which causes prompting to occur (and failing if `--no-prompt` is specified) when running in CI environments.
 
 ### Other Changes
 

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Bugs Fixed
 
-- [[#1527]](https://github.com/Azure/azure-dev/pull/1527) Fix running specific `--output json` commands causing stack overflow errors to occur.
-- [[#1534]](https://github.com/Azure/azure-dev/pull/1534) Fix `-e <environment name>` flags or `AZURE_ENV_NAME` not being respected, which causes prompting to occur (and failing if `--no-prompt` is specified) when running in CI environments.
+- [[#1527]](https://github.com/Azure/azure-dev/pull/1527) Fix running specific commands with `--output json`  causing stack overflow errors to occur.
+- [[#1534]](https://github.com/Azure/azure-dev/pull/1534) Fix running commands with `-e <environment name>` flags or `AZURE_ENV_NAME` not being respected. When running in CI environments, this caused prompting to occur, and failing if `--no-prompt` is specified.
 
 ### Other Changes
 


### PR DESCRIPTION
[version.txt](https://github.com/Azure/azure-dev/blob/main/cli/version.txt) is already up-to-date.