### PR TITLE
Remove Description from template list table format

### DIFF
--- a/cli/azd/cmd/actions/action.go
+++ b/cli/azd/cmd/actions/action.go
@@ -3,8 +3,6 @@ package actions
 
 import (
 	"context"
-
-	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 )
 
 // ActionFunc is an Action implementation for regular functions.
@@ -39,23 +37,3 @@ type Action interface {
 
 // A function that lazily returns the specified action type T
 type ActionInitializer[T Action] func() (T, error)
-
-func ToUxItem(actionResult *ActionResult, err error) ux.UxItem {
-	if err != nil {
-		return &ux.ActionResult{
-			Err: err,
-		}
-	}
-
-	if actionResult == nil {
-		return &ux.ActionResult{}
-	}
-	if actionResult.Message == nil {
-		return &ux.ActionResult{}
-	}
-	return &ux.ActionResult{
-		SuccessMessage: actionResult.Message.Header,
-		FollowUp:       actionResult.Message.FollowUp,
-		Err:            nil,
-	}
-}

--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -143,7 +143,7 @@ func (a *templatesShowAction) Run(ctx context.Context) (*actions.ActionResult, e
 	}
 
 	if a.formatter.Kind() == output.NoneFormat {
-		fmt.Fprintf(a.writer, "%s\n", matchingTemplate.Display())
+		err = matchingTemplate.Display(a.writer)
 	} else {
 		err = a.formatter.Format(matchingTemplate, a.writer, nil)
 	}

--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -53,8 +53,8 @@ func templatesActions(root *actions.ActionDescriptor) *actions.ActionDescriptor 
 	group.Add("show", &actions.ActionDescriptorOptions{
 		Command:        newTemplateShowCmd(),
 		ActionResolver: newTemplatesShowAction,
-		OutputFormats:  []output.Format{output.JsonFormat, output.TableFormat},
-		DefaultFormat:  output.TableFormat,
+		OutputFormats:  []output.Format{output.JsonFormat, output.NoneFormat},
+		DefaultFormat:  output.NoneFormat,
 	})
 
 	return group
@@ -92,7 +92,26 @@ func (tl *templatesListAction) Run(ctx context.Context) (*actions.ActionResult, 
 		return nil, err
 	}
 
-	return nil, formatTemplates(ctx, tl.formatter, tl.writer, listedTemplates...)
+	if tl.formatter.Kind() == output.TableFormat {
+		columns := []output.Column{
+			{
+				Heading:       "RepositoryPath",
+				ValueTemplate: "{{.RepositoryPath}}",
+			},
+			{
+				Heading:       "Name",
+				ValueTemplate: "{{.Name}}",
+			},
+		}
+
+		err = tl.formatter.Format(listedTemplates, tl.writer, output.TableFormatterOptions{
+			Columns: columns,
+		})
+	} else {
+		err = tl.formatter.Format(listedTemplates, tl.writer, nil)
+	}
+
+	return nil, err
 }
 
 type templatesShowAction struct {
@@ -123,7 +142,13 @@ func (a *templatesShowAction) Run(ctx context.Context) (*actions.ActionResult, e
 		return nil, err
 	}
 
-	return nil, formatTemplates(ctx, a.formatter, a.writer, matchingTemplate)
+	if a.formatter.Kind() == output.NoneFormat {
+		fmt.Fprintf(a.writer, "%s\n", matchingTemplate.Display())
+	} else {
+		err = a.formatter.Format(matchingTemplate, a.writer, nil)
+	}
+
+	return nil, err
 }
 
 func newTemplateShowCmd() *cobra.Command {
@@ -132,43 +157,6 @@ func newTemplateShowCmd() *cobra.Command {
 		Short: fmt.Sprintf("Show details for a given template. %s", output.WithWarningFormat("(Beta)")),
 		Args:  cobra.ExactArgs(1),
 	}
-}
-
-func formatTemplates(
-	ctx context.Context,
-	formatter output.Formatter,
-	writer io.Writer,
-	templates ...templates.Template,
-) error {
-	var err error
-	if formatter.Kind() == output.TableFormat {
-		columns := []output.Column{
-			{
-				Heading:       "RepositoryPath",
-				ValueTemplate: "{{.RepositoryPath}}",
-			},
-			{
-				Heading:       "Name",
-				ValueTemplate: "{{.Name}}",
-			},
-			{
-				Heading:       "Description",
-				ValueTemplate: "{{.Description}}",
-			},
-		}
-
-		err = formatter.Format(templates, writer, output.TableFormatterOptions{
-			Columns: columns,
-		})
-	} else {
-		err = formatter.Format(templates, writer, nil)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func getCmdTemplateHelpDescription(*cobra.Command) string {

--- a/cli/azd/pkg/templates/template.go
+++ b/cli/azd/pkg/templates/template.go
@@ -1,5 +1,7 @@
 package templates
 
+import "fmt"
+
 type Template struct {
 	// Name is the friendly short name of the template.
 	Name string `json:"name"`
@@ -11,4 +13,16 @@ type Template struct {
 	// "{owner}/{repo}" for GitHub repositories,
 	// or "{repo}" for GitHub repositories under Azure-Samples (default organization).
 	RepositoryPath string `json:"repositoryPath"`
+}
+
+// Display returns a string representation of the template suitable for display.
+func (t *Template) Display() string {
+	return fmt.Sprintf(
+		"%s: %s\n%s: %s\n%s: %s",
+		"RepositoryPath",
+		t.RepositoryPath,
+		"Name",
+		t.Name,
+		"Description",
+		t.Description)
 }

--- a/cli/azd/pkg/templates/template.go
+++ b/cli/azd/pkg/templates/template.go
@@ -1,6 +1,12 @@
 package templates
 
-import "fmt"
+import (
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+)
 
 type Template struct {
 	// Name is the friendly short name of the template.
@@ -15,14 +21,27 @@ type Template struct {
 	RepositoryPath string `json:"repositoryPath"`
 }
 
-// Display returns a string representation of the template suitable for display.
-func (t *Template) Display() string {
-	return fmt.Sprintf(
-		"%s: %s\n%s: %s\n%s: %s",
-		"RepositoryPath",
-		t.RepositoryPath,
-		"Name",
-		t.Name,
-		"Description",
-		t.Description)
+// Display writes a string representation of the template suitable for display.
+func (t *Template) Display(writer io.Writer) error {
+	tabs := tabwriter.NewWriter(
+		writer,
+		0,
+		output.TableTabSize,
+		1,
+		output.TablePadCharacter,
+		output.TableFlags)
+	text := [][]string{
+		{"RepositoryPath", ":", t.RepositoryPath},
+		{"Name", ":", t.Name},
+		{"Description", ":", t.Description},
+	}
+
+	for _, line := range text {
+		_, err := tabs.Write([]byte(strings.Join(line, "\t") + "\n"))
+		if err != nil {
+			return err
+		}
+	}
+
+	return tabs.Flush()
 }


### PR DESCRIPTION
This change makes the default `template list` format more readable by removing Description (which is long text) from display. The UI changes can be seen in the issue linked below.

Two other improvements were also made as part of this change:
- Do not use `table` format for `template show` as it is a single item list. Display the items in a better human-readable format:
```
$ azd template show todo-csharp-sql 
RepositoryPath : todo-csharp-sql
Name           : React Web App with C# API and SQL Database
Description    : A blueprint for getting a React web app with a C# API and a SQL database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly.
```
- Fix empty actionResult from being displayed in `--output json` mode

Fixes #2198