### PR TITLE
Ensure default generated docker repo/tags are all lowercase

### DIFF
--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -135,7 +135,11 @@ func (p *dockerProject) Build(
 				dockerOptions.Context,
 			)
 
-			imageName := fmt.Sprintf("%s-%s", serviceConfig.Project.Name, serviceConfig.Name)
+			imageName := fmt.Sprintf(
+				"%s-%s",
+				strings.ToLower(serviceConfig.Project.Name),
+				strings.ToLower(serviceConfig.Name),
+			)
 
 			// Build the container
 			task.SetProgress(NewServiceProgress("Building docker image"))

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -231,6 +231,12 @@ func Test_DockerProject_Build(t *testing.T) {
 		},
 		runArgs.Args,
 	)
+
+	dockerBuildResult, ok := result.Details.(*dockerBuildResult)
+	require.True(t, ok)
+	require.NotNil(t, dockerBuildResult)
+	require.Equal(t, "test-app-api", dockerBuildResult.ImageName)
+	require.NotEmpty(t, dockerBuildResult.ImageId)
 }
 
 func Test_DockerProject_Package(t *testing.T) {

--- a/cli/azd/pkg/project/service_config_test.go
+++ b/cli/azd/pkg/project/service_config_test.go
@@ -230,7 +230,7 @@ func createTestServiceConfig(path string, host ServiceTargetKind, language Servi
 		Language:     language,
 		RelativePath: filepath.Join(path),
 		Project: &ProjectConfig{
-			Name: "test-app",
+			Name: "Test-App",
 			Path: ".",
 		},
 		EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),


### PR DESCRIPTION
Fixes #1874 

Docker enforces all lowercase on docker image repositories.  By default we generate the repo name from the combination of project/service name.

This fix ensures that generated names are all lowercased before invoking docker CLI commands.