### PR TITLE
Add `requiredVersions` to `azure.yaml`

### DIFF
--- a/cli/azd/cmd/version.go
+++ b/cli/azd/cmd/version.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/spf13/cobra"
@@ -57,8 +58,13 @@ func (v *versionAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 	case output.NoneFormat:
 		fmt.Fprintf(v.console.Handles().Stdout, "azd version %s\n", internal.Version)
 	case output.JsonFormat:
-		versionSpec := internal.GetVersionSpec()
-		err := v.formatter.Format(versionSpec, v.writer, nil)
+		var result contracts.VersionResult
+		versionSpec := internal.VersionInfo()
+
+		result.Azd.Commit = versionSpec.Commit
+		result.Azd.Version = versionSpec.Version.String()
+
+		err := v.formatter.Format(result, v.writer, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/cli/azd/internal/telemetry/resource/resource.go
+++ b/cli/azd/internal/telemetry/resource/resource.go
@@ -22,7 +22,7 @@ func New() *resource.Resource {
 		resource.NewWithAttributes(
 			semconv.SchemaURL,
 			fields.ServiceNameKey.String(fields.ServiceNameAzd),
-			fields.ServiceVersionKey.String(internal.GetVersionNumber()),
+			fields.ServiceVersionKey.String(internal.VersionInfo().Version.String()),
 			fields.OSTypeKey.String(runtime.GOOS),
 			fields.OSVersionKey.String(getOsVersion()),
 			fields.HostArchKey.String(runtime.GOARCH),

--- a/cli/azd/internal/useragent.go
+++ b/cli/azd/internal/useragent.go
@@ -79,7 +79,7 @@ func MakeUserAgentString(template string) string {
 }
 
 func getAzDevCliIdentifier() string {
-	return fmt.Sprintf("%s/%s %s", azDevProductIdentifierKey, GetVersionNumber(), getPlatformInfo())
+	return fmt.Sprintf("%s/%s %s", azDevProductIdentifierKey, VersionInfo().Version.String(), getPlatformInfo())
 }
 
 func getPlatformInfo() string {

--- a/cli/azd/internal/useragent_test.go
+++ b/cli/azd/internal/useragent_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGetAzDevCliIdentifier(t *testing.T) {
-	version := GetVersionNumber()
+	version := VersionInfo().Version.String()
 	require.NotEmpty(t, version)
 
 	require.Equal(t, fmt.Sprintf("%s/%s %s", azDevProductIdentifierKey, version, getPlatformInfo()), getAzDevCliIdentifier())
@@ -62,7 +62,7 @@ func TestFormatTemplate(t *testing.T) {
 
 // Scenario tests
 func TestUserAgentStringScenarios(t *testing.T) {
-	version := GetVersionNumber()
+	version := VersionInfo().Version.String()
 	require.NotEmpty(t, version)
 
 	azDevIdentifier := fmt.Sprintf("azdev/%s %s", version, getPlatformInfo())

--- a/cli/azd/internal/version.go
+++ b/cli/azd/internal/version.go
@@ -18,16 +18,17 @@ const cDevVersionString = "0.0.0-dev.0 (commit 000000000000000000000000000000000
 //
 // This MUST be of the form "<semver> (commit <full commit hash>)"
 //
-// The default value here is used for a version built directly by a developer when running
-// `go install`
+// The default value here is used for a version built directly by a developer when running either
+// `go install` or `go build` without overriding the value at link time (the default behavior when
+// build or install are run without arguments).
 //
-// Official build set this value based on the version and commit we are building, using `-ldflags`
+// Official builds set this value based on the version and commit we are building, using `-ldflags`
 //
 // Example:
 //
 //	-ldflags="-X 'github.com/azure/azure-dev/cli/azd/internal.Version=0.0.1-alpha.1 (commit 8a49ae5ae9ab13beeade35f91ad4b4611c2f5574)'"
 //
-// This value is exported and not const so it can be mutated by certain tests. Instead of access this member
+// This value is exported and not const so it can be mutated by certain tests. Instead of accessing this member
 // directly, use [VersionInfo] which returns a structured version of this value.
 //
 // nolint: lll
@@ -60,9 +61,10 @@ func IsNonProdVersion() bool {
 	return strings.Contains(VersionInfo().Version.String(), "pr")
 }
 
+var cVersionStringRegexp = regexp.MustCompile(`^(\S+) \(commit ([0-9a-f]{40})\)$`)
+
 func VersionInfo() AzdVersionInfo {
-	r := regexp.MustCompile(`^(\S+) \(commit ([0-9a-f]{40})\)$`)
-	matches := r.FindStringSubmatch(Version)
+	matches := cVersionStringRegexp.FindStringSubmatch(Version)
 
 	if len(matches) != 3 {
 		panic("azd version is malformed, ensure github.com/azure/azure-dev/cli/azd/internal.Version is correct")

--- a/cli/azd/internal/version.go
+++ b/cli/azd/internal/version.go
@@ -6,31 +6,47 @@ package internal
 import (
 	"regexp"
 	"strings"
+
+	"github.com/blang/semver/v4"
 )
 
-// Version is the version string printed out by the `Version` command.
-// It's updated using ldflags in CI.
+// cDevVersionString is the default version that is used when [Version] is not overridden at build time, i.e.
+// a developer building locally using `go install`.
+const cDevVersionString = "0.0.0-dev.0 (commit 0000000000000000000000000000000000000000)"
+
+// The version string, as printed by `azd version`.
+//
+// This MUST be of the form "<semver> (commit <full commit hash>)"
+//
+// The default value here is used for a version built directly by a developer when running
+// `go install`
+//
+// Official build set this value based on the version and commit we are building, using `-ldflags`
+//
 // Example:
 //
-//	-ldflags="-X 'github.com/azure/azure-dev/cli/azd/internal.Version=0.0.1-alpha.1 (commit
+//	-ldflags="-X 'github.com/azure/azure-dev/cli/azd/internal.Version=0.0.1-alpha.1 (commit 8a49ae5ae9ab13beeade35f91ad4b4611c2f5574)'"
 //
-// 8a49ae5ae9ab13beeade35f91ad4b4611c2f5574)'"
-var Version = "0.0.0-dev.0 (commit 0000000000000000000000000000000000000000)"
+// This value is exported and not const so it can be mutated by certain tests. Instead of access this member
+// directly, use [VersionInfo] which returns a structured version of this value.
+//
+// nolint: lll
+var Version = cDevVersionString
 
-const UnknownVersion string = "unknown"
-const UnknownCommit string = "unknown"
-
-type VersionSpec struct {
-	Azd AzdVersionSpec `json:"azd"`
+func init() {
+	// VersionInfo panics if the version string is malformed, run the code at package startup to
+	// ensure everything is okay. This allows the rest of the system to call VersionInfo() to get
+	// parsed version information without having to worry about error handling.
+	_ = VersionInfo()
 }
 
-type AzdVersionSpec struct {
-	Version string `json:"version"`
-	Commit  string `json:"commit"`
+type AzdVersionInfo struct {
+	Version semver.Version
+	Commit  string
 }
 
 func IsDevVersion() bool {
-	return GetVersionNumber() == "0.0.0-dev.0"
+	return Version == cDevVersionString
 }
 
 func IsNonProdVersion() bool {
@@ -41,45 +57,19 @@ func IsNonProdVersion() bool {
 	// This currently relies on checking for specific internal release tags.
 	// This can be improved to instead check for any presence of prerelease versioning
 	// once the product is GA.
-	ver := GetVersionNumber()
-	return strings.Contains(ver, "pr")
+	return strings.Contains(VersionInfo().Version.String(), "pr")
 }
 
-// GetVersionNumber splits the cmd.Version string to get the
-// semver for the command.
-// Returns a version string like `0.0.1-alpha.1`.
-func GetVersionNumber() string {
-	pieces := strings.SplitN(Version, " ", 2)
+func VersionInfo() AzdVersionInfo {
+	r := regexp.MustCompile(`^(\S+) \(commit ([0-9a-f]{40})\)$`)
+	matches := r.FindStringSubmatch(Version)
 
-	if len(pieces) < 2 {
-		return UnknownVersion
+	if len(matches) != 3 {
+		panic("azd version is malformed, ensure github.com/azure/azure-dev/cli/azd/internal.Version is correct")
 	}
 
-	return pieces[0]
-}
-
-// Non-whitespace (version number), followed by some whitespace, followed by open parenthesis,
-// optional whitespace, and word
-// 'commit', followed by not-whitespace, not-closing-parenthesis (commit hash),
-// followed by optional whitespace and closing
-// parenthesis.
-var azdVersionStrRegex = regexp.MustCompile(`(\S+)\s+\(\s*commit\s+([^)\s]+)\s*\)`)
-
-func GetVersionSpec() VersionSpec {
-	matches := azdVersionStrRegex.FindStringSubmatch(Version)
-	if matches == nil {
-		return VersionSpec{
-			Azd: AzdVersionSpec{
-				Version: UnknownVersion,
-				Commit:  UnknownCommit,
-			},
-		}
-	} else {
-		return VersionSpec{
-			Azd: AzdVersionSpec{
-				Version: matches[1],
-				Commit:  matches[2],
-			},
-		}
+	return AzdVersionInfo{
+		Version: semver.MustParse(matches[1]),
+		Commit:  matches[2],
 	}
 }

--- a/cli/azd/internal/version_test.go
+++ b/cli/azd/internal/version_test.go
@@ -9,35 +9,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetVersionNumber(t *testing.T) {
-	require.Equal(t, "0.0.0-dev.0", GetVersionNumber())
-
-	orig := Version
-	Version = "invalid"
-	defer func() { Version = orig }()
-
-	require.Equal(t, "unknown", GetVersionNumber())
-
-	Version = ""
-	require.Equal(t, "unknown", GetVersionNumber())
-}
-
-func TestGetVersionSpec(t *testing.T) {
+func TestVersionInfo(t *testing.T) {
 	orig := Version
 	defer func() { Version = orig }()
 
 	Version = "0.1.0-beta.2 (commit 13ec2b11aa755b11640fa16b8664cb8741d5d300)"
-	vSpec := GetVersionSpec()
-	require.Equal(t, "0.1.0-beta.2", vSpec.Azd.Version)
-	require.Equal(t, "13ec2b11aa755b11640fa16b8664cb8741d5d300", vSpec.Azd.Commit)
+	info := VersionInfo()
+	require.Equal(t, "0.1.0-beta.2", info.Version.String())
+	require.Equal(t, "13ec2b11aa755b11640fa16b8664cb8741d5d300", info.Commit)
 
 	Version = "invalid"
-	vSpec = GetVersionSpec()
-	require.Equal(t, "unknown", vSpec.Azd.Version)
-	require.Equal(t, "unknown", vSpec.Azd.Commit)
+	require.Panics(t, func() { _ = VersionInfo() })
 
 	Version = ""
-	vSpec = GetVersionSpec()
-	require.Equal(t, "unknown", vSpec.Azd.Version)
-	require.Equal(t, "unknown", vSpec.Azd.Commit)
+	require.Panics(t, func() { _ = VersionInfo() })
 }

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -65,14 +65,11 @@ func main() {
 	// Don't write this message when JSON output is enabled, since in that case we use stderr to return structured
 	// information about command progress.
 	if !isJsonOutput() && ok {
-		curVersion, err := semver.Parse(internal.GetVersionNumber())
-		if err != nil {
-			log.Printf("failed to parse %s as a semver", internal.GetVersionNumber())
-		} else if curVersion.Equals(semver.MustParse("0.0.0-dev.0")) {
+		if internal.IsDevVersion() {
 			// This is a dev build (i.e. built using `go install without setting a version`) - don't print a warning in this
 			// case
 			log.Printf("eliding update message for dev build")
-		} else if latestVersion.GT(curVersion) {
+		} else if latestVersion.GT(internal.VersionInfo().Version) {
 			var upgradeUrl string
 			if runtime.GOOS == "windows" {
 				upgradeUrl = "https://aka.ms/azd/upgrade/windows"
@@ -89,7 +86,7 @@ func main() {
 				os.Stderr,
 				output.WithWarningFormat(
 					"warning: your version of azd is out of date, you have %s and the latest version is %s",
-					curVersion.String(), latestVersion.String()))
+					internal.VersionInfo().Version.String(), latestVersion.String()))
 			fmt.Fprintln(os.Stderr)
 			fmt.Fprintln(
 				os.Stderr,

--- a/cli/azd/pkg/contracts/version.go
+++ b/cli/azd/pkg/contracts/version.go
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package contracts
+
+// VersionResult is the contract for the output of `azd version`
+type VersionResult struct {
+	Azd struct {
+		Version string `json:"version"`
+		Commit  string `json:"commit"`
+	} `json:"azd"`
+}

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -9,10 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry/fields"
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/blang/semver/v4"
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
@@ -48,6 +50,21 @@ func Parse(ctx context.Context, yamlContent string) (*ProjectConfig, error) {
 	}
 
 	projectConfig.EventDispatcher = ext.NewEventDispatcher[ProjectLifecycleEventArgs]()
+
+	if projectConfig.RequiredVersions != nil && projectConfig.RequiredVersions.Azd != nil {
+		supportedRange, err := semver.ParseRange(*projectConfig.RequiredVersions.Azd)
+		if err != nil {
+			return nil, fmt.Errorf("%s is not a valid semver range (for requiredVersions.azd): %w",
+				*projectConfig.RequiredVersions.Azd, err)
+		}
+
+		if !internal.IsDevVersion() && !supportedRange(internal.VersionInfo().Version) {
+			return nil, fmt.Errorf("this project requires a version of azd within the range '%s', but you have '%s'. "+
+				"Visit https://aka.ms/azure-dev/install to install a supported version.",
+				*projectConfig.RequiredVersions.Azd,
+				internal.VersionInfo().Version.String())
+		}
+	}
 
 	for key, svc := range projectConfig.Services {
 		svc.Name = key

--- a/cli/azd/pkg/project/project_config.go
+++ b/cli/azd/pkg/project/project_config.go
@@ -12,6 +12,7 @@ import (
 // When changing project structure, make sure to update the JSON schema file for azure.yaml (<workspace
 // root>/schemas/vN.M/azure.yaml.json).
 type ProjectConfig struct {
+	RequiredVersions  *RequiredVersions          `yaml:"requiredVersions,omitempty"`
 	Name              string                     `yaml:"name"`
 	ResourceGroupName ExpandableString           `yaml:"resourceGroup,omitempty"`
 	Path              string                     `yaml:",omitempty"`
@@ -22,6 +23,13 @@ type ProjectConfig struct {
 	Hooks             map[string]*ext.HookConfig `yaml:"hooks,omitempty"`
 
 	*ext.EventDispatcher[ProjectLifecycleEventArgs] `yaml:",omitempty"`
+}
+
+// RequiredVersions contains information about what versions of tools this project requires.
+// If a value is nil, it is treated as if there is no constraint.
+type RequiredVersions struct {
+	// When non nil, a semver range (in the format expected by semver.ParseRange).
+	Azd *string `yaml:"azd,omitempty"`
 }
 
 // options supported in azure.yaml

--- a/cli/azd/test/functional/version_test.go
+++ b/cli/azd/test/functional/version_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
 	"github.com/azure/azure-dev/cli/azd/test/azdcli"
 	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
@@ -20,7 +21,7 @@ import (
 //   - When running in CI, the version specified by the CI pipeline.
 //   - When running locally, the version specified in source.
 func getExpectedVersion(t *testing.T) string {
-	expected := internal.GetVersionNumber()
+	expected := internal.VersionInfo().Version.String()
 
 	if os.Getenv("GITHUB_RUN_NUMBER") != "" {
 		// By using CLI_VERSION, we validate that azd was built with the correct version.
@@ -51,7 +52,7 @@ func Test_CLI_Version_Json(t *testing.T) {
 	result, err := cli.RunCommand(ctx, "version", "--output", "json")
 	require.NoError(t, err)
 
-	versionJson := &internal.VersionSpec{}
+	versionJson := &contracts.VersionResult{}
 	err = json.Unmarshal([]byte(result.Stdout), versionJson)
 	require.NoError(t, err)
 

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -329,6 +329,20 @@
                     "$ref": "#/definitions/hook"
                 }
             }
+        },
+        "requiredVersions": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "azd": {
+                    "type": "string",
+                    "title": "A range of supported versions of `azd` for this project",
+                    "description": "A range of supported versions of `azd` for this project. If the version of `azd` is outside this range, the project will fail to load. Optional (allows all versions if absent).",
+                    "examples": [
+                        ">= 0.6.0-beta.3"
+                    ]
+                }
+            }
         }
     },
     "definitions": {


### PR DESCRIPTION
This allows a project to specify a range of supported versions of
`azd`, by introducing a new `requiredVersions` object to
`azure.yaml`. Today, the only supported key is `azd`, which allows the
project author to specify a set of supported versions.

When parsing a project file, if this member is set, we ensure that the
current version is within the allowed range.

Dev versions of the CLI ignore this check.

Fixes #1504