### PR TITLE
Move codespaces out of CI detection

### DIFF
--- a/cli/azd/internal/telemetry/resource/ci.go
+++ b/cli/azd/internal/telemetry/resource/ci.go
@@ -51,9 +51,6 @@ var ciVarSetRules = []struct {
 	{"bamboo.buildKey", fields.EnvBamboo},
 	// BitBucket - https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
 	{"BITBUCKET_BUILD_NUMBER", fields.EnvBitBucketPipelines},
-	// GitHub Codespaces -
-	// https://docs.github.com/en/codespaces/developing-in-codespaces/default-environment-variables-for-your-codespace
-	{"CODESPACES", fields.EnvCodespaces},
 	// Unknown CI cases
 	{"CI", fields.EnvUnknownCI},
 	{"BUILD_ID", fields.EnvUnknownCI},

--- a/cli/azd/internal/telemetry/resource/exec_environment.go
+++ b/cli/azd/internal/telemetry/resource/exec_environment.go
@@ -17,6 +17,11 @@ func getExecutionEnvironment() string {
 	env := execEnvFromCaller()
 
 	if env == "" {
+		// machine-level execution environments
+		env = execEnvForHosts()
+	}
+
+	if env == "" {
 		// machine-level CI execution environments
 		env = execEnvForCi()
 	}
@@ -39,8 +44,18 @@ func execEnvFromCaller() string {
 		return fields.EnvVisualStudioCode
 	}
 
+	return ""
+}
+
+func execEnvForHosts() string {
 	if _, ok := os.LookupEnv("AZD_IN_CLOUDSHELL"); ok {
 		return fields.EnvCloudShell
+	}
+
+	// GitHub Codespaces
+	// https://docs.github.com/en/codespaces/developing-in-codespaces/default-environment-variables-for-your-codespacei
+	if _, ok := os.LookupEnv("CODESPACES"); ok {
+		return fields.EnvCodespaces
 	}
 
 	return ""


### PR DESCRIPTION
The current CI detection logic includes "Codespaces" in the ruleset. This was done prior when the detection logic wasn't specific to CI, but was not moved out correctly. This change addresses the incorrect classification.