### PR TITLE
Upgrade go to 1.20, pin golangci-lint

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -21,11 +21,12 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "^1.19.0"
+          go-version: "^1.20.0"
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
+          version: v1.51
           args: -v --timeout 5m0s
           working-directory: cli/azd
 

--- a/cli/azd/CONTRIBUTING.md
+++ b/cli/azd/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-`azd` is written in Golang and requires Go 1.19 or above:
+`azd` is written in Golang and requires Go 1.20 or above:
 
 - [Go](https://go.dev/dl/)
 

--- a/cli/azd/ci-build.ps1
+++ b/cli/azd/ci-build.ps1
@@ -40,7 +40,7 @@ if ($IsWindows) {
 }
 
 # Force DNS resolution to not use cgo
-$env:GODEBUG=netdns=go+1
+$env:GODEBUG='netdns=go+1'
 
 Write-Host "go build"
 go build -ldflags="-X 'github.com/azure/azure-dev/cli/azd/internal.Version=$Version (commit $SourceVersion)'"

--- a/cli/azd/ci-build.ps1
+++ b/cli/azd/ci-build.ps1
@@ -39,6 +39,9 @@ if ($IsWindows) {
     Write-Host "go generate succeeded"
 }
 
+# Force DNS resolution to not use cgo
+$env:GODEBUG=netdns=go+1
+
 Write-Host "go build"
 go build -ldflags="-X 'github.com/azure/azure-dev/cli/azd/internal.Version=$Version (commit $SourceVersion)'"
 

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"io/fs"
 	"log"
-	"math/rand"
 	"net/http"
 	"os"
 	"os/exec"
@@ -39,9 +38,6 @@ func main() {
 
 	restoreColorMode := colorable.EnableColorsStdout(nil)
 	defer restoreColorMode()
-
-	// Ensure random numbers from default random number generator are unpredictable
-	rand.Seed(time.Now().UTC().UnixNano())
 
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -147,7 +147,7 @@ func (m *Manager) CredentialForCurrentUser(
 			TenantID: options.TenantID,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to create credential: %v: %w", err, ErrNoCurrentUser)
+			return nil, fmt.Errorf("failed to create credential: %w: %w", err, ErrNoCurrentUser)
 		}
 		return cred, nil
 	}
@@ -184,7 +184,7 @@ func (m *Manager) CredentialForCurrentUser(
 	} else if currentUser.TenantID != nil && currentUser.ClientID != nil {
 		ps, err := m.loadSecret(*currentUser.TenantID, *currentUser.ClientID)
 		if err != nil {
-			return nil, fmt.Errorf("loading secret: %v: %w", err, ErrNoCurrentUser)
+			return nil, fmt.Errorf("loading secret: %w: %w", err, ErrNoCurrentUser)
 		}
 
 		// by default we used the stored tenant (i.e. the one provided with the tenant id parameter when a user ran
@@ -254,7 +254,7 @@ func (m *Manager) GetLoggedInServicePrincipalTenantID() (*string, error) {
 func newCredentialFromClientSecret(tenantID string, clientID string, clientSecret string) (azcore.TokenCredential, error) {
 	cred, err := azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret, nil)
 	if err != nil {
-		return nil, fmt.Errorf("creating credential: %v: %w", err, ErrNoCurrentUser)
+		return nil, fmt.Errorf("creating credential: %w: %w", err, ErrNoCurrentUser)
 	}
 
 	return cred, nil
@@ -267,12 +267,12 @@ func newCredentialFromClientCertificate(
 ) (azcore.TokenCredential, error) {
 	certData, err := base64.StdEncoding.DecodeString(clientCertificate)
 	if err != nil {
-		return nil, fmt.Errorf("decoding certificate: %v: %w", err, ErrNoCurrentUser)
+		return nil, fmt.Errorf("decoding certificate: %w: %w", err, ErrNoCurrentUser)
 	}
 
 	certs, key, err := azidentity.ParseCertificates(certData, nil)
 	if err != nil {
-		return nil, fmt.Errorf("parsing certificate: %v: %w", err, ErrNoCurrentUser)
+		return nil, fmt.Errorf("parsing certificate: %w: %w", err, ErrNoCurrentUser)
 	}
 
 	cred, err := azidentity.NewClientCertificateCredential(
@@ -280,7 +280,7 @@ func newCredentialFromClientCertificate(
 	)
 
 	if err != nil {
-		return nil, fmt.Errorf("creating credential: %v: %w", err, ErrNoCurrentUser)
+		return nil, fmt.Errorf("creating credential: %w: %w", err, ErrNoCurrentUser)
 	}
 
 	return cred, nil
@@ -301,7 +301,7 @@ func newCredentialFromClientAssertion(
 	)
 
 	if err != nil {
-		return nil, fmt.Errorf("creating credential: %v: %w", err, ErrNoCurrentUser)
+		return nil, fmt.Errorf("creating credential: %w: %w", err, ErrNoCurrentUser)
 	}
 
 	return cred, nil

--- a/cli/azd/pkg/ioc/container.go
+++ b/cli/azd/pkg/ioc/container.go
@@ -141,7 +141,7 @@ func RegisterNamedInstance[F any](c *NestedContainer, name string, instance F) {
 // returned while instantiating a dependency.
 func inspectResolveError(err error) error {
 	if containerErrorRegex.Match([]byte(err.Error())) {
-		return fmt.Errorf("%w: %s", ErrResolveInstance, err.Error())
+		return fmt.Errorf("%w: %w", ErrResolveInstance, err)
 	}
 
 	return err

--- a/eng/pipelines/templates/steps/setup-go.yml
+++ b/eng/pipelines/templates/steps/setup-go.yml
@@ -1,5 +1,5 @@
 parameters:
-  GoVersion: 1.19
+  GoVersion: 1.20
   Condition: succeeded()
 
 steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/azure/azure-dev
 
-go 1.19
+go 1.20
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.2


### PR DESCRIPTION
Address following lint issues:
- Use of '%v' formatting for multiple errors -- `go` 1.20 supports formatting multiple errors in an error formatting directive. 
- Remove `rand.Seed` in `main.go` to provide a random seed value since this is no longer required. From release notes:
> The [math/rand](https://tip.golang.org/pkg/math/rand/) package now automatically seeds the global random number generator (used by top-level functions like Float64 and Int) with a random value, and the top-level [Seed](https://tip.golang.org/pkg/math/rand/#Seed) function has been deprecated. Programs that need a reproducible sequence of random numbers should prefer to allocate their own random source, using rand.New(rand.NewSource(seed)).

Pin `golangci-lint` version to avoid future unexpected breakage. We should examine this version monthly, alongside with all other dependencies.

Release notes for convenience:
https://tip.golang.org/doc/go1.20#errors