### PR TITLE
Use a unique deployment name when provisioning

### DIFF
--- a/cli/azd/cmd/util_test.go
+++ b/cli/azd/cmd/util_test.go
@@ -1,26 +1,16 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
-	"strings"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
-	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazcli"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,55 +40,6 @@ func Test_promptEnvironmentName(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, "someEnv", environmentName)
-	})
-
-	t.Run("duplicate resource groups ignored", func(t *testing.T) {
-		mockDeployment := armresources.DeploymentExtended{
-			Properties: &armresources.DeploymentPropertiesExtended{
-				OutputResources: []*armresources.ResourceReference{
-					{
-						ID: convert.RefOf("/subscriptions/sub-id/resourceGroups/groupA"),
-					},
-					{
-						ID: convert.RefOf("/subscriptions/sub-id/resourceGroups/groupA/Microsoft.Storage/storageAccounts/storageAccount"),
-					},
-					{
-						ID: convert.RefOf("/subscriptions/sub-id/resourceGroups/groupB"),
-					},
-					{
-						ID: convert.RefOf("/subscriptions/sub-id/resourceGroups/groupB/Microsoft.web/sites/test"),
-					},
-					{
-						ID: convert.RefOf("/subscriptions/sub-id/resourceGroups/groupC"),
-					},
-				},
-			},
-		}
-
-		mockContext := mocks.NewMockContext(context.Background())
-
-		mockContext.HttpClient.When(func(request *http.Request) bool {
-			return request.Method == http.MethodGet && strings.Contains(
-				request.URL.Path,
-				"/subscriptions/sub-id/providers/Microsoft.Resources/deployments",
-			)
-		}).RespondFn(func(request *http.Request) (*http.Response, error) {
-			subscriptionsListBytes, _ := json.Marshal(mockDeployment)
-
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewBuffer(subscriptionsListBytes)),
-			}, nil
-		})
-
-		azCli := mockazcli.NewAzCliFromMockContext(mockContext)
-
-		resourceManager := infra.NewAzureResourceManager(azCli)
-		groups, err := resourceManager.GetResourceGroupsForDeployment(*mockContext.Context, "sub-id", "deployment-name")
-		require.NoError(t, err)
-
-		sort.Strings(groups)
-		require.Equal(t, []string{"groupA", "groupB", "groupC"}, groups)
 	})
 }
 

