### PR TITLE
[install-azd.sh] Add check for Rosetta on install

### DIFF
--- a/cli/installer/install-azd.sh
+++ b/cli/installer/install-azd.sh
@@ -139,11 +139,11 @@ ensure_rosetta() {
 
         # Ensure that softwareupdate gets input from the terminal
         if /usr/sbin/softwareupdate --install-rosetta </dev/tty; then
-        	say "Rosetta has been successfully installed."
+            say "Rosetta has been successfully installed."
         else
-        	say_error "Rosetta 2 installation failed!"
+            say_error "Rosetta 2 installation failed!"
             save_error_report_if_enabled "InstallFailed" "Rosetta2InstallFailed"
-        	exit 1
+            exit 1
         fi
     fi
 }

--- a/cli/installer/install-azd.sh
+++ b/cli/installer/install-azd.sh
@@ -136,9 +136,9 @@ ensure_rosetta() {
         say "Rosetta 2 is already installed and running. Nothing to do."
     else
         say "Rosetta 2 is not installed. You may be prompted to accept terms necessary to install Rosetta 2."
-        /usr/sbin/softwareupdate --install-rosetta
+
        
-        if [[ $? -eq 0 ]]; then
+        if /usr/sbin/softwareupdate --install-rosetta; then
         	say "Rosetta has been successfully installed."
         else
         	say_error "Rosetta 2 installation failed!"

--- a/cli/installer/install-azd.sh
+++ b/cli/installer/install-azd.sh
@@ -137,8 +137,8 @@ ensure_rosetta() {
     else
         say "Rosetta 2 is not installed. You may be prompted to accept terms necessary to install Rosetta 2."
 
-       
-        if /usr/sbin/softwareupdate --install-rosetta; then
+        # Ensure that softwareupdate gets input from the terminal
+        if /usr/sbin/softwareupdate --install-rosetta </dev/tty; then
         	say "Rosetta has been successfully installed."
         else
         	say_error "Rosetta 2 installation failed!"

--- a/cli/installer/install-azd.sh
+++ b/cli/installer/install-azd.sh
@@ -128,10 +128,10 @@ ensure_rosetta() {
         # The current system is identified as an Intel system (either because it
         # is running in Rosetta 2 or the system is running on Intel silicon) so
         # Rosetta 2 is not needed.
+        say_verbose "Detected x86_64 system. Rosetta 2 is not needed."
         return
     fi
 
-    # TODO: Is this the right way to check for Rosetta 2?
     if /usr/bin/pgrep oahd >/dev/null 2>&1; then
         say "Rosetta 2 is already installed and running. Nothing to do."
     else
@@ -141,7 +141,8 @@ ensure_rosetta() {
         if [[ $? -eq 0 ]]; then
         	say "Rosetta has been successfully installed."
         else
-        	say_error "Rosetta installation failed!"
+        	say_error "Rosetta 2 installation failed!"
+            save_error_report_if_enabled "InstallFailed" "Rosetta2InstallFailed"
         	exit 1
         fi
     fi

--- a/eng/templates/brew.template
+++ b/eng/templates/brew.template
@@ -1,23 +1,37 @@
 class Azd < Formula
-    desc "Azure Developer CLI"
-    homepage "https://github.com/azure/azure-dev"
-    url "https://github.com/Azure/azure-dev/releases/download/azure-dev-cli_%VERSION%/azd-darwin-amd64.zip"
-    version "%VERSION%"
-    sha256 "%SHA256%"
-    license "MIT"
+  desc "Azure Developer CLI"
+  homepage "https://github.com/azure/azure-dev"
+  url "https://github.com/Azure/azure-dev/releases/download/azure-dev-cli_%VERSION%/azd-darwin-amd64.zip"
+  version "%VERSION%"
+  sha256 "%SHA256%"
+  license "MIT"
 
-    def install
-        bin.install "azd-darwin-amd64" => "azd"
+  def install
+    bin.install "azd-darwin-amd64" => "azd"
+  end
 
-        ohai "The Azure Developer CLI collects usage data and sends that usage data to Microsoft in order to help us improve your experience."
-        ohai "You can opt-out of telemetry by setting the AZURE_DEV_COLLECT_TELEMETRY environment variable to 'no' in the shell you use."
-        ohai ""
-        ohai "Read more about Azure Developer CLI telemetry: https://github.com/Azure/azure-dev#data-collection"
+  def caveats
+    caveat = <<~EOS
+      The #{desc} collects usage data and sends that usage data to Microsoft in order to help us improve your experience.
+      You can opt-out of telemetry by setting the AZURE_DEV_COLLECT_TELEMETRY environment variable to 'no' in the shell you use.
+
+      Read more about #{desc} telemetry: https://github.com/Azure/azure-dev#data-collection
+    EOS
+    on_arm do
+      caveat += <<~EOS
+
+        The #{desc} is built for Intel macOS and so requires Rosetta 2 to be installed.
+        You can install Rosetta 2 with:
+          softwareupdate --install-rosetta
+        Note that it is very difficult to remove Rosetta 2 once it is installed.
+      EOS
     end
+    caveat
+  end
 
-    test do
-        version_output = shell_output "#{bin}/azd version"
-        assert_equal 0, $CHILD_STATUS.exitstatus
-        assert_match "azd version", version_output
-    end
+  test do
+    version_output = shell_output "#{bin}/azd version"
+    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_match "azd version", version_output
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-dev/issues/1548

Includes install caveats in `brew install` scenaio: 

![image](https://user-images.githubusercontent.com/2158838/225993984-8926542f-247e-4a34-938f-37cfe04c725a.png)

Brew documents recommend using caveats to describe Rosetta requirements. There's a bit more functionality in [Casks](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cask/dsl/caveats.rb#L140-L143)
than Formulas but given we're just outputting text to the console it doesn't warrant a switch from Formula to Cask at this time for our scenario. 

There's no obvious prior art in Brew formulae or casks that attempts to detect or install Rosetta 2.