### PR TITLE
Write azd and tool versions to debug log

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -57,6 +57,7 @@ functionapp
 GOARCH
 godotenv
 golangci
+hotspot
 ineffassign
 javac
 jmes

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -49,6 +49,8 @@ func main() {
 		log.SetOutput(io.Discard)
 	}
 
+	log.Printf("azd version: %s", internal.Version)
+
 	ts := telemetry.GetTelemetrySystem()
 
 	latest := make(chan semver.Version)

--- a/cli/azd/pkg/commands/pipeline/github_provider_test.go
+++ b/cli/azd/pkg/commands/pipeline/github_provider_test.go
@@ -6,11 +6,13 @@ package pipeline
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/github"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +46,7 @@ func Test_gitHub_provider_getRepoDetails(t *testing.T) {
 func Test_gitHub_provider_preConfigure_check(t *testing.T) {
 	t.Run("success with all default values", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		setupGithubAuthMock(mockContext)
+		setupGithubCliMocks(mockContext)
 
 		provider := NewGitHubCiProvider(mockContext.Credentials, mockContext.CommandRunner, mockContext.Console)
 		updatedConfig, err := provider.preConfigureCheck(
@@ -71,7 +73,7 @@ func Test_gitHub_provider_preConfigure_check(t *testing.T) {
 		}
 
 		mockContext := mocks.NewMockContext(context.Background())
-		setupGithubAuthMock(mockContext)
+		setupGithubCliMocks(mockContext)
 
 		provider := NewGitHubCiProvider(mockContext.Credentials, mockContext.CommandRunner, mockContext.Console)
 		updatedConfig, err := provider.preConfigureCheck(
@@ -91,7 +93,7 @@ func Test_gitHub_provider_preConfigure_check(t *testing.T) {
 		}
 
 		mockContext := mocks.NewMockContext(context.Background())
-		setupGithubAuthMock(mockContext)
+		setupGithubCliMocks(mockContext)
 
 		provider := NewGitHubCiProvider(mockContext.Credentials, mockContext.CommandRunner, mockContext.Console)
 		updatedConfig, err := provider.preConfigureCheck(
@@ -105,10 +107,16 @@ func Test_gitHub_provider_preConfigure_check(t *testing.T) {
 	})
 }
 
-func setupGithubAuthMock(mockContext *mocks.MockContext) {
+func setupGithubCliMocks(mockContext *mocks.MockContext) {
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 		return strings.Contains(command, "auth status")
 	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
 		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "--version")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		return exec.NewRunResult(0, fmt.Sprintf("gh version %s", github.GitHubCliVersion), ""), nil
 	})
 }

--- a/cli/azd/pkg/tools/bicep/bicep.go
+++ b/cli/azd/pkg/tools/bicep/bicep.go
@@ -93,6 +93,8 @@ func newBicepCliWithTransporter(
 		return nil, fmt.Errorf("checking bicep version: %w", err)
 	}
 
+	log.Printf("bicep version: %s", ver)
+
 	if ver.LT(cBicepVersion) {
 		log.Printf("installed bicep version %s is older than %s; updating.", ver.String(), cBicepVersion.String())
 

--- a/cli/azd/pkg/tools/docker/docker.go
+++ b/cli/azd/pkg/tools/docker/docker.go
@@ -199,6 +199,7 @@ func (d *docker) CheckInstalled(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("checking %s version: %w", d.Name(), err)
 	}
+	log.Printf("docker version: %s", dockerRes)
 	supported, err := isSupportedDockerVersion(dockerRes)
 	if err != nil {
 		return false, err

--- a/cli/azd/pkg/tools/dotnet/dotnet.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
@@ -54,6 +55,7 @@ func (cli *dotNetCli) CheckInstalled(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("checking %s version: %w", cli.Name(), err)
 	}
+	log.Printf("dotnet version: %s", dotnetRes)
 	dotnetSemver, err := tools.ExtractVersion(dotnetRes)
 	if err != nil {
 		return false, fmt.Errorf("converting to semver version fails: %w", err)

--- a/cli/azd/pkg/tools/git/git.go
+++ b/cli/azd/pkg/tools/git/git.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"regexp"
 	"runtime"
@@ -68,6 +69,7 @@ func (cli *gitCli) CheckInstalled(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("checking %s version: %w", cli.Name(), err)
 	}
+	log.Printf("git version: %s", gitRes)
 	gitSemver, err := tools.ExtractVersion(gitRes)
 	if err != nil {
 		return false, fmt.Errorf("converting to semver version fails: %w", err)

--- a/cli/azd/pkg/tools/github/github_test.go
+++ b/cli/azd/pkg/tools/github/github_test.go
@@ -108,7 +108,7 @@ func TestNewGitHubCli(t *testing.T) {
 		return strings.Contains(args.Cmd, "gh") && len(args.Args) == 1 && args.Args[0] == "--version"
 	}).Respond(exec.NewRunResult(
 		0,
-		fmt.Sprintf("gh version %s (abcdef0123)", cGitHubCliVersion.String()),
+		fmt.Sprintf("gh version %s (abcdef0123)", GitHubCliVersion.String()),
 		"",
 	))
 
@@ -144,6 +144,10 @@ func TestNewGitHubCli(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, []byte("this is github cli"), contents)
+
+	ver, err := cli.(*ghCli).extractVersion(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, GitHubCliVersion.String(), ver)
 }
 
 func createSampleZip(path, content, file string) (string, error) {

--- a/cli/azd/pkg/tools/javac/javac.go
+++ b/cli/azd/pkg/tools/javac/javac.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	osexec "os/exec"
 	"path/filepath"
@@ -53,17 +54,19 @@ func (j *javacCli) CheckInstalled(ctx context.Context) (bool, error) {
 		// On older versions of javac (8 and below), `javac -version` is supported instead.
 		// If this returns successfully, we know that it's an older version
 		// and can safely recommend an upgrade.
-		_, err := j.cmdRun.Run(ctx, exec.RunArgs{
+		runResult, err = j.cmdRun.Run(ctx, exec.RunArgs{
 			Cmd:  path,
 			Args: []string{"-version"},
 		})
 
 		if err == nil {
+			log.Printf("javac version: %s", runResult.Stdout)
 			return false, &tools.ErrSemver{ToolName: j.Name(), VersionInfo: j.VersionInfo()}
 		}
 
 		return false, fmt.Errorf("checking javac version: %w", err)
 	}
+	log.Printf("javac version: %s", runResult.Stdout)
 
 	jdkVer, err := tools.ExtractVersion(runResult.Stdout)
 	if err != nil {

--- a/cli/azd/pkg/tools/maven/maven.go
+++ b/cli/azd/pkg/tools/maven/maven.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sync"
 
 	osexec "os/exec"
@@ -46,6 +47,10 @@ func (m *mavenCli) CheckInstalled(ctx context.Context) (bool, error) {
 	_, err := m.mvnCmd()
 	if err != nil {
 		return false, err
+	}
+
+	if ver, err := m.extractVersion(ctx); err == nil {
+		log.Printf("maven version: %s", ver)
 	}
 
 	return true, nil
@@ -136,6 +141,36 @@ func getMavenWrapperPath(projectPath string, rootProjectPath string) (string, er
 			return "", nil
 		}
 	}
+}
+
+// cMavenVersionRegexp captures the version number of maven from the output of "mvn --version"
+//
+// the output of mvn --version looks something like this:
+// Apache Maven 3.9.1 (2e178502fcdbffc201671fb2537d0cb4b4cc58f8)
+// Maven home: C:\Tools\apache-maven-3.9.1
+// Java version: 17.0.6, vendor: Microsoft, runtime: C:\Program Files\Microsoft\jdk-17.0.6.10-hotspot
+// Default locale: en_US, platform encoding: Cp1252
+// OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"
+var cMavenVersionRegexp = regexp.MustCompile(`Apache Maven (.*) \(`)
+
+func (cli *mavenCli) extractVersion(ctx context.Context) (string, error) {
+	mvnCmd, err := cli.mvnCmd()
+	if err != nil {
+		return "", err
+	}
+
+	runArgs := exec.NewRunArgs(mvnCmd, "--version")
+	res, err := cli.commandRunner.Run(ctx, runArgs)
+	if err != nil {
+		return "", fmt.Errorf("failed to run %s --version: %w", mvnCmd, err)
+	}
+
+	parts := cMavenVersionRegexp.FindStringSubmatch(res.Stdout)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("could not parse %s --version output, did not match expected format", mvnCmd)
+	}
+
+	return parts[1], nil
 }
 
 func (cli *mavenCli) Compile(ctx context.Context, projectPath string) error {

--- a/cli/azd/pkg/tools/maven/maven_test.go
+++ b/cli/azd/pkg/tools/maven/maven_test.go
@@ -1,12 +1,16 @@
 package maven
 
 import (
+	"context"
 	"log"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockexec"
 	"github.com/azure/azure-dev/cli/azd/test/ostest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -102,6 +106,25 @@ func Test_getMavenPath(t *testing.T) {
 			assert.Equal(t, tt.want, actual)
 		})
 	}
+}
+
+func Test_extractVersion(t *testing.T) {
+	execMock := mockexec.NewMockCommandRunner().
+		When(func(a exec.RunArgs, command string) bool { return a.Args[0] == "--version" }).
+		RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+			return exec.NewRunResult(0, heredoc.Doc(`
+			Apache Maven 3.9.1 (2e178502fcdbffc201671fb2537d0cb4b4cc58f8)
+			Maven home: C:\Tools\apache-maven-3.9.1
+			Java version: 17.0.6, vendor: Microsoft, runtime: C:\Program Files\Microsoft\jdk-17.0.6.10-hotspot
+			Default locale: en_US, platform encoding: Cp1252
+			OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"
+			`), ""), nil
+		})
+
+	mvn := NewMavenCli(execMock).(*mavenCli)
+	ver, err := mvn.extractVersion(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "3.9.1", ver)
 }
 
 func placeExecutable(t *testing.T, name string, dirs ...string) {

--- a/cli/azd/pkg/tools/python/python.go
+++ b/cli/azd/pkg/tools/python/python.go
@@ -6,6 +6,7 @@ package python
 import (
 	"context"
 	"fmt"
+	"log"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -44,6 +45,9 @@ func (cli *PythonCli) CheckInstalled(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("checking %s version: %w", cli.Name(), err)
 	}
+
+	log.Printf("python version: %s", pythonRes)
+
 	pythonSemver, err := tools.ExtractVersion(pythonRes)
 	if err != nil {
 		return false, fmt.Errorf("converting to semver version fails: %w", err)

--- a/cli/azd/pkg/tools/swa/swa.go
+++ b/cli/azd/pkg/tools/swa/swa.go
@@ -12,6 +12,9 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 )
 
+// cSwaCliPackage is the npm package (including the version version) we execute with npx to run the SWA CLI.
+const cSwaCliPackage = "@azure/static-web-apps-cli@1.0.6"
+
 func NewSwaCli(commandRunner exec.CommandRunner) SwaCli {
 	return &swaCli{
 		commandRunner: commandRunner,
@@ -95,7 +98,6 @@ func (cli *swaCli) Deploy(
 }
 
 func (cli *swaCli) CheckInstalled(_ context.Context) (bool, error) {
-
 	return tools.ToolInPath("npx")
 }
 
@@ -109,7 +111,7 @@ func (cli *swaCli) InstallUrl() string {
 
 func (cli *swaCli) executeCommand(ctx context.Context, cwd string, args ...string) (exec.RunResult, error) {
 	runArgs := exec.
-		NewRunArgs("npx", "-y", "@azure/static-web-apps-cli@1.0.6").
+		NewRunArgs("npx", "-y", cSwaCliPackage).
 		AppendParams(args...).
 		WithCwd(cwd).
 		WithEnrichError(true)

--- a/cli/azd/pkg/tools/terraform/terraform.go
+++ b/cli/azd/pkg/tools/terraform/terraform.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
@@ -72,6 +73,9 @@ func (cli *terraformCli) CheckInstalled(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("checking %s version:  %w", cli.Name(), err)
 	}
+
+	log.Printf("terraform version: %s", tfVer)
+
 	tfSemver, err := semver.Parse(tfVer)
 	if err != nil {
 		return false, fmt.Errorf("converting to semver version fails: %w", err)


### PR DESCRIPTION
This change ensures that we log both the version of `azd` itself and all the external tools that we end up using the debug log.  This is useful for diagnostics purposes.

Fixes #1936