### PR TITLE
Set default docker platform to linux/amd64

### DIFF
--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -214,7 +214,7 @@ func getDockerOptionsWithDefaults(options DockerProjectOptions) DockerProjectOpt
 	}
 
 	if options.Platform == "" {
-		options.Platform = "amd64"
+		options.Platform = "linux/amd64"
 	}
 
 	if options.Context == "" {

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -214,7 +214,7 @@ func getDockerOptionsWithDefaults(options DockerProjectOptions) DockerProjectOpt
 	}
 
 	if options.Platform == "" {
-		options.Platform = "linux/amd64"
+		options.Platform = docker.DefaultPlatform
 	}
 
 	if options.Context == "" {

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -61,7 +61,7 @@ services:
 		require.Equal(t, []string{
 			"build", "-q",
 			"-f", "./Dockerfile",
-			"--platform", "linux/amd64",
+			"--platform", docker.DefaultPlatform,
 			"-t", "test-proj-web",
 			".",
 		}, args.Args)
@@ -149,7 +149,7 @@ services:
 		require.Equal(t, []string{
 			"build", "-q",
 			"-f", "./Dockerfile.dev",
-			"--platform", "linux/amd64",
+			"--platform", docker.DefaultPlatform,
 			"-t", "test-proj-web",
 			"../",
 		}, args.Args)
@@ -225,7 +225,7 @@ func Test_DockerProject_Build(t *testing.T) {
 		[]string{
 			"build", "-q",
 			"-f", "./Dockerfile",
-			"--platform", "linux/amd64",
+			"--platform", docker.DefaultPlatform,
 			"-t", "test-app-api",
 			".",
 		},

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -61,7 +61,7 @@ services:
 		require.Equal(t, []string{
 			"build", "-q",
 			"-f", "./Dockerfile",
-			"--platform", "amd64",
+			"--platform", "linux/amd64",
 			"-t", "test-proj-web",
 			".",
 		}, args.Args)
@@ -149,7 +149,7 @@ services:
 		require.Equal(t, []string{
 			"build", "-q",
 			"-f", "./Dockerfile.dev",
-			"--platform", "amd64",
+			"--platform", "linux/amd64",
 			"-t", "test-proj-web",
 			"../",
 		}, args.Args)
@@ -225,7 +225,7 @@ func Test_DockerProject_Build(t *testing.T) {
 		[]string{
 			"build", "-q",
 			"-f", "./Dockerfile",
-			"--platform", "amd64",
+			"--platform", "linux/amd64",
 			"-t", "test-app-api",
 			".",
 		},

--- a/cli/azd/pkg/tools/docker/docker.go
+++ b/cli/azd/pkg/tools/docker/docker.go
@@ -64,7 +64,7 @@ func (d *docker) Build(
 	tagName string,
 ) (string, error) {
 	if strings.TrimSpace(platform) == "" {
-		platform = "amd64"
+		platform = "linux/amd64"
 	}
 
 	args := []string{

--- a/cli/azd/pkg/tools/docker/docker.go
+++ b/cli/azd/pkg/tools/docker/docker.go
@@ -13,6 +13,8 @@ import (
 	"github.com/blang/semver/v4"
 )
 
+const DefaultPlatform string = "linux/amd64"
+
 type Docker interface {
 	tools.ExternalTool
 	Login(ctx context.Context, loginServer string, username string, password string) error
@@ -64,7 +66,7 @@ func (d *docker) Build(
 	tagName string,
 ) (string, error) {
 	if strings.TrimSpace(platform) == "" {
-		platform = "linux/amd64"
+		platform = DefaultPlatform
 	}
 
 	args := []string{

--- a/cli/azd/pkg/tools/docker/docker_test.go
+++ b/cli/azd/pkg/tools/docker/docker_test.go
@@ -16,7 +16,7 @@ func Test_DockerBuild(t *testing.T) {
 	cwd := "."
 	dockerFile := "./Dockerfile"
 	dockerContext := "../"
-	platform := "linux/amd64"
+	platform := DefaultPlatform
 	imageName := "IMAGE_NAME"
 
 	t.Run("NoError", func(t *testing.T) {
@@ -103,7 +103,7 @@ func Test_DockerBuildEmptyPlatform(t *testing.T) {
 	cwd := "."
 	dockerFile := "./Dockerfile"
 	dockerContext := "../"
-	platform := "linux/amd64"
+	platform := DefaultPlatform
 	imageName := "IMAGE_NAME"
 
 	mockContext := mocks.NewMockContext(context.Background())

--- a/cli/azd/pkg/tools/docker/docker_test.go
+++ b/cli/azd/pkg/tools/docker/docker_test.go
@@ -13,11 +13,10 @@ import (
 )
 
 func Test_DockerBuild(t *testing.T) {
-
 	cwd := "."
 	dockerFile := "./Dockerfile"
 	dockerContext := "../"
-	platform := "amd64"
+	platform := "linux/amd64"
 	imageName := "IMAGE_NAME"
 
 	t.Run("NoError", func(t *testing.T) {
@@ -104,7 +103,7 @@ func Test_DockerBuildEmptyPlatform(t *testing.T) {
 	cwd := "."
 	dockerFile := "./Dockerfile"
 	dockerContext := "../"
-	platform := "amd64"
+	platform := "linux/amd64"
 	imageName := "IMAGE_NAME"
 
 	mockContext := mocks.NewMockContext(context.Background())


### PR DESCRIPTION
As of Docker for Desktop build 4.19.0 the docker CLI expects os/arch when specifying the `--platform` flag.  This change is backwards compatible and also works for older docker versions.

Resolves #2118 