### PR TITLE
Add small login error-handling improvements

### DIFF
--- a/cli/azd/cmd/login.go
+++ b/cli/azd/cmd/login.go
@@ -167,6 +167,10 @@ func newLoginAction(
 
 func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	if !la.flags.onlyCheckStatus {
+		if err := la.accountSubManager.ClearSubscriptions(ctx); err != nil {
+			log.Printf("failed clearing subscriptions: %v", err)
+		}
+
 		if err := la.login(ctx); err != nil {
 			return nil, err
 		}
@@ -198,17 +202,26 @@ func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		// The caching is done here to increase responsiveness of listing subscriptions (during azd init).
 		// It also allows an implicit command for the user to refresh cached subscriptions.
 		if la.flags.clientID == "" {
+			// Deleting subscriptions on file is very unlikely to fail, unless there are serious filesystem issues.
+			// If this does fail, we want the user to be aware of this. Like other stored azd account data,
+			// stored subscriptions are currently tied to the OS user, and not the individual account being logged in,
+			// this means cross-contamination is possible.
+			if err := la.accountSubManager.ClearSubscriptions(ctx); err != nil {
+				return nil, err
+			}
+
 			err := la.accountSubManager.RefreshSubscriptions(ctx)
 			if err != nil {
 				// If this fails, the subscriptions will still be loaded on-demand.
-				log.Printf("failed retrieving subscriptions: %s", err)
+				// erroring out when the user interacts with subscriptions is much more user-friendly.
+				log.Printf("failed retrieving subscriptions: %v", err)
 			}
 		} else {
 			// Service principals do not typically require subscription caching (running in CI scenarios)
 			// We simply clear the cache, which is much faster than rehydrating.
 			err := la.accountSubManager.ClearSubscriptions(ctx)
 			if err != nil {
-				log.Printf("failed clearing subscriptions: %s", err)
+				log.Printf("failed clearing subscriptions: %v", err)
 			}
 		}
 	}

--- a/cli/azd/pkg/account/subscriptions_manager.go
+++ b/cli/azd/pkg/account/subscriptions_manager.go
@@ -66,7 +66,7 @@ func NewSubscriptionsManager(
 	}, nil
 }
 
-// Clears stored cached subscriptions.
+// Clears stored cached subscriptions. This can only return an error is a filesystem error other than ErrNotExist occurred.
 func (m *SubscriptionsManager) ClearSubscriptions(ctx context.Context) error {
 	err := m.cache.Clear()
 	if err != nil {

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -118,6 +118,11 @@ func EnsureLoggedInCredential(ctx context.Context, credential azcore.TokenCreden
 		Scopes: cLoginScopes,
 	})
 	if err != nil {
+		// It is important that we dump the failure which contains error code, correlation IDs from AAD to log
+		// An improvement to make here is to classify 'unhandled' vs 'handled' errors
+		// where handled errors would be fixed with rerunning login (i.e. token expiry), vs.
+		// unhandled errors where it indicates a setup issue.
+		log.Printf("failed fetching access token: %s", err.Error())
 		return &azcore.AccessToken{}, ErrNoCurrentUser
 	}
 


### PR DESCRIPTION
Log when access token retrieval fails. The error currently looks like:

```golang
"http call(%s)(%s) error: reply status code was %d:\n%s", req.URL.String(), req.Method, reply.StatusCode, sd
```

`sd` is the body of the AAD response, which is safe for logging.

Add additional safety-nets to prevent users from getting into stale subscriptions due to cross-account logins.

Fixes #1609 