### PR TITLE
Update "Dev" to "Developer" in template READMEs

### DIFF
--- a/templates/todo/projects/csharp-cosmos-sql/README.md
+++ b/templates/todo/projects/csharp-cosmos-sql/README.md
@@ -153,7 +153,7 @@ azd pipeline config
 
 #### Monitor the application using `azd monitor`
 
-To help with monitoring applications, the Azure Dev CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
+To help with monitoring applications, the Azure Developer CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
 
 - Run the following command to open the "Overview" dashboard:
 
@@ -222,7 +222,7 @@ The Azure Developer CLI includes many other commands to help with your Azure dev
 
 ## Troubleshooting/Known issues
 
-Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Dev](https://aka.ms/azure-dev/issues) repository.
+Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Developer CLI](https://aka.ms/azure-dev/issues) repository.
 
 ## Security
 

--- a/templates/todo/projects/csharp-sql-swa-func/README.md
+++ b/templates/todo/projects/csharp-sql-swa-func/README.md
@@ -155,7 +155,7 @@ azd pipeline config
 
 #### Monitor the application using `azd monitor`
 
-To help with monitoring applications, the Azure Dev CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
+To help with monitoring applications, the Azure Developer CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
 
 - Run the following command to open the "Overview" dashboard:
 
@@ -229,7 +229,7 @@ The Azure Developer CLI includes many other commands to help with your Azure dev
 
 ## Troubleshooting/Known issues
 
-Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Dev](https://aka.ms/azure-dev/issues) repository.
+Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Developer CLI](https://aka.ms/azure-dev/issues) repository.
 
 ## Security
 

--- a/templates/todo/projects/csharp-sql/README.md
+++ b/templates/todo/projects/csharp-sql/README.md
@@ -153,7 +153,7 @@ azd pipeline config
 
 #### Monitor the application using `azd monitor`
 
-To help with monitoring applications, the Azure Dev CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
+To help with monitoring applications, the Azure Developer CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
 
 - Run the following command to open the "Overview" dashboard:
 
@@ -222,7 +222,7 @@ The Azure Developer CLI includes many other commands to help with your Azure dev
 
 ## Troubleshooting/Known issues
 
-Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Dev](https://aka.ms/azure-dev/issues) repository.
+Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Developer CLI](https://aka.ms/azure-dev/issues) repository.
 
 ## Security
 

--- a/templates/todo/projects/java-mongo-aca/README.md
+++ b/templates/todo/projects/java-mongo-aca/README.md
@@ -176,7 +176,7 @@ azd pipeline config
 
 #### Monitor the application using `azd monitor`
 
-To help with monitoring applications, the Azure Dev CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
+To help with monitoring applications, the Azure Developer CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
 
 - Run the following command to open the "Overview" dashboard:
 
@@ -245,7 +245,7 @@ The Azure Developer CLI includes many other commands to help with your Azure dev
 
 ## Troubleshooting/Known issues
 
-Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Dev](https://aka.ms/azure-dev/issues) repository.
+Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Developer CLI](https://aka.ms/azure-dev/issues) repository.
 
 ## Security
 

--- a/templates/todo/projects/java-mongo/README.md
+++ b/templates/todo/projects/java-mongo/README.md
@@ -152,7 +152,7 @@ azd pipeline config
 
 #### Monitor the application using `azd monitor`
 
-To help with monitoring applications, the Azure Dev CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
+To help with monitoring applications, the Azure Developer CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
 
 - Run the following command to open the "Overview" dashboard:
 
@@ -221,7 +221,7 @@ The Azure Developer CLI includes many other commands to help with your Azure dev
 
 ## Troubleshooting/Known issues
 
-Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Dev](https://aka.ms/azure-dev/issues) repository.
+Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Developer CLI](https://aka.ms/azure-dev/issues) repository.
 
 ## Security
 

--- a/templates/todo/projects/java-postgresql/README.md
+++ b/templates/todo/projects/java-postgresql/README.md
@@ -130,7 +130,7 @@ azd pipeline config
 
 #### Monitor the application using `azd monitor`
 
-To help with monitoring applications, the Azure Dev CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
+To help with monitoring applications, the Azure Developer CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
 
 - Run the following command to open the "Overview" dashboard:
 
@@ -172,7 +172,7 @@ The Azure Developer CLI includes many other commands to help with your Azure dev
 
 ## Troubleshooting/Known issues
 
-Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Dev](https://aka.ms/azure-dev/issues) repository.
+Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Developer CLI](https://aka.ms/azure-dev/issues) repository.
 
 ### Error: creating Administrator
 

--- a/templates/todo/projects/nodejs-mongo-aca/README.md
+++ b/templates/todo/projects/nodejs-mongo-aca/README.md
@@ -174,7 +174,7 @@ azd pipeline config
 
 #### Monitor the application using `azd monitor`
 
-To help with monitoring applications, the Azure Dev CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
+To help with monitoring applications, the Azure Developer CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
 
 - Run the following command to open the "Overview" dashboard:
 
@@ -243,7 +243,7 @@ The Azure Developer CLI includes many other commands to help with your Azure dev
 
 ## Troubleshooting/Known issues
 
-Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Dev](https://aka.ms/azure-dev/issues) repository.
+Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Developer CLI](https://aka.ms/azure-dev/issues) repository.
 
 ## Security
 

--- a/templates/todo/projects/nodejs-mongo-aks/README.md
+++ b/templates/todo/projects/nodejs-mongo-aks/README.md
@@ -153,7 +153,7 @@ azd pipeline config
 
 #### Monitor the application using `azd monitor`
 
-To help with monitoring applications, the Azure Dev CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
+To help with monitoring applications, the Azure Developer CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
 
 - Run the following command to open the "Overview" dashboard:
 
@@ -206,7 +206,7 @@ If you are deploying via CI/CD and are using `azd pipeline config` ensure you se
 
 > This template does NOT currently support Azure API Management (APIM)
 
-Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Dev](https://aka.ms/azure-dev/issues) repository.
+Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Developer CLI](https://aka.ms/azure-dev/issues) repository.
 
 ## Security
 

--- a/templates/todo/projects/nodejs-mongo-swa-func/README.md
+++ b/templates/todo/projects/nodejs-mongo-swa-func/README.md
@@ -163,7 +163,7 @@ azd pipeline config
 
 #### Monitor the application using `azd monitor`
 
-To help with monitoring applications, the Azure Dev CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
+To help with monitoring applications, the Azure Developer CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
 
 - Run the following command to open the "Overview" dashboard:
 
@@ -232,7 +232,7 @@ The Azure Developer CLI includes many other commands to help with your Azure dev
 
 ## Troubleshooting/Known issues
 
-Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Dev](https://aka.ms/azure-dev/issues) repository.
+Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Developer](https://aka.ms/azure-dev/issues) repository.
 
 ## Security
 

--- a/templates/todo/projects/nodejs-mongo/.repo/bicep/README.md
+++ b/templates/todo/projects/nodejs-mongo/.repo/bicep/README.md
@@ -150,7 +150,7 @@ azd pipeline config
 
 #### Monitor the application using `azd monitor`
 
-To help with monitoring applications, the Azure Dev CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
+To help with monitoring applications, the Azure Developer CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
 
 - Run the following command to open the "Overview" dashboard:
 
@@ -219,7 +219,7 @@ The Azure Developer CLI includes many other commands to help with your Azure dev
 
 ## Troubleshooting/Known issues
 
-Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Dev](https://aka.ms/azure-dev/issues) repository.
+Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Developer CLI](https://aka.ms/azure-dev/issues) repository.
 
 ## Security
 

--- a/templates/todo/projects/nodejs-mongo/.repo/terraform/README.md
+++ b/templates/todo/projects/nodejs-mongo/.repo/terraform/README.md
@@ -153,7 +153,7 @@ azd pipeline config
 
 #### Monitor the application using `azd monitor`
 
-To help with monitoring applications, the Azure Dev CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
+To help with monitoring applications, the Azure Developer CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
 
 - Run the following command to open the "Overview" dashboard:
 
@@ -222,7 +222,7 @@ The Azure Developer CLI includes many other commands to help with your Azure dev
 
 ## Troubleshooting/Known issues
 
-Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Dev](https://aka.ms/azure-dev/issues) repository.
+Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Developer CLI](https://aka.ms/azure-dev/issues) repository.
 
 ## Security
 

--- a/templates/todo/projects/python-mongo-aca/README.md
+++ b/templates/todo/projects/python-mongo-aca/README.md
@@ -176,7 +176,7 @@ azd pipeline config
 
 #### Monitor the application using `azd monitor`
 
-To help with monitoring applications, the Azure Dev CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
+To help with monitoring applications, the Azure Developer CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
 
 - Run the following command to open the "Overview" dashboard:
 
@@ -245,7 +245,7 @@ The Azure Developer CLI includes many other commands to help with your Azure dev
 
 ## Troubleshooting/Known issues
 
-Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Dev](https://aka.ms/azure-dev/issues) repository.
+Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Developer CLI](https://aka.ms/azure-dev/issues) repository.
 
 ## Security
 

--- a/templates/todo/projects/python-mongo-swa-func/README.md
+++ b/templates/todo/projects/python-mongo-swa-func/README.md
@@ -164,7 +164,7 @@ azd pipeline config
 
 #### Monitor the application using `azd monitor`
 
-To help with monitoring applications, the Azure Dev CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
+To help with monitoring applications, the Azure Developer CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
 
 - Run the following command to open the "Overview" dashboard:
 
@@ -233,7 +233,7 @@ The Azure Developer CLI includes many other commands to help with your Azure dev
 
 ## Troubleshooting/Known issues
 
-Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Dev](https://aka.ms/azure-dev/issues) repository.
+Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Developer CLI](https://aka.ms/azure-dev/issues) repository.
 
 ## Security
 

--- a/templates/todo/projects/python-mongo/.repo/terraform/README.md
+++ b/templates/todo/projects/python-mongo/.repo/terraform/README.md
@@ -155,7 +155,7 @@ azd pipeline config
 
 #### Monitor the application using `azd monitor`
 
-To help with monitoring applications, the Azure Dev CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
+To help with monitoring applications, the Azure Developer CLI provides a `monitor` command to help you get to the various Application Insights dashboards.
 
 - Run the following command to open the "Overview" dashboard:
 
@@ -224,7 +224,7 @@ The Azure Developer CLI includes many other commands to help with your Azure dev
 
 ## Troubleshooting/Known issues
 
-Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Dev](https://aka.ms/azure-dev/issues) repository.
+Sometimes, things go awry. If you happen to run into issues, then please review our ["Known Issues"](https://aka.ms/azure-dev/knownissues) page for help. If you continue to have issues, then please file an issue in our main [Azure Developer CLI](https://aka.ms/azure-dev/issues) repository.
 
 ## Security
 


### PR DESCRIPTION
This reflects marketing approval for our name (we technically can't use Azure Dev CLI).

Closes #256 