### PR TITLE
support adding new host as alpha feature

### DIFF
--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -215,16 +215,21 @@ func (da *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 
 	for _, svc := range da.projectConfig.GetServicesStable() {
 		stepMessage := fmt.Sprintf("Deploying service %s", svc.Name)
-		da.console.ShowSpinner(ctx, stepMessage, input.Step)
 
 		// Skip this service if both cases are true:
 		// 1. The user specified a service name
 		// 2. This service is not the one the user specified
 		if targetServiceName != "" && targetServiceName != svc.Name {
-			da.console.StopSpinner(ctx, stepMessage, input.StepSkipped)
 			continue
 		}
 
+		if alphaFeatureId, isAlphaFeature := alpha.IsFeatureKey(string(svc.Host)); isAlphaFeature {
+			// alpha feature on/off detection for host is done during initialization.
+			// This is just for displaying the warning during deployment.
+			da.console.MessageUxItem(ctx, alpha.WarningMessage(alphaFeatureId))
+		}
+
+		da.console.ShowSpinner(ctx, stepMessage, input.Step)
 		var packageResult *project.ServicePackageResult
 		if da.flags.fromPackage != "" {
 			// --from-package set, skip packaging

--- a/cli/azd/pkg/alpha/alpha_feature_manager.go
+++ b/cli/azd/pkg/alpha/alpha_feature_manager.go
@@ -24,6 +24,12 @@ func NewFeaturesManager(configManager config.UserConfigManager) *FeatureManager 
 	}
 }
 
+func NewFeaturesManagerWithConfig(config config.Config) *FeatureManager {
+	return &FeatureManager{
+		userConfigCache: config,
+	}
+}
+
 // ListFeatures pulls the list of features in alpha mode available within the application and displays its current state
 // which is `on` or `off`.
 func (m *FeatureManager) ListFeatures() (map[string]Feature, error) {

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -435,7 +435,7 @@ func (sm *serviceManager) GetServiceTarget(ctx context.Context, serviceConfig *S
 
 	if alphaFeatureId, isAlphaFeature := alpha.IsFeatureKey(host); isAlphaFeature {
 		if !sm.alphaFeatureManager.IsEnabled(alphaFeatureId) {
-			return nil, fmt.Errorf("service host '%s' is alpha feature and it is not enabled. Run `%s` to enable it.",
+			return nil, fmt.Errorf("service host '%s' is currently in alpha and needs to be enabled explicitly. Run `%s` to enable the feature.",
 				host,
 				alpha.GetEnableCommand(alphaFeatureId),
 			)

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -435,7 +435,7 @@ func (sm *serviceManager) GetServiceTarget(ctx context.Context, serviceConfig *S
 
 	if alphaFeatureId, isAlphaFeature := alpha.IsFeatureKey(host); isAlphaFeature {
 		if !sm.alphaFeatureManager.IsEnabled(alphaFeatureId) {
-			return nil, fmt.Errorf("provider '%s' is alpha feature and it is not enabled. Run `%s` to enable it.",
+			return nil, fmt.Errorf("service host '%s' is alpha feature and it is not enabled. Run `%s` to enable it.",
 				host,
 				alpha.GetEnableCommand(alphaFeatureId),
 			)

--- a/cli/azd/pkg/project/service_manager_test.go
+++ b/cli/azd/pkg/project/service_manager_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
@@ -39,7 +41,14 @@ func createServiceManager(mockContext *mocks.MockContext, env *environment.Envir
 	resourceManager := NewResourceManager(env, azCli)
 	serviceLocator := ioc.NewServiceLocator(mockContext.Container)
 
-	return NewServiceManager(env, resourceManager, serviceLocator)
+	alphaManager := alpha.NewFeaturesManagerWithConfig(config.NewConfig(
+		map[string]any{
+			"alpha": map[string]any{
+				"all": "on",
+			},
+		}))
+
+	return NewServiceManager(env, resourceManager, serviceLocator, alphaManager)
 }
 
 func Test_ServiceManager_GetRequiredTools(t *testing.T) {


### PR DESCRIPTION
This changes set a central point to validate when a service-host is an alpha feature and if it is ON/OFF

The validation is done while resolving the service-host implementation to be used, making next commands to fail if the alpha feature is off:
- up
- provision
- deploy
- package
- restore

When adding a new `host` as alpha feature or changing an existing host to alpha, the only need to do is to add the name of the host in the list of `alpha_features.yaml`