### PR TITLE
Store encrypted MSAL cache with algorithm type

### DIFF
--- a/cli/azd/pkg/auth/cache_windows.go
+++ b/cli/azd/pkg/auth/cache_windows.go
@@ -7,12 +7,30 @@
 package auth
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"unsafe"
 
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/cache"
 	"golang.org/x/sys/windows"
 )
+
+// envelopedData stores both the type of encryption used as well as the encrypted data (as a base64 encoded string),
+// allowing us to change the underlying encryption algorithm as needed (and then understand what we need to do decrypt)
+type envelopedData struct {
+	// The type of encryption that was used to store data.
+	Type encryptionType `json:"type"`
+	// The encrypted data, represented as a Base64 encoded string (using base64.StdEncoding)
+	Data string `json:"data"`
+}
+
+type encryptionType string
+
+// cCryptProtectDataEncryptionType is the encryption type that uses CryptProtectData/CryptUnprotectData for
+// encryption and decryption.  See https://learn.microsoft.com/windows/win32/api/dpapi/nf-dpapi-cryptprotectdata
+// for more information on these APIs.
+const cCryptProtectDataEncryptionType encryptionType = "CryptProtectData"
 
 func newCache(root string) cache.ExportReplace {
 	return &msalCacheAdapter{
@@ -57,9 +75,34 @@ func (c *encryptedCache) Read(key string) ([]byte, error) {
 		return val, nil
 	}
 
-	encryptedBlob := windows.DataBlob{
-		Size: uint32(len(val)),
-		Data: &val[0],
+	var encryptedBlob windows.DataBlob
+	var data envelopedData
+
+	if err := json.Unmarshal(val, &data); err != nil {
+		// early versions of `azd` did not write the encrypted data in an envelope and instead just persisted
+		// the result from CryptProtectData directly. If we fail to unmarshal the persisted data into the enveloped
+		// structure, treat it as if the data was directly stored. The next call to Set will transparently upgrade
+		// to the new format.
+
+		encryptedBlob = windows.DataBlob{
+			Size: uint32(len(val)),
+			Data: &val[0],
+		}
+	} else {
+
+		if data.Type != cCryptProtectDataEncryptionType {
+			return nil, fmt.Errorf("unsupported encryption type: %s", data.Type)
+		}
+
+		data, err := base64.StdEncoding.DecodeString(data.Data)
+		if err != nil {
+			return nil, fmt.Errorf("decoding base64 data: %w", err)
+		}
+
+		encryptedBlob = windows.DataBlob{
+			Size: uint32(len(data)),
+			Data: &data[0],
+		}
 	}
 
 	var plaintext windows.DataBlob
@@ -104,5 +147,15 @@ func (c *encryptedCache) Set(key string, val []byte) error {
 		return fmt.Errorf("failed to free encrypted data: %w", err)
 	}
 
-	return c.inner.Set(key, cs)
+	toStore, err := json.Marshal(envelopedData{
+		Type: cCryptProtectDataEncryptionType,
+		Data: base64.StdEncoding.EncodeToString(cs),
+	})
+
+	// We never expect the above to fail.
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal enveloped data: %s", err))
+	}
+
+	return c.inner.Set(key, toStore)
 }


### PR DESCRIPTION
When storing the MSAL cache on Windows we use CryptProtectData to ensure that the data is encrypted at rest. Previously, we stored just the raw data as returned by CryptProtectData. This would make it difficult in the future for us to change our encryption strategy because we would be unable to determine from the opquae encrypted data how it was encrypted (and hence what we needed to do to decrypt it).

This change updates our strategy to encrypt the data as before, but then store it as part of a JSON object which contains a string denoting how the data was encrypted.

To support transparent upgrades, care is taken to fall back to the older strategy in the case where we can't succesfully unmarshall the stored data as a JSON object (this allows new versions of `azd` to read the cache written by older versions). Future writes to the cache will store the data in the new format.

This introduces a slight breaking change where if you upgrade to a version of `azd` that has this change and then downgrade to an earlier version, the earlier version will not be able to use the cache. In practice, this will cause the CLI to behave as if it was logged out (since all our auth logic will fail) and the user will need to `azd login` again with the older version, which will recreate the cache in the older format that it can read.

Fixes https://github.com/Azure/azure-dev-pr/issues/1545