### PR TITLE
Add tags to ARM deployments

### DIFF
--- a/cli/azd/pkg/infra/scope.go
+++ b/cli/azd/pkg/infra/scope.go
@@ -18,8 +18,8 @@ type Scope interface {
 	Name() string
 	// Gets the url to check deployment progress
 	DeploymentUrl() string
-	// Deploy a given template with a set of parameters.
-	Deploy(ctx context.Context, template azure.RawArmTemplate, parameters azure.ArmParameters) error
+	// Deploy a given template with a set of parameters
+	Deploy(ctx context.Context, template azure.RawArmTemplate, parameters azure.ArmParameters, tags map[string]*string) error
 	// GetDeployment fetches the result of the most recent deployment.
 	GetDeployment(ctx context.Context) (*armresources.DeploymentExtended, error)
 	// Gets the resource deployment operations for the current scope
@@ -49,9 +49,9 @@ func (s *ResourceGroupScope) ResourceGroup() string {
 }
 
 func (s *ResourceGroupScope) Deploy(
-	ctx context.Context, template azure.RawArmTemplate, parameters azure.ArmParameters,
+	ctx context.Context, template azure.RawArmTemplate, parameters azure.ArmParameters, tags map[string]*string,
 ) error {
-	_, err := s.azCli.DeployToResourceGroup(ctx, s.subscriptionId, s.resourceGroup, s.name, template, parameters)
+	_, err := s.azCli.DeployToResourceGroup(ctx, s.subscriptionId, s.resourceGroup, s.name, template, parameters, tags)
 	return err
 }
 
@@ -110,9 +110,9 @@ func (s *SubscriptionScope) Location() string {
 
 // Deploy a given template with a set of parameters.
 func (s *SubscriptionScope) Deploy(
-	ctx context.Context, template azure.RawArmTemplate, parameters azure.ArmParameters,
+	ctx context.Context, template azure.RawArmTemplate, parameters azure.ArmParameters, tags map[string]*string,
 ) error {
-	_, err := s.azCli.DeployToSubscription(ctx, s.subscriptionId, s.name, template, parameters, s.location)
+	_, err := s.azCli.DeployToSubscription(ctx, s.subscriptionId, s.name, template, parameters, s.location, tags)
 	return err
 }
 

--- a/cli/azd/pkg/infra/scope_test.go
+++ b/cli/azd/pkg/infra/scope_test.go
@@ -134,7 +134,7 @@ func TestScopeDeploy(t *testing.T) {
 		scope := NewSubscriptionScope(azCli, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
 
 		armTemplate := azure.RawArmTemplate(testArmTemplate)
-		err := scope.Deploy(*mockContext.Context, armTemplate, testArmParameters)
+		err := scope.Deploy(*mockContext.Context, armTemplate, testArmParameters, nil)
 		require.NoError(t, err)
 	})
 
@@ -161,7 +161,7 @@ func TestScopeDeploy(t *testing.T) {
 		scope := NewResourceGroupScope(azCli, "SUBSCRIPTION_ID", "RESOURCE_GROUP", "DEPLOYMENT_NAME")
 
 		armTemplate := azure.RawArmTemplate(testArmTemplate)
-		err := scope.Deploy(*mockContext.Context, armTemplate, testArmParameters)
+		err := scope.Deploy(*mockContext.Context, armTemplate, testArmParameters, nil)
 		require.NoError(t, err)
 	})
 }

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -94,8 +94,9 @@ type AzCli interface {
 		ctx context.Context, subscriptionId, deploymentName string,
 		armTemplate azure.RawArmTemplate,
 		parameters azure.ArmParameters,
-		location string) (
-		AzCliDeploymentResult, error)
+		location string,
+		tags map[string]*string,
+	) (AzCliDeploymentResult, error)
 	DeployToResourceGroup(
 		ctx context.Context,
 		subscriptionId,
@@ -103,6 +104,7 @@ type AzCli interface {
 		deploymentName string,
 		armTemplate azure.RawArmTemplate,
 		parameters azure.ArmParameters,
+		tags map[string]*string,
 	) (AzCliDeploymentResult, error)
 	DeleteSubscriptionDeployment(ctx context.Context, subscriptionId string, deploymentName string) error
 	DeleteResourceGroup(ctx context.Context, subscriptionId string, resourceGroupName string) error

--- a/cli/azd/pkg/tools/azcli/deployments.go
+++ b/cli/azd/pkg/tools/azcli/deployments.go
@@ -80,6 +80,7 @@ func (cli *azCli) DeployToSubscription(
 	armTemplate azure.RawArmTemplate,
 	parameters azure.ArmParameters,
 	location string,
+	tags map[string]*string,
 ) (AzCliDeploymentResult, error) {
 	deploymentClient, err := cli.createDeploymentsClient(ctx, subscriptionId)
 	if err != nil {
@@ -95,6 +96,7 @@ func (cli *azCli) DeployToSubscription(
 				Mode:       to.Ptr(armresources.DeploymentModeIncremental),
 			},
 			Location: to.Ptr(location),
+			Tags:     tags,
 		}, nil)
 	if err != nil {
 		return AzCliDeploymentResult{}, fmt.Errorf("starting deployment to subscription: %w", err)
@@ -122,6 +124,7 @@ func (cli *azCli) DeployToResourceGroup(
 	subscriptionId, resourceGroup, deploymentName string,
 	armTemplate azure.RawArmTemplate,
 	parameters azure.ArmParameters,
+	tags map[string]*string,
 ) (AzCliDeploymentResult, error) {
 	deploymentClient, err := cli.createDeploymentsClient(ctx, subscriptionId)
 	if err != nil {
@@ -136,6 +139,7 @@ func (cli *azCli) DeployToResourceGroup(
 				Parameters: parameters,
 				Mode:       to.Ptr(armresources.DeploymentModeIncremental),
 			},
+			Tags: tags,
 		}, nil)
 	if err != nil {
 		return AzCliDeploymentResult{}, fmt.Errorf("starting deployment to resource group: %w", err)


### PR DESCRIPTION
This change updates the Bicep provisioning provider such that deployments we create are tagged with both the name of the azd project they came from as well as the environment that was used for the deployment.

Having this metadata avaliable will be useful in the future as we start changing the name of the deployment object we create from just the environment name to a combination of the environment name the project name and a timestamp (so a seperate deployment object is created per `azd provision`). When we do that, this will provide a way to find the deployment object (or objects) that correspond to a specific project/environment pair, without having to do name matching.

It can also be useful for querying purposes.