### PR TITLE
Improve captured usage

### DIFF
--- a/cli/azd/cmd/cobra_builder.go
+++ b/cli/azd/cmd/cobra_builder.go
@@ -125,6 +125,7 @@ func (cb *CobraBuilder) configureActionResolver(cmd *cobra.Command, descriptor *
 			Name:        cmd.Name(),
 			CommandPath: cmd.CommandPath(),
 			Aliases:     cmd.Aliases,
+			Cmd:         cmd,
 		}
 
 		// Run the middleware chain with action

--- a/cli/azd/cmd/middleware/middleware.go
+++ b/cli/azd/cmd/middleware/middleware.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
+	"github.com/spf13/cobra"
 )
 
 // Registration function that returns a constructed middleware
@@ -32,6 +33,7 @@ type Options struct {
 	CommandPath   string
 	Name          string
 	Aliases       []string
+	Cmd           *cobra.Command
 	isChildAction bool
 }
 

--- a/cli/azd/cmd/middleware/telemetry.go
+++ b/cli/azd/cmd/middleware/telemetry.go
@@ -6,6 +6,9 @@ import (
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry/events"
+	"github.com/azure/azure-dev/cli/azd/internal/telemetry/fields"
+	"github.com/spf13/pflag"
+
 	"go.opentelemetry.io/otel/codes"
 )
 
