### PR TITLE
do not log spinner changes for json output

### DIFF
--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -152,7 +152,6 @@ func (c *AskerConsole) MessageUxItem(ctx context.Context, item ux.UxItem) {
 func (c *AskerConsole) ShowSpinner(ctx context.Context, title string, format SpinnerUxType) {
 	if c.formatter != nil && c.formatter.Kind() == output.JsonFormat {
 		// Spinner is disabled when using json format.
-		c.Message(ctx, "Show spinner with title: "+title)
 		return
 	}
 
@@ -209,7 +208,6 @@ func (c *AskerConsole) getIndent(format SpinnerUxType) string {
 func (c *AskerConsole) StopSpinner(ctx context.Context, lastMessage string, format SpinnerUxType) {
 	if c.formatter != nil && c.formatter.Kind() == output.JsonFormat {
 		// Spinner is disabled when using json format.
-		c.Message(ctx, "Stop spinner with title: "+lastMessage)
 		return
 	}
 

--- a/cli/azd/pkg/output/ux/created_resource.go
+++ b/cli/azd/pkg/output/ux/created_resource.go
@@ -22,5 +22,5 @@ func (cr *CreatedResource) ToString(currentIndentation string) string {
 func (cr *CreatedResource) MarshalJSON() ([]byte, error) {
 	// reusing the same envelope from console messages
 	return json.Marshal(output.EventForMessage(
-		fmt.Sprintf("%s Creating %s: %s", donePrefix, cr.Type, cr.Name)))
+		fmt.Sprintf("Done: Creating %s: %s", cr.Type, cr.Name)))
 }


### PR DESCRIPTION

fix: https://github.com/Azure/azure-dev/issues/1689

Removing the json-logs for state changes from the spinner.  
Also updating the json messages for Resource-Create without the special char `(✓)` (which is not parsed correctly from Visual Studio)