### PR TITLE
Remove `Scope` parameter from `infra.Provider` and `infra.Manager`

### DIFF
--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -15,7 +15,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -401,9 +400,7 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 		return nil, fmt.Errorf("creating provisioning manager: %w", err)
 	}
 
-	scope := infra.NewSubscriptionScope(ef.azCli, ef.env.GetLocation(), ef.env.GetSubscriptionId(), ef.env.GetEnvName())
-
-	getStateResult, err := infraManager.State(ctx, scope)
+	getStateResult, err := infraManager.State(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting deployment: %w", err)
 	}

--- a/cli/azd/cmd/provision.go
+++ b/cli/azd/cmd/provision.go
@@ -12,7 +12,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -172,14 +171,11 @@ func (p *provisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 		return nil, fmt.Errorf("planning deployment: %w", err)
 	}
 
-	provisioningScope := infra.NewSubscriptionScope(
-		p.azCli, p.env.GetLocation(), p.env.GetSubscriptionId(), p.env.GetEnvName(),
-	)
-	deployResult, err := infraManager.Deploy(ctx, deploymentPlan, provisioningScope)
+	deployResult, err := infraManager.Deploy(ctx, deploymentPlan)
 
 	if err != nil {
 		if p.formatter.Kind() == output.JsonFormat {
-			stateResult, err := infraManager.State(ctx, provisioningScope)
+			stateResult, err := infraManager.State(ctx)
 			if err != nil {
 				return nil, fmt.Errorf(
 					"deployment failed and the deployment result is unavailable: %w",
@@ -214,7 +210,7 @@ func (p *provisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 	}
 
 	if p.formatter.Kind() == output.JsonFormat {
-		stateResult, err := infraManager.State(ctx, provisioningScope)
+		stateResult, err := infraManager.State(ctx)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"deployment succeeded but the deployment result is unavailable: %w",

--- a/cli/azd/pkg/infra/azure_resource_manager.go
+++ b/cli/azd/pkg/infra/azure_resource_manager.go
@@ -23,7 +23,7 @@ type AzureResourceManager struct {
 
 type ResourceManager interface {
 	GetDeploymentResourceOperations(
-		ctx context.Context, scope Scope, queryStart *time.Time) ([]*armresources.DeploymentOperation, error)
+		ctx context.Context, deployment Deployment, queryStart *time.Time) ([]*armresources.DeploymentOperation, error)
 	GetResourceTypeDisplayName(
 		ctx context.Context,
 		subscriptionId string,
@@ -40,22 +40,22 @@ func NewAzureResourceManager(azCli azcli.AzCli) *AzureResourceManager {
 
 func (rm *AzureResourceManager) GetDeploymentResourceOperations(
 	ctx context.Context,
-	scope Scope,
+	deployment Deployment,
 	queryStart *time.Time,
 ) ([]*armresources.DeploymentOperation, error) {
 	// Gets all the scope level resource operations
-	topLevelDeploymentOperations, err := scope.GetResourceOperations(ctx)
+	topLevelDeploymentOperations, err := deployment.Operations(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting subscription deployment: %w", err)
 	}
 
-	subscriptionId := scope.SubscriptionId()
+	subscriptionId := deployment.SubscriptionId()
 	var resourceGroupName string
-	resourceGroupScope, ok := scope.(*ResourceGroupScope)
+	resourceGroupDeployment, ok := deployment.(*ResourceGroupDeployment)
 
 	if ok {
 		// If the scope is a resource group scope get the resource group directly
-		resourceGroupName = resourceGroupScope.ResourceGroup()
+		resourceGroupName = resourceGroupDeployment.ResourceGroupName()
 	} else {
 		// Otherwise find the resource group within the deployment operations
 		for _, operation := range topLevelDeploymentOperations {

--- a/cli/azd/pkg/infra/azure_resource_manager_test.go
+++ b/cli/azd/pkg/infra/azure_resource_manager_test.go
@@ -164,7 +164,7 @@ func TestGetDeploymentResourceOperationsSuccess(t *testing.T) {
 
 	mockContext := mocks.NewMockContext(context.Background())
 	azCli := mockazcli.NewAzCliFromMockContext(mockContext)
-	scope := NewSubscriptionScope(azCli, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
+	scope := NewSubscriptionDeployment(azCli, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
 
 	mockContext.HttpClient.When(func(request *http.Request) bool {
 		return request.Method == http.MethodGet && strings.Contains(
@@ -214,7 +214,7 @@ func TestGetDeploymentResourceOperationsFail(t *testing.T) {
 
 	mockContext := mocks.NewMockContext(context.Background())
 	azCli := mockazcli.NewAzCliFromMockContext(mockContext)
-	scope := NewSubscriptionScope(azCli, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
+	scope := NewSubscriptionDeployment(azCli, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
 
 	/*NOTE: Mocking first response as an `StatusForbidden` error which is not retried by the sdk client.
 	  Adding an extra mock to test that it is not called*/
@@ -265,7 +265,7 @@ func TestGetDeploymentResourceOperationsNoResourceGroup(t *testing.T) {
 
 	mockContext := mocks.NewMockContext(context.Background())
 	azCli := mockazcli.NewAzCliFromMockContext(mockContext)
-	scope := NewSubscriptionScope(azCli, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
+	scope := NewSubscriptionDeployment(azCli, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
 
 	mockContext.HttpClient.When(func(request *http.Request) bool {
 		return request.Method == http.MethodGet && strings.Contains(
@@ -314,7 +314,7 @@ func TestGetDeploymentResourceOperationsWithNestedDeployments(t *testing.T) {
 
 	mockContext := mocks.NewMockContext(context.Background())
 	azCli := mockazcli.NewAzCliFromMockContext(mockContext)
-	scope := NewSubscriptionScope(azCli, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
+	scope := NewSubscriptionDeployment(azCli, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
 
 	mockContext.HttpClient.When(func(request *http.Request) bool {
 		return request.Method == http.MethodGet && strings.Contains(

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -52,6 +52,9 @@ type BicepDeploymentDetails struct {
 	Parameters azure.ArmParameters
 	// TemplateOutputs are the outputs as specified by the template.
 	TemplateOutputs azure.ArmTemplateOutputs
+	// Target is the unique resource in azure that represents the deployment that will happen. A target can be scoped to
+	// either subscriptions, or resource groups.
+	Target infra.Deployment
 }
 
 // BicepProvider exposes infrastructure provisioning using Azure Bicep templates
@@ -81,10 +84,16 @@ func (p *BicepProvider) EnsureConfigured(ctx context.Context) error {
 
 func (p *BicepProvider) State(
 	ctx context.Context,
-	scope infra.Scope,
 ) *async.InteractiveTaskWithProgress[*StateResult, *StateProgress] {
 	return async.RunInteractiveTaskWithProgress(
 		func(asyncContext *async.InteractiveTaskContextWithProgress[*StateResult, *StateProgress]) {
+			target := infra.NewSubscriptionDeployment(
+				p.azCli,
+				p.env.GetLocation(),
+				p.env.GetSubscriptionId(),
+				p.env.GetEnvName(),
+			)
+
 			asyncContext.SetProgress(&StateProgress{Message: "Loading Bicep template", Timestamp: time.Now()})
 			modulePath := p.modulePath()
 			_, template, err := p.compileBicep(ctx, modulePath)
@@ -94,7 +103,7 @@ func (p *BicepProvider) State(
 			}
 
 			asyncContext.SetProgress(&StateProgress{Message: "Retrieving Azure deployment", Timestamp: time.Now()})
-			armDeployment, err := scope.GetDeployment(ctx)
+			armDeployment, err := target.Deployment(ctx)
 			if err != nil {
 				asyncContext.SetError(fmt.Errorf("retrieving deployment: %w", err))
 				return
@@ -160,12 +169,20 @@ func (p *BicepProvider) Plan(
 				return
 			}
 
+			target := infra.NewSubscriptionDeployment(
+				p.azCli,
+				p.env.GetLocation(),
+				p.env.GetSubscriptionId(),
+				p.env.GetEnvName(),
+			)
+
 			result := DeploymentPlan{
 				Deployment: *deployment,
 				Details: BicepDeploymentDetails{
 					Template:        rawTemplate,
 					TemplateOutputs: template.Outputs,
 					Parameters:      configuredParameters,
+					Target:          target,
 				},
 			}
 			// remove the spinner with no message as no message is expected
@@ -178,7 +195,6 @@ func (p *BicepProvider) Plan(
 func (p *BicepProvider) Deploy(
 	ctx context.Context,
 	pd *DeploymentPlan,
-	scope infra.Scope,
 ) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress] {
 	return async.RunInteractiveTaskWithProgress(
 		func(asyncContext *async.InteractiveTaskContextWithProgress[*DeployResult, *DeployProgress]) {
@@ -189,10 +205,12 @@ func (p *BicepProvider) Deploy(
 				done <- true
 			}()
 
+			bicepDeploymentData := pd.Details.(BicepDeploymentDetails)
+
 			// Report incremental progress
 			go func() {
 				resourceManager := infra.NewAzureResourceManager(p.azCli)
-				progressDisplay := NewProvisioningProgressDisplay(resourceManager, p.console, scope)
+				progressDisplay := NewProvisioningProgressDisplay(resourceManager, p.console, bicepDeploymentData.Target)
 				// Make initial delay shorter to be more responsive in displaying initial progress
 				initialDelay := 3 * time.Second
 				regularDelay := 10 * time.Second
@@ -219,9 +237,13 @@ func (p *BicepProvider) Deploy(
 
 			// Start the deployment
 			p.console.ShowSpinner(ctx, "Creating/Updating resources", input.Step)
-			bicepDeploymentData := pd.Details.(BicepDeploymentDetails)
 
-			deployResult, err := p.deployModule(ctx, scope, bicepDeploymentData.Template, bicepDeploymentData.Parameters)
+			deployResult, err := p.deployModule(
+				ctx,
+				bicepDeploymentData.Target,
+				bicepDeploymentData.Template,
+				bicepDeploymentData.Parameters,
+			)
 			if err != nil {
 				asyncContext.SetError(err)
 				return
@@ -334,7 +356,6 @@ func (p *BicepProvider) Destroy(
 				asyncContext.SetError(fmt.Errorf("purging resources: %w", err))
 				return
 			}
-
 			if err := p.deleteDeployment(ctx); err != nil {
 				asyncContext.SetError(fmt.Errorf("deleting subscription deployment: %w", err))
 				return
@@ -716,7 +737,6 @@ func (p *BicepProvider) deleteDeployment(ctx context.Context) error {
 	p.console.StopSpinner(ctx, message, input.GetStepResultFormat(err))
 	return err
 }
-
 func (p *BicepProvider) mapBicepTypeToInterfaceType(s string) ParameterType {
 	switch s {
 	case "String", "string", "secureString", "securestring":
@@ -860,11 +880,11 @@ func (p *BicepProvider) convertToDeployment(bicepTemplate azure.ArmTemplate) (*D
 // Deploys the specified Bicep module and parameters with the selected provisioning scope (subscription vs resource group)
 func (p *BicepProvider) deployModule(
 	ctx context.Context,
-	scope infra.Scope,
+	target infra.Deployment,
 	armTemplate azure.RawArmTemplate,
 	armParameters azure.ArmParameters,
 ) (*armresources.DeploymentExtended, error) {
-	return scope.Deploy(ctx, armTemplate, armParameters)
+	return target.Deploy(ctx, armTemplate, armParameters)
 }
 
 // Gets the path to the project parameters file path

--- a/cli/azd/pkg/infra/provisioning/bicep/prompt_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt_test.go
@@ -218,7 +218,7 @@ func TestPromptForParameterAllowedValues(t *testing.T) {
 
 	mockContext := mocks.NewMockContext(context.Background())
 
-	preparePlanningMocks(mockContext)
+	prepareBicepMocks(mockContext)
 
 	p := createBicepProvider(t, mockContext)
 

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -14,7 +14,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azureutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/spin"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
@@ -45,7 +44,7 @@ func (m *Manager) Plan(ctx context.Context) (*DeploymentPlan, error) {
 }
 
 // Gets the latest deployment details for the specified scope
-func (m *Manager) State(ctx context.Context, scope infra.Scope) (*StateResult, error) {
+func (m *Manager) State(ctx context.Context) (*StateResult, error) {
 	var stateResult *StateResult
 
 	err := m.runAction(
@@ -53,7 +52,7 @@ func (m *Manager) State(ctx context.Context, scope infra.Scope) (*StateResult, e
 		"Retrieving Infrastructure State",
 		m.interactive,
 		func(ctx context.Context, spinner *spin.Spinner) error {
-			queryTask := m.provider.State(ctx, scope)
+			queryTask := m.provider.State(ctx)
 
 			go func() {
 				for progress := range queryTask.Progress() {
@@ -82,9 +81,9 @@ func (m *Manager) State(ctx context.Context, scope infra.Scope) (*StateResult, e
 }
 
 // Deploys the Azure infrastructure for the specified project
-func (m *Manager) Deploy(ctx context.Context, plan *DeploymentPlan, scope infra.Scope) (*DeployResult, error) {
+func (m *Manager) Deploy(ctx context.Context, plan *DeploymentPlan) (*DeployResult, error) {
 	// Apply the infrastructure deployment
-	deployResult, err := m.deploy(ctx, plan, scope)
+	deployResult, err := m.deploy(ctx, plan)
 	if err != nil {
 		return nil, err
 	}
@@ -139,9 +138,8 @@ func (m *Manager) plan(ctx context.Context) (*DeploymentPlan, error) {
 func (m *Manager) deploy(
 	ctx context.Context,
 	plan *DeploymentPlan,
-	scope infra.Scope,
 ) (*DeployResult, error) {
-	deployTask := m.provider.Deploy(ctx, plan, scope)
+	deployTask := m.provider.Deploy(ctx, plan)
 
 	go func() {
 		for progress := range deployTask.Progress() {

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	. "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	_ "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/test"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -146,13 +145,7 @@ func TestManagerGetState(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	provisioningScope := infra.NewSubscriptionScope(
-		azCli,
-		"eastus2",
-		env.GetSubscriptionId(),
-		env.GetEnvName(),
-	)
-	getResult, err := mgr.State(*mockContext.Context, provisioningScope)
+	getResult, err := mgr.State(*mockContext.Context)
 
 	require.NotNil(t, getResult)
 	require.Nil(t, err)
@@ -188,13 +181,7 @@ func TestManagerDeploy(t *testing.T) {
 	require.NoError(t, err)
 
 	deploymentPlan, _ := mgr.Plan(*mockContext.Context)
-	provisioningScope := infra.NewSubscriptionScope(
-		azCli,
-		"eastus2",
-		env.GetSubscriptionId(),
-		env.GetEnvName(),
-	)
-	deployResult, err := mgr.Deploy(*mockContext.Context, deploymentPlan, provisioningScope)
+	deployResult, err := mgr.Deploy(*mockContext.Context, deploymentPlan)
 
 	require.NotNil(t, deployResult)
 	require.Nil(t, err)

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -14,7 +14,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
@@ -125,12 +124,11 @@ type Provider interface {
 	EnsureConfigured(ctx context.Context) error
 	// State gets the current state of the infrastructure, this contains both the provisioned resources and any outputs from
 	// the module.
-	State(ctx context.Context, scope infra.Scope) *async.InteractiveTaskWithProgress[*StateResult, *StateProgress]
+	State(ctx context.Context) *async.InteractiveTaskWithProgress[*StateResult, *StateProgress]
 	Plan(ctx context.Context) *async.InteractiveTaskWithProgress[*DeploymentPlan, *DeploymentPlanningProgress]
 	Deploy(
 		ctx context.Context,
 		plan *DeploymentPlan,
-		scope infra.Scope,
 	) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress]
 	Destroy(
 		ctx context.Context,

--- a/cli/azd/pkg/infra/provisioning/provisioning_progress_display.go
+++ b/cli/azd/pkg/infra/provisioning/provisioning_progress_display.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -32,17 +31,17 @@ type ProvisioningProgressDisplay struct {
 	displayedResources map[string]bool
 	resourceManager    infra.ResourceManager
 	console            input.Console
-	scope              infra.Scope
+	target             infra.Deployment
 }
 
 func NewProvisioningProgressDisplay(
 	rm infra.ResourceManager,
 	console input.Console,
-	scope infra.Scope,
+	target infra.Deployment,
 ) ProvisioningProgressDisplay {
 	return ProvisioningProgressDisplay{
 		displayedResources: map[string]bool{},
-		scope:              scope,
+		target:             target,
 		resourceManager:    rm,
 		console:            console,
 	}
@@ -58,7 +57,7 @@ func (display *ProvisioningProgressDisplay) ReportProgress(
 	}
 
 	if !display.deploymentStarted {
-		_, err := display.scope.GetDeployment(ctx)
+		_, err := display.target.Deployment(ctx)
 		if err != nil {
 			// Return default progress
 			log.Printf("error while reporting progress: %s", err.Error())
@@ -66,10 +65,7 @@ func (display *ProvisioningProgressDisplay) ReportProgress(
 		}
 
 		display.deploymentStarted = true
-		deploymentUrl := fmt.Sprintf(
-			output.WithLinkFormat("https://portal.azure.com/#blade/HubsExtension/DeploymentDetailsBlade/overview/id/%s\n"),
-			url.PathEscape(display.scope.DeploymentUrl()),
-		)
+		deploymentUrl := fmt.Sprintf(output.WithLinkFormat("%s\n"), display.target.PortalUrl())
 
 		display.console.MessageUxItem(
 			ctx,
@@ -82,7 +78,7 @@ func (display *ProvisioningProgressDisplay) ReportProgress(
 		)
 	}
 
-	operations, err := display.resourceManager.GetDeploymentResourceOperations(ctx, display.scope, queryStart)
+	operations, err := display.resourceManager.GetDeploymentResourceOperations(ctx, display.target, queryStart)
 	if err != nil {
 		// Status display is best-effort activity.
 		return &progress, err
@@ -133,7 +129,7 @@ func (display *ProvisioningProgressDisplay) logNewlyCreatedResources(
 		resourceTypeName := *resource.Properties.TargetResource.ResourceType
 		resourceTypeDisplayName, err := display.resourceManager.GetResourceTypeDisplayName(
 			ctx,
-			display.scope.SubscriptionId(),
+			display.target.SubscriptionId(),
 			*resource.Properties.TargetResource.ID,
 			infra.AzureResourceType(resourceTypeName),
 		)
@@ -172,7 +168,7 @@ func (display *ProvisioningProgressDisplay) logNewlyCreatedResources(
 		resourceTypeName := *inProgResource.Properties.TargetResource.ResourceType
 		resourceTypeDisplayName, err := display.resourceManager.GetResourceTypeDisplayName(
 			ctx,
-			display.scope.SubscriptionId(),
+			display.target.SubscriptionId(),
 			*inProgResource.Properties.TargetResource.ID,
 			infra.AzureResourceType(resourceTypeName),
 		)

--- a/cli/azd/pkg/infra/provisioning/provisioning_progress_display_test.go
+++ b/cli/azd/pkg/infra/provisioning/provisioning_progress_display_test.go
@@ -29,7 +29,7 @@ type mockResourceManager struct {
 
 func (mock *mockResourceManager) GetDeploymentResourceOperations(
 	ctx context.Context,
-	scope infra.Scope,
+	target infra.Deployment,
 	startTime *time.Time,
 ) ([]*armresources.DeploymentOperation, error) {
 	return mock.operations, nil
@@ -103,7 +103,7 @@ func TestReportProgress(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	azCli := mockazcli.NewAzCliFromMockContext(mockContext)
 
-	scope := infra.NewSubscriptionScope(azCli, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
+	scope := infra.NewSubscriptionDeployment(azCli, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
 	mockAzDeploymentShow(t, *mockContext)
 
 	startTime := time.Now()

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -24,7 +24,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	. "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
@@ -182,7 +181,6 @@ func (t *TerraformProvider) Plan(
 func (t *TerraformProvider) Deploy(
 	ctx context.Context,
 	deployment *DeploymentPlan,
-	scope infra.Scope,
 ) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress] {
 	return async.RunInteractiveTaskWithProgress(
 		func(asyncContext *async.InteractiveTaskContextWithProgress[*DeployResult, *DeployProgress]) {
@@ -275,7 +273,6 @@ func (t *TerraformProvider) Destroy(
 
 func (t *TerraformProvider) State(
 	ctx context.Context,
-	_ infra.Scope,
 ) *async.InteractiveTaskWithProgress[*StateResult, *StateProgress] {
 	return async.RunInteractiveTaskWithProgress(
 		func(asyncContext *async.InteractiveTaskContextWithProgress[*StateResult, *StateProgress]) {

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
@@ -12,11 +12,9 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	. "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 
-	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazcli"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockexec"
 	"github.com/stretchr/testify/require"
 )
@@ -82,7 +80,6 @@ func TestTerraformDeploy(t *testing.T) {
 	prepareGenericMocks(mockContext.CommandRunner)
 	preparePlanningMocks(mockContext.CommandRunner)
 	prepareDeployMocks(mockContext.CommandRunner)
-	azCli := mockazcli.NewAzCliFromMockContext(mockContext)
 
 	infraProvider := createTerraformProvider(mockContext)
 
@@ -96,13 +93,7 @@ func TestTerraformDeploy(t *testing.T) {
 		},
 	}
 
-	scope := infra.NewSubscriptionScope(
-		azCli,
-		infraProvider.env.Values["AZURE_LOCATION"],
-		infraProvider.env.GetSubscriptionId(),
-		infraProvider.env.GetEnvName(),
-	)
-	deployTask := infraProvider.Deploy(*mockContext.Context, &deploymentPlan, scope)
+	deployTask := infraProvider.Deploy(*mockContext.Context, &deploymentPlan)
 
 	go func() {
 		for deployProgress := range deployTask.Progress() {
@@ -174,16 +165,9 @@ func TestTerraformState(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	prepareGenericMocks(mockContext.CommandRunner)
 	prepareShowMocks(mockContext.CommandRunner)
-	azCli := mockazcli.NewAzCliFromMockContext(mockContext)
 
 	infraProvider := createTerraformProvider(mockContext)
-	scope := infra.NewSubscriptionScope(
-		azCli,
-		infraProvider.env.Values["AZURE_LOCATION"],
-		infraProvider.env.GetSubscriptionId(),
-		infraProvider.env.GetEnvName(),
-	)
-	getStateTask := infraProvider.State(*mockContext.Context, scope)
+	getStateTask := infraProvider.State(*mockContext.Context)
 
 	go func() {
 		for progressReport := range getStateTask.Progress() {

--- a/cli/azd/pkg/infra/provisioning/test/test_provider.go
+++ b/cli/azd/pkg/infra/provisioning/test/test_provider.go
@@ -20,7 +20,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	. "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
@@ -74,7 +73,6 @@ func (p *TestProvider) Plan(
 
 func (p *TestProvider) State(
 	ctx context.Context,
-	scope infra.Scope,
 ) *async.InteractiveTaskWithProgress[*StateResult, *StateProgress] {
 	return async.RunInteractiveTaskWithProgress(
 		func(asyncContext *async.InteractiveTaskContextWithProgress[*StateResult, *StateProgress]) {
@@ -98,7 +96,6 @@ func (p *TestProvider) State(
 
 func (p *TestProvider) GetDeployment(
 	ctx context.Context,
-	scope infra.Scope,
 ) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress] {
 	return async.RunInteractiveTaskWithProgress(
 		func(asyncContext *async.InteractiveTaskContextWithProgress[*DeployResult, *DeployProgress]) {
@@ -124,7 +121,6 @@ func (p *TestProvider) GetDeployment(
 func (p *TestProvider) Deploy(
 	ctx context.Context,
 	pd *DeploymentPlan,
-	scope infra.Scope,
 ) *async.InteractiveTaskWithProgress[*DeployResult, *DeployProgress] {
 	return async.RunInteractiveTaskWithProgress(
 		func(asyncContext *async.InteractiveTaskContextWithProgress[*DeployResult, *DeployProgress]) {

--- a/cli/azd/pkg/infra/scope_test.go
+++ b/cli/azd/pkg/infra/scope_test.go
@@ -65,9 +65,9 @@ func TestScopeGetDeployment(t *testing.T) {
 			}, nil
 		})
 
-		scope := NewSubscriptionScope(azCli, "eastus2", subscriptionId, deploymentName)
+		target := NewSubscriptionDeployment(azCli, "eastus2", subscriptionId, deploymentName)
 
-		deployment, err := scope.GetDeployment(*mockContext.Context)
+		deployment, err := target.Deployment(*mockContext.Context)
 		require.NoError(t, err)
 		responseOutputs := deployment.Properties.Outputs.(map[string]interface{})["APP_URL"].(map[string]interface{})
 		require.Equal(t, outputs["APP_URL"].Value, responseOutputs["value"].(string))
@@ -100,9 +100,9 @@ func TestScopeGetDeployment(t *testing.T) {
 			}, nil
 		})
 
-		scope := NewResourceGroupScope(azCli, subscriptionId, resourceGroupName, deploymentName)
+		target := NewResourceGroupDeployment(azCli, subscriptionId, resourceGroupName, deploymentName)
 
-		deployment, err := scope.GetDeployment(*mockContext.Context)
+		deployment, err := target.Deployment(*mockContext.Context)
 		require.NoError(t, err)
 		responseOutputs := deployment.Properties.Outputs.(map[string]interface{})["APP_URL"].(map[string]interface{})
 		require.Equal(t, outputs["APP_URL"].Value, responseOutputs["value"].(string))
@@ -131,10 +131,10 @@ func TestScopeDeploy(t *testing.T) {
 			}, nil
 		})
 
-		scope := NewSubscriptionScope(azCli, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
+		target := NewSubscriptionDeployment(azCli, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
 
 		armTemplate := azure.RawArmTemplate(testArmTemplate)
-		_, err := scope.Deploy(*mockContext.Context, armTemplate, testArmParameters)
+		_, err := target.Deploy(*mockContext.Context, armTemplate, testArmParameters)
 		require.NoError(t, err)
 	})
 
@@ -158,10 +158,10 @@ func TestScopeDeploy(t *testing.T) {
 			}, nil
 		})
 
-		scope := NewResourceGroupScope(azCli, "SUBSCRIPTION_ID", "RESOURCE_GROUP", "DEPLOYMENT_NAME")
+		target := NewResourceGroupDeployment(azCli, "SUBSCRIPTION_ID", "RESOURCE_GROUP", "DEPLOYMENT_NAME")
 
 		armTemplate := azure.RawArmTemplate(testArmTemplate)
-		_, err := scope.Deploy(*mockContext.Context, armTemplate, testArmParameters)
+		_, err := target.Deploy(*mockContext.Context, armTemplate, testArmParameters)
 		require.NoError(t, err)
 	})
 }
@@ -186,9 +186,9 @@ func TestScopeGetResourceOperations(t *testing.T) {
 			}, nil
 		})
 
-		scope := NewSubscriptionScope(azCli, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
+		target := NewSubscriptionDeployment(azCli, "eastus2", "SUBSCRIPTION_ID", "DEPLOYMENT_NAME")
 
-		operations, err := scope.GetResourceOperations(*mockContext.Context)
+		operations, err := target.Operations(*mockContext.Context)
 		require.NoError(t, err)
 		require.Len(t, operations, 1)
 	})
@@ -211,9 +211,9 @@ func TestScopeGetResourceOperations(t *testing.T) {
 				},
 			}, nil
 		})
-		scope := NewResourceGroupScope(azCli, "SUBSCRIPTION_ID", "RESOURCE_GROUP", "DEPLOYMENT_NAME")
+		target := NewResourceGroupDeployment(azCli, "SUBSCRIPTION_ID", "RESOURCE_GROUP", "DEPLOYMENT_NAME")
 
-		operations, err := scope.GetResourceOperations(*mockContext.Context)
+		operations, err := target.Operations(*mockContext.Context)
 		require.NoError(t, err)
 		require.Len(t, operations, 1)
 	})

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -92,10 +92,12 @@ type AzCli interface {
 		funcName string,
 	) (*AzCliFunctionAppProperties, error)
 	DeployToSubscription(
-		ctx context.Context, subscriptionId, deploymentName string,
+		ctx context.Context,
+		subscriptionId string,
+		location string,
+		deploymentName string,
 		armTemplate azure.RawArmTemplate,
-		parameters azure.ArmParameters,
-		location string) (
+		parameters azure.ArmParameters) (
 		*armresources.DeploymentExtended, error)
 	DeployToResourceGroup(
 		ctx context.Context,

--- a/cli/azd/pkg/tools/azcli/deployments.go
+++ b/cli/azd/pkg/tools/azcli/deployments.go
@@ -81,10 +81,11 @@ func (cli *azCli) createDeploymentsClient(
 
 func (cli *azCli) DeployToSubscription(
 	ctx context.Context,
-	subscriptionId, deploymentName string,
+	subscriptionId string,
+	location string,
+	deploymentName string,
 	armTemplate azure.RawArmTemplate,
 	parameters azure.ArmParameters,
-	location string,
 ) (*armresources.DeploymentExtended, error) {
 	deploymentClient, err := cli.createDeploymentsClient(ctx, subscriptionId)
 	if err != nil {


### PR DESCRIPTION
The `Scope` concept is something which is very ARM specific. The fact that it was a prameter on `Manager` and `Provider` is an artifact of how the interfaces were birthed (by refactoring the at the time only provider we had, which talked to to ARM) and the the fact that we were doing ARM deployments for ACA.

We are now at a point where we can remove it from the interface, so let's go ahead and do that.