### PR TITLE
Add prompts for subscription and location in `pipeline config`

### DIFF
--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -79,6 +79,10 @@ func pipelineActions(root *actions.ActionDescriptor) *actions.ActionDescriptor {
 		Command:        newPipelineConfigCmd(),
 		FlagsResolver:  newPipelineConfigFlags,
 		ActionResolver: newPipelineConfigAction,
+		HelpOptions: actions.ActionHelpOptions{
+			Description: getCmdPipelineConfigHelpDescription,
+			Footer:      getCmdPipelineConfigHelpFooter,
+		},
 	})
 
 	return group
@@ -144,7 +148,7 @@ func (p *pipelineConfigAction) Run(ctx context.Context) (*actions.ActionResult, 
 	// We need to ensure the env is set up correctly for provisioning,
 	// i.e., AZURE_SUBSCRIPTION_ID and AZURE_LOCATION must be set,
 	// so that the variables are set automatically on CI.
-	err := provisioning.EnsureSubscriptionAndLocation(ctx, p.console, p.env, p.accountManager)
+	err := provisioning.EnsureEnv(ctx, p.console, p.env, p.accountManager)
 	if err != nil {
 		return nil, err
 	}
@@ -202,5 +206,30 @@ func getCmdPipelineHelpFooter(c *cobra.Command) string {
 	return generateCmdHelpSamplesBlock(map[string]string{
 		"Walk through the steps required " +
 			"to set up your deployment pipeline.": output.WithHighLightFormat("azd pipeline config"),
+	})
+}
+
+func getCmdPipelineConfigHelpDescription(*cobra.Command) string {
+	return generateCmdHelpDescription(
+		"Create and configure your deployment pipeline by using GitHub or Azure Pipelines.",
+		[]string{
+			formatHelpNote("By default, " +
+				output.WithHighLightFormat("pipeline config") +
+				" will configure and set deployment pipeline variables using the current environment. " +
+				"To configure for a new or a different existing environment, use the '-e' flag."),
+		})
+}
+
+func getCmdPipelineConfigHelpFooter(c *cobra.Command) string {
+	return generateCmdHelpSamplesBlock(map[string]string{
+		"Set up a deployment pipeline for 'app-test' environment": fmt.Sprintf("%s %s",
+			output.WithHighLightFormat("azd pipeline config -e"),
+			output.WithWarningFormat("app-test"),
+		),
+		"Set up a deployment pipeline for 'app-test' environment on Azure Pipelines.": fmt.Sprintf("%s %s %s",
+			output.WithHighLightFormat("azd pipeline config -e"),
+			output.WithWarningFormat("app-test"),
+			output.WithHighLightFormat("--provider azdo"),
+		),
 	})
 }

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -11,6 +11,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
+	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/commands/pipeline"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
@@ -116,6 +117,7 @@ func newPipelineConfigAction(
 	azdCtx *azdcontext.AzdContext,
 	env *environment.Environment,
 	accountManager account.Manager,
+	_ auth.LoggedInGuard,
 	console input.Console,
 	flags *pipelineConfigFlags,
 	commandRunner exec.CommandRunner,

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -145,9 +145,6 @@ func newPipelineConfigAction(
 
 // Run implements action interface
 func (p *pipelineConfigAction) Run(ctx context.Context) (*actions.ActionResult, error) {
-	// We need to ensure the env is set up correctly for provisioning,
-	// i.e., AZURE_SUBSCRIPTION_ID and AZURE_LOCATION must be set,
-	// so that the variables are set automatically on CI.
 	err := provisioning.EnsureEnv(ctx, p.console, p.env, p.accountManager)
 	if err != nil {
 		return nil, err

--- a/cli/azd/cmd/testdata/TestUsage-azd-pipeline-config.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-pipeline-config.snap
@@ -1,6 +1,8 @@
 
 Create and configure your deployment pipeline by using GitHub or Azure Pipelines.
 
+  • By default, pipeline config will configure and set deployment pipeline variables using the current environment. To configure for a new or a different existing environment, use the '-e' flag.
+
 Usage
   azd pipeline config [flags]
 
@@ -18,6 +20,11 @@ Global Flags
         --debug      	: Enables debugging and diagnostics logging.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
-Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.
+Examples
+  Set up a deployment pipeline for 'app-test' environment
+    azd pipeline config -e app-test
+
+  Set up a deployment pipeline for 'app-test' environment on Azure Pipelines.
+    azd pipeline config -e app-test --provider azdo
 
 

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -100,7 +100,7 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 			output.WithWarningFormat("WARNING: The '--service' flag is deprecated and will be removed in a future release."))
 	}
 
-	err := provisioning.EnsureSubscriptionAndLocation(ctx, u.console, u.env, u.accountManager)
+	err := provisioning.EnsureEnv(ctx, u.console, u.env, u.accountManager)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -307,7 +307,7 @@ func (m *Manager) promptLocation(
 }
 
 func (m *Manager) ensureSubscriptionLocation(ctx context.Context, env *environment.Environment) error {
-	return EnsureSubscriptionAndLocation(ctx, m.console, m.env, m.accountManager)
+	return EnsureEnv(ctx, m.console, m.env, m.accountManager)
 }
 
 type CurrentPrincipalIdProvider interface {

--- a/cli/azd/pkg/infra/provisioning/util.go
+++ b/cli/azd/pkg/infra/provisioning/util.go
@@ -16,9 +16,11 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 )
 
-// EnsureSubscriptionAndLocation ensures that a subscription and location are configured in the environment, prompting
-// for values if they are not.
-func EnsureSubscriptionAndLocation(
+// EnsureEnv ensures that the environment is in a provision-ready state with required values set, prompting the user if
+// values are unset.
+//
+// This currently means that subscription and location are set.
+func EnsureEnv(
 	ctx context.Context,
 	console input.Console,
 	env *environment.Environment,

--- a/cli/azd/pkg/infra/provisioning/util.go
+++ b/cli/azd/pkg/infra/provisioning/util.go
@@ -19,7 +19,7 @@ import (
 // EnsureEnv ensures that the environment is in a provision-ready state with required values set, prompting the user if
 // values are unset.
 //
-// This currently means that subscription and location are set.
+// This currently means that subscription (AZURE_SUBSCRIPTION_ID) and location (AZURE_LOCATION) variables are set.
 func EnsureEnv(
 	ctx context.Context,
 	console input.Console,

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -313,7 +313,6 @@ func Test_CLI_ProvisionIsNeeded(t *testing.T) {
 	}{
 		{command: "deploy"},
 		{command: "monitor"},
-		{command: "pipeline config"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add prompts for subscription and location in `pipeline config`

`pipeline config` needs the environment is a provision-ready state. Instead of erroring out, we should prompt the user to fill it in. This restores the old behavior prior to #1752. 

Fixes #2058