### PR TITLE
Ensure generated deployment name is not too long

### DIFF
--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazcli"
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -813,4 +814,29 @@ func TestResourceGroupsFromLatestDeployment(t *testing.T) {
 		sort.Strings(groups)
 		require.Equal(t, []string{"groupA", "groupB", "groupC"}, groups)
 	})
+}
+
+func TestDeploymentNameForEnv(t *testing.T) {
+	clock := clock.NewMock()
+	clock.Set(time.Unix(1683303710, 0))
+
+	tcs := []struct {
+		envName  string
+		expected string
+	}{
+		{
+			envName:  "simple-name",
+			expected: "simple-name-1683303710",
+		},
+		{
+			envName:  "azd-template-test-apim-todo-csharp-sql-swa-func-2750207-2",
+			expected: "template-test-apim-todo-csharp-sql-swa-func-2750207-2-1683303710",
+		},
+	}
+
+	for _, tc := range tcs {
+		deploymentName := deploymentNameForEnv(tc.envName, clock)
+		assert.Equal(t, tc.expected, deploymentName)
+		assert.LessOrEqual(t, len(deploymentName), 64)
+	}
 }


### PR DESCRIPTION
Since we started to append a timestamp to the deployment name we ran into an issue where it was possible to generate a deployment name that was longer than the ARM allowed limit.

With this change, we now truncate the generated name to length (taking the last 64 chracters of the string, on the assumption that the "interesting" parts of the environment name are near the end of when you have a very long name).

The deployment object is still tagged with the full environment name so that `azd env refresh` and others who want to query by full environment name can find it.