### PR TITLE
Add timing information to commands

### DIFF
--- a/cli/azd/cmd/build.go
+++ b/cli/azd/cmd/build.go
@@ -200,7 +200,7 @@ func (ba *buildAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header: fmt.Sprintf("Your Azure app was built in %s.", ux.DurationAsText(time.Since(startTime))),
+			Header: fmt.Sprintf("Your application was built for Azure in %s.", ux.DurationAsText(time.Since(startTime))),
 		},
 	}, nil
 }

--- a/cli/azd/cmd/build.go
+++ b/cli/azd/cmd/build.go
@@ -123,6 +123,8 @@ func (ba *buildAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		Title: "Building services (azd build)",
 	})
 
+	startTime := time.Now()
+
 	targetServiceName := ""
 	if len(ba.args) == 1 {
 		targetServiceName = ba.args[0]
@@ -198,7 +200,7 @@ func (ba *buildAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header: "Your Azure app has been built!",
+			Header: fmt.Sprintf("Your Azure app was built in %s.", ux.DurationAsText(time.Since(startTime))),
 		},
 	}, nil
 }

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -290,7 +290,7 @@ func (da *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header:   fmt.Sprintf("Your Azure app was deployed in %s.", ux.DurationAsText(time.Since(startTime))),
+			Header:   fmt.Sprintf("Your application was deployed to Azure in %s.", ux.DurationAsText(time.Since(startTime))),
 			FollowUp: getResourceGroupFollowUp(ctx, da.formatter, da.projectConfig, da.resourceManager, da.env),
 		},
 	}, nil

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -212,6 +212,8 @@ func (da *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 		Title: "Deploying services (azd deploy)",
 	})
 
+	startTime := time.Now()
+
 	deployResults := map[string]*project.ServiceDeployResult{}
 
 	for _, svc := range da.projectConfig.GetServicesStable() {
@@ -288,7 +290,7 @@ func (da *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header:   "Your Azure app has been deployed!",
+			Header:   fmt.Sprintf("Your Azure app was deployed in %s.", ux.DurationAsText(time.Since(startTime))),
 			FollowUp: getResourceGroupFollowUp(ctx, da.formatter, da.projectConfig, da.resourceManager, da.env),
 		},
 	}, nil

--- a/cli/azd/cmd/down.go
+++ b/cli/azd/cmd/down.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
@@ -110,6 +111,8 @@ func (a *downAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		TitleNote: "Local application code is not deleted when running 'azd down'.",
 	})
 
+	startTime := time.Now()
+
 	destroyOptions := provisioning.NewDestroyOptions(a.flags.forceDelete, a.flags.purgeDelete)
 	destroyResult, err := infraManager.Destroy(ctx, destroyOptions)
 	if err != nil {
@@ -128,7 +131,7 @@ func (a *downAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header: "Your Azure resources have been deleted.",
+			Header: fmt.Sprintf("Your Azure resources were deleted in %s.", ux.DurationAsText(time.Since(startTime))),
 		},
 	}, nil
 }

--- a/cli/azd/cmd/down.go
+++ b/cli/azd/cmd/down.go
@@ -131,7 +131,7 @@ func (a *downAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header: fmt.Sprintf("Your Azure resources were deleted in %s.", ux.DurationAsText(time.Since(startTime))),
+			Header: fmt.Sprintf("Your application was removed from Azure in %s.", ux.DurationAsText(time.Since(startTime))),
 		},
 	}, nil
 }

--- a/cli/azd/cmd/package.go
+++ b/cli/azd/cmd/package.go
@@ -101,6 +101,8 @@ func (pa *packageAction) Run(ctx context.Context) (*actions.ActionResult, error)
 		Title: "Packaging services (azd package)",
 	})
 
+	startTime := time.Now()
+
 	targetServiceName := ""
 	if len(pa.args) == 1 {
 		targetServiceName = pa.args[0]
@@ -176,7 +178,7 @@ func (pa *packageAction) Run(ctx context.Context) (*actions.ActionResult, error)
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header: "Your Azure app has been packaged!",
+			Header: fmt.Sprintf("Your Azure app was packaged in %s.", ux.DurationAsText(time.Since(startTime))),
 		},
 	}, nil
 }

--- a/cli/azd/cmd/package.go
+++ b/cli/azd/cmd/package.go
@@ -178,7 +178,7 @@ func (pa *packageAction) Run(ctx context.Context) (*actions.ActionResult, error)
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header: fmt.Sprintf("Your Azure app was packaged in %s.", ux.DurationAsText(time.Since(startTime))),
+			Header: fmt.Sprintf("Your application was packaged for Azure in %s.", ux.DurationAsText(time.Since(startTime))),
 		},
 	}, nil
 }

--- a/cli/azd/cmd/provision.go
+++ b/cli/azd/cmd/provision.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
@@ -144,6 +145,8 @@ func (p *provisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 		TitleNote: "Provisioning Azure resources can take some time"},
 	)
 
+	startTime := time.Now()
+
 	if err := p.projectManager.Initialize(ctx, p.projectConfig); err != nil {
 		return nil, err
 	}
@@ -238,7 +241,7 @@ func (p *provisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header: "Your project has been provisioned!",
+			Header: fmt.Sprintf("Your Azure app was provisioned in %s.", ux.DurationAsText(time.Since(startTime))),
 			FollowUp: getResourceGroupFollowUp(
 				ctx, p.formatter, p.projectConfig, p.resourceManager, p.env),
 		},

--- a/cli/azd/cmd/provision.go
+++ b/cli/azd/cmd/provision.go
@@ -241,7 +241,8 @@ func (p *provisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header: fmt.Sprintf("Your Azure app was provisioned in %s.", ux.DurationAsText(time.Since(startTime))),
+			Header: fmt.Sprintf(
+				"Your application was provisioned in Azure in %s.", ux.DurationAsText(time.Since(startTime))),
 			FollowUp: getResourceGroupFollowUp(
 				ctx, p.formatter, p.projectConfig, p.resourceManager, p.env),
 		},

