### PR TITLE
Update `exec.environment` telemetry reporting

### DIFF
--- a/cli/azd/internal/telemetry/fields/fields.go
+++ b/cli/azd/internal/telemetry/fields/fields.go
@@ -95,14 +95,22 @@ const (
 )
 
 // All possible enumerations of ExecutionEnvironmentKey
+//
+// Environments are mutually exclusive. Modifiers can be set additionally to signal different types of usages.
+// An execution environment is formatted as follows:
+// `<environment>[;<modifier1>;<modifier2>...]`
 const (
-	// Desktop environments
+	// A desktop environment. The user is directly interacting with azd via a terminal.
+	EnvDesktop = "Desktop"
 
-	EnvDesktop          = "Desktop"
+	// Environments that are wrapped by an intermediate calling program, and are significant enough to warrant
+	// being an environment and not an environment modifier.
+
 	EnvVisualStudio     = "Visual Studio"
 	EnvVisualStudioCode = "Visual Studio Code"
+	EnvCloudShell       = "Azure CloudShell"
 
-	// Hosted/Continuous Integration environments
+	// Continuous Integration environments
 
 	EnvUnknownCI          = "UnknownCI"
 	EnvAzurePipelines     = "Azure Pipelines"
@@ -119,7 +127,11 @@ const (
 	EnvTeamCity           = "TeamCity"
 	EnvJetBrainsSpace     = "JetBrains Space"
 	EnvCodespaces         = "GitHub Codespaces"
-	EnvCloudShell         = "Azure CloudShell"
+
+	// Environment modifiers. These are not environments themselves, but rather modifiers to the environment
+	// that signal specific types of usages.
+
+	EnvModifierAzureSpace = "Azure App Spaces Portal"
 )
 
 // All possible enumerations of AccountTypeKey

--- a/cli/azd/internal/telemetry/resource/ci.go
+++ b/cli/azd/internal/telemetry/resource/ci.go
@@ -1,0 +1,82 @@
+package resource
+
+import (
+	"os"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/internal/telemetry/fields"
+)
+
+// Rules that apply when the specified environment variable is set to "true" (case-insensitive)
+var ciVarBoolRules = []struct {
+	envVar      string
+	environment string
+}{
+	// Azure Pipelines -
+	// https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables#system-variables-devops-servicesQ
+	{"TF_BUILD", fields.EnvAzurePipelines},
+	// GitHub Actions,
+	// https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+	{"GITHUB_ACTIONS", fields.EnvGitHubActions},
+	// AppVeyor - https://www.appveyor.com/docs/environment-variables/
+	{"APPVEYOR", fields.EnvAppVeyor},
+	// Travis CI - https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+	{"TRAVIS", fields.EnvTravisCI},
+	// Circle CI - https://circleci.com/docs/env-vars#built-in-environment-variables
+	{"CIRCLECI", fields.EnvCircleCI},
+	// GitLab CI
+	{"GITLAB_CI", fields.EnvGitLabCI},
+}
+
+// Rules that apply when the specified environment variable is set to any value
+var ciVarSetRules = []struct {
+	envVar      string
+	environment string
+}{
+	// AWS CodeBuild - https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+	{"CODEBUILD_BUILD_ID", fields.EnvAwsCodeBuild},
+	//nolint:lll
+	// Jenkins -
+	// https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
+	{"JENKINS_URL", fields.EnvJenkins},
+	//nolint:lll
+	// TeamCity - https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html#Predefined+Server+Build+Parameters
+	{"TEAMCITY_VERSION", fields.EnvTeamCity},
+	//nolint:lll
+	// JetBrains Space -
+	// https://www.jetbrains.com/help/space/automation-environment-variables.html#when-does-automation-resolve-its-environment-variables
+	{"JB_SPACE_API_URL", fields.EnvJetBrainsSpace},
+	// Bamboo -
+	// https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html#Bamboovariables-Build-specificvariables
+	{"bamboo.buildKey", fields.EnvBamboo},
+	// BitBucket - https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
+	{"BITBUCKET_BUILD_NUMBER", fields.EnvBitBucketPipelines},
+	// GitHub Codespaces -
+	// https://docs.github.com/en/codespaces/developing-in-codespaces/default-environment-variables-for-your-codespace
+	{"CODESPACES", fields.EnvCodespaces},
+	// Unknown CI cases
+	{"CI", fields.EnvUnknownCI},
+	{"BUILD_ID", fields.EnvUnknownCI},
+}
+
+// getExecutionEnvironmentForHosted detects the execution environment for CI/CD providers and returns the corresponding
+// named environment.
+//
+// Returns an empty string if no CI/CD provider is detected.
+func execEnvForCi() string {
+	for _, rule := range ciVarBoolRules {
+		// Some CI providers specify 'True' on Windows vs 'true' on Linux, while others use `True` always
+		// Thus, it's better to err on the side of being generous and be case-insensitive
+		if strings.ToLower(os.Getenv(rule.envVar)) == "true" {
+			return rule.environment
+		}
+	}
+
+	for _, rule := range ciVarSetRules {
+		if _, ok := os.LookupEnv(rule.envVar); ok {
+			return rule.environment
+		}
+	}
+
+	return ""
+}

--- a/cli/azd/internal/telemetry/resource/exec_environment.go
+++ b/cli/azd/internal/telemetry/resource/exec_environment.go
@@ -21,7 +21,7 @@ func getExecutionEnvironment() string {
 		env = execEnvForCi()
 	}
 
-	// no execution environment found, default to plain desktop
+	// no special execution environment found, default to plain desktop
 	if env == "" {
 		env = fields.EnvDesktop
 	}

--- a/cli/azd/internal/telemetry/resource/exec_environment.go
+++ b/cli/azd/internal/telemetry/resource/exec_environment.go
@@ -11,93 +11,48 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry/fields"
 )
 
