### PR TITLE
Feat: Update terraform provider versions

### DIFF
--- a/cli/azd/test/functional/testdata/samples/resourcegroupterraform/infra/provider.tf
+++ b/cli/azd/test/functional/testdata/samples/resourcegroupterraform/infra/provider.tf
@@ -5,12 +5,12 @@ terraform {
   required_version = ">= 1.1.7, < 2.0.0"
   required_providers {
     azurerm = {
-      version = "~>3.18.0"
+      version = "~>3.47.0"
       source  = "hashicorp/azurerm"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"
-      version = "~>1.2.15"
+      version = "~>1.2.24"
     }
   }
 }

--- a/cli/azd/test/functional/testdata/samples/resourcegroupterraformremote/infra/provider.tf
+++ b/cli/azd/test/functional/testdata/samples/resourcegroupterraformremote/infra/provider.tf
@@ -7,12 +7,12 @@ terraform {
   }
   required_providers {
     azurerm = {
-      version = "~>3.18.0"
+      version = "~>3.47.0"
       source  = "hashicorp/azurerm"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"
-      version = "~>1.2.15"
+      version = "~>1.2.24"
     }
   }
 }

--- a/templates/common/infra/terraform/core/database/cosmos/cosmos.tf
+++ b/templates/common/infra/terraform/core/database/cosmos/cosmos.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "~>3.18.0"
+      version = "~>3.47.0"
       source  = "hashicorp/azurerm"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"
-      version = "~>1.2.15"
+      version = "~>1.2.24"
     }
   }
 }

--- a/templates/common/infra/terraform/core/gateway/apim-api/apim-api.tf
+++ b/templates/common/infra/terraform/core/gateway/apim-api/apim-api.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "~>3.18.0"
+      version = "~>3.47.0"
       source  = "hashicorp/azurerm"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"
-      version = "~>1.2.15"
+      version = "~>1.2.24"
     }
   }
 }

--- a/templates/common/infra/terraform/core/gateway/apim/apim.tf
+++ b/templates/common/infra/terraform/core/gateway/apim/apim.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "~>3.18.0"
+      version = "~>3.47.0"
       source  = "hashicorp/azurerm"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"
-      version = "~>1.2.15"
+      version = "~>1.2.24"
     }
   }
 }

--- a/templates/common/infra/terraform/core/host/appservice/appservicenode/appservicenode.tf
+++ b/templates/common/infra/terraform/core/host/appservice/appservicenode/appservicenode.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "~>3.18.0"
+      version = "~>3.47.0"
       source  = "hashicorp/azurerm"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"
-      version = "~>1.2.15"
+      version = "~>1.2.24"
     }
   }
 }

--- a/templates/common/infra/terraform/core/host/appservice/appservicepython/appservicepython.tf
+++ b/templates/common/infra/terraform/core/host/appservice/appservicepython/appservicepython.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "~>3.18.0"
+      version = "~>3.47.0"
       source  = "hashicorp/azurerm"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"
-      version = "~>1.2.15"
+      version = "~>1.2.24"
     }
   }
 }

--- a/templates/common/infra/terraform/core/host/appserviceplan/appserviceplan.tf
+++ b/templates/common/infra/terraform/core/host/appserviceplan/appserviceplan.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "~>3.18.0"
+      version = "~>3.47.0"
       source  = "hashicorp/azurerm"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"
-      version = "~>1.2.15"
+      version = "~>1.2.24"
     }
   }
 }

--- a/templates/common/infra/terraform/core/monitor/applicationinsights/applicationinsights.tf
+++ b/templates/common/infra/terraform/core/monitor/applicationinsights/applicationinsights.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "~>3.18.0"
+      version = "~>3.47.0"
       source  = "hashicorp/azurerm"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"
-      version = "~>1.2.15"
+      version = "~>1.2.24"
     }
   }
 }

--- a/templates/common/infra/terraform/core/monitor/loganalytics/loganalytics.tf
+++ b/templates/common/infra/terraform/core/monitor/loganalytics/loganalytics.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "~>3.18.0"
+      version = "~>3.47.0"
       source  = "hashicorp/azurerm"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"
-      version = "~>1.2.15"
+      version = "~>1.2.24"
     }
   }
 }

--- a/templates/common/infra/terraform/core/security/keyvault/keyvault.tf
+++ b/templates/common/infra/terraform/core/security/keyvault/keyvault.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "~>3.18.0"
+      version = "~>3.47.0"
       source  = "hashicorp/azurerm"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"
-      version = "~>1.2.15"
+      version = "~>1.2.24"
     }
   }
 }

--- a/templates/todo/projects/nodejs-mongo/.repo/terraform/infra/provider.tf
+++ b/templates/todo/projects/nodejs-mongo/.repo/terraform/infra/provider.tf
@@ -5,12 +5,12 @@ terraform {
   required_version = ">= 1.1.7, < 2.0.0"
   required_providers {
     azurerm = {
-      version = "~>3.18.0"
+      version = "~>3.47.0"
       source  = "hashicorp/azurerm"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"
-      version = "~>1.2.15"
+      version = "~>1.2.24"
     }
   }
 }

--- a/templates/todo/projects/python-mongo/.repo/terraform/infra/provider.tf
+++ b/templates/todo/projects/python-mongo/.repo/terraform/infra/provider.tf
@@ -5,12 +5,12 @@ terraform {
   required_version = ">= 1.1.7, < 2.0.0"
   required_providers {
     azurerm = {
-      version = "~>3.18.0"
+      version = "~>3.47.0"
       source  = "hashicorp/azurerm"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"
-      version = "~>1.2.15"
+      version = "~>1.2.24"
     }
   }
 }


### PR DESCRIPTION
As described in issue #1716 the Terraform provider version in the templates is not supporting Node.js version 18-lts. 
This PR updates the `azurerm` provider to the latest available minor version and this way fixes issue #1716 .

In addition this PR updates the version of the `azurecaf` provider. This is more a "cosmetic" update as due to the version restriction in the Terraform files this version was fetched anyways. 