### PR TITLE
Fix todo swa templates to work on CI builds

### DIFF
--- a/templates/todo/web/react-fluent/package.json
+++ b/templates/todo/web/react-fluent/package.json
@@ -17,7 +17,7 @@
     "prestart": "npm run envconfig",
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "postbuild": "shx cp ./entrypoint.sh ./build && ls staticwebapp.config.json && cp staticwebapp.config.json ./build || true ",
+    "postbuild": "shx cp ./entrypoint.sh ./build && shx cp staticwebapp.config.json ./build || echo 'post-build completed'",
     "pretest": "npm run envconfig",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/templates/todo/web/react-fluent/package.json
+++ b/templates/todo/web/react-fluent/package.json
@@ -17,7 +17,7 @@
     "prestart": "npm run envconfig",
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "postbuild": "shx cp ./entrypoint.sh ./build",
+    "postbuild": "shx cp ./entrypoint.sh ./build && ls staticwebapp.config.json && cp staticwebapp.config.json ./build || true ",
     "pretest": "npm run envconfig",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
This change ensures swa-apps can be deployed from CI pipelines.

This is a temporally patch until swa-cli is fixed. See: https://github.com/Azure/static-web-apps-cli/issues/688