### PR TITLE
Fix template tests

### DIFF
--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
@@ -201,7 +201,6 @@ func TestTerraformState(t *testing.T) {
 func createTerraformProvider(mockContext *mocks.MockContext) *TerraformProvider {
 	projectDir := "../../../../test/functional/testdata/samples/resourcegroupterraform"
 	options := Options{
-		Path:   "infra",
 		Module: "main",
 	}
 

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
@@ -201,6 +201,7 @@ func TestTerraformState(t *testing.T) {
 func createTerraformProvider(mockContext *mocks.MockContext) *TerraformProvider {
 	projectDir := "../../../../test/functional/testdata/samples/resourcegroupterraform"
 	options := Options{
+		Path:   "infra",
 		Module: "main",
 	}
 

--- a/eng/pipelines/template-tests.yml
+++ b/eng/pipelines/template-tests.yml
@@ -15,7 +15,7 @@ parameters:
 
 - name: TemplateList
   displayName: |
-    Comma-delimited list of templates to test against (by default, results of azd template list). Example: 'Azure-Samples/todo-csharp-sql, Azure-Samples/todo-nodejs-mongo'
+    Comma-delimited list of templates to test against (by default, 'all' to run all). Example: 'Azure-Samples/todo-csharp-sql, Azure-Samples/todo-nodejs-mongo'
   type: string
   default: 'all'
 

--- a/eng/pipelines/template-tests.yml
+++ b/eng/pipelines/template-tests.yml
@@ -35,7 +35,7 @@ parameters:
     Comma-delimited list of environment variables in the format of (KEY=VALUE) to set for the template test run.
     Example: USE_APIM=true,ENV_SUFFIX=MYSUFFIX
   type: string
-  default: ''
+  default: ' '
 
 - name: AzureLocation
   displayName: Azure location for templates to be deployed to

--- a/eng/pipelines/template-tests.yml
+++ b/eng/pipelines/template-tests.yml
@@ -17,7 +17,7 @@ parameters:
   displayName: |
     Comma-delimited list of templates to test against (by default, results of azd template list). Example: 'Azure-Samples/todo-csharp-sql, Azure-Samples/todo-nodejs-mongo'
   type: string
-  default: '(azd template list)'
+  default: 'all'
 
 - name: TemplateListFilter
   displayName: | 

--- a/eng/pipelines/templates/jobs/run-template-tests.yml
+++ b/eng/pipelines/templates/jobs/run-template-tests.yml
@@ -9,7 +9,7 @@ parameters:
 
 - name: TemplateList
   displayName: |
-    Comma-delimited list of templates to test against (by default, results of azd template list). Example: 'Azure-Samples/todo-csharp-sql, Azure-Samples/todo-nodejs-mongo'
+    Comma-delimited list of templates to test against (by default, 'all' to run all). Example: 'Azure-Samples/todo-csharp-sql, Azure-Samples/todo-nodejs-mongo'
   type: string
   default: 'all'
 

--- a/eng/pipelines/templates/jobs/run-template-tests.yml
+++ b/eng/pipelines/templates/jobs/run-template-tests.yml
@@ -11,7 +11,7 @@ parameters:
   displayName: |
     Comma-delimited list of templates to test against (by default, results of azd template list). Example: 'Azure-Samples/todo-csharp-sql, Azure-Samples/todo-nodejs-mongo'
   type: string
-  default: '(azd template list)'
+  default: 'all'
 
 - name: TemplateListFilter
   displayName: | 

--- a/eng/pipelines/templates/steps/template-test-generate-jobs.yml
+++ b/eng/pipelines/templates/steps/template-test-generate-jobs.yml
@@ -3,7 +3,7 @@ parameters:
   displayName: |
     Comma-delimited list of templates to test against (by default, results of azd template list). Example: 'Azure-Samples/todo-csharp-sql, Azure-Samples/todo-nodejs-mongo'
   type: string
-  default: '(azd template list)'
+  default: 'all'
 
 - name: TemplateListFilter
   displayName: | 

--- a/eng/pipelines/templates/steps/template-test-generate-jobs.yml
+++ b/eng/pipelines/templates/steps/template-test-generate-jobs.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: TemplateList
   displayName: |
-    Comma-delimited list of templates to test against (by default, results of azd template list). Example: 'Azure-Samples/todo-csharp-sql, Azure-Samples/todo-nodejs-mongo'
+    Comma-delimited list of templates to test against (by default, 'all' to run all). Example: 'Azure-Samples/todo-csharp-sql, Azure-Samples/todo-nodejs-mongo'
   type: string
   default: 'all'
 

--- a/eng/pipelines/templates/steps/template-test-run-job.yml
+++ b/eng/pipelines/templates/steps/template-test-run-job.yml
@@ -22,8 +22,14 @@ steps:
     - template: /eng/pipelines/templates/steps/set-git-credentials.yml
 
     - pwsh: |
-          # Remove 'Azure-Samples/'
-          $templateName = '$(TemplateName)'.Substring(14)
+          # Get the name without any path
+          $template = '$(TemplateName)'
+          $lastSlash = $template.LastIndexOf('/')
+          if ($lastSlash -ne -1) {
+            $templateName = $template.Substring($lastSlash + 1)
+          } else {
+            $templateName = $template
+          }
           $scenario = "$env:TEST_SCENARIO"
           $envPrefixName = "azd-template-test"
           if($scenario -ne '') {

--- a/eng/scripts/Set-TemplateTestMatrixVariable.ps1
+++ b/eng/scripts/Set-TemplateTestMatrixVariable.ps1
@@ -78,7 +78,7 @@ $templateNames = @()
 if ($TemplateList -eq '(azd template list)') {
     Write-Host "Using results of (azd template list --output json)"
     
-    $templateNames += (azd template list --output json | ConvertFrom-Json).RepositoryPath
+    $templateNames += (azd template list --output json | ConvertFrom-Json).repositoryPath
     if ($LASTEXITCODE -ne 0) {
         Write-Error "azd template list failed"
         exit 1

--- a/eng/scripts/Set-TemplateTestMatrixVariable.ps1
+++ b/eng/scripts/Set-TemplateTestMatrixVariable.ps1
@@ -78,7 +78,7 @@ $templateNames = @()
 if ($TemplateList -eq '(azd template list)') {
     Write-Host "Using results of (azd template list --output json)"
     
-    $templateNames += (azd template list --output json | ConvertFrom-Json).name
+    $templateNames += (azd template list --output json | ConvertFrom-Json).RepositoryPath
     if ($LASTEXITCODE -ne 0) {
         Write-Error "azd template list failed"
         exit 1

--- a/eng/scripts/Set-TemplateTestMatrixVariable.ps1
+++ b/eng/scripts/Set-TemplateTestMatrixVariable.ps1
@@ -91,12 +91,11 @@ if ($TemplateList -eq 'all') {
         exit 1
     }
 
-    $templateNames += $officialTemplates
-
     # Other templates outside of `azd template list` can be added here.
     # To add a template, add the repository path {owner}/{repo} to the list below.
     $otherTemplates = @()
 
+    $templateNames += $officialTemplates
     $templateNames += $otherTemplates
 } else {
     Write-Host "Using provided TemplateList value: $TemplateList"

--- a/eng/scripts/Set-TemplateTestMatrixVariable.ps1
+++ b/eng/scripts/Set-TemplateTestMatrixVariable.ps1
@@ -3,7 +3,7 @@
 Generates a matrix of template test jobs.
 
 .PARAMETER TemplateList
-List of templates to run. By default, uses `azd template list` to run all templates.
+List of templates to run. By default, uses `all` to run all templates.
 
 .PARAMETER TemplateListFilter
 Regex filter expression to filter templates. Examples: 'csharp', 'terraform', 'python-mongo'.
@@ -22,7 +22,7 @@ The matrix job definition will contain:
 #>
 param (
     # This is a string and not a string[] to avoid issues with parameter passing in CI yaml.
-    [string]$TemplateList = '(azd template list)',
+    [string]$TemplateList = 'all',
     [string]$TemplateListFilter = '.*',
     [string]$OutputMatrixVariable = 'Matrix',
     [string]$JobVariablesDefinition = ''
@@ -71,18 +71,33 @@ function Copy-RandomJob([System.Collections.Hashtable]$JobMatrix) {
     return $copyJob
 }
 
+$JobVariablesDefinition = $JobVariablesDefinition.Trim()
 $jobVariables = Get-JobVariables -JobVariablesDefinition $JobVariablesDefinition
 
 $templateNames = @()
 
-if ($TemplateList -eq '(azd template list)') {
-    Write-Host "Using results of (azd template list --output json)"
+if ($TemplateList -eq 'all') {
+    Write-Host "Running all templates "
     
-    $templateNames += (azd template list --output json | ConvertFrom-Json).repositoryPath
+    $officialTemplates = (azd template list --output json | ConvertFrom-Json).repositoryPath | ForEach-Object {
+        if (!$_.StartsWith("Azure-Samples/")) {
+            "Azure-Samples/" + $_
+        } else {
+            $_
+        }
+    }
     if ($LASTEXITCODE -ne 0) {
         Write-Error "azd template list failed"
         exit 1
     }
+
+    $templateNames += $officialTemplates
+
+    # Other templates outside of `azd template list` can be added here.
+    # To add a template, add the repository path {owner}/{repo} to the list below.
+    $otherTemplates = @()
+
+    $templateNames += $otherTemplates
 } else {
     Write-Host "Using provided TemplateList value: $TemplateList"
 

--- a/templates/tests/test-templates.sh
+++ b/templates/tests/test-templates.sh
@@ -110,16 +110,16 @@ function deployTemplate {
 # $2 - The branch name
 # $3 - The environment name
 function testTemplate {
-    if [[ "$1" == "azd-starter"* || "$1" == "Azure-Samples/azd-starter"* ]]; then
-        echo "Skipped smoke tests for azd-starter templates"
-        return
-    fi
-
     echo "Running template smoke tests for $3..."
     if [ $DEVCONTAINER == false ]; then
         cd "$FOLDER_PATH/$3/tests"
     else
         cd "tests"
+    fi
+
+    if [[ "$1" == "azd-starter"* || "$1" == "Azure-Samples/azd-starter"* ]]; then
+        echo "Skipped smoke tests for azd-starter templates"
+        return
     fi
 
     npm i && npx playwright install

--- a/templates/tests/test-templates.sh
+++ b/templates/tests/test-templates.sh
@@ -110,7 +110,7 @@ function deployTemplate {
 # $2 - The branch name
 # $3 - The environment name
 function testTemplate {
-    if [[ "$1" == "Azure-Samples/azd-starter"* ]]; then
+    if [[ "$1" == "azd-starter"* || "$1" == "Azure-Samples/azd-starter"* ]]; then
         echo "Skipped smoke tests for azd-starter templates"
         return
     fi
@@ -154,7 +154,7 @@ if [[ -z $TEMPLATE_NAME ]]; then
     while read -r TEMPLATE; do
         ENV_NAME="${ENV_NAME_PREFIX}-${TEMPLATE:14}-$ENV_SUFFIX"
         ENV_TEMPLATE_MAP[$TEMPLATE]=$ENV_NAME
-    done < <(echo "$TEMPLATES_JSON" | jq -r '.[].name' | sed 's/\\n/\n/g')
+    done < <(echo "$TEMPLATES_JSON" | jq -r '.[].repositoryPath' | sed 's/\\n/\n/g')
 
     if [ $TEST_ONLY == false ]; then
         # Deploy the templates in parallel

--- a/templates/tests/test-templates.sh
+++ b/templates/tests/test-templates.sh
@@ -121,6 +121,7 @@ function testTemplate {
     else
         cd "tests"
     fi
+
     npm i && npx playwright install
     npx -y playwright test --retries="$PLAYWRIGHT_RETRIES" --reporter="$PLAYWRIGHT_REPORTER"
 }


### PR DESCRIPTION
Template tests currently use template.Name instead of template.RepositoryPath to construct the reference to the template. This used to work fine since they were both always set to the same values, until #2093. This change fixes the incorrect logic in the test setup scripts.