### PR TITLE
Update `deploy` and `up` UX

### DIFF
--- a/cli/azd/cmd/package.go
+++ b/cli/azd/cmd/package.go
@@ -66,8 +66,6 @@ type packageAction struct {
 	console        input.Console
 	formatter      output.Formatter
 	writer         io.Writer
-	// if true, (BETA) is omitted from the title message
-	omitBetaInTitle bool
 }
 
 func newPackageAction(
@@ -98,14 +96,9 @@ type PackageResult struct {
 }
 
 func (pa *packageAction) Run(ctx context.Context) (*actions.ActionResult, error) {
-	title := fmt.Sprintf("Packaging services (azd package) %s", output.WithWarningFormat("(Beta)"))
-	if pa.omitBetaInTitle {
-		title = "Packaging services (azd package)"
-	}
-
 	// Command title
 	pa.console.MessageUxItem(ctx, &ux.MessageTitle{
-		Title: title,
+		Title: "Packaging services (azd package)",
 	})
 
 	targetServiceName := ""

--- a/cli/azd/cmd/package.go
+++ b/cli/azd/cmd/package.go
@@ -66,6 +66,8 @@ type packageAction struct {
 	console        input.Console
 	formatter      output.Formatter
 	writer         io.Writer
+	// if true, (BETA) is omitted from the title message
+	omitBetaInTitle bool
 }
 
 func newPackageAction(
@@ -96,9 +98,14 @@ type PackageResult struct {
 }
 
 func (pa *packageAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	title := fmt.Sprintf("Packaging services (azd package) %s", output.WithWarningFormat("(Beta)"))
+	if pa.omitBetaInTitle {
+		title = "Packaging services (azd package)"
+	}
+
 	// Command title
 	pa.console.MessageUxItem(ctx, &ux.MessageTitle{
-		Title: fmt.Sprintf("Packaging services (azd package) %s", output.WithWarningFormat("(Beta)")),
+		Title: title,
 	})
 
 	targetServiceName := ""

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -109,6 +109,7 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	packageAction.omitBetaInTitle = true
 	packageOptions := &middleware.Options{CommandPath: "package"}
 	_, err = u.runner.RunChildAction(ctx, packageOptions, packageAction)
 	if err != nil {

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -109,7 +109,6 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	packageAction.omitBetaInTitle = true
 	packageOptions := &middleware.Options{CommandPath: "package"}
 	_, err = u.runner.RunChildAction(ctx, packageOptions, packageAction)
 	if err != nil {

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -285,6 +285,7 @@ func Test_CLI_ProjectIsNeeded(t *testing.T) {
 	}
 }
 
+// Verifies commands that requires `azd provision` to be successfully run beforehand correctly errors out.
 func Test_CLI_ProvisionIsNeeded(t *testing.T) {
 	ctx, cancel := newTestContext(t)
 	defer cancel()

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -285,6 +285,52 @@ func Test_CLI_ProjectIsNeeded(t *testing.T) {
 	}
 }
 
+func Test_CLI_ProvisionIsNeeded(t *testing.T) {
+	ctx, cancel := newTestContext(t)
+	defer cancel()
+
+	dir := tempDirWithDiagnostics(t)
+	t.Logf("DIR: %s", dir)
+
+	envName := randomEnvName()
+	t.Logf("AZURE_ENV_NAME: %s", envName)
+
+	cli := azdcli.NewCLI(t)
+	cli.WorkingDirectory = dir
+	cli.Env = append(os.Environ(), "AZURE_LOCATION=eastus2")
+
+	err := copySample(dir, "webapp")
+	require.NoError(t, err, "failed expanding sample")
+
+	_, err = cli.RunCommandWithStdIn(ctx, stdinForInit(envName), "init")
+	require.NoError(t, err)
+
+	tests := []struct {
+		command       string
+		args          []string
+		errorToStdOut bool
+	}{
+		{command: "deploy"},
+		{command: "monitor"},
+		{command: "pipeline config"},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		args := []string{"--cwd", dir}
+		args = append(args, strings.Split(test.command, " ")...)
+		if len(test.args) > 0 {
+			args = append(args, test.args...)
+		}
+
+		t.Run(test.command, func(t *testing.T) {
+			result, err := cli.RunCommand(ctx, args...)
+			assert.Error(t, err)
+			assert.Contains(t, result.Stdout, "azd provision")
+		})
+	}
+}
+
 func Test_CLI_NoDebugSpewWhenHelpPassedWithoutDebug(t *testing.T) {
 	cli := azdcli.NewCLI(t)
 	ctx := context.Background()

--- a/cli/azd/test/functional/deploy_test.go
+++ b/cli/azd/test/functional/deploy_test.go
@@ -30,6 +30,10 @@ func Test_CLI_Deploy_Err_WorkingDirectory(t *testing.T) {
 	_, err = cli.RunCommandWithStdIn(ctx, stdinForInit("testenv"), "init")
 	require.NoError(t, err)
 
+	// Otherwise, deploy with 'infrastructure has not been provisioned. Please run `azd provision`'
+	_, err = cli.RunCommand(ctx, "env", "set", "AZURE_SUBSCRIPTION_ID", testSubscriptionId)
+	require.NoError(t, err)
+
 	// cd infra
 	err = os.MkdirAll(filepath.Join(dir, "infra"), osutil.PermissionDirectory)
 	require.NoError(t, err)


### PR DESCRIPTION
Hide package output from `deploy`.  Do not show `(BETA)` in packaging title for `azd up` use case.

Add tests to verify invalid flag behaviors, since some behaviors were not tested and incorrect.

With this change, the output is now:

![image](https://user-images.githubusercontent.com/2322434/230675267-67233efa-195b-4bfd-b0c5-467fb3edcc17.png)

Fixes #1904, #1905