### PR TITLE
Notify user if install folder does not exist

### DIFF
--- a/cli/installer/install-azd.sh
+++ b/cli/installer/install-azd.sh
@@ -237,6 +237,13 @@ do
 done
 
 
+if [ ! -d "$install_folder" ]; then
+    say_error "Install folder does not exist: $install_folder. The install folder should be an existing directory."
+    say_error "Create the folder (and ensure that it is in your PATH) or specify a different install folder with the -i or --install-folder argument."
+    save_error_report_if_enabled "InstallFailed" "InstallFolderDoesNotExist"
+    exit 1
+fi
+
 say_verbose "Version: $version"
 say_verbose "Platform: $platform"
 say_verbose "Architecture: $architecture"

--- a/cli/installer/test-sh-install.sh
+++ b/cli/installer/test-sh-install.sh
@@ -9,6 +9,21 @@ say() {
     printf "test-sh-install: %b\n" "$1"
 }
 
+# Test install when folder does not exist
+install_folder_error=$(cat ./install-azd.sh | "$1" -s -- --verbose --base-url "$2" --version "$3" --install-folder "/install/folder/does/not/exist" 2>&1)
+
+if [ ! $? ]; then
+    say_error "Install should have failed on folder not existing"
+    exit 1
+fi  
+
+if [[ "$install_folder_error" != *"Install folder does not exist"* ]]; then
+    say_error "Install should have notified the user that the folder does not exist"
+    exit 1
+fi
+
+
+# Normal install scenario
 if ! cat ./install-azd.sh | "$1" -s -- --verbose --base-url "$2" --version "$3"; then
     say_error "Install failed"
     exit 1


### PR DESCRIPTION
Partially addresses concerns in https://github.com/Azure/azure-dev/issues/1670 

Today: Ensure that the path exists and notify the user if it does not exist.