### PR TITLE
Handle arm tenant optional fields

### DIFF
--- a/cli/azd/pkg/account/subscriptions_manager.go
+++ b/cli/azd/pkg/account/subscriptions_manager.go
@@ -199,15 +199,24 @@ func (m *SubscriptionsManager) ListSubscriptions(ctx context.Context) ([]Subscri
 			azSubs, err := service.ListSubscriptions(ctx, *tenant.TenantID)
 			if err != nil {
 				errorMsg := err.Error()
-				displayName := *tenant.DisplayName
+				name := *tenant.TenantID
+				if tenant.DisplayName != nil {
+					name = *tenant.DisplayName
+				}
+
 				if strings.Contains(errorMsg, "AADSTS50076") {
+					idOrDomain := *tenant.TenantID
+					if tenant.DefaultDomain != nil {
+						idOrDomain = *tenant.DefaultDomain
+					}
+
 					err = fmt.Errorf(
 						"%s requires Multi-Factor Authentication (MFA). "+
 							"To authenticate, login with `azd login --tenant-id %s`",
-						displayName,
-						*tenant.DefaultDomain)
+						name,
+						idOrDomain)
 				} else {
-					err = fmt.Errorf("failed to load subscriptions from tenant '%s' : %w", displayName, err)
+					err = fmt.Errorf("failed to load subscriptions from tenant '%s' : %w", name, err)
 				}
 			}
 

--- a/cli/azd/pkg/tools/azcli/subscriptions.go
+++ b/cli/azd/pkg/tools/azcli/subscriptions.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 	azdinternal "github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
@@ -164,14 +165,15 @@ func (s *SubscriptionsService) ListTenants(ctx context.Context) ([]armsubscripti
 		}
 
 		for _, tenant := range page.TenantListResult.Value {
-			if tenant != nil {
+			if tenant != nil && tenant.TenantID != nil {
 				tenants = append(tenants, *tenant)
 			}
 		}
 	}
 
 	sort.Slice(tenants, func(i, j int) bool {
-		return *tenants[i].DisplayName < *tenants[j].DisplayName
+		return convert.ToValueWithDefault(tenants[i].DisplayName, "") <
+			convert.ToValueWithDefault(tenants[j].DisplayName, "")
 	})
 
 	return tenants, nil


### PR DESCRIPTION
User experienced crash while running `azd login`, due to a tenant `DisplayName` being `nil`.

This adds minimal runtime safety guards against `armsubscriptions.TenantIDDescription` fields being `nill`. #1577 will examine how we handle `nil` data contracts from `azure-sdk-for-go` holistically (incremental steps).

Fixes #1573