### PR TITLE
Don't default necessary values to empty strings

### DIFF
--- a/templates/common/infra/bicep/core/host/container-app.bicep
+++ b/templates/common/infra/bicep/core/host/container-app.bicep
@@ -2,9 +2,9 @@ param name string
 param location string = resourceGroup().location
 param tags object = {}
 
-param containerAppsEnvironmentName string = ''
+param containerAppsEnvironmentName string
 param containerName string = 'main'
-param containerRegistryName string = ''
+param containerRegistryName string
 param env array = []
 param external bool = true
 param imageName string

--- a/templates/common/infra/bicep/core/host/container-apps.bicep
+++ b/templates/common/infra/bicep/core/host/container-apps.bicep
@@ -2,9 +2,9 @@ param name string
 param location string = resourceGroup().location
 param tags object = {}
 
-param containerAppsEnvironmentName string = ''
-param containerRegistryName string = ''
-param logAnalyticsWorkspaceName string = ''
+param containerAppsEnvironmentName string
+param containerRegistryName string
+param logAnalyticsWorkspaceName string
 
 module containerAppsEnvironment 'container-apps-environment.bicep' = {
   name: '${name}-container-apps-environment'

--- a/templates/common/infra/bicep/core/security/keyvault-access.bicep
+++ b/templates/common/infra/bicep/core/security/keyvault-access.bicep
@@ -1,6 +1,6 @@
 param name string = 'add'
 
-param keyVaultName string = ''
+param keyVaultName string
 param permissions object = { secrets: [ 'get', 'list' ] }
 param principalId string
 


### PR DESCRIPTION
The template analyzer pointed out this issue with container-app.bicep, that it sets the names to empty strings that are later used to define existing resources. You can't define an existing resource with an empty string, so that's not a valid default value for it. These values always need to be set, as far as I can see.