### PR TITLE
Assert package outputs and more verbose error messages

### DIFF
--- a/cli/azd/pkg/project/framework_service.go
+++ b/cli/azd/pkg/project/framework_service.go
@@ -103,8 +103,13 @@ type CompositeFrameworkService interface {
 }
 
 func validatePackageOutput(packagePath string) error {
-	if entries, err := os.ReadDir(packagePath); err != nil || len(entries) == 0 {
-		return fmt.Errorf("package output '%s' is empty or does not exist", packagePath)
+	entries, err := os.ReadDir(packagePath)
+	if err != nil && os.IsNotExist(err) {
+		return fmt.Errorf("package output '%s' does not exist, %w", packagePath, err)
+	} else if err != nil {
+		return fmt.Errorf("failed to read package output '%s', %w", packagePath, err)
+	} else if err == nil && len(entries) == 0 {
+		return fmt.Errorf("package output '%s' is empty", packagePath)
 	}
 
 	return nil

--- a/cli/azd/pkg/project/framework_service.go
+++ b/cli/azd/pkg/project/framework_service.go
@@ -6,6 +6,7 @@ package project
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
@@ -99,4 +100,12 @@ type FrameworkService interface {
 type CompositeFrameworkService interface {
 	FrameworkService
 	SetSource(inner FrameworkService)
+}
+
+func validatePackageOutput(packagePath string) error {
+	if entries, err := os.ReadDir(packagePath); err != nil || len(entries) == 0 {
+		return fmt.Errorf("package output '%s' is empty or does not exist", packagePath)
+	}
+
+	return nil
 }

--- a/cli/azd/pkg/project/framework_service_npm.go
+++ b/cli/azd/pkg/project/framework_service_npm.go
@@ -115,7 +115,11 @@ func (np *npmProject) Package(
 			// Exec custom `package` script if available
 			// If `package` script is not defined in the package.json the NPM script will NOT fail
 			task.SetProgress(NewServiceProgress("Running NPM package script"))
-			if err := np.cli.RunScript(ctx, serviceConfig.Path(), "package", envs); err != nil {
+
+			// Long term this script we call should better align with our inner-loop scenarios
+			// Keeping this defaulted to `build` will create confusion for users when we start to support
+			// both local dev / debug builds and production bundled builds
+			if err := np.cli.RunScript(ctx, serviceConfig.Path(), "build", envs); err != nil {
 				task.SetError(err)
 				return
 			}
@@ -130,7 +134,7 @@ func (np *npmProject) Package(
 				task.SetError(
 					fmt.Errorf(
 						//nolint:lll
-						"package source '%s' is empty or does not exist. If your service has custom packaging requirements create an NPM script named 'package' within your package.json and ensure your package artifacts are written to the '%s' directory",
+						"package source '%s' is empty or does not exist. If your service has custom packaging requirements create an NPM script named 'build' within your package.json and ensure your package artifacts are written to the '%s' directory",
 						packageSource,
 						packageSource,
 					),

--- a/cli/azd/pkg/project/framework_service_npm_test.go
+++ b/cli/azd/pkg/project/framework_service_npm_test.go
@@ -88,7 +88,7 @@ func Test_NpmProject_Package(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	mockContext.CommandRunner.
 		When(func(args exec.RunArgs, command string) bool {
-			return strings.Contains(command, "npm run package")
+			return strings.Contains(command, "npm run build")
 		}).
 		RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
 			runArgs = args
@@ -119,7 +119,7 @@ func Test_NpmProject_Package(t *testing.T) {
 	require.NotEmpty(t, result.PackagePath)
 	require.Equal(t, "npm", runArgs.Cmd)
 	require.Equal(t,
-		[]string{"run", "package", "--if-present"},
+		[]string{"run", "build", "--if-present"},
 		runArgs.Args,
 	)
 }

--- a/cli/azd/pkg/project/framework_service_npm_test.go
+++ b/cli/azd/pkg/project/framework_service_npm_test.go
@@ -3,6 +3,7 @@ package project
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -98,6 +99,8 @@ func Test_NpmProject_Package(t *testing.T) {
 	npmCli := npm.NewNpmCli(mockContext.CommandRunner)
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageTypeScript)
 	err := os.MkdirAll(serviceConfig.Path(), osutil.PermissionDirectory)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(serviceConfig.Path(), "package.json"), nil, osutil.PermissionFile)
 	require.NoError(t, err)
 
 	npmProject := NewNpmProject(npmCli, env)

--- a/cli/azd/pkg/project/framework_service_python_test.go
+++ b/cli/azd/pkg/project/framework_service_python_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -109,6 +110,8 @@ func Test_PythonProject_Package(t *testing.T) {
 	pythonCli := python.NewPythonCli(mockContext.CommandRunner)
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguagePython)
 	err := os.MkdirAll(serviceConfig.Path(), osutil.PermissionDirectory)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(serviceConfig.Path(), "requirements.txt"), nil, osutil.PermissionFile)
 	require.NoError(t, err)
 
 	pythonProject := NewPythonProject(pythonCli, env)

--- a/templates/common/.devcontainer/devcontainer.json/aks/nodejs/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/aks/nodejs/devcontainer.json
@@ -7,8 +7,7 @@
         }
     },
     "features": {
-        "ghcr.io/devcontainers/features/docker-from-docker:1": {
-            "version": "20.10"
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
         },
         "ghcr.io/devcontainers/features/node:1": {
             "version": "16",

--- a/templates/common/.devcontainer/devcontainer.json/aks/nodejs/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/aks/nodejs/devcontainer.json
@@ -3,7 +3,7 @@
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
-            "VARIANT": "bullseye"
+            "IMAGE": "javascript-node:16"
         }
     },
     "features": {

--- a/templates/common/.devcontainer/devcontainer.json/csharp/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/csharp/devcontainer.json
@@ -7,8 +7,7 @@
         }
     },
     "features": {
-        "ghcr.io/devcontainers/features/docker-from-docker:1": {
-            "version": "20.10"
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
         },
         "ghcr.io/devcontainers/features/node:1": {
             "version": "16",

--- a/templates/common/.devcontainer/devcontainer.json/java/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/java/devcontainer.json
@@ -7,8 +7,7 @@
         }
     },
     "features": {
-        "ghcr.io/devcontainers/features/docker-from-docker:1": {
-            "version": "20.10"
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
         },
         "ghcr.io/devcontainers/features/node:1": {
             "version": "16",

--- a/templates/common/.devcontainer/devcontainer.json/nodejs/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/nodejs/devcontainer.json
@@ -7,8 +7,7 @@
         }
     },
     "features": {
-        "ghcr.io/devcontainers/features/docker-from-docker:1": {
-            "version": "20.10"
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
         }
     },
     "customizations": {

--- a/templates/common/.devcontainer/devcontainer.json/nodejs/terraform/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/nodejs/terraform/devcontainer.json
@@ -10,8 +10,7 @@
         "ghcr.io/devcontainers/features/azure-cli:1": {
             "version": "2.38"
         },
-        "ghcr.io/devcontainers/features/docker-from-docker:1": {
-            "version": "20.10"
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
         },
         "ghcr.io/devcontainers/features/terraform:1": {
             "version": "latest"

--- a/templates/common/.devcontainer/devcontainer.json/python/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/devcontainer.json
@@ -7,8 +7,7 @@
         }
     },
     "features": {
-        "ghcr.io/devcontainers/features/docker-from-docker:1": {
-            "version": "20.10"
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
         },
         "ghcr.io/devcontainers/features/node:1": {
             "version": "16",

--- a/templates/common/.devcontainer/devcontainer.json/python/terraform/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/terraform/devcontainer.json
@@ -10,8 +10,7 @@
         "ghcr.io/devcontainers/features/azure-cli:1": {
             "version": "2.38"
         },
-        "ghcr.io/devcontainers/features/docker-from-docker:1": {
-            "version": "20.10"
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
         },
         "ghcr.io/devcontainers/features/node:1": {
             "version": "16",

--- a/templates/todo/common/infra/bicep/app/api-appservice-node.bicep
+++ b/templates/todo/common/infra/bicep/app/api-appservice-node.bicep
@@ -23,7 +23,7 @@ module api '../../../../../common/infra/bicep/core/host/appservice.bicep' = {
     appSettings: appSettings
     keyVaultName: keyVaultName
     runtimeName: 'node'
-    runtimeVersion: '16-lts'
+    runtimeVersion: '18-lts'
     scmDoBuildDuringDeployment: true
   }
 }

--- a/templates/todo/common/infra/bicep/app/web-appservice.bicep
+++ b/templates/todo/common/infra/bicep/app/web-appservice.bicep
@@ -15,7 +15,7 @@ module web '../../../../../common/infra/bicep/core/host/appservice.bicep' = {
     applicationInsightsName: applicationInsightsName
     appServicePlanId: appServicePlanId
     runtimeName: 'node'
-    runtimeVersion: '16-lts'
+    runtimeVersion: '18-lts'
     tags: union(tags, { 'azd-service-name': serviceName })
   }
 }

--- a/templates/todo/web/react-fluent/Dockerfile
+++ b/templates/todo/web/react-fluent/Dockerfile
@@ -12,7 +12,7 @@ RUN apk update && apk add --no-cache dos2unix \
 
 # install project dependencies
 RUN npm ci
-RUN npm run package
+RUN npm run build
 
 FROM nginx:alpine
 

--- a/templates/todo/web/react-fluent/package.json
+++ b/templates/todo/web/react-fluent/package.json
@@ -17,6 +17,7 @@
     "prestart": "npm run envconfig",
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "postbuild": "shx cp ./entrypoint.sh ./build",
     "pretest": "npm run envconfig",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/templates/todo/web/react-fluent/package.json
+++ b/templates/todo/web/react-fluent/package.json
@@ -16,12 +16,9 @@
     "envconfig": "node entrypoint.js -e .env -o ./public/env-config.js",
     "prestart": "npm run envconfig",
     "start": "react-scripts start",
-    "prebuild": "npm run lint",
-    "build": "tsc -b .",
+    "build": "react-scripts build",
     "pretest": "npm run envconfig",
     "test": "react-scripts test",
-    "package": "react-scripts build",
-    "postpackage": "shx cp ./entrypoint.sh ./build",
     "eject": "react-scripts eject",
     "lint": "eslint ./src --ext .ts,.tsx"
   },


### PR DESCRIPTION
- [x] Reverts to default to call `npm run build` instead of `npm run package`
- [x] Asserts that the package outputs actually contain files
- [x] More verbose error message when configured `build` output folder is empty 
- [x] Updates app service node version used by default to Node 18 LTS 

Resolves #1867

> Note: Template tests will fail for all file based templates until new `daily` build is available.