### PR TITLE
fix cors stategy for Java/NodeJs/Python

### DIFF
--- a/templates/todo/api/java/README.md
+++ b/templates/todo/api/java/README.md
@@ -15,6 +15,9 @@ The following environment variables are available for configuration:
 - `AZURE_KEY_VAULT_ENDPOINT`. If set, other secret environment properties such as `AZURE_COSMOS_CONNECTION_STRING` are loaded from KeyVault.
 - `AZURE_COSMOS_CONNECTION_STRING`. A direct override for specifying the Cosmos DB connection string (Mongo DB also supported).
 - `APPLICATIONINSIGHTS_CONNECTION_STRING`. (Optional) Connection string of an Application Insights instance for telemetry to be logged.
+- `API_ALLOW_ORIGINS`. Comma separated list of urls to be registered as allowed origins by the api server.
+- `API_ENVIRONMENT`. Set this to `develop` to:
+  - Disable CORS and allow all origins.
 
 ### Build & Compile
 

--- a/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/WebConfiguration.java
+++ b/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/WebConfiguration.java
@@ -13,7 +13,7 @@ public class WebConfiguration implements WebMvcConfigurer {
 
     // Use API_ALLOW_ORIGINS env var with comma separated urls like
     // `http://localhost:300, http://otherurl:100`
-    // Requests comming to the api server from other urls will be rejected as per
+    // Requests coming to the api server from other urls will be rejected as per
     // CORS.
     private static String allowOrigins = System.getenv("API_ALLOW_ORIGINS");
 

--- a/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/WebConfiguration.java
+++ b/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/WebConfiguration.java
@@ -1,14 +1,21 @@
 package com.microsoft.azure.simpletodo.configuration;
 
+import java.io.*;
+import java.util.ArrayList;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import java.io.*;
 
 @Configuration
 public class WebConfiguration implements WebMvcConfigurer {
+
+    // For Azure services which don't support setting CORS directly within the service (like Azure Container Apps)
+    // You can enable localhost cors access here.
+    //    example: localhostOrigin = "http://localhost:3000";
+    // Keep empty string to deny localhost origin.
+    private static String localhostOrigin = "";
 
     @Override
     public void addFormatters(FormatterRegistry registry) {
@@ -22,27 +29,42 @@ public class WebConfiguration implements WebMvcConfigurer {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
-                String apiUrl = System.getenv("REACT_APP_WEB_BASE_URL");
+                // env.ENABLE_ORYX_BUILD is only set on Azure environment during azd provision for todo-templates
+                // You can update this to env.JAVA_ENV if your app is using `development` to run locally and another value
+                // when the app is running on Azure (like production or stating)
+                String runningOnAzure = System.getenv("ENABLE_ORYX_BUILD");
 
-                if (apiUrl != null) {
-                    String localHostUrl = "http://localhost:3000/";
-                    registry.addMapping("/**").allowedOrigins("https://portal.azure.com",
-                            "https://ms.portal.azure.com", localHostUrl,
-                            apiUrl).allowedMethods("*").allowedHeaders("*");
-                    String fileName = Thread.currentThread().getStackTrace()[1].getFileName();
-                    File file = new File(fileName);
-                    String absolutePath = file.getAbsolutePath();
-                    System.out.println(
-                            "CORS with " + localHostUrl
-                                    + " is allowed for local host debugging. If you want to change pin number, go to "
-                                    + absolutePath);
+                if (runningOnAzure != null) {
+                    ArrayList<String> origins = new ArrayList<>();
+                    origins.add("https://portal.azure.com");
+                    origins.add("https://ms.portal.azure.com");
 
+                    if (localhostOrigin != "") {
+                        origins.add(localhostOrigin);
+                        String fileName = Thread.currentThread().getStackTrace()[1].getFileName();
+                        File file = new File(fileName);
+                        String absolutePath = file.getAbsolutePath();
+                        System.out.println(
+                            "Allowing requests from" + localhostOrigin + ". To change or disable, go to " + absolutePath
+                        );
+                    }
+
+                    // REACT_APP_WEB_BASE_URL must be set for the api service as a property
+                    // otherwise the api server will reject the origin.
+                    String apiUrlSet = System.getenv("REACT_APP_WEB_BASE_URL");
+                    if (apiUrlSet != null) {
+                        origins.add(apiUrlSet);
+                    }
+
+                    registry
+                        .addMapping("/**")
+                        .allowedOrigins(origins.toArray(new String[0]))
+                        .allowedMethods("*")
+                        .allowedHeaders("*");
                 } else {
                     registry.addMapping("/**").allowedOrigins("*").allowedMethods("*").allowedHeaders("*");
-                    System.out.println(
-                            "Setting CORS to allow all origins because env var REACT_APP_WEB_BASE_URL has no value or is not set.");
+                    System.out.println("Allowing requests from any origin because the server is running locally.");
                 }
-
             }
         };
     }

--- a/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/WebConfiguration.java
+++ b/templates/todo/api/java/src/main/java/com/microsoft/azure/simpletodo/configuration/WebConfiguration.java
@@ -18,7 +18,7 @@ public class WebConfiguration implements WebMvcConfigurer {
     private static String allowOrigins = System.getenv("API_ALLOW_ORIGINS");
 
     // Use API_ENVIRONMENT to change webConfiguration based on this value.
-    // For example, setting API_ENVIRONMENT=development disables CORS checking,
+    // For example, setting API_ENVIRONMENT=develop disables CORS checking,
     // allowing all origins.
     private static String environment = System.getenv("API_ENVIRONMENT");
 

--- a/templates/todo/api/js/src/app.ts
+++ b/templates/todo/api/js/src/app.ts
@@ -30,7 +30,7 @@ export const createApp = async (): Promise<Express> => {
     const runningOnAzure = process.env.ENABLE_ORYX_BUILD;
 
     if (runningOnAzure) {
-        // REACT_APP_WEB_BASE_URL must be set for the api service as a proporty
+        // REACT_APP_WEB_BASE_URL must be set for the api service as a property
         // otherwise the api server will reject the origin.
         const apiUrlSet = process.env.REACT_APP_WEB_BASE_URL;
         const originList = [

--- a/templates/todo/api/js/src/app.ts
+++ b/templates/todo/api/js/src/app.ts
@@ -8,9 +8,9 @@ import items from "./routes/items";
 import { configureMongoose } from "./models/mongoose";
 import { observability } from "./config/observability";
 
-// For Azure services which don't support setting CORS directly within the service (like Static Web Apps)
-// You can enable localhost cors access if you want to allow request from a localhost here.
-//    example: const localhostOrigin = "http://localhost:3000/";
+// For Azure services which don't support setting CORS directly within the service (like Azure Container Apps)
+// You can enable localhost cors access here.
+//    example: const localhostOrigin = "http://localhost:3000";
 // Keep empty string to deny localhost origin.
 const localhostOrigin = "";
 
@@ -25,7 +25,7 @@ export const createApp = async (): Promise<Express> => {
     app.use(express.json());
 
     // env.ENABLE_ORYX_BUILD is only set on Azure environment during azd provision for todo-templates
-    // You can update this to env.NODE_ENV in your app is using `development` to run locally and another value
+    // You can update this to env.NODE_ENV if your app is using `development` to run locally and another value
     // when the app is running on Azure (like production or stating)
     const runningOnAzure = process.env.ENABLE_ORYX_BUILD;
 

--- a/templates/todo/api/python/todo/app.py
+++ b/templates/todo/api/python/todo/app.py
@@ -10,15 +10,15 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 import os
 from pathlib import Path
 
-# For Azure services which don't support setting CORS directly within the service (like Static Web Apps)
-# You can enable localhost cors access if you want to allow request from a localhost here.
-#    example: const localhostOrigin = "http://localhost:3000/";
+# For Azure services which don't support setting CORS directly within the service (like Azure Container Apps)
+# You can enable localhost cors access here.
+#    example: localhostOrigin = "http://localhost:3000";
 # Keep empty string to deny localhost origin.
 localhostOrigin = ""
 
 # CORS origins
 # env.ENABLE_ORYX_BUILD is only set on Azure environment during azd provision for todo-templates
-# You can update this to env.NODE_ENV in your app is using `development` to run locally and another value
+# You can update this to env.PYTHON_ENV if your app is using `development` to run locally and another value
 # when the app is running on Azure (like production or stating)
 runningOnAzure = os.environ.get('ENABLE_ORYX_BUILD')
 if runningOnAzure is not None:

--- a/templates/todo/api/python/todo/app.py
+++ b/templates/todo/api/python/todo/app.py
@@ -17,7 +17,7 @@ from pathlib import Path
 allowOrigins = os.environ.get('API_ALLOW_ORIGINS')
 
 # Use API_ENVIRONMENT to change webConfiguration based on this value.
-# For example, setting API_ENVIRONMENT=development disables CORS checking,
+# For example, setting API_ENVIRONMENT=develop disables CORS checking,
 # allowing all origins.
 environment = os.environ.get('API_ENVIRONMENT')
 

--- a/templates/todo/common/infra/bicep/app/api-container-app.bicep
+++ b/templates/todo/common/infra/bicep/app/api-container-app.bicep
@@ -30,7 +30,7 @@ module app '../../../../../common/infra/bicep/core/host/container-app.bicep' = {
         value: applicationInsights.properties.ConnectionString
       }
       {
-        name: 'REACT_APP_WEB_BASE_URL'
+        name: 'API_ALLOW_ORIGINS'
         value: corsAcaUrl
       }
     ]

--- a/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/infra/main.bicep
@@ -83,7 +83,7 @@ module api '../../../../../common/infra/bicep/app/api-appservice-dotnet.bicep' =
       AZURE_COSMOS_CONNECTION_STRING_KEY: cosmos.outputs.connectionStringKey
       AZURE_COSMOS_DATABASE_NAME: cosmos.outputs.databaseName
       AZURE_COSMOS_ENDPOINT: cosmos.outputs.endpoint
-      REACT_APP_WEB_BASE_URL: web.outputs.SERVICE_WEB_URI
+      API_ALLOW_ORIGINS: web.outputs.SERVICE_WEB_URI
     }
   }
 }

--- a/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/infra/main.bicep
@@ -83,6 +83,7 @@ module api '../../../../../common/infra/bicep/app/api-appservice-dotnet.bicep' =
       AZURE_COSMOS_CONNECTION_STRING_KEY: cosmos.outputs.connectionStringKey
       AZURE_COSMOS_DATABASE_NAME: cosmos.outputs.databaseName
       AZURE_COSMOS_ENDPOINT: cosmos.outputs.endpoint
+      REACT_APP_WEB_BASE_URL: web.outputs.SERVICE_WEB_URI
     }
   }
 }

