### PR TITLE
Ensure directory has user "execute" permissions so it is accessible

### DIFF
--- a/cli/azd/pkg/config/manager.go
+++ b/cli/azd/pkg/config/manager.go
@@ -127,7 +127,7 @@ func GetUserConfigDir() (string, error) {
 		permissions := info.Mode().Perm()
 		if permissions&0100 == 0 {
 			// Ensure user execute permissions
-			err := os.Chmod(configDirPath, permissions|100)
+			err := os.Chmod(configDirPath, permissions|0100)
 			return configDirPath, err
 		}
 	}

--- a/cli/azd/pkg/config/manager.go
+++ b/cli/azd/pkg/config/manager.go
@@ -14,7 +14,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 )
 
-const configDir = ".azd"
+const cConfigDir = ".azd"
 
 // Config Manager provides the ability to load, parse and save azd configuration files
 type manager struct {
@@ -107,7 +107,7 @@ func GetUserConfigDir() (string, error) {
 			return "", fmt.Errorf("could not determine current home directory: %w", err)
 		}
 
-		configDirPath = filepath.Join(homeDir, configDir)
+		configDirPath = filepath.Join(homeDir, cConfigDir)
 	}
 
 	err := os.MkdirAll(configDirPath, osutil.PermissionDirectoryOwnerOnly)

--- a/cli/azd/pkg/config/manager.go
+++ b/cli/azd/pkg/config/manager.go
@@ -125,9 +125,9 @@ func GetUserConfigDir() (string, error) {
 		}
 
 		permissions := info.Mode().Perm()
-		if permissions&0100 == 0 {
+		if permissions&osutil.PermissionMaskDirectoryExecute == 0 {
 			// Ensure user execute permissions
-			err := os.Chmod(configDirPath, permissions|0100)
+			err := os.Chmod(configDirPath, permissions|osutil.PermissionMaskDirectoryExecute)
 			return configDirPath, err
 		}
 	}

--- a/cli/azd/pkg/config/manager_test.go
+++ b/cli/azd/pkg/config/manager_test.go
@@ -71,11 +71,11 @@ func Test_DirectoryPermissions(t *testing.T) {
 	require.NotZero(t, permissions&100)
 
 	// Ensure max permission is 0644 ()
-	os.Chmod(configDir, permissions&0644)
+	err := os.Chmod(configDir, permissions&0644)
+	require.NoError(t, err)
 
-	configDir, err = GetUserConfigDir()
+	configDir, err := GetUserConfigDir()
 	require.NoError(t, err)
 	permissions = getPermissions(t, configDir)
 	require.NotZero(t, permissions&100)
-
 }

--- a/cli/azd/pkg/config/manager_test.go
+++ b/cli/azd/pkg/config/manager_test.go
@@ -89,7 +89,7 @@ func Test_GetUserConfigDir(t *testing.T) {
 		// Directory permissions are set so directory can be accessed by
 		// current user.
 		permissions := getPermissions(t, configDir)
-		require.NotZero(t, permissions&100)
+		require.NotZero(t, permissions&0100)
 	})
 
 	t.Run("Updates permissions if not correct", func(t *testing.T) {
@@ -101,7 +101,7 @@ func Test_GetUserConfigDir(t *testing.T) {
 		os.RemoveAll(testDir)
 		// Setup: Ensure user does not have "x" permission on the configDir
 		// Permissions 644 (rw-r--r--)
-		err := os.MkdirAll(testDir, 644)
+		err := os.MkdirAll(testDir, 0644)
 		require.NoError(t, err)
 		t.Cleanup(func() { os.RemoveAll(testDir) })
 		t.Setenv("AZD_CONFIG_DIR", testDir)
@@ -111,6 +111,6 @@ func Test_GetUserConfigDir(t *testing.T) {
 		require.NoError(t, err)
 		permissions := getPermissions(t, configDir)
 		// Ensure permissions for user are "rwx" (user has access to directory)
-		require.NotZero(t, permissions&100)
+		require.NotZero(t, permissions&0100)
 	})
 }

--- a/cli/azd/pkg/config/manager_test.go
+++ b/cli/azd/pkg/config/manager_test.go
@@ -93,7 +93,7 @@ func Test_GetUserConfigDir(t *testing.T) {
 		// Directory permissions are set so directory can be accessed by
 		// current user.
 		permissions := getPermissions(t, configDir)
-		require.NotZero(t, permissions&cDirExecutePermission)
+		require.NotZero(t, permissions&osutil.PermissionMaskDirectoryExecute)
 	})
 
 	t.Run("Updates permissions if not correct", func(t *testing.T) {
@@ -119,6 +119,6 @@ func Test_GetUserConfigDir(t *testing.T) {
 
 		permissions := getPermissions(t, configDir)
 		// Ensure permissions for user are "rwx" (user has access to directory)
-		require.NotZero(t, permissions&cDirExecutePermission)
+		require.NotZero(t, permissions&osutil.PermissionMaskDirectoryExecute)
 	})
 }

--- a/cli/azd/pkg/osutil/permissions.go
+++ b/cli/azd/pkg/osutil/permissions.go
@@ -9,4 +9,6 @@ const (
 
 	PermissionDirectoryOwnerOnly os.FileMode = 0700
 	PermissionFileOwnerOnly      os.FileMode = 0600
+
+	PermissionMaskDirectoryExecute os.FileMode = 0100
 )


### PR DESCRIPTION
Fixes #1691 

I spotted this behavior on a mac after an upgrade in the course of doing other work. The fix for now is to ensure that the directory has the "x" bit set for the user so that it's accessible to the user. At this point I'm not entirely sure why an outside process is resetting this bit during OS upgrades. It would seem that the upgrade is determining that this directory should not be accessible. 

There is a [`repairHomePermissions` tool on macOS](https://eclecticlight.co/2020/03/28/apple-has-changed-resetting-permissions-again/) which can be run in recovery mode. Running that tool does not change these file permissions. We'd need to test an OS upgrade directly in detail to learn more. 