### PR TITLE
Automatically set `ErrorActionPreference` to `Stop` for pwsh inline hooks

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -64,6 +64,7 @@ ineffassign
 javac
 jmes
 keychain
+LASTEXITCODE
 ldflags
 lechnerc77
 mgmt

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -158,6 +158,9 @@ func createTempScript(hookConfig *HookConfig) (string, error) {
 		}
 	case ShellTypePowershell:
 		ext = "ps1"
+		scriptHeader = []string{
+			"$ErrorActionPreference='Stop'",
+		}
 	}
 
 	// Write the temporary script file to OS temp dir

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -149,17 +149,22 @@ func inferScriptTypeFromFilePath(path string) (ShellType, error) {
 func createTempScript(hookConfig *HookConfig) (string, error) {
 	var ext string
 	scriptHeader := []string{}
+	scriptFooter := []string{}
 
 	switch hookConfig.Shell {
 	case ShellTypeBash:
 		ext = "sh"
 		scriptHeader = []string{
 			"#!/bin/sh",
+			"set -eo pipefail",
 		}
 	case ShellTypePowershell:
 		ext = "ps1"
 		scriptHeader = []string{
-			"$ErrorActionPreference='Stop'",
+			"$ErrorActionPreference = 'Stop'",
+		}
+		scriptFooter = []string{
+			"if ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }",
 		}
 	}
 
@@ -175,9 +180,15 @@ func createTempScript(hookConfig *HookConfig) (string, error) {
 	for _, line := range scriptHeader {
 		scriptBuilder.WriteString(fmt.Sprintf("%s\n", line))
 	}
+
 	scriptBuilder.WriteString("\n")
 	scriptBuilder.WriteString("# Auto generated file from Azure Developer CLI\n")
 	scriptBuilder.WriteString(hookConfig.script)
+	scriptBuilder.WriteString("\n")
+
+	for _, line := range scriptFooter {
+		scriptBuilder.WriteString(fmt.Sprintf("%s\n", line))
+	}
 
 	// Temp generated files are cleaned up automatically after script execution has completed.
 	_, err = file.WriteString(scriptBuilder.String())


### PR DESCRIPTION
Fixes #2170 

More information about the `ErrorActionPreference` can be found in the [docs](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.3#erroractionpreference)

> Error handling influenced from [GitHub](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference)