### PR TITLE
Fix `azd down` deletion logic

### DIFF
--- a/cli/azd/cmd/util_test.go
+++ b/cli/azd/cmd/util_test.go
@@ -55,38 +55,21 @@ func Test_promptEnvironmentName(t *testing.T) {
 	t.Run("duplicate resource groups ignored", func(t *testing.T) {
 		mockDeployment := armresources.DeploymentExtended{
 			Properties: &armresources.DeploymentPropertiesExtended{
-				Dependencies: []*armresources.Dependency{
+				OutputResources: []*armresources.ResourceReference{
 					{
-						DependsOn: []*armresources.BasicDependency{
-							{
-								ResourceName: convert.RefOf("groupA"),
-								ResourceType: convert.RefOf(string(infra.AzureResourceTypeResourceGroup)),
-							},
-							{
-								ResourceName: convert.RefOf("groupB"),
-								ResourceType: convert.RefOf(string(infra.AzureResourceTypeResourceGroup)),
-							},
-							{
-								ResourceName: convert.RefOf("ignoredForWrongType"),
-								ResourceType: convert.RefOf(string(infra.AzureResourceTypeStorageAccount)),
-							},
-						},
+						ID: convert.RefOf("/subscriptions/sub-id/resourceGroups/groupA"),
 					},
 					{
-						DependsOn: []*armresources.BasicDependency{
-							{
-								ResourceName: convert.RefOf("groupA"),
-								ResourceType: convert.RefOf(string(infra.AzureResourceTypeResourceGroup)),
-							},
-							{
-								ResourceName: convert.RefOf("groupB"),
-								ResourceType: convert.RefOf(string(infra.AzureResourceTypeResourceGroup)),
-							},
-							{
-								ResourceName: convert.RefOf("groupC"),
-								ResourceType: convert.RefOf(string(infra.AzureResourceTypeResourceGroup)),
-							},
-						},
+						ID: convert.RefOf("/subscriptions/sub-id/resourceGroups/groupA/Microsoft.Storage/storageAccounts/storageAccount"),
+					},
+					{
+						ID: convert.RefOf("/subscriptions/sub-id/resourceGroups/groupB"),
+					},
+					{
+						ID: convert.RefOf("/subscriptions/sub-id/resourceGroups/groupB/Microsoft.web/sites/test"),
+					},
+					{
+						ID: convert.RefOf("/subscriptions/sub-id/resourceGroups/groupC"),
 					},
 				},
 			},

--- a/cli/azd/pkg/infra/azure_resource_manager.go
+++ b/cli/azd/pkg/infra/azure_resource_manager.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/azureutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/compare"
@@ -133,6 +134,15 @@ func (rm *AzureResourceManager) GetResourceGroupsForDeployment(
 		for _, dependent := range dependency.DependsOn {
 			if *dependent.ResourceType == string(AzureResourceTypeResourceGroup) {
 				resourceGroups[*dependent.ResourceName] = struct{}{}
+			}
+		}
+	}
+
+	for _, resourceId := range deployment.Properties.OutputResources {
+		if resourceId != nil && resourceId.ID != nil {
+			resId, err := arm.ParseResourceID(*resourceId.ID)
+			if err == nil && resId.ResourceGroupName != "" {
+				resourceGroups[resId.ResourceGroupName] = struct{}{}
 			}
 		}
 	}

--- a/cli/azd/pkg/infra/azure_resource_manager.go
+++ b/cli/azd/pkg/infra/azure_resource_manager.go
@@ -130,14 +130,6 @@ func (rm *AzureResourceManager) GetResourceGroupsForDeployment(
 	// unique set.
 	resourceGroups := map[string]struct{}{}
 
-	for _, dependency := range deployment.Properties.Dependencies {
-		for _, dependent := range dependency.DependsOn {
-			if *dependent.ResourceType == string(AzureResourceTypeResourceGroup) {
-				resourceGroups[*dependent.ResourceName] = struct{}{}
-			}
-		}
-	}
-
 	for _, resourceId := range deployment.Properties.OutputResources {
 		if resourceId != nil && resourceId.ID != nil {
 			resId, err := arm.ParseResourceID(*resourceId.ID)

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -511,15 +511,9 @@ func prepareDeployShowMocks(
 		Name: convert.RefOf("DEPLOYMENT_NAME"),
 		Properties: &armresources.DeploymentPropertiesExtended{
 			Outputs: deployOutputs,
-			Dependencies: []*armresources.Dependency{
+			OutputResources: []*armresources.ResourceReference{
 				{
-					DependsOn: []*armresources.BasicDependency{
-						{
-							ID:           convert.RefOf("RESOURCE_ID"),
-							ResourceName: convert.RefOf("RESOURCE_GROUP"),
-							ResourceType: convert.RefOf(string(infra.AzureResourceTypeResourceGroup)),
-						},
-					},
+					ID: convert.RefOf("/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP"),
 				},
 			},
 		},


### PR DESCRIPTION
Improve `azd down` deletion logic, addressing two issues:

1. Change how resource groups were fetched from an ARM deployment. Previously, we relied on `deployment.DependsOn.ResourceName` to determine resource groups. This did not work for empty resource groups, as described in #619. This change modifies the logic to summarize resource groups based on `deployment.OutputResources` instead. Schema of deployment is documented [here](https://learn.microsoft.com/en-us/rest/api/resources/deployments/get#deploymentpropertiesextended). From observation, it includes all resources across resource groups from a subscription-level deployment. A sanitized example return response for `Microsoft.Resources/deployment` for a subscription-level deployment grabbed from running `azd up` on a ToDo template is available [here](https://gist.github.com/weikanglim/435f0840b92978c4438b2a857dfdb837)
2. Fix the deletion logic, where resource groups that were already deleted, would have caused a failure in deletion. Deletion should be idempotent, and if a resource group is already deleted, it should be ignored.

I had ran into this trying to run `azd provision` and `azd down` on an empty skeleton starter.

Fixes #619