### PR TITLE
Support environment name as explicit argument for `env refresh`

### DIFF
--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -320,10 +321,39 @@ func newEnvRefreshFlags(cmd *cobra.Command, global *internal.GlobalCommandOption
 }
 
 func newEnvRefreshCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "refresh",
+	cmd := &cobra.Command{
+		Use:   "refresh <environment>",
 		Short: "Refresh environment settings by using information from a previous infrastructure provision.",
+
+		// We want to support the usual -e / --environment arguments as all our commands which take environments do, but for
+		// ergonomics, we'd also like you to be able to run `azd env refresh some-environment-name` to behave the same way as
+		// `azd env refresh -e some-environment-name` would have.
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.MaximumNArgs(1)(cmd, args); err != nil {
+				return err
+			}
+
+			if len(args) == 0 {
+				return nil
+			}
+
+			if flagValue, err := cmd.Flags().GetString(environmentNameFlag); err == nil {
+				if flagValue != "" && args[0] != flagValue {
+					return errors.New(
+						"the --environment flag and an explicit environment name as an argument may not be used together")
+				}
+			}
+
+			return cmd.Flags().Set(environmentNameFlag, args[0])
+		},
+		Annotations: map[string]string{},
 	}
+
+	// This is like the Use property above, but does not include the hint to show an environment name is supported. This
+	// is used by some tests which need to construct a valid command line to run `azd` and here using `<environment>` would
+	// be invalid, since it is an invalid name.
+	cmd.Annotations["azdtest.use"] = "refresh"
+	return cmd
 }
 
 type envRefreshAction struct {

--- a/cli/azd/cmd/testdata/TestUsage-azd-env-refresh.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env-refresh.snap
@@ -2,7 +2,7 @@
 Refresh environment settings by using information from a previous infrastructure provision.
 
 Usage
-  azd env refresh [flags]
+  azd env refresh <environment> [flags]
 
 Flags
     -e, --environment string 	: The name of the environment to use.

--- a/cli/azd/test/functional/env_test.go
+++ b/cli/azd/test/functional/env_test.go
@@ -96,6 +96,10 @@ func Test_CLI_Env_Management(t *testing.T) {
 	environmentList = envList(ctx, t, cli)
 	require.Len(t, environmentList, 2)
 	requireIsDefault(t, environmentList, envName)
+
+	// Verify that running refresh with an explicit env name from an argument and from a flag leads to an error.
+	_, err = cli.RunCommand(context.Background(), "env", "refresh", "-e", "from-flag", "from-arg")
+	require.Error(t, err)
 }
 
 // Verifies azd env commands that manage environment values.

--- a/cli/azd/test/functional/initialize_test.go
+++ b/cli/azd/test/functional/initialize_test.go
@@ -68,7 +68,13 @@ func testCommand(
 	// Run the command when we find a leaf command
 	if testCmd.Runnable() {
 		t.Run(testCmd.CommandPath(), func(t *testing.T) {
-			fullCmd := fmt.Sprintf("%s %s", testCmd.Parent().CommandPath(), testCmd.Use)
+			use := testCmd.Use
+
+			if v, has := testCmd.Annotations["azdtest.use"]; has {
+				use = v
+			}
+
+			fullCmd := fmt.Sprintf("%s %s", testCmd.Parent().CommandPath(), use)
 			args := strings.Split(fullCmd, " ")[1:]
 			args = append(args, "--cwd", cwd)
 			childCmd := cmd.NewRootCmd(true, chain)

--- a/cli/azd/test/functional/up_test.go
+++ b/cli/azd/test/functional/up_test.go
@@ -110,7 +110,7 @@ func Test_CLI_Up_Down_WebApp(t *testing.T) {
 	secrets, err = commandRunner.Run(ctx, runArgs)
 	require.NoError(t, err)
 
-	_, err = cli.RunCommand(ctx, "env", "refresh")
+	_, err = cli.RunCommand(ctx, "env", "refresh", envName)
 	require.NoError(t, err)
 
 	env, err = godotenv.Read(filepath.Join(dir, azdcontext.EnvironmentDirectoryName, envName, ".env"))


### PR DESCRIPTION
With this change, `azd env refresh some-environment-name` is now supported and behaves the same as if the user had typed `azd env refresh -e some-environment-name`.

When an explicit environment name is not provided via the `-e` or `--environment` flag and there are no arguments, `azd env refresh` refreshes the default environment, as before.

Fixes #1746