### PR TITLE
Only show 'create' resource operations during provision

### DIFF
--- a/cli/azd/pkg/infra/azure_resource_manager.go
+++ b/cli/azd/pkg/infra/azure_resource_manager.go
@@ -370,6 +370,7 @@ func (rm *AzureResourceManager) appendDeploymentResourcesRecursive(
 
 		_, alreadyAdded := (*resourceOperations)[*operation.OperationID]
 		if !alreadyAdded &&
+			*operation.Properties.ProvisioningOperation == armresources.ProvisioningOperationCreate &&
 			operation.Properties.Timestamp.After(*queryStart) {
 			(*resourceOperations)[*operation.OperationID] = operation
 		}


### PR DESCRIPTION
Rolls back one unintentional change when showing `deleted` resources from PR #1967 