### PR TITLE
Move `SubscriptionsService` into `account` Package

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -282,7 +282,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.RegisterSingleton(templates.NewTemplateManager)
 	container.RegisterSingleton(auth.NewManager)
 	container.RegisterSingleton(azcli.NewUserProfileService)
-	container.RegisterSingleton(azcli.NewSubscriptionsService)
+	container.RegisterSingleton(account.NewSubscriptionsService)
 	container.RegisterSingleton(account.NewManager)
 	container.RegisterSingleton(account.NewSubscriptionsManager)
 	container.RegisterSingleton(azcli.NewManagedClustersService)

--- a/cli/azd/cmd/util_test.go
+++ b/cli/azd/cmd/util_test.go
@@ -167,7 +167,7 @@ func Test_getSubscriptionOptions(t *testing.T) {
 					IsDefault:          false,
 				},
 			},
-			Locations: []azcli.AzCliLocation{},
+			Locations: []account.Location{},
 		}
 
 		subList, result, err := getSubscriptionOptions(ctx, mockAccount)
@@ -277,7 +277,13 @@ func Test_createAndInitEnvironment(t *testing.T) {
 			mockContext.Console,
 			&mockaccount.MockAccountManager{
 				Subscriptions: []account.Subscription{{Id: expectedSub}},
-				Locations:     []azcli.AzCliLocation{{DisplayName: "west", Name: expectedLocation}},
+				Locations: []account.Location{
+					{
+						Name:                expectedLocation,
+						DisplayName:         "West",
+						RegionalDisplayName: "(US) West",
+					},
+				},
 			},
 			azcli.NewUserProfileService(
 				&mocks.MockMultiTenantCredentialProvider{},

--- a/cli/azd/pkg/account/manager_test.go
+++ b/cli/azd/pkg/account/manager_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
-	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockarmresources"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockconfig"
@@ -42,7 +41,7 @@ func Test_GetAccountDefaults(t *testing.T) {
 		manager, err := NewManager(
 			mockConfig.WithConfig(expectedConfig),
 			NewSubscriptionsManagerWithCache(
-				azcli.NewSubscriptionsService(
+				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
 					mockHttp,
 				),
@@ -67,7 +66,7 @@ func Test_GetAccountDefaults(t *testing.T) {
 		manager, err := NewManager(
 			mockConfig.WithConfig(emptyConfig),
 			NewSubscriptionsManagerWithCache(
-				azcli.NewSubscriptionsService(
+				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
 					mockHttp,
 				),
@@ -101,7 +100,7 @@ func Test_GetAccountDefaults(t *testing.T) {
 		manager, err := NewManager(
 			mockConfig.WithConfig(emptyConfig),
 			NewSubscriptionsManagerWithCache(
-				azcli.NewSubscriptionsService(
+				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
 					mockHttp,
 				),
@@ -135,7 +134,7 @@ func Test_GetAccountDefaults(t *testing.T) {
 		manager, err := NewManager(
 			mockConfig.WithConfig(emptyConfig),
 			NewSubscriptionsManagerWithCache(
-				azcli.NewSubscriptionsService(
+				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
 					mockHttp,
 				),
@@ -157,7 +156,7 @@ func Test_GetSubscriptionsWithDefaultSet(t *testing.T) {
 		setupAccountMocks(mockHttp)
 
 		manager, err := NewManager(mockConfig, NewSubscriptionsManagerWithCache(
-			azcli.NewSubscriptionsService(
+			NewSubscriptionsService(
 				&mocks.MockMultiTenantCredentialProvider{},
 				mockHttp,
 			),
@@ -192,7 +191,7 @@ func Test_GetSubscriptionsWithDefaultSet(t *testing.T) {
 		manager, err := NewManager(
 			mockConfig.WithConfig(defaultConfig),
 			NewSubscriptionsManagerWithCache(
-				azcli.NewSubscriptionsService(
+				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
 					mockHttp,
 				),
@@ -221,7 +220,7 @@ func Test_GetSubscriptionsWithDefaultSet(t *testing.T) {
 		manager, err := NewManager(
 			mockConfig,
 			NewSubscriptionsManagerWithCache(
-				azcli.NewSubscriptionsService(
+				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
 					mockHttp,
 				),
@@ -259,7 +258,7 @@ func Test_GetLocations(t *testing.T) {
 		manager, err := NewManager(
 			mockConfig.WithConfig(defaultConfig),
 			NewSubscriptionsManagerWithCache(
-				azcli.NewSubscriptionsService(
+				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
 					mockHttp,
 				),
@@ -280,7 +279,7 @@ func Test_GetLocations(t *testing.T) {
 		setupAccountErrorMocks(mockHttp)
 
 		manager, err := NewManager(mockConfig, NewSubscriptionsManagerWithCache(
-			azcli.NewSubscriptionsService(
+			NewSubscriptionsService(
 				&mocks.MockMultiTenantCredentialProvider{},
 				mockHttp,
 			),
@@ -300,7 +299,7 @@ func Test_GetLocations(t *testing.T) {
 		setupGetSubscriptionMock(mockHttp, &subscription, nil)
 
 		manager, err := NewManager(mockConfig, NewSubscriptionsManagerWithCache(
-			azcli.NewSubscriptionsService(
+			NewSubscriptionsService(
 				&mocks.MockMultiTenantCredentialProvider{},
 				mockHttp,
 			),
@@ -328,7 +327,7 @@ func Test_SetDefaultSubscription(t *testing.T) {
 		setupGetSubscriptionMock(mockHttp, &expectedSubscription, nil)
 
 		manager, err := NewManager(mockConfig, NewSubscriptionsManagerWithCache(
-			azcli.NewSubscriptionsService(
+			NewSubscriptionsService(
 				&mocks.MockMultiTenantCredentialProvider{},
 				mockHttp,
 			),
@@ -354,7 +353,7 @@ func Test_SetDefaultSubscription(t *testing.T) {
 		setupGetSubscriptionMock(mockHttp, &expectedSubscription, errors.New("Not found"))
 
 		manager, err := NewManager(mockConfig, NewSubscriptionsManagerWithCache(
-			azcli.NewSubscriptionsService(
+			NewSubscriptionsService(
 				&mocks.MockMultiTenantCredentialProvider{},
 				mockHttp,
 			),
@@ -393,7 +392,7 @@ func Test_SetDefaultLocation(t *testing.T) {
 		manager, err := NewManager(
 			mockConfig.WithConfig(defaultConfig),
 			NewSubscriptionsManagerWithCache(
-				azcli.NewSubscriptionsService(
+				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
 					mockHttp,
 				),
@@ -417,7 +416,7 @@ func Test_SetDefaultLocation(t *testing.T) {
 		setupGetSubscriptionMock(mockHttp, &subscription, nil)
 
 		manager, err := NewManager(mockConfig, NewSubscriptionsManagerWithCache(
-			azcli.NewSubscriptionsService(
+			NewSubscriptionsService(
 				&mocks.MockMultiTenantCredentialProvider{},
 				mockHttp,
 			),
@@ -444,7 +443,7 @@ func Test_Clear(t *testing.T) {
 	setupGetSubscriptionMock(mockHttp, &expectedSubscription, nil)
 
 	manager, err := NewManager(mockConfig, NewSubscriptionsManagerWithCache(
-		azcli.NewSubscriptionsService(
+		NewSubscriptionsService(
 			&mocks.MockMultiTenantCredentialProvider{},
 			mockHttp,
 		),
@@ -495,7 +494,7 @@ func Test_HasDefaults(t *testing.T) {
 		manager, err := NewManager(
 			mockConfig.WithConfig(azdConfig),
 			NewSubscriptionsManagerWithCache(
-				azcli.NewSubscriptionsService(
+				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
 					mockHttp,
 				),
@@ -514,7 +513,7 @@ func Test_HasDefaults(t *testing.T) {
 		manager, err := NewManager(
 			mockConfig.WithConfig(azdConfig),
 			NewSubscriptionsManagerWithCache(
-				azcli.NewSubscriptionsService(
+				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
 					mockHttp,
 				),
@@ -683,7 +682,7 @@ func NewInMemorySubscriptionsCache() *InMemorySubCache {
 }
 
 func NewSubscriptionsManagerWithCache(
-	service *azcli.SubscriptionsService,
+	service *SubscriptionsService,
 	cache subCache) *SubscriptionsManager {
 	return &SubscriptionsManager{
 		service:       service,

--- a/cli/azd/pkg/account/models.go
+++ b/cli/azd/pkg/account/models.go
@@ -16,6 +16,11 @@ type Subscription struct {
 }
 
 type Location struct {
-	Name        string `json:"name"`
+	// The name of the location (e.g. "westus2")
+	Name string `json:"name"`
+	// The human friendly name of the location (e.g. "West US 2")
 	DisplayName string `json:"displayName"`
+	// The human friendly name of the location, prefixed with a
+	// region name (e.g "(US) West US 2")
+	RegionalDisplayName string `json:"regionalDisplayName"`
 }

--- a/cli/azd/pkg/account/subscriptions_manager.go
+++ b/cli/azd/pkg/account/subscriptions_manager.go
@@ -15,8 +15,8 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry/events"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry/fields"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
-	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"go.uber.org/multierr"
 )
 
@@ -43,14 +43,14 @@ type subCache interface {
 // To lookup access to a given subscription, LookupTenant can be used to lookup the
 // current account's required tenantID to access a given subscription.
 type SubscriptionsManager struct {
-	service       *azcli.SubscriptionsService
+	service       *SubscriptionsService
 	principalInfo principalInfoProvider
 	cache         subCache
 	msg           input.Messaging
 }
 
 func NewSubscriptionsManager(
-	service *azcli.SubscriptionsService,
+	service *SubscriptionsService,
 	auth *auth.Manager,
 	msg input.Messaging) (*SubscriptionsManager, error) {
 	cache, err := NewSubscriptionsCache()
@@ -178,7 +178,7 @@ func (m *SubscriptionsManager) ListSubscriptions(ctx context.Context) ([]Subscri
 
 		tenantSubscriptions := []Subscription{}
 		for _, subscription := range subscriptions {
-			tenantSubscriptions = append(tenantSubscriptions, toSubscription(subscription, *principalTenantId))
+			tenantSubscriptions = append(tenantSubscriptions, toSubscription(*subscription, *principalTenantId))
 		}
 
 		return tenantSubscriptions, nil
@@ -194,7 +194,7 @@ func (m *SubscriptionsManager) ListSubscriptions(ctx context.Context) ([]Subscri
 	listForTenant := func(
 		jobs <-chan armsubscriptions.TenantIDDescription,
 		results chan<- tenantSubsResult,
-		service *azcli.SubscriptionsService) {
+		service *SubscriptionsService) {
 		for tenant := range jobs {
 			azSubs, err := service.ListSubscriptions(ctx, *tenant.TenantID)
 			if err != nil {
@@ -277,7 +277,10 @@ func (m *SubscriptionsManager) ListSubscriptions(ctx context.Context) ([]Subscri
 	return allSubscriptions, nil
 }
 
-func (m *SubscriptionsManager) ListLocations(ctx context.Context, subscriptionId string) ([]azcli.AzCliLocation, error) {
+func (m *SubscriptionsManager) ListLocations(
+	ctx context.Context,
+	subscriptionId string,
+) ([]Location, error) {
 	stop := m.msg.ShowProgress(ctx, "Retrieving locations...")
 	defer stop()
 
@@ -303,23 +306,23 @@ func (m *SubscriptionsManager) GetSubscription(ctx context.Context, subscription
 	return &sub, nil
 }
 
-func toSubscriptions(azSubs []azcli.AzCliSubscriptionInfo, userAccessTenantId string) []Subscription {
+func toSubscriptions(azSubs []*armsubscriptions.Subscription, userAccessTenantId string) []Subscription {
 	if azSubs == nil {
 		return nil
 	}
 
 	subs := make([]Subscription, 0, len(azSubs))
 	for _, azSub := range azSubs {
-		subs = append(subs, toSubscription(azSub, userAccessTenantId))
+		subs = append(subs, toSubscription(*azSub, userAccessTenantId))
 	}
 	return subs
 }
 
-func toSubscription(subscription azcli.AzCliSubscriptionInfo, userAccessTenantId string) Subscription {
+func toSubscription(subscription armsubscriptions.Subscription, userAccessTenantId string) Subscription {
 	return Subscription{
-		Id:                 subscription.Id,
-		Name:               subscription.Name,
-		TenantId:           subscription.TenantId,
+		Id:                 *subscription.SubscriptionID,
+		Name:               convert.ToValueWithDefault(subscription.DisplayName, *subscription.SubscriptionID),
+		TenantId:           *subscription.TenantID,
 		UserAccessTenantId: userAccessTenantId,
 	}
 }

--- a/cli/azd/pkg/account/subscriptions_manager_test.go
+++ b/cli/azd/pkg/account/subscriptions_manager_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
-	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockarmresources"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockhttp"
@@ -157,7 +156,7 @@ func TestSubscriptionsManager_ListSubscriptions(t *testing.T) {
 			}
 
 			subManager := &SubscriptionsManager{
-				service: azcli.NewSubscriptionsService(
+				service: NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
 					mockHttp,
 				),

--- a/cli/azd/pkg/azureutil/location.go
+++ b/cli/azd/pkg/azureutil/location.go
@@ -7,22 +7,13 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sort"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
-	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
+	"golang.org/x/exp/slices"
 )
-
-type Locs []azcli.AzCliLocation
-
-func (s Locs) Len() int { return len(s) }
-func (s Locs) Less(i, j int) bool {
-	return strings.Compare(strings.ToLower(s[i].RegionalDisplayName), strings.ToLower(s[j].RegionalDisplayName)) < 0
-}
-func (s Locs) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
 // PromptLocation asks the user to select a location from a list of supported azure locations for a given subscription.
 func PromptLocation(
@@ -30,7 +21,7 @@ func PromptLocation(
 	accountManager account.Manager,
 ) (string, error) {
 	return PromptLocationWithFilter(ctx, subscriptionId, message, help, console, accountManager,
-		func(acl azcli.AzCliLocation) bool {
+		func(_ account.Location) bool {
 			return true
 		})
 }
@@ -42,21 +33,25 @@ func PromptLocationWithFilter(
 	help string,
 	console input.Console,
 	accountManager account.Manager,
-	shouldDisplay func(azcli.AzCliLocation) bool,
+	shouldDisplay func(account.Location) bool,
 ) (string, error) {
 	allLocations, err := accountManager.GetLocations(ctx, subscriptionId)
 	if err != nil {
 		return "", fmt.Errorf("listing locations: %w", err)
 	}
 
-	locations := make([]azcli.AzCliLocation, 0, len(allLocations))
+	locations := make([]account.Location, 0, len(allLocations))
+
 	for _, location := range allLocations {
 		if shouldDisplay(location) {
 			locations = append(locations, location)
 		}
 	}
 
-	sort.Sort(Locs(locations))
+	slices.SortFunc(locations, func(a, b account.Location) bool {
+		return strings.Compare(
+			strings.ToLower(a.RegionalDisplayName), strings.ToLower(b.RegionalDisplayName)) < 0
+	})
 
 	// Allow the environment variable `AZURE_LOCATION` to control the default value for the location
 	// selection.

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appconfiguration/armappconfiguration"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
@@ -443,7 +444,7 @@ func createBicepProvider(t *testing.T, mockContext *mocks.MockContext) *BicepPro
 		HttpClient: mockContext.HttpClient,
 	})
 
-	locationPrompter := func(msg string, filter func(loc azcli.AzCliLocation) bool) (location string, err error) {
+	locationPrompter := func(msg string, filter func(loc account.Location) bool) (location string, err error) {
 		return "", nil
 	}
 

--- a/cli/azd/pkg/infra/provisioning/bicep/prompt.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
-	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"golang.org/x/exp/slices"
 
 	. "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
@@ -28,7 +28,7 @@ func (p *BicepProvider) promptForParameter(
 	var value any
 
 	if paramType == ParameterTypeString && azdMetadata.Type != nil && *azdMetadata.Type == "location" {
-		location, err := p.prompters.Location(msg, func(loc azcli.AzCliLocation) bool {
+		location, err := p.prompters.Location(msg, func(loc account.Location) bool {
 			if param.AllowedValues == nil {
 				return true
 			}

--- a/cli/azd/pkg/infra/provisioning/bicep/prompt_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt_test.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
-	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
 )
@@ -259,7 +259,7 @@ func TestPromptForParametersLocation(t *testing.T) {
 		Stderr: "",
 	})
 
-	locations := []azcli.AzCliLocation{
+	locations := []account.Location{
 		{
 			Name:                "eastus",
 			DisplayName:         "East US",
@@ -278,7 +278,10 @@ func TestPromptForParametersLocation(t *testing.T) {
 	}
 
 	p := createBicepProvider(t, mockContext)
-	p.prompters.Location = func(msg string, shouldDisplay func(loc azcli.AzCliLocation) bool) (location string, err error) {
+	p.prompters.Location = func(
+		msg string,
+		shouldDisplay func(loc account.Location) bool,
+	) (location string, err error) {
 		displayLocations := []string{}
 		for _, location := range locations {
 			if shouldDisplay(location) {

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -227,7 +227,7 @@ func (m *Manager) ensureLocation(ctx context.Context, deployment *Deployment) (s
 		// project.
 		selected, err := m.prompters.Location(
 			"Please select an Azure location to use to store deployment metadata:",
-			func(_ azcli.AzCliLocation) bool {
+			func(_ account.Location) bool {
 				return true
 			})
 		if err != nil {
@@ -296,7 +296,7 @@ func NewManager(
 	commandRunner exec.CommandRunner,
 	accountManager account.Manager,
 ) (*Manager, error) {
-	locationPrompt := func(msg string, filter func(loc azcli.AzCliLocation) bool) (location string, err error) {
+	locationPrompt := func(msg string, filter func(loc account.Location) bool) (location string, err error) {
 		return azureutil.PromptLocationWithFilter(ctx, env.GetSubscriptionId(), msg, "", console, accountManager, filter)
 	}
 

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
@@ -18,7 +19,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 )
 
-type LocationPromptFunc func(msg string, shouldDisplay func(loc azcli.AzCliLocation) bool) (location string, err error)
+type LocationPromptFunc func(msg string, shouldDisplay func(loc account.Location) bool) (location string, err error)
 
 // Prompters contains prompt functions that can be used for general scenarios.
 type Prompters struct {

--- a/cli/azd/pkg/tools/azcli/account.go
+++ b/cli/azd/pkg/tools/azcli/account.go
@@ -17,23 +17,6 @@ var (
 	isRefreshTokenExpiredMessageRegex = regexp.MustCompile(`AADSTS(70043|700082)`)
 )
 
-type AzCliSubscriptionInfo struct {
-	Name      string `json:"name"`
-	Id        string `json:"id"`
-	TenantId  string `json:"tenantId"`
-	IsDefault bool   `json:"isDefault"`
-}
-
-type AzCliLocation struct {
-	// The human friendly name of the location (e.g. "West US 2")
-	DisplayName string `json:"displayName"`
-	// The name of the location (e.g. "westus2")
-	Name string `json:"name"`
-	// The human friendly name of the location, prefixed with a
-	// region name (e.g "(US) West US 2")
-	RegionalDisplayName string `json:"regionalDisplayName"`
-}
-
 // AzCliAccessToken represents the value returned by `az account get-access-token`
 type AzCliAccessToken struct {
 	AccessToken string

--- a/cli/azd/test/mocks/mockaccount/mock_manager.go
+++ b/cli/azd/test/mocks/mockaccount/mock_manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
-	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 )
 
 type MockAccountManager struct {
@@ -12,7 +11,7 @@ type MockAccountManager struct {
 	DefaultSubscription string
 
 	Subscriptions []account.Subscription
-	Locations     []azcli.AzCliLocation
+	Locations     []account.Location
 }
 
 func (a *MockAccountManager) Clear(ctx context.Context) error {
@@ -59,7 +58,7 @@ func (a *MockAccountManager) GetDefaultSubscriptionID(ctx context.Context) strin
 	return a.DefaultSubscription
 }
 
-func (a *MockAccountManager) GetLocations(ctx context.Context, subscriptionId string) ([]azcli.AzCliLocation, error) {
+func (a *MockAccountManager) GetLocations(ctx context.Context, subscriptionId string) ([]account.Location, error) {
 	return a.Locations, nil
 }
 
@@ -81,8 +80,9 @@ func (a *MockAccountManager) SetDefaultLocation(
 	for _, loc := range a.Locations {
 		if loc.Name == location {
 			return &account.Location{
-				Name:        loc.Name,
-				DisplayName: loc.DisplayName,
+				Name:                loc.Name,
+				DisplayName:         loc.DisplayName,
+				RegionalDisplayName: loc.RegionalDisplayName,
 			}, nil
 		}
 	}


### PR DESCRIPTION
As part of some future work, I need to be able to take a dependency on the `auth` and `account` packages from `azcli`. That can't be done today because some code in the `account` package depended on the `azcli` package and so what I wanted to do would lead to an import cycle.

Looking at the code, it seemed like the best thing to do as move the SubscriptionsService out of the `azcli` package and into `account`. This change does the refactoring of doing that.

I tried to this as non destructively as possible to the existing implementation, but did need to move away from some of the model types in the `azcli` package (which I think long term we should just remove) in favor of the types exposed by the armsubscriptions SDK.