### PR TITLE
Remove netgo build constraint

### DIFF
--- a/cli/azd/ci-build.ps1
+++ b/cli/azd/ci-build.ps1
@@ -43,7 +43,7 @@ if ($IsWindows) {
     Write-Host "go build (windows)"
     go build `
         -buildmode=exe `
-        -tags="cfi,cfg,osusergo,netgo" `
+        -tags="cfi,cfg,osusergo" `
         -trimpath `
         -gcflags="-trimpath" `
         -asmflags="-trimpath" `
@@ -53,7 +53,7 @@ elseif ($IsLinux) {
     Write-Host "go build (linux)"
     go build `
         -buildmode=pie `
-        -tags="cfi,cfg,cfgo,osusergo,netgo" `
+        -tags="cfi,cfg,cfgo,osusergo" `
         -gcflags="-trimpath" `
         -asmflags="-trimpath" `
         -ldflags="-s -w -X 'github.com/azure/azure-dev/cli/azd/internal.Version=$Version (commit $SourceVersion)' -extldflags=-Wl,--high-entropy-va"
@@ -62,7 +62,7 @@ elseif ($IsMacOS) {
     Write-Host "go build (macos)"
     go build `
         -buildmode=pie `
-        -tags="cfi,cfg,cfgo,osusergo,netgo" `
+        -tags="cfi,cfg,cfgo,osusergo" `
         -gcflags="-trimpath" `
         -asmflags="-trimpath" `
         -ldflags="-s -w -X 'github.com/azure/azure-dev/cli/azd/internal.Version=$Version (commit $SourceVersion)' -linkmode=auto"


### PR DESCRIPTION
With `netgo` build constraint added (which removes `cgo`-based DNS resolution), users are seeing that `azd auth login` now fails on Windows with VPN enabled due to `localhost` DNS resolution failing. Removing this build constraint allows `azd auth login` to work even under VPN conditions. Verified the behavior locally

Fixes #1994