### PR TITLE
breaking: Do not default `language` to dotnet 

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+- [[2066]](https://github.com/Azure/azure-dev/pull/2066) `azd` no longer assumes `dotnet` by default when `services.language` is not set, or empty in `azure.yaml`. If you receive an error message 'language property must not be empty', specify `language: dotnet` explicitly in `azure.yaml`.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/cli/azd/pkg/project/framework_service.go
+++ b/cli/azd/pkg/project/framework_service.go
@@ -26,6 +26,10 @@ const (
 )
 
 func parseServiceLanguage(kind ServiceLanguageKind) (ServiceLanguageKind, error) {
+	if string(kind) == "" {
+		return ServiceLanguageKind(""), fmt.Errorf("language property must not be empty")
+	}
+
 	// aliases
 	if string(kind) == "py" {
 		return ServiceLanguagePython, nil

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -71,10 +71,6 @@ func Parse(ctx context.Context, yamlContent string) (*ProjectConfig, error) {
 		svc.Project = &projectConfig
 		svc.EventDispatcher = ext.NewEventDispatcher[ServiceLifecycleEventArgs]()
 
-		if svc.Language == "" {
-			svc.Language = "dotnet"
-		}
-
 		var err error
 		svc.Language, err = parseServiceLanguage(svc.Language)
 		if err != nil {

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -94,9 +94,7 @@
                     "language": {
                         "type": "string",
                         "title": "Service implementation language",
-                        "description": "If omitted, .NET will be assumed.",
                         "enum": [
-                            "",
                             "dotnet",
                             "csharp",
                             "fsharp",

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -66,7 +66,8 @@
                 "type": "object",
                 "additionalProperties": false,
                 "required": [
-                    "project"
+                    "project",
+                    "language"
                 ],
                 "properties": {
                     "resourceName": {


### PR DESCRIPTION
We will no longer default `language` to `dotnet` when unset. Instead, the user receives an error in `azure.yaml` schema validation. If an `azd` command runs with `language` unset, the following error would be observed:
`Error: parsing project file: parsing service myService: language property must be set`

Fixes #1645