--- a/templates/todo/projects/java-mongo-aca/.vscode/launch.json
+++ b/templates/todo/projects/java-mongo-aca/.vscode/launch.json
@@ -9,7 +9,9 @@
             "mainClass": "com.microsoft.azure.simpletodo.SimpleTodoApplication",
             "args": [],
             "cwd": "${workspaceFolder}/src/api",
-            "env": {},
+            "env": {
+                "API_ENVIRONMENT":"develop"
+            },
             "envFile": "${input:dotEnvFilePath}"
         },
         {

--- a/templates/todo/projects/java-mongo-aca/.vscode/tasks.json
+++ b/templates/todo/projects/java-mongo-aca/.vscode/tasks.json
@@ -14,7 +14,10 @@
             "type": "shell",
             "command": "./mvnw spring-boot:run",
             "options": {
-                "cwd": "${workspaceFolder}/src/api/"
+                "cwd": "${workspaceFolder}/src/api/",
+                "env": {
+                    "API_ENVIRONMENT": "develop"
+                }
             },
             "presentation": {
                 "panel": "dedicated",

--- a/templates/todo/projects/java-mongo/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/java-mongo/.repo/bicep/infra/main.bicep
@@ -83,7 +83,7 @@ module api '../../../../../common/infra/bicep/app/api-appservice-java.bicep' = {
       AZURE_COSMOS_CONNECTION_STRING_KEY: cosmos.outputs.connectionStringKey
       AZURE_COSMOS_DATABASE_NAME: cosmos.outputs.databaseName
       AZURE_COSMOS_ENDPOINT: cosmos.outputs.endpoint
-      REACT_APP_WEB_BASE_URL: web.outputs.SERVICE_WEB_URI
+      API_ALLOW_ORIGINS: web.outputs.SERVICE_WEB_URI
     }
   }
 }

