### PR TITLE
Azd-Starshot Integration Phase 1

### DIFF
--- a/templates/common/.github/workflows/bicep/azure-dev.yml
+++ b/templates/common/.github/workflows/bicep/azure-dev.yml
@@ -20,6 +20,8 @@ jobs:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+      AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+      AZURE_DEV_USER_AGENT: ${{ secrets.AZURE_DEV_USER_AGENT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -53,6 +55,7 @@ jobs:
           AZURE_ENV_NAME: ${{ secrets.AZURE_ENV_NAME }}
           AZURE_LOCATION: ${{ secrets.AZURE_LOCATION }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_TAGS: ${{ secrets.AZURE_TAGS }}
 
       - name: Azure Dev Deploy
         run: azd deploy --no-prompt

--- a/templates/todo/projects/csharp-sql/.repo/bicep/infra/main.parameters.json
+++ b/templates/todo/projects/csharp-sql/.repo/bicep/infra/main.parameters.json
@@ -19,6 +19,12 @@
     },
     "useAPIM": {
       "value": "${USE_APIM=false}"
+    },
+    "resourceGroupName": {
+      "value": "${AZURE_RESOURCE_GROUP}"
+    },
+    "tags": {
+      "value": "${AZURE_TAGS}"
     }
   }
 }

--- a/templates/todo/projects/nodejs-mongo/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo/.repo/bicep/infra/main.bicep
@@ -108,7 +108,7 @@ module cosmos '../../../../../common/infra/bicep/app/cosmos-mongo-db.bicep' = {
     accountName: !empty(cosmosAccountName) ? cosmosAccountName : '${abbrs.documentDBDatabaseAccounts}${resourceToken}'
     databaseName: cosmosDatabaseName
     location: location
-    tags: tags
+    tags: updatedTags
     keyVaultName: keyVault.outputs.name
   }
 }

--- a/templates/todo/projects/nodejs-mongo/.repo/bicep/infra/main.parameters.json
+++ b/templates/todo/projects/nodejs-mongo/.repo/bicep/infra/main.parameters.json
@@ -13,6 +13,12 @@
     },
     "useAPIM": {
       "value": "${USE_APIM=false}"
+    },
+    "resourceGroupName": {
+      "value": "${AZURE_RESOURCE_GROUP}"
+    },
+    "tags": {
+      "value": "${AZURE_TAGS}"
     }
   }
 }

--- a/templates/todo/projects/python-mongo/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/python-mongo/.repo/bicep/infra/main.bicep
@@ -24,6 +24,7 @@ param logAnalyticsName string = ''
 param resourceGroupName string = ''
 param webServiceName string = ''
 param apimServiceName string = ''
+param tags string = ''
 
 @description('Flag to use Azure API Management to mediate the calls between the Web frontend and the backend API')
 param useAPIM bool = false
@@ -33,13 +34,14 @@ param principalId string = ''
 
 var abbrs = loadJsonContent('../../../../../../common/infra/bicep/abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
-var tags = { 'azd-env-name': environmentName }
+var baseTags = { 'azd-env-name': environmentName }
+var updatedTags = union(empty(tags) ? {} : base64ToJson(tags), baseTags)
 
 // Organize resources in a resource group
 resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: !empty(resourceGroupName) ? resourceGroupName : '${abbrs.resourcesResourceGroups}${environmentName}'
   location: location
-  tags: tags
+  tags: updatedTags
 }
 
 // The application frontend
