### PR TITLE
Updates pipeline default roles to include user access admin

### DIFF
--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -51,11 +51,12 @@ func (pc *pipelineConfigFlags) Bind(local *pflag.FlagSet, global *internal.Globa
 		"",
 		"The authentication type used between the pipeline provider and Azure for deployment (Only valid for GitHub provider). Valid values: federated, client-credentials.",
 	)
+	//nolint:lll
 	local.StringArrayVar(
 		&pc.PipelineRoleNames,
 		"principal-role",
 		pipeline.DefaultRoleNames,
-		"The roles to assign to the service principal.",
+		"The roles to assign to the service principal. By default the service principal will be granted the Contributor and User Access Administrator roles.",
 	)
 	// default provider is empty because it can be set from azure.yaml. By letting default here be empty, we know that
 	// there no customer input using --provider

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -51,7 +51,12 @@ func (pc *pipelineConfigFlags) Bind(local *pflag.FlagSet, global *internal.Globa
 		"",
 		"The authentication type used between the pipeline provider and Azure for deployment (Only valid for GitHub provider). Valid values: federated, client-credentials.",
 	)
-	local.StringVar(&pc.PipelineRoleName, "principal-role", "contributor", "The role to assign to the service principal.")
+	local.StringArrayVar(
+		&pc.PipelineRoleNames,
+		"principal-role",
+		pipeline.DefaultRoleNames,
+		"The roles to assign to the service principal.",
+	)
 	// default provider is empty because it can be set from azure.yaml. By letting default here be empty, we know that
 	// there no customer input using --provider
 	local.StringVar(&pc.PipelineProvider, "provider", "",

--- a/cli/azd/cmd/testdata/TestUsage-azd-pipeline-config.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-pipeline-config.snap
@@ -7,13 +7,13 @@ Usage
   azd pipeline config [flags]
 
 Flags
-        --auth-type string      	: The authentication type used between the pipeline provider and Azure for deployment (Only valid for GitHub provider). Valid values: federated, client-credentials.
-    -e, --environment string    	: The name of the environment to use.
-    -h, --help                  	: Gets help for config.
-        --principal-name string 	: The name of the service principal to use to grant access to Azure resources as part of the pipeline.
-        --principal-role string 	: The role to assign to the service principal.
-        --provider string       	: The pipeline provider to use (github for Github Actions and azdo for Azure Pipelines).
-        --remote-name string    	: The name of the git remote to configure the pipeline to run on.
+        --auth-type string           	: The authentication type used between the pipeline provider and Azure for deployment (Only valid for GitHub provider). Valid values: federated, client-credentials.
+    -e, --environment string         	: The name of the environment to use.
+    -h, --help                       	: Gets help for config.
+        --principal-name string      	: The name of the service principal to use to grant access to Azure resources as part of the pipeline.
+        --principal-role stringArray 	: The roles to assign to the service principal.
+        --provider string            	: The pipeline provider to use (github for Github Actions and azdo for Azure Pipelines).
+        --remote-name string         	: The name of the git remote to configure the pipeline to run on.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd-pipeline-config.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-pipeline-config.snap
@@ -11,7 +11,7 @@ Flags
     -e, --environment string         	: The name of the environment to use.
     -h, --help                       	: Gets help for config.
         --principal-name string      	: The name of the service principal to use to grant access to Azure resources as part of the pipeline.
-        --principal-role stringArray 	: The roles to assign to the service principal.
+        --principal-role stringArray 	: The roles to assign to the service principal. By default the service principal will be granted the Contributor and User Access Administrator roles.
         --provider string            	: The pipeline provider to use (github for Github Actions and azdo for Azure Pipelines).
         --remote-name string         	: The name of the git remote to configure the pipeline to run on.
 

--- a/cli/azd/pkg/commands/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline_manager.go
@@ -33,12 +33,15 @@ const (
 	AuthTypeClientCredentials PipelineAuthType = "client-credentials"
 )
 
-var ErrAuthNotSupported = errors.New("pipeline authentication configuration is not supported")
+var (
+	ErrAuthNotSupported = errors.New("pipeline authentication configuration is not supported")
+	DefaultRoleNames    = []string{"Contributor", "User Access Administrator"}
+)
 
 type PipelineManagerArgs struct {
 	PipelineServicePrincipalName string
 	PipelineRemoteName           string
-	PipelineRoleName             string
+	PipelineRoleNames            []string
 	PipelineProvider             string
 	PipelineAuthTypeName         string
 }
@@ -328,7 +331,7 @@ func (manager *PipelineManager) Configure(ctx context.Context) (
 		ctx,
 		manager.Environment.GetSubscriptionId(),
 		manager.PipelineServicePrincipalName,
-		manager.PipelineRoleName)
+		manager.PipelineRoleNames)
 	manager.console.StopSpinner(ctx, displayMsg, input.GetStepResultFormat(err))
 	if err != nil {
 		return result, fmt.Errorf("failed to create or update service principal: %w", err)

--- a/cli/azd/pkg/tools/azcli/ad.go
+++ b/cli/azd/pkg/tools/azcli/ad.go
@@ -30,7 +30,7 @@ func (cli *azCli) CreateOrUpdateServicePrincipal(
 	ctx context.Context,
 	subscriptionId string,
 	applicationName string,
-	roleName string,
+	roleNames []string,
 ) (json.RawMessage, error) {
 	graphClient, err := cli.createGraphClient(ctx, subscriptionId)
 	if err != nil {
@@ -55,8 +55,8 @@ func (cli *azCli) CreateOrUpdateServicePrincipal(
 		return nil, fmt.Errorf("failed resetting application credentials: %w", err)
 	}
 
-	// Apply specified role assignment
-	err = cli.ensureRoleAssignments(ctx, subscriptionId, roleName, servicePrincipal)
+	// Apply specified role assignments
+	err = cli.ensureRoleAssignments(ctx, subscriptionId, roleNames, servicePrincipal)
 	if err != nil {
 		return nil, fmt.Errorf("failed applying role assignment: %w", err)
 	}
@@ -192,6 +192,23 @@ func resetCredentials(
 
 // Applies the Azure selected RBAC role assignments to the specified service principal
 func (cli *azCli) ensureRoleAssignments(
+	ctx context.Context,
+	subscriptionId string,
+	roleNames []string,
+	servicePrincipal *graphsdk.ServicePrincipal,
+) error {
+	for _, roleName := range roleNames {
+		err := cli.ensureRoleAssignment(ctx, subscriptionId, roleName, servicePrincipal)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Applies the Azure selected RBAC role assignments to the specified service principal
+func (cli *azCli) ensureRoleAssignment(
 	ctx context.Context,
 	subscriptionId string,
 	roleName string,

--- a/cli/azd/pkg/tools/azcli/ad_test.go
+++ b/cli/azd/pkg/tools/azcli/ad_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var defaultRoleNames = []string{"Contributor", "User Access Administrator"}
+
 var expectedServicePrincipalCredential AzureCredentials = AzureCredentials{
 	ClientId:                   "CLIENT_ID",
 	ClientSecret:               "CLIENT_SECRET",
@@ -71,7 +73,7 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 			*mockContext.Context,
 			expectedServicePrincipalCredential.SubscriptionId,
 			"APPLICATION_NAME",
-			"Contributor",
+			defaultRoleNames,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, rawMessage)
@@ -98,7 +100,7 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 			*mockContext.Context,
 			expectedServicePrincipalCredential.SubscriptionId,
 			"APPLICATION_NAME",
-			"Contributor",
+			defaultRoleNames,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, rawMessage)
@@ -126,7 +128,7 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 			*mockContext.Context,
 			expectedServicePrincipalCredential.SubscriptionId,
 			"APPLICATION_NAME",
-			"Contributor",
+			defaultRoleNames,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, rawMessage)
@@ -149,7 +151,7 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 			*mockContext.Context,
 			expectedServicePrincipalCredential.SubscriptionId,
 			"APPLICATION_NAME",
-			"Contributor",
+			defaultRoleNames,
 		)
 		require.Error(t, err)
 		require.Nil(t, rawMessage)
@@ -167,7 +169,7 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 			*mockContext.Context,
 			expectedServicePrincipalCredential.SubscriptionId,
 			"APPLICATION_NAME",
-			"Contributor",
+			defaultRoleNames,
 		)
 		require.Error(t, err)
 		require.Nil(t, rawMessage)

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -150,7 +150,7 @@ type AzCli interface {
 		ctx context.Context,
 		subscriptionId string,
 		applicationName string,
-		roleToAssign string,
+		rolesToAssign []string,
 	) (json.RawMessage, error)
 	GetAppServiceProperties(
 		ctx context.Context,


### PR DESCRIPTION
Updates `azd pipeline config` default roles that are assigned to the created/updated service principal.

**Roles**
- [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor) (Existing)
- [User Access Administrator](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#user-access-administrator) (New)

Users can override and set their own roles by using one or more `--principal-role` flags.

**Example**
```bash
azd pipeline config --principal-role Role1 --principal-role Role2
```

> [Example run in GitHub](https://github.com/wbreza/aca-test-multiple-roles/actions/runs/4984195646/jobs/8922207829) with service principal generated from new build

