### PR TITLE
Brings back 'module' property and mark as deprecated

### DIFF
--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -107,6 +107,11 @@
                             "java"
                         ]
                     },
+                    "module": {
+                        "type": "string",
+                        "title": "(DEPRECATED) Path of the infrastructure module used to deploy the service relative to the root infra folder",
+                        "description": "If omitted, the CLI will assume the module name is the same as the service name. This property will be deprecated in a future release."
+                    },
                     "dist": {
                         "type": "string",
                         "title": "Relative path to service deployment artifacts"


### PR DESCRIPTION
We currently have an issue where are schema for `azure.yaml` references our main branch the removal of this property is causing our issues confusion.

Bring back the property and mark as deprecated for now till we have a better yaml schema versioning strategy.