### PR TITLE
Statically link CRT in CA

### DIFF
--- a/cli/installer/windows-actions/actions.vcxproj
+++ b/cli/installer/windows-actions/actions.vcxproj
@@ -40,6 +40,8 @@
       <Optimization>MaxSpeed</Optimization>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <RuntimeLibrary Condition="'$(Configuration)'=='Debug'">MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary Condition="'$(Configuration)'=='Release'">MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalDependencies>msi.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
Mitigates needing a specific CRT installed on the target machine.
Typically for CAs.
