### PR TITLE
check for "python" OR "py" on windows to verify python cli installation

### DIFF
--- a/cli/azd/pkg/tools/python/python.go
+++ b/cli/azd/pkg/tools/python/python.go
@@ -128,11 +128,10 @@ func (cli *PythonCli) CreateVirtualEnv(ctx context.Context, workingDir, name str
 	return nil
 }
 
-func checkPath() (string, bool, error) {
-	var found bool
-	var err error
+func checkPath() (pyString string, found bool, err error) {
 	if runtime.GOOS == "windows" {
 		// py for https://peps.python.org/pep-0397
+		// order is important. we want to resolve 'py', if available, first
 		pyString := [2]string{"py", "python"}
 
 		for _, py := range pyString {


### PR DESCRIPTION
fix #1623 
I installed python 3.10 with winget but not able to reproduce the same issue. I realize that the latest winget is using "py.exe" where this issue is caused if other winget is using "python.exe". Adding a check for either "python" or "py" to verify python cli installation. 