### PR TITLE
Login with scope specified

### DIFF
--- a/cli/azd/cmd/testdata/TestUsage-azd-login.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-login.snap
@@ -11,6 +11,7 @@ Flags:
   -h, --help                                   Gets help for login.
   -o, --output string                          The output format (the supported formats are json, none). (default "none")
       --redirect-port int                      Choose the port to be used as part of the redirect URI during interactive login.
+      --scope stringArray                      The scope to acquire during login
       --tenant-id string                       The tenant id or domain name to authenticate with.
       --use-device-code                        When true, log in by using a device code instead of a browser.
 

--- a/cli/azd/pkg/auth/azd_credential.go
+++ b/cli/azd/pkg/auth/azd_credential.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
+	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 )
 
 type azdCredential struct {
@@ -32,11 +33,14 @@ func (c *azdCredential) GetToken(ctx context.Context, options policy.TokenReques
 		if strings.Contains(err.Error(), "AADSTS50158") {
 			loginCmd := "azd login"
 			for _, scope := range options.Scopes {
-				loginCmd += fmt.Sprintf(" --scope %s", scope)
+				// azure.ManagementScope is the default scope we would always use.
+				if scope != azure.ManagementScope {
+					loginCmd += fmt.Sprintf(" --scope %s", scope)
+				}
 			}
 
 			return azcore.AccessToken{},
-				fmt.Errorf("%w\nYou are required to reauthenticate. Run `%s`", err, loginCmd)
+				fmt.Errorf("%w\nre-authentication required, run `%s`", err, loginCmd)
 		}
 
 		return azcore.AccessToken{}, err

--- a/cli/azd/pkg/auth/credential_providers.go
+++ b/cli/azd/pkg/auth/credential_providers.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -47,6 +49,10 @@ func (t *multiTenantCredentialProvider) GetTokenCredential(
 	}
 
 	if _, err := EnsureLoggedInCredential(ctx, credential); err != nil {
+		if errors.Is(err, ErrNoCurrentUser) && tenantId != "" {
+			return nil, errors.New(fmt.Sprintf("not logged in, run `azd login --tenant-id %s` to login", tenantId))
+		}
+
 		return nil, err
 	}
 

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -120,8 +120,11 @@ func EnsureLoggedInCredential(
 	ctx context.Context,
 	credential azcore.TokenCredential,
 	scopes ...string) (*azcore.AccessToken, error) {
+	if scopes == nil {
+		scopes = cLoginScopes
+	}
 	token, err := credential.GetToken(ctx, policy.TokenRequestOptions{
-		Scopes: append(cLoginScopes, scopes...),
+		Scopes: scopes,
 	})
 	if err != nil {
 		return &azcore.AccessToken{}, ErrNoCurrentUser
@@ -327,7 +330,11 @@ func (m *Manager) LoginInteractive(
 		options = append(options, public.WithTenantID(tenantID))
 	}
 
-	res, err := m.publicClient.AcquireTokenInteractive(ctx, append(cLoginScopes, scopes...), options...)
+	if scopes == nil {
+		scopes = cLoginScopes
+	}
+
+	res, err := m.publicClient.AcquireTokenInteractive(ctx, scopes, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -346,7 +353,11 @@ func (m *Manager) LoginWithDeviceCode(
 		options = append(options, public.WithTenantID(tenantID))
 	}
 
-	code, err := m.publicClient.AcquireTokenByDeviceCode(ctx, append(cLoginScopes, scopes...), options...)
+	if scopes == nil {
+		scopes = cLoginScopes
+	}
+
+	code, err := m.publicClient.AcquireTokenByDeviceCode(ctx, scopes, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -115,7 +115,7 @@ var ErrNoCurrentUser = errors.New("not logged in, run `azd login` to login")
 // nil, ErrNoCurrentUser is returned. On success, the token we fetched is returned.
 //
 // By default, a token with Azure management scope is fetched.
-// Additional scopes can be passed to verify access to specified scopes.
+// To override this, pass in the desired scopes.
 func EnsureLoggedInCredential(
 	ctx context.Context,
 	credential azcore.TokenCredential,

--- a/cli/azd/pkg/auth/manager_test.go
+++ b/cli/azd/pkg/auth/manager_test.go
@@ -218,7 +218,7 @@ func TestLoginInteractive(t *testing.T) {
 		publicClient:  &mockPublicClient{},
 	}
 
-	cred, err := m.LoginInteractive(context.Background(), 0, "")
+	cred, err := m.LoginInteractive(context.Background(), []string{}, 0, "")
 
 	require.NoError(t, err)
 	require.IsType(t, new(azdCredential), cred)
@@ -245,7 +245,7 @@ func TestLoginDeviceCode(t *testing.T) {
 
 	buf := bytes.Buffer{}
 
-	cred, err := m.LoginWithDeviceCode(context.Background(), &buf, "")
+	cred, err := m.LoginWithDeviceCode(context.Background(), []string{}, &buf, "")
 
 	require.Regexp(t, "using the code 123-456", buf.String())
 


### PR DESCRIPTION
User that is requesting authorization to more sensitive resources like updating service principals can encounter errors during authorization flow, due to unfulfillment of MFA policies, or general user consent.

This change introduces the following:
1. `login --scope <scope>` for specifying a scope to seek authorization for as part of authentication. 
2. When a request fails due to MFA policies, point user to the login command required to obtain authorization.

I would hold off on merging this. Wanted to get a PR out for any real-world testing. I'm still unsure if this is the best way to help the user.

Fixes #1516