### PR TITLE
Update GitHub template for issues. Do not ask for `az version` 

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_report.md
+++ b/.github/ISSUE_TEMPLATE/issue_report.md
@@ -12,9 +12,6 @@ assignees: ''
 **Output from `azd version`**
 Run `azd version` and copy and paste the output here:
 
-**Output from `az version`** 
-Run `az version` and copy and paste the output here (minimum required version is 2.38.0): 
-
 **Describe the bug**
 Description of issue you're seeing...
 


### PR DESCRIPTION
Since `az` is no longer required, we should not ask for it at the top