### PR TITLE
Rename "Azure Dev CLI" -> "Azure Developer CLI"

### DIFF
--- a/eng/scripts/Update-VscodeExtensionVersion.Tests.ps1
+++ b/eng/scripts/Update-VscodeExtensionVersion.Tests.ps1
@@ -18,7 +18,7 @@ BeforeAll {
 @"
 # Change Log
 
-All notable changes to the Azure Dev CLI extension will be documented in this file.
+All notable changes to the Azure Developer CLI extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 

--- a/ext/vscode/README.md
+++ b/ext/vscode/README.md
@@ -1,4 +1,4 @@
-# Azure Dev CLI Visual Studio Code extension
+# Azure Developer CLI Visual Studio Code extension
 
 This extension makes it easier to run, create Azure Resources, and deploy Azure applications with the Azure Developer CLI.
 

--- a/ext/vscode/package.json
+++ b/ext/vscode/package.json
@@ -428,7 +428,7 @@
                         "description": "%azure-dev.walkthroughs.start.steps.scaffold.description%",
                         "media": {
                             "svg": "resources/walkthrough/azdScaffold.svg",
-                            "altText": "Choosing a template to initialize a new project with the Azure Dev CLI"
+                            "altText": "Choosing a template to initialize a new project with the Azure Developer CLI"
                         },
                         "completionEvents": [
                             "onContext:hideAzdScaffoldStep",

--- a/ext/vscode/src/commands/cmdUtil.ts
+++ b/ext/vscode/src/commands/cmdUtil.ts
@@ -11,7 +11,7 @@ import { fileExists } from '../utils/fileUtils';
 
 const AzureYamlGlobPattern: vscode.GlobPattern = '**/[aA][zZ][uU][rR][eE].[yY][aA][mM][lL]';
 
-// If the command was invoked with a specific file context, use the file context as the working directory for running Azure dev CLI commands.
+// If the command was invoked with a specific file context, use the file context as the working directory for running Azure developer CLI commands.
 // Otherwise search the workspace for "azure.yaml" files. If only one is found, use it (i.e. its folder). If more than one is found, ask the user which one to use.
 // If at this point we still do not have a working directory, prompt the user to select one.
 export async function getWorkingFolder(context: IActionContext, selectedFile?: vscode.Uri): Promise<string> {

--- a/ext/vscode/src/commands/env.ts
+++ b/ext/vscode/src/commands/env.ts
@@ -76,7 +76,7 @@ export async function deleteEnvironment(context: IActionContext, selectedItem?: 
         
         await vscode.workspace.fs.delete(environmentDirectory, { recursive: true, useTrash: false });
                 
-        // TODO: Use Azure Dev CLI to delete environment. https://github.com/Azure/azure-dev/issues/1554
+        // TODO: Use Azure Developer CLI to delete environment. https://github.com/Azure/azure-dev/issues/1554
         // const azureCli = await createAzureDevCli(context);
         // azureCli.commandBuilder.withArg('env').withArg('delete').withQuotedArg(name);
         // await spawnAsync(azureCli.commandBuilder.build(), azureCli.spawnOptions(cwd));


### PR DESCRIPTION
For #256

Per https://github.com/Azure/azure-dev/issues/256#issuecomment-1545965833, we will not change the install folder, so those references will remain untouched in `./ext/vscode/src/utils/azureDevCli.ts`.