### PR TITLE
Update messaging for deprecated commands/flags

### DIFF
--- a/cli/azd/cmd/auth_login.go
+++ b/cli/azd/cmd/auth_login.go
@@ -207,10 +207,11 @@ func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	if la.annotations[loginCmdParentAnnotation] == "" {
 		fmt.Fprintln(
 			la.console.Handles().Stderr,
-			//nolint:lll
 			output.WithWarningFormat(
-				"WARNING: `azd login` has been deprecated and will be removed in a future release. Please use `azd auth login` instead."),
-		)
+				"WARNING: `azd login` is deprecated and will be removed in a future release."))
+		fmt.Fprintln(
+			la.console.Handles().Stderr,
+			"Next time use `azd auth login`.")
 	}
 
 	if !la.flags.onlyCheckStatus {

--- a/cli/azd/cmd/auth_logout.go
+++ b/cli/azd/cmd/auth_logout.go
@@ -57,10 +57,11 @@ func (la *logoutAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 	if la.annotations[loginCmdParentAnnotation] == "" {
 		fmt.Fprintln(
 			la.console.Handles().Stderr,
-			//nolint:lll
 			output.WithWarningFormat(
-				"WARNING: `azd logout` has been deprecated and will be removed in a future release. Please use `azd auth logout` instead."),
-		)
+				"WARNING: `azd logout` is deprecated and will be removed in a future release."))
+		fmt.Fprintln(
+			la.console.Handles().Stderr,
+			"Next time use `azd auth logout`.")
 	}
 
 	err := la.authManager.Logout(ctx)

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -53,7 +53,9 @@ func (a *infraCreateAction) Run(ctx context.Context) (*actions.ActionResult, err
 	fmt.Fprintln(
 		a.console.Handles().Stderr,
 		output.WithWarningFormat(
-			"`azd infra create` is deprecated and will be removed in a future release. Please use `azd provision` instead."),
-	)
+			"WARNING: `azd infra create` is deprecated and will be removed in a future release."))
+	fmt.Fprintln(
+		a.console.Handles().Stderr,
+		"Next time use `azd provision`")
 	return a.infraCreate.Run(ctx)
 }

--- a/cli/azd/cmd/infra_delete.go
+++ b/cli/azd/cmd/infra_delete.go
@@ -53,7 +53,9 @@ func (a *infraDeleteAction) Run(ctx context.Context) (*actions.ActionResult, err
 	fmt.Fprintln(
 		a.console.Handles().Stderr,
 		output.WithWarningFormat(
-			"`azd infra delete` is deprecated and will be removed in a future release. Please use `azd down` instead."),
-	)
+			"WARNING: `azd infra delete` is deprecated and will be removed in a future release."))
+	fmt.Fprintln(
+		a.console.Handles().Stderr,
+		"Next time use `azd down`")
 	return a.down.Run(ctx)
 }

--- a/cli/azd/cmd/provision.go
+++ b/cli/azd/cmd/provision.go
@@ -130,10 +130,10 @@ func newProvisionAction(
 
 func (p *provisionAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	if p.flags.noProgress {
-		fmt.Fprintf(
+		fmt.Fprintln(
 			p.console.Handles().Stderr,
 			//nolint:Lll
-			output.WithWarningFormat("--no-progress flag is deprecated and will be removed in the future.")+"\n")
+			output.WithWarningFormat("WARNING: The '--no-progress' flag is deprecated and will be removed in a future release."))
 	}
 
 	// Command title

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -72,7 +72,8 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	if u.flags.provisionFlags.noProgress {
 		fmt.Fprintln(
 			u.console.Handles().Stderr,
-			output.WithWarningFormat("The --no-progress flag is deprecated and will be removed in the future."))
+			//nolint:lll
+			output.WithWarningFormat("WARNING: The '--no-progress' flag is deprecated and will be removed in a future release."))
 		// this flag actually isn't used by the provision command, we set it to false to hide the extra warning
 		u.flags.provisionFlags.noProgress = false
 	}
@@ -80,7 +81,8 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	if u.flags.deployFlags.serviceName != "" {
 		fmt.Fprintln(
 			u.console.Handles().Stderr,
-			output.WithWarningFormat("The --service flag is deprecated and will be removed in the future."))
+			//nolint:lll
+			output.WithWarningFormat("WARNING: The '--service' flag is deprecated and will be removed in a future release."))
 	}
 
 	provision, err := u.provisionActionInitializer()


### PR DESCRIPTION
Update messaging for deprecated commands/flags based on UX feedback.

Fixes: https://github.com/Azure/azure-dev-pr/issues/1496, https://github.com/Azure/azure-dev-pr/issues/1495