### PR TITLE
Move dependencies required for build/deploy from "devDependencies" into "dependencies"

### DIFF
--- a/templates/todo/api/js/package.json
+++ b/templates/todo/api/js/package.json
@@ -37,7 +37,10 @@
     "swagger-ui-express": "^4.4.0",
     "winston": "^3.7.2",
     "winston-transport": "^4.5.0",
-    "yamljs": "^0.3.0"
+    "yamljs": "^0.3.0",
+    "@typescript-eslint/eslint-plugin": "^5.27.1",
+    "@typescript-eslint/parser": "^5.27.1",
+    "eslint": "^8.17.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.18.2",
@@ -51,9 +54,6 @@
     "@types/swagger-ui-express": "^4.1.3",
     "@types/uuid": "^8.3.4",
     "@types/yamljs": "^0.2.31",
-    "@typescript-eslint/eslint-plugin": "^5.27.1",
-    "@typescript-eslint/parser": "^5.27.1",
-    "eslint": "^8.17.0",
     "jest": "^28.1.1",
     "supertest": "^6.2.3",
     "ts-jest": "^28.0.4",

--- a/templates/todo/web/react-fluent/package.json
+++ b/templates/todo/web/react-fluent/package.json
@@ -10,7 +10,12 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.3.0",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "@typescript-eslint/eslint-plugin": "^5.27.1",
+    "@typescript-eslint/parser": "^5.27.1",
+    "eslint": "^8.17.0",
+    "eslint-config-react-app": "^7.0.1",
+    "shx": "^0.3.4"
   },
   "scripts": {
     "envconfig": "node entrypoint.js -e .env -o ./public/env-config.js",
@@ -51,15 +56,10 @@
     "@types/react": "^17.0.41",
     "@types/react-dom": "^17.0.14",
     "@types/react-router-dom": "^5.3.3",
-    "@typescript-eslint/eslint-plugin": "^5.27.1",
-    "@typescript-eslint/parser": "^5.27.1",
     "dotenv": "^16.0.1",
-    "eslint": "^8.17.0",
-    "eslint-config-react-app": "^7.0.1",
     "if-node-version": "^1.1.1",
     "immer": "^9.0.14",
     "react-scripts": "^5.0.1",
-    "shx": "^0.3.4",
     "typescript": "^4.7.3"
   },
   "overrides": {


### PR DESCRIPTION
Spotted this in CloudShell where the environment has `NODE_ENV=production`

* Are `build` dependencies expected to be in place when `NODE_ENV=production`? If not, we should discuss 