### PR TITLE
Deploy from existing package

### DIFF
--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -30,6 +30,7 @@ import (
 type deployFlags struct {
 	serviceName string
 	all         bool
+	fromPackage string
 	global      *internal.GlobalCommandOptions
 	*envFlag
 }
@@ -42,6 +43,12 @@ func (d *deployFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandO
 func (d *deployFlags) bindNonCommon(
 	local *pflag.FlagSet,
 	global *internal.GlobalCommandOptions) {
+	local.StringVar(
+		&d.fromPackage,
+		"from-package",
+		"",
+		"Deploys the application from an existing package file.",
+	)
 	local.StringVar(
 		&d.serviceName,
 		"service",
@@ -158,18 +165,21 @@ func (da *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 		targetServiceName = da.args[0]
 	}
 
-	packageAction, err := da.packageActionInitializer()
-	if err != nil {
-		return nil, err
-	}
+	// Only run package action if --from-package is specified
+	if da.flags.fromPackage == "" {
+		packageAction, err := da.packageActionInitializer()
+		if err != nil {
+			return nil, err
+		}
 
-	packageAction.flags.all = da.flags.all
-	packageAction.args = []string{targetServiceName}
+		packageAction.flags.all = da.flags.all
+		packageAction.args = []string{targetServiceName}
 
-	packageOptions := &middleware.Options{CommandPath: "package"}
-	_, err = da.middlewareRunner.RunChildAction(ctx, packageOptions, packageAction)
-	if err != nil {
-		return nil, err
+		packageOptions := &middleware.Options{CommandPath: "package"}
+		_, err = da.middlewareRunner.RunChildAction(ctx, packageOptions, packageAction)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Command title
@@ -185,7 +195,7 @@ func (da *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 		)
 	}
 
-	targetServiceName, err = getTargetServiceName(
+	targetServiceName, err := getTargetServiceName(
 		ctx,
 		da.projectManager,
 		da.projectConfig,
@@ -195,6 +205,10 @@ func (da *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	if da.flags.fromPackage != "" && (targetServiceName == "" || da.flags.all) {
+		return nil, errors.New("cannot use --from-package with --all or without specifying a service")
 	}
 
 	if err := da.projectManager.Initialize(ctx, da.projectConfig); err != nil {
@@ -221,7 +235,14 @@ func (da *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 			continue
 		}
 
-		deployTask := da.serviceManager.Deploy(ctx, svc, nil)
+		var packageOutput *project.ServicePackageResult
+		if da.flags.fromPackage != "" {
+			packageOutput = &project.ServicePackageResult{
+				PackagePath: da.flags.fromPackage,
+			}
+		}
+
+		deployTask := da.serviceManager.Deploy(ctx, svc, packageOutput)
 		go func() {
 			for deployProgress := range deployTask.Progress() {
 				progressMessage := fmt.Sprintf("Deploying service %s (%s)", svc.Name, deployProgress.Message)

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -44,12 +44,6 @@ func (d *deployFlags) bindNonCommon(
 	local *pflag.FlagSet,
 	global *internal.GlobalCommandOptions) {
 	local.StringVar(
-		&d.fromPackage,
-		"from-package",
-		"",
-		"Deploys the application from an existing package file.",
-	)
-	local.StringVar(
 		&d.serviceName,
 		"service",
 		"",
@@ -70,6 +64,12 @@ func (d *deployFlags) bindCommon(local *pflag.FlagSet, global *internal.GlobalCo
 		"all",
 		false,
 		"Deploys all services that are listed in "+azdcontext.ProjectFileName,
+	)
+	local.StringVar(
+		&d.fromPackage,
+		"from-package",
+		"",
+		"Deploys the application from an existing package file.",
 	)
 	local.StringVar(
 		&d.fromPackage,

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -296,9 +296,17 @@ func getCmdDeployHelpDescription(*cobra.Command) string {
 
 func getCmdDeployHelpFooter(*cobra.Command) string {
 	return generateCmdHelpSamplesBlock(map[string]string{
-		"Deploy all services in the current project to Azure.":                         output.WithHighLightFormat("azd deploy --all"),
-		"Deploy the service named 'api' to Azure.":                                     output.WithHighLightFormat("azd deploy api"),
-		"Deploy the service named 'web' to Azure.":                                     output.WithHighLightFormat("azd deploy web"),
-		"Deploy the service named 'api' to Azure from a previously generated package.": output.WithHighLightFormat("azd deploy api --from-package <package-path>"),
+		"Deploy all services in the current project to Azure.": output.WithHighLightFormat(
+			"azd deploy --all",
+		),
+		"Deploy the service named 'api' to Azure.": output.WithHighLightFormat(
+			"azd deploy api",
+		),
+		"Deploy the service named 'web' to Azure.": output.WithHighLightFormat(
+			"azd deploy web",
+		),
+		"Deploy the service named 'api' to Azure from a previously generated package.": output.WithHighLightFormat(
+			"azd deploy api --from-package <package-path>",
+		),
 	})
 }

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -44,12 +44,6 @@ func (d *deployFlags) bindNonCommon(
 	local *pflag.FlagSet,
 	global *internal.GlobalCommandOptions) {
 	local.StringVar(
-		&d.fromPackage,
-		"from-package",
-		"",
-		"Deploys the application from an existing package file.",
-	)
-	local.StringVar(
 		&d.serviceName,
 		"service",
 		"",
@@ -70,6 +64,12 @@ func (d *deployFlags) bindCommon(local *pflag.FlagSet, global *internal.GlobalCo
 		"all",
 		false,
 		"Deploys all services that are listed in "+azdcontext.ProjectFileName,
+	)
+	local.StringVar(
+		&d.fromPackage,
+		"from-package",
+		"",
+		"Deploys the application from an existing package file.",
 	)
 }
 

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -69,7 +69,7 @@ func (d *deployFlags) bindCommon(local *pflag.FlagSet, global *internal.GlobalCo
 		&d.fromPackage,
 		"from-package",
 		"",
-		"Deploys the application from an existing package file.",
+		"Deploys the application from an existing package.",
 	)
 }
 
@@ -296,8 +296,9 @@ func getCmdDeployHelpDescription(*cobra.Command) string {
 
 func getCmdDeployHelpFooter(*cobra.Command) string {
 	return generateCmdHelpSamplesBlock(map[string]string{
-		"Deploy all services in the current project to Azure.": output.WithHighLightFormat("azd deploy --all"),
-		"Deploy the service named 'api' to Azure.":             output.WithHighLightFormat("azd deploy api"),
-		"Deploy the service named 'web' to Azure.":             output.WithHighLightFormat("azd deploy web"),
+		"Deploy all services in the current project to Azure.":                         output.WithHighLightFormat("azd deploy --all"),
+		"Deploy the service named 'api' to Azure.":                                     output.WithHighLightFormat("azd deploy api"),
+		"Deploy the service named 'web' to Azure.":                                     output.WithHighLightFormat("azd deploy web"),
+		"Deploy the service named 'api' to Azure from a previously generated package.": output.WithHighLightFormat("azd deploy api --from-package <package-path>"),
 	})
 }

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -69,12 +69,6 @@ func (d *deployFlags) bindCommon(local *pflag.FlagSet, global *internal.GlobalCo
 		&d.fromPackage,
 		"from-package",
 		"",
-		"Deploys the application from an existing package file.",
-	)
-	local.StringVar(
-		&d.fromPackage,
-		"from-package",
-		"",
 		"Deploys the application from an existing package.",
 	)
 }

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -44,6 +44,12 @@ func (d *deployFlags) bindNonCommon(
 	local *pflag.FlagSet,
 	global *internal.GlobalCommandOptions) {
 	local.StringVar(
+		&d.fromPackage,
+		"from-package",
+		"",
+		"Deploys the application from an existing package file.",
+	)
+	local.StringVar(
 		&d.serviceName,
 		"service",
 		"",

--- a/cli/azd/cmd/provision.go
+++ b/cli/azd/cmd/provision.go
@@ -133,7 +133,10 @@ func (p *provisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 		fmt.Fprintln(
 			p.console.Handles().Stderr,
 			//nolint:Lll
-			output.WithWarningFormat("WARNING: The '--no-progress' flag is deprecated and will be removed in a future release."))
+			output.WithWarningFormat(
+				"WARNING: The '--no-progress' flag is deprecated and will be removed in a future release.",
+			),
+		)
 	}
 
 	// Command title

--- a/cli/azd/cmd/testdata/TestUsage-azd-deploy.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-deploy.snap
@@ -9,9 +9,10 @@ Usage
   azd deploy <service> [flags]
 
 Flags
-        --all                	: Deploys all services that are listed in azure.yaml
-    -e, --environment string 	: The name of the environment to use.
-    -h, --help               	: Gets help for deploy.
+        --all                 	: Deploys all services that are listed in azure.yaml
+    -e, --environment string  	: The name of the environment to use.
+        --from-package string 	: Deploys the application from an existing package file.
+    -h, --help                	: Gets help for deploy.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd-deploy.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-deploy.snap
@@ -11,7 +11,7 @@ Usage
 Flags
         --all                 	: Deploys all services that are listed in azure.yaml
     -e, --environment string  	: The name of the environment to use.
-        --from-package string 	: Deploys the application from an existing package file.
+        --from-package string 	: Deploys the application from an existing package.
     -h, --help                	: Gets help for deploy.
 
 Global Flags
@@ -22,6 +22,9 @@ Global Flags
 Examples
   Deploy all services in the current project to Azure.
     azd deploy --all
+
+  Deploy the service named 'api' to Azure from a previously generated package.
+    azd deploy api --from-package <package-path>
 
   Deploy the service named 'api' to Azure.
     azd deploy api

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -85,7 +85,10 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		fmt.Fprintln(
 			u.console.Handles().Stderr,
 			//nolint:lll
-			output.WithWarningFormat("WARNING: The '--no-progress' flag is deprecated and will be removed in a future release."))
+			output.WithWarningFormat(
+				"WARNING: The '--no-progress' flag is deprecated and will be removed in a future release.",
+			),
+		)
 		// this flag actually isn't used by the provision command, we set it to false to hide the extra warning
 		u.flags.provisionFlags.noProgress = false
 	}

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -109,9 +109,6 @@ func (ch *ContainerHelper) Deploy(
 			}
 
 			if localImageTag == "" {
-			}
-
-			if localImageTag == "" {
 				task.SetError(errors.New("failed retrieving package result details"))
 				return
 			}

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -102,8 +102,13 @@ func (ch *ContainerHelper) Deploy(
 				return
 			}
 
+			localImageTag := packageOutput.PackagePath
 			packageDetails, ok := packageOutput.Details.(*dockerPackageResult)
-			if !ok {
+			if ok && packageDetails != nil {
+				localImageTag = packageDetails.ImageTag
+			}
+
+			if localImageTag == "" {
 				task.SetError(errors.New("failed retrieving package result details"))
 				return
 			}
@@ -118,14 +123,14 @@ func (ch *ContainerHelper) Deploy(
 
 			// Tag image
 			// Get remote tag from the container helper then call docker cli tag command
-			remoteTag, err := ch.RemoteImageTag(ctx, serviceConfig, packageDetails.ImageTag)
+			remoteTag, err := ch.RemoteImageTag(ctx, serviceConfig, localImageTag)
 			if err != nil {
 				task.SetError(fmt.Errorf("getting remote image tag: %w", err))
 				return
 			}
 
 			task.SetProgress(NewServiceProgress("Tagging container image"))
-			if err := ch.docker.Tag(ctx, serviceConfig.Path(), packageDetails.ImageTag, remoteTag); err != nil {
+			if err := ch.docker.Tag(ctx, serviceConfig.Path(), localImageTag, remoteTag); err != nil {
 				task.SetError(fmt.Errorf("tagging image: %w", err))
 				return
 			}

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -109,6 +109,9 @@ func (ch *ContainerHelper) Deploy(
 			}
 
 			if localImageTag == "" {
+			}
+
+			if localImageTag == "" {
 				task.SetError(errors.New("failed retrieving package result details"))
 				return
 			}


### PR DESCRIPTION
Adds `--from-package` param to `azd deploy` to support deploying a service from an existing package.