-// Rules that apply when the specified environment variable is set to "true" (case-insensitive)
-var booleanEnvVarRules = []struct {
-	envVar      string
-	environment string
-}{
-	// Azure Pipelines -
-	// https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables#system-variables-devops-servicesQ
-	{"TF_BUILD", fields.EnvAzurePipelines},
-	// GitHub Actions,
-	// https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-	{"GITHUB_ACTIONS", fields.EnvGitHubActions},
-	// AppVeyor - https://www.appveyor.com/docs/environment-variables/
-	{"APPVEYOR", fields.EnvAppVeyor},
-	// Travis CI - https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
-	{"TRAVIS", fields.EnvTravisCI},
-	// Circle CI - https://circleci.com/docs/env-vars#built-in-environment-variables
-	{"CIRCLECI", fields.EnvCircleCI},
-	// GitLab CI
-	{"GITLAB_CI", fields.EnvGitLabCI},
-}
-
-// Rules that apply when the specified environment variable is set to any value
-var nonNullEnvVarRules = []struct {
-	envVar      string
-	environment string
-}{
-	// AWS CodeBuild - https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
-	{"CODEBUILD_BUILD_ID", fields.EnvAwsCodeBuild},
-	//nolint:lll
-	// Jenkins -
-	// https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
-	{"JENKINS_URL", fields.EnvJenkins},
-	//nolint:lll
-	// TeamCity - https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html#Predefined+Server+Build+Parameters
-	{"TEAMCITY_VERSION", fields.EnvTeamCity},
-	//nolint:lll
-	// JetBrains Space -
-	// https://www.jetbrains.com/help/space/automation-environment-variables.html#when-does-automation-resolve-its-environment-variables
-	{"JB_SPACE_API_URL", fields.EnvJetBrainsSpace},
-	// Bamboo -
-	// https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html#Bamboovariables-Build-specificvariables
-	{"bamboo.buildKey", fields.EnvBamboo},
-	// BitBucket - https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
-	{"BITBUCKET_BUILD_NUMBER", fields.EnvBitBucketPipelines},
-	// GitHub Codespaces -
-	// https://docs.github.com/en/codespaces/developing-in-codespaces/default-environment-variables-for-your-codespace
-	{"CODESPACES", fields.EnvCodespaces},
-	// Azure CloudShell
-	{"AZD_IN_CLOUDSHELL", fields.EnvCloudShell},
-	// Unknown CI cases
-	{"CI", fields.EnvUnknownCI},
-	{"BUILD_ID", fields.EnvUnknownCI},
-}
-
 func getExecutionEnvironment() string {
-	hostedEnv, ok := getExecutionEnvironmentForHosted()
-	if ok {
-		return hostedEnv
+	// calling programs receive the highest priority, since they end up wrapping the CLI and are the most
+	// inner layers.
+	env := execEnvFromCaller()
+
+	if env == "" {
+		// machine-level CI execution environments
+		env = execEnvForCi()
 	}
 
-	return getExecutionEnvironmentForDesktop()
+	// no execution environment found, default to plain desktop
+	if env == "" {
+		env = fields.EnvDesktop
+	}
+
+	// global modifiers that are applicable to all environments
+	modifiers := execEnvModifiers()
+
+	return strings.Join(append([]string{env}, modifiers...), ";")
 }
 
-func getExecutionEnvironmentForHosted() (string, bool) {
-	for _, rule := range booleanEnvVarRules {
-		// Some CI providers specify 'True' on Windows vs 'true' on Linux, while others use `True` always
-		// Thus, it's better to err on the side of being generous and be case-insensitive
-		if strings.ToLower(os.Getenv(rule.envVar)) == "true" {
-			return rule.environment, true
-		}
-	}
-
-	for _, rule := range nonNullEnvVarRules {
-		if _, ok := os.LookupEnv(rule.envVar); ok {
-			return rule.environment, true
-		}
-	}
-
-	return "", false
-}
-
-func getExecutionEnvironmentForDesktop() string {
+func execEnvFromCaller() string {
 	userAgent := internal.GetCallerUserAgent()
 
-	if strings.HasPrefix(userAgent, internal.VsCodeAgentPrefix) {
+	if strings.Contains(userAgent, internal.VsCodeAgentPrefix) {
 		return fields.EnvVisualStudioCode
 	}
 
-	return fields.EnvDesktop
+	if _, ok := os.LookupEnv("AZD_IN_CLOUDSHELL"); ok {
+		return fields.EnvCloudShell
+	}
+
+	return ""
+}
+
+func execEnvModifiers() []string {
+	modifiers := []string{}
+	userAgent := internal.GetCallerUserAgent()
+
+	if strings.Contains(userAgent, "azure_app_space_portal") {
+		modifiers = append(modifiers, fields.EnvModifierAzureSpace)
+	}
+
+	return modifiers
 }


### PR DESCRIPTION
Update `exec.environment` telemetry reporting to include `azure_app_space_portal`.

The existing logic for `exec.environment` reporting is also updated with two specific goals:

1. Refactor our CI detection to its own `ci.go` file. This allows reuse for other cases in the application when we need to detect CI. This means moving the logic for `AZD_IN_CLOUDSHELL` detection appropriately.
2. Add support for environment modifiers, which allows us to supplement the environment information. `azure_app_space_portal` takes advantage of this.

Partially addresses #1977 