### PR TITLE
Support lower-cased bicep types

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -86,6 +86,8 @@ pyapp
 restoreapp
 retriable
 rzip
+securestring
+secureobject
 semconv
 serverfarms
 setenvs

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -733,13 +733,13 @@ func (p *BicepProvider) deleteDeployment(
 
 func (p *BicepProvider) mapBicepTypeToInterfaceType(s string) ParameterType {
 	switch s {
-	case "String", "string", "secureString":
+	case "String", "string", "secureString", "securestring":
 		return ParameterTypeString
 	case "Bool", "bool":
 		return ParameterTypeBoolean
 	case "Int", "int":
 		return ParameterTypeNumber
-	case "Object", "object", "secureObject":
+	case "Object", "object", "secureObject", "secureobject":
 		return ParameterTypeObject
 	case "Array", "array":
 		return ParameterTypeArray

--- a/cli/azd/test/functional/testdata/samples/storage/infra/main.bicep
+++ b/cli/azd/test/functional/testdata/samples/storage/infra/main.bicep
@@ -17,11 +17,21 @@ param intTagValue int
 @description('Test parameter for bool-typed values.')
 param boolTagValue bool
 
+@description('Test parameter for secureString-typed values.')
+@secure()
+param secureValue string
+
+@description('Test parameter for secureObject-typed values.')
+@secure()
+param secureObject object = {}
+
 var tags = {
   'azd-env-name': environmentName
   DeleteAfter: deleteAfterTime
   IntTag: string(intTagValue)
   BoolTag: string(boolTagValue)
+  SecureTag: secureValue
+  SecureObjectTag: string(secureObject)
 }
 
 resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {


### PR DESCRIPTION
This fixes a `panic` that is now happening with the pinned `azd` `bicep` version. With bicep >=0.14.46, secure string types are emitted with lowercase names.

Without this change, `azd` panics with the message:

```
panic: unexpected bicep type: 'securestring'

goroutine 46 [running]:
github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/bicep.(*BicepProvider).mapBicepTypeToInterfaceType(0xfa39e0?, {0xc000138a80?, 0xc000138aa0?})
        D:/repos/azure-dev/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go:747 +0x1f9
```