### PR TITLE
WIP: Resource Group Provision Scope

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -91,6 +91,7 @@ preinit
 pulumi
 pyapp
 pyvenv
+resourcegroup
 restoreapp
 retriable
 rzip

--- a/cli/azd/internal/repository/testdata/empty/azureyaml_created.txt
+++ b/cli/azd/internal/repository/testdata/empty/azureyaml_created.txt
@@ -5,5 +5,6 @@ infra:
     provider: ""
     path: ""
     module: ""
+    scope: ""
 pipeline:
     provider: ""

--- a/cli/azd/pkg/environment/names.go
+++ b/cli/azd/pkg/environment/names.go
@@ -3,10 +3,20 @@
 
 package environment
 
+import "os"
+
 func GetResourceGroupNameFromEnvVar(env *Environment) string {
+	// First check azd environment
 	resourceGroupName, ok := env.Values[ResourceGroupEnvVarName]
 	if ok {
 		return resourceGroupName
 	}
+
+	// Next check OS environment
+	resourceGroupName = os.Getenv(ResourceGroupEnvVarName)
+	if resourceGroupName != "" {
+		return resourceGroupName
+	}
+
 	return ""
 }

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -44,6 +44,7 @@ type Prompters struct {
 }
 
 type ProviderKind string
+type ScopeKind string
 
 type NewProviderFn func(
 	ctx context.Context,
@@ -62,17 +63,26 @@ var (
 )
 
 const (
+	// Provider Provider Types
+
 	Bicep     ProviderKind = "bicep"
 	Arm       ProviderKind = "arm"
 	Terraform ProviderKind = "terraform"
 	Pulumi    ProviderKind = "pulumi"
 	Test      ProviderKind = "test"
+
+	// Provision Scope Types
+
+	SubscriptionScope  ScopeKind = "subscription"
+	ResourceGroupScope ScopeKind = "resourcegroup"
+	NotSpecifiedScope       ScopeKind = ""
 )
 
 type Options struct {
 	Provider ProviderKind `yaml:"provider"`
 	Path     string       `yaml:"path"`
 	Module   string       `yaml:"module"`
+	Scope    ScopeKind    `yaml:"scope"`
 }
 
 type DeploymentPlan struct {

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -75,7 +75,7 @@ const (
 
 	SubscriptionScope  ScopeKind = "subscription"
 	ResourceGroupScope ScopeKind = "resourcegroup"
-	NotSpecifiedScope       ScopeKind = ""
+	NotSpecifiedScope  ScopeKind = ""
 )
 
 type Options struct {

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -13,6 +13,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry/fields"
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/blang/semver/v4"
 	"golang.org/x/exp/slices"
@@ -64,6 +65,10 @@ func Parse(ctx context.Context, yamlContent string) (*ProjectConfig, error) {
 				*projectConfig.RequiredVersions.Azd,
 				internal.VersionInfo().Version.String())
 		}
+	}
+
+	if projectConfig.Infra.Scope == provisioning.NotSpecifiedScope {
+		projectConfig.Infra.Scope = provisioning.SubscriptionScope
 	}
 
 	for key, svc := range projectConfig.Services {


### PR DESCRIPTION
Adds support for resource group scoped resource provisioning

How to use this build to run headless without any prompts
```bash
# Set env var to set the resource group
export AZURE_RESOURCE_GROUP=<name>

# Set location of RG, subscription and your default environment name
azd init --location <location> --subscription <subscription> --environment <env_name>

# Provision your resources
azd provision

# Deploy code to resources
azd deploy
```

Resolves: #1888, #337