### PR TITLE
Update python todo apps to use Azure SDK identity preview 1.13.0b4

### DIFF
--- a/templates/todo/api/python/requirements.txt
+++ b/templates/todo/api/python/requirements.txt
@@ -2,9 +2,9 @@ fastapi == 0.78.*
 uvicorn == 0.17.*
 beanie == 1.11.*
 python-dotenv == 0.20.*
-# 1.13.0b2 provides AzureDeveloperCredential
-# https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/identity/azure-identity/CHANGELOG.md#1130b2-2023-02-07
-azure-identity == 1.13.0b2
+# 1.13.0b4 has a update supporting configurable timeouts on AzureDeveloperCredential
+# https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/identity/azure-identity/CHANGELOG.md#1130b4-2023-04-11
+azure-identity == 1.13.0b4
 azure-keyvault-secrets == 4.4.*
 opentelemetry-instrumentation-fastapi == 0.30b1
 azure-monitor-opentelemetry-exporter == 1.0.0b5


### PR DESCRIPTION
azure-sdk-for-python's release on 1.13.0b4 support configurable timeouts on `AzureDeveloperCliCredential`