### PR TITLE
Fix devcontainer syntax

### DIFF
--- a/templates/common/.devcontainer/devcontainer.json/csharp/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/csharp/devcontainer.json
@@ -21,15 +21,19 @@
             "nodeGypDependencies": false
         }
     },
-    "extensions": [
-        "ms-azuretools.azure-dev",
-        "ms-azuretools.vscode-bicep",
-        "ms-azuretools.vscode-docker",
-        "ms-vscode.vscode-node-azure-pack",
-        "ms-dotnettools.csharp",
-        "ms-dotnettools.vscode-dotnet-runtime",
-        "ms-azuretools.vscode-azurefunctions"
-    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-azuretools.azure-dev",
+                "ms-azuretools.vscode-bicep",
+                "ms-azuretools.vscode-docker",
+                "ms-vscode.vscode-node-azure-pack",
+                "ms-dotnettools.csharp",
+                "ms-dotnettools.vscode-dotnet-runtime",
+                "ms-azuretools.vscode-azurefunctions"
+            ]
+        }
+    },
     "forwardPorts": [
         3000,
         3100

--- a/templates/common/.devcontainer/devcontainer.json/java/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/java/devcontainer.json
@@ -21,14 +21,18 @@
             "nodeGypDependencies": false
         }
     },
-    "extensions": [
-        "ms-azuretools.azure-dev",
-        "ms-azuretools.vscode-bicep",
-        "ms-azuretools.vscode-docker",
-        "ms-vscode.vscode-node-azure-pack",
-        "vscjava.vscode-java-pack",
-        "ms-azuretools.vscode-azurefunctions"
-    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-azuretools.azure-dev",
+                "ms-azuretools.vscode-bicep",
+                "ms-azuretools.vscode-docker",
+                "ms-vscode.vscode-node-azure-pack",
+                "vscjava.vscode-java-pack",
+                "ms-azuretools.vscode-azurefunctions"
+            ]
+        }
+    },
     "forwardPorts": [
         3000,
         3100

--- a/templates/common/.devcontainer/devcontainer.json/nodejs/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/nodejs/devcontainer.json
@@ -18,17 +18,21 @@
             "nodeGypDependencies": false
         }
     },
-    "extensions": [
-        "ms-azuretools.azure-dev",
-        "ms-azuretools.vscode-bicep",
-        "ms-azuretools.vscode-docker",
-        "ms-vscode.vscode-node-azure-pack",
-        "ms-vscode.js-debug",
-        "esbenp.prettier-vscode",
-        "eg2.vscode-npm-script",
-        "dbaeumer.vscode-eslint",
-        "ms-azuretools.vscode-azurefunctions"
-    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-azuretools.azure-dev",
+                "ms-azuretools.vscode-bicep",
+                "ms-azuretools.vscode-docker",
+                "ms-vscode.vscode-node-azure-pack",
+                "ms-vscode.js-debug",
+                "esbenp.prettier-vscode",
+                "eg2.vscode-npm-script",
+                "dbaeumer.vscode-eslint",
+                "ms-azuretools.vscode-azurefunctions"
+            ]
+        }
+    },
     "forwardPorts": [
         3000,
         3100

--- a/templates/common/.devcontainer/devcontainer.json/python/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/devcontainer.json
@@ -21,14 +21,18 @@
             "version": "os-provided"
         }
     },
-    "extensions": [
-        "ms-azuretools.azure-dev",
-        "ms-azuretools.vscode-bicep",
-        "ms-azuretools.vscode-docker",
-        "ms-vscode.vscode-node-azure-pack",
-        "ms-python.python",
-        "ms-azuretools.vscode-azurefunctions"
-    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-azuretools.azure-dev",
+                "ms-azuretools.vscode-bicep",
+                "ms-azuretools.vscode-docker",
+                "ms-vscode.vscode-node-azure-pack",
+                "ms-python.python",
+                "ms-azuretools.vscode-azurefunctions"
+            ]
+        }
+    },
     "forwardPorts": [
         3000,
         3100


### PR DESCRIPTION
The "extensions" key is supposed to be nested inside "customizations"/"vscode". See reference here:
https://containers.dev/supporting#visual-studio-code

VS Code also tells you as soon as you start editing any devcontainer.json with "features" at outer level.

I assume it was originally "extensions" at outer level, so current syntax might still work, but this change will make VS Code happy.
