### PR TITLE
Update dependency `git` for init

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Bugs Fixed
 
+- [[#1631]](https://github.com/Azure/azure-dev/pull/1631) Fail fast during `azd init` when `git` is not installed.
+
 ### Other Changes
 
 ## 0.6.0-beta.2 (2023-02-10)

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -136,14 +136,8 @@ func (i *initAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		return nil, errors.New("template name required when specifying a branch name")
 	}
 
-	requiredTools := []tools.ExternalTool{}
-
-	// When using a template, we also require `git`, to acquire the template.
-	if i.flags.template.Name != "" {
-		requiredTools = append(requiredTools, i.gitCli)
-	}
-
-	if err := tools.EnsureInstalled(ctx, requiredTools...); err != nil {
+	// init now requires git all the time, as even for empty template, azd initialize a local git project
+	if err := tools.EnsureInstalled(ctx, []tools.ExternalTool{i.gitCli}...); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
`azd init` not depends on `git` all the time, as it creates a local git project even for `empty template`