### PR TITLE
Bump `@microsoft/vscode-azext-utils` dependency

### DIFF
--- a/ext/vscode/package-lock.json
+++ b/ext/vscode/package-lock.json
@@ -28,7 +28,6 @@
                 "@vscode/test-electron": "~2.3",
                 "@vscode/vsce": "~2",
                 "chai": "~4.3",
-                "copy-webpack-plugin": "~11.0",
                 "eslint": "~8.23",
                 "glob": "~8.0",
                 "mocha": "~9.2",
@@ -974,45 +973,6 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/ajv-formats": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-            "dev": true,
-            "dependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "ajv": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/ajv-formats/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dev": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
-        },
         "node_modules/ajv-keywords": {
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -1538,61 +1498,6 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true
-        },
-        "node_modules/copy-webpack-plugin": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
-            "integrity": "sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==",
-            "dev": true,
-            "dependencies": {
-                "fast-glob": "^3.2.11",
-                "glob-parent": "^6.0.1",
-                "globby": "^13.1.1",
-                "normalize-path": "^3.0.0",
-                "schema-utils": "^4.0.0",
-                "serialize-javascript": "^6.0.0"
-            },
-            "engines": {
-                "node": ">= 14.15.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^5.1.0"
-            }
-        },
-        "node_modules/copy-webpack-plugin/node_modules/globby": {
-            "version": "13.1.4",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
-            "integrity": "sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==",
-            "dev": true,
-            "dependencies": {
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.11",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/copy-webpack-plugin/node_modules/slash": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-            "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",
@@ -4309,15 +4214,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/require-from-string": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/resolve": {
             "version": "1.22.2",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
@@ -4459,59 +4355,6 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-            "dev": true
-        },
-        "node_modules/schema-utils": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.1.tgz",
-            "integrity": "sha512-lELhBAAly9NowEsX0yZBlw9ahZG+sK/1RJ21EpzdYHKEs13Vku3LJ+MIPhh4sMs0oCCeufZQEQbMekiA4vuVIQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "ajv": "^8.9.0",
-                "ajv-formats": "^2.1.1",
-                "ajv-keywords": "^5.1.0"
-            },
-            "engines": {
-                "node": ">= 12.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
-        "node_modules/schema-utils/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dev": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/schema-utils/node_modules/ajv-keywords": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-            "dev": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3"
-            },
-            "peerDependencies": {
-                "ajv": "^8.8.2"
-            }
-        },
-        "node_modules/schema-utils/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true
         },
         "node_modules/selderee": {

--- a/ext/vscode/package-lock.json
+++ b/ext/vscode/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.6.0-alpha.1",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/vscode-azext-utils": "~0.4",
+                "@microsoft/vscode-azext-utils": "~1",
                 "@microsoft/vscode-azureresources-api": "~2",
                 "dayjs": "~1.11",
                 "dotenv": "~16.0",
@@ -42,6 +42,12 @@
             "engines": {
                 "vscode": "^1.76.0"
             }
+        },
+        "node_modules/@azure/ms-rest-azure-env": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz",
+            "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==",
+            "peer": true
         },
         "node_modules/@discoveryjs/json-ext": {
             "version": "0.5.7",
@@ -243,19 +249,22 @@
             "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "0.4.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.4.6.tgz",
-            "integrity": "sha512-CPIIvdod95Qdz5vdGg4j7HpryjKEsDVmdir/VduJZHgdVs1iuqa/9UY0+kIg2JnsnpThAdQH36A1GVA8jQeheg==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-1.2.2.tgz",
+            "integrity": "sha512-mOTcJF8IMsz+Xn8QTUP1AC3K5tPl/3f17L2xGTTtLeV/HJ2sTh/3712NFuN58tnOwdISdazId4tHwaqUta8HEA==",
             "dependencies": {
-                "@microsoft/vscode-azureresources-api": "^2.0.2",
+                "@microsoft/vscode-azureresources-api": "^2.0.4",
                 "@vscode/extension-telemetry": "^0.6.2",
                 "dayjs": "^1.11.2",
                 "escape-string-regexp": "^2.0.0",
                 "html-to-text": "^8.2.0",
-                "open": "^8.0.4",
                 "semver": "^7.3.7",
-                "vscode-nls": "^5.0.1",
-                "vscode-tas-client": "^0.1.47"
+                "uuid": "^9.0.0",
+                "vscode-tas-client": "^0.1.47",
+                "vscode-uri": "^3.0.6"
+            },
+            "peerDependencies": {
+                "@azure/ms-rest-azure-env": "^2.0.0"
             }
         },
         "node_modules/@microsoft/vscode-azureresources-api": {
@@ -1719,14 +1728,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/define-lazy-prop": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/detect-libc": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
@@ -2926,20 +2927,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3010,17 +2997,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dependencies": {
-                "is-docker": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/isarray": {
@@ -3833,22 +3809,6 @@
             "dev": true,
             "dependencies": {
                 "wrappy": "1"
-            }
-        },
-        "node_modules/open": {
-            "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-            "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
-            "dependencies": {
-                "define-lazy-prop": "^2.0.0",
-                "is-docker": "^2.1.1",
-                "is-wsl": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/opener": {
@@ -5235,10 +5195,13 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
         },
-        "node_modules/vscode-nls": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
-            "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="
+        "node_modules/uuid": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+            "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
         },
         "node_modules/vscode-tas-client": {
             "version": "0.1.63",
@@ -5250,6 +5213,11 @@
             "engines": {
                 "vscode": "^1.19.1"
             }
+        },
+        "node_modules/vscode-uri": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
+            "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
         },
         "node_modules/watchpack": {
             "version": "2.4.0",

--- a/ext/vscode/package.json
+++ b/ext/vscode/package.json
@@ -488,7 +488,6 @@
         "@vscode/test-electron": "~2.3",
         "@vscode/vsce": "~2",
         "chai": "~4.3",
-        "copy-webpack-plugin": "~11.0",
         "eslint": "~8.23",
         "glob": "~8.0",
         "mocha": "~9.2",

--- a/ext/vscode/package.json
+++ b/ext/vscode/package.json
@@ -500,7 +500,7 @@
         "webpack-cli": "~4.10"
     },
     "dependencies": {
-        "@microsoft/vscode-azext-utils": "~0.4",
+        "@microsoft/vscode-azext-utils": "~1",
         "@microsoft/vscode-azureresources-api": "~2",
         "dayjs": "~1.11",
         "dotenv": "~16.0",

--- a/ext/vscode/webpack.config.js
+++ b/ext/vscode/webpack.config.js
@@ -12,7 +12,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 const fs = require('fs/promises');
-const CopyPlugin = require('copy-webpack-plugin');
+// const CopyPlugin = require('copy-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 /* eslint-enable @typescript-eslint/no-var-requires */
@@ -60,12 +60,12 @@ const config = {
         ]
     },
     plugins: [
-        // Copy some needed resource files from external sources
-        new CopyPlugin({
-            patterns: [
-                './node_modules/open/xdg-open*', // This script isn't included in the webpack but is needed by `open` on certain systems, so copy it in
-            ],
-        }),
+        // // Copy some needed resource files from external sources
+        // new CopyPlugin({
+        //     patterns: [
+        //         
+        //     ],
+        // }),
         {
             // Webpack does not preserve the execute permission on the above xdg-open script, so apply it again within the bundle
             apply: (compiler) => {

--- a/ext/vscode/webpack.config.js
+++ b/ext/vscode/webpack.config.js
@@ -66,14 +66,6 @@ const config = {
         //         
         //     ],
         // }),
-        {
-            // Webpack does not preserve the execute permission on the above xdg-open script, so apply it again within the bundle
-            apply: (compiler) => {
-                compiler.hooks.afterEmit.tapPromise('AzCodeCopyWorkaround', async () => {
-                    await fs.chmod('./dist/node_modules/open/xdg-open', '755');
-                });
-            },
-        },
     ],
     optimization: {
         minimizer: [

--- a/ext/vscode/webpack.config.js
+++ b/ext/vscode/webpack.config.js
@@ -11,8 +11,6 @@
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
-const fs = require('fs/promises');
-// const CopyPlugin = require('copy-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 /* eslint-enable @typescript-eslint/no-var-requires */
@@ -60,12 +58,6 @@ const config = {
         ]
     },
     plugins: [
-        // // Copy some needed resource files from external sources
-        // new CopyPlugin({
-        //     patterns: [
-        //         
-        //     ],
-        // }),
     ],
     optimization: {
         minimizer: [


### PR DESCRIPTION
This version contains, among other things, the changeover to VSCode's native localization API, which means we can remove `vscode-nls`.

Also, the issue with `open` is fixed, so the copy of `xdg-open` can be removed.