### PR TITLE
Only use adapters which have an active IP address for creating a machine id

### DIFF
--- a/cli/azd/internal/telemetry/resource/machine_id.go
+++ b/cli/azd/internal/telemetry/resource/machine_id.go
@@ -67,11 +67,11 @@ func getMacAddress() (string, bool) {
 	for _, ift := range interfaces {
 		if len(ift.HardwareAddr) > 0 && ift.Flags&net.FlagLoopback == 0 {
 			hwAddr, err := net.ParseMAC(ift.HardwareAddr.String())
-			ipAddr, _ := ift.Addrs()
 			if err != nil {
 				continue
 			}
 
+			ipAddr, _ := ift.Addrs()
 			if len(ipAddr) == 0 {
 				continue
 			}

--- a/cli/azd/internal/telemetry/resource/machine_id.go
+++ b/cli/azd/internal/telemetry/resource/machine_id.go
@@ -67,7 +67,12 @@ func getMacAddress() (string, bool) {
 	for _, ift := range interfaces {
 		if len(ift.HardwareAddr) > 0 && ift.Flags&net.FlagLoopback == 0 {
 			hwAddr, err := net.ParseMAC(ift.HardwareAddr.String())
+			ipAddr, _ := ift.Addrs()
 			if err != nil {
+				continue
+			}
+
+			if len(ipAddr) == 0 {
 				continue
 			}
 


### PR DESCRIPTION
To standardize on a process for determining a machine id, we only want to use adapters which have an active IP address. This aligns with the process that VS Code uses, whereas previously the first non-loopback device was used. 