### PR TITLE
Provide a sugesstion for an environment name during `init`

### DIFF
--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
@@ -171,10 +172,16 @@ func (i *initAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		return nil, environment.NewEnvironmentInitError(envName)
 	}
 
+	suggest := environment.CleanName(filepath.Base(wd) + "-main")
+	if len(suggest) > environment.EnvironmentNameMaxLength {
+		suggest = suggest[len(suggest)-environment.EnvironmentNameMaxLength:]
+	}
+
 	envSpec := environmentSpec{
 		environmentName: i.flags.environmentName,
 		subscription:    i.flags.subscription,
 		location:        i.flags.location,
+		suggest:         suggest,
 	}
 
 	env, err := createEnvironment(ctx, envSpec, azdCtx, i.console)

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -172,7 +172,7 @@ func (i *initAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		return nil, environment.NewEnvironmentInitError(envName)
 	}
 
-	suggest := environment.CleanName(filepath.Base(wd) + "-main")
+	suggest := environment.CleanName(filepath.Base(wd) + "-dev")
 	if len(suggest) > environment.EnvironmentNameMaxLength {
 		suggest = suggest[len(suggest)-environment.EnvironmentNameMaxLength:]
 	}

--- a/cli/azd/cmd/util_test.go
+++ b/cli/azd/cmd/util_test.go
@@ -23,7 +23,7 @@ func Test_promptEnvironmentName(t *testing.T) {
 
 		environmentName := "hello"
 
-		err := ensureValidEnvironmentName(*mockContext.Context, &environmentName, mockContext.Console)
+		err := ensureValidEnvironmentName(*mockContext.Context, &environmentName, "", mockContext.Console)
 
 		require.NoError(t, err)
 	})
@@ -36,7 +36,7 @@ func Test_promptEnvironmentName(t *testing.T) {
 			return true
 		}).Respond("someEnv")
 
-		err := ensureValidEnvironmentName(*mockContext.Context, &environmentName, mockContext.Console)
+		err := ensureValidEnvironmentName(*mockContext.Context, &environmentName, "", mockContext.Console)
 
 		require.NoError(t, err)
 		require.Equal(t, "someEnv", environmentName)

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -61,10 +61,36 @@ type EnvironmentResolver func() (*Environment, error)
 
 // Same restrictions as a deployment name (ref:
 // https://docs.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftresources)
-var environmentNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9-\(\)_\.]{1,64}$`)
+var EnvironmentNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9-\(\)_\.]{1,64}$`)
+
+// The maximum length of an environment name.
+var EnvironmentNameMaxLength = 64
 
 func IsValidEnvironmentName(name string) bool {
-	return environmentNameRegexp.MatchString(name)
+	return EnvironmentNameRegexp.MatchString(name)
+}
+
+// CleanName returns a version of [name] where all characters not allowed in an environment name have been replaced
+// with hyphens
+func CleanName(name string) string {
+	result := strings.Builder{}
+
+	for _, c := range name {
+		if (c >= 'a' && c <= 'z') ||
+			(c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') ||
+			c == '-' ||
+			c == '(' ||
+			c == ')' ||
+			c == '_' ||
+			c == '.' {
+			result.WriteRune(c)
+		} else {
+			result.WriteRune('-')
+		}
+	}
+
+	return result.String()
 }
 
 // FromRoot loads an environment located in a directory. On error,

--- a/cli/azd/pkg/environment/environment_test.go
+++ b/cli/azd/pkg/environment/environment_test.go
@@ -149,3 +149,8 @@ func Test_SaveAndReload(t *testing.T) {
 	require.Equal(t, "SUBSCRIPTION_ID", env.GetSubscriptionId())
 	require.Equal(t, "eastus2", env.GetLocation())
 }
+
+func TestCleanName(t *testing.T) {
+	require.Equal(t, "already-clean-name", CleanName("already-clean-name"))
+	require.Equal(t, "was-CLEANED-with--bad--things-(123)", CleanName("was CLEANED with *bad* things (123)"))
+}


### PR DESCRIPTION
This change provides a suggessting for the initial environment name that the user needs to create during `azd init`.  The suggestion is based on the name of the current directory, suffixed with `-main`.

In addition, some help text is added to help give users some idea as to what this value is used for.

I had hoped that we would be able to default this value to something like `main` and simply not ask the question to the user, but that is more difficult than expected, given how `azd` is used today. Most existing `azd` templates assume that `AZURE_ENV_NAME` is going to be used in a way that forces it to be unique across the user's subscription (since it is used to both create the name of the resource group we provision resources into and used to generate the resource suffix that we append to most resources to get unique names)

In addition, even when starting from scratch, our system wants you to tag your resource groups and resources with an `azd-env-name` tag so that other parts of `azd` can discover these resources. So even if we hid the concept during `init`, you'd have to learn about an azd environment as soon as you start interacting with your IaC.

Given that, the best we can do to ease the pain for folks getting started is to provide a reasonable default, and using the name of the current directory (suffixed with something like `-main` since there can be multiple environments per project) feels reasonable.

Fixes #335