--- a/templates/todo/projects/java-mongo/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/java-mongo/.repo/bicep/infra/main.bicep
@@ -83,6 +83,7 @@ module api '../../../../../common/infra/bicep/app/api-appservice-java.bicep' = {
       AZURE_COSMOS_CONNECTION_STRING_KEY: cosmos.outputs.connectionStringKey
       AZURE_COSMOS_DATABASE_NAME: cosmos.outputs.databaseName
       AZURE_COSMOS_ENDPOINT: cosmos.outputs.endpoint
+      REACT_APP_WEB_BASE_URL: web.outputs.SERVICE_WEB_URI
     }
   }
 }

--- a/templates/todo/projects/java-mongo/.vscode/launch.json
+++ b/templates/todo/projects/java-mongo/.vscode/launch.json
@@ -9,7 +9,9 @@
             "mainClass": "com.microsoft.azure.simpletodo.SimpleTodoApplication",
             "args": [],
             "cwd": "${workspaceFolder}/src/api",
-            "env": {},
+            "env": {
+                "API_ENVIRONMENT":"develop"
+            },
             "envFile": "${input:dotEnvFilePath}"
         },
         {

--- a/templates/todo/projects/java-mongo/.vscode/tasks.json
+++ b/templates/todo/projects/java-mongo/.vscode/tasks.json
@@ -14,7 +14,10 @@
             "type": "shell",
             "command": "./mvnw spring-boot:run",
             "options": {
-                "cwd": "${workspaceFolder}/src/api/"
+                "cwd": "${workspaceFolder}/src/api/",
+                "env": {
+                    "API_ENVIRONMENT": "develop"
+                }
             },
             "presentation": {
                 "panel": "dedicated",

--- a/templates/todo/projects/nodejs-mongo-swa-func/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo-swa-func/.repo/bicep/infra/main.bicep
@@ -71,7 +71,7 @@ module api '../../../../../common/infra/bicep/app/api-functions-node.bicep' = {
       AZURE_COSMOS_CONNECTION_STRING_KEY: cosmos.outputs.connectionStringKey
       AZURE_COSMOS_DATABASE_NAME: cosmos.outputs.databaseName
       AZURE_COSMOS_ENDPOINT: cosmos.outputs.endpoint
-      REACT_APP_WEB_BASE_URL: web.outputs.SERVICE_WEB_URI
+      API_ALLOW_ORIGINS: web.outputs.SERVICE_WEB_URI
      }
   }
 }

