### PR TITLE
Split template ID and version in telemetry

### DIFF
--- a/cli/azd/internal/telemetry/fields/fields.go
+++ b/cli/azd/internal/telemetry/fields/fields.go
@@ -61,10 +61,12 @@ const (
 	SubscriptionIdKey = attribute.Key("ad.subscription.id")
 )
 
-// Project related attributes
+// Project (azure.yaml) related attributes
 const (
-	// Hashed template referenced in the project.
+	// Hashed template ID metadata
 	ProjectTemplateIdKey = attribute.Key("project.template.id")
+	// Hashed template.version metadata
+	ProjectTemplateVersionKey = attribute.Key("project.template.version")
 	// Hashed project name. Could be used as an indicator for number of different azd projects.
 	ProjectNameKey = attribute.Key("project.name")
 	// The collection of hashed service hosts in the project.

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -159,8 +159,13 @@ func Test_CLI_Telemetry_UsageData_EnvProjectLoad(t *testing.T) {
 			require.Contains(t, m, fields.SubscriptionIdKey)
 			require.Equal(t, getEnvSubscriptionId(t, dir, envName), m[fields.SubscriptionIdKey])
 
+			templateAndVersion := strings.Split(projConfig.Metadata.Template, "@")
+			require.Len(t, templateAndVersion, 2)
 			require.Contains(t, m, fields.ProjectTemplateIdKey)
-			require.Equal(t, fields.CaseInsensitiveHash(projConfig.Metadata.Template), m[fields.ProjectTemplateIdKey])
+			require.Equal(t, fields.CaseInsensitiveHash(templateAndVersion[0]), m[fields.ProjectTemplateIdKey])
+
+			require.Contains(t, m, fields.ProjectTemplateVersionKey)
+			require.Equal(t, fields.CaseInsensitiveHash(templateAndVersion[1]), m[fields.ProjectTemplateVersionKey])
 
 			require.Contains(t, m, fields.ProjectNameKey)
 			require.Equal(t, fields.CaseInsensitiveHash(projConfig.Name), m[fields.ProjectNameKey])


### PR DESCRIPTION
When emitting usage telemetry for template references, split the template reference by ID and version (if applicable).

Fixes #1836