### PR TITLE
Disable telemetry during MSI test

### DIFF
--- a/cli/installer/windows/test-win-msi.ps1
+++ b/cli/installer/windows/test-win-msi.ps1
@@ -40,11 +40,13 @@ $originalPath = $regKey.GetValue( `
     [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames `
 )
 
+Write-Host "Starting install..."
 $process = Start-Process $MSIEXEC `
     -ArgumentList "/i", $MsiPath, "/qn", $additionalParameters `
     -PassThru `
     -Wait
 assertSuccessfulExecution "Install failed. Last exit code: $($process.ExitCode)" $process
+Write-Host "Install finished"
 
 $currentPath = $regKey.GetValue( `
     'PATH', `
@@ -60,14 +62,18 @@ if (!$currentPath.Contains($expectedPathEntry)) {
   exit 1
 }
 
+Write-Host "Running azd version..."
 & $installFolder/azd version
 assertSuccessfulExecution "Could not execute 'azd version'"
+Write-Host "Running azd version finished"
 
+Write-Host "Starting uninstall..."
 $process = Start-Process $MSIEXEC `
     -ArgumentList "/x", $MsiPath, "/qn" `
     -PassThru `
     -Wait
 assertSuccessfulExecution "Uninstall failed. Exit code: $($process.ExitCode)" $process
+Write-Host "Uninstall finished" 
 
 $currentPath = $regKey.GetValue( `
     'PATH', `

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -609,6 +609,8 @@ stages:
       - job: Verify_MSI
         dependsOn: Compress_For_Hosting
         pool: azsdk-pool-mms-win-2022-general
+        variables: 
+          AZURE_DEV_COLLECT_TELEMETRY: no
         strategy:
           matrix:
             PerUser:


### PR DESCRIPTION
Prevents race conditions which could lock up azd.exe and prevent a clean uninstall.