### PR TITLE
Fix maven test failing when not installed

### DIFF
--- a/cli/azd/pkg/tools/maven/maven_test.go
+++ b/cli/azd/pkg/tools/maven/maven_test.go
@@ -122,6 +122,7 @@ func Test_extractVersion(t *testing.T) {
 		})
 
 	mvn := NewMavenCli(execMock).(*mavenCli)
+	placeExecutable(t, mvnwWithExt(), mvn.projectPath)
 	ver, err := mvn.extractVersion(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "3.9.1", ver)


### PR DESCRIPTION
Test_extractVersion was failing on my machine due to `mvn` not being installed. Add a mock for `mvnw` so that the test is happy.