--- a/cli/azd/cmd/restore.go
+++ b/cli/azd/cmd/restore.go
@@ -194,7 +194,8 @@ func (ra *restoreAction) Run(ctx context.Context) (*actions.ActionResult, error)
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header: fmt.Sprintf("Your Azure app was restored in %s.", ux.DurationAsText(time.Since(startTime))),
+			Header: fmt.Sprintf(
+				"Your applications dependencies were restored in %s.", ux.DurationAsText(time.Since(startTime))),
 		},
 	}, nil
 }

--- a/cli/azd/cmd/restore.go
+++ b/cli/azd/cmd/restore.go
@@ -118,6 +118,8 @@ func (ra *restoreAction) Run(ctx context.Context) (*actions.ActionResult, error)
 		Title: "Restoring services (azd restore)",
 	})
 
+	startTime := time.Now()
+
 	serviceNameWarningCheck(ra.console, ra.flags.serviceName, "restore")
 
 	targetServiceName := ra.flags.serviceName
@@ -192,7 +194,7 @@ func (ra *restoreAction) Run(ctx context.Context) (*actions.ActionResult, error)
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header: "Your Azure app has been restored!",
+			Header: fmt.Sprintf("Your Azure app was restored in %s.", ux.DurationAsText(time.Since(startTime))),
 		},
 	}, nil
 }

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -155,7 +155,7 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header: fmt.Sprintf("Your Azure app was provisioned and deployed in %s.",
+			Header: fmt.Sprintf("Your application was provisioned and deployed to Azure in %s.",
 				ux.DurationAsText(time.Since(startTime))),
 		},
 	}, nil

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/cmd/middleware"
@@ -13,6 +14,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -107,6 +109,8 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		return nil, err
 	}
 
+	startTime := time.Now()
+
 	packageAction, err := u.packageActionInitializer()
 	if err != nil {
 		return nil, err
@@ -144,11 +148,17 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		deploy.flags.serviceName = ""
 	}
 	deployOptions := &middleware.Options{CommandPath: "deploy"}
-	deployResult, err := u.runner.RunChildAction(ctx, deployOptions, deploy)
+	_, err = u.runner.RunChildAction(ctx, deployOptions, deploy)
 	if err != nil {
 		return nil, err
 	}
-	return deployResult, nil
+
+	return &actions.ActionResult{
+		Message: &actions.ResultMessage{
+			Header: fmt.Sprintf("Your Azure app was provisioned and deployed in %s.",
+				ux.DurationAsText(time.Since(startTime))),
+		},
+	}, nil
 }
 
 func getCmdUpHelpDescription(c *cobra.Command) string {

--- a/cli/azd/pkg/output/ux/time.go
+++ b/cli/azd/pkg/output/ux/time.go
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package ux
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// DurationAsText provides a slightly nicer string representation of a duration
+// when compared to default formatting in go, by spelling out the words hour,
+// minute and second and providing some spacing and eliding the fractional component
+// of the seconds part.
+func DurationAsText(d time.Duration) string {
+	if d.Seconds() < 1.0 {
+		return "less than a second"
+	}
+
+	var builder strings.Builder
+
+	if (d / time.Hour) > 0 {
+		writePart(&builder, fmt.Sprintf("%d", d/time.Hour), "hour")
+		d = d - ((d / time.Hour) * time.Hour)
+	}
+
+	if (d / time.Minute) > 0 {
+		writePart(&builder, fmt.Sprintf("%d", d/time.Minute), "minute")
+		d = d - ((d / time.Minute) * time.Minute)
+	}
+
+	if (d / time.Second) > 0 {
+		writePart(&builder, fmt.Sprintf("%d", d/time.Second), "second")
+	}
+
+	return builder.String()
+}
+
+// writePart writes the string [part] followed by [unit] into [builder], unless
+// part is empty or the string "0". If part is "1", the [unit] string is suffixed
+// with s. If builder is non empty, the written string is preceded by a space.
+func writePart(builder *strings.Builder, part string, unit string) {
+	if part != "" && part != "0" {
+		if builder.Len() > 0 {
+			builder.WriteByte(' ')
+		}
+
+		builder.WriteString(part)
+		builder.WriteByte(' ')
+		builder.WriteString(unit)
+		if part != "1" {
+			builder.WriteByte('s')
+		}
+	}
+}

--- a/cli/azd/pkg/output/ux/time_test.go
+++ b/cli/azd/pkg/output/ux/time_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package ux
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDurationAsText(t *testing.T) {
+	tcs := []struct {
+		str      string
+		expected string
+	}{
+		{str: "1.5s", expected: "1 second"},
+		{str: "2.5s", expected: "2 seconds"},
+		{str: "1m", expected: "1 minute"},
+		{str: "2m", expected: "2 minutes"},
+		{str: "1h", expected: "1 hour"},
+		{str: "2h", expected: "2 hours"},
+		{str: "1h2m3s", expected: "1 hour 2 minutes 3 seconds"},
+	}
+
+	MustParseDuration := func(s string) time.Duration {
+		d, err := time.ParseDuration(s)
+		require.NoError(t, err)
+		return d
+	}
+
+	for _, tc := range tcs {
+		require.Equal(t, tc.expected, DurationAsText(MustParseDuration(tc.str)))
+	}
+}


### PR DESCRIPTION
This change adds timing information to the success messages printed by
`build`, `deploy`, `down`, `package`, `provision`, `restore` and `up`.

Fixes https://github.com/Azure/azure-dev/issues/414