### PR TITLE
Call Environment.GetSubscriptionId in fewer places

### DIFF
--- a/cli/azd/cmd/monitor.go
+++ b/cli/azd/cmd/monitor.go
@@ -92,7 +92,8 @@ func (m *monitorAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 	}
 
 	resourceManager := infra.NewAzureResourceManager(m.azCli)
-	resourceGroups, err := resourceManager.GetResourceGroupsForEnvironment(ctx, m.env)
+	resourceGroups, err := resourceManager.GetResourceGroupsForEnvironment(
+		ctx, m.env.GetSubscriptionId(), m.env.GetEnvName())
 	if err != nil {
 		return nil, fmt.Errorf("discovering resource groups from deployment: %w", err)
 	}

--- a/cli/azd/cmd/monitor.go
+++ b/cli/azd/cmd/monitor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
+	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
@@ -100,7 +101,8 @@ func (m *monitorAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 	var portalResources []azcli.AzCliResource
 
 	for _, resourceGroup := range resourceGroups {
-		resources, err := m.azCli.ListResourceGroupResources(ctx, m.env.GetSubscriptionId(), resourceGroup.Name, nil)
+		resources, err := m.azCli.ListResourceGroupResources(
+			ctx, azure.SubscriptionFromRID(resourceGroup.Id), resourceGroup.Name, nil)
 		if err != nil {
 			return nil, fmt.Errorf("listing resources: %w", err)
 		}

--- a/cli/azd/cmd/show.go
+++ b/cli/azd/cmd/show.go
@@ -116,7 +116,7 @@ func (s *showAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 	if rgName, err := resourceManager.FindResourceGroupForEnvironment(ctx, subId, envName); err == nil {
 		for svcName, serviceConfig := range s.projectConfig.Services {
-			if resources, err := s.resourceManager.GetServiceResources(ctx, serviceConfig, subId, rgName); err == nil {
+			if resources, err := s.resourceManager.GetServiceResources(ctx, subId, rgName, serviceConfig); err == nil {
 				resourceIds := make([]string, len(resources))
 				for idx, res := range resources {
 					resourceIds[idx] = res.Id

--- a/cli/azd/cmd/show.go
+++ b/cli/azd/cmd/show.go
@@ -111,22 +111,24 @@ func (s *showAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	// Add information about the target of each service, if we can determine it (if the infrastructure has
 	// not been deployed, for example, we'll just not include target information)
 	resourceManager := infra.NewAzureResourceManager(s.azCli)
+	subId := s.env.GetSubscriptionId()
+	envName := s.env.GetEnvName()
 
-	if resourceGroupName, err := resourceManager.FindResourceGroupForEnvironment(ctx, s.env); err == nil {
-		for name, serviceConfig := range s.projectConfig.Services {
-			if resources, err := s.resourceManager.GetServiceResources(ctx, serviceConfig, resourceGroupName); err == nil {
+	if rgName, err := resourceManager.FindResourceGroupForEnvironment(ctx, subId, envName); err == nil {
+		for svcName, serviceConfig := range s.projectConfig.Services {
+			if resources, err := s.resourceManager.GetServiceResources(ctx, serviceConfig, subId, rgName); err == nil {
 				resourceIds := make([]string, len(resources))
 				for idx, res := range resources {
 					resourceIds[idx] = res.Id
 				}
 
-				resSvc := res.Services[name]
+				resSvc := res.Services[svcName]
 				resSvc.Target = &contracts.ShowTargetArm{
 					ResourceIds: resourceIds,
 				}
-				res.Services[name] = resSvc
+				res.Services[svcName] = resSvc
 			} else {
-				log.Printf("ignoring error determining resource id for service %s: %v", name, err)
+				log.Printf("ignoring error determining resource id for service %s: %v", svcName, err)
 			}
 		}
 	} else {

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -280,7 +280,7 @@ func ensureEnvironmentInitialized(
 			env.SetLocation(envSpec.location)
 		} else {
 			location, err := azureutil.PromptLocation(
-				ctx, env, "Please select an Azure location to use:", "", console, accountManager)
+				ctx, env.GetSubscriptionId(), "Please select an Azure location to use:", "", console, accountManager)
 			if err != nil {
 				return fmt.Errorf("prompting for location: %w", err)
 			}
@@ -366,11 +366,13 @@ func getResourceGroupFollowUp(
 	env *environment.Environment,
 ) (followUp string) {
 	if formatter.Kind() != output.JsonFormat {
-		if resourceGroupName, err := resourceManager.GetResourceGroupName(ctx, projectConfig); err == nil {
+		subscriptionId := env.GetSubscriptionId()
+
+		if resourceGroupName, err := resourceManager.GetResourceGroupName(ctx, projectConfig, subscriptionId); err == nil {
 			followUp = fmt.Sprintf("You can view the resources created under the resource group %s in Azure Portal:\n%s",
 				resourceGroupName, output.WithLinkFormat(fmt.Sprintf(
 					"https://portal.azure.com/#@/resource/subscriptions/%s/resourceGroups/%s/overview",
-					env.GetSubscriptionId(),
+					subscriptionId,
 					resourceGroupName)))
 		}
 	}

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -368,7 +368,7 @@ func getResourceGroupFollowUp(
 	if formatter.Kind() != output.JsonFormat {
 		subscriptionId := env.GetSubscriptionId()
 
-		if resourceGroupName, err := resourceManager.GetResourceGroupName(ctx, projectConfig, subscriptionId); err == nil {
+		if resourceGroupName, err := resourceManager.GetResourceGroupName(ctx, subscriptionId, projectConfig); err == nil {
 			followUp = fmt.Sprintf("You can view the resources created under the resource group %s in Azure Portal:\n%s",
 				resourceGroupName, output.WithLinkFormat(fmt.Sprintf(
 					"https://portal.azure.com/#@/resource/subscriptions/%s/resourceGroups/%s/overview",

--- a/cli/azd/pkg/azure/resource_ids.go
+++ b/cli/azd/pkg/azure/resource_ids.go
@@ -6,9 +6,23 @@ package azure
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 )
+
+// SubscriptionFromRID returns the subscription id component of a resource, or empty if the ID does not
+// contain a subscriptions component.
+func SubscriptionFromRID(rid string) string {
+	parts := strings.Split(rid, "/")
+	for idx, part := range parts {
+		if part == "subscriptions" && idx+1 < len(parts) {
+			return parts[idx+1]
+		}
+	}
+
+	return ""
+}
 
 // Creates Azure subscription resource ID
 func SubscriptionRID(subscriptionId string) string {

--- a/cli/azd/pkg/azure/resource_ids.go
+++ b/cli/azd/pkg/azure/resource_ids.go
@@ -11,8 +11,8 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 )
 
-// SubscriptionFromRID returns the subscription id component of a resource, or empty if the ID does not
-// contain a subscriptions component.
+// SubscriptionFromRID returns the subscription id component of a resource or panics if the resource id does not
+// contain a subscription.
 func SubscriptionFromRID(rid string) string {
 	parts := strings.Split(rid, "/")
 	for idx, part := range parts {
@@ -21,7 +21,7 @@ func SubscriptionFromRID(rid string) string {
 		}
 	}
 
-	return ""
+	panic(fmt.Sprintf("no subscription id component in in %s", rid))
 }
 
 // Creates Azure subscription resource ID

--- a/cli/azd/pkg/azureutil/location.go
+++ b/cli/azd/pkg/azureutil/location.go
@@ -24,26 +24,27 @@ func (s Locs) Less(i, j int) bool {
 }
 func (s Locs) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
-// PromptLocation asks the user to select a location from a list of supported azure location
+// PromptLocation asks the user to select a location from a list of supported azure locations for a given subscription.
 func PromptLocation(
-	ctx context.Context, env *environment.Environment, message string, help string, console input.Console,
+	ctx context.Context, subscriptionId string, message string, help string, console input.Console,
 	accountManager account.Manager,
 ) (string, error) {
-	return PromptLocationWithFilter(ctx, env, message, help, console, accountManager, func(acl azcli.AzCliLocation) bool {
-		return true
-	})
+	return PromptLocationWithFilter(ctx, subscriptionId, message, help, console, accountManager,
+		func(acl azcli.AzCliLocation) bool {
+			return true
+		})
 }
 
 func PromptLocationWithFilter(
 	ctx context.Context,
-	env *environment.Environment,
+	subscriptionId string,
 	message string,
 	help string,
 	console input.Console,
 	accountManager account.Manager,
 	shouldDisplay func(azcli.AzCliLocation) bool,
 ) (string, error) {
-	allLocations, err := accountManager.GetLocations(ctx, env.GetSubscriptionId())
+	allLocations, err := accountManager.GetLocations(ctx, subscriptionId)
 	if err != nil {
 		return "", fmt.Errorf("listing locations: %w", err)
 	}

--- a/cli/azd/pkg/infra/azure_resource_manager_test.go
+++ b/cli/azd/pkg/infra/azure_resource_manager_test.go
@@ -457,7 +457,8 @@ func TestFindResourceGroupForEnvironment(t *testing.T) {
 			})
 
 			arm := NewAzureResourceManager(azCli)
-			rgName, err := arm.FindResourceGroupForEnvironment(*mockContext.Context, env)
+			rgName, err := arm.FindResourceGroupForEnvironment(
+				*mockContext.Context, env.GetSubscriptionId(), env.GetEnvName())
 
 			if tt.expectedErrorText == "" {
 				require.NoError(t, err)

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -499,7 +499,7 @@ func (p *BicepProvider) getKeyVaults(
 	for resourceGroup, groupResources := range groupedResources {
 		for _, resource := range groupResources {
 			if resource.Type == string(infra.AzureResourceTypeKeyVault) {
-				vault, err := p.azCli.GetKeyVault(ctx, p.env.GetSubscriptionId(), resourceGroup, resource.Name)
+				vault, err := p.azCli.GetKeyVault(ctx, azure.SubscriptionFromRID(resource.Id), resourceGroup, resource.Name)
 				if err != nil {
 					return nil, fmt.Errorf("listing key vault %s properties: %w", resource.Name, err)
 				}
@@ -563,7 +563,7 @@ func (p *BicepProvider) purgeKeyVaults(
 
 		asyncContext.SetProgress(&progressReport)
 
-		err := p.azCli.PurgeKeyVault(ctx, p.env.GetSubscriptionId(), keyVault.Name, keyVault.Location)
+		err := p.azCli.PurgeKeyVault(ctx, azure.SubscriptionRID(keyVault.Id), keyVault.Name, keyVault.Location)
 		if err != nil {
 			return fmt.Errorf("purging key vault %s: %w", keyVault.Name, err)
 		}
@@ -586,7 +586,7 @@ func (p *BicepProvider) getAppConfigsToPurge(
 	for resourceGroup, groupResources := range groupedResources {
 		for _, resource := range groupResources {
 			if resource.Type == string(infra.AzureResourceTypeAppConfig) {
-				config, err := p.azCli.GetAppConfig(ctx, p.env.GetSubscriptionId(), resourceGroup, resource.Name)
+				config, err := p.azCli.GetAppConfig(ctx, azure.SubscriptionFromRID(resource.Id), resourceGroup, resource.Name)
 				if err != nil {
 					return nil, fmt.Errorf("listing app configuration %s properties: %w", resource.Name, err)
 				}
@@ -610,7 +610,7 @@ func (p *BicepProvider) getApiManagementsToPurge(
 	for resourceGroup, groupResources := range groupedResources {
 		for _, resource := range groupResources {
 			if resource.Type == string(infra.AzureResourceTypeApim) {
-				apim, err := p.azCli.GetApim(ctx, p.env.GetSubscriptionId(), resourceGroup, resource.Name)
+				apim, err := p.azCli.GetApim(ctx, azure.SubscriptionFromRID(resource.Id), resourceGroup, resource.Name)
 				if err != nil {
 					return nil, fmt.Errorf("listing api management service %s properties: %w", resource.Name, err)
 				}
@@ -654,7 +654,7 @@ func (p *BicepProvider) purgeAppConfigs(
 
 		asyncContext.SetProgress(&progressReport)
 
-		err := p.azCli.PurgeAppConfig(ctx, p.env.GetSubscriptionId(), appConfig.Name, appConfig.Location)
+		err := p.azCli.PurgeAppConfig(ctx, azure.SubscriptionFromRID(appConfig.Id), appConfig.Name, appConfig.Location)
 		if err != nil {
 			return fmt.Errorf("purging app configuration %s: %w", appConfig.Name, err)
 		}
@@ -690,7 +690,7 @@ func (p *BicepProvider) purgeAPIManagement(
 
 		asyncContext.SetProgress(&progressReport)
 
-		err := p.azCli.PurgeApim(ctx, p.env.GetSubscriptionId(), apim.Name, apim.Location)
+		err := p.azCli.PurgeApim(ctx, azure.SubscriptionFromRID(apim.Id), apim.Name, apim.Location)
 		if err != nil {
 			return fmt.Errorf("purging api management service %s: %w", apim.Name, err)
 		}

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -563,7 +563,7 @@ func (p *BicepProvider) purgeKeyVaults(
 
 		asyncContext.SetProgress(&progressReport)
 
-		err := p.azCli.PurgeKeyVault(ctx, azure.SubscriptionRID(keyVault.Id), keyVault.Name, keyVault.Location)
+		err := p.azCli.PurgeKeyVault(ctx, azure.SubscriptionFromRID(keyVault.Id), keyVault.Name, keyVault.Location)
 		if err != nil {
 			return fmt.Errorf("purging key vault %s: %w", keyVault.Name, err)
 		}

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -562,50 +563,27 @@ func prepareDeployShowMocks(
 }
 
 func prepareDestroyMocks(mockContext *mocks.MockContext) {
+	makeItem := func(resourceType infra.AzureResourceType, resourceName string) *armresources.GenericResourceExpanded {
+		id := fmt.Sprintf("subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP/%s/%s",
+			string(resourceType), resourceName)
+
+		return &armresources.GenericResourceExpanded{
+			ID:       convert.RefOf(id),
+			Name:     convert.RefOf(resourceName),
+			Type:     convert.RefOf(string(resourceType)),
+			Location: convert.RefOf("eastus2"),
+		}
+	}
+
 	resourceList := armresources.ResourceListResult{
 		Value: []*armresources.GenericResourceExpanded{
-			{
-				ID:       convert.RefOf("webapp"),
-				Name:     convert.RefOf("app-123"),
-				Type:     convert.RefOf(string(infra.AzureResourceTypeWebSite)),
-				Location: convert.RefOf("eastus2"),
-			},
-			{
-				ID:       convert.RefOf("keyvault"),
-				Name:     convert.RefOf("kv-123"),
-				Type:     convert.RefOf(string(infra.AzureResourceTypeKeyVault)),
-				Location: convert.RefOf("eastus2"),
-			},
-			{
-				ID:       convert.RefOf("keyvault2"),
-				Name:     convert.RefOf("kv2-123"),
-				Type:     convert.RefOf(string(infra.AzureResourceTypeKeyVault)),
-				Location: convert.RefOf("eastus2"),
-			},
-			{
-				ID:       convert.RefOf("appconfiguration"),
-				Name:     convert.RefOf("ac-123"),
-				Type:     convert.RefOf(string(infra.AzureResourceTypeAppConfig)),
-				Location: convert.RefOf("eastus2"),
-			},
-			{
-				ID:       convert.RefOf("appconfiguration2"),
-				Name:     convert.RefOf("ac2-123"),
-				Type:     convert.RefOf(string(infra.AzureResourceTypeAppConfig)),
-				Location: convert.RefOf("eastus2"),
-			},
-			{
-				ID:       convert.RefOf("ApiManagement"),
-				Name:     convert.RefOf("apim-123"),
-				Type:     convert.RefOf(string(infra.AzureResourceTypeApim)),
-				Location: convert.RefOf("eastus2"),
-			},
-			{
-				ID:       convert.RefOf("ApiManagement"),
-				Name:     convert.RefOf("apim2-123"),
-				Type:     convert.RefOf(string(infra.AzureResourceTypeApim)),
-				Location: convert.RefOf("eastus2"),
-			},
+			makeItem(infra.AzureResourceTypeWebSite, "app-123"),
+			makeItem(infra.AzureResourceTypeKeyVault, "kv-123"),
+			makeItem(infra.AzureResourceTypeKeyVault, "kv2-123"),
+			makeItem(infra.AzureResourceTypeAppConfig, "ac-123"),
+			makeItem(infra.AzureResourceTypeAppConfig, "ac2-123"),
+			makeItem(infra.AzureResourceTypeApim, "apim-123"),
+			makeItem(infra.AzureResourceTypeApim, "apim2-123"),
 		},
 	}
 
@@ -693,7 +671,9 @@ func getKeyVaultMock(mockContext *mocks.MockContext, keyVaultString string, name
 	}).RespondFn(func(request *http.Request) (*http.Response, error) {
 		keyVaultResponse := armkeyvault.VaultsClientGetResponse{
 			Vault: armkeyvault.Vault{
-				ID:       convert.RefOf(name),
+				ID: convert.RefOf(
+					fmt.Sprintf("/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP/%s/%s",
+						string(infra.AzureResourceTypeKeyVault), name)),
 				Name:     convert.RefOf(name),
 				Location: convert.RefOf(location),
 				Properties: &armkeyvault.VaultProperties{
@@ -718,7 +698,10 @@ func getAppConfigMock(mockContext *mocks.MockContext, appConfigString string, na
 	}).RespondFn(func(request *http.Request) (*http.Response, error) {
 		appConfigResponse := armappconfiguration.ConfigurationStoresClientGetResponse{
 			ConfigurationStore: armappconfiguration.ConfigurationStore{
-				ID:       convert.RefOf(name),
+				ID: convert.RefOf(
+					fmt.Sprintf("/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP/%s/%s",
+						string(infra.AzureResourceTypeAppConfig), name)),
+
 				Name:     convert.RefOf(name),
 				Location: convert.RefOf(location),
 				Properties: &armappconfiguration.ConfigurationStoreProperties{
@@ -742,7 +725,10 @@ func getAPIMMock(mockContext *mocks.MockContext, apimString string, name string,
 	}).RespondFn(func(request *http.Request) (*http.Response, error) {
 		apimResponse := armapimanagement.ServiceClientGetResponse{
 			ServiceResource: armapimanagement.ServiceResource{
-				ID:       convert.RefOf(name),
+				ID: convert.RefOf(
+					fmt.Sprintf("/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP/%s/%s",
+						string(infra.AzureResourceTypeApim), name)),
+
 				Name:     convert.RefOf(name),
 				Location: convert.RefOf(location),
 			},

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -297,7 +297,7 @@ func NewManager(
 	accountManager account.Manager,
 ) (*Manager, error) {
 	locationPrompt := func(msg string, filter func(loc azcli.AzCliLocation) bool) (location string, err error) {
-		return azureutil.PromptLocationWithFilter(ctx, env, msg, "", console, accountManager, filter)
+		return azureutil.PromptLocationWithFilter(ctx, env.GetSubscriptionId(), msg, "", console, accountManager, filter)
 	}
 
 	prompters := Prompters{

--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -54,7 +54,7 @@ services:
 
 	resourceManager := NewResourceManager(env, azCli)
 	targetResource, err := resourceManager.GetTargetResource(
-		*mockContext.Context, projectConfig.Services["api"], env.GetSubscriptionId())
+		*mockContext.Context, env.GetSubscriptionId(), projectConfig.Services["api"])
 	require.NoError(t, err)
 	require.NotNil(t, targetResource)
 
@@ -100,7 +100,7 @@ services:
 
 	resourceManager := NewResourceManager(env, azCli)
 	targetResource, err := resourceManager.GetTargetResource(
-		*mockContext.Context, projectConfig.Services["api"], env.GetSubscriptionId())
+		*mockContext.Context, env.GetSubscriptionId(), projectConfig.Services["api"])
 	require.NoError(t, err)
 	require.NotNil(t, targetResource)
 	require.Equal(t, resourceName, targetResource.ResourceName())
@@ -157,7 +157,7 @@ services:
 	resourceManager := NewResourceManager(env, azCli)
 
 	for _, svc := range projectConfig.Services {
-		targetResource, err := resourceManager.GetTargetResource(*mockContext.Context, svc, env.GetSubscriptionId())
+		targetResource, err := resourceManager.GetTargetResource(*mockContext.Context, env.GetSubscriptionId(), svc)
 		require.NoError(t, err)
 		require.NotNil(t, targetResource)
 		require.Equal(t, resourceGroupName, targetResource.ResourceGroupName())
@@ -216,12 +216,12 @@ services:
 
 	resourceManager := NewResourceManager(env, azCli)
 	targetResource, err := resourceManager.GetTargetResource(
-		*mockContext.Context, projectConfig.Services["api"], env.GetSubscriptionId())
+		*mockContext.Context, env.GetSubscriptionId(), projectConfig.Services["api"])
 	require.NoError(t, err)
 	require.NotNil(t, targetResource)
 
 	for _, svc := range projectConfig.Services {
-		targetResource, err := resourceManager.GetTargetResource(*mockContext.Context, svc, env.GetSubscriptionId())
+		targetResource, err := resourceManager.GetTargetResource(*mockContext.Context, env.GetSubscriptionId(), svc)
 		require.NoError(t, err)
 		require.NotNil(t, targetResource)
 		require.Equal(t, expectedResourceGroupName, targetResource.ResourceGroupName())

--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -53,7 +53,8 @@ services:
 	require.NoError(t, err)
 
 	resourceManager := NewResourceManager(env, azCli)
-	targetResource, err := resourceManager.GetTargetResource(*mockContext.Context, projectConfig.Services["api"])
+	targetResource, err := resourceManager.GetTargetResource(
+		*mockContext.Context, projectConfig.Services["api"], env.GetSubscriptionId())
 	require.NoError(t, err)
 	require.NotNil(t, targetResource)
 
@@ -98,7 +99,8 @@ services:
 	require.NoError(t, err)
 
 	resourceManager := NewResourceManager(env, azCli)
-	targetResource, err := resourceManager.GetTargetResource(*mockContext.Context, projectConfig.Services["api"])
+	targetResource, err := resourceManager.GetTargetResource(
+		*mockContext.Context, projectConfig.Services["api"], env.GetSubscriptionId())
 	require.NoError(t, err)
 	require.NotNil(t, targetResource)
 	require.Equal(t, resourceName, targetResource.ResourceName())
@@ -155,7 +157,7 @@ services:
 	resourceManager := NewResourceManager(env, azCli)
 
 	for _, svc := range projectConfig.Services {
-		targetResource, err := resourceManager.GetTargetResource(*mockContext.Context, svc)
+		targetResource, err := resourceManager.GetTargetResource(*mockContext.Context, svc, env.GetSubscriptionId())
 		require.NoError(t, err)
 		require.NotNil(t, targetResource)
 		require.Equal(t, resourceGroupName, targetResource.ResourceGroupName())
@@ -213,12 +215,13 @@ services:
 	require.NoError(t, err)
 
 	resourceManager := NewResourceManager(env, azCli)
-	targetResource, err := resourceManager.GetTargetResource(*mockContext.Context, projectConfig.Services["api"])
+	targetResource, err := resourceManager.GetTargetResource(
+		*mockContext.Context, projectConfig.Services["api"], env.GetSubscriptionId())
 	require.NoError(t, err)
 	require.NotNil(t, targetResource)
 
 	for _, svc := range projectConfig.Services {
-		targetResource, err := resourceManager.GetTargetResource(*mockContext.Context, svc)
+		targetResource, err := resourceManager.GetTargetResource(*mockContext.Context, svc, env.GetSubscriptionId())
 		require.NoError(t, err)
 		require.NotNil(t, targetResource)
 		require.Equal(t, expectedResourceGroupName, targetResource.ResourceGroupName())

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -347,7 +347,7 @@ func (sm *serviceManager) Publish(
 			return
 		}
 
-		targetResource, err := sm.resourceManager.GetTargetResource(ctx, serviceConfig, sm.env.GetSubscriptionId())
+		targetResource, err := sm.resourceManager.GetTargetResource(ctx, sm.env.GetSubscriptionId(), serviceConfig)
 		if err != nil {
 			task.SetError(fmt.Errorf("getting target resource: %w", err))
 			return

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -347,7 +347,7 @@ func (sm *serviceManager) Publish(
 			return
 		}
 
-		targetResource, err := sm.resourceManager.GetTargetResource(ctx, serviceConfig)
+		targetResource, err := sm.resourceManager.GetTargetResource(ctx, serviceConfig, sm.env.GetSubscriptionId())
 		if err != nil {
 			task.SetError(fmt.Errorf("getting target resource: %w", err))
 			return

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -224,7 +224,8 @@ func (t *aksTarget) Publish(
 			log.Printf("logging into container registry '%s'\n", packageDetails.LoginServer)
 
 			task.SetProgress(NewServiceProgress("Logging into container registry"))
-			if err := t.containerRegistryService.LoginAcr(ctx, targetResource.SubscriptionId(), packageDetails.LoginServer); err != nil {
+			err = t.containerRegistryService.LoginAcr(ctx, targetResource.SubscriptionId(), packageDetails.LoginServer)
+			if err != nil {
 				task.SetError(fmt.Errorf("failed logging into registry '%s': %w", packageDetails.LoginServer, err))
 				return
 			}

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -195,7 +195,7 @@ func (t *aksTarget) Publish(
 			task.SetProgress(NewServiceProgress("Getting AKS credentials"))
 			clusterCreds, err := t.managedClustersService.GetAdminCredentials(
 				ctx,
-				t.env.GetSubscriptionId(),
+				targetResource.SubscriptionId(),
 				targetResource.ResourceGroupName(),
 				clusterName,
 			)
@@ -224,7 +224,7 @@ func (t *aksTarget) Publish(
 			log.Printf("logging into container registry '%s'\n", packageDetails.LoginServer)
 
 			task.SetProgress(NewServiceProgress("Logging into container registry"))
-			if err := t.containerRegistryService.LoginAcr(ctx, t.env.GetSubscriptionId(), packageDetails.LoginServer); err != nil {
+			if err := t.containerRegistryService.LoginAcr(ctx, targetResource.SubscriptionId(), packageDetails.LoginServer); err != nil {
 				task.SetError(fmt.Errorf("failed logging into registry '%s': %w", packageDetails.LoginServer, err))
 				return
 			}
@@ -344,7 +344,7 @@ func (t *aksTarget) Publish(
 			task.SetResult(&ServicePublishResult{
 				Package: packageOutput,
 				TargetResourceId: azure.KubernetesServiceRID(
-					t.env.GetSubscriptionId(),
+					targetResource.SubscriptionId(),
 					targetResource.ResourceGroupName(),
 					targetResource.ResourceName(),
 				),

--- a/cli/azd/pkg/project/service_target_appservice.go
+++ b/cli/azd/pkg/project/service_target_appservice.go
@@ -94,7 +94,7 @@ func (st *appServiceTarget) Publish(
 			task.SetProgress(NewServiceProgress("Publishing deployment package"))
 			res, err := st.cli.DeployAppServiceZip(
 				ctx,
-				st.env.GetSubscriptionId(),
+				targetResource.SubscriptionId(),
 				targetResource.ResourceGroupName(),
 				targetResource.ResourceName(),
 				zipFile,
@@ -113,7 +113,7 @@ func (st *appServiceTarget) Publish(
 
 			sdr := NewServicePublishResult(
 				azure.WebsiteRID(
-					st.env.GetSubscriptionId(),
+					targetResource.SubscriptionId(),
 					targetResource.ResourceGroupName(),
 					targetResource.ResourceName(),
 				),
@@ -136,7 +136,7 @@ func (st *appServiceTarget) Endpoints(
 ) ([]string, error) {
 	appServiceProperties, err := st.cli.GetAppServiceProperties(
 		ctx,
-		st.env.GetSubscriptionId(),
+		targetResource.SubscriptionId(),
 		targetResource.ResourceGroupName(),
 		targetResource.ResourceName(),
 	)

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -181,7 +181,8 @@ func (at *containerAppTarget) Publish(
 
 			log.Printf("logging into registry %s", packageDetails.LoginServer)
 			task.SetProgress(NewServiceProgress("Logging into container registry"))
-			if err := at.containerRegistryService.LoginAcr(ctx, at.env.GetSubscriptionId(), packageDetails.LoginServer); err != nil {
+			err := at.containerRegistryService.LoginAcr(ctx, targetResource.SubscriptionId(), packageDetails.LoginServer)
+			if err != nil {
 				task.SetError(fmt.Errorf("logging into registry '%s': %w", packageDetails.LoginServer, err))
 				return
 			}
@@ -223,7 +224,7 @@ func (at *containerAppTarget) Publish(
 			deploymentName := fmt.Sprintf("%s-%s", at.env.GetEnvName(), serviceConfig.Name)
 			scope := infra.NewResourceGroupScope(
 				at.cli,
-				at.env.GetSubscriptionId(),
+				targetResource.SubscriptionId(),
 				targetResource.ResourceGroupName(),
 				deploymentName,
 			)
@@ -256,7 +257,7 @@ func (at *containerAppTarget) Publish(
 
 				// Fill in the target resource
 				targetResource = environment.NewTargetResource(
-					at.env.GetSubscriptionId(),
+					targetResource.SubscriptionId(),
 					targetResource.ResourceGroupName(),
 					azureResource.Name,
 					azureResource.Type,
@@ -278,7 +279,7 @@ func (at *containerAppTarget) Publish(
 			task.SetResult(&ServicePublishResult{
 				Package: packageOutput,
 				TargetResourceId: azure.ContainerAppRID(
-					at.env.GetSubscriptionId(),
+					targetResource.SubscriptionId(),
 					targetResource.ResourceGroupName(),
 					targetResource.ResourceName(),
 				),
@@ -297,7 +298,8 @@ func (at *containerAppTarget) Endpoints(
 	targetResource *environment.TargetResource,
 ) ([]string, error) {
 	if containerAppProperties, err := at.cli.GetContainerAppProperties(
-		ctx, at.env.GetSubscriptionId(),
+		ctx,
+		targetResource.SubscriptionId(),
 		targetResource.ResourceGroupName(),
 		targetResource.ResourceName(),
 	); err != nil {

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -246,9 +246,9 @@ func (at *containerAppTarget) Publish(
 			if targetResource.ResourceName() == "" {
 				azureResource, err := at.resourceManager.GetServiceResource(
 					ctx,
-					serviceConfig,
 					targetResource.SubscriptionId(),
 					targetResource.ResourceGroupName(),
+					serviceConfig,
 					"deploy",
 				)
 				if err != nil {

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -247,6 +247,7 @@ func (at *containerAppTarget) Publish(
 				azureResource, err := at.resourceManager.GetServiceResource(
 					ctx,
 					serviceConfig,
+					targetResource.SubscriptionId(),
 					targetResource.ResourceGroupName(),
 					"deploy",
 				)

--- a/cli/azd/pkg/project/service_target_functionapp.go
+++ b/cli/azd/pkg/project/service_target_functionapp.go
@@ -95,7 +95,7 @@ func (f *functionAppTarget) Publish(
 			task.SetProgress(NewServiceProgress("Publishing deployment package"))
 			res, err := f.cli.DeployFunctionAppUsingZipFile(
 				ctx,
-				f.env.GetSubscriptionId(),
+				targetResource.SubscriptionId(),
 				targetResource.ResourceGroupName(),
 				targetResource.ResourceName(),
 				zipFile,
@@ -114,7 +114,7 @@ func (f *functionAppTarget) Publish(
 
 			sdr := NewServicePublishResult(
 				azure.WebsiteRID(
-					f.env.GetSubscriptionId(),
+					targetResource.SubscriptionId(),
 					targetResource.ResourceGroupName(),
 					targetResource.ResourceName(),
 				),
@@ -139,7 +139,8 @@ func (f *functionAppTarget) Endpoints(
 	// a nil error.  In `deploy` we just loop over the endpoint array and print any endpoints, so returning
 	// an empty array and nil error will mean "no endpoints".
 	if props, err := f.cli.GetFunctionAppProperties(
-		ctx, f.env.GetSubscriptionId(),
+		ctx,
+		targetResource.SubscriptionId(),
 		targetResource.ResourceGroupName(),
 		targetResource.ResourceName()); err != nil {
 		return nil, fmt.Errorf("fetching service properties: %w", err)

--- a/cli/azd/pkg/project/service_target_staticwebapp.go
+++ b/cli/azd/pkg/project/service_target_staticwebapp.go
@@ -90,7 +90,7 @@ func (at *staticWebAppTarget) Publish(
 			task.SetProgress(NewServiceProgress("Retrieving deployment token"))
 			deploymentToken, err := at.cli.GetStaticWebAppApiKey(
 				ctx,
-				at.env.GetSubscriptionId(),
+				targetResource.SubscriptionId(),
 				targetResource.ResourceGroupName(),
 				targetResource.ResourceName(),
 			)
@@ -104,7 +104,7 @@ func (at *staticWebAppTarget) Publish(
 			res, err := at.swa.Deploy(ctx,
 				serviceConfig.Project.Path,
 				at.env.GetTenantId(),
-				at.env.GetSubscriptionId(),
+				targetResource.SubscriptionId(),
 				targetResource.ResourceGroupName(),
 				targetResource.ResourceName(),
 				serviceConfig.RelativePath,
@@ -132,7 +132,7 @@ func (at *staticWebAppTarget) Publish(
 
 			sdr := NewServicePublishResult(
 				azure.StaticWebAppRID(
-					at.env.GetSubscriptionId(),
+					targetResource.SubscriptionId(),
 					targetResource.ResourceGroupName(),
 					targetResource.ResourceName(),
 				),
@@ -157,7 +157,7 @@ func (at *staticWebAppTarget) Endpoints(
 	// https://github.com/Azure/azure-dev/issues/1152
 	if envProps, err := at.cli.GetStaticWebAppEnvironmentProperties(
 		ctx,
-		at.env.GetSubscriptionId(),
+		targetResource.SubscriptionId(),
 		targetResource.ResourceGroupName(),
 		targetResource.ResourceName(),
 		DefaultStaticWebAppEnvironmentName,
@@ -191,7 +191,7 @@ func (at *staticWebAppTarget) verifyDeployment(ctx context.Context, targetResour
 	for {
 		envProps, err := at.cli.GetStaticWebAppEnvironmentProperties(
 			ctx,
-			at.env.GetSubscriptionId(),
+			targetResource.SubscriptionId(),
 			targetResource.ResourceGroupName(),
 			targetResource.ResourceName(),
 			DefaultStaticWebAppEnvironmentName,

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -195,7 +195,7 @@ func Test_CLI_InfraCreateAndDelete(t *testing.T) {
 
 	// Verify that resource groups are created with tag
 	resourceManager := infra.NewAzureResourceManager(azCli)
-	rgs, err := resourceManager.GetResourceGroupsForEnvironment(ctx, env)
+	rgs, err := resourceManager.GetResourceGroupsForEnvironment(ctx, env.GetSubscriptionId(), env.GetEnvName())
 	require.NoError(t, err)
 	require.NotNil(t, rgs)
 
@@ -251,7 +251,7 @@ func Test_CLI_InfraCreateAndDeleteUpperCase(t *testing.T) {
 
 	// Verify that resource groups are created with tag
 	resourceManager := infra.NewAzureResourceManager(azCli)
-	rgs, err := resourceManager.GetResourceGroupsForEnvironment(ctx, env)
+	rgs, err := resourceManager.GetResourceGroupsForEnvironment(ctx, env.GetSubscriptionId(), env.GetEnvName())
 	require.NoError(t, err)
 	require.NotNil(t, rgs)
 


### PR DESCRIPTION
To prepare for this value be initialized later (and hence the caller needs to think about "will this value have a value?", I was looking at all the places we call `GetSubscriptionId` today.  For some of them, we already have a resource ID around and we could just pick the value from there.  In other cases, I tried to push the use "up" by making `subscriptionId` a parameter of a function (instead of taking the `env` as a parameter and just calling `GetSubscriptionId` on it).