### PR TITLE
add all language check for `getFullPathToProjectForService` in `show.go`

### DIFF
--- a/cli/azd/cmd/show.go
+++ b/cli/azd/cmd/show.go
@@ -165,8 +165,7 @@ func showTypeFromLanguage(language project.ServiceLanguageKind) contracts.ShowTy
 // does not include the project file, we attempt to determine it by looking for a single .csproj/.vbproj/.fsproj file
 // in that directory. If there are multiple, an error is returned.
 func getFullPathToProjectForService(svc *project.ServiceConfig) (string, error) {
-	language := svc.Language
-	if !(language == "dotnet" || language == "csharp" || language == "fsharp") {
+	if showTypeFromLanguage(svc.Language) != contracts.ShowTypeDotNet {
 		return svc.Path(), nil
 	}
 


### PR DESCRIPTION
fix #1877 
We had the code where if language is either "", "dotnet", "csharp", "fsharp", we create it as NewDotNetProject() in `GetFrameworkService` function, so svc.Language reads "dotnet" instead of "csharp". Since `GetFrameworkService` function is updated, we need to add all language checks.