### PR TITLE
Fix maven tool dependencies

### DIFF
--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -126,6 +126,10 @@ type DeploymentResult struct {
 }
 
 func (d *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	if err := d.projectManager.Initialize(ctx, d.projectConfig); err != nil {
+		return nil, err
+	}
+
 	// Collect all the tools we will need to do the deployment and validate that
 	// the are installed. When a single project is being deployed, we need just
 	// the tools for that project, otherwise we need the tools from all project.
@@ -151,10 +155,6 @@ func (d *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 	var svcDeploymentResult *project.ServiceDeployResult
 	var deploymentResults []*project.ServiceDeployResult
-
-	if err := d.projectManager.Initialize(ctx, d.projectConfig); err != nil {
-		return nil, err
-	}
 
 	for _, svc := range d.projectConfig.Services {
 		// Skip this service if both cases are true:

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -382,6 +382,10 @@ func newEnvRefreshAction(
 }
 
 func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	if err := ef.projectManager.Initialize(ctx, ef.projectConfig); err != nil {
+		return nil, err
+	}
+
 	infraManager, err := provisioning.NewManager(
 		ctx,
 		ef.env,
@@ -415,10 +419,6 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 		if err != nil {
 			return nil, fmt.Errorf("writing deployment result in JSON format: %w", err)
 		}
-	}
-
-	if err = ef.projectManager.Initialize(ctx, ef.projectConfig); err != nil {
-		return nil, err
 	}
 
 	for _, svc := range ef.projectConfig.Services {


### PR DESCRIPTION
This fixes an issue where azd cannot find maven `mvn` external tools.  This ensures that the project is initialized before performing any tool checks.  The project init ensures the project path is set correctly within the maven project.