### PR TITLE
azure.yaml schema update: Hooks `run` only required if `windows` or `posix` is not specified

### DIFF
--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -335,9 +335,6 @@
         "hook": {
             "type": "object",
             "additionalProperties": false,
-            "required": [
-                "run"
-            ],
             "properties": {
                 "shell": {
                     "type": "string",
@@ -378,6 +375,27 @@
                     "default": null,
                     "$ref": "#/definitions/hook"
                 }
+            },
+            "if": {
+                "not": {
+                    "anyOf": [
+                        {
+                            "required": [
+                                "windows"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "posix"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "then": {
+                "required": [
+                    "run"
+                ]
             }
         },
         "docker": {


### PR DESCRIPTION
Resolves #1552 
Updates the azure.yaml JSON for hooks so `run` is only required if `windows` or `posix` has not been specified.