### PR TITLE
Use `--no-prompt` as appropriate and cap the maximum number of `azure.yaml` files to autodiscover

### DIFF
--- a/ext/vscode/package.json
+++ b/ext/vscode/package.json
@@ -132,7 +132,14 @@
             }
         ],
         "configuration": {
-            "title": "azure-dev"
+            "title": "Azure Developer CLI",
+            "properties": {
+                "azure-dev.maximumAppsToDisplay": {
+                    "type": "number",
+                    "default": 5,
+                    "description": "%azure-dev.maximumAppsToDisplay.description%"
+                }
+            }
         },
         "menus": {
             "explorer/context": [

--- a/ext/vscode/package.nls.json
+++ b/ext/vscode/package.nls.json
@@ -21,6 +21,8 @@
     "azure-dev.commands.azureWorkspace.revealAzureResourceGroup.title": "Show Azure Resource Group",
     "azure-dev.commands.getDotEnvFilePath.title": "Get Azure developer environment's .env file path",
 
+    "azure-dev.maximumAppsToDisplay.description": "Maximum number of Azure Developer CLI apps to display in the Workspace Resource view",
+
     "azure-dev.tasks.dotenv.properties.file": "The .env file to use to populate the target task environment",
     "azure-dev.tasks.dotenv.properties.targetTasks": "Name of the task(s) that will be launched with environment populated from the .env file",
 

--- a/ext/vscode/src/commands/cmdUtil.ts
+++ b/ext/vscode/src/commands/cmdUtil.ts
@@ -123,7 +123,8 @@ export async function getEnvironments(context: IActionContext, cwd: string): Pro
     const azureCli = await createAzureDevCli(context);
     const command = azureCli.commandBuilder
         .withArg('env').withArg('list')
-        .withArg('--output').withArg('json')
+        .withArg('--no-prompt')
+        .withNamedArg('--output', 'json')
         .build();
 
     const result = await execAsync(command, azureCli.spawnOptions(cwd));

--- a/ext/vscode/src/services/AzureDevApplicationProvider.ts
+++ b/ext/vscode/src/services/AzureDevApplicationProvider.ts
@@ -16,7 +16,8 @@ export interface AzureDevApplicationProvider {
 const azureYamlFilePattern = '**/azure.{yml,yaml}';
 
 async function getApplications(): Promise<AzureDevApplication[]> {
-    const files = await vscode.workspace.findFiles(azureYamlFilePattern, '**/node_modules/**');
+    const maxResults = vscode.workspace.getConfiguration('azure-dev').get<number>('maximumAppsToDisplay', 5);
+    const files = await vscode.workspace.findFiles(azureYamlFilePattern, '**/node_modules/**', maxResults);
     
     const applications: AzureDevApplication[] = [];
 

--- a/ext/vscode/src/services/AzureDevEnvListProvider.ts
+++ b/ext/vscode/src/services/AzureDevEnvListProvider.ts
@@ -29,6 +29,7 @@ export class WorkspaceAzureDevEnvListProvider implements AzureDevEnvListProvider
         const command = azureCli.commandBuilder
             .withArg('env')
             .withArg('list')
+            .withArg('--no-prompt')
             .withNamedArg('--cwd', configurationFileDirectory)
             .withNamedArg('--output', 'json')
             .build();

--- a/ext/vscode/src/services/AzureDevShowProvider.ts
+++ b/ext/vscode/src/services/AzureDevShowProvider.ts
@@ -42,6 +42,7 @@ export class WorkspaceAzureDevShowProvider implements AzureDevShowProvider {
 
         const command = azureCli.commandBuilder
             .withArg('show')
+            .withArg('--no-prompt')
             .withNamedArg('--cwd', configurationFileDirectory)
             .withNamedArg('--environment', environmentName)
             .withNamedArg('--output', 'json')


### PR DESCRIPTION
Fixes #1688

Also fixes an issue found by @weikanglim where, when this repository was opened, a huge number of `azd` processes were started up to get information about the "apps" (the `azure.yaml` files) in the workspace--from the templates.