### PR TITLE
Add confirmation prompt when running init in non-empty directory

### DIFF
--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -112,6 +112,11 @@ func (i *initAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		return nil, err
 	}
 
+	err = i.repoInitializer.PromptIfNonEmpty(ctx, azdCtx)
+	if err != nil {
+		return nil, err
+	}
+
 	// Command title
 	i.console.MessageUxItem(ctx, &ux.MessageTitle{
 		Title: "Initializing a new project (azd init)",
@@ -119,8 +124,7 @@ func (i *initAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 	// Project not initialized and no template specified
 	// NOTE: Adding `azure.yaml` to a folder removes the option from selecting a template
-	if _, err := os.Stat(azdCtx.ProjectPath()); err != nil && errors.Is(err, os.ErrNotExist) {
-
+	if _, err := os.Stat(azdCtx.ProjectPath()); errors.Is(err, os.ErrNotExist) {
 		if i.flags.template.Name == "" {
 			i.flags.template, err = templates.PromptTemplate(ctx, "Select a project template:", i.console)
 

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -112,19 +112,30 @@ func (i *initAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		return nil, err
 	}
 
-	err = i.repoInitializer.PromptIfNonEmpty(ctx, azdCtx)
-	if err != nil {
-		return nil, err
-	}
-
 	// Command title
 	i.console.MessageUxItem(ctx, &ux.MessageTitle{
 		Title: "Initializing a new project (azd init)",
 	})
 
-	// Project not initialized and no template specified
-	// NOTE: Adding `azure.yaml` to a folder removes the option from selecting a template
-	if _, err := os.Stat(azdCtx.ProjectPath()); errors.Is(err, os.ErrNotExist) {
+	// If azure.yaml project already exists, we should do the following:
+	//   - Not prompt for template selection (user can specify --template if needed to refresh from an existing template)
+	//   - Not overwrite azure.yaml (unless --template is explicitly specified)
+	//   - Allow for environment initialization
+	var existingProject bool
+	if _, err := os.Stat(azdCtx.ProjectPath()); err == nil {
+		existingProject = true
+	} else if errors.Is(err, os.ErrNotExist) {
+		existingProject = false
+	} else {
+		return nil, fmt.Errorf("checking if project exists: %w", err)
+	}
+
+	if !existingProject {
+		err = i.repoInitializer.PromptIfNonEmpty(ctx, azdCtx)
+		if err != nil {
+			return nil, err
+		}
+
 		if i.flags.template.Name == "" {
 			i.flags.template, err = templates.PromptTemplate(ctx, "Select a project template:", i.console)
 
@@ -162,12 +173,10 @@ func (i *initAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		if err != nil {
 			return nil, fmt.Errorf("init from template repository: %w", err)
 		}
-	} else {
-		if _, err := os.Stat(azdCtx.ProjectPath()); errors.Is(err, os.ErrNotExist) {
-			err = i.repoInitializer.InitializeEmpty(ctx, azdCtx)
-			if err != nil {
-				return nil, fmt.Errorf("init empty repository: %w", err)
-			}
+	} else if !existingProject { // do not initialize for empty if azure.yaml is present
+		err = i.repoInitializer.InitializeEmpty(ctx, azdCtx)
+		if err != nil {
+			return nil, fmt.Errorf("init empty repository: %w", err)
 		}
 	}
 

--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -39,9 +39,7 @@ func NewInitializer(
 
 // Initializes a local repository in the project directory from a remote repository.
 //
-// A confirmation prompt is displayed if:
-//  1. The directory is non-empty.
-//  2. The placed files would overwrite existing files.
+// A confirmation prompt is displayed for any existing files to be overwritten.
 func (i *Initializer) Initialize(
 	ctx context.Context,
 	azdCtx *azdcontext.AzdContext,

--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -263,8 +263,7 @@ func parseExecutableFiles(stagedFilesOutput string) ([]string, error) {
 	return executableFiles, nil
 }
 
-// Initializes an empty (bare minimum) azd repository in the given project directory.
-// A confirmation prompt is displayed if the directory is non-empty.
+// Initializes an empty (bare minimum) azd repository.
 func (i *Initializer) InitializeEmpty(ctx context.Context, azdCtx *azdcontext.AzdContext) error {
 	projectDir := azdCtx.ProjectDirectory()
 	var err error

--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -39,7 +39,9 @@ func NewInitializer(
 
 // Initializes a local repository in the project directory from a remote repository.
 //
-// A confirmation prompt is displayed for any existing files to be overwritten.
+// A confirmation prompt is displayed if:
+//  1. The directory is non-empty.
+//  2. The placed files would overwrite existing files.
 func (i *Initializer) Initialize(
 	ctx context.Context,
 	azdCtx *azdcontext.AzdContext,
@@ -263,10 +265,13 @@ func parseExecutableFiles(stagedFilesOutput string) ([]string, error) {
 	return executableFiles, nil
 }
 
-// Initializes an empty (bare minimum) azd repository.
+// Initializes an empty (bare minimum) azd repository in the given project directory.
+// A confirmation prompt is displayed if the directory is non-empty.
 func (i *Initializer) InitializeEmpty(ctx context.Context, azdCtx *azdcontext.AzdContext) error {
-	projectFormatted := output.WithLinkFormat("%s", azdCtx.ProjectDirectory())
+	projectDir := azdCtx.ProjectDirectory()
 	var err error
+
+	projectFormatted := output.WithLinkFormat("%s", projectDir)
 	i.console.ShowSpinner(ctx,
 		fmt.Sprintf("Creating minimal project files at: %s", projectFormatted),
 		input.Step)
@@ -274,7 +279,6 @@ func (i *Initializer) InitializeEmpty(ctx context.Context, azdCtx *azdcontext.Az
 		fmt.Sprintf("Created minimal project files at: %s", projectFormatted)+"\n",
 		input.GetStepResultFormat(err))
 
-	projectDir := azdCtx.ProjectDirectory()
 	isEmpty, err := isEmptyDir(projectDir)
 	if err != nil {
 		return err
@@ -380,6 +384,47 @@ func (i *Initializer) writeAzdAssets(ctx context.Context, azdCtx *azdcontext.Azd
 		_, err := gitignoreFile.WriteString(appendContents)
 		if err != nil {
 			return fmt.Errorf("fail to write '%s' in .gitignore: %w", azdcontext.EnvironmentDirectoryName, err)
+		}
+	}
+
+	return nil
+}
+
+// PromptIfNonEmpty prompts the user for confirmation if the project directory to initialize in is non-empty.
+// Returns error if an error occurred while prompting, or if the user declines confirmation.
+func (i *Initializer) PromptIfNonEmpty(ctx context.Context, azdCtx *azdcontext.AzdContext) error {
+	dir := azdCtx.ProjectDirectory()
+	isEmpty, err := isEmptyDir(dir)
+	if err != nil {
+		return err
+	}
+
+	if !isEmpty {
+		_, err := i.gitCli.GetCurrentBranch(ctx, dir)
+		if err != nil && !errors.Is(err, git.ErrNotRepository) {
+			return fmt.Errorf("determining current git repository state: %w", err)
+		}
+
+		message := fmt.Sprintf(
+			"The current directory is not empty. Would you like to initialize a project here in '%s'?",
+			dir)
+		if err != nil {
+			message = fmt.Sprintf(
+				"The current directory is not empty. "+
+					"Would you like to initialize a project here? "+
+					"Doing so will also initialize a new git repository in '%s'.",
+				dir)
+		}
+
+		confirm, err := i.console.Confirm(ctx, input.ConsoleOptions{
+			Message: message,
+		})
+		if err != nil {
+			return err
+		}
+
+		if !confirm {
+			return fmt.Errorf("confirmation declined")
 		}
 	}
 


### PR DESCRIPTION
This acts as a speed bump to avoid accidentally running `azd init` in the wrong directory.  If `azure.yaml` is present, no prompt is needed.

For other situations, the user can still confirm with 'y' explicitly and initialize the project in a non-empty directory (azdevifying from existing code),

Fixes #1638