### PR TITLE
Update federated auth to allow token re-fetch

### DIFF
--- a/cli/azd/cmd/auth_login.go
+++ b/cli/azd/cmd/auth_login.go
@@ -45,7 +45,6 @@ type loginFlags struct {
 	clientID               string
 	clientSecret           stringPtr
 	clientCertificate      string
-	federatedToken         stringPtr
 	federatedTokenProvider string
 	redirectPort           int
 	global                 *internal.GlobalCommandOptions
@@ -77,7 +76,6 @@ func (p *stringPtr) Type() string {
 const (
 	cClientSecretFlagName                = "client-secret"
 	cClientCertificateFlagName           = "client-certificate"
-	cFederatedCredentialFlagName         = "federated-credential"
 	cFederatedCredentialProviderFlagName = "federated-credential-provider"
 )
 
@@ -103,11 +101,6 @@ func (lf *loginFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandO
 		cClientCertificateFlagName,
 		"",
 		"The path to the client certificate for the service principal to authenticate with.")
-	local.Var(
-		&lf.federatedToken,
-		cFederatedCredentialFlagName,
-		"The federated token for the service principal to authenticate with. "+
-			"Set to the empty string to read the value from the console.")
 	local.StringVar(
 		&lf.federatedTokenProvider,
 		cFederatedCredentialProviderFlagName,
@@ -145,7 +138,7 @@ func newLoginCmd(parent string) *cobra.Command {
 		--use-device-code.
 		
 		To log in as a service principal, pass --client-id and --tenant-id as well as one of: --client-secret, 
-		--client-certificate, --federated-credential, or --federated-credential-provider.
+		--client-certificate, or --federated-credential-provider.
 		`),
 		Annotations: map[string]string{
 			loginCmdParentAnnotation: parent,
@@ -308,14 +301,12 @@ func (la *loginAction) login(ctx context.Context) error {
 		if countTrue(
 			la.flags.clientSecret.ptr != nil,
 			la.flags.clientCertificate != "",
-			la.flags.federatedToken.ptr != nil,
 			la.flags.federatedTokenProvider != "",
 		) != 1 {
 			return fmt.Errorf(
 				"must set exactly one of %s for service principal", strings.Join([]string{
 					cClientSecretFlagName,
 					cClientCertificateFlagName,
-					cFederatedCredentialFlagName,
 					cFederatedCredentialProviderFlagName,
 				}, ", "))
 		}
@@ -351,22 +342,6 @@ func (la *loginAction) login(ctx context.Context) error {
 
 			if _, err := la.authManager.LoginWithServicePrincipalCertificate(
 				ctx, la.flags.tenantID, la.flags.clientID, cert,
-			); err != nil {
-				return fmt.Errorf("logging in: %w", err)
-			}
-		case la.flags.federatedToken.ptr != nil:
-			if *la.flags.federatedToken.ptr == "" {
-				v, err := la.console.Prompt(ctx, input.ConsoleOptions{
-					Message: "Enter your federated token",
-				})
-				if err != nil {
-					return fmt.Errorf("prompting for federated token: %w", err)
-				}
-				la.flags.federatedToken.ptr = &v
-			}
-
-			if _, err := la.authManager.LoginWithServicePrincipalFederatedToken(
-				ctx, la.flags.tenantID, la.flags.clientID, *la.flags.federatedToken.ptr,
 			); err != nil {
 				return fmt.Errorf("logging in: %w", err)
 			}

--- a/cli/azd/cmd/testdata/TestUsage-azd-auth-login.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-auth-login.snap
@@ -9,7 +9,6 @@ Flags
         --client-certificate string            	: The path to the client certificate for the service principal to authenticate with.
         --client-id string                     	: The client id for the service principal to authenticate with.
         --client-secret string                 	: The client secret for the service principal to authenticate with. Set to the empty string to read the value from the console.
-        --federated-credential string          	: The federated token for the service principal to authenticate with. Set to the empty string to read the value from the console.
         --federated-credential-provider string 	: The provider to use to acquire a federated token to authenticate with.
     -h, --help                                 	: Gets help for login.
         --redirect-port int                    	: Choose the port to be used as part of the redirect URI during interactive login.

--- a/cli/azd/pkg/auth/manager_test.go
+++ b/cli/azd/pkg/auth/manager_test.go
@@ -114,37 +114,6 @@ func TestServicePrincipalLoginClientCertificate(t *testing.T) {
 	require.True(t, errors.Is(err, ErrNoCurrentUser))
 }
 
-func TestServicePrincipalLoginFederatedToken(t *testing.T) {
-	credentialCache := &memoryCache{
-		cache: make(map[string][]byte),
-	}
-
-	m := Manager{
-		configManager:   newMemoryConfigManager(),
-		credentialCache: credentialCache,
-	}
-
-	cred, err := m.LoginWithServicePrincipalFederatedToken(
-		context.Background(), "testClientId", "testTenantId", "testToken",
-	)
-
-	require.NoError(t, err)
-	require.IsType(t, new(azidentity.ClientAssertionCredential), cred)
-
-	cred, err = m.CredentialForCurrentUser(context.Background(), nil)
-
-	require.NoError(t, err)
-	require.IsType(t, new(azidentity.ClientAssertionCredential), cred)
-
-	err = m.Logout(context.Background())
-
-	require.NoError(t, err)
-
-	_, err = m.CredentialForCurrentUser(context.Background(), nil)
-
-	require.True(t, errors.Is(err, ErrNoCurrentUser))
-}
-
 func TestServicePrincipalLoginFederatedTokenProvider(t *testing.T) {
 	credentialCache := &memoryCache{
 		cache: make(map[string][]byte),


### PR DESCRIPTION
Fix implementation of GitHub federated auth token provider to allow for fetching of tokens when tokens expire.

Validated the failing behavior before this change, and success behavior after this change, using a GitHub action that slept for 15 minutes, calling `azd auth token` in-between, and runs full `azd provision` and `azd deploy` after 15 minutes.

Fixes #1901