@@ -49,7 +51,7 @@ module web '../../../../../common/infra/bicep/app/web-appservice.bicep' = {
   params: {
     name: !empty(webServiceName) ? webServiceName : '${abbrs.webSitesAppService}web-${resourceToken}'
     location: location
-    tags: tags
+    tags: updatedTags
     applicationInsightsName: monitoring.outputs.applicationInsightsName
     appServicePlanId: appServicePlan.outputs.id
   }
@@ -74,7 +76,7 @@ module api '../../../../../common/infra/bicep/app/api-appservice-python.bicep' =
   params: {
     name: !empty(apiServiceName) ? apiServiceName : '${abbrs.webSitesAppService}api-${resourceToken}'
     location: location
-    tags: tags
+    tags: updatedTags
     applicationInsightsName: monitoring.outputs.applicationInsightsName
     appServicePlanId: appServicePlan.outputs.id
     keyVaultName: keyVault.outputs.name
@@ -106,7 +108,7 @@ module cosmos '../../../../../common/infra/bicep/app/cosmos-mongo-db.bicep' = {
     accountName: !empty(cosmosAccountName) ? cosmosAccountName : '${abbrs.documentDBDatabaseAccounts}${resourceToken}'
     databaseName: cosmosDatabaseName
     location: location
-    tags: tags
+    tags: updatedTags
     keyVaultName: keyVault.outputs.name
   }
 }
@@ -118,7 +120,7 @@ module appServicePlan '../../../../../../common/infra/bicep/core/host/appservice
   params: {
     name: !empty(appServicePlanName) ? appServicePlanName : '${abbrs.webServerFarms}${resourceToken}'
     location: location
-    tags: tags
+    tags: updatedTags
     sku: {
       name: 'B1'
     }
@@ -132,7 +134,7 @@ module keyVault '../../../../../../common/infra/bicep/core/security/keyvault.bic
   params: {
     name: !empty(keyVaultName) ? keyVaultName : '${abbrs.keyVaultVaults}${resourceToken}'
     location: location
-    tags: tags
+    tags: updatedTags
     principalId: principalId
   }
 }
@@ -143,7 +145,7 @@ module monitoring '../../../../../../common/infra/bicep/core/monitor/monitoring.
   scope: rg
   params: {
     location: location
-    tags: tags
+    tags: updatedTags
     logAnalyticsName: !empty(logAnalyticsName) ? logAnalyticsName : '${abbrs.operationalInsightsWorkspaces}${resourceToken}'
     applicationInsightsName: !empty(applicationInsightsName) ? applicationInsightsName : '${abbrs.insightsComponents}${resourceToken}'
     applicationInsightsDashboardName: !empty(applicationInsightsDashboardName) ? applicationInsightsDashboardName : '${abbrs.portalDashboards}${resourceToken}'
@@ -157,7 +159,7 @@ module apim '../../../../../../common/infra/bicep/core/gateway/apim.bicep' = if 
   params: {
     name: !empty(apimServiceName) ? apimServiceName : '${abbrs.apiManagementService}${resourceToken}'
     location: location
-    tags: tags
+    tags: updatedTags
     applicationInsightsName: monitoring.outputs.applicationInsightsName
   }
 }

--- a/templates/todo/projects/python-mongo/.repo/bicep/infra/main.parameters.json
+++ b/templates/todo/projects/python-mongo/.repo/bicep/infra/main.parameters.json
@@ -13,6 +13,12 @@
     },
     "useAPIM": {
       "value": "${USE_APIM=false}"
+    },
+    "resourceGroupName": {
+      "value": "${AZURE_RESOURCE_GROUP}"
+    },
+    "tags": {
+      "value": "${AZURE_TAGS}"
     }
   }
 }


### PR DESCRIPTION
Takes care of the following -

- Enable to use existing Resource group
We now pass in the resource group using Repository secrets (like subscription, location etc) if we want to use existing, set as Env variable in the Github workflow file and reference it in the bicep file.

- Fix the issue wherein the tags are being replaced for the Existing Resource group
We are passing in the base64 encoded tags and merging it with the base tags in the bicep file.

- Add User agent for azd telemetry purposes
User agent is being passed as a secret (similar to subscription, location etc) and set as Env variable in GitHub workflow file.

Issue - https://github.com/Azure/azure-dev/issues/1977