### PR TITLE
Pin `golangci-lint` version to undo breakage

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -26,6 +26,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
+          version: v1.51.1
           args: -v --timeout 5m0s
           working-directory: cli/azd
 


### PR DESCRIPTION
`golangci-lint` v1.51.2 introduces a new lint rule to catch error formatting errors when dealing with multiple errors. This lint rule is only applicable on go 1.20, and ends up creating false positives on go 1.19.