### PR TITLE
codespaces azdo git config azd only

### DIFF
--- a/cli/azd/pkg/azdo/utils.go
+++ b/cli/azd/pkg/azdo/utils.go
@@ -41,8 +41,8 @@ func EnsurePatExists(ctx context.Context, env *environment.Environment, console 
 			output.WithHighLightFormat("%s", AzDoPatName)))
 
 		pat, err := console.Prompt(ctx, input.ConsoleOptions{
-			Message:      "Personal Access Token (PAT):",
-			DefaultValue: "",
+			Message:    "Personal Access Token (PAT):",
+			IsPassword: true,
 		})
 		if err != nil {
 			return "", false, fmt.Errorf("asking for pat: %w", err)

--- a/cli/azd/pkg/commands/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/commands/pipeline/azdo_provider.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"regexp"
@@ -75,9 +76,9 @@ func (p *AzdoScmProvider) preConfigureCheck(
 	}
 
 	if updatedPat {
-		// pat was requested. Set git-credential helper
+		// setting credential helper is a plus. It should not interrupt the process
 		if err := setPatCredentialHelperForGit(ctx, p.commandRunner, projectPath); err != nil {
-			return updatedPat, err
+			log.Printf("Error trying to set git credential helper for PAT: %s", err.Error())
 		}
 	}
 
@@ -641,9 +642,9 @@ func (p *AzdoCiProvider) preConfigureCheck(
 	}
 
 	if updatedPat {
-		// pat was requested. Set git-credential helper
+		// setting credential helper is a plus. It should not interrupt the process
 		if err := setPatCredentialHelperForGit(ctx, p.commandRunner, projectPath); err != nil {
-			return updatedPat, err
+			log.Printf("Error trying to set git credential helper for PAT: %s", err.Error())
 		}
 	}
 

--- a/cli/azd/pkg/commands/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/commands/pipeline/azdo_provider.go
@@ -108,11 +108,14 @@ func createCredentialHelper(ctx context.Context, projectPath string) (string, er
 
 	for _, line := range []string{
 		"#!/bin/sh",
-		"echo protocol=https",
-		"echo host=dev.azure.com",
-		"echo path=",
-		"echo username=PersonalAccessToken",
-		"echo password=$AZURE_DEVOPS_EXT_PAT",
+		"# Only if AZURE_DEVOPS_EXT_PAT has a value",
+		"if [ $AZURE_DEVOPS_EXT_PAT ]; then",
+		"    echo protocol=https",
+		"    echo host=dev.azure.com",
+		"    echo path=",
+		"    echo username=PersonalAccessToken",
+		"    echo password=$AZURE_DEVOPS_EXT_PAT",
+		"fi",
 	} {
 		if _, err := file.WriteString(line + "\n"); err != nil {
 			return "", err

--- a/cli/azd/pkg/commands/pipeline/github_provider.go
+++ b/cli/azd/pkg/commands/pipeline/github_provider.go
@@ -660,6 +660,19 @@ func applyFederatedCredentials(
 	return nil
 }
 
+func (p *GitHubScmProvider) additionalScmConfigurationBeforePush(
+	ctx context.Context,
+	gitRepo *gitRepositoryDetails,
+	remoteName string,
+	branchName string) {
+}
+func (p *GitHubScmProvider) additionalScmConfigurationAfterPush(
+	ctx context.Context,
+	gitRepo *gitRepositoryDetails,
+	remoteName string,
+	branchName string) {
+}
+
 // configurePipeline is a no-op for GitHub, as the pipeline is automatically
 // created by creating the workflow files in .github folder.
 func (p *GitHubCiProvider) configurePipeline(

--- a/cli/azd/pkg/commands/pipeline/github_provider.go
+++ b/cli/azd/pkg/commands/pipeline/github_provider.go
@@ -188,12 +188,13 @@ func (p *GitHubScmProvider) preventGitPush(
 	return false, nil
 }
 
-func (p *GitHubScmProvider) postGitPush(
+func (p *GitHubScmProvider) GitPush(
 	ctx context.Context,
+	gitCli git.GitCli,
 	gitRepo *gitRepositoryDetails,
 	remoteName string,
 	branchName string) error {
-	return nil
+	return gitCli.PushUpstream(ctx, gitRepo.gitProjectPath, remoteName, branchName)
 }
 
 // enum type for taking a choice after finding GitHub actions disabled.
@@ -658,19 +659,6 @@ func applyFederatedCredentials(
 	}
 
 	return nil
-}
-
-func (p *GitHubScmProvider) additionalScmConfigurationBeforePush(
-	ctx context.Context,
-	gitRepo *gitRepositoryDetails,
-	remoteName string,
-	branchName string) {
-}
-func (p *GitHubScmProvider) additionalScmConfigurationAfterPush(
-	ctx context.Context,
-	gitRepo *gitRepositoryDetails,
-	remoteName string,
-	branchName string) {
 }
 
 // configurePipeline is a no-op for GitHub, as the pipeline is automatically

--- a/cli/azd/pkg/commands/pipeline/pipeline.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline.go
@@ -81,6 +81,16 @@ type ScmProvider interface {
 		gitRepo *gitRepositoryDetails,
 		remoteName string,
 		branchName string) error
+	additionalScmConfigurationBeforePush(
+		ctx context.Context,
+		gitRepo *gitRepositoryDetails,
+		remoteName string,
+		branchName string)
+	additionalScmConfigurationAfterPush(
+		ctx context.Context,
+		gitRepo *gitRepositoryDetails,
+		remoteName string,
+		branchName string)
 }
 
 type CiPipeline struct {

--- a/cli/azd/pkg/commands/pipeline/pipeline.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline.go
@@ -224,7 +224,7 @@ func DetectProviders(
 		_ = savePipelineProviderToEnv(azdoLabel, env)
 		log.Printf("Using pipeline provider: %s", output.WithHighLightFormat("Azure DevOps"))
 		scmProvider := createAzdoScmProvider(env, azdContext, commandRunner, console)
-		ciProvider := createAzdoCiProvider(env, azdContext, console)
+		ciProvider := createAzdoCiProvider(env, azdContext, commandRunner, console)
 
 		return scmProvider, ciProvider, nil
 	}
@@ -248,12 +248,16 @@ func savePipelineProviderToEnv(provider string, env *environment.Environment) er
 }
 
 func createAzdoCiProvider(
-	env *environment.Environment, azdCtx *azdcontext.AzdContext, console input.Console,
+	env *environment.Environment,
+	azdCtx *azdcontext.AzdContext,
+	commandRunner exec.CommandRunner,
+	console input.Console,
 ) *AzdoCiProvider {
 	return &AzdoCiProvider{
-		Env:        env,
-		AzdContext: azdCtx,
-		console:    console,
+		Env:           env,
+		AzdContext:    azdCtx,
+		console:       console,
+		commandRunner: commandRunner,
 	}
 }
 

--- a/cli/azd/pkg/commands/pipeline/pipeline.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline.go
@@ -21,6 +21,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/git"
 )
 
 // subareaProvider defines the base behavior from any pipeline provider
@@ -77,20 +78,11 @@ type ScmProvider interface {
 		remoteName string,
 		branchName string) (bool, error)
 	//Hook function to allow SCM providers to handle scenarios after the git push is complete
-	postGitPush(ctx context.Context,
+	GitPush(ctx context.Context,
+		gitCli git.GitCli,
 		gitRepo *gitRepositoryDetails,
 		remoteName string,
 		branchName string) error
-	additionalScmConfigurationBeforePush(
-		ctx context.Context,
-		gitRepo *gitRepositoryDetails,
-		remoteName string,
-		branchName string)
-	additionalScmConfigurationAfterPush(
-		ctx context.Context,
-		gitRepo *gitRepositoryDetails,
-		remoteName string,
-		branchName string)
 }
 
 type CiPipeline struct {

--- a/cli/azd/pkg/commands/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline_manager.go
@@ -384,6 +384,19 @@ func (manager *PipelineManager) Configure(ctx context.Context) (
 	}
 
 	if doPush {
+		// ScmProvider can use this function for setting up things like authentication during the scope of azd
+		// The configuration is expected to be reverted by additionalScmConfigurationAfterPush as a defer action
+		// regardless of the operation result. This should ensure any additional configuration will persist only
+		// while while config() method finishes
+		manager.ScmProvider.additionalScmConfigurationBeforePush(ctx,
+			gitRepoInfo,
+			manager.PipelineRemoteName,
+			currentBranch)
+		defer manager.ScmProvider.additionalScmConfigurationAfterPush(ctx,
+			gitRepoInfo,
+			manager.PipelineRemoteName,
+			currentBranch)
+
 		err = manager.pushGitRepo(ctx, currentBranch)
 		if err != nil {
 			return result, fmt.Errorf("git push: %w", err)

--- a/cli/azd/pkg/exec/command_runner.go
+++ b/cli/azd/pkg/exec/command_runner.go
@@ -91,7 +91,8 @@ func (r *commandRunner) Run(ctx context.Context, args RunArgs) (RunResult, error
 		}
 	}
 
-	log.Printf("Run exec: '%s %s'", args.Cmd, redactSensitiveData(strings.Join(args.Args, " ")))
+	log.Printf("Run exec: '%s %s'", args.Cmd, redactSensitiveData(strings.Join(
+		redactSensitiveArgs(args.Args, args.SensitiveData), " ")))
 
 	if args.Debug && len(args.Env) > 0 {
 		log.Println("Additional env:")
@@ -255,6 +256,16 @@ func newCmdTree(ctx context.Context, cmd string, args []string, useShell bool, i
 type redactData struct {
 	matchString   *regexp.Regexp
 	replaceString string
+}
+
+func redactSensitiveArgs(args []string, sensitiveDataMatch []string) []string {
+	redactedArgs := make([]string, len(args))
+	for _, arg := range args {
+		for _, sensitiveData := range sensitiveDataMatch {
+			redactedArgs = append(redactedArgs, strings.ReplaceAll(arg, sensitiveData, "***"))
+		}
+	}
+	return redactedArgs
 }
 
 func redactSensitiveData(msg string) string {

--- a/cli/azd/pkg/exec/command_runner.go
+++ b/cli/azd/pkg/exec/command_runner.go
@@ -258,15 +258,19 @@ type redactData struct {
 	replaceString string
 }
 
+const cRedacted = "<redacted>"
+
 func redactSensitiveArgs(args []string, sensitiveDataMatch []string) []string {
 	if len(sensitiveDataMatch) == 0 {
 		return args
 	}
 	redactedArgs := make([]string, len(args))
-	for _, arg := range args {
+	for i, arg := range args {
+		redacted := arg
 		for _, sensitiveData := range sensitiveDataMatch {
-			redactedArgs = append(redactedArgs, strings.ReplaceAll(arg, sensitiveData, "***"))
+			redacted = strings.ReplaceAll(redacted, sensitiveData, cRedacted)
 		}
+		redactedArgs[i] = redacted
 	}
 	return redactedArgs
 }
@@ -275,23 +279,23 @@ func redactSensitiveData(msg string) string {
 	var regexpRedactRules = map[string]redactData{
 		"access token": {
 			regexp.MustCompile("\"accessToken\": \".*\""),
-			"\"accessToken\": \"<redacted>\"",
+			"\"accessToken\": \"" + cRedacted + "\"",
 		},
 		"deployment token": {
 			regexp.MustCompile(`--deployment-token \S+`),
-			"--deployment-token <redacted>",
+			"--deployment-token " + cRedacted,
 		},
 		"username": {
 			regexp.MustCompile(`--username \S+`),
-			"--username <redacted>",
+			"--username " + cRedacted,
 		},
 		"password": {
 			regexp.MustCompile(`--password \S+`),
-			"--password <redacted>",
+			"--password " + cRedacted,
 		},
 		"kubectl-from-literal": {
 			regexp.MustCompile(`--from-literal=([^=]+)=(\S+)`),
-			"--from-literal=$1=<redacted>",
+			"--from-literal=$1=" + cRedacted,
 		},
 	}
 

--- a/cli/azd/pkg/exec/command_runner.go
+++ b/cli/azd/pkg/exec/command_runner.go
@@ -259,6 +259,9 @@ type redactData struct {
 }
 
 func redactSensitiveArgs(args []string, sensitiveDataMatch []string) []string {
+	if len(sensitiveDataMatch) == 0 {
+		return args
+	}
 	redactedArgs := make([]string, len(args))
 	for _, arg := range args {
 		for _, sensitiveData := range sensitiveDataMatch {

--- a/cli/azd/pkg/exec/runargs.go
+++ b/cli/azd/pkg/exec/runargs.go
@@ -8,8 +8,10 @@ import (
 type RunArgs struct {
 	Cmd  string
 	Args []string
-	Cwd  string
-	Env  []string
+	// Any string from SensitiveData will be redacted as *** if found in Args
+	SensitiveData []string
+	Cwd           string
+	Env           []string
 
 	// Stderr will receive a copy of the text written to Stderr by
 	// the command.
@@ -39,6 +41,16 @@ func NewRunArgs(cmd string, args ...string) RunArgs {
 	return RunArgs{
 		Cmd:  cmd,
 		Args: args,
+	}
+}
+
+// NewRunArgs creates a new instance with the specified cmd and args and a list of SensitiveData
+// Use this constructor to protect known sensitive data from going to logs
+func NewRunArgsWithSensitiveData(cmd string, args, sensitiveData []string) RunArgs {
+	return RunArgs{
+		Cmd:           cmd,
+		Args:          args,
+		SensitiveData: sensitiveData,
 	}
 }
 

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -88,6 +88,7 @@ type ConsoleOptions struct {
 	Help         string
 	Options      []string
 	DefaultValue any
+	IsPassword   bool
 }
 
 type ConsoleHandles struct {
@@ -274,23 +275,30 @@ func (c *AskerConsole) getStopChar(format SpinnerUxType) string {
 	return fmt.Sprintf("%s%s", c.getIndent(format), stopChar)
 }
 
-// Prompts the user for a single value
-func (c *AskerConsole) Prompt(ctx context.Context, options ConsoleOptions) (string, error) {
+func promptFromOptions(options ConsoleOptions) survey.Prompt {
+	if options.IsPassword {
+		return &survey.Password{
+			Message: options.Message,
+		}
+	}
+
 	var defaultValue string
 	if value, ok := options.DefaultValue.(string); ok {
 		defaultValue = value
 	}
-
-	survey := &survey.Input{
+	return &survey.Input{
 		Message: options.Message,
 		Default: defaultValue,
 		Help:    options.Help,
 	}
+}
 
+// Prompts the user for a single value
+func (c *AskerConsole) Prompt(ctx context.Context, options ConsoleOptions) (string, error) {
 	var response string
 
 	err := c.doInteraction(func(c *AskerConsole) error {
-		return c.asker(survey, &response)
+		return c.asker(promptFromOptions(options), &response)
 	})
 	if err != nil {
 		return response, err

--- a/cli/azd/pkg/tools/git/git.go
+++ b/cli/azd/pkg/tools/git/git.go
@@ -272,7 +272,7 @@ func (cli *gitCli) SetAzdoPatAuth(ctx context.Context, repositoryPath, azdoPatFi
 
 	runArgs = newRunArgs(
 		"-C", repositoryPath,
-		"config", "--local", "add", "credential.helper", azdoPatFile)
+		"config", "--local", "--add", "credential.helper", azdoPatFile)
 	if _, err := cli.commandRunner.Run(ctx, runArgs); err != nil {
 		return fmt.Errorf("failed to set break for azdo credential helper: %w", err)
 	}

--- a/cli/azd/pkg/tools/git/git.go
+++ b/cli/azd/pkg/tools/git/git.go
@@ -35,8 +35,6 @@ type GitCli interface {
 	AddFileExecPermission(ctx context.Context, repositoryPath string, file string) error
 	// make current repo to use gh-cli as credential helper.
 	SetGitHubAuthForRepo(ctx context.Context, repositoryPath, credential, ghPath string) error
-	// make current repo to use $AZURE_DEVOPS_EXT_PAT as credential helper.
-	SetAzdoPatAuth(ctx context.Context, repositoryPath, azdoPatFile string) error
 }
 
 type gitCli struct {
@@ -251,33 +249,6 @@ func (cli *gitCli) IsUntrackedFile(ctx context.Context, repositoryPath string, f
 	}
 
 	return false, nil
-}
-
-// SetAzdoPatAuth creates git config for the repositoryPath like
-//
-// [credential]
-// helper =
-// helper = azdoPatFile
-//
-// This way, git commands run from repositoryPath will use $AZURE_DEVOPS_EXT_PAT for auth.
-// Note: Removes any previous configuration for the credential.
-// Note: `helper = ` is intentional to break the chain of previously configured global helpers.
-func (cli *gitCli) SetAzdoPatAuth(ctx context.Context, repositoryPath, azdoPatFile string) error {
-	runArgs := newRunArgs(
-		"-C", repositoryPath,
-		"config", "--local", "--replace-all", "credential.helper", "")
-	if _, err := cli.commandRunner.Run(ctx, runArgs); err != nil {
-		return fmt.Errorf("failed to set break for azdo credential helper: %w", err)
-	}
-
-	runArgs = newRunArgs(
-		"-C", repositoryPath,
-		"config", "--local", "--add", "credential.helper", azdoPatFile)
-	if _, err := cli.commandRunner.Run(ctx, runArgs); err != nil {
-		return fmt.Errorf("failed to set break for azdo credential helper: %w", err)
-	}
-
-	return nil
 }
 
 // SetGitHubAuthForRepo creates git config for the repositoryPath like


### PR DESCRIPTION
Based on the feedback from https://github.com/Azure/azure-dev/pull/2068, we don't really want azd to set git credential-helpers. Specially if the helper is just a quick bridge to pull a PAT from an env-var.

We would prefer to let customer's git-config unchanged.

This PR introduces a different approach which uses `-c url.<PAT+Host>.insteadOf=<Host>` to use the PAT on https for pushing code. The configuration is not persisted to config,

Users might face a later challenge if they try to use git later, as git will either prompt for PAT again or fail if there is another configuration (like in Codespaces).  But, at least for azd, it will all work as expected.

I tested this on Codespaces :)

fix: https://github.com/Azure/azure-dev/issues/1993


Updating command runner as well to support getting a list of values which the caller knows are sensitive and should be redacted before logging them.  Example:

![image](https://user-images.githubusercontent.com/24213737/236342763-a3bc1580-e92f-40a9-8345-2310a7f12422.png)
