### PR TITLE
Add early login check to `up`

### DIFF
--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -8,6 +8,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/cmd/middleware"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
+	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -61,6 +62,7 @@ type upAction struct {
 func newUpAction(
 	flags *upFlags,
 	env *environment.Environment,
+	_ auth.LoggedInGuard,
 	accountManager account.Manager,
 	packageActionInitializer actions.ActionInitializer[*packageAction],
 	provisionActionInitializer actions.ActionInitializer[*provisionAction],


### PR DESCRIPTION
Make `up` perform a early login check before prompting for subscriptions.

Usually, this is not required as our dependency constraints will always guarantee that the login check is performed first. However, `up` is special since it is an orchestrating command that creates other commands and has a special prompt for subscriptions.

Related: #2054

Fixes #2037