### PR TITLE
Use MSI_VERSION instead of WinGetVersion in WinGet publishing script

### DIFF
--- a/eng/pipelines/templates/steps/publish-cli-winget.yml
+++ b/eng/pipelines/templates/steps/publish-cli-winget.yml
@@ -43,7 +43,7 @@ steps:
       filePath: eng/scripts/Update-WinGetManifest.ps1
       arguments: >-
         -PackageIdentifier Microsoft.Azd
-        -Version '$(WinGetVersion)'
+        -Version '$(MSI_VERSION)'
         -Url "https://github.com/Azure/azure-dev/releases/download/azure-dev-cli_${{ parameters.CliVersion }}/azd-windows-amd64.msi"
         -GitHubToken ${{ parameters.GitHubToken }}
         -Submit:$$(SubmitWinGetPackage)


### PR DESCRIPTION
@ItzLevvie [pointed out](https://github.com/microsoft/winget-pkgs/pull/99040#issuecomment-1462526639) that our automation was not setting the winget package version properly. Thanks, @ItzLevvie! 

This PR fixes that issue. 

## What happened? 

There was some back and forth over how we will structure version numbers when releasing to WinGet and Choco and it was ultimately decided that we'd follow the MSI versioning scheme. I updated the PR with that strategy but missed that variable. This corrects it so future release will have the correct variables in place. 