--- a/templates/todo/projects/nodejs-mongo-swa-func/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo-swa-func/.repo/bicep/infra/main.bicep
@@ -71,6 +71,7 @@ module api '../../../../../common/infra/bicep/app/api-functions-node.bicep' = {
       AZURE_COSMOS_CONNECTION_STRING_KEY: cosmos.outputs.connectionStringKey
       AZURE_COSMOS_DATABASE_NAME: cosmos.outputs.databaseName
       AZURE_COSMOS_ENDPOINT: cosmos.outputs.endpoint
+      REACT_APP_WEB_BASE_URL: web.outputs.SERVICE_WEB_URI
      }
   }
 }

--- a/templates/todo/projects/nodejs-mongo/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo/.repo/bicep/infra/main.bicep
@@ -83,6 +83,7 @@ module api '../../../../../common/infra/bicep/app/api-appservice-node.bicep' = {
       AZURE_COSMOS_CONNECTION_STRING_KEY: cosmos.outputs.connectionStringKey
       AZURE_COSMOS_DATABASE_NAME: cosmos.outputs.databaseName
       AZURE_COSMOS_ENDPOINT: cosmos.outputs.endpoint
+      REACT_APP_WEB_BASE_URL: web.outputs.SERVICE_WEB_URI
     }
   }
 }

