### PR TITLE
Rename pwa-node launch type to node

### DIFF
--- a/templates/todo/projects/nodejs-mongo-aca/.vscode/launch.json
+++ b/templates/todo/projects/nodejs-mongo-aca/.vscode/launch.json
@@ -26,7 +26,7 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "type": "pwa-node",
+            "type": "node",
             "cwd": "${workspaceFolder}/src/api",
             "envFile": "${input:dotEnvFilePath}",
             "env": {

--- a/templates/todo/projects/nodejs-mongo-swa-func/.vscode/launch.json
+++ b/templates/todo/projects/nodejs-mongo-swa-func/.vscode/launch.json
@@ -27,7 +27,7 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "type": "pwa-node",
+            "type": "node",
             "cwd": "${workspaceFolder}/src/api",
             "envFile": "${input:dotEnvFilePath}",
             "env": {

--- a/templates/todo/projects/nodejs-mongo/.vscode/launch.json
+++ b/templates/todo/projects/nodejs-mongo/.vscode/launch.json
@@ -26,7 +26,7 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "type": "pwa-node",
+            "type": "node",
             "cwd": "${workspaceFolder}/src/api",
             "envFile": "${input:dotEnvFilePath}",
             "env": {


### PR DESCRIPTION
VS Code pops up an error on "pwa-node" instructing dev to use "node" instead. Looks like "pwa-node" has been deprecated. (Some discussion of history at https://github.com/microsoft/vscode/issues/151910 )

In my quick test, changing to "node" seemed to work.