--- a/cli/azd/pkg/azure/tags.go
+++ b/cli/azd/pkg/azure/tags.go
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azure
+
+const (
+	// TagKeyAzdEnvName is the name of the key in the tags map of a resource
+	// used to store the azd environment a resource is associated with.
+	TagKeyAzdEnvName = "azd-env-name"
+	// TagKeyAzdServiceName is the name of the key in the tags map of a resource
+	// used to store the azd service a resource is associated with.
+	TagKeyAzdServiceName = "azd-service-name"
+)

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
@@ -87,11 +88,9 @@ func (p *BicepProvider) State(
 ) *async.InteractiveTaskWithProgress[*StateResult, *StateProgress] {
 	return async.RunInteractiveTaskWithProgress(
 		func(asyncContext *async.InteractiveTaskContextWithProgress[*StateResult, *StateProgress]) {
-			target := infra.NewSubscriptionDeployment(
+			scope := infra.NewSubscriptionScope(
 				p.azCli,
-				p.env.GetLocation(),
 				p.env.GetSubscriptionId(),
-				p.env.GetEnvName(),
 			)
 
 			asyncContext.SetProgress(&StateProgress{Message: "Loading Bicep template", Timestamp: time.Now()})
@@ -103,7 +102,7 @@ func (p *BicepProvider) State(
 			}
 
 			asyncContext.SetProgress(&StateProgress{Message: "Retrieving Azure deployment", Timestamp: time.Now()})
-			armDeployment, err := target.Deployment(ctx)
+			armDeployment, err := p.latestDeployment(ctx, scope)
 			if err != nil {
 				asyncContext.SetError(fmt.Errorf("retrieving deployment: %w", err))
 				return
@@ -173,7 +172,7 @@ func (p *BicepProvider) Plan(
 				p.azCli,
 				p.env.GetLocation(),
 				p.env.GetSubscriptionId(),
-				p.env.GetEnvName(),
+				fmt.Sprintf("%s-%d", p.env.GetEnvName(), time.Now().Unix()),
 			)
 
 			result := DeploymentPlan{
@@ -243,6 +242,9 @@ func (p *BicepProvider) Deploy(
 				bicepDeploymentData.Target,
 				bicepDeploymentData.Template,
 				bicepDeploymentData.Parameters,
+				map[string]*string{
+					"azd-env-name": to.Ptr(p.env.GetEnvName()),
+				},
 			)
 			if err != nil {
 				asyncContext.SetError(err)
@@ -278,7 +280,7 @@ func (p *BicepProvider) Destroy(
 	return async.RunInteractiveTaskWithProgress(
 		func(asyncContext *async.InteractiveTaskContextWithProgress[*DestroyResult, *DestroyProgress]) {
 			asyncContext.SetProgress(&DestroyProgress{Message: "Fetching resource groups", Timestamp: time.Now()})
-			rgsFromDeployment, err := p.getResourceGroupsFromDeployment(ctx)
+			rgsFromDeployment, err := p.getResourceGroups(ctx)
 			if err != nil {
 				asyncContext.SetError(err)
 				return
@@ -356,10 +358,6 @@ func (p *BicepProvider) Destroy(
 				asyncContext.SetError(fmt.Errorf("purging resources: %w", err))
 				return
 			}
-			if err := p.deleteDeployment(ctx); err != nil {
-				asyncContext.SetError(fmt.Errorf("deleting subscription deployment: %w", err))
-				return
-			}
 
 			destroyResult := DestroyResult{
 				Resources: allResources,
@@ -370,9 +368,51 @@ func (p *BicepProvider) Destroy(
 		})
 }
 
-func (p *BicepProvider) getResourceGroupsFromDeployment(ctx context.Context) ([]string, error) {
+// latestDeployment finds the most recent deployment for the given environment in the provided scope.
+func (p *BicepProvider) latestDeployment(ctx context.Context, scope infra.Scope) (*armresources.DeploymentExtended, error) {
+	deployments, err := scope.ListDeployments(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	slices.SortFunc(deployments, func(x, y *armresources.DeploymentExtended) bool {
+		return x.Properties.Timestamp.After(*y.Properties.Timestamp)
+	})
+
+	// Earlier versions of `azd` did not use unique deployment names per deployment and also did not tag the deployment
+	// with an `azd` specific tag. Instead, the name of the deployment simply matched the environment name.
+	//
+	// As we walk the list of deployments, we note if we find a deployment matching this older strategy and will return
+	// it if we can't find a deployment that matches the newer one.
+	var matchingBareDeployment *armresources.DeploymentExtended
+
+	for _, deployment := range deployments {
+		if v, has := deployment.Tags["azd-env-name"]; has && *v == p.env.GetEnvName() {
+			return deployment, nil
+		}
+
+		if *deployment.Name == p.env.GetEnvName() {
+			matchingBareDeployment = deployment
+		}
+	}
+
+	if matchingBareDeployment != nil {
+		return matchingBareDeployment, nil
+	}
+
+	return nil, fmt.Errorf("no deployment found for environment %s", p.env.GetEnvName())
+}
+
+func (p *BicepProvider) getResourceGroups(ctx context.Context) ([]string, error) {
+	scope := infra.NewSubscriptionScope(p.azCli, p.env.GetSubscriptionId())
+	latestDeployment, err := p.latestDeployment(ctx, scope)
+	if err != nil {
+		return []string{}, err
+	}
+
 	resourceManager := infra.NewAzureResourceManager(p.azCli)
-	resourceGroups, err := resourceManager.GetResourceGroupsForDeployment(ctx, p.env.GetSubscriptionId(), p.env.GetEnvName())
+	resourceGroups, err := resourceManager.GetResourceGroupsForDeployment(
+		ctx, p.env.GetSubscriptionId(), *latestDeployment.Name)
 	if err != nil {
 		return []string{}, err
 	}
@@ -728,15 +768,6 @@ func (p *BicepProvider) purgeAPIManagement(
 	return nil
 }
 
-// Deletes the azure deployment
-func (p *BicepProvider) deleteDeployment(ctx context.Context) error {
-	deploymentName := p.env.GetEnvName()
-	message := fmt.Sprintf("Deleting deployment: %s", output.WithHighLightFormat(deploymentName))
-	p.console.ShowSpinner(ctx, message, input.Step)
-	err := p.azCli.DeleteSubscriptionDeployment(ctx, p.env.GetSubscriptionId(), deploymentName)
-	p.console.StopSpinner(ctx, message, input.GetStepResultFormat(err))
-	return err
-}
 func (p *BicepProvider) mapBicepTypeToInterfaceType(s string) ParameterType {
 	switch s {
 	case "String", "string", "secureString", "securestring":
@@ -883,8 +914,9 @@ func (p *BicepProvider) deployModule(
 	target infra.Deployment,
 	armTemplate azure.RawArmTemplate,
 	armParameters azure.ArmParameters,
+	tags map[string]*string,
 ) (*armresources.DeploymentExtended, error) {
-	return target.Deploy(ctx, armTemplate, armParameters)
+	return target.Deploy(ctx, armTemplate, armParameters, tags)
 }
 
 // Gets the path to the project parameters file path

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -503,6 +503,26 @@ func prepareDeployMocks(mockContext *mocks.MockContext) {
 			},
 		}, nil
 	})
+
+	deploymentsPage := &armresources.DeploymentListResult{
+		Value: []*armresources.DeploymentExtended{
+			&cTestEnvDeployment,
+		},
+	}
+
+	deploymentsPageResultBytes, _ := json.Marshal(deploymentsPage)
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && strings.HasSuffix(
+			request.URL.Path,
+			"/SUBSCRIPTION_ID/providers/Microsoft.Resources/deployments/",
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewBuffer(deploymentsPageResultBytes)),
+		}, nil
+	})
 }
 
 func prepareStateMocks(mockContext *mocks.MockContext) {
@@ -518,6 +538,26 @@ func prepareStateMocks(mockContext *mocks.MockContext) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(bytes.NewBuffer(deployResultBytes)),
+		}, nil
+	})
+
+	deploymentsPage := &armresources.DeploymentListResult{
+		Value: []*armresources.DeploymentExtended{
+			&cTestEnvDeployment,
+		},
+	}
+
+	deploymentsPageResultBytes, _ := json.Marshal(deploymentsPage)
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && strings.HasSuffix(
+			request.URL.Path,
+			"/SUBSCRIPTION_ID/providers/Microsoft.Resources/deployments/",
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewBuffer(deploymentsPageResultBytes)),
 		}, nil
 	})
 }

--- a/cli/azd/pkg/infra/scope_test.go
+++ b/cli/azd/pkg/infra/scope_test.go
@@ -134,7 +134,7 @@ func TestScopeDeploy(t *testing.T) {
 		target := NewSubscriptionDeployment(azCli, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
 
 		armTemplate := azure.RawArmTemplate(testArmTemplate)
-		_, err := target.Deploy(*mockContext.Context, armTemplate, testArmParameters)
+		_, err := target.Deploy(*mockContext.Context, armTemplate, testArmParameters, nil)
 		require.NoError(t, err)
 	})
 
@@ -161,7 +161,7 @@ func TestScopeDeploy(t *testing.T) {
 		target := NewResourceGroupDeployment(azCli, "SUBSCRIPTION_ID", "RESOURCE_GROUP", "DEPLOYMENT_NAME")
 
 		armTemplate := azure.RawArmTemplate(testArmTemplate)
-		_, err := target.Deploy(*mockContext.Context, armTemplate, testArmParameters)
+		_, err := target.Deploy(*mockContext.Context, armTemplate, testArmParameters, nil)
 		require.NoError(t, err)
 	})
 }