--- a/templates/todo/projects/nodejs-mongo/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo/.repo/bicep/infra/main.bicep
@@ -83,7 +83,7 @@ module api '../../../../../common/infra/bicep/app/api-appservice-node.bicep' = {
       AZURE_COSMOS_CONNECTION_STRING_KEY: cosmos.outputs.connectionStringKey
       AZURE_COSMOS_DATABASE_NAME: cosmos.outputs.databaseName
       AZURE_COSMOS_ENDPOINT: cosmos.outputs.endpoint
-      REACT_APP_WEB_BASE_URL: web.outputs.SERVICE_WEB_URI
+      API_ALLOW_ORIGINS: web.outputs.SERVICE_WEB_URI
     }
   }
 }

--- a/templates/todo/projects/nodejs-mongo/.repo/terraform/infra/main.tf
+++ b/templates/todo/projects/nodejs-mongo/.repo/terraform/infra/main.tf
@@ -126,6 +126,7 @@ module "api" {
     "SCM_DO_BUILD_DURING_DEPLOYMENT"        = "true"
     "AZURE_KEY_VAULT_ENDPOINT"              = module.keyvault.AZURE_KEY_VAULT_ENDPOINT
     "APPLICATIONINSIGHTS_CONNECTION_STRING" = module.applicationinsights.APPLICATIONINSIGHTS_CONNECTION_STRING
+    "API_ALLOW_ORIGINS"                     = "https://app-web-${local.resource_token}.azurewebsites.net"
   }
 
   app_command_line = ""

--- a/templates/todo/projects/python-mongo-aca/.vscode/launch.json
+++ b/templates/todo/projects/python-mongo-aca/.vscode/launch.json
@@ -32,7 +32,10 @@
             "windows": {
                 "python": "${workspaceFolder}/src/api/api_env/scripts/python.exe",
             },
-            "preLaunchTask": "Restore API"
+            "preLaunchTask": "Restore API",
+            "env": {
+                "API_ENVIRONMENT":"develop"
+            }
         }
     ],
 

--- a/templates/todo/projects/python-mongo-aca/.vscode/tasks.json
+++ b/templates/todo/projects/python-mongo-aca/.vscode/tasks.json
@@ -61,7 +61,10 @@
             "type": "shell",
             "command": "api_env/bin/uvicorn todo.app:app --port 3100 --reload",
             "options": {
-                "cwd": "${workspaceFolder}/src/api/"
+                "cwd": "${workspaceFolder}/src/api/",
+                "env": {
+                    "API_ENVIRONMENT": "develop"
+                }
             },
             "windows": {
                 "command": "api_env/scripts/uvicorn todo.app:app --port 3100 --reload"

--- a/templates/todo/projects/python-mongo-swa-func/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/python-mongo-swa-func/.repo/bicep/infra/main.bicep
@@ -71,7 +71,7 @@ module api '../../../../../common/infra/bicep/app/api-functions-python.bicep' = 
       AZURE_COSMOS_CONNECTION_STRING_KEY: cosmos.outputs.connectionStringKey
       AZURE_COSMOS_DATABASE_NAME: cosmos.outputs.databaseName
       AZURE_COSMOS_ENDPOINT: cosmos.outputs.endpoint
-      REACT_APP_WEB_BASE_URL: web.outputs.SERVICE_WEB_URI
+      API_ALLOW_ORIGINS: web.outputs.SERVICE_WEB_URI
     }
   }
 }

