### PR TITLE
Move `EnsureConfigured` to be part of provider initialization

### DIFF
--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -47,10 +47,6 @@ func (m *Manager) Plan(ctx context.Context) (*DeploymentPlan, error) {
 
 // Gets the latest deployment details for the specified scope
 func (m *Manager) State(ctx context.Context, scope infra.Scope) (*StateResult, error) {
-	if err := m.provider.EnsureConfigured(ctx); err != nil {
-		return nil, err
-	}
-
 	var stateResult *StateResult
 
 	err := m.runAction(
@@ -125,10 +121,6 @@ func (m *Manager) Destroy(ctx context.Context, deployment *Deployment, options D
 
 // Plans the infrastructure provisioning and orchestrates interactive terminal operations
 func (m *Manager) plan(ctx context.Context) (*DeploymentPlan, error) {
-	if err := m.provider.EnsureConfigured(ctx); err != nil {
-		return nil, err
-	}
-
 	planningTask := m.provider.Plan(ctx)
 	go func() {
 		for progress := range planningTask.Progress() {
@@ -150,10 +142,6 @@ func (m *Manager) deploy(
 	plan *DeploymentPlan,
 	scope infra.Scope,
 ) (*DeployResult, error) {
-	if err := m.provider.EnsureConfigured(ctx); err != nil {
-		return nil, err
-	}
-
 	deployTask := m.provider.Deploy(ctx, plan, scope)
 
 	go func() {
@@ -175,10 +163,6 @@ func (m *Manager) deploy(
 
 // Destroys the specified infrastructure provisioning and orchestrates the interactive terminal operations
 func (m *Manager) destroy(ctx context.Context, deployment *Deployment, options DestroyOptions) (*DestroyResult, error) {
-	if err := m.provider.EnsureConfigured(ctx); err != nil {
-		return nil, err
-	}
-
 	var destroyResult *DestroyResult
 
 	err := m.runAction(
@@ -321,6 +305,9 @@ func NewManager(
 	}
 
 	m.provider = infraProvider
+	if err := m.provider.EnsureConfigured(ctx); err != nil {
+		return nil, err
+	}
 
 	return m, nil
 }

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -119,7 +119,9 @@ type Provider interface {
 	Name() string
 	RequiredExternalTools() []tools.ExternalTool
 	// EnsureConfigured ensures that any required configuration for the provider has been loaded, prompting the user for
-	// any missing values. It should be called before [State], [Plan], [Deploy], or [Destroy].
+	// any missing values.
+	//
+	// EnsureConfigured is called when a provider is constructed.
 	EnsureConfigured(ctx context.Context) error
 	// State gets the current state of the infrastructure, this contains both the provisioned resources and any outputs from
 	// the module.


### PR DESCRIPTION
Moving `EnsureConfigured` to be part of provider initialization creates invariant that avoids incorrect usage of a provider. For example, in this particular issue -- `State()` requires a `Scope`, which cannot be determined until the provider initializes `env.SubscriptionId`.

Fixes #1956