@@ -31,6 +34,20 @@ func (m *TelemetryMiddleware) Run(ctx context.Context, next NextFn) (*actions.Ac
 	// Note: CommandPath is constructed using the Use member on each command up to the root.
 	// It does not contain user input, and is safe for telemetry emission.
 	spanCtx, span := telemetry.GetTracer().Start(ctx, events.GetCommandEventName(m.options.CommandPath))
+
+	if m.options.Cmd != nil {
+		changedFlags := []string{}
+		m.options.Cmd.Flags().VisitAll(func(f *pflag.Flag) {
+			if f.Changed {
+				changedFlags = append(changedFlags, f.Name)
+			}
+		})
+		telemetry.SetUsageAttributes(fields.CmdFlags.StringSlice(changedFlags))
+
+		hasArgSet := m.options.Cmd.Args != nil
+		telemetry.SetUsageAttributes(fields.CmdHasArg.Bool(hasArgSet))
+	}
+
 	defer func() {
 		// Include any usage attributes set
 		span.SetAttributes(telemetry.GetUsageAttributes()...)

--- a/cli/azd/internal/telemetry/fields/fields.go
+++ b/cli/azd/internal/telemetry/fields/fields.go
@@ -59,8 +59,26 @@ const (
 	AccountTypeKey = attribute.Key("ad.account.type")
 	// Currently selected Subscription ID.
 	SubscriptionIdKey = attribute.Key("ad.subscription.id")
-	// Currently selected Project Template ID.
-	TemplateIdKey = attribute.Key("project.template.id")
+)
+
+// Project related attributes
+const (
+	// Hashed template referenced in the project.
+	ProjectTemplateIdKey = attribute.Key("project.template.id")
+	// Hashed project name. Could be used as an indicator for number of different azd projects.
+	ProjectNameKey = attribute.Key("project.name")
+	// The collection of hashed service hosts in the project.
+	ProjectServiceHostsKey = attribute.Key("project.service.hosts")
+	// The collection of hashed service languages in the project.
+	ProjectServiceLanguagesKey = attribute.Key("project.service.languages")
+)
+
+// Command entry-point attributes
+const (
+	// Flags set by the user. Only parsed flag names are available. Values are not recorded.
+	CmdFlags = attribute.Key("cmd.flags")
+	// Boolean. Whether the user provided a positional argument.
+	CmdHasArg = attribute.Key("cmd.has-arg")
 )
 
 // All possible enumerations of ExecutionEnvironmentKey

--- a/cli/azd/internal/telemetry/fields/key.go
+++ b/cli/azd/internal/telemetry/fields/key.go
@@ -16,14 +16,19 @@ func StringHashed(k attribute.Key, v string) attribute.KeyValue {
 }
 
 func StringSliceHashed(k attribute.Key, v []string) attribute.KeyValue {
-	val := make([]string, len(v))
-	for i := range v {
-		val[i] = CaseInsensitiveHash(v[i])
-	}
+	val := CaseInsensitiveSliceHash(v)
 	return attribute.KeyValue{
 		Key:   attribute.Key(k),
 		Value: attribute.StringSliceValue(val),
 	}
+}
+
+func CaseInsensitiveSliceHash(value []string) []string {
+	hashed := make([]string, len(value))
+	for i := range value {
+		hashed[i] = CaseInsensitiveHash(value[i])
+	}
+	return hashed
 }
 
 func CaseInsensitiveHash(value string) string {

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -12,6 +12,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry/fields"
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
 
@@ -83,7 +84,28 @@ func Load(ctx context.Context, projectFilePath string) (*ProjectConfig, error) {
 	}
 
 	if projectConfig.Metadata != nil {
-		telemetry.SetUsageAttributes(fields.StringHashed(fields.TemplateIdKey, projectConfig.Metadata.Template))
+		telemetry.SetUsageAttributes(fields.StringHashed(fields.ProjectTemplateIdKey, projectConfig.Metadata.Template))
+	}
+
+	if projectConfig.Name != "" {
+		telemetry.SetUsageAttributes(fields.StringHashed(fields.ProjectNameKey, projectConfig.Name))
+	}
+
+	if projectConfig.Services != nil {
+		hosts := make([]string, len(projectConfig.Services))
+		languages := make([]string, len(projectConfig.Services))
+		i := 0
+		for _, svcConfig := range projectConfig.Services {
+			hosts[i] = svcConfig.Host
+			languages[i] = svcConfig.Language
+			i++
+		}
+
+		slices.Sort(hosts)
+		slices.Sort(languages)
+
+		telemetry.SetUsageAttributes(fields.StringSliceHashed(fields.ProjectServiceLanguagesKey, languages))
+		telemetry.SetUsageAttributes(fields.StringSliceHashed(fields.ProjectServiceHostsKey, hosts))
 	}
 
 	projectConfig.Path = filepath.Dir(projectFilePath)

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -388,9 +388,14 @@ func Test_CLI_NoDebugSpewWhenHelpPassedWithoutDebug(t *testing.T) {
 //go:embed testdata/samples/*
 var samples embed.FS
 
+func samplePath(paths ...string) string {
+	elem := append([]string{"testdata", "samples"}, paths...)
+	return path.Join(elem...)
+}
+
 // copySample copies the given sample to targetRoot.
 func copySample(targetRoot string, sampleName string) error {
-	sampleRoot := path.Join("testdata", "samples", sampleName)
+	sampleRoot := samplePath(sampleName)
 
 	return fs.WalkDir(samples, sampleRoot, func(name string, d fs.DirEntry, err error) error {
 		// If there was some error that was preventing is from walking into the directory, just fail now,

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -43,8 +43,8 @@ type Attribute struct {
 
 var Sha256Regex = regexp.MustCompile("^[A-Fa-f0-9]{64}$")
 
-// Verifies telemetry usage data generated when environments are created.
-func Test_CLI_Telemetry_Usage_Data_EnvCreate(t *testing.T) {
+// Verifies telemetry usage data generated for simple commands, such as when environments are created.
+func Test_CLI_Telemetry_UsageData_Simple_Command(t *testing.T) {
 	// CLI process and working directory are isolated
 	t.Parallel()
 	ctx, cancel := newTestContext(t)
@@ -87,6 +87,13 @@ func Test_CLI_Telemetry_Usage_Data_EnvCreate(t *testing.T) {
 			m := attributesMap(span.Attributes)
 			require.Contains(t, m, fields.SubscriptionIdKey)
 			require.Equal(t, m[fields.SubscriptionIdKey], getEnvSubscriptionId(t, dir, envName))
+
+			require.Contains(t, m, fields.CmdFlags)
+			require.ElementsMatch(t, m[fields.CmdFlags], []string{"trace-log-file"})
+
+			// env new provides a arg. This should be set.
+			require.Contains(t, m, fields.CmdHasArg)
+			require.Equal(t, m[fields.CmdHasArg], true)
 		}
 	}
 
@@ -94,7 +101,7 @@ func Test_CLI_Telemetry_Usage_Data_EnvCreate(t *testing.T) {
 }
 
 // Verifies telemetry usage data generated when environments and projects are loaded.
-func Test_CLI_Telemetry_Usage_Data_EnvProjectLoad(t *testing.T) {
+func Test_CLI_Telemetry_UsageData_EnvProjectLoad(t *testing.T) {
 	// CLI process and working directory are isolated
 	ctx, cancel := newTestContext(t)
 	defer cancel()
@@ -165,6 +172,11 @@ func Test_CLI_Telemetry_Usage_Data_EnvProjectLoad(t *testing.T) {
 			require.Contains(t, m, fields.ProjectServiceLanguagesKey)
 			require.ElementsMatch(t, m[fields.ProjectServiceLanguagesKey], fields.CaseInsensitiveSliceHash(languages))
 
+			require.Contains(t, m, fields.CmdFlags)
+			require.ElementsMatch(t, m[fields.CmdFlags], []string{"service", "trace-log-file"})
+
+			require.Contains(t, m, fields.CmdHasArg)
+			require.Equal(t, m[fields.CmdHasArg], false)
 		}
 	}
 	require.True(t, usageCmdFound)


### PR DESCRIPTION
Add additional `project` and `cmd` anonymous usage attributes to be captured.

Details:
- `project.name` captured anonymously to get a rough count of azd projects.
- For each service, capture the `host` and `language` used anonymously to understand distribution.
- Capture command flags and whether a positional arg is passed anonymously.

Fixes #1736