### PR TITLE
Add YAML validation contribution point

### DIFF
--- a/ext/vscode/.vscode/settings.json
+++ b/ext/vscode/.vscode/settings.json
@@ -9,5 +9,7 @@
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
     "typescript.tsc.autoDetect": "off",
     // Help the cSpell extension find our configuration files (it doesn't import .yaml by default)
-    "cSpell.import": ["./.vscode/cspell.yaml"]
+    "cSpell.import": ["./.vscode/cspell.yaml"],
+    // Block committing directly to main branch
+    "git.branchProtection": ["main"],
 }

--- a/ext/vscode/package.json
+++ b/ext/vscode/package.json
@@ -461,6 +461,12 @@
                     }
                 ]
             }
+        ],
+        "yamlValidation": [
+            {
+                "fileMatch": "azure.yaml",
+                "url": "https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json"
+            }
         ]
     },
     "scripts": {


### PR DESCRIPTION
RedHat's [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) has a way to specify a [contribution point](https://github.com/redhat-developer/vscode-yaml#mapping-a-schema-in-an-extension) that will map certain file name patterns to a given schema. The comment (e.g. [this](https://github.com/Azure/azure-dev/blob/2cfcc6d7de1c052856e9cd5898bf4dae67d7b4f6/templates/todo/projects/csharp-sql/.repo/bicep/azure.yaml#L1))at the top of our `azure.yaml` files does this already, but for user-provided or user-modified `azure.yaml` files where that comment is gone, this adds an extra layer of association between `azure.yaml` and its schema.

