### PR TITLE
deprecated extension

### DIFF
--- a/templates/common/.devcontainer/devcontainer.json/aks/nodejs/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/aks/nodejs/devcontainer.json
@@ -19,7 +19,6 @@
         "vscode": {
             "extensions": [
                 "dbaeumer.vscode-eslint",
-                "eg2.vscode-npm-script",
                 "esbenp.prettier-vscode",
                 "GitHub.vscode-github-actions",
                 "ms-azuretools.azure-dev",

--- a/templates/common/.devcontainer/devcontainer.json/nodejs/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/nodejs/devcontainer.json
@@ -14,7 +14,6 @@
         "vscode": {
             "extensions": [
                 "dbaeumer.vscode-eslint",
-                "eg2.vscode-npm-script",
                 "esbenp.prettier-vscode",
                 "GitHub.vscode-github-actions",
                 "ms-azuretools.azure-dev",

--- a/templates/common/.devcontainer/devcontainer.json/nodejs/terraform/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/nodejs/terraform/devcontainer.json
@@ -20,7 +20,6 @@
         "vscode": {
             "extensions": [
                 "dbaeumer.vscode-eslint",
-                "eg2.vscode-npm-script",
                 "esbenp.prettier-vscode",
                 "GitHub.vscode-github-actions",
                 "hashicorp.terraform",


### PR DESCRIPTION
Extension `eg2.vscode-npm-script` is deprecated:

![image](https://github.com/Azure/azure-dev/assets/24213737/f780c468-ced2-47e7-b0e3-98c6fd194613)

Functionality is now supported by vscode directly:

![image](https://github.com/Azure/azure-dev/assets/24213737/f6feac55-4017-44e3-bd59-219159a235cc)

https://code.visualstudio.com/updates/v1_23#_npm-script-running