### PR TITLE
Container App Service Target refactor

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -34,6 +34,7 @@ cflags
 circleci
 cmdsubst
 containerapp
+containerapps
 contoso
 csharpapp
 csharpapptest

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -269,6 +269,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.RegisterSingleton(account.NewSubscriptionCredentialProvider)
 	container.RegisterSingleton(azcli.NewManagedClustersService)
 	container.RegisterSingleton(azcli.NewContainerRegistryService)
+	container.RegisterSingleton(azcli.NewContainerAppService)
 	container.RegisterSingleton(project.NewContainerHelper)
 	container.RegisterSingleton(func() ioc.ServiceLocator {
 		return ioc.NewServiceLocator(container)

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -14,6 +14,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/azure/azure-dev/cli/azd/pkg/containerapps"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
@@ -269,7 +270,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.RegisterSingleton(account.NewSubscriptionCredentialProvider)
 	container.RegisterSingleton(azcli.NewManagedClustersService)
 	container.RegisterSingleton(azcli.NewContainerRegistryService)
-	container.RegisterSingleton(azcli.NewContainerAppService)
+	container.RegisterSingleton(containerapps.NewContainerAppService)
 	container.RegisterSingleton(project.NewContainerHelper)
 	container.RegisterSingleton(func() ioc.ServiceLocator {
 		return ioc.NewServiceLocator(container)

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -193,7 +193,8 @@ func (da *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 	if targetServiceName == "" && da.flags.fromPackage != "" {
 		return nil, errors.New(
 			//nolint:lll
-			"'--from-package' cannot be specified when deploying all services. Specify a specific service by passing a <service>")
+			"'--from-package' cannot be specified when deploying all services. Specify a specific service by passing a <service>",
+		)
 	}
 
 	if err := da.projectManager.Initialize(ctx, da.projectConfig); err != nil {

--- a/cli/azd/pkg/auth/cloudshell_credential.go
+++ b/cli/azd/pkg/auth/cloudshell_credential.go
@@ -24,9 +24,9 @@ const cDefaultSuffix = "/.default"
 type TokenFromCloudShell struct {
 	AccessToken  string      `json:"access_token"`
 	RefreshToken string      `json:"refresh_token"`
-	ExpiresIn    json.Number `json:"expires_in" type:"integer"`
-	ExpiresOn    json.Number `json:"expires_on" type:"integer" `
-	NotBefore    json.Number `json:"not_before" type:"integer" `
+	ExpiresIn    json.Number `json:"expires_in"    type:"integer"`
+	ExpiresOn    json.Number `json:"expires_on"    type:"integer"`
+	NotBefore    json.Number `json:"not_before"    type:"integer"`
 	Resource     string      `json:"resource"`
 	TokenType    string      `json:"token_type"`
 }

--- a/cli/azd/pkg/azsdk/azsdk.go
+++ b/cli/azd/pkg/azsdk/azsdk.go
@@ -1,0 +1,9 @@
+package azsdk
+
+import "github.com/azure/azure-dev/cli/azd/pkg/httputil"
+
+func DefaultClientOptionsBuilder(httpClient httputil.HttpClient, userAgent string) *ClientOptionsBuilder {
+	return NewClientOptionsBuilder().
+		WithTransport(httpClient).
+		WithPerCallPolicy(NewUserAgentPolicy(userAgent))
+}

--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -1,4 +1,4 @@
-package azcli
+package containerapps
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers"
 	azdinternal "github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
+	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/benbjohnson/clock"
@@ -250,7 +251,7 @@ func (cas *containerAppService) createContainerAppsClient(
 		return nil, err
 	}
 
-	options := clientOptionsBuilder(cas.httpClient, cas.userAgent).BuildArmClientOptions()
+	options := azsdk.DefaultClientOptionsBuilder(cas.httpClient, cas.userAgent).BuildArmClientOptions()
 	client, err := armappcontainers.NewContainerAppsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating ContainerApps client: %w", err)
@@ -268,7 +269,7 @@ func (cas *containerAppService) createRevisionsClient(
 		return nil, err
 	}
 
-	options := clientOptionsBuilder(cas.httpClient, cas.userAgent).BuildArmClientOptions()
+	options := azsdk.DefaultClientOptionsBuilder(cas.httpClient, cas.userAgent).BuildArmClientOptions()
 	client, err := armappcontainers.NewContainerAppsRevisionsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating ContainerApps client: %w", err)

--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/benbjohnson/clock"
 )
 
+// ContainerAppService exposes operations for managing Azure Container Apps
 type ContainerAppService interface {
 	// Gets the ingress configuration for the specified container app
 	GetIngressConfiguration(
@@ -31,6 +32,7 @@ type ContainerAppService interface {
 	) error
 }
 
+// NewContainerAppService creates a new ContainerAppService
 func NewContainerAppService(
 	credentialProvider account.SubscriptionCredentialProvider,
 	httpClient httputil.HttpClient,

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -151,5 +151,9 @@ func (ch *ContainerHelper) Deploy(
 				task.SetError(fmt.Errorf("saving image name to environment: %w", err))
 				return
 			}
+
+			task.SetResult(&ServiceDeployResult{
+				Package: packageOutput,
+			})
 		})
 }

--- a/cli/azd/pkg/project/muted_console.go
+++ b/cli/azd/pkg/project/muted_console.go
@@ -1,0 +1,76 @@
+package project
+
+import (
+	"context"
+	"io"
+	"log"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
+)
+
+// A console implementation which output goes only to logs
+// This is used to prevent or stop actions using the terminal output, for
+// example, when calling provision during deploying a service.
+type MutedConsole struct {
+	ParentConsole input.Console
+}
+
+// Sets the underlying writer for output the console or
+// if writer is nil, sets it back to the default writer.
+func (sc *MutedConsole) SetWriter(writer io.Writer) {
+	log.Println("tried to set writer for silent console is a no-op action")
+}
+
+func (sc *MutedConsole) GetFormatter() output.Formatter {
+	return nil
+}
+
+func (sc *MutedConsole) IsUnformatted() bool {
+	return true
+}
+
+// Prints out a message to the underlying console write
+func (sc *MutedConsole) Message(ctx context.Context, message string) {
+	log.Println(message)
+}
+
+func (sc *MutedConsole) MessageUxItem(ctx context.Context, item ux.UxItem) {
+	sc.Message(ctx, item.ToString(""))
+}
+
+func (sc *MutedConsole) ShowSpinner(ctx context.Context, title string, format input.SpinnerUxType) {
+	log.Printf("request to show spinner on silent console with message: %s", title)
+}
+
+func (sc *MutedConsole) StopSpinner(ctx context.Context, lastMessage string, format input.SpinnerUxType) {
+	log.Printf("request to stop spinner on silent console with message: %s", lastMessage)
+}
+
+func (sc *MutedConsole) IsSpinnerRunning(ctx context.Context) bool {
+	return false
+}
+
+// Use parent console for input
+func (sc *MutedConsole) Prompt(ctx context.Context, options input.ConsoleOptions) (string, error) {
+	return sc.ParentConsole.Prompt(ctx, options)
+}
+
+// Use parent console for input
+func (sc *MutedConsole) Select(ctx context.Context, options input.ConsoleOptions) (int, error) {
+	return sc.ParentConsole.Select(ctx, options)
+}
+
+// Use parent console for input
+func (sc *MutedConsole) Confirm(ctx context.Context, options input.ConsoleOptions) (bool, error) {
+	return sc.ParentConsole.Confirm(ctx, options)
+}
+
+func (sc *MutedConsole) GetWriter() io.Writer {
+	return nil
+}
+
+func (sc *MutedConsole) Handles() input.ConsoleHandles {
+	return sc.ParentConsole.Handles()
+}

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -71,12 +71,6 @@ func Parse(ctx context.Context, yamlContent string) (*ProjectConfig, error) {
 		svc.Project = &projectConfig
 		svc.EventDispatcher = ext.NewEventDispatcher[ServiceLifecycleEventArgs]()
 
-		// By convention, the name of the infrastructure module to use when doing an IaC based deployment is the friendly
-		// name of the service. This may be overridden by the `module` property of `azure.yaml`
-		if svc.Module == "" {
-			svc.Module = key
-		}
-
 		if svc.Language == "" {
 			svc.Language = "dotnet"
 		}

--- a/cli/azd/pkg/project/project_config_test.go
+++ b/cli/azd/pkg/project/project_config_test.go
@@ -89,7 +89,6 @@ services:
 	require.Equal(t, 2, len(projectConfig.Services))
 
 	for key, svc := range projectConfig.Services {
-		require.Equal(t, key, svc.Module)
 		require.Equal(t, key, svc.Name)
 		require.Equal(t, projectConfig, svc.Project)
 	}
@@ -147,31 +146,6 @@ services:
 
 	require.Equal(t, "./Dockerfile.dev", service.Docker.Path)
 	require.Equal(t, "../", service.Docker.Context)
-}
-
-func TestProjectWithCustomModule(t *testing.T) {
-	const testProj = `
-name: test-proj
-metadata:
-  template: test-proj-template
-resourceGroup: rg-test
-services:
-  api:
-    project: src/api
-    language: js
-    host: containerapp
-    module: ./api/api
-`
-
-	mockContext := mocks.NewMockContext(context.Background())
-	projectConfig, err := Parse(*mockContext.Context, testProj)
-
-	require.NotNil(t, projectConfig)
-	require.Nil(t, err)
-
-	service := projectConfig.Services["api"]
-
-	require.Equal(t, "./api/api", service.Module)
 }
 
 func TestProjectConfigAddHandler(t *testing.T) {
@@ -322,7 +296,6 @@ services:
     project: src/api
     language: js
     host: containerapp
-    module: ./api/api
 `
 
 	mockContext := mocks.NewMockContext(context.Background())
@@ -393,7 +366,6 @@ services:
     project: src/api
     language: js
     host: containerapp
-    module: ./api/api
     `
 
 	mockContext := mocks.NewMockContext(context.Background())

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -22,8 +22,6 @@ type ServiceConfig struct {
 	Language ServiceLanguageKind `yaml:"language"`
 	// The output path for build artifacts
 	OutputPath string `yaml:"dist"`
-	// The infrastructure module path relative to the root infra folder to use for this project
-	Module string `yaml:"module"`
 	// The optional docker options
 	Docker DockerProjectOptions `yaml:"docker"`
 	// The optional K8S / AKS options

--- a/cli/azd/pkg/project/service_config_test.go
+++ b/cli/azd/pkg/project/service_config_test.go
@@ -164,7 +164,6 @@ services:
     project: src/api
     language: js
     host: containerapp
-    module: ./api/api
 `
 
 	mockContext := mocks.NewMockContext(context.Background())

--- a/cli/azd/pkg/project/service_models.go
+++ b/cli/azd/pkg/project/service_models.go
@@ -100,8 +100,12 @@ func (spr *ServiceDeployResult) ToString(currentIndentation string) string {
 
 	builder := strings.Builder{}
 
-	for _, endpoint := range spr.Endpoints {
-		builder.WriteString(fmt.Sprintf("%s- Endpoint: %s\n", currentIndentation, output.WithLinkFormat(endpoint)))
+	if len(spr.Endpoints) == 0 {
+		builder.WriteString(fmt.Sprintf("%s- No endpoints were found\n", currentIndentation))
+	} else {
+		for _, endpoint := range spr.Endpoints {
+			builder.WriteString(fmt.Sprintf("%s- Endpoint: %s\n", currentIndentation, output.WithLinkFormat(endpoint)))
+		}
 	}
 
 	return builder.String()

--- a/cli/azd/pkg/project/service_target.go
+++ b/cli/azd/pkg/project/service_target.go
@@ -115,7 +115,7 @@ func resourceTypeMismatchError(
 // As an example, ContainerAppTarget is able to provision the container app as part of deployment,
 // and thus returns true.
 func (st ServiceTargetKind) SupportsDelayedProvisioning() bool {
-	return st == ContainerAppTarget || st == AksTarget
+	return st == AksTarget
 }
 
 func checkResourceType(resource *environment.TargetResource, expectedResourceType infra.AzureResourceType) error {

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -36,7 +36,7 @@ func Test_NewAksTarget(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api", AksTarget, ServiceLanguageTypeScript)
 	env := createEnv()
 
-	serviceTarget := createServiceTarget(mockContext, serviceConfig, env)
+	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env)
 
 	require.NotNil(t, serviceTarget)
 	require.NotNil(t, serviceConfig)
@@ -53,7 +53,7 @@ func Test_Required_Tools(t *testing.T) {
 	serviceConfig := createTestServiceConfig(tempDir, AksTarget, ServiceLanguageTypeScript)
 	env := createEnv()
 
-	serviceTarget := createServiceTarget(mockContext, serviceConfig, env)
+	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env)
 
 	requiredTools := serviceTarget.RequiredExternalTools(*mockContext.Context)
 	require.Len(t, requiredTools, 2)
@@ -72,7 +72,7 @@ func Test_Package_Deploy_HappyPath(t *testing.T) {
 	serviceConfig := createTestServiceConfig(tempDir, AksTarget, ServiceLanguageTypeScript)
 	env := createEnv()
 
-	serviceTarget := createServiceTarget(mockContext, serviceConfig, env)
+	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env)
 	err = setupK8sManifests(t, serviceConfig)
 	require.NoError(t, err)
 
@@ -122,7 +122,7 @@ func Test_Deploy_No_Cluster_Name(t *testing.T) {
 	// Simulate AKS cluster name not found in env file
 	delete(env.Values, environment.AksClusterEnvVarName)
 
-	serviceTarget := createServiceTarget(mockContext, serviceConfig, env)
+	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env)
 	scope := environment.NewTargetResource("SUB_ID", "RG_ID", "CLUSTER_NAME", string(infra.AzureResourceTypeManagedCluster))
 	packageOutput := &ServicePackageResult{
 		Build: &ServiceBuildResult{BuildOutputPath: "IMAGE_ID"},
@@ -156,7 +156,7 @@ func Test_Deploy_No_Admin_Credentials(t *testing.T) {
 	serviceConfig := createTestServiceConfig(tempDir, AksTarget, ServiceLanguageTypeScript)
 	env := createEnv()
 
-	serviceTarget := createServiceTarget(mockContext, serviceConfig, env)
+	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env)
 	scope := environment.NewTargetResource("SUB_ID", "RG_ID", "CLUSTER_NAME", string(infra.AzureResourceTypeManagedCluster))
 	packageOutput := &ServicePackageResult{
 		Build: &ServiceBuildResult{BuildOutputPath: "IMAGE_ID"},
@@ -185,6 +185,19 @@ func setupK8sManifests(t *testing.T, serviceConfig *ServiceConfig) error {
 		err = os.WriteFile(filepath.Join(manifestsDir, filename), []byte(""), osutil.PermissionFile)
 		require.NoError(t, err)
 	}
+
+	return nil
+}
+
+func setupMocksForAksTarget(mockContext *mocks.MockContext) error {
+	err := setupListClusterAdminCredentialsMock(mockContext, http.StatusOK)
+	if err != nil {
+		return err
+	}
+
+	setupMocksForAcr(mockContext)
+	setupMocksForKubectl(mockContext)
+	setupMocksForDocker(mockContext)
 
 	return nil
 }
@@ -219,47 +232,7 @@ func setupListClusterAdminCredentialsMock(mockContext *mocks.MockContext, status
 	return nil
 }
 
-func setupMocksForAksTarget(mockContext *mocks.MockContext) error {
-	err := setupListClusterAdminCredentialsMock(mockContext, http.StatusOK)
-	if err != nil {
-		return err
-	}
-
-	// Config view
-	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.Contains(command, "kubectl config view")
-	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-		return exec.NewRunResult(0, "", ""), nil
-	})
-
-	// Config use context
-	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.Contains(command, "kubectl config use-context")
-	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-		return exec.NewRunResult(0, "", ""), nil
-	})
-
-	// Create Namespace
-	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.Contains(command, "kubectl create namespace")
-	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-		return exec.NewRunResult(0, "", ""), nil
-	})
-
-	// Apply Pipe
-	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.Contains(command, "kubectl apply -f -")
-	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-		return exec.NewRunResult(0, "", ""), nil
-	})
-
-	// Create Secret
-	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.Contains(command, "kubectl create secret generic")
-	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-		return exec.NewRunResult(0, "", ""), nil
-	})
-
+func setupMocksForAcr(mockContext *mocks.MockContext) {
 	// List container registries
 	mockContext.HttpClient.When(func(request *http.Request) bool {
 		return request.Method == http.MethodGet &&
@@ -301,24 +274,40 @@ func setupMocksForAksTarget(mockContext *mocks.MockContext) error {
 
 		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, result)
 	})
+}
 
-	// Docker login
+func setupMocksForKubectl(mockContext *mocks.MockContext) {
+	// Config view
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.Contains(command, "docker login")
+		return strings.Contains(command, "kubectl config view")
 	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
 		return exec.NewRunResult(0, "", ""), nil
 	})
 
-	// Docker Tag
+	// Config use context
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.Contains(command, "docker tag")
+		return strings.Contains(command, "kubectl config use-context")
 	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
 		return exec.NewRunResult(0, "", ""), nil
 	})
 
-	// Push Container Image
+	// Create Namespace
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.Contains(command, "docker push")
+		return strings.Contains(command, "kubectl create namespace")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	// Apply Pipe
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "kubectl apply -f -")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	// Create Secret
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "kubectl create secret generic")
 	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
 		return exec.NewRunResult(0, "", ""), nil
 	})
@@ -435,8 +424,29 @@ func setupMocksForAksTarget(mockContext *mocks.MockContext) error {
 
 		return exec.NewRunResult(0, string(jsonBytes), ""), nil
 	})
+}
 
-	return nil
+func setupMocksForDocker(mockContext *mocks.MockContext) {
+	// Docker login
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "docker login")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	// Docker Tag
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "docker tag")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	// Push Container Image
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "docker push")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		return exec.NewRunResult(0, "", ""), nil
+	})
 }
 
 func createK8sResourceList[T any](resource T) *kubectl.List[T] {
@@ -466,7 +476,7 @@ func createEnv() *environment.Environment {
 	})
 }
 
-func createServiceTarget(
+func createAksServiceTarget(
 	mockContext *mocks.MockContext,
 	serviceConfig *ServiceConfig,
 	env *environment.Environment,

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -113,7 +113,7 @@ func (at *containerAppTarget) Deploy(
 			containerDeployTask := at.containerHelper.Deploy(ctx, serviceConfig, packageOutput, targetResource)
 			syncProgress(task, containerDeployTask.Progress())
 
-			deployResult, err := containerDeployTask.Await()
+			_, err := containerDeployTask.Await()
 			if err != nil {
 				task.SetError(err)
 				return
@@ -148,7 +148,6 @@ func (at *containerAppTarget) Deploy(
 					targetResource.ResourceName(),
 				),
 				Kind:      ContainerAppTarget,
-				Details:   deployResult,
 				Endpoints: endpoints,
 			})
 		},
@@ -161,7 +160,7 @@ func (at *containerAppTarget) Endpoints(
 	serviceConfig *ServiceConfig,
 	targetResource *environment.TargetResource,
 ) ([]string, error) {
-	if containerAppProperties, err := at.containerAppService.GetAppProperties(
+	if ingressConfig, err := at.containerAppService.GetIngressConfiguration(
 		ctx,
 		targetResource.SubscriptionId(),
 		targetResource.ResourceGroupName(),
@@ -169,8 +168,8 @@ func (at *containerAppTarget) Endpoints(
 	); err != nil {
 		return nil, fmt.Errorf("fetching service properties: %w", err)
 	} else {
-		endpoints := make([]string, len(containerAppProperties.HostNames))
-		for idx, hostName := range containerAppProperties.HostNames {
+		endpoints := make([]string, len(ingressConfig.HostNames))
+		for idx, hostName := range ingressConfig.HostNames {
 			endpoints[idx] = fmt.Sprintf("https://%s/", hostName)
 		}
 

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -57,3 +57,7 @@ func TestNewContainerAppTargetTypeValidation(t *testing.T) {
 		})
 	}
 }
+
+func Test_ContainerApp_Deploy(t *testing.T) {
+	// TODO: Write test
+}

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -5,12 +5,23 @@ package project
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers"
+	"github.com/azure/azure-dev/cli/azd/pkg/containerapps"
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockaccount"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazsdk"
+	"github.com/azure/azure-dev/cli/azd/test/ostest"
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,5 +70,143 @@ func TestNewContainerAppTargetTypeValidation(t *testing.T) {
 }
 
 func Test_ContainerApp_Deploy(t *testing.T) {
-	// TODO: Write test
+	tempDir := t.TempDir()
+	ostest.Chdir(t, tempDir)
+
+	mockContext := mocks.NewMockContext(context.Background())
+	setupMocksForContainerAppTarget(mockContext)
+
+	serviceConfig := createTestServiceConfig(tempDir, ContainerAppTarget, ServiceLanguageTypeScript)
+	env := createEnv()
+
+	serviceTarget := createContainerAppServiceTarget(mockContext, serviceConfig, env)
+
+	packageTask := serviceTarget.Package(
+		*mockContext.Context,
+		serviceConfig,
+		&ServicePackageResult{
+			PackagePath: "test-app/api-test:azd-deploy-0",
+			Details: &dockerPackageResult{
+				ImageHash: "IMAGE_HASH",
+				ImageTag:  "test-app/api-test:azd-deploy-0",
+			},
+		},
+	)
+	logProgress(packageTask)
+	packageResult, err := packageTask.Await()
+
+	require.NoError(t, err)
+	require.NotNil(t, packageResult)
+	require.IsType(t, new(dockerPackageResult), packageResult.Details)
+
+	scope := environment.NewTargetResource(
+		"SUBSCRIPTION_ID",
+		"RESOURCE_GROUP",
+		"CONTAINER_APP",
+		string(infra.AzureResourceTypeContainerApp),
+	)
+	deployTask := serviceTarget.Deploy(*mockContext.Context, serviceConfig, packageResult, scope)
+	logProgress(deployTask)
+	deployResult, err := deployTask.Await()
+
+	require.NoError(t, err)
+	require.NotNil(t, deployResult)
+	require.Equal(t, ContainerAppTarget, deployResult.Kind)
+	require.Greater(t, len(deployResult.Endpoints), 0)
+	// New env variable is created
+	require.Equal(t, "REGISTRY.azurecr.io/test-app/api-test:azd-deploy-0", env.Values["SERVICE_API_IMAGE_NAME"])
+}
+
+func createContainerAppServiceTarget(
+	mockContext *mocks.MockContext,
+	serviceConfig *ServiceConfig,
+	env *environment.Environment,
+) ServiceTarget {
+	dockerCli := docker.NewDocker(mockContext.CommandRunner)
+	credentialProvider := mockaccount.SubscriptionCredentialProviderFunc(
+		func(_ context.Context, _ string) (azcore.TokenCredential, error) {
+			return mockContext.Credentials, nil
+		})
+
+	containerAppService := containerapps.NewContainerAppService(credentialProvider, mockContext.HttpClient, clock.NewMock())
+	containerRegistryService := azcli.NewContainerRegistryService(credentialProvider, mockContext.HttpClient, dockerCli)
+	containerHelper := NewContainerHelper(env, clock.NewMock(), containerRegistryService, dockerCli)
+
+	return NewContainerAppTarget(
+		env,
+		containerHelper,
+		containerAppService,
+	)
+}
+
+func setupMocksForContainerAppTarget(mockContext *mocks.MockContext) {
+	setupMocksForDocker(mockContext)
+	setupMocksForAcr(mockContext)
+	setupMocksForContainerApps(mockContext)
+}
+
+func setupMocksForContainerApps(mockContext *mocks.MockContext) {
+	subscriptionId := "SUBSCRIPTION_ID"
+	location := "eastus2"
+	resourceGroup := "RESOURCE_GROUP"
+	appName := "CONTAINER_APP"
+	originalImageName := "ORIGINAL_IMAGE_NAME"
+	originalRevisionName := "ORIGINAL_REVISION_NAME"
+	updatedRevisionName := "UPDATED_REVISION_NAME"
+	hostName := fmt.Sprintf("%s.%s.azurecontainerapps.io", appName, location)
+
+	containerApp := &armappcontainers.ContainerApp{
+		Location: &location,
+		Name:     &appName,
+		Properties: &armappcontainers.ContainerAppProperties{
+			LatestRevisionName: &originalRevisionName,
+			Configuration: &armappcontainers.Configuration{
+				ActiveRevisionsMode: convert.RefOf(armappcontainers.ActiveRevisionsModeSingle),
+				Secrets: []*armappcontainers.Secret{
+					{
+						Name:  convert.RefOf("secret"),
+						Value: nil,
+					},
+				},
+				Ingress: &armappcontainers.Ingress{
+					Fqdn: &hostName,
+				},
+			},
+			Template: &armappcontainers.Template{
+				Containers: []*armappcontainers.Container{
+					{
+						Image: &originalImageName,
+					},
+				},
+			},
+		},
+	}
+
+	revision := &armappcontainers.Revision{
+		Properties: &armappcontainers.RevisionProperties{
+			Template: &armappcontainers.Template{
+				Containers: []*armappcontainers.Container{
+					{
+						Image: &updatedRevisionName,
+					},
+				},
+			},
+		},
+	}
+
+	secrets := &armappcontainers.SecretsCollection{
+		Value: []*armappcontainers.ContainerAppSecret{},
+	}
+
+	mockazsdk.MockContainerAppGet(mockContext, subscriptionId, resourceGroup, appName, containerApp)
+	mockazsdk.MockContainerAppRevisionGet(
+		mockContext,
+		subscriptionId,
+		resourceGroup,
+		appName,
+		originalRevisionName,
+		revision,
+	)
+	mockazsdk.MockContainerAppSecretsList(mockContext, subscriptionId, resourceGroup, appName, secrets)
+	mockazsdk.MockContainerAppUpdate(mockContext, subscriptionId, resourceGroup, appName, containerApp)
 }

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -145,12 +145,6 @@ type AzCli interface {
 		resourceGroupName string,
 		applicationName string,
 	) (*AzCliAppServiceProperties, error)
-	GetContainerAppProperties(
-		ctx context.Context,
-		subscriptionId string,
-		resourceGroupName string,
-		applicationName string,
-	) (*AzCliContainerAppProperties, error)
 	GetStaticWebAppProperties(
 		ctx context.Context,
 		subscriptionID string,

--- a/cli/azd/pkg/tools/azcli/container_app.go
+++ b/cli/azd/pkg/tools/azcli/container_app.go
@@ -5,17 +5,47 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers"
+	azdinternal "github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/account"
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
+	"github.com/benbjohnson/clock"
 )
+
+type ContainerAppService interface {
+	GetAppProperties(ctx context.Context, subscriptionId, resourceGroup, appName string) (*AzCliContainerAppProperties, error)
+	AddRevision(ctx context.Context, subscriptionId string, resourceGroupName string, appName string, imageName string) error
+}
+
+func NewContainerAppService(
+	credentialProvider account.SubscriptionCredentialProvider,
+	httpClient httputil.HttpClient,
+	clock clock.Clock,
+) ContainerAppService {
+	return &containerAppService{
+		credentialProvider: credentialProvider,
+		httpClient:         httpClient,
+		userAgent:          azdinternal.MakeUserAgentString(""),
+		clock:              clock,
+	}
+}
+
+type containerAppService struct {
+	credentialProvider account.SubscriptionCredentialProvider
+	httpClient         httputil.HttpClient
+	userAgent          string
+	clock              clock.Clock
+}
 
 type AzCliContainerAppProperties struct {
 	HostNames []string
 }
 
-func (cli *azCli) GetContainerAppProperties(
+func (cas *containerAppService) GetAppProperties(
 	ctx context.Context,
 	subscriptionId, resourceGroup, appName string,
 ) (*AzCliContainerAppProperties, error) {
-	client, err := cli.createContainerAppsClient(ctx, subscriptionId)
+	client, err := cas.createContainerAppsClient(ctx, subscriptionId)
 	if err != nil {
 		return nil, err
 	}
@@ -40,17 +70,96 @@ func (cli *azCli) GetContainerAppProperties(
 	}, nil
 }
 
-func (cli *azCli) createContainerAppsClient(
+func (cas *containerAppService) AddRevision(
+	ctx context.Context,
+	subscriptionId string,
+	resourceGroupName string,
+	appName string,
+	imageName string,
+) error {
+	appClient, err := cas.createContainerAppsClient(ctx, subscriptionId)
+	if err != nil {
+		return err
+	}
+
+	containerApp, err := appClient.Get(ctx, resourceGroupName, appName, nil)
+	if err != nil {
+		return fmt.Errorf("getting container app: %w", err)
+	}
+
+	updated := containerApp.ContainerApp
+	currentRevisionName := *updated.Properties.LatestRevisionName
+	revisionsClient, err := cas.createRevisionsClient(ctx, subscriptionId)
+	if err != nil {
+		return err
+	}
+
+	revision, err := revisionsClient.GetRevision(ctx, resourceGroupName, appName, currentRevisionName, nil)
+	if err != nil {
+		return fmt.Errorf("getting revision '%s': %w", currentRevisionName, err)
+	}
+
+	revision.Properties.Template.RevisionSuffix = convert.RefOf(fmt.Sprintf("azd-deploy-%d", cas.clock.Now().Unix()))
+	revision.Properties.Template.Containers[0].Image = convert.RefOf(imageName)
+	updated.Properties.Template = revision.Properties.Template
+
+	secretsResponse, err := appClient.ListSecrets(ctx, resourceGroupName, appName, nil)
+	if err != nil {
+		return fmt.Errorf("listing secrets: %w", err)
+	}
+
+	secrets := []*armappcontainers.Secret{}
+	for _, secret := range secretsResponse.SecretsCollection.Value {
+		secrets = append(secrets, &armappcontainers.Secret{
+			Name:  secret.Name,
+			Value: secret.Value,
+		})
+	}
+
+	updated.Properties.Configuration.Secrets = secrets
+
+	poller, err := appClient.BeginUpdate(ctx, resourceGroupName, appName, updated, nil)
+	if err != nil {
+		return fmt.Errorf("begin updating container app: %w", err)
+	}
+
+	_, err = poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("polling for update: %w", err)
+	}
+
+	return nil
+}
+
+func (cas *containerAppService) createContainerAppsClient(
 	ctx context.Context,
 	subscriptionId string,
 ) (*armappcontainers.ContainerAppsClient, error) {
-	credential, err := cli.credentialProvider.CredentialForSubscription(ctx, subscriptionId)
+	credential, err := cas.credentialProvider.CredentialForSubscription(ctx, subscriptionId)
 	if err != nil {
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := clientOptionsBuilder(cas.httpClient, cas.userAgent).BuildArmClientOptions()
 	client, err := armappcontainers.NewContainerAppsClient(subscriptionId, credential, options)
+	if err != nil {
+		return nil, fmt.Errorf("creating ContainerApps client: %w", err)
+	}
+
+	return client, nil
+}
+
+func (cas *containerAppService) createRevisionsClient(
+	ctx context.Context,
+	subscriptionId string,
+) (*armappcontainers.ContainerAppsRevisionsClient, error) {
+	credential, err := cas.credentialProvider.CredentialForSubscription(ctx, subscriptionId)
+	if err != nil {
+		return nil, err
+	}
+
+	options := clientOptionsBuilder(cas.httpClient, cas.userAgent).BuildArmClientOptions()
+	client, err := armappcontainers.NewContainerAppsRevisionsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating ContainerApps client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/container_app_test.go
+++ b/cli/azd/pkg/tools/azcli/container_app_test.go
@@ -1,0 +1,245 @@
+package azcli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers"
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/benbjohnson/clock"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO: Write tests
+
+func Test_ContainerApp_GetIngressConfiguration(t *testing.T) {
+	subscriptionId := "SUBSCRIPTION_ID"
+	location := "eastus2"
+	resourceGroup := "RESOURCE_GROUP"
+	appName := "APP_NAME"
+	hostName := fmt.Sprintf("%s.%s.azurecontainerapps.io", appName, location)
+
+	containerApp := &armappcontainers.ContainerApp{
+		Location: &location,
+		Name:     &appName,
+		Properties: &armappcontainers.ContainerAppProperties{
+			Configuration: &armappcontainers.Configuration{
+				ActiveRevisionsMode: convert.RefOf(armappcontainers.ActiveRevisionsModeSingle),
+				Ingress: &armappcontainers.Ingress{
+					Fqdn: &hostName,
+				},
+			},
+		},
+	}
+
+	mockContext := mocks.NewMockContext(context.Background())
+	mockRequest := mockContainerAppGet(mockContext, subscriptionId, resourceGroup, appName, containerApp)
+
+	cas := NewContainerAppService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, clock.NewMock())
+	ingressConfig, err := cas.GetIngressConfiguration(*mockContext.Context, subscriptionId, resourceGroup, appName)
+	require.NoError(t, err)
+	require.NotNil(t, ingressConfig)
+
+	expectedPath := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/containerApps/%s",
+		subscriptionId,
+		resourceGroup,
+		appName,
+	)
+
+	require.Equal(t, expectedPath, mockRequest.URL.Path)
+	require.Equal(t, hostName, ingressConfig.HostNames[0])
+}
+
+func Test_ContainerApp_AddRevision(t *testing.T) {
+	subscriptionId := "SUBSCRIPTION_ID"
+	location := "eastus2"
+	resourceGroup := "RESOURCE_GROUP"
+	appName := "APP_NAME"
+	originalImageName := "ORIGINAL_IMAGE_NAME"
+	updatedImageName := "UPDATED_IMAGE_NAME"
+	originalRevisionName := "ORIGINAL_REVISION_NAME"
+	updatedRevisionName := "UPDATED_REVISION_NAME"
+
+	containerApp := &armappcontainers.ContainerApp{
+		Location: &location,
+		Name:     &appName,
+		Properties: &armappcontainers.ContainerAppProperties{
+			LatestRevisionName: &originalRevisionName,
+			Configuration: &armappcontainers.Configuration{
+				ActiveRevisionsMode: convert.RefOf(armappcontainers.ActiveRevisionsModeSingle),
+				Secrets: []*armappcontainers.Secret{
+					{
+						Name:  convert.RefOf("secret"),
+						Value: nil,
+					},
+				},
+			},
+			Template: &armappcontainers.Template{
+				Containers: []*armappcontainers.Container{
+					{
+						Image: &originalImageName,
+					},
+				},
+			},
+		},
+	}
+
+	revision := &armappcontainers.Revision{
+		Properties: &armappcontainers.RevisionProperties{
+			Template: &armappcontainers.Template{
+				Containers: []*armappcontainers.Container{
+					{
+						Image: &updatedRevisionName,
+					},
+				},
+			},
+		},
+	}
+
+	secrets := &armappcontainers.SecretsCollection{
+		Value: []*armappcontainers.ContainerAppSecret{
+			{
+				Name:  convert.RefOf("secret"),
+				Value: convert.RefOf("value"),
+			},
+		},
+	}
+
+	mockContext := mocks.NewMockContext(context.Background())
+	_ = mockContainerAppGet(mockContext, subscriptionId, resourceGroup, appName, containerApp)
+	getRevisionRequest := mockContainerAppRevisionGet(mockContext, subscriptionId, resourceGroup, appName, originalRevisionName, revision)
+	_ = mockContainerAppSecretsList(mockContext, subscriptionId, resourceGroup, appName, secrets)
+	updateContainerAppRequest := mockContainerAppUpdate(mockContext, subscriptionId, resourceGroup, appName, containerApp)
+
+	cas := NewContainerAppService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, clock.NewMock())
+	err := cas.AddRevision(*mockContext.Context, subscriptionId, resourceGroup, appName, updatedImageName)
+	require.NoError(t, err)
+
+	// Verify lastest revision is read
+	expectedGetRevisionPath := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/containerApps/%s/revisions/%s",
+		subscriptionId,
+		resourceGroup,
+		appName,
+		originalRevisionName,
+	)
+
+	require.Equal(t, expectedGetRevisionPath, getRevisionRequest.URL.Path)
+
+	// Verify container image is updated
+	var updatedContainerApp *armappcontainers.ContainerApp
+	jsonDecoder := json.NewDecoder(updateContainerAppRequest.Body)
+	err = jsonDecoder.Decode(&updatedContainerApp)
+	require.NoError(t, err)
+	require.Equal(t, updatedImageName, *updatedContainerApp.Properties.Template.Containers[0].Image)
+	require.Equal(t, "azd-deploy-0", *updatedContainerApp.Properties.Template.RevisionSuffix)
+}
+
+func mockContainerAppGet(mockContext *mocks.MockContext, subscriptionId string, resourceGroup string, appName string, containerApp *armappcontainers.ContainerApp) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && strings.Contains(
+			request.URL.Path,
+			fmt.Sprintf(
+				"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/containerApps/%s",
+				subscriptionId,
+				resourceGroup,
+				appName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		response := armappcontainers.ContainerAppsClientGetResponse{
+			ContainerApp: *containerApp,
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}
+
+func mockContainerAppUpdate(mockContext *mocks.MockContext, subscriptionId string, resourceGroup string, appName string, containerApp *armappcontainers.ContainerApp) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodPatch && strings.Contains(
+			request.URL.Path,
+			fmt.Sprintf(
+				"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/containerApps/%s",
+				subscriptionId,
+				resourceGroup,
+				appName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		response := armappcontainers.ContainerAppsClientUpdateResponse{}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusAccepted, response)
+	})
+
+	return mockRequest
+}
+
+func mockContainerAppRevisionGet(mockContext *mocks.MockContext, subscriptionId string, resourceGroup string, appName string, revisionName string, revision *armappcontainers.Revision) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && strings.Contains(
+			request.URL.Path,
+			fmt.Sprintf(
+				"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/containerApps/%s/revisions/%s",
+				subscriptionId,
+				resourceGroup,
+				appName,
+				revisionName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		response := armappcontainers.ContainerAppsRevisionsClientGetRevisionResponse{
+			Revision: *revision,
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}
+
+func mockContainerAppSecretsList(mockContext *mocks.MockContext, subscriptionId string, resourceGroup string, appName string, secrets *armappcontainers.SecretsCollection) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodPost && strings.Contains(
+			request.URL.Path,
+			fmt.Sprintf(
+				"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/containerApps/%s/listSecrets",
+				subscriptionId,
+				resourceGroup,
+				appName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		response := armappcontainers.ContainerAppsClientListSecretsResponse{
+			SecretsCollection: *secrets,
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}

--- a/cli/azd/test/functional/testdata/samples/containerapp/infra/main.bicep
+++ b/cli/azd/test/functional/testdata/samples/containerapp/infra/main.bicep
@@ -11,9 +11,6 @@ param location string
 @description('A time to mark on created resource groups, so they can be cleaned up via an automated process.')
 param deleteAfterTime string = dateTimeAdd(utcNow('o'), 'PT1H')
 
-@description('If true, a dummy container app instance is created during infrastructure provisioning. Otherwise, the container app instance is created during deploy.')
-param provisionContainerApp string = 'false'
-
 var tags = { 'azd-env-name': environmentName, DeleteAfter: deleteAfterTime }
 
 resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
@@ -32,7 +29,7 @@ module resources 'resources.bicep' = {
 }
 
 
-module web 'web.bicep' = if(provisionContainerApp == 'true') {
+module web 'web.bicep' = {
   name: 'web'
   scope: rg
   params: {
@@ -47,4 +44,4 @@ module web 'web.bicep' = if(provisionContainerApp == 'true') {
 output AZURE_CONTAINER_REGISTRY_NAME string = resources.outputs.containerRegistryName
 output AZURE_CONTAINER_ENVIRONMENT_NAME string = resources.outputs.containerAppsEnvironmentName
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = resources.outputs.containerRegistryloginServer
-output WEBSITE_URL string = provisionContainerApp == 'true' ? web.outputs.WEBSITE_URL : ''
+output WEBSITE_URL string = web.outputs.WEBSITE_URL

--- a/cli/azd/test/mocks/mock_context.go
+++ b/cli/azd/test/mocks/mock_context.go
@@ -17,21 +17,21 @@ import (
 )
 
 type MockContext struct {
-	Credentials          *MockCredentials
-	Context              *context.Context
-	Console              *mockinput.MockConsole
-	HttpClient           *mockhttp.MockHttpClient
-	CommandRunner        *mockexec.MockCommandRunner
-	ConfigManager        *mockconfig.MockConfigManager
-	Container            *ioc.NestedContainer
-	AlphaFeaturesManager *alpha.FeatureManager
+	Credentials                    *MockCredentials
+	Context                        *context.Context
+	Console                        *mockinput.MockConsole
+	HttpClient                     *mockhttp.MockHttpClient
+	CommandRunner                  *mockexec.MockCommandRunner
+	ConfigManager                  *mockconfig.MockConfigManager
+	Container                      *ioc.NestedContainer
+	AlphaFeaturesManager           *alpha.FeatureManager
+	SubscriptionCredentialProvider *MockSubscriptionCredentialProvider
+	MultiTenantCredentialProvider  *MockMultiTenantCredentialProvider
 }
 
 func NewMockContext(ctx context.Context) *MockContext {
-	mockConsole := mockinput.NewMockConsole()
 	commandRunner := mockexec.NewMockCommandRunner()
 	httpClient := mockhttp.NewMockHttpUtil()
-	credentials := MockCredentials{}
 	configManager := mockconfig.NewMockConfigManager()
 
 	mockexec.AddAzLoginMocks(commandRunner)
@@ -40,13 +40,15 @@ func NewMockContext(ctx context.Context) *MockContext {
 	ctx = config.WithConfigManager(ctx, configManager)
 
 	mockContext := &MockContext{
-		Credentials:   &credentials,
-		Context:       &ctx,
-		Console:       mockConsole,
-		CommandRunner: commandRunner,
-		HttpClient:    httpClient,
-		ConfigManager: configManager,
-		Container:     ioc.NewNestedContainer(nil),
+		Credentials:                    &MockCredentials{},
+		Context:                        &ctx,
+		Console:                        mockinput.NewMockConsole(),
+		CommandRunner:                  mockexec.NewMockCommandRunner(),
+		HttpClient:                     httpClient,
+		ConfigManager:                  configManager,
+		SubscriptionCredentialProvider: &MockSubscriptionCredentialProvider{},
+		MultiTenantCredentialProvider:  &MockMultiTenantCredentialProvider{},
+		Container:                      ioc.NewNestedContainer(nil),
 	}
 
 	registerCommonMocks(mockContext)

--- a/cli/azd/test/mocks/mock_credentials.go
+++ b/cli/azd/test/mocks/mock_credentials.go
@@ -43,3 +43,13 @@ func (c *MockMultiTenantCredentialProvider) GetTokenCredential(
 		},
 	}, nil
 }
+
+type MockSubscriptionCredentialProvider struct {
+}
+
+func (scp *MockSubscriptionCredentialProvider) CredentialForSubscription(
+	ctx context.Context,
+	subscriptionId string,
+) (azcore.TokenCredential, error) {
+	return &MockCredentials{}, nil
+}

--- a/cli/azd/test/mocks/mockazsdk/container_apps.go
+++ b/cli/azd/test/mocks/mockazsdk/container_apps.go
@@ -1,0 +1,138 @@
+package mockazsdk
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+)
+
+func MockContainerAppGet(
+	mockContext *mocks.MockContext,
+	subscriptionId string,
+	resourceGroup string,
+	appName string,
+	containerApp *armappcontainers.ContainerApp,
+) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && strings.Contains(
+			request.URL.Path,
+			fmt.Sprintf(
+				"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/containerApps/%s",
+				subscriptionId,
+				resourceGroup,
+				appName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		response := armappcontainers.ContainerAppsClientGetResponse{
+			ContainerApp: *containerApp,
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}
+
+func MockContainerAppUpdate(
+	mockContext *mocks.MockContext,
+	subscriptionId string,
+	resourceGroup string,
+	appName string,
+	containerApp *armappcontainers.ContainerApp,
+) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodPatch && strings.Contains(
+			request.URL.Path,
+			fmt.Sprintf(
+				"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/containerApps/%s",
+				subscriptionId,
+				resourceGroup,
+				appName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		response := armappcontainers.ContainerAppsClientUpdateResponse{}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusAccepted, response)
+	})
+
+	return mockRequest
+}
+
+func MockContainerAppRevisionGet(
+	mockContext *mocks.MockContext,
+	subscriptionId string,
+	resourceGroup string,
+	appName string,
+	revisionName string,
+	revision *armappcontainers.Revision,
+) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && strings.Contains(
+			request.URL.Path,
+			fmt.Sprintf(
+				"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/containerApps/%s/revisions/%s",
+				subscriptionId,
+				resourceGroup,
+				appName,
+				revisionName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		response := armappcontainers.ContainerAppsRevisionsClientGetRevisionResponse{
+			Revision: *revision,
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}
+
+func MockContainerAppSecretsList(
+	mockContext *mocks.MockContext,
+	subscriptionId string,
+	resourceGroup string,
+	appName string,
+	secrets *armappcontainers.SecretsCollection,
+) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodPost && strings.Contains(
+			request.URL.Path,
+			fmt.Sprintf(
+				"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/containerApps/%s/listSecrets",
+				subscriptionId,
+				resourceGroup,
+				appName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		response := armappcontainers.ContainerAppsClientListSecretsResponse{
+			SecretsCollection: *secrets,
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -107,11 +107,6 @@
                             "java"
                         ]
                     },
-                    "module": {
-                        "type": "string",
-                        "title": "Path of the infrastructure module used to deploy the service relative to the root infra folder",
-                        "description": "If omitted, the CLI will assume the module name is the same as the service name."
-                    },
                     "dist": {
                         "type": "string",
                         "title": "Relative path to service deployment artifacts"


### PR DESCRIPTION
## Details

This update brings the implementation of container apps inline with our other service targets.  Previously ACA apps performed an additional `provision` operation to perform container image modifications during deployment.

This additional internal `provision` step introduced additional complexity and also made it difficult to support other infra providers.

This update performs the following:
- [x] Build, tag & push new container images (no change)
- [x] Publish and activate new container app provision
  - Leverages the Azure SDK for Go
  - Modeled after [az cli command](https://github.com/Azure/azure-cli-extensions/blob/64fcab983940b3a7b259bf2ff9dd2f5cbd16c85a/src/containerapp/azext_containerapp/custom.py#L1644)
 - [x] Unit tests
 
 ## In Scope
 **Single Revision Mode**
- New revision is published automatically when container app is updated

Multiple Revision Mode
- New revision ingress traffic weights sets 100% of traffic to new revision

## Out of Scope
- Advanced deployment scenarios
  - Different traffic weights by revision
  - Blue/Green | Canary deployments

## Breaking Change

**This should also be treated as a breaking change.**  
- Deploy will fail for anyone using ACA apps that are not deploying the ACA resources as part of the initial `provision` step.

**Workaround**
- Move your ACA resources from their own modules into the `main` module of the azd deployment.

### Resolves Issues
- #1662
- #1720