### PR TITLE
Allow local files to be kept when running `init`

### DIFF
--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -154,7 +154,7 @@ func (i *Initializer) promptForDuplicates(
 	if len(duplicateFiles) > 0 {
 		i.console.StopSpinner(ctx, "", input.StepDone)
 		i.console.MessageUxItem(ctx, &ux.WarningMessage{
-			Description: "the following files will be overwritten with the versions from the template:",
+			Description: "The following files are present both locally and in the template:",
 		})
 
 		for _, file := range duplicateFiles {
@@ -165,7 +165,7 @@ func (i *Initializer) promptForDuplicates(
 			Message: "What would you like to do with these files?",
 			Options: []string{
 				"Overwrite with versions from template",
-				"Keep the current files as-is",
+				"Keep my existing files unchanged",
 			},
 		})
 

--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -91,7 +91,6 @@ func (i *Initializer) Initialize(
 				if skip, err := filepath.Match(fileToSkip, src); err != nil {
 					return false, err
 				} else if skip {
-					fmt.Printf("skipped file: %s\n", src)
 					return true, nil
 				}
 			}

--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -173,7 +173,6 @@ func (i *Initializer) promptForDuplicates(
 			Options: []string{
 				"Overwrite with versions from template",
 				"Keep the current files as-is",
-				"Cancel init",
 			},
 		}); err != nil {
 			return nil, fmt.Errorf("prompting to overwrite: %w", err)
@@ -187,8 +186,6 @@ func (i *Initializer) promptForDuplicates(
 					skipSourceFiles[i] = filepath.Join(staging, file)
 				}
 				return skipSourceFiles, nil
-			case 2:
-				return nil, errors.New("user cancellation")
 			}
 		}
 	}

--- a/cli/azd/internal/repository/initializer_test.go
+++ b/cli/azd/internal/repository/initializer_test.go
@@ -102,9 +102,9 @@ func Test_Initializer_InitializeWithOverwritePrompt(t *testing.T) {
 		name      string
 		selection int
 	}{
-		//{"Overwrite", 0},
+		{"Overwrite", 0},
 		{"Keep", 1},
-		//{"Cancel", 2},
+		{"Cancel", 2},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cli/azd/internal/repository/initializer_test.go
+++ b/cli/azd/internal/repository/initializer_test.go
@@ -104,7 +104,6 @@ func Test_Initializer_InitializeWithOverwritePrompt(t *testing.T) {
 	}{
 		{"Overwrite", 0},
 		{"Keep", 1},
-		{"Cancel", 2},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -155,10 +154,6 @@ func Test_Initializer_InitializeWithOverwritePrompt(t *testing.T) {
 						return filepath.Match(testDataPath(templateDir, "README.md.txt"), src)
 					},
 				})
-			case 2:
-				// user declined confirmation, error expected
-				require.Error(t, err)
-				return
 			default:
 				require.Fail(t, "unhandled user selection")
 			}


### PR DESCRIPTION
Offer the option to keep local files when initializing from template.

This is useful for azdevifying scenarios.

Fixes #1656