### PR TITLE
Enable debug logging for command runner

### DIFF
--- a/cli/azd/cmd/cobra_builder.go
+++ b/cli/azd/cmd/cobra_builder.go
@@ -188,7 +188,6 @@ func (cb *CobraBuilder) bindCommand(cmd *cobra.Command, descriptor *actions.Acti
 
 	// Create, register and bind flags when required
 	if descriptor.Options.FlagsResolver != nil {
-		log.Printf("registering flags for action '%s'\n", actionName)
 		ioc.RegisterInstance(cb.container, cmd)
 
 		// The flags resolver is constructed and bound to the cobra command via dependency injection
@@ -208,7 +207,6 @@ func (cb *CobraBuilder) bindCommand(cmd *cobra.Command, descriptor *actions.Acti
 	// These functions are typically the constructor function for the action. ex) newDeployAction(...)
 	// Action resolvers can take any number of dependencies and instantiated via the IoC container
 	if descriptor.Options.ActionResolver != nil {
-		log.Printf("registering resolver for action '%s'\n", actionName)
 		if err := cb.container.RegisterNamedSingleton(actionName, descriptor.Options.ActionResolver); err != nil {
 			return fmt.Errorf(
 				//nolint:lll

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -111,12 +111,14 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		}, formatter)
 	})
 
-	container.RegisterSingleton(func(console input.Console) exec.CommandRunner {
+	container.RegisterSingleton(func(console input.Console, rootOptions *internal.GlobalCommandOptions) exec.CommandRunner {
 		return exec.NewCommandRunner(
-			console.Handles().Stdin,
-			console.Handles().Stdout,
-			console.Handles().Stderr,
-		)
+			&exec.RunnerOptions{
+				Stdin:        console.Handles().Stdin,
+				Stdout:       console.Handles().Stdout,
+				Stderr:       console.Handles().Stderr,
+				DebugLogging: rootOptions.EnableDebugLogging,
+			})
 	})
 	container.RegisterSingleton(input.NewConsoleMessaging)
 

--- a/cli/azd/internal/repository/initializer_test.go
+++ b/cli/azd/internal/repository/initializer_test.go
@@ -41,7 +41,7 @@ func Test_Initializer_Initialize(t *testing.T) {
 			ctx := context.Background()
 			azdCtx := azdcontext.NewAzdContextWithDirectory(projectDir)
 			console := mockinput.NewMockConsole()
-			realRunner := exec.NewCommandRunner(os.Stdin, os.Stdout, os.Stderr)
+			realRunner := exec.NewCommandRunner(nil)
 			mockRunner := mockexec.NewMockCommandRunner()
 			mockRunner.When(func(args exec.RunArgs, command string) bool { return true }).
 				RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
@@ -128,7 +128,7 @@ func Test_Initializer_InitializeWithOverwritePrompt(t *testing.T) {
 				return strings.Contains(options.Message, "What would you like to do with these files?")
 			}).Respond(tt.selection)
 
-			realRunner := exec.NewCommandRunner(os.Stdin, os.Stdout, os.Stderr)
+			realRunner := exec.NewCommandRunner(nil)
 			mockRunner := mockexec.NewMockCommandRunner()
 			mockRunner.When(func(args exec.RunArgs, command string) bool { return true }).
 				RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
@@ -341,7 +341,7 @@ func Test_Initializer_WriteCoreAssets(t *testing.T) {
 			}
 
 			console := mockinput.NewMockConsole()
-			realRunner := exec.NewCommandRunner(os.Stdin, os.Stdout, os.Stderr)
+			realRunner := exec.NewCommandRunner(nil)
 			i := NewInitializer(console, git.NewGitCli(realRunner))
 			err := i.writeCoreAssets(context.Background(), azdCtx)
 			require.NoError(t, err)

--- a/cli/azd/pkg/exec/command_runner.go
+++ b/cli/azd/pkg/exec/command_runner.go
@@ -169,7 +169,7 @@ func (r *commandRunner) Run(ctx context.Context, args RunArgs) (RunResult, error
 	} else {
 		if debugLogEnabled {
 			log.Printf(
-				"Exit Code:%d\nOut:%s\nErr:%s\n",
+				"exit code: %d, stdout: %s, stderr: %s",
 				cmd.ProcessState.ExitCode(),
 				redactSensitiveData(stdout.String()),
 				redactSensitiveData(stderr.String()))

--- a/cli/azd/pkg/exec/runargs.go
+++ b/cli/azd/pkg/exec/runargs.go
@@ -18,8 +18,8 @@ type RunArgs struct {
 	// NOTE: RunResult.Stderr will still contain stderr output.
 	Stderr io.Writer
 
-	// Debug will `log.Printf` the command and it's results after it completes.
-	Debug bool
+	// Enables debug logging.
+	DebugLogging *bool
 
 	// EnrichError will include any command output if there is a failure
 	// and output is available.
@@ -92,8 +92,8 @@ func (b RunArgs) WithEnrichError(enrichError bool) RunArgs {
 }
 
 // Updates whether or not debug output will be written to default logger
-func (b RunArgs) WithDebug(debug bool) RunArgs {
-	b.Debug = debug
+func (b RunArgs) WithDebugLogging(debug bool) RunArgs {
+	b.DebugLogging = &debug
 	return b
 }
 

--- a/cli/azd/pkg/exec/runargs_test.go
+++ b/cli/azd/pkg/exec/runargs_test.go
@@ -18,7 +18,7 @@ func TestNewRunArgs(t *testing.T) {
 		require.Equal(t, false, runArgs.EnrichError)
 		require.Equal(t, "", runArgs.Cwd)
 		require.Equal(t, false, runArgs.EnrichError)
-		require.Equal(t, false, runArgs.Debug)
+		require.Nil(t, runArgs.DebugLogging)
 		require.Len(t, runArgs.Env, 0)
 	})
 
@@ -29,7 +29,7 @@ func TestNewRunArgs(t *testing.T) {
 			WithInteractive(true).
 			WithShell(true).
 			WithEnrichError(true).
-			WithDebug(true).
+			WithDebugLogging(true).
 			AppendParams("param1", "param2")
 
 		require.Equal(t, "az", runArgs.Cmd)
@@ -40,7 +40,7 @@ func TestNewRunArgs(t *testing.T) {
 		require.Equal(t, true, runArgs.EnrichError)
 		require.Equal(t, "cwd", runArgs.Cwd)
 		require.Equal(t, true, runArgs.EnrichError)
-		require.Equal(t, true, runArgs.Debug)
+		require.Equal(t, true, *runArgs.DebugLogging)
 		require.Len(t, runArgs.Env, 2)
 		require.Equal(t, runArgs.Env, []string{"foo", "bar"})
 	})

--- a/cli/azd/pkg/exec/util_test.go
+++ b/cli/azd/pkg/exec/util_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestRunCommand(t *testing.T) {
-	runner := NewCommandRunner(os.Stdin, os.Stdout, os.Stderr)
+	runner := NewCommandRunner(nil)
 
 	args := RunArgs{
 		Cmd:  "git",
@@ -49,7 +49,7 @@ func TestKillCommand(t *testing.T) {
 
 	s := time.Now()
 
-	runner := NewCommandRunner(os.Stdin, os.Stdout, os.Stderr)
+	runner := NewCommandRunner(nil)
 	_, err := runner.Run(ctx, RunArgs{
 		Cmd: "pwsh",
 		Args: []string{
@@ -88,7 +88,7 @@ func TestAppendEnv(t *testing.T) {
 }
 
 func TestRunList(t *testing.T) {
-	runner := NewCommandRunner(os.Stdin, os.Stdout, os.Stderr)
+	runner := NewCommandRunner(nil)
 	res, err := runner.RunList(context.Background(), []string{
 		"git --version",
 	}, RunArgs{})
@@ -113,7 +113,7 @@ func TestRunList(t *testing.T) {
 func TestRunCapturingStderr(t *testing.T) {
 	myStderr := &bytes.Buffer{}
 
-	runner := NewCommandRunner(os.Stdin, os.Stdout, os.Stderr)
+	runner := NewCommandRunner(nil)
 	res, _ := runner.Run(context.Background(), RunArgs{
 		Cmd:    "go",
 		Args:   []string{"--help"},
@@ -125,7 +125,7 @@ func TestRunCapturingStderr(t *testing.T) {
 }
 
 func TestRunEnrichError(t *testing.T) {
-	runner := NewCommandRunner(os.Stdin, os.Stdout, os.Stderr)
+	runner := NewCommandRunner(nil)
 	_, err := runner.Run(context.Background(), RunArgs{
 		Cmd:  "go",
 		Args: []string{"--help"},

--- a/cli/azd/pkg/tools/kubectl/kube_config_test.go
+++ b/cli/azd/pkg/tools/kubectl/kube_config_test.go
@@ -3,7 +3,6 @@ package kubectl
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
@@ -13,7 +12,7 @@ import (
 
 func Test_MergeKubeConfig(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
-	commandRunner := exec.NewCommandRunner(os.Stdin, os.Stdout, os.Stderr)
+	commandRunner := exec.NewCommandRunner(nil)
 	cli := NewKubectl(commandRunner)
 	kubeConfigManager, err := NewKubeConfigManager(cli)
 	require.NoError(t, err)

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -422,14 +422,14 @@ func Test_CLI_InfraCreateAndDeleteResourceTerraformRemote(t *testing.T) {
 	require.NoError(t, err, "failed expanding sample")
 
 	//Create remote state resources
-	commandRunner := exec.NewCommandRunner(os.Stdin, os.Stdout, os.Stderr)
+	commandRunner := exec.NewCommandRunner(nil)
 	runArgs := newRunArgs("az", "group", "create", "--name", backendResourceGroupName, "--location", location)
 
 	_, err = commandRunner.Run(ctx, runArgs)
 	require.NoError(t, err)
 
 	defer func() {
-		commandRunner := exec.NewCommandRunner(os.Stdin, os.Stdout, os.Stderr)
+		commandRunner := exec.NewCommandRunner(nil)
 		runArgs := newRunArgs("az", "group", "delete", "--name", backendResourceGroupName, "--yes")
 		_, err = commandRunner.Run(ctx, runArgs)
 		require.NoError(t, err)
@@ -533,7 +533,7 @@ func logHandles(t *testing.T, path string) {
 	}
 
 	args := exec.NewRunArgs(handle, path, "-nobanner")
-	cmd := exec.NewCommandRunner(os.Stdin, os.Stdout, os.Stderr)
+	cmd := exec.NewCommandRunner(nil)
 	rr, err := cmd.Run(context.Background(), args)
 	if err != nil {
 		t.Logf("handle.exe failed. stdout: %s, stderr: %s\n", rr.Stdout, rr.Stderr)

--- a/cli/azd/test/functional/init_test.go
+++ b/cli/azd/test/functional/init_test.go
@@ -132,7 +132,7 @@ func Test_CLI_Init_CanUseTemplate(t *testing.T) {
 
 	// While `init` uses git behind the scenes to pull a template, we don't want to bring the history over in the new git
 	// repository.
-	cmdRun := exec.NewCommandRunner(os.Stdin, os.Stdout, os.Stderr)
+	cmdRun := exec.NewCommandRunner(nil)
 	cmdRes, err := cmdRun.Run(ctx, exec.NewRunArgs("git", "-C", dir, "log", "--oneline", "-n", "1").WithEnrichError(true))
 	require.Error(t, err)
 	require.Contains(t, cmdRes.Stderr, "does not have any commits yet")

--- a/cli/azd/test/functional/up_test.go
+++ b/cli/azd/test/functional/up_test.go
@@ -91,7 +91,7 @@ func Test_CLI_Up_Down_WebApp(t *testing.T) {
 	err = probeServiceHealth(t, ctx, url, expectedTestAppResponse)
 	require.NoError(t, err)
 
-	commandRunner := exec.NewCommandRunner(os.Stdin, os.Stdout, os.Stderr)
+	commandRunner := exec.NewCommandRunner(nil)
 	runArgs := newRunArgs("dotnet", "user-secrets", "list", "--project", filepath.Join(dir, "/src/dotnet/webapp.csproj"))
 	secrets, err := commandRunner.Run(ctx, runArgs)
 	require.NoError(t, err)


### PR DESCRIPTION
Enable command runner debug logging when `--debug` is set.

Command runner currently has a switch for debug logging. This makes some sense as debug logging does end up formatting large enough strings that deserves a performant happy path. This change enables debug logging based on `--debug` flag.