### PR TITLE
Configure `azd` for use behind an an HTTP/HTTPS proxy

### DIFF
--- a/cli/azd/docs/proxy-configuration.md
+++ b/cli/azd/docs/proxy-configuration.md
@@ -3,7 +3,7 @@
 If behind a proxy server, `HTTP_PROXY` and `HTTPS_PROXY` and environment variables can be configured which will set the proxy that `azd` will use for all http/https requests.
 
 The following examples illustrate using [Telerik Fiddler](https://www.telerik.com/fiddler) as a local proxy server.
-After setting the below environment variables you will start seeing requests within the fiddler trace output. 
+After setting the below environment variables, you will start seeing requests within the fiddler trace output. 
 An example `PROXY_ADDRESS` for fiddler would look like `127.0.0.1:8888`
 
 Setting the environment variables to invalid values will result in various HTTP related error messages when running `azd` commands.

--- a/cli/azd/docs/proxy-configuration.md
+++ b/cli/azd/docs/proxy-configuration.md
@@ -1,0 +1,31 @@
+# Proxy Configuration
+
+If users are behind a proxy server then can configure the `HTTP_PROXY` and `HTTPS_PROXY` environment variables that `azd` will use for all http/https requests.
+
+The following examples illustrate using [Telerik Fiddler](https://www.telerik.com/fiddler) as a local proxy server.
+After setting the below environment variables you will start seeing requests within the fiddler trace output
+
+Setting the environment variables to invalid values will result in various HTTP related error messages when running `azd` commands.
+
+## Windows
+
+```powershell
+$env:HTTP_PROXY = 127.0.0.1:8888
+$env:HTTPS_PROXY = 127.0.0.1:8888
+```
+
+## Linux / Mac OS
+
+```bash
+export HTTP_PROXY=127.0.0.1:8888
+export HTTPS_PROXY=127.0.0.1:8888
+```
+
+## References
+
+- [Go http package docs](https://pkg.go.dev/net/http)
+- [StackOverflow](https://stackoverflow.com/questions/14661511/setting-up-proxy-for-http-client)
+
+Per Go `net/http` package docs
+
+> DefaultTransport is the default implementation of Transport and is used by DefaultClient. It establishes network connections as needed and caches them for reuse by subsequent calls. It uses HTTP proxies as directed by the environment variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY (or the lowercase versions thereof).

--- a/cli/azd/docs/proxy-configuration.md
+++ b/cli/azd/docs/proxy-configuration.md
@@ -3,22 +3,23 @@
 If users are behind a proxy server then can configure the `HTTP_PROXY` and `HTTPS_PROXY` environment variables that `azd` will use for all http/https requests.
 
 The following examples illustrate using [Telerik Fiddler](https://www.telerik.com/fiddler) as a local proxy server.
-After setting the below environment variables you will start seeing requests within the fiddler trace output
+After setting the below environment variables you will start seeing requests within the fiddler trace output. 
+An example `PROXY_ADDRESS` for fiddler would look like `127.0.0.1:8888`
 
 Setting the environment variables to invalid values will result in various HTTP related error messages when running `azd` commands.
 
 ## Windows
 
 ```powershell
-$env:HTTP_PROXY = 127.0.0.1:8888
-$env:HTTPS_PROXY = 127.0.0.1:8888
+$env:HTTP_PROXY = <PROXY_ADDRESS>
+$env:HTTPS_PROXY = <PROXY_ADDRESS>
 ```
 
 ## Linux / Mac OS
 
 ```bash
-export HTTP_PROXY=127.0.0.1:8888
-export HTTPS_PROXY=127.0.0.1:8888
+export HTTP_PROXY=<PROXY_ADDRESS>
+export HTTPS_PROXY=<PROXY_ADDRESS>
 ```
 
 ## References

--- a/cli/azd/docs/proxy-configuration.md
+++ b/cli/azd/docs/proxy-configuration.md
@@ -1,6 +1,6 @@
 # Proxy Configuration
 
-If users are behind a proxy server then can configure the `HTTP_PROXY` and `HTTPS_PROXY` environment variables that `azd` will use for all http/https requests.
+If behind a proxy server, `HTTP_PROXY` and `HTTPS_PROXY` and environment variables can be configured which will set the proxy that `azd` will use for all http/https requests.
 
 The following examples illustrate using [Telerik Fiddler](https://www.telerik.com/fiddler) as a local proxy server.
 After setting the below environment variables you will start seeing requests within the fiddler trace output. 


### PR DESCRIPTION
Adds docs for using `azd` behind a proxy.

Resolves #1600 