### PR TITLE
Remove need to run `go build` for running e2e tests

### DIFF
--- a/cli/azd/CONTRIBUTING.md
+++ b/cli/azd/CONTRIBUTING.md
@@ -75,26 +75,23 @@ example:
 We use `gotestsum`, which is a simple tool that wraps `go test` except with better formatting output. Install the tool by
 running `go install gotest.tools/gotestsum@latest`.
 
-### Run all unit tests
+### Run unit tests
 
 `gotestsum -- -short ./...`
 
-### Run all end-to-end tests
+### Run end-to-end tests
+
+`gotestsum -- -timeout 20m -run Test_CLI ./...`
+
+This runs all end-to-end tests that target the standalone `azd` binary locally and **will** deploy live resources.
+By default, the `azd` binary produced in the cli/azd folder is automatically built once if not up-to-date,
+so it is sufficient to run end-to-end tests without having to first running `go build`.
+
+If testing against a custom binary, set `CLI_TEST_AZD_PATH` explicitly. See test/azdcli package for more details.
+
+### Run all tests
 
 ```bash
-go build
-gotestsum -- -timeout 20m -run Test_CLI ./...
-```
-
-This runs all end-to-end tests that run `azd` locally and deploy live resources. Run `go build` first to ensure the
-integration tests target the latest `azd` binary built at the root of `cli/azd`. Note that `go install` "helpfully" removes
-the binary produced by `go build` when run, and so if you've run `go install` since the last time you ran `go build` you'll
-have to run `go build` again or the end-to-end tests will fail.
-
-### Run all tests (including end-to-end tests)
-
-```bash
-go build
 gotestsum -- -timeout 20m ./...
 ```
 

--- a/cli/azd/test/azdcli/cli.go
+++ b/cli/azd/test/azdcli/cli.go
@@ -12,10 +12,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -23,6 +26,9 @@ import (
 const (
 	HeartbeatInterval = 10 * time.Second
 )
+
+// sync.Once for one-time build for the process invocation
+var buildOnce sync.Once
 
 // The result of calling an azd CLI command
 type CliResult struct {
@@ -38,14 +44,71 @@ type CLI struct {
 	T                *testing.T
 	WorkingDirectory string
 	Env              []string
-	// The location of azd to invoke. By default, set to GetAzdLocation()
-	AzdLocation string
+	// Path to the azd binary
+	AzdPath string
 }
 
+// Constructs the CLI.
+// On a local developer machine, this also ensures that the azd binary is up-to-date before running.
+//
+// By default, the path to the default source location is used, see GetSourcePath.
+// Environment variable CLI_TEST_AZD_PATH can be used to set the path to the azd binary. This can be done in CI to
+// run the tests against a specific azd binary.
+//
+// When CI is detected, no automatic build is performed. To disable automatic build behavior, CLI_TEST_SKIP_BUILD
+// can be set to a truthy value.
 func NewCLI(t *testing.T) *CLI {
+	// Allow a override for custom build
+	if os.Getenv("CLI_TEST_AZD_PATH") != "" {
+		return &CLI{
+			T:       t,
+			AzdPath: os.Getenv("CLI_TEST_AZD_PATH"),
+		}
+	}
+
+	// Reference the binary that is built in the same folder as source
+	cliPath := GetSourcePath()
+	if runtime.GOOS == "windows" {
+		cliPath = filepath.Join(cliPath, "azd.exe")
+	} else {
+		cliPath = filepath.Join(cliPath, "azd")
+	}
+
+	cli := &CLI{
+		T:       t,
+		AzdPath: cliPath,
+	}
+
+	// Manual override for skipping automatic build
+	skip, err := strconv.ParseBool(os.Getenv("CLI_TEST_SKIP_BUILD"))
+	if err == nil && skip {
+		return cli
+	}
+
+	// Skip automatic build in CI always
+	if os.Getenv("CI") != "" ||
+		strings.ToLower(os.Getenv("TF_BUILD")) == "true" ||
+		strings.ToLower(os.Getenv("GITHUB_ACTIONS")) == "true" {
+		return cli
+	}
+
+	buildOnce.Do(func() {
+		cmd := exec.Command("go", "build")
+		cmd.Dir = filepath.Dir(cliPath)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			panic(fmt.Errorf(
+				"failed to build azd (ran %s in %s): %w:\n%s",
+				strings.Join(cmd.Args, " "),
+				cmd.Dir,
+				err,
+				output))
+		}
+	})
+
 	return &CLI{
-		T:           t,
-		AzdLocation: GetAzdLocation(),
+		T:       t,
+		AzdPath: cliPath,
 	}
 }
 
@@ -53,7 +116,7 @@ func (cli *CLI) RunCommandWithStdIn(ctx context.Context, stdin string, args ...s
 	description := "azd " + strings.Join(args, " ") + " in " + cli.WorkingDirectory
 
 	/* #nosec G204 - Subprocess launched with a potential tainted input or cmd arguments false positive */
-	cmd := exec.CommandContext(ctx, cli.AzdLocation, args...)
+	cmd := exec.CommandContext(ctx, cli.AzdPath, args...)
 	if cli.WorkingDirectory != "" {
 		cmd.Dir = cli.WorkingDirectory
 	}
@@ -125,12 +188,7 @@ func (cli *CLI) heartbeat(description string, done <-chan struct{}) {
 	}
 }
 
-func GetAzdLocation() string {
+func GetSourcePath() string {
 	_, b, _, _ := runtime.Caller(0)
-
-	if runtime.GOOS == "windows" {
-		return filepath.Join(filepath.Dir(b), "..", "..", "azd.exe")
-	} else {
-		return filepath.Join(filepath.Dir(b), "..", "..", "azd")
-	}
+	return filepath.Join(filepath.Dir(b), "..", "..")
 }

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -5,7 +5,6 @@
 package cli_test
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"embed"
@@ -381,21 +380,13 @@ func Test_CLI_ProjectIsNeeded(t *testing.T) {
 }
 
 func Test_CLI_NoDebugSpewWhenHelpPassedWithoutDebug(t *testing.T) {
-	stdErrBuf := bytes.Buffer{}
-
-	/* #nosec G204 - Subprocess launched with a potential tainted input or cmd arguments false positive */
-	cmd := osexec.Command(azdcli.GetAzdLocation(), "--help")
-	cmd.Stderr = &stdErrBuf
-
-	// Run the command and wait for it to complete, we don't expect any errors.
-	err := cmd.Start()
-	assert.NoError(t, err)
-
-	err = cmd.Wait()
-	assert.NoError(t, err)
+	cli := azdcli.NewCLI(t)
+	ctx := context.Background()
+	result, err := cli.RunCommand(ctx, "--help")
+	require.NoError(t, err)
 
 	// Ensure no output was written to stderr
-	assert.Equal(t, "", stdErrBuf.String(), "no output should be written to stderr when --help is passed")
+	assert.Equal(t, "", result.Stderr, "no output should be written to stderr when --help is passed")
 }
 
 //go:embed testdata/samples/*


### PR DESCRIPTION
Add logic to automatically invoke `go build` for local e2e tests. This is inspired by the Rust implementation of `assert_cmd::Command::cargo_bin`, where the CLI is automatically built if needed ([docs](https://rust-cli.github.io/book/tutorial/testing.html#testing-cli-applications-by-running-them)).