### PR TITLE
Remove `azd login` references

### DIFF
--- a/cli/azd/cmd/auth_login.go
+++ b/cli/azd/cmd/auth_login.go
@@ -204,6 +204,15 @@ func newLoginAction(
 }
 
 func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	if la.annotations[loginCmdParentAnnotation] == "" {
+		fmt.Fprintln(
+			la.console.Handles().Stderr,
+			//nolint:lll
+			output.WithWarningFormat(
+				"WARNING: `azd login` has been deprecated and will be removed in a future release. Please use `azd auth login` instead."),
+		)
+	}
+
 	if !la.flags.onlyCheckStatus {
 		if err := la.accountSubManager.ClearSubscriptions(ctx); err != nil {
 			log.Printf("failed clearing subscriptions: %v", err)
@@ -268,7 +277,7 @@ func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		if res.Status == contracts.LoginStatusSuccess {
 			fmt.Fprintln(la.console.Handles().Stdout, "Logged in to Azure.")
 		} else {
-			fmt.Fprintln(la.console.Handles().Stdout, "Not logged in, run `azd login` to login to Azure.")
+			fmt.Fprintln(la.console.Handles().Stdout, "Not logged in, run `azd auth login` to login to Azure.")
 		}
 
 		return nil, nil

--- a/cli/azd/cmd/auth_logout.go
+++ b/cli/azd/cmd/auth_logout.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
@@ -53,6 +54,15 @@ func newLogoutAction(
 }
 
 func (la *logoutAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	if la.annotations[loginCmdParentAnnotation] == "" {
+		fmt.Fprintln(
+			la.console.Handles().Stderr,
+			//nolint:lll
+			output.WithWarningFormat(
+				"WARNING: `azd logout` has been deprecated and will be removed in a future release. Please use `azd auth logout` instead."),
+		)
+	}
+
 	err := la.authManager.Logout(ctx)
 	if err != nil {
 		return nil, err

--- a/cli/azd/pkg/account/subscriptions_manager.go
+++ b/cli/azd/pkg/account/subscriptions_manager.go
@@ -122,9 +122,9 @@ func (m *SubscriptionsManager) LookupTenant(ctx context.Context, subscriptionId 
 
 	return "", fmt.Errorf(
 		"failed to resolve user access to subscription with ID '%s'. "+
-			"If you recently gained access to this subscription, run `azd login` again to reload subscriptions.\n"+
+			"If you recently gained access to this subscription, run `azd auth login` again to reload subscriptions.\n"+
 			"Otherwise, visit this subscription in Azure Portal using the browser, "+
-			"then run `azd login` ",
+			"then run `azd auth login` ",
 		subscriptionId)
 }
 
@@ -212,7 +212,7 @@ func (m *SubscriptionsManager) ListSubscriptions(ctx context.Context) ([]Subscri
 
 					err = fmt.Errorf(
 						"%s requires Multi-Factor Authentication (MFA). "+
-							"To authenticate, login with `azd login --tenant-id %s`",
+							"To authenticate, login with `azd auth login --tenant-id %s`",
 						name,
 						idOrDomain)
 				} else {

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -109,7 +109,7 @@ func NewManager(configManager config.UserConfigManager) (*Manager, error) {
 	}, nil
 }
 
-var ErrNoCurrentUser = errors.New("not logged in, run `azd login` to login")
+var ErrNoCurrentUser = errors.New("not logged in, run `azd auth login` to login")
 
 // EnsureLoggedInCredential uses the credential's GetToken method to ensure an access token can be fetched. If this fails,
 // nil, ErrNoCurrentUser is returned. On success, the token we fetched is returned.
@@ -194,7 +194,7 @@ func (m *Manager) CredentialForCurrentUser(
 		}
 
 		// by default we used the stored tenant (i.e. the one provided with the tenant id parameter when a user ran
-		// `azd login`), but we allow an override using the options bag, when
+		// `azd auth login`), but we allow an override using the options bag, when
 		// TenantID is non-empty and PreferFallbackTenant is not true.
 		tenantID := *currentUser.TenantID
 

--- a/cli/azd/pkg/contracts/login.go
+++ b/cli/azd/pkg/contracts/login.go
@@ -17,7 +17,7 @@ const (
 	LoginStatusUnauthenticated LoginStatus = "unauthenticated"
 )
 
-// LoginResult is the contract for the output of `azd login`.
+// LoginResult is the contract for the output of `azd auth login`.
 type LoginResult struct {
 	// The result of checking for a valid access token.
 	Status LoginStatus `json:"status"`

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -19,8 +19,8 @@ import (
 )
 
 var (
-	ErrAzCliNotLoggedIn         = errors.New("cli is not logged in. Try running \"azd login\" to fix")
-	ErrAzCliRefreshTokenExpired = errors.New("refresh token has expired. Try running \"azd login\" to fix")
+	ErrAzCliNotLoggedIn         = errors.New("cli is not logged in. Try running \"az login\" to fix")
+	ErrAzCliRefreshTokenExpired = errors.New("refresh token has expired. Try running \"az login\" to fix")
 	ErrClientAssertionExpired   = errors.New("client assertion expired")
 	ErrDeploymentNotFound       = errors.New("deployment not found")
 	ErrNoConfigurationValue     = errors.New("no value configured")

--- a/cli/azd/test/functional/env_test.go
+++ b/cli/azd/test/functional/env_test.go
@@ -37,7 +37,7 @@ func Test_CLI_EnvCommandsWorkWhenLoggedOut(t *testing.T) {
 	t.Setenv("AZD_CONFIG_DIR", configDir)
 
 	// check to make sure we are logged out as expected.
-	res, err := cli.RunCommand(ctx, "login", "--check-status", "--output", "json")
+	res, err := cli.RunCommand(ctx, "auth", "login", "--check-status", "--output", "json")
 	require.NoError(t, err)
 
 	var lr contracts.LoginResult

--- a/cli/azd/test/functional/initialize_test.go
+++ b/cli/azd/test/functional/initialize_test.go
@@ -51,7 +51,7 @@ func Test_CommandsAndActions_Initialize(t *testing.T) {
 	err = env.Save()
 	require.NoError(t, err)
 
-	// Also requires that the user is logged in. This is automatically done in CI. Locally, `azd login` is required.
+	// Also requires that the user is logged in. This is automatically done in CI. Locally, `azd auth login` is required.
 
 	// Creates the azd root command with a "Skip" middleware that will skip the invocation
 	// of the underlying command / actions

--- a/eng/pipelines/templates/steps/template-test-run-job.yml
+++ b/eng/pipelines/templates/steps/template-test-run-job.yml
@@ -101,7 +101,7 @@ steps:
           subFolder: "$(Build.SourcesDirectory)/temp"
           runCmd: |
               # Login
-              azd login \
+              azd auth login \
                 --client-id "$(arm-client-id)" \
                 --client-secret "$(arm-client-secret)" \
                 --tenant-id "$(arm-tenant-id)"

--- a/templates/common/.github/workflows/bicep/azure-dev.yml
+++ b/templates/common/.github/workflows/bicep/azure-dev.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Log in with Azure (Federated Credentials)
         if: ${{ env.AZURE_CLIENT_ID != '' }}
         run: |
-          azd login `
+          azd auth login `
             --client-id "$Env:AZURE_CLIENT_ID" `
             --federated-credential-provider "github" `
             --tenant-id "$Env:AZURE_TENANT_ID"
@@ -39,7 +39,7 @@ jobs:
           $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;
           Write-Host "::add-mask::$($info.clientSecret)"
 
-          azd login `
+          azd auth login `
             --client-id "$($info.clientId)" `
             --client-secret "$($info.clientSecret)" `
             --tenant-id "$($info.tenantId)"

--- a/templates/common/.github/workflows/terraform/azure-dev.yml
+++ b/templates/common/.github/workflows/terraform/azure-dev.yml
@@ -19,7 +19,7 @@ jobs:
           $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;
           Write-Host "::add-mask::$($info.clientSecret)"
 
-          azd login `
+          azd auth login `
             --client-id "$($info.clientId)" `
             --client-secret "$($info.clientSecret)" `
             --tenant-id "$($info.tenantId)"


### PR DESCRIPTION
Remove `azd login` references. Emit warning message when `azd login` and `azd logout` is used. 

There are no `azd logout` references.