### PR TITLE
Fix idiosyncrasies in `azd env list`

### DIFF
--- a/cli/azd/pkg/environment/azdcontext/azdcontext.go
+++ b/cli/azd/pkg/environment/azdcontext/azdcontext.go
@@ -70,11 +70,14 @@ func (c *AzdContext) ListEnvironments() ([]contracts.EnvListEnvironment, error) 
 	}
 
 	ents, err := os.ReadDir(c.EnvironmentDirectory())
+	if errors.Is(err, os.ErrNotExist) {
+		return []contracts.EnvListEnvironment{}, nil
+	}
 	if err != nil {
 		return nil, fmt.Errorf("listing entries: %w", err)
 	}
 
-	var envs []contracts.EnvListEnvironment
+	envs := []contracts.EnvListEnvironment{}
 	for _, ent := range ents {
 		if ent.IsDir() {
 			ev := contracts.EnvListEnvironment{
@@ -114,41 +117,18 @@ func (c *AzdContext) GetDefaultEnvironmentName() (string, error) {
 
 func (c *AzdContext) SetDefaultEnvironmentName(name string) error {
 	path := filepath.Join(c.EnvironmentDirectory(), ConfigFileName)
-	bytes, err := json.Marshal(configFile{
+	config := configFile{
 		Version:            ConfigFileVersion,
 		DefaultEnvironment: name,
-	})
-	if err != nil {
-		return fmt.Errorf("serializing config file: %w", err)
 	}
 
-	if err := os.MkdirAll(c.EnvironmentDirectory(), osutil.PermissionDirectory); err != nil {
-		return fmt.Errorf("creating environment root: %w", err)
-	}
-
-	if err := os.WriteFile(path, bytes, osutil.PermissionFile); err != nil {
-		return fmt.Errorf("writing config file: %w", err)
-	}
-
-	return nil
+	return writeConfig(path, config)
 }
 
 var ErrEnvironmentExists = errors.New("environment already exists")
 
 func (c *AzdContext) NewEnvironment(name string) error {
-	if err := os.MkdirAll(c.EnvironmentDirectory(), osutil.PermissionDirectory); err != nil {
-		return fmt.Errorf("creating environment root: %w", err)
-	}
-
-	if err := os.Mkdir(filepath.Join(c.EnvironmentDirectory(), name), osutil.PermissionDirectory); err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return ErrEnvironmentExists
-		}
-
-		return fmt.Errorf("creating environment directory: %w", err)
-	}
-
-	return nil
+	return createEnvironment(c.EnvironmentDirectory(), name)
 }
 
 // Creates context with project directory set to the desired directory.
@@ -205,4 +185,37 @@ func NewAzdContext() (*AzdContext, error) {
 type configFile struct {
 	Version            int    `json:"version"`
 	DefaultEnvironment string `json:"defaultEnvironment"`
+}
+
+func createEnvironment(dir string, name string) error {
+	if err := os.MkdirAll(dir, osutil.PermissionDirectory); err != nil {
+		return fmt.Errorf("creating environment root: %w", err)
+	}
+
+	if err := os.Mkdir(filepath.Join(dir, name), osutil.PermissionDirectory); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return ErrEnvironmentExists
+		}
+
+		return fmt.Errorf("creating environment directory: %w", err)
+	}
+
+	return nil
+}
+
+func writeConfig(path string, config configFile) error {
+	bytes, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("serializing config file: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), osutil.PermissionDirectory); err != nil {
+		return fmt.Errorf("creating environment root: %w", err)
+	}
+
+	if err := os.WriteFile(path, bytes, osutil.PermissionFile); err != nil {
+		return fmt.Errorf("writing config file: %w", err)
+	}
+
+	return nil
 }

--- a/cli/azd/pkg/environment/azdcontext/azdcontext.go
+++ b/cli/azd/pkg/environment/azdcontext/azdcontext.go
@@ -77,6 +77,8 @@ func (c *AzdContext) ListEnvironments() ([]contracts.EnvListEnvironment, error) 
 		return nil, fmt.Errorf("listing entries: %w", err)
 	}
 
+	// prefer empty array over `nil` since this is a contracted return value,
+	// where empty array is preferred for "NotFound" semantics.
 	envs := []contracts.EnvListEnvironment{}
 	for _, ent := range ents {
 		if ent.IsDir() {

--- a/cli/azd/pkg/environment/azdcontext/azdcontext_test.go
+++ b/cli/azd/pkg/environment/azdcontext/azdcontext_test.go
@@ -12,7 +12,7 @@ func TestAzdContext_ListEnvironments(t *testing.T) {
 	tests := []struct {
 		name                string
 		setupEnv            []string
-		defaultEnv          string
+		setupDefaultEnv     string
 		expectedWithRelPath []contracts.EnvListEnvironment
 		expectedErr         error
 	}{
@@ -98,10 +98,10 @@ func TestAzdContext_ListEnvironments(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			temp := t.TempDir()
 			azdCtx := NewAzdContextWithDirectory(temp)
-			if tt.defaultEnv != "" {
+			if tt.setupDefaultEnv != "" {
 				config := configFile{
 					Version:            ConfigFileVersion,
-					DefaultEnvironment: tt.defaultEnv,
+					DefaultEnvironment: tt.setupDefaultEnv,
 				}
 				path := filepath.Join(temp, EnvironmentDirectoryName, ConfigFileName)
 				err := writeConfig(path, config)

--- a/cli/azd/pkg/environment/azdcontext/azdcontext_test.go
+++ b/cli/azd/pkg/environment/azdcontext/azdcontext_test.go
@@ -1,0 +1,127 @@
+package azdcontext
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAzdContext_ListEnvironments(t *testing.T) {
+	tests := []struct {
+		name                string
+		setupEnv            []string
+		defaultEnv          string
+		expectedWithRelPath []contracts.EnvListEnvironment
+		expectedErr         error
+	}{
+		{
+			"EmptyDir",
+			nil,
+			"",
+			[]contracts.EnvListEnvironment{},
+			nil,
+		},
+		{
+			"NoEnvironments",
+			nil,
+			"default", // Set this to a non-empty value. This creates a config and the environment directory.
+			[]contracts.EnvListEnvironment{},
+			nil,
+		},
+		{
+			"WithEnvironments",
+			[]string{
+				"env1",
+				"env2",
+			},
+			"",
+			[]contracts.EnvListEnvironment{
+				{
+					Name:       "env1",
+					IsDefault:  false,
+					DotEnvPath: "./.azure/env1/.env",
+				},
+				{
+					Name:       "env2",
+					IsDefault:  false,
+					DotEnvPath: "./.azure/env2/.env",
+				},
+			},
+			nil,
+		},
+		{
+			"WithEnvironmentsAndDefault",
+			[]string{
+				"env1",
+				"env2",
+			},
+			"env2",
+			[]contracts.EnvListEnvironment{
+				{
+					Name:       "env1",
+					IsDefault:  false,
+					DotEnvPath: "./.azure/env1/.env",
+				},
+				{
+					Name:       "env2",
+					IsDefault:  true,
+					DotEnvPath: "./.azure/env2/.env",
+				},
+			},
+			nil,
+		},
+		{
+			"WithEnvironmentsAndUnknownDefault",
+			[]string{
+				"env1",
+				"env2",
+			},
+			"unknown",
+			[]contracts.EnvListEnvironment{
+				{
+					Name:       "env1",
+					IsDefault:  false,
+					DotEnvPath: "./.azure/env1/.env",
+				},
+				{
+					Name:       "env2",
+					IsDefault:  false,
+					DotEnvPath: "./.azure/env2/.env",
+				},
+			},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			temp := t.TempDir()
+			azdCtx := NewAzdContextWithDirectory(temp)
+			if tt.defaultEnv != "" {
+				config := configFile{
+					Version:            ConfigFileVersion,
+					DefaultEnvironment: tt.defaultEnv,
+				}
+				path := filepath.Join(temp, EnvironmentDirectoryName, ConfigFileName)
+				err := writeConfig(path, config)
+				require.NoError(t, err)
+			}
+
+			for _, env := range tt.setupEnv {
+				err := createEnvironment(filepath.Join(temp, EnvironmentDirectoryName), env)
+				require.NoError(t, err)
+			}
+
+			actual, err := azdCtx.ListEnvironments()
+			require.NoError(t, err)
+
+			expectedEnvironments := make([]contracts.EnvListEnvironment, len(tt.expectedWithRelPath))
+			for i, expected := range tt.expectedWithRelPath {
+				expected.DotEnvPath = filepath.Join(temp, EnvironmentDirectoryName, expected.Name, DotEnvFileName)
+				expectedEnvironments[i] = expected
+			}
+			require.Equal(t, expectedEnvironments, actual)
+		})
+	}
+}


### PR DESCRIPTION
Fixes two issues with environment list implementation:
1. `azd env list` reports error instead of returning `[]` when no `.azure` directory exists: #2011
2. `azd env list` returns `null` instead of `[]` with `azd env list --output json` is ran on a project with no environment directories'

Add test coverage for modified code.

Fixes #2011