### PR TITLE
Uninstall removes extra files

### DIFF
--- a/cli/installer/fpm/install-notice.sh
+++ b/cli/installer/fpm/install-notice.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+echo ""
+echo "===================================="
+echo " Azure Developer CLI Install Notice "
+echo "===================================="
+echo "The Azure Developer CLI collects usage data and sends that usage data to Microsoft in order to help us improve your experience."
+echo "You can opt-out of telemetry by setting the AZURE_DEV_COLLECT_TELEMETRY environment variable to 'no' in the shell you use."
+echo ""
+echo "Read more about Azure Developer CLI telemetry: https://github.com/Azure/azure-dev#data-collection"
+echo ""

--- a/cli/installer/fpm/uninstall.sh
+++ b/cli/installer/fpm/uninstall.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+if [ -w "$HOME/.azd/bin" ]; then
+    if ! rm -rf "$HOME/.azd/bin"; then
+        echo "Could not remove files in $HOME/.azd/bin. These will need to be removed manually"
+    fi
+fi
+
+echo ""
+echo "======================================"
+echo " Azure Developer CLI Uninstall Notice "
+echo "======================================"
+echo "The Azure Developer CLI may have downloaded binaries to ~/.azd/bin and,"
+echo "depending on how azd was used on this machine, may have downloaded binaries"
+echo "to other users' home directories in their .azd/bin directory."
+echo "These binaries will need to be removed manually."
+echo "To remove such binaries from your home directory, run 'rm -rf ~/.azd/bin'."
+echo ""

--- a/cli/installer/uninstall-azd.sh
+++ b/cli/installer/uninstall-azd.sh
@@ -14,6 +14,17 @@ else
     sudo rm "$install_location"
 fi
 
+if [ -w "$HOME/.azd/bin" ]; then
+    if ! rm -rf "$HOME/.azd/bin"; then
+        echo "Could not remove files in $HOME/.azd/bin. These will need to be removed manually"
+    fi
+fi
+
+echo "azd may have downloaded binaries to ~/.azd/bin and, depending on how azd was used on this machine,"
+echo "may have downloaded binaries to other users' home directories in their .azd/bin directory."
+echo "These binaries will need to be removed manually."
+echo "To remove such binaries from your home directory, run 'rm -rf ~/.azd/bin'."
+
 still_installed_location="$(command -v azd)";
 if [ "$still_installed_location" ]; then
     echo "Uninstallation may not be complete: azd was still found at an unmanaged location ($still_installed_location). Please remove manually."

--- a/eng/scripts/New-LinuxPackages.ps1
+++ b/eng/scripts/New-LinuxPackages.ps1
@@ -17,7 +17,6 @@ try {
     # Symlink points to potentially invalid location but will point correctly 
     # once package is installed
     ln -s /opt/microsoft/azd/azd-linux-amd64 azd
-    chmod +x azd
     chmod +x azd-linux-amd64
 
     foreach ($type in $PackageTypes) { 
@@ -26,6 +25,8 @@ try {
             --output-type $type `
             --version $Version `
             --architecture amd64 `
+            --after-install install-notice.sh `
+            --after-remove uninstall.sh `
             azd-linux-amd64=/opt/microsoft/azd/azd-linux-amd64 `
             azd=/usr/local/bin/azd `
             NOTICE.txt=/opt/microsoft/azd/NOTICE.txt `

--- a/eng/templates/brew.template
+++ b/eng/templates/brew.template
@@ -25,7 +25,7 @@ class Azd < Formula
     EOS
     on_arm do
       caveat += <<~EOS
-      
+
         The #{desc} is built for Intel macOS and so requires Rosetta 2 to be installed.
         You can install Rosetta 2 with:
           softwareupdate --install-rosetta

--- a/eng/templates/brew.template
+++ b/eng/templates/brew.template
@@ -16,10 +16,16 @@ class Azd < Formula
       You can opt-out of telemetry by setting the AZURE_DEV_COLLECT_TELEMETRY environment variable to 'no' in the shell you use.
 
       Read more about #{desc} telemetry: https://github.com/Azure/azure-dev#data-collection
+
+      azd may download binaries to ~/.azd/bin and, depending on how azd was used on this machine,
+      may download binaries to other users' home directories in their .azd/bin directory.
+      These binaries will need to be removed manually upon uninstall.
+      To remove such binaries from your home directory, run 'rm -rf ~/.azd/bin'.
+
     EOS
     on_arm do
       caveat += <<~EOS
-
+      
         The #{desc} is built for Intel macOS and so requires Rosetta 2 to be installed.
         You can install Rosetta 2 with:
           softwareupdate --install-rosetta


### PR DESCRIPTION
This change follows the changes we made to MSI. On Linux: 

* Remove files from ~/.azd/bin for the current user
* Output warnings to the console that there may be other ~/.azd/bin folders for other users on the machine with files in them and that they should be updated. 

On MacOS: 

* Add caveat during install to warn the user about removing files from ~/.azd/bin. 
* Note: brew does not support custom uninstall actions (like cleaning up files in ~/.azd/bin) 