### PR TITLE
Filter Azure locations that do not have physical location listed

### DIFF
--- a/cli/azd/pkg/account/subscriptions.go
+++ b/cli/azd/pkg/account/subscriptions.go
@@ -11,6 +11,7 @@ import (
 	azdinternal "github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
+	"github.com/azure/azure-dev/cli/azd/pkg/compare"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
@@ -124,19 +125,17 @@ func (s *SubscriptionsService) ListSubscriptionLocations(
 		}
 
 		for _, location := range page.LocationListResult.Value {
-			// Ignore non-physical locations
-			if *location.Metadata.RegionType != "Physical" {
-				continue
+			// Only include physical locations
+			if *location.Metadata.RegionType == "Physical" && !compare.PtrValueEquals(location.Metadata.PhysicalLocation, "") {
+				displayName := convert.ToValueWithDefault(location.DisplayName, *location.Name)
+				regionalDisplayName := convert.ToValueWithDefault(location.RegionalDisplayName, displayName)
+
+				locations = append(locations, Location{
+					Name:                *location.Name,
+					DisplayName:         displayName,
+					RegionalDisplayName: regionalDisplayName,
+				})
 			}
-
-			displayName := convert.ToValueWithDefault(location.DisplayName, *location.Name)
-			regionalDisplayName := convert.ToValueWithDefault(location.RegionalDisplayName, displayName)
-
-			locations = append(locations, Location{
-				Name:                *location.Name,
-				DisplayName:         displayName,
-				RegionalDisplayName: regionalDisplayName,
-			})
 		}
 	}
 


### PR DESCRIPTION
Addresses #2165 

`azd` already filters where `regionType == 'Physical'`. This change will additionally check to ensure that `physicalLocation` is also defined. This additional filter was the only other distinguishing factor. 

The following locations match this additional filter and will now be excluded from the location listing:

- (South America) Brazil US
- (US) Central US EUAP
- East US 2 EUAP

> Note: Just because a location is listed as available to not mean that all locations support all Azure resources.  Refer to resource provider documentation for each resource for more information on supported regions