--- a/templates/todo/projects/python-mongo-swa-func/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/python-mongo-swa-func/.repo/bicep/infra/main.bicep
@@ -70,7 +70,9 @@ module api '../../../../../common/infra/bicep/app/api-functions-python.bicep' = 
     appSettings: {
       AZURE_COSMOS_CONNECTION_STRING_KEY: cosmos.outputs.connectionStringKey
       AZURE_COSMOS_DATABASE_NAME: cosmos.outputs.databaseName
-      AZURE_COSMOS_ENDPOINT: cosmos.outputs.endpoint }
+      AZURE_COSMOS_ENDPOINT: cosmos.outputs.endpoint
+      REACT_APP_WEB_BASE_URL: web.outputs.SERVICE_WEB_URI
+    }
   }
 }
 

--- a/templates/todo/projects/python-mongo-swa-func/.vscode/launch.json
+++ b/templates/todo/projects/python-mongo-swa-func/.vscode/launch.json
@@ -32,7 +32,10 @@
             "windows": {
                 "python": "${workspaceFolder}/src/api/api_env/scripts/python.exe"
             },
-            "preLaunchTask": "Restore API"
+            "preLaunchTask": "Restore API",
+            "env": {
+                "API_ENVIRONMENT":"develop"
+            }
         }
     ],
 

--- a/templates/todo/projects/python-mongo/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/python-mongo/.repo/bicep/infra/main.bicep
@@ -83,7 +83,7 @@ module api '../../../../../common/infra/bicep/app/api-appservice-python.bicep' =
       AZURE_COSMOS_CONNECTION_STRING_KEY: cosmos.outputs.connectionStringKey
       AZURE_COSMOS_DATABASE_NAME: cosmos.outputs.databaseName
       AZURE_COSMOS_ENDPOINT: cosmos.outputs.endpoint
-      REACT_APP_WEB_BASE_URL: web.outputs.SERVICE_WEB_URI
+      API_ALLOW_ORIGINS: web.outputs.SERVICE_WEB_URI
     }
   }
 }

--- a/templates/todo/projects/python-mongo/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/python-mongo/.repo/bicep/infra/main.bicep
@@ -83,6 +83,7 @@ module api '../../../../../common/infra/bicep/app/api-appservice-python.bicep' =
       AZURE_COSMOS_CONNECTION_STRING_KEY: cosmos.outputs.connectionStringKey
       AZURE_COSMOS_DATABASE_NAME: cosmos.outputs.databaseName
       AZURE_COSMOS_ENDPOINT: cosmos.outputs.endpoint
+      REACT_APP_WEB_BASE_URL: web.outputs.SERVICE_WEB_URI
     }
   }
 }

--- a/templates/todo/projects/python-mongo/.repo/terraform/infra/main.tf
+++ b/templates/todo/projects/python-mongo/.repo/terraform/infra/main.tf
@@ -127,6 +127,7 @@ module "api" {
     "SCM_DO_BUILD_DURING_DEPLOYMENT"        = "true"
     "AZURE_KEY_VAULT_ENDPOINT"              = module.keyvault.AZURE_KEY_VAULT_ENDPOINT
     "APPLICATIONINSIGHTS_CONNECTION_STRING" = module.applicationinsights.APPLICATIONINSIGHTS_CONNECTION_STRING
+    "API_ALLOW_ORIGINS"                     = "https://app-web-${local.resource_token}.azurewebsites.net"
   }
 
   app_command_line = local.api_command_line

