### PR TITLE
codespaces azdo git credential

### DIFF
--- a/cli/azd/pkg/azdo/utils.go
+++ b/cli/azd/pkg/azdo/utils.go
@@ -41,8 +41,8 @@ func EnsurePatExists(ctx context.Context, env *environment.Environment, console 
 			output.WithHighLightFormat("%s", AzDoPatName)))
 
 		pat, err := console.Prompt(ctx, input.ConsoleOptions{
-			Message:      "Personal Access Token (PAT):",
-			DefaultValue: "",
+			Message:    "Personal Access Token (PAT):",
+			IsPassword: true,
 		})
 		if err != nil {
 			return "", false, fmt.Errorf("asking for pat: %w", err)

--- a/cli/azd/pkg/commands/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/commands/pipeline/azdo_provider.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"regexp"
@@ -75,9 +76,9 @@ func (p *AzdoScmProvider) preConfigureCheck(
 	}
 
 	if updatedPat {
-		// pat was requested. Set git-credential helper
+		// setting credential helper is a plus. It should not interrupt the process
 		if err := setPatCredentialHelperForGit(ctx, p.commandRunner, projectPath); err != nil {
-			return updatedPat, err
+			log.Printf("Error trying to set git credential helper for PAT: %s", err.Error())
 		}
 	}
 
@@ -641,9 +642,9 @@ func (p *AzdoCiProvider) preConfigureCheck(
 	}
 
 	if updatedPat {
-		// pat was requested. Set git-credential helper
+		// setting credential helper is a plus. It should not interrupt the process
 		if err := setPatCredentialHelperForGit(ctx, p.commandRunner, projectPath); err != nil {
-			return updatedPat, err
+			log.Printf("Error trying to set git credential helper for PAT: %s", err.Error())
 		}
 	}
 

--- a/cli/azd/pkg/commands/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/commands/pipeline/azdo_provider.go
@@ -108,11 +108,14 @@ func createCredentialHelper(ctx context.Context, projectPath string) (string, er
 
 	for _, line := range []string{
 		"#!/bin/sh",
-		"echo protocol=https",
-		"echo host=dev.azure.com",
-		"echo path=",
-		"echo username=PersonalAccessToken",
-		"echo password=$AZURE_DEVOPS_EXT_PAT",
+		"# Only if AZURE_DEVOPS_EXT_PAT has a value",
+		"if [ $AZURE_DEVOPS_EXT_PAT ]; then",
+		"    echo protocol=https",
+		"    echo host=dev.azure.com",
+		"    echo path=",
+		"    echo username=PersonalAccessToken",
+		"    echo password=$AZURE_DEVOPS_EXT_PAT",
+		"fi",
 	} {
 		if _, err := file.WriteString(line + "\n"); err != nil {
 			return "", err

--- a/cli/azd/pkg/commands/pipeline/pipeline.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline.go
@@ -224,7 +224,7 @@ func DetectProviders(
 		_ = savePipelineProviderToEnv(azdoLabel, env)
 		log.Printf("Using pipeline provider: %s", output.WithHighLightFormat("Azure DevOps"))
 		scmProvider := createAzdoScmProvider(env, azdContext, commandRunner, console)
-		ciProvider := createAzdoCiProvider(env, azdContext, console)
+		ciProvider := createAzdoCiProvider(env, azdContext, commandRunner, console)
 
 		return scmProvider, ciProvider, nil
 	}
@@ -248,12 +248,16 @@ func savePipelineProviderToEnv(provider string, env *environment.Environment) er
 }
 
 func createAzdoCiProvider(
-	env *environment.Environment, azdCtx *azdcontext.AzdContext, console input.Console,
+	env *environment.Environment,
+	azdCtx *azdcontext.AzdContext,
+	commandRunner exec.CommandRunner,
+	console input.Console,
 ) *AzdoCiProvider {
 	return &AzdoCiProvider{
-		Env:        env,
-		AzdContext: azdCtx,
-		console:    console,
+		Env:           env,
+		AzdContext:    azdCtx,
+		console:       console,
+		commandRunner: commandRunner,
 	}
 }
 

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -88,6 +88,7 @@ type ConsoleOptions struct {
 	Help         string
 	Options      []string
 	DefaultValue any
+	IsPassword   bool
 }
 
 type ConsoleHandles struct {
@@ -274,23 +275,30 @@ func (c *AskerConsole) getStopChar(format SpinnerUxType) string {
 	return fmt.Sprintf("%s%s", c.getIndent(format), stopChar)
 }
 
-// Prompts the user for a single value
-func (c *AskerConsole) Prompt(ctx context.Context, options ConsoleOptions) (string, error) {
+func promptFromOptions(options ConsoleOptions) survey.Prompt {
+	if options.IsPassword {
+		return &survey.Password{
+			Message: options.Message,
+		}
+	}
+
 	var defaultValue string
 	if value, ok := options.DefaultValue.(string); ok {
 		defaultValue = value
 	}
-
-	survey := &survey.Input{
+	return &survey.Input{
 		Message: options.Message,
 		Default: defaultValue,
 		Help:    options.Help,
 	}
+}
 
+// Prompts the user for a single value
+func (c *AskerConsole) Prompt(ctx context.Context, options ConsoleOptions) (string, error) {
 	var response string
 
 	err := c.doInteraction(func(c *AskerConsole) error {
-		return c.asker(survey, &response)
+		return c.asker(promptFromOptions(options), &response)
 	})
 	if err != nil {
 		return response, err

--- a/cli/azd/pkg/tools/git/git.go
+++ b/cli/azd/pkg/tools/git/git.go
@@ -272,7 +272,7 @@ func (cli *gitCli) SetAzdoPatAuth(ctx context.Context, repositoryPath, azdoPatFi
 
 	runArgs = newRunArgs(
 		"-C", repositoryPath,
-		"config", "--local", "add", "credential.helper", azdoPatFile)
+		"config", "--local", "--add", "credential.helper", azdoPatFile)
 	if _, err := cli.commandRunner.Run(ctx, runArgs); err != nil {
 		return fmt.Errorf("failed to set break for azdo credential helper: %w", err)
 	}


### PR DESCRIPTION
Set a credential helper for azdo (same approach than github).
Use the approach for azdo running in codespaces or locally, as it will help in both cases to ensure pushing code by using the PAT provided to azd process (so it is not re-asked for pushing code)

fix: https://github.com/Azure/azure-dev/issues/1993

