### PR TITLE
Shorten revision suffix for ACA apps

### DIFF
--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -111,7 +111,7 @@ func (cas *containerAppService) AddRevision(
 
 	// Update the revision with the new image name and suffix
 	revision := revisionResponse.Revision
-	revision.Properties.Template.RevisionSuffix = convert.RefOf(fmt.Sprintf("azd-deploy-%d", cas.clock.Now().Unix()))
+	revision.Properties.Template.RevisionSuffix = convert.RefOf(fmt.Sprintf("azd-%d", cas.clock.Now().Unix()))
 	revision.Properties.Template.Containers[0].Image = convert.RefOf(imageName)
 
 	// Update the container app with the new revision

--- a/cli/azd/pkg/containerapps/container_app_test.go
+++ b/cli/azd/pkg/containerapps/container_app_test.go
@@ -148,5 +148,5 @@ func Test_ContainerApp_AddRevision(t *testing.T) {
 	err = jsonDecoder.Decode(&updatedContainerApp)
 	require.NoError(t, err)
 	require.Equal(t, updatedImageName, *updatedContainerApp.Properties.Template.Containers[0].Image)
-	require.Equal(t, "azd-deploy-0", *updatedContainerApp.Properties.Template.RevisionSuffix)
+	require.Equal(t, "azd-0", *updatedContainerApp.Properties.Template.RevisionSuffix)
 }


### PR DESCRIPTION
Fixes #2178 

Max length of ACA resource name is 32 chars
Max length of ACA resource name + revision suffix is 54 chars

This leaves us with a maximum of 22 chars for revision suffix.  Our previous length was exactly at 22 but were still hitting the limit.

This reduces our revision to be `azd-<timestamp>` giving us a few extra buffer chars.