### PR TITLE
Ensures that docker init calls source framework init

### DIFF
--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -57,7 +57,7 @@ func (p *dockerProject) RequiredExternalTools(context.Context) []tools.ExternalT
 
 // Initializes the docker project
 func (p *dockerProject) Initialize(ctx context.Context, serviceConfig *ServiceConfig) error {
-	return nil
+	return p.framework.Initialize(ctx, serviceConfig)
 }
 
 // Sets the inner framework service used for restore and build command


### PR DESCRIPTION
Fixes issue where container based apps that use the docker framework service are not initializing the source framework which was causing build paths to not be set for Maven java projects.