### PR TITLE
Move "current-user" settings out of `config.json`

### DIFF
--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -315,7 +315,7 @@ func newConfigResetAction(configManager config.UserConfigManager, args []string)
 
 // Executes the `azd config reset` action
 func (a *configResetAction) Run(ctx context.Context) (*actions.ActionResult, error) {
-	emptyConfig := config.NewConfig(nil)
+	emptyConfig := config.NewEmptyConfig()
 	return nil, a.configManager.Save(emptyConfig)
 }
 

--- a/cli/azd/pkg/account/manager.go
+++ b/cli/azd/pkg/account/manager.go
@@ -60,7 +60,7 @@ func NewManager(
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			log.Printf("configuration file '%s' does not exist. Creating new empty config.", filePath)
-			azdConfig = config.NewConfig(nil)
+			azdConfig = config.NewEmptyConfig()
 		} else {
 			return nil, err
 		}

--- a/cli/azd/pkg/account/manager_test.go
+++ b/cli/azd/pkg/account/manager_test.go
@@ -57,7 +57,7 @@ func Test_GetAccountDefaults(t *testing.T) {
 	})
 
 	t.Run("FromCodeDefaults", func(t *testing.T) {
-		emptyConfig := config.NewConfig(nil)
+		emptyConfig := config.NewEmptyConfig()
 
 		mockConfig := mockconfig.NewMockConfigManager()
 		mockHttp := mockhttp.NewMockHttpUtil()
@@ -508,7 +508,7 @@ func Test_HasDefaults(t *testing.T) {
 	})
 
 	t.Run("DefaultsNotSet", func(t *testing.T) {
-		azdConfig := config.NewConfig(nil)
+		azdConfig := config.NewEmptyConfig()
 
 		manager, err := NewManager(
 			mockConfig.WithConfig(azdConfig),

--- a/cli/azd/pkg/auth/manager_test.go
+++ b/cli/azd/pkg/auth/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
 	"testing"
 
 	_ "embed"
@@ -17,6 +18,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/github"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
@@ -55,8 +57,9 @@ func TestServicePrincipalLoginClientSecret(t *testing.T) {
 	}
 
 	m := Manager{
-		configManager:   newMemoryConfigManager(),
-		credentialCache: credentialCache,
+		configManager:     newMemoryConfigManager(),
+		userConfigManager: newMemoryUserConfigManager(),
+		credentialCache:   credentialCache,
 	}
 
 	cred, err := m.LoginWithServicePrincipalSecret(
@@ -89,8 +92,9 @@ func TestServicePrincipalLoginClientCertificate(t *testing.T) {
 	}
 
 	m := Manager{
-		configManager:   newMemoryConfigManager(),
-		credentialCache: credentialCache,
+		configManager:     newMemoryConfigManager(),
+		userConfigManager: newMemoryUserConfigManager(),
+		credentialCache:   credentialCache,
 	}
 
 	cred, err := m.LoginWithServicePrincipalCertificate(
@@ -131,8 +135,9 @@ func TestServicePrincipalLoginFederatedTokenProvider(t *testing.T) {
 	})
 
 	m := Manager{
-		configManager:   newMemoryConfigManager(),
-		credentialCache: credentialCache,
+		configManager:     newMemoryConfigManager(),
+		userConfigManager: newMemoryUserConfigManager(),
+		credentialCache:   credentialCache,
 		ghClient: github.NewFederatedTokenClient(&policy.ClientOptions{
 			Transport: mockContext.HttpClient,
 		}),
@@ -160,7 +165,7 @@ func TestServicePrincipalLoginFederatedTokenProvider(t *testing.T) {
 }
 
 func TestLegacyAzCliCredentialSupport(t *testing.T) {
-	mgr := newMemoryConfigManager()
+	mgr := newMemoryUserConfigManager()
 
 	cfg, err := mgr.Load()
 	require.NoError(t, err)
@@ -172,7 +177,7 @@ func TestLegacyAzCliCredentialSupport(t *testing.T) {
 	require.NoError(t, err)
 
 	m := Manager{
-		configManager: mgr,
+		userConfigManager: mgr,
 	}
 
 	cred, err := m.CredentialForCurrentUser(context.Background(), nil)
@@ -184,7 +189,8 @@ func TestLegacyAzCliCredentialSupport(t *testing.T) {
 func TestCloudShellCredentialSupport(t *testing.T) {
 	t.Setenv("AZD_IN_CLOUDSHELL", "1")
 	m := Manager{
-		configManager: newMemoryConfigManager(),
+		configManager:     newMemoryConfigManager(),
+		userConfigManager: newMemoryUserConfigManager(),
 	}
 
 	cred, err := m.CredentialForCurrentUser(context.Background(), nil)
@@ -194,8 +200,9 @@ func TestCloudShellCredentialSupport(t *testing.T) {
 
 func TestLoginInteractive(t *testing.T) {
 	m := &Manager{
-		configManager: newMemoryConfigManager(),
-		publicClient:  &mockPublicClient{},
+		configManager:     newMemoryConfigManager(),
+		userConfigManager: newMemoryUserConfigManager(),
+		publicClient:      &mockPublicClient{},
 	}
 
 	cred, err := m.LoginInteractive(context.Background(), 0, "")
@@ -219,8 +226,9 @@ func TestLoginInteractive(t *testing.T) {
 
 func TestLoginDeviceCode(t *testing.T) {
 	m := &Manager{
-		configManager: newMemoryConfigManager(),
-		publicClient:  &mockPublicClient{},
+		configManager:     newMemoryConfigManager(),
+		userConfigManager: newMemoryUserConfigManager(),
+		publicClient:      &mockPublicClient{},
 	}
 
 	buf := bytes.Buffer{}
@@ -246,22 +254,73 @@ func TestLoginDeviceCode(t *testing.T) {
 	require.True(t, errors.Is(err, ErrNoCurrentUser))
 }
 
-func newMemoryConfigManager() config.UserConfigManager {
-	return &memoryConfigManager{
+func TestAuthFileConfigUpgrade(t *testing.T) {
+	cfgMgr := newMemoryConfigManager()
+	userCfg := config.NewConfig(nil)
+	userCfgMgr := newMemoryUserConfigManager()
+
+	err := userCfg.Set(cCurrentUserKey, &userProperties{
+		HomeAccountID: convert.RefOf("homeAccountID"),
+	})
+	require.NoError(t, err)
+
+	err = userCfgMgr.Save(userCfg)
+	require.NoError(t, err)
+
+	m := &Manager{
+		configManager:     cfgMgr,
+		userConfigManager: userCfgMgr,
+		publicClient:      &mockPublicClient{},
+	}
+
+	cfg, err := m.readAuthConfig()
+	require.NoError(t, err)
+
+	properties, err := readUserProperties(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, properties.HomeAccountID)
+	require.Equal(t, "homeAccountID", *properties.HomeAccountID)
+}
+
+func newMemoryUserConfigManager() *memoryUserConfigManager {
+	return &memoryUserConfigManager{
 		config: config.NewConfig(nil),
 	}
 }
 
-type memoryConfigManager struct {
+type memoryUserConfigManager struct {
 	config config.Config
 }
 
-func (m *memoryConfigManager) Load() (config.Config, error) {
+func (m *memoryUserConfigManager) Load() (config.Config, error) {
 	return m.config, nil
 }
 
-func (m *memoryConfigManager) Save(cfg config.Config) error {
+func (m *memoryUserConfigManager) Save(cfg config.Config) error {
 	m.config = cfg
+	return nil
+}
+
+func newMemoryConfigManager() *memoryConfigManager {
+	return &memoryConfigManager{
+		configs: map[string]config.Config{},
+	}
+}
+
+type memoryConfigManager struct {
+	configs map[string]config.Config
+}
+
+func (m *memoryConfigManager) Load(path string) (config.Config, error) {
+	c, has := m.configs[path]
+	if !has {
+		return nil, os.ErrNotExist
+	}
+	return c, nil
+}
+
+func (m *memoryConfigManager) Save(cfg config.Config, path string) error {
+	m.configs[path] = cfg
 	return nil
 }
 

--- a/cli/azd/pkg/auth/manager_test.go
+++ b/cli/azd/pkg/auth/manager_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestReadUserProperties(t *testing.T) {
 	t.Run("homeID", func(t *testing.T) {
-		cfg := config.NewConfig(nil)
+		cfg := config.NewEmptyConfig()
 		require.NoError(t, cfg.Set("auth.account.currentUser.homeAccountId", "testAccountId"))
 
 		props, err := readUserProperties(cfg)
@@ -38,7 +38,7 @@ func TestReadUserProperties(t *testing.T) {
 	})
 
 	t.Run("clientID", func(t *testing.T) {
-		cfg := config.NewConfig(nil)
+		cfg := config.NewEmptyConfig()
 		require.NoError(t, cfg.Set("auth.account.currentUser.clientId", "testClientId"))
 		require.NoError(t, cfg.Set("auth.account.currentUser.tenantId", "testTenantId"))
 
@@ -256,7 +256,7 @@ func TestLoginDeviceCode(t *testing.T) {
 
 func TestAuthFileConfigUpgrade(t *testing.T) {
 	cfgMgr := newMemoryConfigManager()
-	userCfg := config.NewConfig(nil)
+	userCfg := config.NewEmptyConfig()
 	userCfgMgr := newMemoryUserConfigManager()
 
 	err := userCfg.Set(cCurrentUserKey, &userProperties{
@@ -280,11 +280,16 @@ func TestAuthFileConfigUpgrade(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, properties.HomeAccountID)
 	require.Equal(t, "homeAccountID", *properties.HomeAccountID)
+
+	// as part of running readAuthConfig, we migrated the setting from the user config to the auth config
+	// so the current user key should no longer be set in the user configuration.
+	_, has := userCfgMgr.config.Get(cCurrentUserKey)
+	require.False(t, has)
 }
 
 func newMemoryUserConfigManager() *memoryUserConfigManager {
 	return &memoryUserConfigManager{
-		config: config.NewConfig(nil),
+		config: config.NewEmptyConfig(),
 	}
 }
 

--- a/cli/azd/pkg/config/config.go
+++ b/cli/azd/pkg/config/config.go
@@ -21,7 +21,13 @@ type Config interface {
 	IsEmpty() bool
 }
 
-// Creates a new empty configuration
+// NewEmptyConfig creates a empty configuration object.
+func NewEmptyConfig() Config {
+	return NewConfig(nil)
+}
+
+// NewConfig creates a configuration object, populated with an initial set of keys and values. If [data] is nil or an
+// empty map, and empty configuration object is returned, but [NewEmptyConfig] might better express your intention.
 func NewConfig(data map[string]any) Config {
 	if data == nil {
 		data = map[string]any{}

--- a/cli/azd/pkg/config/manager.go
+++ b/cli/azd/pkg/config/manager.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,24 +27,6 @@ type Manager interface {
 // Creates a new Configuration Manager
 func NewManager() Manager {
 	return &manager{}
-}
-
-type contextKey string
-
-const (
-	configManagerContextKey contextKey = "configManagerContextKey"
-)
-
-func WithConfigManager(ctx context.Context, manager Manager) context.Context {
-	return context.WithValue(ctx, configManagerContextKey, manager)
-}
-
-func GetConfigManager(ctx context.Context) Manager {
-	configManager, ok := ctx.Value(configManagerContextKey).(Manager)
-	if ok {
-		return configManager
-	}
-	return NewManager()
 }
 
 // Saves the azd configuration to the specified file path

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -96,14 +96,14 @@ func EmptyWithRoot(root string) *Environment {
 	return &Environment{
 		Root:   root,
 		Values: make(map[string]string),
-		Config: config.NewConfig(nil),
+		Config: config.NewEmptyConfig(),
 	}
 }
 
 func Ephemeral() *Environment {
 	return &Environment{
 		Values: make(map[string]string),
-		Config: config.NewConfig(nil),
+		Config: config.NewEmptyConfig(),
 	}
 }
 
@@ -148,7 +148,7 @@ func (e *Environment) Reload() error {
 	cfgPath := filepath.Join(e.Root, azdcontext.ConfigFileName)
 	cfgMgr := config.NewManager()
 	if cfg, err := cfgMgr.Load(cfgPath); errors.Is(err, os.ErrNotExist) {
-		e.Config = config.NewConfig(nil)
+		e.Config = config.NewEmptyConfig()
 	} else if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	} else {

--- a/cli/azd/test/mocks/mock_context.go
+++ b/cli/azd/test/mocks/mock_context.go
@@ -37,7 +37,6 @@ func NewMockContext(ctx context.Context) *MockContext {
 	mockexec.AddAzLoginMocks(commandRunner)
 
 	ctx = httputil.WithHttpClient(ctx, httpClient)
-	ctx = config.WithConfigManager(ctx, configManager)
 
 	mockContext := &MockContext{
 		Credentials:                    &MockCredentials{},

--- a/cli/azd/test/mocks/mockconfig/mock_config.go
+++ b/cli/azd/test/mocks/mockconfig/mock_config.go
@@ -8,7 +8,7 @@ type MockConfigManager struct {
 
 func NewMockConfigManager() *MockConfigManager {
 	return &MockConfigManager{
-		config: config.NewConfig(nil),
+		config: config.NewEmptyConfig(),
 	}
 }
 


### PR DESCRIPTION
Previously, the identity of currently logged in user (either the home account id, when logged in as a user, or the client and tenant id when logged in as a service principal) as stored in user's `config.json`.

A downside of storing this information in `config.json` is that when a user did `azd config reset`, it would "log out" the current user, which is very surprising behavior. In addition, anyone looking at `config.json` would see properties that were much more like state of the auth subsystem instead of actual config values that a user would want to change.

So, this change moves this information out of `config.json` and instead stores it in `auth.json` (a new file) which is also stored in `~/.azd`.

On first use, we'll migrate the relevent properties from `config.json` into `auth.json`.

Fixes #1721