### PR TITLE
Adding check to ensure the selected adapter is "up"

### DIFF
--- a/cli/azd/internal/telemetry/resource/machine_id.go
+++ b/cli/azd/internal/telemetry/resource/machine_id.go
@@ -72,7 +72,7 @@ func getMacAddress() (string, bool) {
 			}
 
 			ipAddr, _ := ift.Addrs()
-			if len(ipAddr) == 0 {
+			if len(ipAddr) == 0 || ift.Flags&net.FlagUp == 0 {
 				continue
 			}
 


### PR DESCRIPTION
Discovered a scenario on Windows where IP addresses are not always zero-length, even if the adapter is not active/assigned. Checking that adapters are both up and have an assigned IP