### PR TITLE
Adds support to call cross-platform shell commands in NPM scripts

### DIFF
--- a/templates/todo/web/react-fluent/package-lock.json
+++ b/templates/todo/web/react-fluent/package-lock.json
@@ -34,6 +34,7 @@
         "if-node-version": "^1.1.1",
         "immer": "^9.0.14",
         "react-scripts": "^5.0.1",
+        "shx": "^0.3.4",
         "typescript": "^4.7.3"
       }
     },
@@ -9663,6 +9664,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
@@ -15109,6 +15119,18 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
@@ -15873,6 +15895,39 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/side-channel": {
@@ -25127,6 +25182,12 @@
         "side-channel": "^1.0.4"
       }
     },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
+    },
     "ipaddr.js": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
@@ -29133,6 +29194,15 @@
         "picomatch": "^2.2.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "recursive-readdir": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
@@ -29698,6 +29768,27 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
       "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
+    "shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      }
     },
     "side-channel": {
       "version": "1.0.4",

--- a/templates/todo/web/react-fluent/package.json
+++ b/templates/todo/web/react-fluent/package.json
@@ -15,14 +15,14 @@
   "scripts": {
     "envconfig": "node entrypoint.js -e .env -o ./public/env-config.js",
     "prestart": "npm run envconfig",
-    "start": "if-node-version '>= 17' && react-scripts --openssl-legacy-provider start || react-scripts start",
+    "start": "react-scripts start",
     "prebuild": "npm run lint",
     "build": "tsc -b .",
     "pretest": "npm run envconfig",
-    "test": "if-node-version '>= 17' && react-scripts --openssl-legacy-provider test || react-scripts test",
-    "package": "if-node-version '>= 17' && react-scripts --openssl-legacy-provider build || react-scripts build",
-    "postpackage": "cp ./entrypoint.sh ./build",
-    "eject": "if-node-version '>= 17' && react-scripts --openssl-legacy-provider eject || react-scripts eject",
+    "test": "react-scripts test",
+    "package": "react-scripts build",
+    "postpackage": "shx cp ./entrypoint.sh ./build",
+    "eject": "react-scripts eject",
     "lint": "eslint ./src --ext .ts,.tsx"
   },
   "eslintConfig": {
@@ -61,6 +61,7 @@
     "if-node-version": "^1.1.1",
     "immer": "^9.0.14",
     "react-scripts": "^5.0.1",
+    "shx": "^0.3.4",
     "typescript": "^4.7.3"
   },
   "overrides": {
@@ -68,7 +69,7 @@
     "nth-check": "^2.0.1",
     "ejs": "^3.1.7",
     "svgo": "^2.8.0",
-    "react-scripts":{
+    "react-scripts": {
       "react-dev-utils": {
         "recursive-readdir": {
           "minimatch": "^3.0.5"


### PR DESCRIPTION
Leverages [`shx`](https://www.npmjs.com/package/shx) library to enable cross-platform commands in NPM scripts