### PR TITLE
Display better names in `azd init`

### DIFF
--- a/cli/azd/cmd/cmd_help.go
+++ b/cli/azd/cmd/cmd_help.go
@@ -145,7 +145,7 @@ func getCmdHelpAvailableCommands(commands string) string {
 func getCmdHelpDescriptionNoteForInit(c *cobra.Command) (notes []string) {
 	notes = append(notes, formatHelpNote(
 		fmt.Sprintf("Running %s without a template will prompt "+
-			"you to start with an empty template or select from a curated list of presets.",
+			"you to start with a minimal template or select from a curated list of presets.",
 			output.WithHighLightFormat(c.CommandPath()),
 		)))
 	notes = append(notes, formatHelpNote(

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -137,7 +137,7 @@ func (i *initAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 		if i.flags.templatePath == "" {
 			template, err := templates.PromptTemplate(ctx, "Select a project template:", i.console)
-			i.flags.templatePath = template.Path
+			i.flags.templatePath = template.RepositoryPath
 
 			if err != nil {
 				return nil, err

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
@@ -42,7 +41,7 @@ func newInitCmd() *cobra.Command {
 }
 
 type initFlags struct {
-	template       templates.Template
+	templatePath   string
 	templateBranch string
 	subscription   string
 	location       string
@@ -52,7 +51,7 @@ type initFlags struct {
 
 func (i *initFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	local.StringVarP(
-		&i.template.Name,
+		&i.templatePath,
 		"template",
 		"t",
 		"",
@@ -103,11 +102,11 @@ func (i *initAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 	azdCtx := azdcontext.NewAzdContextWithDirectory(wd)
 
-	if i.flags.templateBranch != "" && i.flags.template.Name == "" {
-		return nil, errors.New("template name required when specifying a branch name")
+	if i.flags.templateBranch != "" && i.flags.templatePath == "" {
+		return nil, errors.New("template required when specifying a branch name")
 	}
 
-	// init now requires git all the time, even for empty template, azd initializes a local git project
+	// ensure that git is available
 	if err := tools.EnsureInstalled(ctx, []tools.ExternalTool{i.gitCli}...); err != nil {
 		return nil, err
 	}
@@ -136,8 +135,9 @@ func (i *initAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 			return nil, err
 		}
 
-		if i.flags.template.Name == "" {
-			i.flags.template, err = templates.PromptTemplate(ctx, "Select a project template:", i.console)
+		if i.flags.templatePath == "" {
+			template, err := templates.PromptTemplate(ctx, "Select a project template:", i.console)
+			i.flags.templatePath = template.Path
 
 			if err != nil {
 				return nil, err
@@ -145,36 +145,18 @@ func (i *initAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		}
 	}
 
-	if i.flags.template.Name != "" {
-		var templateUrl string
-
-		if i.flags.template.RepositoryPath == "" {
-			// using template name directly from command line
-			i.flags.template.RepositoryPath = i.flags.template.Name
+	if i.flags.templatePath != "" {
+		gitUri, err := templates.Absolute(i.flags.templatePath)
+		if err != nil {
+			return nil, err
 		}
 
-		// treat names that start with http or git as full URLs and don't change them
-		if strings.HasPrefix(i.flags.template.RepositoryPath, "git") ||
-			strings.HasPrefix(i.flags.template.RepositoryPath, "http") {
-			templateUrl = i.flags.template.RepositoryPath
-		} else {
-			switch strings.Count(i.flags.template.RepositoryPath, "/") {
-			case 0:
-				templateUrl = fmt.Sprintf("https://github.com/Azure-Samples/%s", i.flags.template.RepositoryPath)
-			case 1:
-				templateUrl = fmt.Sprintf("https://github.com/%s", i.flags.template.RepositoryPath)
-			default:
-				return nil, fmt.Errorf(
-					"template '%s' should be either <repository> or <repo>/<repository>", i.flags.template.RepositoryPath)
-			}
-		}
-
-		err = i.repoInitializer.Initialize(ctx, azdCtx, templateUrl, i.flags.templateBranch)
+		err = i.repoInitializer.Initialize(ctx, azdCtx, gitUri, i.flags.templateBranch)
 		if err != nil {
 			return nil, fmt.Errorf("init from template repository: %w", err)
 		}
 	} else if !existingProject { // do not initialize for empty if azure.yaml is present
-		err = i.repoInitializer.InitializeEmpty(ctx, azdCtx)
+		err = i.repoInitializer.InitializeMinimal(ctx, azdCtx)
 		if err != nil {
 			return nil, fmt.Errorf("init empty repository: %w", err)
 		}

--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -92,12 +92,7 @@ func (tl *templatesListAction) Run(ctx context.Context) (*actions.ActionResult, 
 		return nil, err
 	}
 
-	results := make([]templates.ContractedTemplate, 0, len(listedTemplates))
-	for _, template := range listedTemplates {
-		results = append(results, templates.NewContract(template))
-	}
-
-	return nil, formatTemplates(ctx, tl.formatter, tl.writer, results...)
+	return nil, formatTemplates(ctx, tl.formatter, tl.writer, listedTemplates...)
 }
 
 type templatesShowAction struct {
@@ -128,7 +123,7 @@ func (a *templatesShowAction) Run(ctx context.Context) (*actions.ActionResult, e
 		return nil, err
 	}
 
-	return nil, formatTemplates(ctx, a.formatter, a.writer, templates.NewContract(matchingTemplate))
+	return nil, formatTemplates(ctx, a.formatter, a.writer, matchingTemplate)
 }
 
 func newTemplateShowCmd() *cobra.Command {
@@ -143,14 +138,14 @@ func formatTemplates(
 	ctx context.Context,
 	formatter output.Formatter,
 	writer io.Writer,
-	templates ...templates.ContractedTemplate,
+	templates ...templates.Template,
 ) error {
 	var err error
 	if formatter.Kind() == output.TableFormat {
 		columns := []output.Column{
 			{
-				Heading:       "Path",
-				ValueTemplate: "{{.Path}}",
+				Heading:       "RepositoryPath",
+				ValueTemplate: "{{.RepositoryPath}}",
 			},
 			{
 				Heading:       "Name",

--- a/cli/azd/cmd/templates_test.go
+++ b/cli/azd/cmd/templates_test.go
@@ -24,7 +24,7 @@ func TestTemplateList(t *testing.T) {
 	_, err := templateList.Run(context.Background())
 	require.NoError(t, err)
 
-	// Should be parsable JSON and non-empty
+	// The result should be parsable JSON and non-empty
 	storedTemplates := make([]templates.Template, 0)
 	err = json.Unmarshal(result.Bytes(), &storedTemplates)
 	require.NoError(t, err)

--- a/cli/azd/cmd/templates_test.go
+++ b/cli/azd/cmd/templates_test.go
@@ -4,14 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"sort"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/templates"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 )
 
 func TestTemplateList(t *testing.T) {
@@ -27,21 +25,16 @@ func TestTemplateList(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should be parsable JSON and non-empty
-	templates := make([]templates.Template, 0)
-	err = json.Unmarshal(result.Bytes(), &templates)
+	storedTemplates := make([]templates.Template, 0)
+	err = json.Unmarshal(result.Bytes(), &storedTemplates)
 	require.NoError(t, err)
-	assert.NotEmpty(t, templates)
-
-	// Should be sorted
-	names := make([]string, 0, len(templates))
-	for _, template := range templates {
-		names = append(names, template.Name)
-	}
-	sorted := sort.StringsAreSorted(names)
-	assert.True(t, sorted, "Templates are not sorted")
+	assert.NotEmpty(t, storedTemplates)
 
 	// Should match what template manager shows
-	templatesSet, err := templatesManager.ListTemplates()
+	templates, err := templatesManager.ListTemplates()
 	assert.NoError(t, err)
-	assert.ElementsMatch(t, names, maps.Keys(templatesSet))
+	assert.Len(t, templates, len(storedTemplates))
+	for i, template := range templates {
+		assert.Equal(t, template.Name, storedTemplates[i].Name)
+	}
 }

--- a/cli/azd/cmd/testdata/TestUsage-azd-init.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-init.snap
@@ -1,7 +1,7 @@
 
 Initialize a new application in your current directory.
 
-  • Running azd init without a template will prompt you to start with an empty template or select from a curated list of presets.
+  • Running azd init without a template will prompt you to start with a minimal template or select from a curated list of presets.
   • To view all currently available sample templates visit: azd init.
 
 Usage

--- a/cli/azd/cmd/testdata/TestUsage-azd-template.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-template.snap
@@ -3,7 +3,7 @@ View details of your current template or browse a list of curated sample templat
 
   • The azd CLI includes a curated list of sample templates viewable by running azd template list.
   • To view all available sample templates, including those submitted by the azd community visit: https://azure.github.io/awesome-azd.
-  • Running azd init without a template will prompt you to start with an empty template or select from our curated list of samples.
+  • Running azd init without a template will prompt you to start with a minimal template or select from our curated list of samples.
 
 Usage
   azd template [command]

--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -263,8 +263,8 @@ func parseExecutableFiles(stagedFilesOutput string) ([]string, error) {
 	return executableFiles, nil
 }
 
-// Initializes an empty (bare minimum) azd repository.
-func (i *Initializer) InitializeEmpty(ctx context.Context, azdCtx *azdcontext.AzdContext) error {
+// Initializes a minimal azd project.
+func (i *Initializer) InitializeMinimal(ctx context.Context, azdCtx *azdcontext.AzdContext) error {
 	projectDir := azdCtx.ProjectDirectory()
 	var err error
 

--- a/cli/azd/internal/repository/initializer_test.go
+++ b/cli/azd/internal/repository/initializer_test.go
@@ -287,7 +287,7 @@ func verifyExecutableFilePermissions(t *testing.T,
 	}
 }
 
-func Test_Initializer_InitializeEmpty(t *testing.T) {
+func Test_Initializer_InitializeMinimal(t *testing.T) {
 	type setup struct {
 		projectFile   string
 		gitignoreFile string
@@ -343,7 +343,7 @@ func Test_Initializer_InitializeEmpty(t *testing.T) {
 			console := mockinput.NewMockConsole()
 			realRunner := exec.NewCommandRunner(os.Stdin, os.Stdout, os.Stderr)
 			i := NewInitializer(console, git.NewGitCli(realRunner))
-			err := i.InitializeEmpty(context.Background(), azdCtx)
+			err := i.InitializeMinimal(context.Background(), azdCtx)
 			require.NoError(t, err)
 
 			projectFileContent := readFile(t, testDataPath("empty", tt.expected.projectFile))

--- a/cli/azd/pkg/templates/path.go
+++ b/cli/azd/pkg/templates/path.go
@@ -1,0 +1,28 @@
+package templates
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Absolute returns an absolute template path, given a possibly relative template path. An absolute path also corresponds to
+// a fully-qualified URI to a git repository.
+//
+// See Template.Path for more details.
+func Absolute(path string) (string, error) {
+	// already a git URI, return as-is
+	if strings.HasPrefix(path, "git") || strings.HasPrefix(path, "http") {
+		return path, nil
+	}
+
+	switch strings.Count(path, "/") {
+	case 0:
+		return fmt.Sprintf("https://github.com/Azure-Samples/%s", path), nil
+	case 1:
+		return fmt.Sprintf("https://github.com/%s", path), nil
+	default:
+		return "", fmt.Errorf(
+			"template '%s' should either be <owner>/<repo> for GitHub repositories, "+
+				"or <repo> for Azure-Samples GitHub repositories", path)
+	}
+}

--- a/cli/azd/pkg/templates/template.go
+++ b/cli/azd/pkg/templates/template.go
@@ -10,5 +10,5 @@ type Template struct {
 	// RepositoryPath is a fully qualified URI to a git repository,
 	// "{owner}/{repo}" for GitHub repositories,
 	// or "{repo}" for GitHub repositories under Azure-Samples (default organization).
-	RepositoryPath string `json:"path"`
+	RepositoryPath string `json:"repositoryPath"`
 }

--- a/cli/azd/pkg/templates/template.go
+++ b/cli/azd/pkg/templates/template.go
@@ -13,12 +13,15 @@ type Template struct {
 	Path string `json:"path"`
 }
 
+// ContractedTemplate is the template contract that is used expose by the CLI.
+//
+// Use NewContract to create a ContractedTemplate from a Template.
 type ContractedTemplate struct {
 	Template
 
 	// RepositoryPath is always set to the same value as template.Path
-	// It is added for backwards compatibility with the old contract.
-	// This can be removed once the old contract is no longer used.
+	// It is added for backwards compatibility with old versions of azd where repositoryPath was surfaced in the contract.
+	// This can be removed once backwards compatibility is no longer required.
 	RepositoryPath string `json:"repositoryPath"`
 }
 

--- a/cli/azd/pkg/templates/template.go
+++ b/cli/azd/pkg/templates/template.go
@@ -1,8 +1,30 @@
 package templates
 
 type Template struct {
-	Name           string `json:"name"`
-	DisplayName    string `json:"displayName,omitempty"`
-	Description    string `json:"description"`
+	// Name is the friendly short name of the template.
+	Name string `json:"name"`
+
+	// Description is a long description of the template.
+	Description string `json:"description"`
+
+	// Path is a fully qualified URI to a git repository,
+	// "{owner}/{repo}" for GitHub repositories,
+	// or "{repo}" for GitHub repositories under Azure-Samples (default organization).
+	Path string `json:"path"`
+}
+
+type ContractedTemplate struct {
+	Template
+
+	// RepositoryPath is always set to the same value as template.Path
+	// It is added for backwards compatibility with the old contract.
+	// This can be removed once the old contract is no longer used.
 	RepositoryPath string `json:"repositoryPath"`
+}
+
+func NewContract(template Template) ContractedTemplate {
+	return ContractedTemplate{
+		Template:       template,
+		RepositoryPath: template.Path,
+	}
 }

--- a/cli/azd/pkg/templates/template.go
+++ b/cli/azd/pkg/templates/template.go
@@ -7,27 +7,8 @@ type Template struct {
 	// Description is a long description of the template.
 	Description string `json:"description"`
 
-	// Path is a fully qualified URI to a git repository,
+	// RepositoryPath is a fully qualified URI to a git repository,
 	// "{owner}/{repo}" for GitHub repositories,
 	// or "{repo}" for GitHub repositories under Azure-Samples (default organization).
-	Path string `json:"path"`
-}
-
-// ContractedTemplate is the template contract that is used expose by the CLI.
-//
-// Use NewContract to create a ContractedTemplate from a Template.
-type ContractedTemplate struct {
-	Template
-
-	// RepositoryPath is always set to the same value as template.Path
-	// It is added for backwards compatibility with old versions of azd where repositoryPath was surfaced in the contract.
-	// This can be removed once backwards compatibility is no longer required.
-	RepositoryPath string `json:"repositoryPath"`
-}
-
-func NewContract(template Template) ContractedTemplate {
-	return ContractedTemplate{
-		Template:       template,
-		RepositoryPath: template.Path,
-	}
+	RepositoryPath string `json:"path"`
 }

--- a/cli/azd/pkg/templates/template_manager.go
+++ b/cli/azd/pkg/templates/template_manager.go
@@ -5,86 +5,73 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/resources"
-	"golang.org/x/exp/slices"
 )
 
 type TemplateManager struct {
 }
 
-// Get a set of templates where each key is the name of the template
-func (tm *TemplateManager) ListTemplates() (map[string]Template, error) {
-	result := make(map[string]Template)
+// ListTemplates retrieves the list of templates in a deterministic order.
+func (tm *TemplateManager) ListTemplates() ([]Template, error) {
 	var templates []Template
 	err := json.Unmarshal(resources.TemplatesJson, &templates)
 	if err != nil {
 		return nil, fmt.Errorf("unable to unmarshal templates JSON %w", err)
 	}
 
-	for _, template := range templates {
-		result[template.Name] = template
-	}
-
-	return result, nil
+	return templates, nil
 }
 
-func (tm *TemplateManager) GetTemplate(templateName string) (Template, error) {
+func (tm *TemplateManager) GetTemplate(path string) (Template, error) {
+	abs, err := Absolute(path)
+	if err != nil {
+		return Template{}, err
+	}
+
 	templates, err := tm.ListTemplates()
 
 	if err != nil {
 		return Template{}, fmt.Errorf("unable to list templates: %w", err)
 	}
 
-	if matchingTemplate, ok := templates[templateName]; ok {
-		return matchingTemplate, nil
+	for _, template := range templates {
+		absPath, err := Absolute(template.Path)
+		if err != nil {
+			panic(err)
+		}
+
+		if absPath == abs {
+			return template, nil
+		}
 	}
 
-	return Template{}, fmt.Errorf("template with name '%s' was not found", templateName)
+	return Template{}, fmt.Errorf("template with name '%s' was not found", path)
 }
 
 func NewTemplateManager() *TemplateManager {
 	return &TemplateManager{}
 }
 
-// PromptTemplate ask the user to select a template.
-// An empty Template with default values is returned if the user selects 'Empty Template' from the choices
+// PromptTemplate asks the user to select a template.
+// An empty Template can be returned if the user selects the minimal template. This corresponds to the minimal azd template.
+// See
 func PromptTemplate(ctx context.Context, message string, console input.Console) (Template, error) {
 	templateManager := NewTemplateManager()
-	templatesSet, err := templateManager.ListTemplates()
+	templates, err := templateManager.ListTemplates()
 
 	if err != nil {
 		return Template{}, fmt.Errorf("prompting for template: %w", err)
 	}
 
-	// Create a map of PromptText->Template to be used by the prompt
-	// This will be used to map the user selection to the template
-	templateSelect := make(map[string]Template, len(templatesSet))
-	for _, template := range templatesSet {
-		// We trim the default prefix to make the template names more user-friendly
-		// This is okay since templates without an organization name are assumed to be under "Azure-Samples/" by default
-		name := strings.TrimPrefix(template.Name, "Azure-Samples/")
-		if template.DisplayName != "" {
-			// always show the proper name to the user
-			templateSelect[template.DisplayName+" ("+name+")"] = template
-		} else {
-			templateSelect[name] = template
-		}
-	}
+	choices := make([]string, 0, len(templates)+1)
 
-	choices := make([]string, 0, len(templateSelect)+1)
-	for key := range templateSelect {
-		choices = append(choices, key)
+	// prepend the minimal template option to guarantee first selection
+	choices = append(choices, "Minimal")
+	for _, template := range templates {
+		choices = append(choices, template.Name+" ("+template.Path+")")
 	}
-	// sort based on the template name to provider stable ordering
-	slices.SortFunc(choices, func(a, b string) bool {
-		return templateSelect[a].Name < templateSelect[b].Name
-	})
-
-	// prepend the empty template option to guarantee first selection
-	choices = append([]string{"Empty Template"}, choices...)
 
 	selected, err := console.Select(ctx, input.ConsoleOptions{
 		Message:      message,
@@ -103,8 +90,8 @@ func PromptTemplate(ctx context.Context, message string, console input.Console) 
 		return Template{}, nil
 	}
 
-	template := templateSelect[choices[selected]]
-	log.Printf("Selected template: %s", fmt.Sprint(template.Name))
+	template := templates[selected-1]
+	log.Printf("Selected template: %s", fmt.Sprint(template.Path))
 
 	return template, nil
 }

--- a/cli/azd/pkg/templates/template_manager.go
+++ b/cli/azd/pkg/templates/template_manager.go
@@ -37,7 +37,7 @@ func (tm *TemplateManager) GetTemplate(path string) (Template, error) {
 	}
 
 	for _, template := range templates {
-		absPath, err := Absolute(template.Path)
+		absPath, err := Absolute(template.RepositoryPath)
 		if err != nil {
 			panic(err)
 		}
@@ -91,7 +91,7 @@ func PromptTemplate(ctx context.Context, message string, console input.Console) 
 	}
 
 	template := templates[selected-1]
-	log.Printf("Selected template: %s", fmt.Sprint(template.Path))
+	log.Printf("Selected template: %s", fmt.Sprint(template.RepositoryPath))
 
 	return template, nil
 }

--- a/cli/azd/pkg/templates/template_manager.go
+++ b/cli/azd/pkg/templates/template_manager.go
@@ -70,7 +70,7 @@ func PromptTemplate(ctx context.Context, message string, console input.Console) 
 	// prepend the minimal template option to guarantee first selection
 	choices = append(choices, "Minimal")
 	for _, template := range templates {
-		choices = append(choices, template.Name+" ("+template.Path+")")
+		choices = append(choices, template.Name)
 	}
 
 	selected, err := console.Select(ctx, input.ConsoleOptions{

--- a/cli/azd/pkg/templates/template_manager_test.go
+++ b/cli/azd/pkg/templates/template_manager_test.go
@@ -36,7 +36,7 @@ func TestListTemplates(t *testing.T) {
 	for i, template := range templates {
 		assert.Equal(t, template.Name, storedTemplates[i].Name)
 		assert.Equal(t, template.Description, storedTemplates[i].Description)
-		assert.Equal(t, template.Path, storedTemplates[i].Path)
+		assert.Equal(t, template.RepositoryPath, storedTemplates[i].RepositoryPath)
 	}
 
 	// Try listing multiple times to naively verify that the list is in a deterministic order
@@ -56,11 +56,11 @@ func TestGetTemplateWithValidPath(t *testing.T) {
 	templateManager := NewTemplateManager()
 	template, err := templateManager.GetTemplate(rel)
 	require.NoError(t, err)
-	require.Equal(t, rel, template.Path)
+	require.Equal(t, rel, template.RepositoryPath)
 
 	template, err = templateManager.GetTemplate(full)
 	require.NoError(t, err)
-	require.Equal(t, rel, template.Path)
+	require.Equal(t, rel, template.RepositoryPath)
 
 }
 

--- a/cli/azd/pkg/templates/template_manager_test.go
+++ b/cli/azd/pkg/templates/template_manager_test.go
@@ -55,13 +55,12 @@ func TestGetTemplateWithValidPath(t *testing.T) {
 	full := "Azure-Samples/" + rel
 	templateManager := NewTemplateManager()
 	template, err := templateManager.GetTemplate(rel)
-	require.NoError(t, err)
-	require.Equal(t, rel, template.RepositoryPath)
+	assert.NoError(t, err)
+	assert.Equal(t, rel, template.RepositoryPath)
 
 	template, err = templateManager.GetTemplate(full)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	require.Equal(t, rel, template.RepositoryPath)
-
 }
 
 func TestGetTemplateWithInvalidPath(t *testing.T) {

--- a/cli/azd/pkg/templates/template_manager_test.go
+++ b/cli/azd/pkg/templates/template_manager_test.go
@@ -1,9 +1,12 @@
 package templates
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/resources"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,19 +22,49 @@ func TestListTemplates(t *testing.T) {
 
 	require.Greater(t, len(templates), 0)
 	require.Nil(t, err)
+
+	// Should be parsable JSON and non-empty
+	var storedTemplates []Template
+	err = json.Unmarshal(resources.TemplatesJson, &storedTemplates)
+	require.NoError(t, err)
+	require.NotEmpty(t, storedTemplates)
+
+	// Should match what is stored in current resources JSON
+	// This also tests that the templates are in the precise order we defined
+	assert.NoError(t, err)
+	assert.Len(t, templates, len(storedTemplates))
+	for i, template := range templates {
+		assert.Equal(t, template.Name, storedTemplates[i].Name)
+		assert.Equal(t, template.Description, storedTemplates[i].Description)
+		assert.Equal(t, template.Path, storedTemplates[i].Path)
+	}
+
+	// Try listing multiple times to naively verify that the list is in a deterministic order
+	for i := 0; i < 10; i++ {
+		templates, err = templateManager.ListTemplates()
+		assert.NoError(t, err)
+		assert.Len(t, templates, len(storedTemplates))
+		for i, template := range templates {
+			assert.Equal(t, template.Name, storedTemplates[i].Name)
+		}
+	}
 }
 
-func TestGetTemplateWithValidName(t *testing.T) {
-	templateName := "Azure-Samples/todo-nodejs-mongo"
+func TestGetTemplateWithValidPath(t *testing.T) {
+	rel := "todo-nodejs-mongo"
+	full := "Azure-Samples/" + rel
 	templateManager := NewTemplateManager()
-	template, err := templateManager.GetTemplate(templateName)
+	template, err := templateManager.GetTemplate(rel)
+	require.NoError(t, err)
+	require.Equal(t, rel, template.Path)
 
-	require.NotNil(t, template)
-	require.Equal(t, template.Name, templateName)
-	require.Nil(t, err)
+	template, err = templateManager.GetTemplate(full)
+	require.NoError(t, err)
+	require.Equal(t, rel, template.Path)
+
 }
 
-func TestGetTemplateWithInvalidName(t *testing.T) {
+func TestGetTemplateWithInvalidPath(t *testing.T) {
 	templateName := "not-a-valid-template-name"
 	templateManager := NewTemplateManager()
 	template, err := templateManager.GetTemplate(templateName)

--- a/cli/azd/resources/templates.json
+++ b/cli/azd/resources/templates.json
@@ -1,84 +1,82 @@
 [
-    {
-        "name": "Azure-Samples/azd-starter-bicep",
-        "displayName": "Starter - Bicep",
-        "description": "A starter template with Bicep as infrastructure provider",
-        "repositoryPath": "Azure-Samples/azd-starter-bicep"
-    },
-    {
-        "name": "Azure-Samples/azd-starter-terraform",
-        "displayName": "Starter - Terraform",
-        "description": "A starter template with Terraform as infrastructure provider",
-        "repositoryPath": "Azure-Samples/azd-starter-terraform"
-    },
-    {
-        "name": "Azure-Samples/todo-nodejs-mongo",
-        "description": "ToDo Application with a Node.js API and Azure Cosmos DB API for MongoDB on Azure App Service",
-        "repositoryPath": "Azure-Samples/todo-nodejs-mongo"
-    },
-    {
-        "name": "Azure-Samples/todo-python-mongo",
-        "description": "ToDo Application with a Python API and Azure Cosmos DB API for MongoDB on Azure App Service",
-        "repositoryPath": "Azure-Samples/todo-python-mongo"
-    },
-    {
-        "name": "Azure-Samples/todo-csharp-cosmos-sql",
-        "description": "ToDo Application with a C# API and Azure Cosmos DB SQL API on Azure App Service",
-        "repositoryPath": "Azure-Samples/todo-csharp-cosmos-sql"
-    },
-    {
-        "name": "Azure-Samples/todo-nodejs-mongo-aca",
-        "description": "ToDo Application with a Node.js API and Azure Cosmos DB API for MongoDB on Azure Container Apps",
-        "repositoryPath": "Azure-Samples/todo-nodejs-mongo-aca"
-    },
-    {
-        "name": "Azure-Samples/todo-python-mongo-aca",
-        "description": "ToDo Application with a Python API and Azure Cosmos DB API for MongoDB on Azure Container Apps",
-        "repositoryPath": "Azure-Samples/todo-python-mongo-aca"
-    },
-    {
-        "name": "Azure-Samples/todo-nodejs-mongo-swa-func",
-        "description": "ToDo Application with a Node.js API and Azure Cosmos DB API for MongoDB on Static Web Apps and Functions",
-        "repositoryPath": "Azure-Samples/todo-nodejs-mongo-swa-func"
-    },
-    {
-        "name": "Azure-Samples/todo-python-mongo-swa-func",
-        "description": "ToDo Application with a Python API and Azure Cosmos DB API for MongoDB on Static Web Apps and Functions",
-        "repositoryPath": "Azure-Samples/todo-python-mongo-swa-func"
-    },
-    {
-        "name": "Azure-Samples/todo-csharp-sql-swa-func",
-        "description": "ToDo Application with a C# API and Azure SQL Database on Static Web Apps and Functions",
-        "repositoryPath": "Azure-Samples/todo-csharp-sql-swa-func"
-    },
-    {
-        "name": "Azure-Samples/todo-csharp-sql",
-        "description": "ToDo Application with a C# API and Azure SQL Database",
-        "repositoryPath": "Azure-Samples/todo-csharp-sql"
-    },
-    {
-        "name": "Azure-Samples/todo-java-mongo",
-        "description": "ToDo Application with a Java API and Azure Cosmos DB API for MongoDB on Azure App Service",
-        "repositoryPath": "Azure-Samples/todo-java-mongo"
-    },
-    {
-        "name": "Azure-Samples/todo-java-mongo-aca",
-        "description": "ToDo Application with a Java API and Azure Cosmos DB API for MongoDB on Azure Container Apps",
-        "repositoryPath": "Azure-Samples/todo-java-mongo-aca"
-    },
-    {
-        "name": "Azure-Samples/todo-nodejs-mongo-terraform",
-        "description": "ToDo Application with a Node.js API and Azure Cosmos DB API for MongoDB on Azure App Service",
-        "repositoryPath": "Azure-Samples/todo-nodejs-mongo-terraform"
-    },
-    {
-        "name": "Azure-Samples/todo-python-mongo-terraform",
-        "description": "ToDo Application with a Python API and Azure Cosmos DB API for MongoDB on Azure App Service",
-        "repositoryPath": "Azure-Samples/todo-python-mongo-terraform"
-    },
-    {
-        "name": "Azure-Samples/todo-nodejs-mongo-aks",
-        "description": "ToDo Application with a Node.js API and Azure Cosmos DB API for MongoDB on Azure Kubernetes Service",
-        "repositoryPath": "Azure-Samples/todo-nodejs-mongo-aks"
-    }
+  {
+    "name": "Starter - Bicep",
+    "description": "A starter template with Bicep as infrastructure provider",
+    "path": "azd-starter-bicep"
+  },
+  {
+    "name": "Starter - Terraform",
+    "description": "A starter template with Terraform as infrastructure provider",
+    "path": "azd-starter-terraform"
+  },
+  {
+    "name": "React Web App with C# API and MongoDB",
+    "description": "A blueprint for getting a React web app with a C# API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly.",
+    "path": "todo-csharp-cosmos-sql"
+  },
+  {
+    "name": "React Web App with C# API and SQL Database",
+    "description": "A blueprint for getting a React web app with a C# API and a SQL database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly.",
+    "path": "todo-csharp-sql"
+  },
+  {
+    "name": "Static React Web App + Functions with C# API and SQL Database",
+    "description": "A blueprint for getting a React web app with a C# API and a SQL database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting static web apps with serverless logic and functionality.",
+    "path": "todo-csharp-sql-swa-func"
+  },
+  {
+    "name": "React Web App with Java API and MongoDB",
+    "description": "A blueprint for getting a React.js web app with a Java API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
+    "path": "todo-java-mongo"
+  },
+  {
+    "name": "Containerized React Web App with Java API and MongoDB",
+    "description": "A blueprint for getting a React web app with a Java API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for running containerized apps or microservices on a serverless platform.",
+    "path": "todo-java-mongo-aca"
+  },
+  {
+    "name": "React Web App with Node.js API and MongoDB",
+    "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
+    "path": "todo-nodejs-mongo"
+  },
+  {
+    "name": "Containerized React Web App with Node.js API and MongoDB",
+    "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database onto Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for running containerized apps or microservices on a serverless platform. This architecture is for running containerized microservices without managing the servers.",
+    "path": "todo-nodejs-mongo-aca"
+  },
+  {
+    "name": "Static React Web App + Functions with Node.js API and MongoDB",
+    "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting static web apps with serverless logic and functionality.",
+    "path": "todo-nodejs-mongo-swa-func"
+  },
+  {
+    "name": "Kubernetes React Web App with Node.js API and MongoDB",
+    "description": "A blueprint for getting a React.js web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for running Kubernetes clusters without setting up the control plane.",
+    "path": "todo-nodejs-mongo-aks"
+  },
+  {
+    "name": "React Web App with Node.js API and MongoDB - Terraform",
+    "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Terraform) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
+    "path": "todo-nodejs-mongo-terraform"
+  },
+  {
+    "name": "React Web App with Python API and MongoDB",
+    "description": "A blueprint for getting a React.js web app with Python (FastAPI) API and a MongoDB API in Cosmos database onto Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
+    "path": "todo-python-mongo"
+  },
+  {
+    "name": "Containerized React Web App with Python API and MongoDB",
+    "description": "A blueprint for getting a React.js web app with Python (FastAPI) API and a MongoDB API in Cosmos database onto Azure. The frontend, currently a ToDo application, is designed as a placeholder that can easily be removed and replaced with your own frontend code. This architecture is for running containerized apps or microservices on a serverless platform.",
+    "path": "todo-python-mongo-aca"
+  },
+  {
+    "name": "Static React Web App + Functions with Python API and MongoDB",
+    "description": "A blueprint for getting a React.js web app with Python (FastAPI) API and a MongoDB API in Cosmos database onto Azure. The frontend, currently a ToDo application, is designed as a placeholder that can easily be removed and replaced with your own frontend code. This architecture is for hosting static web apps with serverless logic and functionality.",
+    "path": "todo-python-mongo-swa-func"
+  },
+  {
+    "name": "React Web App with Python API and MongoDB",
+    "description": "A blueprint for getting a React.js web app with Python (FastAPI) API and a MongoDB API in Cosmos database onto Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Terraform) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
+    "path": "todo-python-mongo-terraform"
+  }
 ]

--- a/cli/azd/resources/templates.json
+++ b/cli/azd/resources/templates.json
@@ -2,81 +2,81 @@
   {
     "name": "Starter - Bicep",
     "description": "A starter template with Bicep as infrastructure provider",
-    "path": "azd-starter-bicep"
+    "repositoryPath": "azd-starter-bicep"
   },
   {
     "name": "Starter - Terraform",
     "description": "A starter template with Terraform as infrastructure provider",
-    "path": "azd-starter-terraform"
+    "repositoryPath": "azd-starter-terraform"
   },
   {
     "name": "React Web App with C# API and MongoDB",
     "description": "A blueprint for getting a React web app with a C# API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly.",
-    "path": "todo-csharp-cosmos-sql"
+    "repositoryPath": "todo-csharp-cosmos-sql"
   },
   {
     "name": "React Web App with C# API and SQL Database",
     "description": "A blueprint for getting a React web app with a C# API and a SQL database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly.",
-    "path": "todo-csharp-sql"
+    "repositoryPath": "todo-csharp-sql"
   },
   {
     "name": "React Web App with Java API and MongoDB",
     "description": "A blueprint for getting a React.js web app with a Java API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
-    "path": "todo-java-mongo"
+    "repositoryPath": "todo-java-mongo"
   },
   {
     "name": "React Web App with Node.js API and MongoDB",
     "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
-    "path": "todo-nodejs-mongo"
+    "repositoryPath": "todo-nodejs-mongo"
   },
   {
     "name": "React Web App with Node.js API and MongoDB - Terraform",
     "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Terraform) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
-    "path": "todo-nodejs-mongo-terraform"
+    "repositoryPath": "todo-nodejs-mongo-terraform"
   },
   {
     "name": "React Web App with Python API and MongoDB",
     "description": "A blueprint for getting a React.js web app with Python (FastAPI) API and a MongoDB API in Cosmos database onto Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
-    "path": "todo-python-mongo"
+    "repositoryPath": "todo-python-mongo"
   },
   {
     "name": "React Web App with Python API and MongoDB - Terraform",
     "description": "A blueprint for getting a React.js web app with Python (FastAPI) API and a MongoDB API in Cosmos database onto Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Terraform) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
-    "path": "todo-python-mongo-terraform"
+    "repositoryPath": "todo-python-mongo-terraform"
   },
   {
     "name": "Containerized React Web App with Java API and MongoDB",
     "description": "A blueprint for getting a React web app with a Java API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for running containerized apps or microservices on a serverless platform.",
-    "path": "todo-java-mongo-aca"
+    "repositoryPath": "todo-java-mongo-aca"
   },
   {
     "name": "Containerized React Web App with Node.js API and MongoDB",
     "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database onto Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for running containerized apps or microservices on a serverless platform. This architecture is for running containerized microservices without managing the servers.",
-    "path": "todo-nodejs-mongo-aca"
+    "repositoryPath": "todo-nodejs-mongo-aca"
   },
   {
     "name": "Containerized React Web App with Python API and MongoDB",
     "description": "A blueprint for getting a React.js web app with Python (FastAPI) API and a MongoDB API in Cosmos database onto Azure. The frontend, currently a ToDo application, is designed as a placeholder that can easily be removed and replaced with your own frontend code. This architecture is for running containerized apps or microservices on a serverless platform.",
-    "path": "todo-python-mongo-aca"
+    "repositoryPath": "todo-python-mongo-aca"
   },
   {
     "name": "Static React Web App + Functions with C# API and SQL Database",
     "description": "A blueprint for getting a React web app with a C# API and a SQL database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting static web apps with serverless logic and functionality.",
-    "path": "todo-csharp-sql-swa-func"
+    "repositoryPath": "todo-csharp-sql-swa-func"
   },
   {
     "name": "Static React Web App + Functions with Node.js API and MongoDB",
     "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting static web apps with serverless logic and functionality.",
-    "path": "todo-nodejs-mongo-swa-func"
+    "repositoryPath": "todo-nodejs-mongo-swa-func"
   },
   {
     "name": "Static React Web App + Functions with Python API and MongoDB",
     "description": "A blueprint for getting a React.js web app with Python (FastAPI) API and a MongoDB API in Cosmos database onto Azure. The frontend, currently a ToDo application, is designed as a placeholder that can easily be removed and replaced with your own frontend code. This architecture is for hosting static web apps with serverless logic and functionality.",
-    "path": "todo-python-mongo-swa-func"
+    "repositoryPath": "todo-python-mongo-swa-func"
   },
   {
     "name": "Kubernetes React Web App with Node.js API and MongoDB",
     "description": "A blueprint for getting a React.js web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for running Kubernetes clusters without setting up the control plane.",
-    "path": "todo-nodejs-mongo-aks"
+    "repositoryPath": "todo-nodejs-mongo-aks"
   }  
 ]

--- a/cli/azd/resources/templates.json
+++ b/cli/azd/resources/templates.json
@@ -20,39 +20,14 @@
     "path": "todo-csharp-sql"
   },
   {
-    "name": "Static React Web App + Functions with C# API and SQL Database",
-    "description": "A blueprint for getting a React web app with a C# API and a SQL database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting static web apps with serverless logic and functionality.",
-    "path": "todo-csharp-sql-swa-func"
-  },
-  {
     "name": "React Web App with Java API and MongoDB",
     "description": "A blueprint for getting a React.js web app with a Java API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
     "path": "todo-java-mongo"
   },
   {
-    "name": "Containerized React Web App with Java API and MongoDB",
-    "description": "A blueprint for getting a React web app with a Java API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for running containerized apps or microservices on a serverless platform.",
-    "path": "todo-java-mongo-aca"
-  },
-  {
     "name": "React Web App with Node.js API and MongoDB",
     "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
     "path": "todo-nodejs-mongo"
-  },
-  {
-    "name": "Containerized React Web App with Node.js API and MongoDB",
-    "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database onto Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for running containerized apps or microservices on a serverless platform. This architecture is for running containerized microservices without managing the servers.",
-    "path": "todo-nodejs-mongo-aca"
-  },
-  {
-    "name": "Static React Web App + Functions with Node.js API and MongoDB",
-    "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting static web apps with serverless logic and functionality.",
-    "path": "todo-nodejs-mongo-swa-func"
-  },
-  {
-    "name": "Kubernetes React Web App with Node.js API and MongoDB",
-    "description": "A blueprint for getting a React.js web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for running Kubernetes clusters without setting up the control plane.",
-    "path": "todo-nodejs-mongo-aks"
   },
   {
     "name": "React Web App with Node.js API and MongoDB - Terraform",
@@ -65,9 +40,34 @@
     "path": "todo-python-mongo"
   },
   {
+    "name": "React Web App with Python API and MongoDB - Terraform",
+    "description": "A blueprint for getting a React.js web app with Python (FastAPI) API and a MongoDB API in Cosmos database onto Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Terraform) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
+    "path": "todo-python-mongo-terraform"
+  },
+  {
+    "name": "Containerized React Web App with Java API and MongoDB",
+    "description": "A blueprint for getting a React web app with a Java API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for running containerized apps or microservices on a serverless platform.",
+    "path": "todo-java-mongo-aca"
+  },
+  {
+    "name": "Containerized React Web App with Node.js API and MongoDB",
+    "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database onto Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for running containerized apps or microservices on a serverless platform. This architecture is for running containerized microservices without managing the servers.",
+    "path": "todo-nodejs-mongo-aca"
+  },
+  {
     "name": "Containerized React Web App with Python API and MongoDB",
     "description": "A blueprint for getting a React.js web app with Python (FastAPI) API and a MongoDB API in Cosmos database onto Azure. The frontend, currently a ToDo application, is designed as a placeholder that can easily be removed and replaced with your own frontend code. This architecture is for running containerized apps or microservices on a serverless platform.",
     "path": "todo-python-mongo-aca"
+  },
+  {
+    "name": "Static React Web App + Functions with C# API and SQL Database",
+    "description": "A blueprint for getting a React web app with a C# API and a SQL database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting static web apps with serverless logic and functionality.",
+    "path": "todo-csharp-sql-swa-func"
+  },
+  {
+    "name": "Static React Web App + Functions with Node.js API and MongoDB",
+    "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting static web apps with serverless logic and functionality.",
+    "path": "todo-nodejs-mongo-swa-func"
   },
   {
     "name": "Static React Web App + Functions with Python API and MongoDB",
@@ -75,8 +75,8 @@
     "path": "todo-python-mongo-swa-func"
   },
   {
-    "name": "React Web App with Python API and MongoDB",
-    "description": "A blueprint for getting a React.js web app with Python (FastAPI) API and a MongoDB API in Cosmos database onto Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Terraform) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
-    "path": "todo-python-mongo-terraform"
-  }
+    "name": "Kubernetes React Web App with Node.js API and MongoDB",
+    "description": "A blueprint for getting a React.js web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for running Kubernetes clusters without setting up the control plane.",
+    "path": "todo-nodejs-mongo-aks"
+  }  
 ]

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -62,7 +62,7 @@ func Test_CLI_Init_CreatesEnvAndProjectFile(t *testing.T) {
 
 	_, err := cli.RunCommandWithStdIn(
 		ctx,
-		"Empty Template\nTESTENV\n",
+		"Minimal\nTESTENV\n",
 		"init",
 	)
 	require.NoError(t, err)

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -241,7 +241,7 @@ func Test_CLI_Telemetry_NestedCommands(t *testing.T) {
 	// The current behavior is that `azd provision` will fail when trying to read the nonexistent bicep folder.
 	_, err := cli.RunCommandWithStdIn(
 		ctx,
-		// Choose the default empty template
+		// Choose the default minimal template
 		"\n"+stdinForInit(envName),
 		"init")
 	require.NoError(t, err)

--- a/ext/vscode/src/commands/cmdUtil.ts
+++ b/ext/vscode/src/commands/cmdUtil.ts
@@ -92,8 +92,8 @@ export async function selectApplicationTemplate(context: IActionContext): Promis
         .withArg('--output').withArg('json')
         .build();
     const result = await execAsync(command);
-    const templates = JSON.parse(result.stdout) as { name: string, description: string, path: string }[];
-    const choices = templates.map(t => { return { label: t.name, detail: t.description, data: t.path } as IAzureQuickPickItem<string>; });
+    const templates = JSON.parse(result.stdout) as { name: string, description: string, repositoryPath: string }[];
+    const choices = templates.map(t => { return { label: t.name, detail: t.description, data: t.repositoryPath } as IAzureQuickPickItem<string>; });
     choices.unshift({ label: vscode.l10n.t('Use another template...'), data: '', id: UseCustomTemplate });
 
     const template = await context.ui.showQuickPick(choices, {

--- a/ext/vscode/src/commands/cmdUtil.ts
+++ b/ext/vscode/src/commands/cmdUtil.ts
@@ -92,8 +92,8 @@ export async function selectApplicationTemplate(context: IActionContext): Promis
         .withArg('--output').withArg('json')
         .build();
     const result = await execAsync(command);
-    const templates = JSON.parse(result.stdout) as { name: string, description: string, repositoryPath: string }[];
-    const choices = templates.map(t => { return { label: t.name, detail: t.description, data: t.repositoryPath } as IAzureQuickPickItem<string>; });
+    const templates = JSON.parse(result.stdout) as { name: string, description: string, path: string }[];
+    const choices = templates.map(t => { return { label: t.name, detail: t.description, data: t.path } as IAzureQuickPickItem<string>; });
     choices.unshift({ label: vscode.l10n.t('Use another template...'), data: '', id: UseCustomTemplate });
 
     const template = await context.ui.showQuickPick(choices, {


### PR DESCRIPTION
`azd init` now displays friendly names for templates.

New:
![image (1)](https://user-images.githubusercontent.com/2322434/236344034-0abf4168-1039-4db3-92a2-05eb77f32706.png)

Old:
![image](https://user-images.githubusercontent.com/2322434/236344145-0a81baac-5e1c-482a-8703-5be6c35e962e.png)

With this change, the following template changes have also been made:

1. Rename 'Empty template' to 'Minimal'
2. Reshape internal template object based on #2075.
    - `DisplayName` (newly added field) has been dropped in favor of `Name`.
4. Templates are now listed based on sorting order in templates.json.

Fixes #2075, #2057 