### PR TITLE
breaking: Remove env variable overrides in `npm build`

### DIFF
--- a/cli/azd/pkg/project/framework_service_npm.go
+++ b/cli/azd/pkg/project/framework_service_npm.go
@@ -109,8 +109,6 @@ func (np *npmProject) Package(
 				return
 			}
 
-			// Exec custom `package` script if available
-			// If `package` script is not defined in the package.json the NPM script will NOT fail
 			task.SetProgress(NewServiceProgress("Running NPM package script"))
 
 			// Long term this script we call should better align with our inner-loop scenarios

--- a/cli/azd/pkg/project/framework_service_npm.go
+++ b/cli/azd/pkg/project/framework_service_npm.go
@@ -77,7 +77,7 @@ func (np *npmProject) Build(
 			// Exec custom `build` script if available
 			// If `build`` script is not defined in the package.json the NPM script will NOT fail
 			task.SetProgress(NewServiceProgress("Running NPM build script"))
-			if err := np.cli.RunScript(ctx, serviceConfig.Path(), "build", np.env.Environ()); err != nil {
+			if err := np.cli.RunScript(ctx, serviceConfig.Path(), "build"); err != nil {
 				task.SetError(err)
 				return
 			}
@@ -109,9 +109,6 @@ func (np *npmProject) Package(
 				return
 			}
 
-			// Run Build, injecting env.
-			envs := append(np.env.Environ(), "NODE_ENV=production")
-
 			// Exec custom `package` script if available
 			// If `package` script is not defined in the package.json the NPM script will NOT fail
 			task.SetProgress(NewServiceProgress("Running NPM package script"))
@@ -119,7 +116,7 @@ func (np *npmProject) Package(
 			// Long term this script we call should better align with our inner-loop scenarios
 			// Keeping this defaulted to `build` will create confusion for users when we start to support
 			// both local dev / debug builds and production bundled builds
-			if err := np.cli.RunScript(ctx, serviceConfig.Path(), "build", envs); err != nil {
+			if err := np.cli.RunScript(ctx, serviceConfig.Path(), "build"); err != nil {
 				task.SetError(err)
 				return
 			}

--- a/cli/azd/pkg/tools/npm/npm.go
+++ b/cli/azd/pkg/tools/npm/npm.go
@@ -15,7 +15,7 @@ import (
 type NpmCli interface {
 	tools.ExternalTool
 	Install(ctx context.Context, project string) error
-	RunScript(ctx context.Context, projectPath string, scriptName string, env []string) error
+	RunScript(ctx context.Context, projectPath string, scriptName string) error
 	Prune(ctx context.Context, projectPath string, production bool) error
 }
 
@@ -83,11 +83,10 @@ func (cli *npmCli) Install(ctx context.Context, project string) error {
 	return nil
 }
 
-func (cli *npmCli) RunScript(ctx context.Context, projectPath string, scriptName string, env []string) error {
+func (cli *npmCli) RunScript(ctx context.Context, projectPath string, scriptName string) error {
 	runArgs := exec.
 		NewRunArgs("npm", "run", scriptName, "--if-present").
-		WithCwd(projectPath).
-		WithEnv(env)
+		WithCwd(projectPath)
 
 	_, err := cli.commandRunner.Run(ctx, runArgs)
 

--- a/cli/azd/pkg/tools/npm/npm.go
+++ b/cli/azd/pkg/tools/npm/npm.go
@@ -15,6 +15,10 @@ import (
 type NpmCli interface {
 	tools.ExternalTool
 	Install(ctx context.Context, project string) error
+
+	// RunScript runs the given npm script (if it exists) in the project.
+	//
+	// Returns an error only if the script execution fails. If the script doesn't exist, no error is returned.
 	RunScript(ctx context.Context, projectPath string, scriptName string) error
 	Prune(ctx context.Context, projectPath string, production bool) error
 }


### PR DESCRIPTION
Note: This change only introduces compatibility issues with previous `staticwebapp` services that also took advantage of `.env` file variables being automatically available at `azd deploy` time.

Unlike other language implementations, our current `npm` implementation auto-injects environment variables when calling `npm run build` during `azd deploy`. This was done to expediently allow static-frontend files to easily perform environment variable [embedding](https://create-react-app.dev/docs/adding-custom-environment-variables/), that allows app configuration to be part of the html/js that runs in the client web browser. This may break static web apps, or apps using older template versions of `azd`. In newer versions of our static web apps, we explicitly perform configuration injection using a predeploy [hook](https://github.com/Azure-Samples/todo-python-mongo-swa-func/blob/01639dd7f42a59803b57525221c00ae84956b5a3/azure.yaml#L16).

There are multiple reasons why we would remove this:
1. `azd up` behavior is currently different than running `provision` than running `deploy`. This is a result of `deploy` being able to observe the `.env` file infrastructure outputs from `provision`. In the `up` flow, `package` happens before `provision`, and thus the `.env` file isn't yet available. This makes it hard to reason about why `azd` works in certain scenarios and not in others.
2. Injecting build environment variables should be a conscious user decision. Injecting silently makes it hard for the user to reason about why running `npm run build` differs from running `azd package`.

In this change, we also remove `NODE_ENV=production`. This is an unnecessary override that does not matter in practice.
1. For react-scripts (i.e. React apps created through `npx create-react-app`, `npm run build` by default ignores `NODE_ENV` and automatically sets this based on the react-script being ran. See the official docs [here](https://create-react-app.dev/docs/adding-custom-environment-variables/).
2. For Node.js backends, this is a runtime environment variable. Setting it at build time does not change the behavior of the running application.

In the future, we would perhaps need to reconsider how `azd up` works for static front-end (specifically `swa`) apps. However, this change is a step in the right direction (removing undefined-ness) as we slowly build the correct features based on user demand.