### PR TITLE
Add doc to outline features + current stages (alpha, beta, stable)

### DIFF
--- a/cli/azd/docs/feature-stages.md
+++ b/cli/azd/docs/feature-stages.md
@@ -1,5 +1,5 @@
 # Alpha, Beta and Stable Feature Stages
-As of `0.8.0-beta.1`, each Azure Developer CLI feature has been evaluated and assigned to a feature stage. You can read more about the definition of each phase and the graduation criteria by visiting [aka.ms/azd-feature-stages](aka.ms/azd-feature-stages). Here are a list of each feature/command supported by `azd` and its current stage.
+As of `0.8.0-beta.1`, each Azure Developer CLI feature has been evaluated and assigned to a feature stage. You can read more about the definition of each phase and the graduation criteria by visiting [aka.ms/azd-feature-stages](aka.ms/azd-feature-stages). Here is a list that includes each feature/command supported by `azd` and its current stage.
 
 | **Category** | **Feature**              | **Stage** |
 | ------------ | ------------------------ | --------- |

--- a/cli/azd/docs/feature-stages.md
+++ b/cli/azd/docs/feature-stages.md
@@ -1,5 +1,5 @@
 # Alpha, Beta and Stable Feature Stages
-As of `0.8.0-beta.1`, each Azure Developer CLI feature has been evaluated and assigned to a feature stage. You can read more about the definition of each phase and the graduation criteria by visiting [aka.ms/azd-feature-stages](aka.ms/azd-feature-stages). Here is a list that includes each feature/command supported by `azd` and its current stage.
+As of `0.8.0-beta.1`, each Azure Developer CLI feature has been evaluated and assigned to a feature stage. You can read more about the definition of each phase and the graduation criteria by visiting [aka.ms/azd](aka.ms/azd). Here is a list that includes each feature/command supported by `azd` and its current stage.
 
 | **Category** | **Feature**              | **Stage** |
 | ------------ | ------------------------ | --------- |

--- a/cli/azd/docs/feature-stages.md
+++ b/cli/azd/docs/feature-stages.md
@@ -1,4 +1,5 @@
 # Alpha, Beta and Stable Feature Stages
+
 As of `0.8.0-beta.1`, each Azure Developer CLI feature has been evaluated and assigned to a feature stage. You can read more about the definition of each phase and the graduation criteria by visiting [aka.ms/azd](aka.ms/azd). Here is a list that includes each feature/command supported by `azd` and its current stage.
 
 | **Category** | **Feature**              | **Stage** |

--- a/cli/azd/docs/feature-stages.md
+++ b/cli/azd/docs/feature-stages.md
@@ -1,0 +1,36 @@
+# Alpha, Beta and Stable Feature Stages
+As of `0.8.0-beta.1`, each Azure Developer CLI feature has been evaluated and assigned to a feature stage. You can read more about the definition of each phase and the graduation criteria by visiting [aka.ms/azd-feature-stages](aka.ms/azd-feature-stages). Here are a list of each feature/command supported by `azd` and its current stage.
+
+| **Category** | **Feature**              | **Stage** |
+| ------------ | ------------------------ | --------- |
+| Command      | config                   | Stable    |
+| Command      | deploy                   | Stable    |
+| Command      | down                     | Stable    |
+| Command      | env                      | Stable    |
+| Command      | help                     | Stable    |
+| Command      | init                     | Stable    |
+| Command      | auth                     | Stable    |
+| Command      | monitor                  | Beta      |
+| Command      | pipeline                 | Beta      |
+| Command      | provision                | Stable    |
+| Command      | restore                  | Beta      |
+| Command      | template                 | Beta      |
+| Command      | up                       | Stable    |
+| Command      | version                  | Stable    |
+| Command      | package                  | Beta      |
+| Language     | Python                   | Stable    |
+| Language     | JavaScript/TypeScript    | Stable    |
+| Language     | Java                     | Stable    |
+| Language     | .NET                     | Stable    |
+| Client       | Visual Studio Code       | Beta      |
+| Client       | Visual Studio            | Alpha     |
+| Client       | Codespaces               | Beta      |
+| CI/CD        | GitHub Actions           | Stable    |
+| CI/CD        | Azure Pipelines          | Stable    |
+| IaC          | Bicep                    | Stable    |
+| IaC          | Terraform                | Alpha     |
+| Host         | Azure App Service        | Stable    |
+| Host         | Azure Static Web Apps    | Stable    |
+| Host         | Azure Container Apps     | Beta      |
+| Host         | Azure Functions          | Stable    |
+| Host         | Azure Kubernetes Service | Beta      |


### PR DESCRIPTION
We need to have this in the repo so that docs can refer out to it for our feature stages for 0.8.0