### PR TITLE
Add support for cross compile

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- [[#1558]](https://github.com/Azure/azure-dev/pull/1558) Upgrade bicep version to 0.14.46 and fetch ARM specific version on ARM platforms.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/cli/azd/pkg/tools/bicep/bicep.go
+++ b/cli/azd/pkg/tools/bicep/bicep.go
@@ -27,7 +27,7 @@ import (
 
 // cBicepVersion is the minimum version of bicep that we require (and the one we fetch when we fetch bicep on behalf of a
 // user).
-var cBicepVersion semver.Version = semver.MustParse("0.12.40")
+var cBicepVersion semver.Version = semver.MustParse("0.14.46")
 
 type BicepCli interface {
 	Build(ctx context.Context, file string) (string, error)
@@ -145,20 +145,34 @@ func azdBicepPath() (string, error) {
 
 // downloadBicep downloads a given version of bicep from the release site, writing the output to name.
 func downloadBicep(ctx context.Context, transporter policy.Transporter, bicepVersion semver.Version, name string) error {
+	var arch string
+	switch runtime.GOARCH {
+	case "amd64":
+		arch = "x64"
+	case "arm64":
+		arch = "arm64"
+	default:
+		return fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
+	}
+
 	var releaseName string
 	switch runtime.GOOS {
 	case "windows":
-		releaseName = "bicep-win-x64.exe"
+		releaseName = fmt.Sprintf("bicep-win-%s.exe", arch)
 	case "darwin":
-		releaseName = "bicep-osx-x64"
+		releaseName = fmt.Sprintf("bicep-osx-%s", arch)
 	case "linux":
 		if _, err := os.Stat("/lib/ld-musl-x86_64.so.1"); err == nil {
-			releaseName = "bicep-linux-musl-x64"
+			// As of 0.14.46, there is no version of for AM64 on musl based systems.
+			if arch == "arm64" {
+				return fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
+			}
+			releaseName = fmt.Sprintf("bicep-linux-musl-x64")
 		} else {
-			releaseName = "bicep-linux-x64"
+			releaseName = fmt.Sprintf("bicep-linux-%s", arch)
 		}
 	default:
-		return fmt.Errorf("unsupported platform")
+		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
 
 	bicepReleaseUrl := fmt.Sprintf("https://downloads.bicep.azure.com/v%s/%s", bicepVersion, releaseName)

--- a/cli/azd/pkg/tools/bicep/bicep.go
+++ b/cli/azd/pkg/tools/bicep/bicep.go
@@ -167,7 +167,7 @@ func downloadBicep(ctx context.Context, transporter policy.Transporter, bicepVer
 			if arch == "arm64" {
 				return fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
 			}
-			releaseName = fmt.Sprintf("bicep-linux-musl-x64")
+			releaseName = "bicep-linux-musl-x64"
 		} else {
 			releaseName = fmt.Sprintf("bicep-linux-%s", arch)
 		}

--- a/cli/installer/test/telemetry/alpine.pwsh.telemetry.json
+++ b/cli/installer/test/telemetry/alpine.pwsh.telemetry.json
@@ -1,6 +1,5 @@
 {
     "os": "alpine",
-    "osVersion": "3.15.6",
     "isWsl": "false",
     "terminal": "pwsh"
 }

--- a/cli/installer/test/telemetry/alpine.sh.telemetry.csv
+++ b/cli/installer/test/telemetry/alpine.sh.telemetry.csv
@@ -1,4 +1,3 @@
 os,alpine
-osVersion,3.15.6
 isWsl,false
 terminal,bash

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -295,6 +295,7 @@ stages:
           - task: DownloadPipelineArtifact@2
             inputs:
               artifact: azd-linux-arm64
+              targetPath: $(Build.SourcesDirectory)
 
           - bash: pwd && ls && chmod +x ./azd-linux-arm64 && ./azd-linux-arm64 version
             displayName: azd version

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -225,8 +225,8 @@ stages:
               GOARCH: arm64
               CGO_ENABLED: 1
             MacARM64:
-              Pool: azsdk-pool-mms-ubuntu-2004-general
-              OSVmImage:  MMSUbuntu20.04
+              Pool: Azure Pipelines
+              OSVmImage: macOS-11
               BuildTarget: azd-darwin-arm64
               BuildOutputName: azd
               SetExecutableBit: true

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -243,6 +243,7 @@ stages:
           - bash: |
               sudo apt update 
               sudo apt install -y $(AptInstall)
+              gcc --version
             condition: and(succeeded(), ne(variables['AptInstall'], ''))
             displayName: Install additional dependencies
 

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -220,7 +220,7 @@ stages:
               BuildTarget: azd-linux-arm64
               BuildOutputName: azd
               SetExecutableBit: true
-              RunAzdVersion: true
+              AptInstall: gcc-arm-linux-gnueabi
               GOOS: linux
               GOARCH: arm64
               CGO_ENABLED: 1
@@ -239,6 +239,12 @@ stages:
         timeoutInMinutes: 20
         steps: 
           - checkout: self
+
+          - bash: |
+              sudo apt update 
+              sudo apt install -y $(AptInstall)
+            condition: and(succeeded(), ne(variables['AptInstall'], ''))
+            displayName: Install additional dependencies
 
           - template: /eng/pipelines/templates/steps/setup-go.yml
             parameters:
@@ -263,6 +269,10 @@ stages:
                 -SourceVersion $(Build.SourceVersion)
               workingDirectory: cli/azd
             displayName: Build Go Binary (cross compile)
+
+          - pwsh: file azd
+            workingDirectory: cli/azd
+            displayName: Get file info
 
           - pwsh: Move-Item $(BuildOutputName) $(BuildTarget)
             workingDirectory: cli/azd

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -377,11 +377,11 @@ stages:
 
         - pwsh: |
             New-Item -ItemType Directory -Path mac
+            
             Compress-Archive `
             -Path mac-artifacts/azd-darwin-amd64 `
             -DestinationPath mac/azd-darwin-amd64.zip
 
-            New-Item -ItemType Directory -Path mac
             Compress-Archive `
             -Path mac-artifacts/azd-darwin-arm64 `
             -DestinationPath mac/azd-darwin-arm64.zip

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -296,7 +296,7 @@ stages:
             inputs:
               artifact: azd-linux-arm64
 
-          - bash: chmod +x ./azd-linux-arm64 && ./azd-linux-arm64 version
+          - bash: pwd && ls && chmod +x ./azd-linux-arm64 && ./azd-linux-arm64 version
             displayName: azd version
 
       - job: GenerateReleaseArtifacts

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -292,7 +292,9 @@ stages:
         steps: 
           - checkout: none 
 
-          - download: azd-linux-arm64
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifact: azd-linux-arm64
 
           - bash: chmod +x ./azd-linux-arm64 && ./azd-linux-arm64 version
             displayName: azd version

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -398,7 +398,10 @@ stages:
 
         - pwsh: |
             Expand-Archive -Path mac/azd-darwin-amd64.zip -DestinationPath mac/
+            Expand-Archive -Path mac/azd-darwin-arm64.zip -DestinationPath mac/
+
             Remove-Item mac/azd-darwin-amd64.zip
+            Remove-Item mac/azd-darwin-arm64.zip
           displayName: Extract azd-darwin-amd64 from zip and remove zip
 
         - pwsh: |
@@ -953,6 +956,7 @@ stages:
               UploadInstaller: true
               DockerImageTags: pr-$(PRNumber)
               UploadMsi: true
+              PublishArm64Binaries: true
 
           - pwsh: |
               $urlBase = "https://$(azdev-storage-account-name).blob.core.windows.net/azd/standalone/pr/$(PRNumber)"
@@ -968,7 +972,9 @@ stages:
           - pwsh: |
               $urlBase = "$(GenerateUrlBase.UrlBase)"
               $linuxReleaseUrl = "$urlBase/azd-linux-amd64.tar.gz"
+              $linuxReleaseUrlArm64 = "$urlBase/azd-linux-arm64.tar.gz"
               $macosReleaseUrl = "$urlBase/azd-darwin-amd64.zip"
+              $macosReleaseUrlArm64 = "$urlBase/azd-darwin-arm64.zip"
               $windowsReleaseUrl = "$urlBase/azd-windows-amd64.zip"
               $msiReleaseUrl = "$urlBase/azd-windows-amd64.msi"
 
@@ -1013,8 +1019,12 @@ stages:
 
               ### Standalone Binary
 
-              * Linux - $linuxReleaseUrl
-              * MacOS - $macosReleaseUrl
+              * Linux - 
+                  * x86_64 - $linuxReleaseUrl
+                  * ARM64 - $linuxReleaseUrlArm64
+              * MacOS - 
+                  * x86_64 - $macosReleaseUrl
+                  * ARM64 - $macosReleaseUrlArm64
               * Windows - $windowsReleaseUrl
 
               ### MSI 

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -232,8 +232,8 @@ stages:
               SetExecutableBit: true
               GOOS: darwin
               GOARCH: arm64
-              # CGO_SUPPORT is required on MacOS to cross-compile pkg/outil/osversion
-              CGO_SUPPORT: 1
+              # CGO_ENABLED is required on MacOS to cross-compile pkg/outil/osversion
+              CGO_ENABLED: 1
         pool: 
           name: $(Pool)
           vmImage: $(OSVmImage)

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -225,13 +225,15 @@ stages:
               GOOS: linux
               GOARCH: arm64
             MacARM64:
-              Pool: azsdk-pool-mms-ubuntu-2004-general
-              OSVmImage:  MMSUbuntu20.04
+              Pool: Azure Pipelines
+              OSVmImage: macOS-11
               BuildTarget: azd-darwin-arm64
               BuildOutputName: azd
               SetExecutableBit: true
               GOOS: darwin
               GOARCH: arm64
+              # CGO_SUPPORT is required on MacOS to cross-compile pkg/outil/osversion
+              CGO_SUPPORT: 1
         pool: 
           name: $(Pool)
           vmImage: $(OSVmImage)

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -370,11 +370,21 @@ stages:
             artifact: azd-darwin-amd64
             path: mac-artifacts
 
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifact: azd-darwin-arm64
+            path: mac-artifacts
+
         - pwsh: |
             New-Item -ItemType Directory -Path mac
             Compress-Archive `
             -Path mac-artifacts/azd-darwin-amd64 `
             -DestinationPath mac/azd-darwin-amd64.zip
+
+            New-Item -ItemType Directory -Path mac
+            Compress-Archive `
+            -Path mac-artifacts/azd-darwin-arm64 `
+            -DestinationPath mac/azd-darwin-arm64.zip
           displayName: Package mac binary for signing
 
         - ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual') }}:

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -211,6 +211,8 @@ stages:
             condition: and(succeeded(), eq(variables['BuildTestMsi'], 'true'))
             displayName: Upload test MSI
 
+      # This is separated today because Skip.LiveTest is a queue-time variable
+      # and cannot be set in a matrix entry. 
       - job: CrossBuildCLI
         strategy: 
           matrix: 
@@ -223,8 +225,8 @@ stages:
               GOOS: linux
               GOARCH: arm64
             MacARM64:
-              Pool: Azure Pipelines
-              OSVmImage: macOS-11
+              Pool: azsdk-pool-mms-ubuntu-2004-general
+              OSVmImage:  MMSUbuntu20.04
               BuildTarget: azd-darwin-arm64
               BuildOutputName: azd
               SetExecutableBit: true

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -220,10 +220,8 @@ stages:
               BuildTarget: azd-linux-arm64
               BuildOutputName: azd
               SetExecutableBit: true
-              AptInstall: gcc-arm-linux-gnueabi
               GOOS: linux
               GOARCH: arm64
-              CGO_ENABLED: 1
             MacARM64:
               Pool: Azure Pipelines
               OSVmImage: macOS-11
@@ -232,20 +230,12 @@ stages:
               SetExecutableBit: true
               GOOS: darwin
               GOARCH: arm64
-              CGO_ENABLED: 1
         pool: 
           name: $(Pool)
           vmImage: $(OSVmImage)
         timeoutInMinutes: 20
         steps: 
           - checkout: self
-
-          - bash: |
-              sudo apt update 
-              sudo apt install -y $(AptInstall)
-              gcc --version
-            condition: and(succeeded(), ne(variables['AptInstall'], ''))
-            displayName: Install additional dependencies
 
           - template: /eng/pipelines/templates/steps/setup-go.yml
             parameters:

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -211,6 +211,87 @@ stages:
             condition: and(succeeded(), eq(variables['BuildTestMsi'], 'true'))
             displayName: Upload test MSI
 
+      - job: CrossBuildCLI
+        strategy: 
+          matrix: 
+            LinuxARM64: 
+              Pool: azsdk-pool-mms-ubuntu-2004-general
+              OSVmImage:  MMSUbuntu20.04
+              BuildTarget: azd-linux-arm64
+              BuildOutputName: azd
+              SetExecutableBit: true
+              RunAzdVersion: true
+              GOOS: linux
+              GOARCH: arm64
+              CGO_ENABLED: 1
+            MacARM64:
+              Pool: azsdk-pool-mms-ubuntu-2004-general
+              OSVmImage:  MMSUbuntu20.04
+              BuildTarget: azd-darwin-arm64
+              BuildOutputName: azd
+              SetExecutableBit: true
+              GOOS: darwin
+              GOARCH: arm64
+              CGO_ENABLED: 1
+        pool: 
+          name: $(Pool)
+          vmImage: $(OSVmImage)
+        timeoutInMinutes: 20
+        steps: 
+          - checkout: self
+
+          - template: /eng/pipelines/templates/steps/setup-go.yml
+            parameters:
+              Condition: false
+
+          - template: /eng/pipelines/templates/steps/set-cli-version-cd.yml
+
+          - task: PowerShell@2
+            inputs:
+              pwsh: true
+              targetType: filePath
+              filePath: eng/scripts/Set-CliVersionVariable.ps1
+            displayName: Set CLI_VERSION
+
+          - task: PowerShell@2
+            inputs:
+              pwsh: true
+              targetType: filePath
+              filePath: cli/azd/ci-build.ps1
+              arguments: >-
+                -Version $(CLI_VERSION)
+                -SourceVersion $(Build.SourceVersion)
+              workingDirectory: cli/azd
+            displayName: Build Go Binary (cross compile)
+
+          - pwsh: Move-Item $(BuildOutputName) $(BuildTarget)
+            workingDirectory: cli/azd
+            displayName: Rename binaries
+
+          - bash: chmod +x $(BuildTarget)
+            condition: and(succeeded(), eq(variables['SetExecutableBit'], 'true'))
+            workingDirectory: cli/azd
+            displayName: Set executable bit for non-Windows binaries
+
+          - publish: cli/azd/$(BuildTarget)
+            artifact: $(BuildTarget)
+            condition: always()
+            displayName: Upload azd binary to artifact store
+
+      - job: ValidateCrossCompile
+        dependsOn: CrossBuildCLI
+        pool: 
+          name: azsdk-pool-mms-ubuntu-2004-arm
+          vmImage: MMSUbuntu20.04ARM64
+        timeoutInMinutes: 5
+        steps: 
+          - checkout: none 
+
+          - download: azd-linux-arm64
+
+          - bash: chmod +x ./azd-linux-arm64 && ./azd-linux-arm64 version
+            displayName: azd version
+
       - job: GenerateReleaseArtifacts
         pool:
           name: azsdk-pool-mms-ubuntu-2004-general

--- a/eng/pipelines/templates/steps/publish-cli.yml
+++ b/eng/pipelines/templates/steps/publish-cli.yml
@@ -17,6 +17,7 @@ parameters:
   SyndicatedAcrUsername: $(azdev-acr-syndicated-username)
   SyndicatedAcrPassword: $(azdev-acr-syndicated-password)
   PublishBrewFormula: false
+  PublishArm64Binaries: false
 
 steps:
   - ${{ if eq('true', parameters.CreateGitHubRelease) }}:
@@ -64,7 +65,19 @@ steps:
       # Copy the item from artifacts straight to where it will go
       path: release-staging
 
-  - bash: chmod +x signed/mac/azd-darwin-amd64 release-staging/azd-linux-amd64
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      artifact: azd-linux-arm64
+      # Copy the item from artifacts straight to where it will go
+      path: release-staging
+
+
+  - bash: | 
+      chmod +x \
+      signed/mac/azd-darwin-amd64 \
+      signed/mac/azd-darwin-arm64 \
+      release-staging/azd-linux-amd64 \
+      release-staging/azd-linux-arm64
     displayName: Set execute bit for the mac and linux release
 
   - pwsh: |
@@ -77,6 +90,18 @@ steps:
       Copy-Item NOTICE.txt ./release-staging/
       tar -C ./release-staging/ -cvzf release/azd-linux-amd64.tar.gz azd-linux-amd64 NOTICE.txt
     displayName: Compress standalone binary for release
+
+  - ${{ if eq('true', parameters.PublishArm64Binaries) }}: 
+    - pwsh: |
+        New-Item -ItemType Directory -Path release -Force
+        zip release/azd-darwin-arm64.zip -j signed/mac/azd-darwin-arm64 NOTICE.txt
+
+        # Must place NOTICE.txt in file tree for tar to pick it up and place it in
+        # the same place in the directory structure
+        Copy-Item NOTICE.txt ./release-staging/
+        tar -C ./release-staging/ -cvzf release/azd-linux-arm64.tar.gz azd-linux-arm64 NOTICE.txt
+      displayName: Compress standalone binary for release (ARM64)
+
 
   - ${{ if eq('true', parameters.UploadMsi) }}: 
     - pwsh: Copy-Item signed/win/azd-windows-amd64.msi release/


### PR DESCRIPTION
Add support for building (but not signing or releasing) ARM64 binaries: 

* Linux ARM64 -- Basic cross-compile, CGO not required, validation of `azd version` on ARM64 Linux machine
* macOS ARM64 -- Cross-compile with CGO enabled (cannot compile without it because of `osutil/osversion` constraints) 