### PR TITLE
Add signature verification to artifacts downloaded

### DIFF
--- a/cli/installer/install-azd.ps1
+++ b/cli/installer/install-azd.ps1
@@ -346,8 +346,9 @@ try {
     try {
         if (isLinuxOrMac) {
             if ($IsMacOS -and (-not $SkipVerify)) {
-                codesign -v "$tempFolder/decompress/$binFilename"
-                if ($LASTEXITCODE) {
+                Write-Verbose "Verifying signature of $binFilename" -Verbose:$Verbose
+                codesign -v "$tempFolder/decompress/$binFilename" *>$null
+                if (-not $?) {
                     Write-Error "Could not verify signature of $binFilename"
                     reportTelemetryIfEnabled 'InstallFailed' 'SignatureVerificationFailed'
                     exit 1

--- a/cli/installer/install-azd.ps1
+++ b/cli/installer/install-azd.ps1
@@ -347,9 +347,16 @@ try {
         if (isLinuxOrMac) {
             if ($IsMacOS -and (-not $SkipVerify)) {
                 Write-Verbose "Verifying signature of $binFilename" -Verbose:$Verbose
-                codesign -v "$tempFolder/decompress/$binFilename" *>$null
+                $codeSignOutput = codesign -v "$tempFolder/decompress/$binFilename" 2>&1
                 if (-not $?) {
-                    Write-Error "Could not verify signature of $binFilename"
+                    Write-Error "Could not verify signature of $binFilename, error output:"
+                    $codeSignOutput |  ForEach-Object {
+                        if ($_ -is [System.Management.Automation.ErrorRecord]) {
+                          Write-Error $_
+                        } else {
+                          Write-Host $_
+                        }
+                    }
                     reportTelemetryIfEnabled 'InstallFailed' 'SignatureVerificationFailed'
                     exit 1
                 }
@@ -384,6 +391,7 @@ try {
                     }
                 } catch {
                     Write-Error "Could not verify signature of $releaseArtifactFilename"
+                    Write-Error $_
                     reportTelemetryIfEnabled 'InstallFailed' 'SignatureVerificationFailed'
                     exit 1
                 }

--- a/cli/installer/install-azd.ps1
+++ b/cli/installer/install-azd.ps1
@@ -304,7 +304,7 @@ try {
     Write-Verbose "Downloading build from $downloadUrl" -Verbose:$Verbose
     $releaseArtifactFilename = Join-Path $tempFolder $packageFilename
     try {
-        $LASTEXITCODE = 0
+        $global:LASTEXITCODE = 0
         Invoke-WebRequest -Uri $downloadUrl -OutFile $releaseArtifactFilename -TimeoutSec $DownloadTimeoutSeconds
         if ($LASTEXITCODE) {
             throw "Invoke-WebRequest failed with nonzero exit code: $LASTEXITCODE"
@@ -348,7 +348,7 @@ try {
             if ($IsMacOS -and (-not $SkipVerify)) {
                 Write-Verbose "Verifying signature of $binFilename" -Verbose:$Verbose
                 $codeSignOutput = codesign -v "$tempFolder/decompress/$binFilename" 2>&1
-                if (-not $?) {
+                if ($LASTEXITCODE) {
                     Write-Error "Could not verify signature of $binFilename, error output:"
                     $codeSignOutput |  ForEach-Object {
                         if ($_ -is [System.Management.Automation.ErrorRecord]) {

--- a/cli/installer/install-azd.ps1
+++ b/cli/installer/install-azd.ps1
@@ -375,8 +375,9 @@ try {
         } else {
             if (-not $SkipVerify) {
                 try {
+                    Write-Verbose "Verifying signature of $releaseArtifactFilename" -Verbose:$Verbose
                     $signature = Get-AuthenticodeSignature $releaseArtifactFilename
-                    if ($signature -ne 'Valid') {
+                    if ($signature.Status -ne 'Valid') {
                         Write-Error "Signature of $releaseArtifactFilename is not valid"
                         reportTelemetryIfEnabled 'InstallFailed' 'SignatureVerificationFailed'
                         exit 1

--- a/cli/installer/install-azd.ps1
+++ b/cli/installer/install-azd.ps1
@@ -345,7 +345,7 @@ try {
 
     try {
         if (isLinuxOrMac) {
-            if ($IsMacOS -and (-not $SkipVerify)) {
+            if ($IsMacOS -and !$SkipVerify) {
                 Write-Verbose "Verifying signature of $binFilename" -Verbose:$Verbose
                 $codeSignOutput = codesign -v "$tempFolder/decompress/$binFilename" 2>&1
                 if ($LASTEXITCODE) {
@@ -380,7 +380,7 @@ try {
                 Copy-Item "$tempFolder/decompress/$binFilename" $outputFilename  -ErrorAction Stop | Out-Null
             }
         } else {
-            if (-not $SkipVerify) {
+            if (!$SkipVerify) {
                 try {
                     Write-Verbose "Verifying signature of $releaseArtifactFilename" -Verbose:$Verbose
                     $signature = Get-AuthenticodeSignature $releaseArtifactFilename

--- a/cli/installer/install-azd.sh
+++ b/cli/installer/install-azd.sh
@@ -314,8 +314,8 @@ chmod +x "$tmp_folder/$bin_name"
 
 if [ "$platform" = "darwin" ] && [ "$skip_verify" = false ]; then
     say_verbose "Verifying signature of $bin_name"
-    if ! output=$( codesign -v "$tmp_folder/$bin_name" ); then
-        say_error "Could not verify signature of $bin_name"
+    if ! output=$( codesign -v "$tmp_folder/$bin_name" 2>&1); then
+        say_error "Could not verify signature of $bin_name, error output:"
         say_error "$output"
         save_error_report_if_enabled "InstallFailed" "SignatureVerificationFailure"
         exit 1

--- a/cli/installer/install-azd.sh
+++ b/cli/installer/install-azd.sh
@@ -313,8 +313,8 @@ extract "$compressed_file_path" "$bin_name" "$tmp_folder"
 chmod +x "$tmp_folder/$bin_name"
 
 if [ "$platform" = "darwin" ] && [ "$skip_verify" = false ]; then
-    codesign -v "$tmp_folder/$bin_name" > /dev/null 2>&1
-    if [ $? -ne 0 ]; then
+    say_verbose "Verifying signature of $bin_name"
+    if ! codesign -v "$tmp_folder/$bin_name" > /dev/null 2>&1; then
         say_error "Could not verify signature of $bin_name"
         save_error_report_if_enabled "InstallFailed" "SignatureVerificationFailure"
         exit 1

--- a/cli/installer/install-azd.sh
+++ b/cli/installer/install-azd.sh
@@ -280,7 +280,7 @@ say_verbose "Architecture: $architecture"
 say_verbose "File extension: $extension"
 
 if [ "$platform" = "darwin" ]; then
-    say_verbose "Mac detected, ensuring compatailbity with amd64 binaries"
+    say_verbose "Mac detected, ensuring compatibility with amd64 binaries"
     ensure_rosetta
 fi
 

--- a/cli/installer/install-azd.sh
+++ b/cli/installer/install-azd.sh
@@ -314,8 +314,9 @@ chmod +x "$tmp_folder/$bin_name"
 
 if [ "$platform" = "darwin" ] && [ "$skip_verify" = false ]; then
     say_verbose "Verifying signature of $bin_name"
-    if ! codesign -v "$tmp_folder/$bin_name" > /dev/null 2>&1; then
+    if ! output=$( codesign -v "$tmp_folder/$bin_name" ); then
         say_error "Could not verify signature of $bin_name"
+        say_error "$output"
         save_error_report_if_enabled "InstallFailed" "SignatureVerificationFailure"
         exit 1
     fi

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -738,6 +738,7 @@ stages:
               OSVmImage: MMS2022
               TestShell: pwsh
               TestInstallCommand: >
+                $ErrorActionPreference = 'Stop';
                 ./test-win-install.ps1 -BaseUrl $env:BASEURL -Version '';
                 ./test-telemetry-functions.ps1 -Shell pwsh -ExpectedFieldMap telemetry/windows.pwsh.telemetry.json
             WindowsPowerShell:
@@ -745,6 +746,7 @@ stages:
               OSVmImage: MMS2022
               TestShell: powershell
               TestInstallCommand: >
+                $ErrorActionPreference = 'Stop';
                 ./test-win-install.ps1 -BaseUrl $env:BASEURL -Version '';
                 ./test-telemetry-functions.ps1 -Shell powershell -ExpectedFieldMap telemetry/windows.powershell.telemetry.json
 
@@ -766,6 +768,35 @@ stages:
               path: hosting
 
           - bash: ls
+            workingDirectory: hosting
+
+          - bash: |
+              unzip ./azd-darwin-amd64.zip -d ./tmp
+
+              # Ad-hoc signing with "-" identity
+              codesign -s - tmp/azd-darwin-amd64
+
+              zip azd-darwin-amd64.zip -j tmp/azd-darwin-amd64
+            displayName: Self-sign (Darwin)
+            condition: and(succeeded(), contains(variables['Agent.OS'], 'Darwin'))
+            workingDirectory: hosting
+
+          - pwsh: |
+              $ErrorActionPreference = 'Stop'
+
+              # Generate self-sign cert
+              $cert = New-SelfSignedCertificate -CertStoreLocation Cert:\CurrentUser\My -Type CodeSigningCert -Subject "azd installer tests code signing"
+              
+              # Add as trusted root CA
+              $store = [System.Security.Cryptography.X509Certificates.X509Store]::new("Root", [System.Security.Cryptography.X509Certificates.StoreLocation]::CurrentUser)
+              $store.Open('ReadWrite')
+              $store.Add($cert)
+              $store.Close()
+
+              # Sign the windows binary
+              Set-AuthenticodeSignature .\azd-windows-amd64.msi -Certificate $cert
+            displayName: Self-sign (Windows)
+            condition: and(succeeded(), contains(variables['Agent.OS'], 'Windows'))
             workingDirectory: hosting
 
           - bash: nohup npx -y http-server &
@@ -844,6 +875,24 @@ stages:
               script: $(TestInstallCommand)
               workingDirectory: cli/installer/
             displayName: Test install script (cmd)
+
+          - pwsh: |
+              Get-ChildItem Cert:\CurrentUser\My | ForEach-Object {
+                if ($_.Subject -match "azd installer tests code signing") {
+                  Write-Host "Deleting $($_.PSPath)"
+                  Remove-Item -Force $_.PSPath
+                }
+              }
+
+              Get-ChildItem Cert:\CurrentUser\Root | ForEach-Object {
+                if ($_.Subject -match "azd installer tests code signing") {
+                  Write-Host "Deleting $($_.PSPath)"
+                  Remove-Item -Force $_.PSPath
+                }
+              }
+            displayName: Clean up self-signed certificates (Windows)
+            condition: contains(variables['Agent.OS'], 'Windows')
+            workingDirectory: hosting
 
       - job: Verify_LinuxPackages
 

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -785,12 +785,12 @@ stages:
               $ErrorActionPreference = 'Stop'
 
               # Generate self-sign cert
-              $cert = New-SelfSignedCertificate -CertStoreLocation Cert:\CurrentUser\My -Type CodeSigningCert -Subject "azd installer tests code signing"
+              $cert = New-SelfSignedCertificate -CertStoreLocation Cert:\LocalMachine\My -Type CodeSigningCert -Subject "azd installer tests code signing"
               
               # Add as temporary trusted root CA
               try {
                 Export-Certificate -Cert $cert -FilePath code_signing.crt
-                Import-Certificate -FilePath .\code_signing.crt -Cert Cert:\CurrentUser\Root
+                Import-Certificate -FilePath .\code_signing.crt -Cert Cert:\LocalMachine\Root
               }
               finally {
                 Remove-Item -Force .\code_signing.crt -ErrorAction SilentlyContinue
@@ -880,14 +880,14 @@ stages:
             displayName: Test install script (cmd)
 
           - pwsh: |
-              Get-ChildItem Cert:\CurrentUser\My | ForEach-Object {
+              Get-ChildItem Cert:\LocalMachine\My | ForEach-Object {
                 if ($_.Subject -match "azd installer tests code signing") {
                   Write-Host "Deleting $($_.PSPath) - $($_.Subject)"
                   Remove-Item -Force $_.PSPath
                 }
               }
 
-              Get-ChildItem Cert:\CurrentUser\Root | ForEach-Object {
+              Get-ChildItem Cert:\LocalMachine\Root | ForEach-Object {
                 if ($_.Subject -match "azd installer tests code signing") {
                   Write-Host "Deleting $($_.PSPath) - $($_.Subject)"
                   Remove-Item -Force $_.PSPath

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -1126,13 +1126,13 @@ stages:
               bash:
               ``````
               curl -fsSL $urlBase/uninstall-azd.sh | bash;
-              curl -fsSL $urlBase/install-azd.sh | bash -s -- --base-url $urlBase --version '' --verbose
+              curl -fsSL $urlBase/install-azd.sh | bash -s -- --base-url $urlBase --version '' --verbose --skip-verify
               ``````
 
               pwsh:
               ``````
               Invoke-RestMethod '$urlBase/uninstall-azd.ps1' -OutFile uninstall-azd.ps1; ./uninstall-azd.ps1
-              Invoke-RestMethod '$urlBase/install-azd.ps1' -OutFile install-azd.ps1; ./install-azd.ps1 -BaseUrl '$urlBase' -Version '' -Verbose
+              Invoke-RestMethod '$urlBase/install-azd.ps1' -OutFile install-azd.ps1; ./install-azd.ps1 -BaseUrl '$urlBase' -Version '' -SkipVerify -Verbose
               ``````
 
 
@@ -1142,7 +1142,7 @@ stages:
 
               ``````
               powershell -c "Set-ExecutionPolicy Bypass Process; irm '$urlBase/uninstall-azd.ps1' > uninstall-azd.ps1; ./uninstall-azd.ps1;"
-              powershell -c "Set-ExecutionPolicy Bypass Process; irm '$urlBase/install-azd.ps1' > install-azd.ps1; ./install-azd.ps1 -BaseUrl '$urlBase' -Version '' -Verbose;"
+              powershell -c "Set-ExecutionPolicy Bypass Process; irm '$urlBase/install-azd.ps1' > install-azd.ps1; ./install-azd.ps1 -BaseUrl '$urlBase' -Version '' -SkipVerify -Verbose;"
               ``````
 
               MSI install

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -787,11 +787,14 @@ stages:
               # Generate self-sign cert
               $cert = New-SelfSignedCertificate -CertStoreLocation Cert:\CurrentUser\My -Type CodeSigningCert -Subject "azd installer tests code signing"
               
-              # Add as trusted root CA
-              $store = [System.Security.Cryptography.X509Certificates.X509Store]::new("Root", [System.Security.Cryptography.X509Certificates.StoreLocation]::CurrentUser)
-              $store.Open('ReadWrite')
-              $store.Add($cert)
-              $store.Close()
+              # Add as temporary trusted root CA
+              try {
+                Export-Certificate -Cert $cert -FilePath code_signing.crt
+                Import-Certificate -FilePath .\code_signing.crt -Cert Cert:\CurrentUser\Root
+              }
+              finally {
+                Remove-Item -Force .\code_signing.crt -ErrorAction SilentlyContinue
+              }
 
               # Sign the windows binary
               Set-AuthenticodeSignature .\azd-windows-amd64.msi -Certificate $cert
@@ -879,14 +882,14 @@ stages:
           - pwsh: |
               Get-ChildItem Cert:\CurrentUser\My | ForEach-Object {
                 if ($_.Subject -match "azd installer tests code signing") {
-                  Write-Host "Deleting $($_.PSPath)"
+                  Write-Host "Deleting $($_.PSPath) - $($_.Subject)"
                   Remove-Item -Force $_.PSPath
                 }
               }
 
               Get-ChildItem Cert:\CurrentUser\Root | ForEach-Object {
                 if ($_.Subject -match "azd installer tests code signing") {
-                  Write-Host "Deleting $($_.PSPath)"
+                  Write-Host "Deleting $($_.PSPath) - $($_.Subject)"
                   Remove-Item -Force $_.PSPath
                 }
               }

--- a/eng/pipelines/templates/steps/install-azd-live-sh.yml
+++ b/eng/pipelines/templates/steps/install-azd-live-sh.yml
@@ -11,7 +11,7 @@ parameters:
 steps:
 - pwsh: |
     if ('${{ parameters.Version }}'.StartsWith('pr/')) {
-      $InstallArgs = "--base-url https://${{ parameters.StorageAccountName }}.blob.core.windows.net/azd/standalone/${{ parameters.Version }} --version ''"
+      $InstallArgs = "--base-url https://${{ parameters.StorageAccountName }}.blob.core.windows.net/azd/standalone/${{ parameters.Version }} --skip-verify --version ''"
       $ContainerImageTag = '${{ parameters.Version }}' -replace '/', '-'
     } else {
       $InstallArgs = "--version '${{ parameters.Version }}'"

--- a/eng/pipelines/templates/steps/template-test-run-job.yml
+++ b/eng/pipelines/templates/steps/template-test-run-job.yml
@@ -92,7 +92,7 @@ steps:
               # Install azd build
               if [[ $(AzdVersion) == pr/* ]];
               then
-                curl -fsSL https://aka.ms/install-azd.sh | sudo bash -s -- --base-url "https://$(azdev-storage-account-name).blob.core.windows.net/azd/standalone/$(AzdVersion)" --version ''
+                curl -fsSL https://aka.ms/install-azd.sh | sudo bash -s -- --base-url "https://$(azdev-storage-account-name).blob.core.windows.net/azd/standalone/$(AzdVersion)" --skip-verify --version ''
               else
                 curl -fsSL https://aka.ms/install-azd.sh | sudo bash -s -- --version $(AzdVersion) --verbose
               fi


### PR DESCRIPTION
For Windows installer scripts, perform `Get-AuthenticodeSignature <msi artifact>` and ensure that the `Status` returned is `Valid`. This verifies that the signed binary originates from a trusted cert chain.

For macOS installer scripts, perform `codesign -v <azd binary>`.

Current output of our code sign designated requirements: `codesign -dv -r- /usr/local/bin/azd`:

```
designated => identifier "azd-darwin-amd64" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UBF8T346G9
```

which verifies for an anchor trusted cert chain. 

Fixes https://github.com/Azure/azure-dev-pr/issues/1548