### PR TITLE
Make `services` not required; clean-up project config.

### DIFF
--- a/cli/azd/internal/repository/testdata/empty/azureyaml_created.txt
+++ b/cli/azd/internal/repository/testdata/empty/azureyaml_created.txt
@@ -1,9 +1,3 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
 
 name: "<project>"
-infra:
-    provider: ""
-    path: ""
-    module: ""
-pipeline:
-    provider: ""

--- a/cli/azd/pkg/project/project_config.go
+++ b/cli/azd/pkg/project/project_config.go
@@ -18,8 +18,8 @@ type ProjectConfig struct {
 	Path              string                     `yaml:",omitempty"`
 	Metadata          *ProjectMetadata           `yaml:"metadata,omitempty"`
 	Services          map[string]*ServiceConfig  `yaml:",omitempty"`
-	Infra             provisioning.Options       `yaml:"infra"`
-	Pipeline          PipelineOptions            `yaml:"pipeline"`
+	Infra             provisioning.Options       `yaml:"infra,omitempty"`
+	Pipeline          PipelineOptions            `yaml:"pipeline,omitempty"`
 	Hooks             map[string]*ext.HookConfig `yaml:"hooks,omitempty"`
 
 	*ext.EventDispatcher[ProjectLifecycleEventArgs] `yaml:",omitempty"`

--- a/ext/vscode/src/commands/azureWorkspace/wizard/PickResourceGroupStep.ts
+++ b/ext/vscode/src/commands/azureWorkspace/wizard/PickResourceGroupStep.ts
@@ -53,16 +53,18 @@ export class PickResourceGroupStep extends SkipIfOneStep<RevealResourceGroupWiza
                 });
         } else {
             const resourceGroupIds = new Set<string>();
-            for (const serviceName of Object.keys(showResults.services)) {
-                const service = showResults.services[serviceName];
+            if (showResults.services) {
+                for (const serviceName of Object.keys(showResults.services)) {
+                    const service = showResults.services[serviceName];
 
-                if (!service?.target?.resourceIds) {
-                    continue;
-                }
+                    if (!service?.target?.resourceIds) {
+                        continue;
+                    }
 
-                for (const resourceId of service.target.resourceIds) {
-                    const { subscription, resourceGroup } = parseAzureResourceId(resourceId);
-                    resourceGroupIds.add(`/subscriptions/${subscription}/resourceGroups/${resourceGroup}`);
+                    for (const resourceId of service.target.resourceIds) {
+                        const { subscription, resourceGroup } = parseAzureResourceId(resourceId);
+                        resourceGroupIds.add(`/subscriptions/${subscription}/resourceGroups/${resourceGroup}`);
+                    }
                 }
             }
 

--- a/ext/vscode/src/services/AzureDevShowProvider.ts
+++ b/ext/vscode/src/services/AzureDevShowProvider.ts
@@ -25,7 +25,7 @@ interface AzureDevResource {
 
 export interface AzDevShowResults {
     readonly name: string;
-    readonly services: { readonly [name: string]: AzureDevService };
+    readonly services?: { readonly [name: string]: AzureDevService };
     readonly environmentName?: string; // Available in version 0.6.0+
     readonly resources?: AzureDevResource[];
 }

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -3,8 +3,7 @@
     "$id": "https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json",
     "type": "object",
     "required": [
-        "name",
-        "services"
+        "name"
     ],
     "additionalProperties": false,
     "properties": {


### PR DESCRIPTION
Make `services` not required; clean-up project config.

It's perfectly fine to have an `azure.yaml` that only does provision. I verified that creating a minimal `azure.yaml` and running `azd deploy` and `azd restore` works correctly.

Project config was also littered with unset properties when running `azd init` with "empty template" selected. This change cleans up the `azure.yaml` generated.

Before:
```yaml
name: test3
infra:
    provider: ""
    path: ""
    module: ""
pipeline:
    provider: ""
```

After:
```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json

name: test3
```

Fixes #1162
