### PR TITLE
Fix test-templates for starters

### DIFF
--- a/templates/tests/test-templates.sh
+++ b/templates/tests/test-templates.sh
@@ -110,6 +110,11 @@ function deployTemplate {
 # $2 - The branch name
 # $3 - The environment name
 function testTemplate {
+    if [[ "$1" == "azd-starter"* || "$1" == "Azure-Samples/azd-starter"* ]]; then
+        echo "Skipped smoke tests for azd-starter templates"
+        return
+    fi
+
     echo "Running template smoke tests for $3..."
     if [ $DEVCONTAINER == false ]; then
         cd "$FOLDER_PATH/$3/tests"
@@ -117,13 +122,14 @@ function testTemplate {
         cd "tests"
     fi
 
-    if [[ "$1" == "azd-starter"* || "$1" == "Azure-Samples/azd-starter"* ]]; then
-        echo "Skipped smoke tests for azd-starter templates"
-        return
-    fi
-
     npm i && npx playwright install
     npx -y playwright test --retries="$PLAYWRIGHT_RETRIES" --reporter="$PLAYWRIGHT_REPORTER"
+
+    if [ $DEVCONTAINER == false ]; then
+        cd "$FOLDER_PATH/$3"
+    else
+        cd ".."
+    fi
 }
 
 # Cleans the specified template
@@ -132,11 +138,6 @@ function testTemplate {
 # $3 - The environment name
 function cleanupTemplate {
     echo "Deprovisioning infrastructure for $3..."
-    if [ $DEVCONTAINER == false ]; then
-        cd "$FOLDER_PATH/$3"
-    else
-        cd ..
-    fi
     azd down -e "$3" --force --purge
 
     echo "Cleaning up local project @ '$FOLDER_PATH/$3'..."


### PR DESCRIPTION
Fix starters failing in template-tests.sh due to choosing the wrong working directory. Slightly improves the working directory changes to be isolated within a given function to avoid context-sensitivity.