### PR TITLE
Force discovery of git repository in parent folder

### DIFF
--- a/cli/azd/.vscode/settings.json
+++ b/cli/azd/.vscode/settings.json
@@ -1,10 +1,11 @@
 {
-    "go.testTimeout": "10m",
-    "go.lintTool": "golangci-lint",
-    "go.lintFlags": ["--fast"],
-    "go.lintOnSave": "package",
-    "editor.rulers": [ 125 ],
     "cSpell.import": [
         "${workspaceFolder}/.vscode/cspell.yaml"
-    ]
+    ],
+    "editor.rulers": [ 125 ],
+    "git.openRepositoryInParentFolders": "always",
+    "go.lintFlags": ["--fast"],
+    "go.lintOnSave": "package",
+    "go.lintTool": "golangci-lint",
+    "go.testTimeout": "10m",
 }


### PR DESCRIPTION
VS Code recently made a change such that when you launch code from a subfolder it does not automatically load the git repository in the parent folder. This was done to prevent user confusion in some cases, and is discussed in more detail in the VS Code source control FAQ:

https://code.visualstudio.com/docs/sourcecontrol/faq#_why-isnt-vs-code-discovering-git-repositories-in-parent-folders-of-workspaces-or-open-files

Due to how our repository is structured, many folks working on `azd` launch code from within `cli/azd` (the root of the tree for the CLI) and this new setting means that you get a toast out of the box asking you if you want to load the repository or not. If you ignore this toast, the source control manager doesn't work (since VS Code doesn't assoicate the folder with the git repository in the parent).

We already have a `settings.json` in `cli/azd/.vscode` to support this type of workflow, so let's go ahead and set this value to say "yes, please load the repository in the parent for me" since this is the behavior we want.

While in the area, I sorted the settings in this file.