--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
@@ -85,7 +86,7 @@ services:
 				Type:     convert.RefOf(string(infra.AzureResourceTypeWebSite)),
 				Location: convert.RefOf("eastus2"),
 				Tags: map[string]*string{
-					defaultServiceTag: convert.RefOf("api"),
+					azure.TagKeyAzdServiceName: convert.RefOf("api"),
 				},
 			},
 		},
@@ -141,7 +142,7 @@ services:
 				Type:     convert.RefOf(string(infra.AzureResourceTypeWebSite)),
 				Location: convert.RefOf("eastus2"),
 				Tags: map[string]*string{
-					defaultServiceTag: convert.RefOf("web"),
+					azure.TagKeyAzdServiceName: convert.RefOf("web"),
 				},
 			},
 		})
@@ -200,7 +201,7 @@ services:
 				Type:     convert.RefOf(string(infra.AzureResourceTypeWebSite)),
 				Location: convert.RefOf("eastus2"),
 				Tags: map[string]*string{
-					defaultServiceTag: convert.RefOf("web"),
+					azure.TagKeyAzdServiceName: convert.RefOf("web"),
 				},
 			},
 		})

--- a/cli/azd/pkg/project/resource_manager.go
+++ b/cli/azd/pkg/project/resource_manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/azureutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
@@ -90,14 +91,14 @@ func (rm *resourceManager) GetResourceGroupName(
 // GetServiceResources finds azure service resources targeted by the service.
 //
 // If an explicit `ResourceName` is specified in `azure.yaml`, a resource with that name is searched for.
-// Otherwise, searches for resources with 'azd-service-name' tag set to the service key.
+// Otherwise, searches for resources with a [azure.TagKeyAzdServiceName] tag set to the service key.
 func (rm *resourceManager) GetServiceResources(
 	ctx context.Context,
 	subscriptionId string,
 	resourceGroupName string,
 	serviceConfig *ServiceConfig,
 ) ([]azcli.AzCliResource, error) {
-	filter := fmt.Sprintf("tagName eq '%s' and tagValue eq '%s'", defaultServiceTag, serviceConfig.Name)
+	filter := fmt.Sprintf("tagName eq '%s' and tagValue eq '%s'", azure.TagKeyAzdServiceName, serviceConfig.Name)
 
 	subst, err := serviceConfig.ResourceName.Envsubst(rm.env.Getenv)
 	if err != nil {
@@ -144,7 +145,7 @@ func (rm *resourceManager) GetServiceResource(
 			err := fmt.Errorf(
 				//nolint:lll
 				"unable to find a resource tagged with '%s: %s'. Ensure the service resource is correctly tagged in your infrastructure configuration, and rerun %s",
-				defaultServiceTag,
+				azure.TagKeyAzdServiceName,
 				serviceConfig.Name,
 				rerunCommand,
 			)
@@ -155,7 +156,7 @@ func (rm *resourceManager) GetServiceResource(
 			return azcli.AzCliResource{}, fmt.Errorf(
 				//nolint:lll
 				"expecting only '1' resource tagged with '%s: %s', but found '%d'. Ensure a unique service resource is correctly tagged in your infrastructure configuration, and rerun %s",
-				defaultServiceTag,
+				azure.TagKeyAzdServiceName,
 				serviceConfig.Name,
 				len(resources),
 				rerunCommand,

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -15,8 +15,6 @@ import (
 )
 
 const (
-	defaultServiceTag = "azd-service-name"
-
 	ServiceEventEnvUpdated ext.Event = "environment updated"
 	ServiceEventRestore    ext.Event = "restore"
 	ServiceEventBuild      ext.Event = "build"

--- a/cli/azd/pkg/project/service_manager_test.go
+++ b/cli/azd/pkg/project/service_manager_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
+	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
@@ -392,7 +393,7 @@ func setupMocksForServiceManager(mockContext *mocks.MockContext) {
 				Location: convert.RefOf("eastus2"),
 				Type:     convert.RefOf(string(infra.AzureResourceTypeWebSite)),
 				Tags: map[string]*string{
-					"azd-service-name": convert.RefOf("api"),
+					azure.TagKeyAzdServiceName: convert.RefOf("api"),
 				},
 			},
 		},

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -97,8 +97,9 @@ type AzCli interface {
 		location string,
 		deploymentName string,
 		armTemplate azure.RawArmTemplate,
-		parameters azure.ArmParameters) (
-		*armresources.DeploymentExtended, error)
+		parameters azure.ArmParameters,
+		tags map[string]*string,
+	) (*armresources.DeploymentExtended, error)
 	DeployToResourceGroup(
 		ctx context.Context,
 		subscriptionId,
@@ -106,6 +107,7 @@ type AzCli interface {
 		deploymentName string,
 		armTemplate azure.RawArmTemplate,
 		parameters azure.ArmParameters,
+		tags map[string]*string,
 	) (*armresources.DeploymentExtended, error)
 	DeleteSubscriptionDeployment(ctx context.Context, subscriptionId string, deploymentName string) error
 	DeleteResourceGroup(ctx context.Context, subscriptionId string, resourceGroupName string) error
@@ -114,12 +116,21 @@ type AzCli interface {
 		subscriptionId string,
 		listOptions *ListResourceGroupOptions,
 	) ([]AzCliResource, error)
+	ListResourceGroupDeployments(
+		ctx context.Context,
+		subscriptionId string,
+		resourceGroupName string,
+	) ([]*armresources.DeploymentExtended, error)
 	ListResourceGroupResources(
 		ctx context.Context,
 		subscriptionId string,
 		resourceGroupName string,
 		listOptions *ListResourceGroupResourcesOptions,
 	) ([]AzCliResource, error)
+	ListSubscriptionDeployments(
+		ctx context.Context,
+		subscriptionId string,
+	) ([]*armresources.DeploymentExtended, error)
 	ListSubscriptionDeploymentOperations(
 		ctx context.Context,
 		subscriptionId string,

--- a/cli/azd/pkg/tools/azcli/deployments.go
+++ b/cli/azd/pkg/tools/azcli/deployments.go
@@ -16,6 +16,30 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/internal"
 )
 
+func (cli *azCli) ListSubscriptionDeployments(
+	ctx context.Context,
+	subscriptionId string,
+) ([]*armresources.DeploymentExtended, error) {
+	deploymentClient, err := cli.createDeploymentsClient(ctx, subscriptionId)
+	if err != nil {
+		return nil, fmt.Errorf("creating deployments client: %w", err)
+	}
+
+	results := []*armresources.DeploymentExtended{}
+
+	pager := deploymentClient.NewListAtSubscriptionScopePager(nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, page.Value...)
+	}
+
+	return results, nil
+}
+
 func (cli *azCli) GetSubscriptionDeployment(
 	ctx context.Context,
 	subscriptionId string,
@@ -36,6 +60,31 @@ func (cli *azCli) GetSubscriptionDeployment(
 	}
 
 	return &deployment.DeploymentExtended, nil
+}
+
+func (cli *azCli) ListResourceGroupDeployments(
+	ctx context.Context,
+	subscriptionId string,
+	resourceGroupName string,
+) ([]*armresources.DeploymentExtended, error) {
+	deploymentClient, err := cli.createDeploymentsClient(ctx, subscriptionId)
+	if err != nil {
+		return nil, fmt.Errorf("creating deployments client: %w", err)
+	}
+
+	results := []*armresources.DeploymentExtended{}
+
+	pager := deploymentClient.NewListByResourceGroupPager(resourceGroupName, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, page.Value...)
+	}
+
+	return results, nil
 }
 
 func (cli *azCli) GetResourceGroupDeployment(
@@ -86,6 +135,7 @@ func (cli *azCli) DeployToSubscription(
 	deploymentName string,
 	armTemplate azure.RawArmTemplate,
 	parameters azure.ArmParameters,
+	tags map[string]*string,
 ) (*armresources.DeploymentExtended, error) {
 	deploymentClient, err := cli.createDeploymentsClient(ctx, subscriptionId)
 	if err != nil {
@@ -101,6 +151,7 @@ func (cli *azCli) DeployToSubscription(
 				Mode:       to.Ptr(armresources.DeploymentModeIncremental),
 			},
 			Location: to.Ptr(location),
+			Tags:     tags,
 		}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("starting deployment to subscription: %w", err)
@@ -124,6 +175,7 @@ func (cli *azCli) DeployToResourceGroup(
 	subscriptionId, resourceGroup, deploymentName string,
 	armTemplate azure.RawArmTemplate,
 	parameters azure.ArmParameters,
+	tags map[string]*string,
 ) (*armresources.DeploymentExtended, error) {
 	deploymentClient, err := cli.createDeploymentsClient(ctx, subscriptionId)
 	if err != nil {
@@ -138,6 +190,7 @@ func (cli *azCli) DeployToResourceGroup(
 				Parameters: parameters,
 				Mode:       to.Ptr(armresources.DeploymentModeIncremental),
 			},
+			Tags: tags,
 		}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("starting deployment to resource group: %w", err)


### PR DESCRIPTION
Previously, when creating a deployment, `azd` would use the
environment name as the name of the deployment (a deployment is
represented in azure as a resource, and has a name).

When running `azd provision` twice, the second invocation would re-use
the previous deployment name, which would overwrite the history of the
old deployment.

This was not ideal, since we would lose all the history from the
previous deployment and could also lead to race conditions in our UI
where we would end up displaying information from the previous
deployment while the new deployment was waiting to start up (since the
deployment name was shared we would fetch the operations from the old
deployment, not the new one).

Also, in the case of subscription based deployments, the deployment
object also has a location tied to it, and reusing the name meant that
if you changed `AZURE_LOCATION` for an environment, and tried to
`provision` again, you'd get an error from ARM saying that a
deployment with that name already existed in another region, which is
very hard to understand.

This change moves to using a unique name per deployment, by taking the
current unix time and appending it to the environment name. We also
now tag the deployment we create with `azd-env-name`, which is used to
find the most recent deployment for a given environment, for example,
when `azd env refresh` is running.

As part of this work, the existing `Scope` interface has been broken
into two parts, a `Scope` which lets you do operations across a scope
and `Deployment` which represent a named deployment tied to a specifc
scope.

Ideally, we would move `infra.Scope` and `infra.Deployment` out of the
`infra` package, since they really are Azure specific concepts, but
that's a task for another PR.