### PR TITLE
Fix serialization for slice attributes in telemetry

### DIFF
--- a/cli/azd/internal/telemetry/appinsights-exporter/span_to_envelope.go
+++ b/cli/azd/internal/telemetry/appinsights-exporter/span_to_envelope.go
@@ -122,7 +122,7 @@ func SetAttributeAsPropertyOrMeasurement(
 	case attribute.FLOAT64:
 		measurements[string(kv.Key)] = kv.Value.AsFloat64()
 	case attribute.BOOLSLICE, attribute.INT64SLICE, attribute.FLOAT64SLICE, attribute.STRINGSLICE:
-		arrayJson, err := json.Marshal(kv.Value)
+		arrayJson, err := json.Marshal(kv.Value.AsInterface())
 		if err != nil {
 			diagLog.Printf("Could not serialize slice of type '%s' as JSON array: %s", kv.Value.Type(), err.Error())
 			return

--- a/cli/azd/internal/telemetry/appinsights-exporter/span_to_envelope_test.go
+++ b/cli/azd/internal/telemetry/appinsights-exporter/span_to_envelope_test.go
@@ -150,7 +150,7 @@ func assertAttributeInPropertiesOrMeasurement(
 		assert.Contains(t, measurements, string(attrib.Key))
 		assert.Equal(t, attrib.Value.AsFloat64(), measurements[string(attrib.Key)])
 	case attribute.BOOLSLICE, attribute.INT64SLICE, attribute.FLOAT64SLICE, attribute.STRINGSLICE:
-		val, err := json.Marshal(attrib.Value)
+		val, err := json.Marshal(attrib.Value.AsInterface())
 		if err != nil {
 			assert.Fail(t, fmt.Sprintf("value cannot be marshaled to JSON: %s", err.Error()))
 		}


### PR DESCRIPTION
Fix serialization for slice-attributes in our telemetry emission pipeline. Recent prerelease changes have only started emitting slice attributes, thus not a concern for existing data.

In our telemetry pipeline, we currently serialize a slice attribute as `{"Type":"STRINGSLICE","Value":["cwd","force","purge"]}`. This is because `attribute.Value` from otel implements a custom `json.Marshaler` that attaches the type information. The type makes it harder to work with since we don't need strong-typing here to consume telemetry.

This fix changes the serialization to `["cwd","force","purge"]`.