### PR TITLE
Updates go build flags

### DIFF
--- a/cli/azd/ci-build.ps1
+++ b/cli/azd/ci-build.ps1
@@ -37,10 +37,26 @@ if ($IsWindows) {
         exit $LASTEXITCODE
     }
     Write-Host "go generate succeeded"
+
+    Write-Host "go build (windows)"
+    go build `
+        -buildmode=exe `
+        -tags="cfi,cfg,osusergo,netgo" `
+        -trimpath `
+        -gcflags="-trimpath" `
+        -asmflags="-trimpath" `
+        -ldflags="-s -w -X 'github.com/azure/azure-dev/cli/azd/internal.Version=$Version (commit $SourceVersion)' -linkmode=auto -extldflags=-Wl,--high-entropy-va"
+}
+else {
+    Write-Host "go build (posix)"
+    go build `
+        -buildmode=pie `
+        -tags="cfi,cfg,cfgo,osusergo,netgo" `
+        -gcflags="-trimpath" `
+        -asmflags="-trimpath" `
+        -ldflags="-s -w -X 'github.com/azure/azure-dev/cli/azd/internal.Version=$Version (commit $SourceVersion)' -extldflags=-Wl,--high-entropy-va"
 }
 
-Write-Host "go build"
-go build -ldflags="-X 'github.com/azure/azure-dev/cli/azd/internal.Version=$Version (commit $SourceVersion)'"
 
 if ($LASTEXITCODE) {
     Write-Host "Error running go build"

--- a/cli/azd/ci-build.ps1
+++ b/cli/azd/ci-build.ps1
@@ -50,7 +50,7 @@ if ($IsWindows) {
         -ldflags="-s -w -X 'github.com/azure/azure-dev/cli/azd/internal.Version=$Version (commit $SourceVersion)' -linkmode=auto -extldflags=-Wl,--high-entropy-va"
 }
 elseif ($IsLinux) {
-    Write-Host "go build (posix)"
+    Write-Host "go build (linux)"
     go build `
         -buildmode=pie `
         -tags="cfi,cfg,cfgo,osusergo,netgo" `
@@ -59,7 +59,7 @@ elseif ($IsLinux) {
         -ldflags="-s -w -X 'github.com/azure/azure-dev/cli/azd/internal.Version=$Version (commit $SourceVersion)' -extldflags=-Wl,--high-entropy-va"
 }
 elseif ($IsMacOS) {
-    Write-Host "go build (posix)"
+    Write-Host "go build (macos)"
     go build `
         -buildmode=pie `
         -tags="cfi,cfg,cfgo,osusergo,netgo" `

--- a/cli/azd/ci-build.ps1
+++ b/cli/azd/ci-build.ps1
@@ -65,7 +65,7 @@ elseif ($IsMacOS) {
         -tags="cfi,cfg,cfgo,osusergo,netgo" `
         -gcflags="-trimpath" `
         -asmflags="-trimpath" `
-        -ldflags="-s -w -X 'github.com/azure/azure-dev/cli/azd/internal.Version=$Version (commit $SourceVersion)'  -linkmode=auto"
+        -ldflags="-s -w -X 'github.com/azure/azure-dev/cli/azd/internal.Version=$Version (commit $SourceVersion)' -linkmode=auto"
 }
 
 if ($LASTEXITCODE) {

--- a/cli/azd/ci-build.ps1
+++ b/cli/azd/ci-build.ps1
@@ -37,7 +37,9 @@ if ($IsWindows) {
         exit $LASTEXITCODE
     }
     Write-Host "go generate succeeded"
+}
 
+if ($IsWindows) {
     Write-Host "go build (windows)"
     go build `
         -buildmode=exe `
@@ -47,7 +49,7 @@ if ($IsWindows) {
         -asmflags="-trimpath" `
         -ldflags="-s -w -X 'github.com/azure/azure-dev/cli/azd/internal.Version=$Version (commit $SourceVersion)' -linkmode=auto -extldflags=-Wl,--high-entropy-va"
 }
-else {
+elseif ($IsLinux) {
     Write-Host "go build (posix)"
     go build `
         -buildmode=pie `
@@ -56,7 +58,15 @@ else {
         -asmflags="-trimpath" `
         -ldflags="-s -w -X 'github.com/azure/azure-dev/cli/azd/internal.Version=$Version (commit $SourceVersion)' -extldflags=-Wl,--high-entropy-va"
 }
-
+elseif ($IsMacOS) {
+    Write-Host "go build (posix)"
+    go build `
+        -buildmode=pie `
+        -tags="cfi,cfg,cfgo,osusergo,netgo" `
+        -gcflags="-trimpath" `
+        -asmflags="-trimpath" `
+        -ldflags="-s -w -X 'github.com/azure/azure-dev/cli/azd/internal.Version=$Version (commit $SourceVersion)'  -linkmode=auto"
+}
 
 if ($LASTEXITCODE) {
     Write-Host "Error running go build"


### PR DESCRIPTION
Resolves Azure/azure-dev-pr#1547

The following are addressed by default by the go compilier:
- Stack protection (stack canaries/cookies) (Enabled by default in Go 1.15 & 1.17)
- Address Space Layout Randomization (ASLR)
- Data Execution Prevention (DEP), the Non-Executable (NX) bit, or W^X functionality

## Windows

```bash
go build -buildmode=exe -tags=cfi,cfg,osusergo,netgo -trimpath -gcflags="-trimpath" -asmflags="-trimpath" -ldflags="-s -w -linkmode=auto -extldflags=-Wl,--high-entropy-va" -o azd.exe .
```

| Flag | Description | 
| --- | --- | 
| `-buildmode=exe` | Set the build mode to build an executable binary file | 
| `-tags=cfi,cfg,osusergo,netgo` | Enable Control Flow Integrity (CFI), Control Flow Guard (CFG), optimize for OS user accounts and network I/O performance |
| `-trimpath` | Security (prevent exposing file system paths) | 
| `-gcflags="-trimpath"` | Pass the `-trimpath` flag to the Go compiler to remove file system paths from the compiled code | 
| `-asmflags="-trimpath"` | Pass the `-trimpath` flag to the Go assembler to remove file system paths from the assembled code | 
| `-ldflags="-s -w -linkmode=auto -extldflags=-Wl,--high-entropy-va"` | Pass flags to the Go linker,  `-s`: Omit symbol table and debug information, `-w`: Omit DWARF symbol table, `-linkmode=auto`: Link Go object files and C object files together, `-extldflags=-Wl,--high-entropy-va`: Pass the high-entropy VA flag to the linker to enable high entropy virtual addresses |

## Linux

```bash
go build -buildmode=pie -tags=cfi,cfg,cfgo,osusergo,netgo -gcflags="-trimpath" -asmflags="-trimpath" -ldflags="-s -w -extldflags=-Wl,--high-entropy-va" -o azd .
```

| Flag | Description | 
| --- | --- | 
| `-buildmode=pie` | Build mode, position independent executable | 
| `-tags=cfi,cfg,cfgo,osusergo,netgo` | Enable Control Flow Integrity (CFI), Control Flow Guard (CFG), optimize for OS user accounts and network I/O performance | 
| `-trimpath` | Security (prevent exposing file system paths) | 
| `-gcflags="-trimpath"` | Garbage collector flags, setting the compiler option `-trimpath` | 
| `-asmflags="-trimpath"` | Assembler flags, setting the compiler option `-trimpath` | 
| `-ldflags="-s -w -extldflags=-Wl,--high-entropy-va"` | Linker flags, disabling symbol table and debug information, enabling high entropy virtual addresses | 

## Mac OS

```bash
go build -buildmode=pie -tags=cfi,cfg,cfgo,osusergo,netgo -gcflags="-trimpath" -asmflags="-trimpath" -ldflags="-s -w" -o azd .
```

| Flag | Description | 
| --- | --- | 
| `-buildmode=pie` | Build mode, position independent executable | 
| `-tags=cfi,cfg,cfgo,osusergo,netgo` | Enable Control Flow Integrity (CFI), Control Flow Guard (CFG), optimize for OS user accounts and network I/O performance | 
| `-trimpath` | Security (prevent exposing file system paths) | 
| `-gcflags="-trimpath"` | Garbage collector flags, setting the compiler option `-trimpath` | 
| `-asmflags="-trimpath"` | Assembler flags, setting the compiler option `-trimpath` | 
| `-ldflags="-s -w"` | Linker flags, disabling symbol table and debug information | 

