### PR TITLE
Fix image rendering in samples browser

### DIFF
--- a/templates/todo/projects/csharp-cosmos-sql/README.md
+++ b/templates/todo/projects/csharp-cosmos-sql/README.md
@@ -29,7 +29,7 @@ A complete ToDo application that includes everything you need to build, deploy, 
 
 Let's jump in and get the ToDo app up and running in Azure. When you are finished, you will have a fully functional web app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.
 
-<img src="assets/web.png" width="75%" alt="Screenshot of deployed ToDo app">
+!["Screenshot of deployed ToDo app"](assets/web.png)
 
 <sup>Screenshot of the deployed ToDo app</sup>
 
@@ -87,7 +87,7 @@ This application utilizes the following Azure resources:
 
 Here's a high level architecture diagram that illustrates these components. Notice that these are all contained within a single [resource group](https://docs.microsoft.com/azure/azure-resource-manager/management/manage-resource-groups-portal), that will be created for you when you create the resources.
 
-<img src="assets/resources.png" width="60%" alt="Application architecture diagram"/>
+!["Application architecture diagram"](assets/resources.png)
 
 > This template provisions resources to an Azure subscription that you will select upon provisioning them. Please refer to the [Pricing calculator for Microsoft Azure](https://azure.microsoft.com/pricing/calculator/) and, if needed, update the included Azure resource definitions found in `infra/main.bicep` to suit your needs.
 
@@ -195,7 +195,7 @@ And then execute `azd up` to provision and deploy. No worries if you already did
 
 Here's the high level architecture diagram when APIM is used:
 
-<img src="assets/resources-with-apim.png" width="60%" alt="Application architecture diagram with APIM"/>
+!["Application architecture diagram with APIM"](assets/resources-with-apim.png)
 
 The frontend will be configured to make API requests through APIM instead of calling the backend directly, so that the following flow gets executed:
 

--- a/templates/todo/projects/csharp-sql-swa-func/README.md
+++ b/templates/todo/projects/csharp-sql-swa-func/README.md
@@ -29,7 +29,7 @@ A complete ToDo application that includes everything you need to build, deploy, 
 
 Let's jump in and get the ToDo app up and running in Azure. When you are finished, you will have a fully functional web app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.
 
-<img src="assets/web.png" width="75%" alt="Screenshot of deployed ToDo app">
+!["Screenshot of deployed ToDo app"](assets/web.png)
 
 <sup>Screenshot of the deployed ToDo app</sup>
 
@@ -89,7 +89,7 @@ This application utilizes the following Azure resources:
 
 Here's a high level architecture diagram that illustrates these components. Notice that these are all contained within a single [resource group](https://docs.microsoft.com/azure/azure-resource-manager/management/manage-resource-groups-portal), that will be created for you when you create the resources.
 
-<img src="assets/resources.png" width="60%" alt="Application architecture diagram"/>
+!["Application architecture diagram"](assets/resources.png)
 
 > This template provisions resources to an Azure subscription that you will select upon provisioning them. Please refer to the [Pricing calculator for Microsoft Azure](https://azure.microsoft.com/pricing/calculator/) and, if needed, update the included Azure resource definitions found in `infra/main.bicep` to suit your needs.
 
@@ -201,7 +201,7 @@ And then execute `azd up` to provision and deploy. No worries if you already did
 
 Here's the high level architecture diagram when APIM is used:
 
-<img src="assets/resources-with-apim.png" width="60%" alt="Application architecture diagram with APIM"/>
+!["Application architecture diagram with APIM"](assets/resources-with-apim.png)
 
 The frontend will be configured to make API requests through APIM instead of calling the backend directly, so that the following flow gets executed:
 

--- a/templates/todo/projects/csharp-sql/README.md
+++ b/templates/todo/projects/csharp-sql/README.md
@@ -29,7 +29,7 @@ A complete ToDo application that includes everything you need to build, deploy, 
 
 Let's jump in and get the ToDo app up and running in Azure. When you are finished, you will have a fully functional web app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.
 
-<img src="assets/web.png" width="75%" alt="Screenshot of deployed ToDo app"/>
+!["Screenshot of deployed ToDo app"](assets/web.png)
 
 <sup>Screenshot of the deployed ToDo app</sup>
 
@@ -87,7 +87,7 @@ This application utilizes the following Azure resources:
 
 Here's a high level architecture diagram that illustrates these components. Notice that these are all contained within a single [resource group](https://docs.microsoft.com/azure/azure-resource-manager/management/manage-resource-groups-portal), that will be created for you when you create the resources.
 
-<img src="assets/resources.png" width="60%" alt="Application architecture diagram"/>
+!["Application architecture diagram"](assets/resources.png)
 
 > This template provisions resources to an Azure subscription that you will select upon provisioning them. Please refer to the [Pricing calculator for Microsoft Azure](https://azure.microsoft.com/pricing/calculator/) and, if needed, update the included Azure resource definitions found in `infra/main.bicep` to suit your needs.
 
@@ -195,7 +195,7 @@ And then execute `azd up` to provision and deploy. No worries if you already did
 
 Here's the high level architecture diagram when APIM is used:
 
-<img src="assets/resources-with-apim.png" width="60%" alt="Application architecture diagram with APIM"/>
+!["Application architecture diagram with APIM"](assets/resources-with-apim.png)
 
 The frontend will be configured to make API requests through APIM instead of calling the backend directly, so that the following flow gets executed:
 

--- a/templates/todo/projects/java-mongo-aca/README.md
+++ b/templates/todo/projects/java-mongo-aca/README.md
@@ -29,7 +29,7 @@ A complete ToDo application that includes everything you need to build, deploy, 
 
 Let's jump in and get the ToDo app up and running in Azure. When you are finished, you will have a fully functional web app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.
 
-<img src="assets/web.png" width="75%" alt="Screenshot of deployed ToDo app">
+!["Screenshot of deployed ToDo app"](assets/web.png)
 
 <sup>Screenshot of the deployed ToDo app</sup>
 
@@ -109,7 +109,7 @@ This application utilizes the following Azure resources:
 
 Here's a high level architecture diagram that illustrates these components. Notice that these are all contained within a single [resource group](https://docs.microsoft.com/azure/azure-resource-manager/management/manage-resource-groups-portal), that will be created for you when you create the resources.
 
-<img src="assets/resources.png" width="60%" alt="Application architecture diagram"/>
+!["Application architecture diagram"](assets/resources.png)
 
 > This template provisions resources to an Azure subscription that you will select upon provisioning them. Please refer to the [Pricing calculator for Microsoft Azure](https://azure.microsoft.com/pricing/calculator/) and, if needed, update the included Azure resource definitions found in `infra/main.bicep` to suit your needs.
 
@@ -217,7 +217,7 @@ And then execute `azd up` to provision and deploy. No worries if you already did
 
 Here's the high level architecture diagram when APIM is used:
 
-<img src="assets/resources-with-apim.png" width="60%" alt="Application architecture diagram with APIM"/>
+!["Application architecture diagram with APIM"](assets/resources-with-apim.png)
 
 The frontend will be configured to make API requests through APIM instead of calling the backend directly, so that the following flow gets executed:
 

--- a/templates/todo/projects/java-mongo/README.md
+++ b/templates/todo/projects/java-mongo/README.md
@@ -28,7 +28,7 @@ A complete ToDo application that includes everything you need to build, deploy, 
 
 Let's jump in and get the ToDo app up and running in Azure. When you are finished, you will have a fully functional web app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.
 
-<img src="assets/web.png" width="75%" alt="Screenshot of deployed ToDo app">
+!["Screenshot of deployed ToDo app"](assets/web.png)
 
 <sup>Screenshot of the deployed ToDo app</sup>
 
@@ -86,7 +86,7 @@ This application utilizes the following Azure resources:
 
 Here's a high level architecture diagram that illustrates these components. Notice that these are all contained within a single [resource group](https://docs.microsoft.com/azure/azure-resource-manager/management/manage-resource-groups-portal), that will be created for you when you create the resources.
 
-<img src="assets/resources.png" width="60%" alt="Application architecture diagram"/>
+!["Application architecture diagram"](assets/resources.png)
 
 > This template provisions resources to an Azure subscription that you will select upon provisioning them. Please refer to the [Pricing calculator for Microsoft Azure](https://azure.microsoft.com/pricing/calculator/) and, if needed, update the included Azure resource definitions found in `infra/main.bicep` to suit your needs.
 
@@ -194,7 +194,7 @@ And then execute `azd up` to provision and deploy. No worries if you already did
 
 Here's the high level architecture diagram when APIM is used:
 
-<img src="assets/resources-with-apim.png" width="60%" alt="Application architecture diagram with APIM"/>
+!["Application architecture diagram with APIM"](assets/resources-with-apim.png)
 
 The frontend will be configured to make API requests through APIM instead of calling the backend directly, so that the following flow gets executed:
 

--- a/templates/todo/projects/nodejs-mongo-aca/README.md
+++ b/templates/todo/projects/nodejs-mongo-aca/README.md
@@ -28,7 +28,7 @@ A complete ToDo application that includes everything you need to build, deploy, 
 
 Let's jump in and get the ToDo app up and running in Azure. When you are finished, you will have a fully functional web app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.
 
-<img src="assets/web.png" width="75%" alt="Screenshot of deployed ToDo app">
+!["Screenshot of deployed ToDo app"](assets/web.png)
 
 <sup>Screenshot of the deployed ToDo app</sup>
 
@@ -107,7 +107,7 @@ This application utilizes the following Azure resources:
 
 Here's a high level architecture diagram that illustrates these components. Notice that these are all contained within a single [resource group](https://docs.microsoft.com/azure/azure-resource-manager/management/manage-resource-groups-portal), that will be created for you when you create the resources.
 
-<img src="assets/resources.png" width="60%" alt="Application architecture diagram"/>
+!["Application architecture diagram"](assets/resources.png)
 
 > This template provisions resources to an Azure subscription that you will select upon provisioning them. Please refer to the [Pricing calculator for Microsoft Azure](https://azure.microsoft.com/pricing/calculator/) and, if needed, update the included Azure resource definitions found in `infra/main.bicep` to suit your needs.
 
@@ -215,7 +215,7 @@ And then execute `azd up` to provision and deploy. No worries if you already did
 
 Here's the high level architecture diagram when APIM is used:
 
-<img src="assets/resources-with-apim.png" width="60%" alt="Application architecture diagram with APIM"/>
+!["Application architecture diagram with APIM"](assets/resources-with-apim.png)
 
 The frontend will be configured to make API requests through APIM instead of calling the backend directly, so that the following flow gets executed:
 

--- a/templates/todo/projects/nodejs-mongo-aks/README.md
+++ b/templates/todo/projects/nodejs-mongo-aks/README.md
@@ -1,3 +1,24 @@
+---
+page_type: sample
+languages:
+- azdeveloper
+- nodejs
+- bicep
+- typescript
+- html
+products:
+- azure
+- azure-cosmos-db
+- azure-functions
+- azure-kubernetes-service
+- azure-monitor
+- azure-pipelines
+urlFragment: todo-nodejs-mongo-aks
+name: Web Application with a Node.js API and Azure Cosmos DB API for MongoDB on Azure Kubernetes Service
+description: A complete ToDo app with Node.js API and Azure Cosmos API for MongoDB for storage. Uses Azure Developer CLI (azd) to build, deploy, and monitor
+---
+<!-- YAML front-matter schema: https://review.learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main#supported-metadata-fields-for-readmemd -->
+
 # ToDo Application with a Node.js API and Azure Cosmos DB API for MongoDB on Azure Kubernetes Service (AKS)
 
 [![Open in GitHub Codespaces](https://img.shields.io/static/v1?style=for-the-badge&label=GitHub+Codespaces&message=Open&color=brightgreen&logo=github)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=607810498&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fdevcontainer.json&location=WestUs2)
@@ -7,7 +28,7 @@ A complete ToDo application that includes everything you need to build, deploy, 
 
 Let's jump in and get the ToDo app up and running in Azure. When you are finished, you will have a fully functional web app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.
 
-<img src="assets/resources.png" width="75%" alt="Screenshot of deployed ToDo app">
+!["Screenshot of deployed ToDo app"](assets/resources.png)
 
 <sup>Screenshot of the deployed ToDo app</sup>
 
@@ -65,7 +86,7 @@ This application utilizes the following Azure resources:
 
 Here's a high level architecture diagram that illustrates these components. Notice that these are all contained within a single [resource group](https://docs.microsoft.com/azure/azure-resource-manager/management/manage-resource-groups-portal), that will be created for you when you create the resources.
 
-<img src="assets/resources.png" width="60%" alt="Application architecture diagram"/>
+!["Application architecture diagram"](assets/resources.png)
 
 > This template provisions resources to an Azure subscription that you will select upon provisioning them. Please refer to the [Pricing calculator for Microsoft Azure](https://azure.microsoft.com/pricing/calculator/) and, if needed, update the included Azure resource definitions found in `infra/main.bicep` to suit your needs.
 

--- a/templates/todo/projects/nodejs-mongo-aks/README.md
+++ b/templates/todo/projects/nodejs-mongo-aks/README.md
@@ -28,7 +28,7 @@ A complete ToDo application that includes everything you need to build, deploy, 
 
 Let's jump in and get the ToDo app up and running in Azure. When you are finished, you will have a fully functional web app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.
 
-!["Screenshot of deployed ToDo app"](assets/resources.png)
+!["Screenshot of deployed ToDo app"](assets/web.png)
 
 <sup>Screenshot of the deployed ToDo app</sup>
 

--- a/templates/todo/projects/nodejs-mongo-swa-func/README.md
+++ b/templates/todo/projects/nodejs-mongo-swa-func/README.md
@@ -27,7 +27,7 @@ A complete ToDo application that includes everything you need to build, deploy, 
 
 Let's jump in and get the ToDo app up and running in Azure. When you are finished, you will have a fully functional web app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.
 
-<img src="assets/web.png" width="75%" alt="Screenshot of deployed ToDo app">
+!["Screenshot of deployed ToDo app"](assets/web.png)
 
 <sup>Screenshot of the deployed ToDo app</sup>
 
@@ -96,7 +96,7 @@ This application utilizes the following Azure resources:
 
 Here's a high level architecture diagram that illustrates these components. Notice that these are all contained within a single [resource group](https://docs.microsoft.com/azure/azure-resource-manager/management/manage-resource-groups-portal), that will be created for you when you create the resources.
 
-<img src="assets/resources.png" width="60%" alt="Application architecture diagram"/>
+!["Application architecture diagram"](assets/resources.png)
 
 > This template provisions resources to an Azure subscription that you will select upon provisioning them. Please refer to the [Pricing calculator for Microsoft Azure](https://azure.microsoft.com/pricing/calculator/) and, if needed, update the included Azure resource definitions found in `infra/main.bicep` to suit your needs.
 
@@ -204,7 +204,7 @@ And then execute `azd up` to provision and deploy. No worries if you already did
 
 Here's the high level architecture diagram when APIM is used:
 
-<img src="assets/resources-with-apim.png" width="60%" alt="Application architecture diagram with APIM"/>
+!["Application architecture diagram with APIM"](assets/resources-with-apim.png)
 
 The frontend will be configured to make API requests through APIM instead of calling the backend directly, so that the following flow gets executed:
 

--- a/templates/todo/projects/nodejs-mongo/.repo/bicep/README.md
+++ b/templates/todo/projects/nodejs-mongo/.repo/bicep/README.md
@@ -27,7 +27,7 @@ A complete ToDo application that includes everything you need to build, deploy, 
 
 Let's jump in and get the ToDo app up and running in Azure. When you are finished, you will have a fully functional web app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.
 
-<img src="assets/web.png" width="75%" alt="Screenshot of deployed ToDo app">
+!["Screenshot of deployed ToDo app"](assets/web.png)
 
 <sup>Screenshot of the deployed ToDo app</sup>
 
@@ -84,7 +84,7 @@ This application utilizes the following Azure resources:
 
 Here's a high level architecture diagram that illustrates these components. Notice that these are all contained within a single [resource group](https://docs.microsoft.com/azure/azure-resource-manager/management/manage-resource-groups-portal), that will be created for you when you create the resources.
 
-<img src="assets/resources.png" width="60%" alt="Application architecture diagram"/>
+!["Application architecture diagram"](assets/resources.png)
 
 > This template provisions resources to an Azure subscription that you will select upon provisioning them. Please refer to the [Pricing calculator for Microsoft Azure](https://azure.microsoft.com/pricing/calculator/) and, if needed, update the included Azure resource definitions found in `infra/main.bicep` to suit your needs.
 
@@ -192,7 +192,7 @@ And then execute `azd up` to provision and deploy. No worries if you already did
 
 Here's the high level architecture diagram when APIM is used:
 
-<img src="assets/resources-with-apim.png" width="60%" alt="Application architecture diagram with APIM"/>
+!["Application architecture diagram with APIM"](assets/resources-with-apim.png)
 
 The frontend will be configured to make API requests through APIM instead of calling the backend directly, so that the following flow gets executed:
 

--- a/templates/todo/projects/nodejs-mongo/.repo/terraform/README.md
+++ b/templates/todo/projects/nodejs-mongo/.repo/terraform/README.md
@@ -27,7 +27,7 @@ A complete ToDo application that includes everything you need to build, deploy, 
 
 Let's jump in and get the ToDo app up and running in Azure. When you are finished, you will have a fully functional web app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.
 
-<img src="assets/web.png" width="75%" alt="Screenshot of deployed ToDo app">
+!["Screenshot of deployed ToDo app"](assets/web.png)
 
 <sup>Screenshot of the deployed ToDo app</sup>
 
@@ -85,7 +85,7 @@ This application utilizes the following Azure resources:
 
 Here's a high level architecture diagram that illustrates these components. Notice that these are all contained within a single [resource group](https://docs.microsoft.com/azure/azure-resource-manager/management/manage-resource-groups-portal), that will be created for you when you create the resources.
 
-<img src="assets/resources.png" width="60%" alt="Application architecture diagram"/>
+!["Application architecture diagram"](assets/resources.png)
 
 > This template provisions resources to an Azure subscription that you will select upon provisioning them. Please refer to the [Pricing calculator for Microsoft Azure](https://azure.microsoft.com/pricing/calculator/) and, if needed, update the included Azure resource definitions found in `infra/main.bicep` to suit your needs.
 
@@ -193,7 +193,7 @@ And then execute `azd up` to provision and deploy. No worries if you already did
 
 Here's the high level architecture diagram when APIM is used:
 
-<img src="assets/resources-with-apim.png" width="60%" alt="Application architecture diagram with APIM"/>
+!["Application architecture diagram with APIM"](assets/resources-with-apim.png)
 
 The frontend will be configured to make API requests through APIM instead of calling the backend directly, so that the following flow gets executed:
 

--- a/templates/todo/projects/python-mongo-aca/README.md
+++ b/templates/todo/projects/python-mongo-aca/README.md
@@ -28,7 +28,7 @@ A complete ToDo application that includes everything you need to build, deploy, 
 
 Let's jump in and get the ToDo app up and running in Azure. When you are finished, you will have a fully functional web app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.
 
-<img src="assets/web.png" width="75%" alt="Screenshot of deployed ToDo app">
+!["Screenshot of deployed ToDo app"](assets/web.png)
 
 <sup>Screenshot of the deployed ToDo app</sup>
 
@@ -109,7 +109,7 @@ This application utilizes the following Azure resources:
 
 Here's a high level architecture diagram that illustrates these components. Notice that these are all contained within a single [resource group](https://docs.microsoft.com/azure/azure-resource-manager/management/manage-resource-groups-portal), that will be created for you when you create the resources.
 
-<img src="assets/resources.png" width="60%" alt="Application architecture diagram"/>
+!["Application architecture diagram"](assets/resources.png)
 
 > This template provisions resources to an Azure subscription that you will select upon provisioning them. Please refer to the [Pricing calculator for Microsoft Azure](https://azure.microsoft.com/pricing/calculator/) and, if needed, update the included Azure resource definitions found in `infra/main.bicep` to suit your needs.
 
@@ -217,7 +217,7 @@ And then execute `azd up` to provision and deploy. No worries if you already did
 
 Here's the high level architecture diagram when APIM is used:
 
-<img src="assets/resources-with-apim.png" width="60%" alt="Application architecture diagram with APIM"/>
+!["Application architecture diagram with APIM"](assets/resources-with-apim.png)
 
 The frontend will be configured to make API requests through APIM instead of calling the backend directly, so that the following flow gets executed:
 

--- a/templates/todo/projects/python-mongo-swa-func/README.md
+++ b/templates/todo/projects/python-mongo-swa-func/README.md
@@ -27,7 +27,7 @@ A complete ToDo application that includes everything you need to build, deploy, 
 
 Let's jump in and get the ToDo app up and running in Azure. When you are finished, you will have a fully functional web app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.
 
-<img src="assets/web.png" width="75%" alt="Screenshot of deployed ToDo app">
+!["Screenshot of deployed ToDo app"](assets/web.png)
 
 <sup>Screenshot of the deployed ToDo app</sup>
 
@@ -97,7 +97,7 @@ This application utilizes the following Azure resources:
 
 Here's a high level architecture diagram that illustrates these components. Notice that these are all contained within a single [resource group](https://docs.microsoft.com/azure/azure-resource-manager/management/manage-resource-groups-portal), that will be created for you when you create the resources.
 
-<img src="assets/resources.png" width="60%" alt="Application architecture diagram"/>
+!["Application architecture diagram"](assets/resources.png)
 
 > This template provisions resources to an Azure subscription that you will select upon provisioning them. Please refer to the [Pricing calculator for Microsoft Azure](https://azure.microsoft.com/pricing/calculator/) and, if needed, update the included Azure resource definitions found in `infra/main.bicep` to suit your needs.
 
@@ -205,7 +205,7 @@ And then execute `azd up` to provision and deploy. No worries if you already did
 
 Here's the high level architecture diagram when APIM is used:
 
-<img src="assets/resources-with-apim.png" width="60%" alt="Application architecture diagram with APIM"/>
+!["Application architecture diagram with APIM"](assets/resources-with-apim.png)
 
 The frontend will be configured to make API requests through APIM instead of calling the backend directly, so that the following flow gets executed:
 

--- a/templates/todo/projects/python-mongo/.repo/bicep/README.md
+++ b/templates/todo/projects/python-mongo/.repo/bicep/README.md
@@ -27,7 +27,7 @@ A complete ToDo application that includes everything you need to build, deploy, 
 
 Let's jump in and get the ToDo app up and running in Azure. When you are finished, you will have a fully functional web app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.
 
-<img src="assets/web.png" width="75%" alt="Screenshot of deployed ToDo app">
+!["Screenshot of deployed ToDo app"](assets/web.png)
 
 <sup>Screenshot of the deployed ToDo app</sup>
 
@@ -86,7 +86,7 @@ This application utilizes the following Azure resources:
 
 Here's a high level architecture diagram that illustrates these components. Notice that these are all contained within a single [resource group](https://docs.microsoft.com/azure/azure-resource-manager/management/manage-resource-groups-portal), that will be created for you when you create the resources.
 
-<img src="assets/resources.png" width="60%" alt="Application architecture diagram"/>
+!["Application architecture diagram"](assets/resources.png)
 
 > This template provisions resources to an Azure subscription that you will select upon provisioning them. Please refer to the [Pricing calculator for Microsoft Azure](https://azure.microsoft.com/pricing/calculator/) and, if needed, update the included Azure resource definitions found in `infra/main.bicep` to suit your needs.
 
@@ -194,7 +194,7 @@ And then execute `azd up` to provision and deploy. No worries if you already did
 
 Here's the high level architecture diagram when APIM is used:
 
-<img src="assets/resources-with-apim.png" width="60%" alt="Application architecture diagram with APIM"/>
+!["Application architecture diagram with APIM"](assets/resources-with-apim.png)
 
 The frontend will be configured to make API requests through APIM instead of calling the backend directly, so that the following flow gets executed:
 

--- a/templates/todo/projects/python-mongo/.repo/terraform/README.md
+++ b/templates/todo/projects/python-mongo/.repo/terraform/README.md
@@ -27,7 +27,7 @@ A complete ToDo application that includes everything you need to build, deploy, 
 
 Let's jump in and get the ToDo app up and running in Azure. When you are finished, you will have a fully functional web app deployed on Azure. In later steps, you'll see how to setup a pipeline and monitor the application.
 
-<img src="assets/web.png" width="75%" alt="Screenshot of deployed ToDo app">
+!["Screenshot of deployed ToDo app"](assets/web.png)
 
 <sup>Screenshot of the deployed ToDo app</sup>
 
@@ -87,7 +87,7 @@ This application utilizes the following Azure resources:
 
 Here's a high level architecture diagram that illustrates these components. Notice that these are all contained within a single [resource group](https://docs.microsoft.com/azure/azure-resource-manager/management/manage-resource-groups-portal), that will be created for you when you create the resources.
 
-<img src="assets/resources.png" width="60%" alt="Application architecture diagram"/>
+!["Application architecture diagram"](assets/resources.png)
 
 > This template provisions resources to an Azure subscription that you will select upon provisioning them. Please refer to the [Pricing calculator for Microsoft Azure](https://azure.microsoft.com/pricing/calculator/) and, if needed, update the included Azure resource definitions found in `infra/main.bicep` to suit your needs.
 
@@ -195,7 +195,7 @@ And then execute `azd up` to provision and deploy. No worries if you already did
 
 Here's the high level architecture diagram when APIM is used:
 
-<img src="assets/resources-with-apim.png" width="60%" alt="Application architecture diagram with APIM"/>
+!["Application architecture diagram with APIM"](assets/resources-with-apim.png)
 
 The frontend will be configured to make API requests through APIM instead of calling the backend directly, so that the following flow gets executed:
 


### PR DESCRIPTION
Our samples in the sample browser aren't rendering certain images. [Example](https://learn.microsoft.com/en-us/samples/azure-samples/todo-nodejs-mongo-terraform/todo-nodejs-mongo-terraform/)

This change removes the image elements in favor of markdown image reference which doesn't allow custom sizing. The UX experience is pretty similar and has been reviewed by @savannahostrowski.

This change also adds frontmatter for the new `aks` template

Example for `nodejs-mongo-swa-func`: [Before](https://github.com/Azure-Samples/todo-python-mongo-aca/tree/main), [After](https://github.com/Azure-Samples/todo-python-mongo-aca/tree/pr/1780)