### PR TITLE
Move `postpackage` to `predeploy` hooks for `staticwebapp`

### DIFF
--- a/templates/todo/projects/csharp-sql-swa-func/.repo/bicep/azure.yaml
+++ b/templates/todo/projects/csharp-sql-swa-func/.repo/bicep/azure.yaml
@@ -10,7 +10,7 @@ services:
     language: js
     host: staticwebapp
     hooks:
-      postpackage:
+      predeploy:
         posix:
           shell: sh
           run: node entrypoint.js -o ./build/env-config.js

--- a/templates/todo/projects/nodejs-mongo-swa-func/.repo/bicep/azure.yaml
+++ b/templates/todo/projects/nodejs-mongo-swa-func/.repo/bicep/azure.yaml
@@ -10,7 +10,7 @@ services:
     language: js
     host: staticwebapp
     hooks:
-      postpackage:
+      predeploy:
         posix:
           shell: sh
           run: node entrypoint.js -o ./build/env-config.js

--- a/templates/todo/projects/python-mongo-swa-func/.repo/bicep/azure.yaml
+++ b/templates/todo/projects/python-mongo-swa-func/.repo/bicep/azure.yaml
@@ -10,7 +10,7 @@ services:
     language: js
     host: staticwebapp
     hooks:
-      postpackage:
+      predeploy:
         posix:
           shell: sh
           run: node entrypoint.js -o ./build/env-config.js


### PR DESCRIPTION
Move `postpackage` to `predeploy` hooks for `staticwebapp` ToDo templates

This allows the `env-config.js` to be correctly generated when observing the environment state from `azd`. This is the current intended integration for `staticwebapp` to observe environment state that also works when invoked through `azd up`.