### PR TITLE
Fix initializing minimal template overwriting files

### DIFF
--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -365,7 +365,7 @@ func (i *Initializer) writeFileSafe(
 			&ux.WarningMessage{
 				Description: fmt.Sprintf("A file already exists at %s, writing to %s instead", path, renamed),
 			})
-		return os.WriteFile(path, content, perm)
+		return os.WriteFile(renamed, content, perm)
 	}
 
 	// If both files exist, do nothing. We don't want to accidentally overwrite a user's file.


### PR DESCRIPTION
A previous change (`2cfcc6d7de1`) introduced the infra folder for the minimal template. Care was taken to avoid overwriting existing user files. However, the implementation had a bug that actually resulted in the file being overwritten. This change fixes the issue and adds appropriate test coverage.