### PR TITLE
Restructuring specific command flags

### DIFF
--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -241,7 +241,7 @@ func (d *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 func getCmdDeployHelpDescription(*cobra.Command) string {
 	return generateCmdHelpDescription("Deploy application to Azure.", []string{
-		formatHelpNote(fmt.Sprintf("When no %s value is specified, all services in the 'azure.yaml'"+
+		formatHelpNote(fmt.Sprintf("When %s is not set, all services in the 'azure.yaml'"+
 			" file (found in the root of your project) are deployed.", output.WithHighLightFormat("<service>"))),
 		formatHelpNote("After the deployment is complete, the endpoint is printed. To start the service, select" +
 			" the endpoint or paste it in a browser."),

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -135,7 +135,7 @@ type DeploymentResult struct {
 
 func (d *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	if d.flags.serviceName != "" {
-		fmt.Fprint(
+		fmt.Println(
 			d.console.Handles().Stderr,
 			//nolint:Lll
 			output.WithWarningFormat("--service flag is no longer required. Simply run azd deploy <service> instead."))

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -47,7 +47,7 @@ func (d *deployFlags) bindNonCommon(
 		"Deploys a specific service (when the string is unspecified, all services that are listed in the "+azdcontext.ProjectFileName+" file are deployed).",
 	)
 	//deprecate:flag hide --service
-	local.MarkHidden("service")
+	_ = local.MarkHidden("service")
 	d.global = global
 }
 

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -121,10 +121,10 @@ func newInfraCreateAction(
 
 func (i *infraCreateAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	if i.flags.noProgress {
-		fmt.Fprint(
+		fmt.Fprintf(
 			i.console.Handles().Stderr,
 			//nolint:Lll
-			output.WithWarningFormat("--no-progress flag is deprecated and will be removed in the future."))
+			output.WithWarningFormat("--no-progress flag is deprecated and will be removed in the future.")+"\n")
 	}
 
 	// Command title

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -37,7 +37,7 @@ func (i *infraCreateFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCom
 func (i *infraCreateFlags) bindNonCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	local.BoolVar(&i.noProgress, "no-progress", false, "Suppresses progress information.")
 	//deprecate:Flag hide --no-progress
-	local.MarkHidden("no-progress")
+	_ = local.MarkHidden("no-progress")
 	i.global = global
 }
 

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -36,7 +36,8 @@ func (i *infraCreateFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCom
 
 func (i *infraCreateFlags) bindNonCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	local.BoolVar(&i.noProgress, "no-progress", false, "Suppresses progress information.")
-
+	//deprecate:Flag hide --no-progress
+	local.MarkHidden("no-progress")
 	i.global = global
 }
 
@@ -119,6 +120,13 @@ func newInfraCreateAction(
 }
 
 func (i *infraCreateAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	if i.flags.noProgress {
+		fmt.Fprint(
+			i.console.Handles().Stderr,
+			//nolint:Lll
+			output.WithWarningFormat("--no-progress flag is deprecated and will be removed."))
+	}
+
 	// Command title
 	i.console.MessageUxItem(ctx, &ux.MessageTitle{
 		Title:     "Provisioning Azure resources (azd provision)",

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -124,7 +124,7 @@ func (i *infraCreateAction) Run(ctx context.Context) (*actions.ActionResult, err
 		fmt.Fprint(
 			i.console.Handles().Stderr,
 			//nolint:Lll
-			output.WithWarningFormat("--no-progress flag is deprecated and will be removed."))
+			output.WithWarningFormat("--no-progress flag is deprecated and will be removed in the future."))
 	}
 
 	// Command title

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -51,15 +51,10 @@ type initFlags struct {
 	subscription   string
 	location       string
 	global         *internal.GlobalCommandOptions
-	*envFlag
+	envFlag
 }
 
 func (i *initFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
-	i.bindNonCommon(local, global)
-	i.bindCommon(local, global)
-}
-
-func (i *initFlags) bindNonCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	local.StringVarP(
 		&i.template.Name,
 		"template",
@@ -76,16 +71,9 @@ func (i *initFlags) bindNonCommon(local *pflag.FlagSet, global *internal.GlobalC
 		"Name or ID of an Azure subscription to use for the new environment",
 	)
 	local.StringVarP(&i.location, "location", "l", "", "Azure location for the new environment")
-	i.global = global
-}
-
-func (i *initFlags) bindCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
-	i.envFlag = &envFlag{}
 	i.envFlag.Bind(local, global)
-}
 
-func (i *initFlags) setCommon(envFlag *envFlag) {
-	i.envFlag = envFlag
+	i.global = global
 }
 
 type initAction struct {

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -59,7 +59,7 @@ func (i *initFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOpt
 	i.bindCommon(local, global)
 }
 
-func (i *initFlags) bindNonCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) []string {
+func (i *initFlags) bindNonCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	local.StringVarP(
 		&i.template.Name,
 		"template",
@@ -77,25 +77,6 @@ func (i *initFlags) bindNonCommon(local *pflag.FlagSet, global *internal.GlobalC
 	)
 	local.StringVarP(&i.location, "location", "l", "", "Azure location for the new environment")
 	i.global = global
-
-	return []string{"template", "branch", "subscription", "location"}
-}
-
-func (i *initFlags) flagsSet() []string {
-	flags := make([]string, 0, 4)
-	if i.template.Name != "" {
-		flags = append(flags, "--template/-t")
-	}
-	if i.templateBranch != "" {
-		flags = append(flags, "--branch/-b")
-	}
-	if i.subscription != "" {
-		flags = append(flags, "--subscription")
-	}
-	if i.location != "" {
-		flags = append(flags, "--location/-t")
-	}
-	return flags
 }
 
 func (i *initFlags) bindCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -59,7 +59,7 @@ func (i *initFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOpt
 	i.bindCommon(local, global)
 }
 
-func (i *initFlags) bindNonCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
+func (i *initFlags) bindNonCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) []string {
 	local.StringVarP(
 		&i.template.Name,
 		"template",
@@ -77,6 +77,25 @@ func (i *initFlags) bindNonCommon(local *pflag.FlagSet, global *internal.GlobalC
 	)
 	local.StringVarP(&i.location, "location", "l", "", "Azure location for the new environment")
 	i.global = global
+
+	return []string{"template", "branch", "subscription", "location"}
+}
+
+func (i *initFlags) flagsSet() []string {
+	flags := make([]string, 0, 4)
+	if i.template.Name != "" {
+		flags = append(flags, "--template/-t")
+	}
+	if i.templateBranch != "" {
+		flags = append(flags, "--branch/-b")
+	}
+	if i.subscription != "" {
+		flags = append(flags, "--subscription")
+	}
+	if i.location != "" {
+		flags = append(flags, "--location/-t")
+	}
+	return flags
 }
 
 func (i *initFlags) bindCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {

--- a/cli/azd/cmd/restore.go
+++ b/cli/azd/cmd/restore.go
@@ -95,7 +95,7 @@ func newRestoreAction(
 
 func (r *restoreAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	if r.flags.serviceName != "" {
-		fmt.Fprint(
+		fmt.Fprintln(
 			r.console.Handles().Stderr,
 			//nolint:Lll
 			output.WithWarningFormat("--service flag is no longer required. Simply run azd deploy <service> instead."))

--- a/cli/azd/cmd/restore.go
+++ b/cli/azd/cmd/restore.go
@@ -38,7 +38,7 @@ func (r *restoreFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommand
 		"Restores a specific service (when the string is unspecified, all services that are listed in the "+azdcontext.ProjectFileName+" file are restored).",
 	)
 	//deprecate:flag hide --service
-	local.MarkHidden("service")
+	_ = local.MarkHidden("service")
 }
 
 func newRestoreFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *restoreFlags {

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -222,7 +222,6 @@ func NewRootCmd(staticHelp bool, middlewareChain []*actions.MiddlewareRegistrati
 			DefaultFormat:  output.NoneFormat,
 			HelpOptions: actions.ActionHelpOptions{
 				Description: getCmdUpHelpDescription,
-				Footer:      getCmdUpHelpFooter,
 			},
 			GroupingOptions: actions.CommandGroupOptions{
 				RootLevelHelp: actions.CmdGroupManage,
@@ -300,15 +299,14 @@ func NewRootCmd(staticHelp bool, middlewareChain []*actions.MiddlewareRegistrati
 }
 
 func getCmdRootHelpFooter(cmd *cobra.Command) string {
-	return fmt.Sprintf("%s\n%s %s %s %s\n%s %s.\n    %s\n\n%s",
+	return fmt.Sprintf("%s\n%s\n\n%s\n\n%s",
 		output.WithBold(output.WithUnderline("Deploying a sample application")),
-		"Initialize, provision, and deploy a template application by running the",
-		output.WithHighLightFormat("azd up --template"),
-		output.WithWarningFormat("[%s]", "template name"),
-		"command in an empty directory.",
-		output.WithGrayFormat("To view available templates run `azd template list` or visit:"),
-		output.WithLinkFormat("https://azure.github.io/awesome-azd"),
-		output.WithHighLightFormat("azd up --template todo-nodejs-mongo"),
+		"Initialize from a sample application by running the "+
+			output.WithHighLightFormat("azd init --template ")+
+			output.WithWarningFormat("[%s]", "template name")+" command in an empty directory."+
+			"Then, run "+output.WithHighLightFormat("azd up")+" to get the application up-and-running in Azure.",
+		output.WithGrayFormat("To view available templates run `azd template list` or visit: ")+
+			output.WithLinkFormat("https://azure.github.io/awesome-azd"),
 		getCmdHelpDefaultFooter(cmd),
 	)
 }

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -227,7 +227,6 @@ func NewRootCmd(staticHelp bool, middlewareChain []*actions.MiddlewareRegistrati
 				RootLevelHelp: actions.CmdGroupManage,
 			},
 		}).
-		AddFlagCompletion("template", templateNameCompletion).
 		UseMiddleware("hooks", middleware.NewHooksMiddleware)
 
 	root.Add("monitor", &actions.ActionDescriptorOptions{
@@ -299,12 +298,12 @@ func NewRootCmd(staticHelp bool, middlewareChain []*actions.MiddlewareRegistrati
 }
 
 func getCmdRootHelpFooter(cmd *cobra.Command) string {
-	return fmt.Sprintf("%s\n%s\n\n%s\n\n%s",
+	return fmt.Sprintf("%s\n%s\n%s\n\n%s\n\n%s",
 		output.WithBold(output.WithUnderline("Deploying a sample application")),
 		"Initialize from a sample application by running the "+
 			output.WithHighLightFormat("azd init --template ")+
-			output.WithWarningFormat("[%s]", "template name")+" command in an empty directory."+
-			"Then, run "+output.WithHighLightFormat("azd up")+" to get the application up-and-running in Azure.",
+			output.WithWarningFormat("[%s]", "template name")+" command in an empty directory.",
+		"Then, run "+output.WithHighLightFormat("azd up")+" to get the application up-and-running in Azure.",
 		output.WithGrayFormat("To view available templates run `azd template list` or visit: ")+
 			output.WithLinkFormat("https://azure.github.io/awesome-azd"),
 		getCmdHelpDefaultFooter(cmd),

--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -187,9 +187,8 @@ func getCmdTemplateHelpDescription(*cobra.Command) string {
 			formatHelpNote(fmt.Sprintf("To view all available sample templates, including those submitted by the azd"+
 				" community visit: %s.",
 				output.WithLinkFormat("https://azure.github.io/awesome-azd"))),
-			formatHelpNote(fmt.Sprintf("Running %s or %s without a template will prompt you to start with an empty"+
+			formatHelpNote(fmt.Sprintf("Running %s without a template will prompt you to start with an empty"+
 				" template or select from our curated list of samples.",
-				output.WithHighLightFormat("azd up"),
 				output.WithHighLightFormat("azd init"))),
 		})
 }

--- a/cli/azd/cmd/testdata/TestUsage-azd-config-get.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-config-get.snap
@@ -5,8 +5,7 @@ Usage
   azd config get <path> [flags]
 
 Flags
-    -h, --help          	: Gets help for get.
-    -o, --output string 	: The output format (the supported formats are json).
+    -h, --help 	: Gets help for get.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd-config-list.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-config-list.snap
@@ -5,8 +5,7 @@ Usage
   azd config list [flags]
 
 Flags
-    -h, --help          	: Gets help for list.
-    -o, --output string 	: The output format (the supported formats are json).
+    -h, --help 	: Gets help for list.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd-deploy.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-deploy.snap
@@ -1,17 +1,15 @@
 
 Deploy application to Azure.
 
-  • When no --service value is specified, all services in the 'azure.yaml' file (found in the root of your project) are deployed.
+  • When <service> is not set, all services in the 'azure.yaml' file (found in the root of your project) are deployed.
   • After the deployment is complete, the endpoint is printed. To start the service, select the endpoint or paste it in a browser.
 
 Usage
-  azd deploy [flags]
+  azd deploy <service> [flags]
 
 Flags
     -e, --environment string 	: The name of the environment to use.
     -h, --help               	: Gets help for deploy.
-    -o, --output string      	: The output format (the supported formats are json, none).
-        --service string     	: Deploys a specific service (when the string is unspecified, all services that are listed in the azure.yaml file are deployed).
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
@@ -20,10 +18,10 @@ Global Flags
 
 Examples
   Deploy all application API services to Azure.
-    azd deploy --service api
+    azd deploy api
 
   Deploy all application web services to Azure.
-    azd deploy --service web
+    azd deploy web
 
   Reviews all code and services in your azure.yaml file and deploys to Azure.
     azd deploy

--- a/cli/azd/cmd/testdata/TestUsage-azd-down.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-down.snap
@@ -8,7 +8,6 @@ Flags
     -e, --environment string 	: The name of the environment to use.
         --force              	: Does not require confirmation before it deletes resources.
     -h, --help               	: Gets help for down.
-    -o, --output string      	: The output format (the supported formats are json, none).
         --purge              	: Does not require confirmation before it permanently deletes resources that are soft-deleted by default (for example, key vaults).
 
 Global Flags

--- a/cli/azd/cmd/testdata/TestUsage-azd-env-get-values.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env-get-values.snap
@@ -7,7 +7,6 @@ Usage
 Flags
     -e, --environment string 	: The name of the environment to use.
     -h, --help               	: Gets help for get-values.
-    -o, --output string      	: The output format (the supported formats are json, dotenv).
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd-env-list.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env-list.snap
@@ -5,8 +5,7 @@ Usage
   azd env list [flags]
 
 Flags
-    -h, --help          	: Gets help for list.
-    -o, --output string 	: The output format (the supported formats are json, table).
+    -h, --help 	: Gets help for list.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd-env-refresh.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env-refresh.snap
@@ -7,7 +7,6 @@ Usage
 Flags
     -e, --environment string 	: The name of the environment to use.
     -h, --help               	: Gets help for refresh.
-    -o, --output string      	: The output format (the supported formats are json, none).
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd-infra-create.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-infra-create.snap
@@ -7,8 +7,6 @@ Usage
 Flags
     -e, --environment string 	: The name of the environment to use.
     -h, --help               	: Gets help for create.
-        --no-progress        	: Suppresses progress information.
-    -o, --output string      	: The output format (the supported formats are json, none).
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd-infra-delete.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-infra-delete.snap
@@ -8,7 +8,6 @@ Flags
     -e, --environment string 	: The name of the environment to use.
         --force              	: Does not require confirmation before it deletes resources.
     -h, --help               	: Gets help for delete.
-    -o, --output string      	: The output format (the supported formats are json, none).
         --purge              	: Does not require confirmation before it permanently deletes resources that are soft-deleted by default (for example, key vaults).
 
 Global Flags

--- a/cli/azd/cmd/testdata/TestUsage-azd-login.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-login.snap
@@ -12,7 +12,6 @@ Flags
         --federated-credential string          	: The federated token for the service principal to authenticate with. Set to the empty string to read the value from the console.
         --federated-credential-provider string 	: The provider to use to acquire a federated token to authenticate with.
     -h, --help                                 	: Gets help for login.
-    -o, --output string                        	: The output format (the supported formats are json, none).
         --redirect-port int                    	: Choose the port to be used as part of the redirect URI during interactive login.
         --tenant-id string                     	: The tenant id or domain name to authenticate with.
         --use-device-code                      	: When true, log in by using a device code instead of a browser.

--- a/cli/azd/cmd/testdata/TestUsage-azd-provision.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-provision.snap
@@ -13,8 +13,6 @@ Usage
 Flags
     -e, --environment string 	: The name of the environment to use.
     -h, --help               	: Gets help for provision.
-        --no-progress        	: Suppresses progress information.
-    -o, --output string      	: The output format (the supported formats are json, none).
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd-restore.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-restore.snap
@@ -5,12 +5,11 @@ Restore application dependencies.
   • For the best local rn and debug experience, go to https://aka.ms/azure-dev/vscode to learn how to use the Visual Studio Code extension.
 
 Usage
-  azd restore [flags]
+  azd restore <service> [flags]
 
 Flags
     -e, --environment string 	: The name of the environment to use.
     -h, --help               	: Gets help for restore.
-        --service string     	: Restores a specific service (when the string is unspecified, all services that are listed in the azure.yaml file are restored).
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
@@ -19,7 +18,7 @@ Global Flags
 
 Examples
   Downloads and installs a specific application service dependency, Individual services are listed in your azure.yaml file.
-    azd restore --service [Service name]
+    azd restore <service> [Service name]
 
   Downloads and installs all application dependencies.
     azd restore

--- a/cli/azd/cmd/testdata/TestUsage-azd-template-list.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-template-list.snap
@@ -5,8 +5,7 @@ Usage
   azd template list [flags]
 
 Flags
-    -h, --help          	: Gets help for list.
-    -o, --output string 	: The output format (the supported formats are json, table).
+    -h, --help 	: Gets help for list.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd-template-show.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-template-show.snap
@@ -5,8 +5,7 @@ Usage
   azd template show <template> [flags]
 
 Flags
-    -h, --help          	: Gets help for show.
-    -o, --output string 	: The output format (the supported formats are json, table).
+    -h, --help 	: Gets help for show.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd-template.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-template.snap
@@ -3,7 +3,7 @@ View details of your current template or browse a list of curated sample templat
 
   • The azd CLI includes a curated list of sample templates viewable by running azd template list.
   • To view all available sample templates, including those submitted by the azd community visit: https://azure.github.io/awesome-azd.
-  • Running azd up or azd init without a template will prompt you to start with an empty template or select from our curated list of samples.
+  • Running azd init without a template will prompt you to start with an empty template or select from our curated list of samples.
 
 Usage
   azd template [command]

--- a/cli/azd/cmd/testdata/TestUsage-azd-up.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-up.snap
@@ -1,8 +1,5 @@
 
-Executes the azd init, azd provision and azd deploy commands in a single step.
-
-  • Running azd up without a template will prompt you to start with an empty template or select from a curated list of presets.
-  • To view all currently available sample templates visit: azd up.
+Executes the azd provision and azd deploy commands in a single step.
 
 Usage
   azd up [flags]

--- a/cli/azd/cmd/testdata/TestUsage-azd-up.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-up.snap
@@ -8,23 +8,14 @@ Usage
   azd up [flags]
 
 Flags
-    -b, --branch string       	: The template branch to initialize from.
-    -e, --environment string  	: The name of the environment to use.
-    -h, --help                	: Gets help for up.
-    -l, --location string     	: Azure location for the new environment
-        --no-progress         	: Suppresses progress information.
-    -o, --output string       	: The output format (the supported formats are json, none).
-        --service string      	: Deploys a specific service (when the string is unspecified, all services that are listed in the azure.yaml file are deployed).
-        --subscription string 	: Name or ID of an Azure subscription to use for the new environment
-    -t, --template string     	: The template to use when you initialize the project. You can use Full URI, <owner>/<repository>, or <repository> if it's part of the azure-samples organization.
+    -e, --environment string 	: The name of the environment to use.
+    -h, --help               	: Gets help for up.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
-Examples
-  Initialize, provision and deploy a template to Azure from a GitHub repo.
-    azd up --template [GitHub repo URL]
+Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.
 
 

--- a/cli/azd/cmd/testdata/TestUsage-azd-version.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-version.snap
@@ -5,8 +5,7 @@ Usage
   azd version [flags]
 
 Flags
-    -h, --help          	: Gets help for version.
-    -o, --output string 	: The output format (the supported formats are json, none).
+    -h, --help 	: Gets help for version.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd.snap
@@ -37,9 +37,10 @@ Flags
 Use azd [command] --help to view examples and more information about a specific command.
 
 Deploying a sample application
-Initialize, provision, and deploy a template application by running the azd up --template [template name] command in an empty directory.
-To view available templates run `azd template list` or visit: https://azure.github.io/awesome-azd.
-    azd up --template todo-nodejs-mongo
+Initialize from a sample application by running the azd init --template [template name] command in an empty directory.
+Then, run azd up to get the application up-and-running in Azure.
+
+To view available templates run `azd template list` or visit: https://azure.github.io/awesome-azd
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.
 

--- a/cli/azd/cmd/testdata/TestUsage-azd.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd.snap
@@ -19,7 +19,7 @@ Commands
     env      	: Manage environments.
     infra    	: Manage your Azure infrastructure.
     provision	: Provision the Azure resources for an application.
-    up       	: Initialize application, provision Azure resources, and deploy your project with a single command.
+    up       	: Provision Azure resources, and deploy your project with a single command.
 
   Monitor, test and release your app
     monitor  	: Monitor a deployed application.

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -122,5 +122,5 @@ func getCmdUpHelpDescription(c *cobra.Command) string {
 	return generateCmdHelpDescription(
 		fmt.Sprintf("Executes the %s and %s commands in a single step.",
 			output.WithHighLightFormat("azd provision"),
-			output.WithHighLightFormat("azd deploy")), getCmdHelpDescriptionNoteForInit(c))
+			output.WithHighLightFormat("azd deploy")), nil)
 }

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -104,8 +104,8 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	}
 
 	deployAction.flags = &u.flags.deployFlags
+	// move flag to args to avoid extra deprecation flag warning
 	if deployAction.flags.serviceName != "" {
-		// move flag to args to avoid extra deprecation flag warning
 		deployAction.args = []string{deployAction.flags.serviceName}
 		deployAction.flags.serviceName = ""
 	}

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -40,7 +40,7 @@ func newUpFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *upFl
 func newUpCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "up",
-		Short: "Initialize application, provision Azure resources, and deploy your project with a single command.",
+		Short: "Provision Azure resources, and deploy your project with a single command.",
 	}
 }
 
@@ -70,7 +70,7 @@ func newUpAction(
 
 func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	if u.flags.infraCreateFlags.noProgress {
-		fmt.Fprint(
+		fmt.Fprintln(
 			u.console.Handles().Stderr,
 			output.WithWarningFormat("The --no-progress flag is deprecated and will be removed in the future."))
 		// this flag actually isn't used by the provision command, we set it to false to hide the extra warning
@@ -78,7 +78,7 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	}
 
 	if u.flags.deployFlags.serviceName != "" {
-		fmt.Fprint(
+		fmt.Fprintln(
 			u.console.Handles().Stderr,
 			output.WithWarningFormat("The --service flag is deprecated and will be removed in the future."))
 	}
@@ -120,8 +120,7 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 func getCmdUpHelpDescription(c *cobra.Command) string {
 	return generateCmdHelpDescription(
-		fmt.Sprintf("Executes the %s, %s and %s commands in a single step.",
-			output.WithHighLightFormat("azd init"),
+		fmt.Sprintf("Executes the %s and %s commands in a single step.",
 			output.WithHighLightFormat("azd provision"),
 			output.WithHighLightFormat("azd deploy")), getCmdHelpDescriptionNoteForInit(c))
 }

--- a/cli/azd/cmd/usage_test.go
+++ b/cli/azd/cmd/usage_test.go
@@ -19,6 +19,8 @@ import (
 // For Pwsh,
 // $env:UPDATE_SNAPSHOTS='true'; go test ./cmd; $env:UPDATE_SNAPSHOTS=$null
 func TestUsage(t *testing.T) {
+	// disable rich formatting output
+	t.Setenv("TERM", "dumb")
 	root := NewRootCmd(false, nil)
 
 	usageSnapshot(t, root)

--- a/cli/azd/pkg/output/parameter.go
+++ b/cli/azd/pkg/output/parameter.go
@@ -25,7 +25,7 @@ func AddOutputFlag(f *pflag.FlagSet, s *string, supportedFormats []Format, defau
 	description := fmt.Sprintf("The output format (the supported formats are %s).", strings.Join(formatNames, ", "))
 	f.StringVarP(s, outputFlagName, "o", string(defaultFormat), description)
 	//preview:flag hide --output
-	f.MarkHidden(outputFlagName)
+	_ = f.MarkHidden(outputFlagName)
 
 	// Only error that can occur is "flag not found", which is not possible given we just added the flag on the previous line
 	_ = f.SetAnnotation(outputFlagName, supportedFormatterAnnotation, formatNames)

--- a/cli/azd/pkg/output/parameter.go
+++ b/cli/azd/pkg/output/parameter.go
@@ -24,6 +24,8 @@ func AddOutputFlag(f *pflag.FlagSet, s *string, supportedFormats []Format, defau
 
 	description := fmt.Sprintf("The output format (the supported formats are %s).", strings.Join(formatNames, ", "))
 	f.StringVarP(s, outputFlagName, "o", string(defaultFormat), description)
+	//preview:flag hide --output
+	f.MarkHidden(outputFlagName)
 
 	// Only error that can occur is "flag not found", which is not possible given we just added the flag on the previous line
 	_ = f.SetAnnotation(outputFlagName, supportedFormatterAnnotation, formatNames)

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -272,7 +272,7 @@ func Test_CLI_InfraCreateAndDeleteUpperCase(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// test for azd deploy, azd deploy --service
+// test for azd deploy, azd deploy <service>
 func Test_CLI_DeployInvalidName(t *testing.T) {
 	// running this test in parallel is ok as it uses a t.TempDir()
 	t.Parallel()
@@ -295,7 +295,7 @@ func Test_CLI_DeployInvalidName(t *testing.T) {
 	_, err = cli.RunCommandWithStdIn(ctx, stdinForTests(envName), "init")
 	require.NoError(t, err)
 
-	_, err = cli.RunCommand(ctx, "deploy", "--service", "badServiceName")
+	_, err = cli.RunCommand(ctx, "deploy", "badServiceName")
 	require.Error(t, err)
 }
 

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -305,7 +305,9 @@ func Test_CLI_ProjectIsNeeded(t *testing.T) {
 		args          []string
 		errorToStdOut bool
 	}{
+		{command: "provision"},
 		{command: "deploy"},
+		{command: "up"},
 		{command: "down"},
 		{command: "env get-values"},
 		{command: "env list"},
@@ -317,7 +319,6 @@ func Test_CLI_ProjectIsNeeded(t *testing.T) {
 		{command: "infra delete"},
 		{command: "monitor"},
 		{command: "pipeline config"},
-		{command: "provision"},
 		{command: "restore"},
 	}
 

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -307,7 +307,7 @@ func Test_CLI_ProjectIsNeeded(t *testing.T) {
 	}{
 		{command: "provision"},
 		{command: "deploy"},
-		{command: "up"},
+		{command: "up", errorToStdOut: true},
 		{command: "down"},
 		{command: "env get-values"},
 		{command: "env list"},

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -133,7 +133,7 @@ func Test_CLI_Telemetry_UsageData_EnvProjectLoad(t *testing.T) {
 	_, err = cli.RunCommandWithStdIn(
 		ctx,
 		stdinForTests(envName),
-		"restore", "--service", "csharpapptest",
+		"restore", "csharpapptest",
 		"--trace-log-file", traceFilePath)
 	require.NoError(t, err)
 

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -185,10 +185,10 @@ func Test_CLI_Telemetry_UsageData_EnvProjectLoad(t *testing.T) {
 			require.ElementsMatch(t, m[fields.ProjectServiceLanguagesKey], languages)
 
 			require.Contains(t, m, fields.CmdFlags)
-			require.ElementsMatch(t, m[fields.CmdFlags], []string{"service", "trace-log-file"})
+			require.ElementsMatch(t, m[fields.CmdFlags], []string{"trace-log-file"})
 
 			require.Contains(t, m, fields.CmdArgsCount)
-			require.Equal(t, float64(0), m[fields.CmdArgsCount])
+			require.Equal(t, float64(1), m[fields.CmdArgsCount])
 		}
 	}
 	require.True(t, usageCmdFound)


### PR DESCRIPTION
Hide specific flags that are being deprecated or hidden for preview. Issue warning messages for deprecated usage.

Changes:
- Remove `azd init` from `azd up` (flags and execution)
- `azd deploy` and `azd restore` now accepts a positional arg. `azd deploy <web>` instead of `azd deploy --service <web>`.
- Hide `--no-progress` flag from `azd provision` and `azd up`
- Hide `--output` flag from all commands

Fixes: https://github.com/Azure/azure-dev-pr/issues/1495