### PR TITLE
Allow `staticwebapp` targets to be repackaged in `up`

### DIFF
--- a/cli/azd/cmd/middleware/middleware.go
+++ b/cli/azd/cmd/middleware/middleware.go
@@ -48,17 +48,15 @@ type NextFn func(ctx context.Context) (*actions.ActionResult, error)
 // Middleware runner stores middleware registrations and orchestrates the
 // invocation of middleware components and actions.
 type MiddlewareRunner struct {
-	chain       []string
-	container   *ioc.NestedContainer
-	actionCache map[actions.Action]*actions.ActionResult
+	chain     []string
+	container *ioc.NestedContainer
 }
 
 // Creates a new middleware runner
 func NewMiddlewareRunner(container *ioc.NestedContainer) *MiddlewareRunner {
 	return &MiddlewareRunner{
-		container:   container,
-		chain:       []string{},
-		actionCache: map[actions.Action]*actions.ActionResult{},
+		container: container,
+		chain:     []string{},
 	}
 }
 
@@ -68,20 +66,9 @@ func (r *MiddlewareRunner) RunChildAction(
 	runOptions *Options,
 	action actions.Action,
 ) (*actions.ActionResult, error) {
-	// If we have previously run this action then return the cached result
-	if cachedActionResult, has := r.actionCache[action]; has {
-		return cachedActionResult, nil
-	}
-
 	// If we have not previously run this action then execute it
 	runOptions.isChildAction = true
 	result, err := r.RunAction(ctx, runOptions, action)
-
-	// Cache the result on action success
-	if err == nil {
-		r.actionCache[action] = result
-	}
-
 	return result, err
 }
 

--- a/cli/azd/cmd/package.go
+++ b/cli/azd/cmd/package.go
@@ -154,11 +154,14 @@ func (pa *packageAction) Run(ctx context.Context) (*actions.ActionResult, error)
 			return nil, err
 		}
 
-		pa.console.StopSpinner(ctx, stepMessage, input.StepDone)
+		if packageResult.FromCached {
+			pa.console.StopSpinner(ctx, stepMessage, input.StepSkipped)
+		} else {
+			pa.console.StopSpinner(ctx, stepMessage, input.StepDone)
+			// report package output
+			pa.console.MessageUxItem(ctx, packageResult)
+		}
 		packageResults[svc.Name] = packageResult
-
-		// report package output
-		pa.console.MessageUxItem(ctx, packageResult)
 	}
 
 	if pa.formatter.Kind() == output.JsonFormat {

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -125,7 +125,10 @@ func (hc *HookConfig) validate() error {
 		hc.Shell = scriptType
 	}
 
-	hc.validated = true
+	// stored validated, except for inline script which needs to be regenerated per-usage
+	if hc.location != ScriptLocationInline {
+		hc.validated = true
+	}
 
 	return nil
 }

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -260,6 +260,7 @@ func (sm *serviceManager) Package(
 		if ok && cachedResult != nil {
 			// Static web apps should always be repackaged (enables the `up` flow to work)
 			if serviceConfig.Host != StaticWebAppTarget {
+				cachedResult.(*ServicePackageResult).FromCached = true
 				task.SetResult(cachedResult.(*ServicePackageResult))
 				return
 			}

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -258,14 +258,20 @@ func (sm *serviceManager) Package(
 	return async.RunTaskWithProgress(func(task *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
 		cachedResult, ok := sm.getOperationResult(ctx, serviceConfig, string(ServiceEventPackage))
 		if ok && cachedResult != nil {
-			task.SetResult(cachedResult.(*ServicePackageResult))
-			return
+			// Static web apps should always be repackaged (enables the `up` flow to work)
+			if serviceConfig.Host != StaticWebAppTarget {
+				task.SetResult(cachedResult.(*ServicePackageResult))
+				return
+			}
 		}
 
 		if buildOutput == nil {
 			cachedResult, ok := sm.getOperationResult(ctx, serviceConfig, string(ServiceEventBuild))
 			if ok && cachedResult != nil {
-				buildOutput = cachedResult.(*ServiceBuildResult)
+				// Static web apps should always be repackaged (enables the `up` flow to work)
+				if serviceConfig.Host != StaticWebAppTarget {
+					buildOutput = cachedResult.(*ServiceBuildResult)
+				}
 			}
 		}
 

--- a/cli/azd/pkg/project/service_models.go
+++ b/cli/azd/pkg/project/service_models.go
@@ -65,6 +65,8 @@ type ServicePackageResult struct {
 	Build       *ServiceBuildResult `json:"build"`
 	PackagePath string              `json:"packagePath"`
 	Details     interface{}         `json:"details"`
+	// true, if the package result from a previous cached run
+	FromCached bool
 }
 
 // Supports rendering messages for UX items


### PR DESCRIPTION
Allow `staticwebapp` targets to be repackaged in `up` workflow.

Basically this means that for a `staticwebapp` target, the following pseudocode describes the overall behavior:

```pwsh
azd package
azd provision
for _, app := range staticwebapp { azd package app } # allow staticwebapp targets to observe the `provision` output
azd deploy
```

This allows hooks to be able to observe the environment state from `azd`, and fixes the `up` behavior for todo-*-swa-func.