### PR TITLE
add longer wait time for `java-mongo` playwright test

### DIFF
--- a/templates/todo/common/tests/todo.spec.ts
+++ b/templates/todo/common/tests/todo.spec.ts
@@ -5,7 +5,7 @@ test("Create and delete item test", async ({ page }) => {
   await page.goto("/", { waitUntil: 'networkidle' });
 
   await expect(page.locator("text=My List").first()).toBeVisible({
-    timeout: 300 * 1000,
+    timeout: 360 * 1000,
   });
 
   await expect(page.locator("text=This list is empty.").first()).toBeVisible()


### PR DESCRIPTION
Java-mongo test fails a couple of times on playwright test and always pass on a re-run. It looks like java tests take a while for webapps, so I'm increasing the wait time. 