### PR TITLE
Retry `Rename` when it fails, on Windows.

### DIFF
--- a/cli/azd/pkg/osutil/rename_unix.go
+++ b/cli/azd/pkg/osutil/rename_unix.go
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build !windows
+// +build !windows
+
+package osutil
+
+import (
+	"context"
+	"os"
+)
+
+// Rename is like os.Rename in every way. The context is ignored.
+func Rename(ctx context.Context, old, new string) error {
+	return os.Rename(old, new)
+}

--- a/cli/azd/pkg/osutil/rename_windows.go
+++ b/cli/azd/pkg/osutil/rename_windows.go
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build windows
+// +build windows
+
+package osutil
+
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
+	"time"
+
+	"github.com/sethvargo/go-retry"
+	"golang.org/x/sys/windows"
+)
+
+// Rename is like os.Rename except it will retry the operation, up to 10 times, waiting a second between each retry when the
+// Rename fails due to what may be transient file system errors. This can help work around issues where the file may
+// temporary be opened by a virus scanner or some other process which prevents us from renaming the file.
+func Rename(ctx context.Context, old, new string) error {
+	return retry.Do(ctx, retry.WithMaxRetries(10, retry.NewConstant(1*time.Second)), func(ctx context.Context) error {
+		err := os.Rename(old, new)
+		if errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+			// If some other process has a open handle to the source file, Rename can fail with ERROR_SHARING_VIOLATION.
+			log.Printf("rename of %s to %s failed due to ERROR_SHARING_VIOLATION, allowing retry", old, new)
+			return retry.RetryableError(err)
+		} else if errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+			// If the target file has already exists and is in use, Rename can fail with ERROR_ACCESS_DENIED.
+			log.Printf("rename of %s to %s failed due to ERROR_ACCESS_DENIED, allowing retry", old, new)
+			return retry.RetryableError(err)
+		}
+		return err
+	})
+}

--- a/cli/azd/pkg/osutil/rename_windows_test.go
+++ b/cli/azd/pkg/osutil/rename_windows_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build windows
+// +build windows
+
+package osutil
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRename(t *testing.T) {
+	t.Run("Source In Use", func(t *testing.T) {
+
+		dir := t.TempDir()
+		file, err := os.Create(filepath.Join(dir, "old"))
+		assert.NoError(t, err)
+
+		// Wait for a moment before closing the file. This allows Rename to exercise the retry logic for a sharing violation
+		// since while we hold the file open, os.Rename will fail.
+		go func() {
+			time.Sleep(1 * time.Second)
+			file.Close()
+		}()
+
+		err = Rename(context.Background(), filepath.Join(dir, "old"), filepath.Join(dir, "new"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("Destination In Use", func(t *testing.T) {
+		dir := t.TempDir()
+		file, err := os.Create(filepath.Join(dir, "old"))
+		assert.NoError(t, err)
+		err = file.Close()
+		assert.NoError(t, err)
+
+		file, err = os.Create(filepath.Join(dir, "new"))
+		assert.NoError(t, err)
+
+		// Wait for a moment before closing the target. This allows Rename to exercise the retry logic for an access is
+		// denied error since we hold the file open, os.Rename will fail.
+
+		go func() {
+			time.Sleep(1 * time.Second)
+			file.Close()
+		}()
+
+		err = Rename(context.Background(), filepath.Join(dir, "old"), filepath.Join(dir, "new"))
+
+		assert.NoError(t, err)
+	})
+}

--- a/cli/azd/pkg/tools/bicep/bicep.go
+++ b/cli/azd/pkg/tools/bicep/bicep.go
@@ -218,7 +218,7 @@ func downloadBicep(ctx context.Context, transporter policy.Transporter, bicepVer
 		return err
 	}
 
-	if err := os.Rename(f.Name(), name); err != nil {
+	if err := osutil.Rename(ctx, f.Name(), name); err != nil {
 		return err
 	}
 

--- a/cli/azd/pkg/tools/github/github.go
+++ b/cli/azd/pkg/tools/github/github.go
@@ -552,7 +552,7 @@ func downloadGh(
 
 	// change file name from temporal name to the final name, as the download has completed
 	compressedFileName := filepath.Join(tmpPath, releaseName)
-	if err := os.Rename(compressedRelease.Name(), compressedFileName); err != nil {
+	if err := osutil.Rename(ctx, compressedRelease.Name(), compressedFileName); err != nil {
 		return err
 	}
 	defer func() {

--- a/cli/azd/pkg/tools/github/github_test.go
+++ b/cli/azd/pkg/tools/github/github_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
 	"github.com/stretchr/testify/require"
@@ -113,7 +114,7 @@ func TestNewGitHubCli(t *testing.T) {
 
 	mockExtract := func(src, dst string) (string, error) {
 		exp, _ := azdGithubCliPath()
-		_ = os.Rename(src, exp)
+		_ = osutil.Rename(context.Background(), src, exp)
 		return src, nil
 	}
 


### PR DESCRIPTION
I noticed recently we've been seen intermittent failures in CI on Windows in our integration tests that look like this:

```
creating provisioning manager: error creating infra provider: error creating provider for type 'bicep' : downloading bicep: rename C:\\Users\\cloudtest\\.azd\\bin\\bicep.exe.tmp4175873399 C:\\Users\\cloudtest\\.azd\\bin\\bicep.exe: Access is denied.
```

I suspect what is happening here is that in CI when we run our integration tests, we have multiple copies of `azd` running concurrently (one per integration test) that are all racing to download bicep (since there is no cached copy of the machine). Each process downloads bicep to a temporary file and then attempts to use os.Rename to move the intermediate file into the final location.

In cases where either the source or destination file are in use, this `os.Rename` can fail. There are two cases:

1. If the source file is in use (imagine that some transient process like a virus scanner has the file open), `os.Rename` with fail with `ERROR_SHARING_VIOLATION`.

2. If the destination file is in use (imagine that two processes are racing to download bicep, the first process wins and then starts running `bicep.exe` to compile a template and then the second process finishes its download operation and tries to do the `os.Rename` it will fail with `ERROR_ACCESS_DENIED` until the first process stops running `bicep.exe`.

This change introduces `osutil.Rename` which is like `os.Rename` except that on Windows it will retry on both `ERROR_ACCESS_DENIED` and `ERROR_SHARING_VIOLATION` for a little bit before giving up. This behavior is specific to Windows.

In practice I suspect that end users were unlikely to run into this issue (and of the two cases, (1) would be more likely, since (2) really manifests itself when multiple copies of `azd` are running concurrently, and `bicep.exe` needs to be acquired which seems less likely on end user machines) but this should help us in CI. Worst case, we spend a little longer on Windows in the doomed case trying to do `os.Rename` a few more times before giving up.