--- a/templates/todo/projects/python-mongo/.vscode/launch.json
+++ b/templates/todo/projects/python-mongo/.vscode/launch.json
@@ -32,7 +32,10 @@
             "windows": {
                 "python": "${workspaceFolder}/src/api/api_env/scripts/python.exe"
             },
-            "preLaunchTask": "Restore API"
+            "preLaunchTask": "Restore API",
+            "env": {
+                "API_ENVIRONMENT":"develop"
+            }
         }
     ],
 

--- a/templates/todo/projects/python-mongo/.vscode/tasks.json
+++ b/templates/todo/projects/python-mongo/.vscode/tasks.json
@@ -61,7 +61,10 @@
             "type": "shell",
             "command": "${workspaceFolder}/src/api/api_env/bin/uvicorn todo.app:app --port 3100 --reload",
             "options": {
-                "cwd": "${workspaceFolder}/src/api/"
+                "cwd": "${workspaceFolder}/src/api/",
+                "env": {
+                    "API_ENVIRONMENT": "develop"
+                }
             },
             "windows": {
                 "command": "${workspaceFolder}/src/api/api_env/scripts/uvicorn todo.app:app --port 3100 --reload"

--- a/templates/todo/web/react-fluent/README.md
+++ b/templates/todo/web/react-fluent/README.md
@@ -7,6 +7,9 @@ This is a [Create React App](https://github.com/facebook/create-react-app) based
 Create a `.env` file within the base of the `reactd-fluent` folder with the following configuration:
 
 - `REACT_APP_API_BASE_URL` - Base URL for all api requests, (ex: `http://localhost:3100`)
+
+> Note: The URL must include the schema, either `http://` or `https://`.
+
 - `REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING` - Azure Application Insights connection string
 
 ## Available Scripts


### PR DESCRIPTION
fix: https://github.com/Azure/azure-dev/issues/1057

This PR re-designs the CORS strategy for the `api` service.

There are 2 layers where CORS (allowed-orings) can be configured:
- Infra:   The Azure Service takes care of validating the incoming http request and lets only allowed-origins to get to the api server.
- runtime Server.  Once the request passes the infra layer, it is received by the server running on the Azure Service and it can also check allowed-origins.

Not every Azure service supports the CORS configuration on `infra` layer. For example, Azure Container Apps does not support the CORS configuration on infra layer.

## Old stategy
- Use CORS on infra layer if supported (web-apps) and do not add CORS on `runtime server`
- Use CORS on `runtime server` when it is not supported on `infra layer`, like Azure container apps.
  - Use web-client url as value for `REACT_APP_WEB_BASE_URL` which is used by the api server as a valid origin.
- Allow all origins when the application is running locally (not in Azure services)

### Old strategy issues
- Wrong detection for running api service locally v/s running on Azure Service.

## New Strategy
- Make api service to configure CORS by default and expose an env var to allow customers to opt-out and allow all origins on demand:
  - Using `API_ENVIRONMENT=develop` makes application to allow all origins on `runtime server` layer.
  - Update `tasks.json` and `lauch.json` to set this env var when lauching the app locally, so CORS is disabled.
  - Document env var in the app Readme for customers who are not using VSCode task to start the api, so they know how to allow all origins.
- Expose env var: `API_ALLOW_ORIGINS` as a way for customers to define a list of allowed origins for the `runtime service` layer.
  - Set API_ALLOW_ORIGINS to include the web client host url when deploying the infrastructure, this values is then used by the runtime server to allow the web client as origin.

### Notes
- If the Azure service supports CORS, the validation will be done by the infra layer and also by the application layer.
- The application can run locally with CORS enabled and customer can define specific list of allowed origins.
- For templates using Azure Functions:
  - CORS is only configured on the `infra layer`
  - As the solution is serverless, there is not a `runtime server` configured and serving the api backend.
  - On every request to Azure Functions, the api-backend is started to dispatch the request without using a server like tomcat for java or uvicorn in python. Hence, there's no layer to configure cors.