### PR TITLE
Use `os.Getenv` instead of accessing `Environment.Values`

### DIFF
--- a/cli/azd/cmd/down.go
+++ b/cli/azd/cmd/down.go
@@ -122,7 +122,7 @@ func (a *downAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	// Remove any outputs from the template from the environment since destroying the infrastructure
 	// invalidated them all.
 	for outputName := range destroyResult.Outputs {
-		delete(a.env.Values, outputName)
+		a.env.DotenvDelete(outputName)
 	}
 
 	if err := a.env.Save(); err != nil {

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -131,7 +131,7 @@ func newEnvSetAction(
 }
 
 func (e *envSetAction) Run(ctx context.Context) (*actions.ActionResult, error) {
-	e.env.Values[e.args[0]] = e.args[1]
+	e.env.DotenvSet(e.args[0], e.args[1])
 
 	if err := e.env.Save(); err != nil {
 		return nil, fmt.Errorf("saving environment: %w", err)
@@ -487,7 +487,7 @@ func newEnvGetValuesAction(
 }
 
 func (eg *envGetValuesAction) Run(ctx context.Context) (*actions.ActionResult, error) {
-	err := eg.formatter.Format(eg.env.Values, eg.writer, nil)
+	err := eg.formatter.Format(eg.env.Dotenv(), eg.writer, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -162,7 +162,7 @@ func getDefinitionVariables(
 		// Sets the terraform remote state environment variables in azure devops
 		remoteStateKeys := []string{"RS_RESOURCE_GROUP", "RS_STORAGE_ACCOUNT", "RS_CONTAINER_NAME"}
 		for _, key := range remoteStateKeys {
-			value, ok := env.Values[key]
+			value, ok := env.LookupEnv(key)
 			if !ok || strings.TrimSpace(value) == "" {
 				return nil, fmt.Errorf(fmt.Sprintf(`terraform remote state is not correctly configured,
 Visit %s for more information on configuring Terraform remote state`,

--- a/cli/azd/pkg/azdo/utils.go
+++ b/cli/azd/pkg/azdo/utils.go
@@ -15,12 +15,7 @@ import (
 
 // helper method to verify that a configuration exists in the .env file or in system environment variables
 func ensureConfigExists(ctx context.Context, env *environment.Environment, key string, label string) (string, error) {
-	value := env.Values[key]
-	if value != "" {
-		return value, nil
-	}
-
-	value, exists := os.LookupEnv(key)
+	value, exists := env.LookupEnv(key)
 	if !exists || value == "" {
 		return value, fmt.Errorf("%s not found in environment variable %s", label, key)
 	}
@@ -80,7 +75,7 @@ func EnsureOrgNameExists(ctx context.Context, env *environment.Environment, cons
 
 // helper function to save configuration values to .env file
 func saveEnvironmentConfig(key string, value string, env *environment.Environment) error {
-	env.Values[key] = value
+	env.DotenvSet(key, value)
 	err := env.Save()
 
 	if err != nil {

--- a/cli/azd/pkg/commands/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/commands/pipeline/azdo_provider.go
@@ -79,7 +79,7 @@ func (p *AzdoScmProvider) preConfigureCheck(
 
 // helper function to save configuration values to .env file
 func (p *AzdoScmProvider) saveEnvironmentConfig(key string, value string) error {
-	p.Env.Values[key] = value
+	p.Env.DotenvSet(key, value)
 	err := p.Env.Save()
 	if err != nil {
 		return err
@@ -454,22 +454,22 @@ func (p *AzdoScmProvider) gitRepoDetails(ctx context.Context, remoteUrl string) 
 	// While using the same .env file, the outputs from creating a project and repository
 	// are memorized in .env file
 	if repoDetails.orgName == "" {
-		repoDetails.orgName = p.Env.Values[azdo.AzDoEnvironmentOrgName]
+		repoDetails.orgName = p.Env.Getenv(azdo.AzDoEnvironmentOrgName)
 	}
 	if repoDetails.projectName == "" {
-		repoDetails.projectName = p.Env.Values[azdo.AzDoEnvironmentProjectName]
+		repoDetails.projectName = p.Env.Getenv(azdo.AzDoEnvironmentProjectName)
 	}
 	if repoDetails.projectId == "" {
-		repoDetails.projectId = p.Env.Values[azdo.AzDoEnvironmentProjectIdName]
+		repoDetails.projectId = p.Env.Getenv(azdo.AzDoEnvironmentProjectIdName)
 	}
 	if repoDetails.repoName == "" {
-		repoDetails.repoName = p.Env.Values[azdo.AzDoEnvironmentRepoName]
+		repoDetails.repoName = p.Env.Getenv(azdo.AzDoEnvironmentRepoName)
 	}
 	if repoDetails.repoId == "" {
-		repoDetails.repoId = p.Env.Values[azdo.AzDoEnvironmentRepoIdName]
+		repoDetails.repoId = p.Env.Getenv(azdo.AzDoEnvironmentRepoIdName)
 	}
 	if repoDetails.repoWebUrl == "" {
-		repoDetails.repoWebUrl = p.Env.Values[azdo.AzDoEnvironmentRepoWebUrl]
+		repoDetails.repoWebUrl = p.Env.Getenv(azdo.AzDoEnvironmentRepoWebUrl)
 	}
 	if repoDetails.remoteUrl == "" {
 		repoDetails.remoteUrl = remoteUrl
@@ -485,9 +485,9 @@ func (p *AzdoScmProvider) gitRepoDetails(ctx context.Context, remoteUrl string) 
 		// azdoSlug => Org/Project/_git/repoName
 		parts := strings.Split(azdoSlug, "_git/")
 		repoDetails.projectName = strings.Split(parts[0], "/")[1]
-		p.Env.Values[azdo.AzDoEnvironmentProjectName] = repoDetails.projectName
+		p.Env.DotenvSet(azdo.AzDoEnvironmentProjectName, repoDetails.projectName)
 		repoDetails.repoName = parts[1]
-		p.Env.Values[azdo.AzDoEnvironmentRepoName] = repoDetails.repoName
+		p.Env.DotenvSet(azdo.AzDoEnvironmentRepoName, repoDetails.repoName)
 
 		connection, err := p.getAzdoConnection(ctx)
 		if err != nil {
@@ -499,16 +499,16 @@ func (p *AzdoScmProvider) gitRepoDetails(ctx context.Context, remoteUrl string) 
 			return nil, fmt.Errorf("Looking for repository: %w", err)
 		}
 		repoDetails.repoId = repo.Id.String()
-		p.Env.Values[azdo.AzDoEnvironmentRepoIdName] = repoDetails.repoId
+		p.Env.DotenvSet(azdo.AzDoEnvironmentRepoIdName, repoDetails.repoId)
 		repoDetails.repoWebUrl = *repo.WebUrl
-		p.Env.Values[azdo.AzDoEnvironmentRepoWebUrl] = repoDetails.repoWebUrl
+		p.Env.DotenvSet(azdo.AzDoEnvironmentRepoWebUrl, repoDetails.repoWebUrl)
 
 		proj, err := azdo.GetProjectByName(ctx, connection, repoDetails.projectName)
 		if err != nil {
 			return nil, fmt.Errorf("Looking for project: %w", err)
 		}
 		repoDetails.projectId = proj.Id.String()
-		p.Env.Values[azdo.AzDoEnvironmentProjectIdName] = repoDetails.projectId
+		p.Env.DotenvSet(azdo.AzDoEnvironmentProjectIdName, repoDetails.projectId)
 
 		_ = p.Env.Save() // best effort to persist in the env
 	}

--- a/cli/azd/pkg/commands/pipeline/azdo_provider_test.go
+++ b/cli/azd/pkg/commands/pipeline/azdo_provider_test.go
@@ -22,8 +22,8 @@ func Test_azdo_provider_getRepoDetails(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		// arrange
 		provider := getAzdoScmProviderTestHarness(mockinput.NewMockConsole())
-		testOrgName := provider.Env.Values[azdo.AzDoEnvironmentOrgName]
-		testRepoName := provider.Env.Values[azdo.AzDoEnvironmentRepoName]
+		testOrgName := provider.Env.Dotenv()[azdo.AzDoEnvironmentOrgName]
+		testRepoName := provider.Env.Dotenv()[azdo.AzDoEnvironmentRepoName]
 		ctx := context.Background()
 
 		// act
@@ -111,7 +111,7 @@ func Test_azdo_scm_provider_preConfigureCheck(t *testing.T) {
 		// assert
 		require.Nil(t, e)
 		// PAT is not persisted to .env
-		require.EqualValues(t, "", provider.Env.Values[azdo.AzDoPatName])
+		require.EqualValues(t, "", provider.Env.Dotenv()[azdo.AzDoPatName])
 		require.True(t, updatedConfig)
 	})
 }
@@ -167,7 +167,8 @@ func Test_saveEnvironmentConfig(t *testing.T) {
 		writtenEnv, err := environment.FromRoot(envPath)
 		require.NoError(t, err)
 
-		require.EqualValues(t, writtenEnv.Values[key], value)
+		readValue := writtenEnv.Dotenv()[key]
+		require.EqualValues(t, readValue, value)
 		require.NoError(t, e)
 	})
 
@@ -175,17 +176,16 @@ func Test_saveEnvironmentConfig(t *testing.T) {
 
 func getEmptyAzdoScmProviderTestHarness(console input.Console) *AzdoScmProvider {
 	return &AzdoScmProvider{
-		Env: &environment.Environment{
-			Values: map[string]string{},
-		},
+		Env:     environment.Ephemeral(),
 		console: console,
 	}
 }
 
 func getAzdoScmProviderTestHarness(console input.Console) *AzdoScmProvider {
 	return &AzdoScmProvider{
-		Env: &environment.Environment{
-			Values: map[string]string{
+		Env: environment.EphemeralWithValues(
+			"test-env",
+			map[string]string{
 				azdo.AzDoEnvironmentOrgName:       "fake_org",
 				azdo.AzDoEnvironmentProjectName:   "project1",
 				azdo.AzDoEnvironmentProjectIdName: "12345",
@@ -193,15 +193,16 @@ func getAzdoScmProviderTestHarness(console input.Console) *AzdoScmProvider {
 				azdo.AzDoEnvironmentRepoIdName:    "9876",
 				azdo.AzDoEnvironmentRepoWebUrl:    "https://repo",
 			},
-		},
+		),
 		console: console,
 	}
 }
 
 func getAzdoCiProviderTestHarness(console input.Console) *AzdoCiProvider {
 	return &AzdoCiProvider{
-		Env: &environment.Environment{
-			Values: map[string]string{
+		Env: environment.EphemeralWithValues(
+			"test-env",
+			map[string]string{
 				azdo.AzDoEnvironmentOrgName:       "fake_org",
 				azdo.AzDoEnvironmentProjectName:   "project1",
 				azdo.AzDoEnvironmentProjectIdName: "12345",
@@ -209,7 +210,7 @@ func getAzdoCiProviderTestHarness(console input.Console) *AzdoCiProvider {
 				azdo.AzDoEnvironmentRepoIdName:    "9876",
 				azdo.AzDoEnvironmentRepoWebUrl:    "https://repo",
 			},
-		},
+		),
 		console: console,
 	}
 }

--- a/cli/azd/pkg/commands/pipeline/github_provider.go
+++ b/cli/azd/pkg/commands/pipeline/github_provider.go
@@ -510,7 +510,7 @@ func (p *GitHubCiProvider) configureClientCredentialsAuth(
 		// Sets the terraform remote state environment variables in github
 		remoteStateKeys := []string{"RS_RESOURCE_GROUP", "RS_STORAGE_ACCOUNT", "RS_CONTAINER_NAME"}
 		for _, key := range remoteStateKeys {
-			value, ok := azdEnvironment.Values[key]
+			value, ok := azdEnvironment.LookupEnv(key)
 			if !ok || strings.TrimSpace(value) == "" {
 				p.console.StopSpinner(ctx, "Configuring terraform", input.StepWarning)
 				p.console.MessageUxItem(ctx, &ux.WarningMessage{
@@ -543,7 +543,7 @@ func (p *GitHubCiProvider) configureClientCredentialsAuth(
 		environment.LocationEnvVarName,
 		environment.SubscriptionIdEnvVarName} {
 
-		if err := ghCli.SetVariable(ctx, repoSlug, envName, azdEnvironment.Values[envName]); err != nil {
+		if err := ghCli.SetVariable(ctx, repoSlug, envName, azdEnvironment.Getenv(envName)); err != nil {
 			return fmt.Errorf("failed setting %s variable: %w", envName, err)
 		}
 		p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{

--- a/cli/azd/pkg/commands/pipeline/pipeline.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline.go
@@ -156,7 +156,7 @@ func resolveProvider(
 	}
 
 	// 2) check if there is a persisted value from a previous run in env
-	if lastUsedProvider, configExists := env.Values[envPersistedKey]; configExists {
+	if lastUsedProvider, configExists := env.LookupEnv(envPersistedKey); configExists {
 		// Setting override value based on last run. This will force detector to use the same
 		// configuration.
 		return lastUsedProvider, nil
@@ -259,7 +259,7 @@ func DetectProviders(
 }
 
 func savePipelineProviderToEnv(provider string, env *environment.Environment) error {
-	env.Values[envPersistedKey] = provider
+	env.DotenvSet(envPersistedKey, provider)
 	err := env.Save()
 	if err != nil {
 		return err

--- a/cli/azd/pkg/commands/pipeline/pipeline_test.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline_test.go
@@ -77,9 +77,7 @@ func Test_detectProviders(t *testing.T) {
 
 		envValues := map[string]string{}
 		envValues[envPersistedKey] = azdoLabel
-		env := &environment.Environment{
-			Values: envValues,
-		}
+		env := environment.EphemeralWithValues("test-env", envValues)
 
 		scmProvider, ciProvider, err := DetectProviders(
 			ctx,
@@ -104,9 +102,7 @@ func Test_detectProviders(t *testing.T) {
 
 		envValues := map[string]string{}
 		envValues[envPersistedKey] = azdoLabel
-		env := &environment.Environment{
-			Values: envValues,
-		}
+		env := environment.EphemeralWithValues("test-env", envValues)
 
 		scmProvider, ciProvider, err := DetectProviders(
 			ctx,
@@ -135,9 +131,7 @@ func Test_detectProviders(t *testing.T) {
 
 		envValues := map[string]string{}
 		envValues[envPersistedKey] = azdoLabel
-		env := &environment.Environment{
-			Values: envValues,
-		}
+		env := environment.EphemeralWithValues("test-env", envValues)
 
 		scmProvider, ciProvider, err := DetectProviders(
 			ctx,
@@ -161,9 +155,7 @@ func Test_detectProviders(t *testing.T) {
 
 		envValues := map[string]string{}
 		envValues[envPersistedKey] = gitHubLabel
-		env := &environment.Environment{
-			Values: envValues,
-		}
+		env := environment.EphemeralWithValues("test-env", envValues)
 		scmProvider, ciProvider, err := DetectProviders(ctx,
 			azdContext,
 			env,
@@ -186,9 +178,7 @@ func Test_detectProviders(t *testing.T) {
 
 		envValues := map[string]string{}
 		envValues[envPersistedKey] = gitHubLabel
-		env := &environment.Environment{
-			Values: envValues,
-		}
+		env := environment.EphemeralWithValues("test-env", envValues)
 
 		scmProvider, ciProvider, err := DetectProviders(ctx,
 			azdContext,
@@ -213,7 +203,7 @@ func Test_detectProviders(t *testing.T) {
 		scmProvider, ciProvider, err := DetectProviders(
 			ctx,
 			azdContext,
-			&environment.Environment{Values: map[string]string{}},
+			environment.Ephemeral(),
 			"other",
 			mockContext.Console,
 			mockContext.Credentials,
@@ -233,9 +223,7 @@ func Test_detectProviders(t *testing.T) {
 
 		envValues := map[string]string{}
 		envValues[envPersistedKey] = "other"
-		env := &environment.Environment{
-			Values: envValues,
-		}
+		env := environment.EphemeralWithValues("test-env", envValues)
 
 		scmProvider, ciProvider, err := DetectProviders(ctx,
 			azdContext,
@@ -289,9 +277,7 @@ func Test_detectProviders(t *testing.T) {
 
 		envValues := map[string]string{}
 		envValues[envPersistedKey] = "persisted"
-		env := &environment.Environment{
-			Values: envValues,
-		}
+		env := environment.EphemeralWithValues("test-env", envValues)
 
 		scmProvider, ciProvider, err := DetectProviders(ctx,
 			azdContext,
@@ -322,9 +308,7 @@ func Test_detectProviders(t *testing.T) {
 
 		envValues := map[string]string{}
 		envValues[envPersistedKey] = "persisted"
-		env := &environment.Environment{
-			Values: envValues,
-		}
+		env := environment.EphemeralWithValues("test-env", envValues)
 
 		scmProvider, ciProvider, err := DetectProviders(
 			ctx,
@@ -430,7 +414,7 @@ func Test_detectProviders(t *testing.T) {
 		assert.IsType(t, &AzdoCiProvider{}, ciProvider)
 		assert.NoError(t, err)
 
-		envValue, found := env.Values[envPersistedKey]
+		envValue, found := env.Dotenv()[envPersistedKey]
 		assert.True(t, found)
 		assert.Equal(t, azdoLabel, envValue)
 
@@ -504,7 +488,7 @@ func Test_detectProviders(t *testing.T) {
 		assert.NoError(t, err)
 
 		// the persisted choice should be updated based on the value set on yaml
-		envValue, found := env.Values[envPersistedKey]
+		envValue, found := env.Dotenv()[envPersistedKey]
 		assert.True(t, found)
 		assert.Equal(t, gitHubLabel, envValue)
 
@@ -536,7 +520,7 @@ func Test_detectProviders(t *testing.T) {
 		assert.NoError(t, err)
 
 		// the persisted selection is now azdo(env) but yaml is github
-		envValue, found = env.Values[envPersistedKey]
+		envValue, found = env.Dotenv()[envPersistedKey]
 		assert.True(t, found)
 		assert.Equal(t, azdoLabel, envValue)
 

--- a/cli/azd/pkg/environment/environment_test.go
+++ b/cli/azd/pkg/environment/environment_test.go
@@ -68,10 +68,10 @@ func TestFromRoot(t *testing.T) {
 		require.NotNil(t, e)
 
 		require.NotNil(t, e.Config)
-		require.NotNil(t, e.Values)
+		require.NotNil(t, e.dotenv)
 
 		require.NotNil(t, e.Config.IsEmpty())
-		require.Equal(t, 0, len(e.Values))
+		require.Equal(t, 0, len(e.dotenv))
 	})
 
 	t.Run("EmptyWhenMissing", func(t *testing.T) {
@@ -82,10 +82,10 @@ func TestFromRoot(t *testing.T) {
 		require.NotNil(t, e)
 
 		require.NotNil(t, e.Config)
-		require.NotNil(t, e.Values)
+		require.NotNil(t, e.dotenv)
 
 		require.NotNil(t, e.Config.IsEmpty())
-		require.Equal(t, 0, len(e.Values))
+		require.Equal(t, 0, len(e.dotenv))
 	})
 
 	// Simulate loading an environment written by an earlier version of `azd` which did not write `config.json`. We should
@@ -105,7 +105,7 @@ func TestFromRoot(t *testing.T) {
 		e, err := FromRoot(testRoot)
 		require.NoError(t, err)
 
-		require.Equal(t, "yes", e.Values["TEST"])
+		require.Equal(t, "yes", e.dotenv["TEST"])
 		require.True(t, e.Config.IsEmpty())
 	})
 }
@@ -144,8 +144,8 @@ func Test_SaveAndReload(t *testing.T) {
 
 	// Verify all values exist with expected values
 	// All values now exist whether or not they were in the env state to start with
-	require.Equal(t, env.Values["SERVICE_WEB_ENDPOINT_URL"], "http://web.example.com")
-	require.Equal(t, env.Values["SERVICE_API_ENDPOINT_URL"], "http://api.example.com")
+	require.Equal(t, env.dotenv["SERVICE_WEB_ENDPOINT_URL"], "http://web.example.com")
+	require.Equal(t, env.dotenv["SERVICE_API_ENDPOINT_URL"], "http://api.example.com")
 	require.Equal(t, "SUBSCRIPTION_ID", env.GetSubscriptionId())
 	require.Equal(t, "eastus2", env.GetLocation())
 }

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -72,10 +72,10 @@ func TestBicepPlan(t *testing.T) {
 	require.IsType(t, BicepDeploymentDetails{}, deploymentPlan.Details)
 	configuredParameters := deploymentPlan.Details.(BicepDeploymentDetails).Parameters
 
-	require.Equal(t, infraProvider.env.Values["AZURE_LOCATION"], configuredParameters["location"].Value)
+	require.Equal(t, infraProvider.env.GetLocation(), configuredParameters["location"].Value)
 	require.Equal(
 		t,
-		infraProvider.env.Values["AZURE_ENV_NAME"],
+		infraProvider.env.GetEnvName(),
 		configuredParameters["environmentName"].Value,
 	)
 }
@@ -210,7 +210,7 @@ func TestBicepDeploy(t *testing.T) {
 			Parameters: testArmParameters,
 			Target: infra.NewSubscriptionDeployment(
 				azCli,
-				infraProvider.env.Values["AZURE_LOCATION"],
+				infraProvider.env.GetLocation(),
 				infraProvider.env.GetSubscriptionId(),
 				infraProvider.env.GetEnvName(),
 			),

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -106,7 +106,7 @@ func (m *Manager) Destroy(ctx context.Context, options DestroyOptions) (*Destroy
 	// Remove any outputs from the template from the environment since destroying the infrastructure
 	// invalidated them all.
 	for outputName := range destroyResult.Outputs {
-		delete(m.env.Values, outputName)
+		m.env.DotenvDelete(outputName)
 	}
 
 	// Update environment files to remove invalid infrastructure parameters

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -113,7 +113,7 @@ func TestManagerPlan(t *testing.T) {
 
 	require.NotNil(t, deploymentPlan)
 	require.Nil(t, err)
-	require.Equal(t, deploymentPlan.Deployment.Parameters["location"].Value, env.Values["AZURE_LOCATION"])
+	require.Equal(t, deploymentPlan.Deployment.Parameters["location"].Value, env.Dotenv()["AZURE_LOCATION"])
 }
 
 func TestManagerGetState(t *testing.T) {

--- a/cli/azd/pkg/infra/provisioning/provisioning.go
+++ b/cli/azd/pkg/infra/provisioning/provisioning.go
@@ -20,9 +20,9 @@ func UpdateEnvironment(env *environment.Environment, outputs map[string]OutputPa
 				if err != nil {
 					return fmt.Errorf("invalid value for output parameter '%s' (%s): %w", key, string(param.Type), err)
 				}
-				env.Values[key] = string(bytes)
+				env.DotenvSet(key, string(bytes))
 			} else {
-				env.Values[key] = fmt.Sprintf("%v", param.Value)
+				env.DotenvSet(key, fmt.Sprintf("%v", param.Value))
 			}
 		}
 

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
@@ -54,10 +54,10 @@ func TestTerraformPlan(t *testing.T) {
 
 	require.Len(t, consoleLog, 0)
 
-	require.Equal(t, infraProvider.env.Values["AZURE_LOCATION"], deploymentPlan.Deployment.Parameters["location"].Value)
+	require.Equal(t, infraProvider.env.Dotenv()["AZURE_LOCATION"], deploymentPlan.Deployment.Parameters["location"].Value)
 	require.Equal(
 		t,
-		infraProvider.env.Values["AZURE_ENV_NAME"],
+		infraProvider.env.Dotenv()["AZURE_ENV_NAME"],
 		deploymentPlan.Deployment.Parameters["environment_name"].Value,
 	)
 
@@ -83,7 +83,7 @@ func TestTerraformDeploy(t *testing.T) {
 
 	infraProvider := createTerraformProvider(mockContext)
 
-	envPath := path.Join(infraProvider.projectPath, ".azure", infraProvider.env.Values["AZURE_ENV_NAME"])
+	envPath := path.Join(infraProvider.projectPath, ".azure", infraProvider.env.Dotenv()["AZURE_ENV_NAME"])
 
 	deploymentPlan := DeploymentPlan{
 		Details: TerraformDeploymentDetails{
@@ -114,7 +114,7 @@ func TestTerraformDeploy(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, deployResult)
 
-	require.Equal(t, deployResult.Deployment.Outputs["AZURE_LOCATION"].Value, infraProvider.env.Values["AZURE_LOCATION"])
+	require.Equal(t, deployResult.Deployment.Outputs["AZURE_LOCATION"].Value, infraProvider.env.Dotenv()["AZURE_LOCATION"])
 	require.Equal(t, deployResult.Deployment.Outputs["RG_NAME"].Value, fmt.Sprintf("rg-%s", infraProvider.env.GetEnvName()))
 }
 
@@ -151,7 +151,7 @@ func TestTerraformDestroy(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, destroyResult)
 
-	require.Equal(t, destroyResult.Outputs["AZURE_LOCATION"].Value, infraProvider.env.Values["AZURE_LOCATION"])
+	require.Equal(t, destroyResult.Outputs["AZURE_LOCATION"].Value, infraProvider.env.Dotenv()["AZURE_LOCATION"])
 	require.Equal(t, destroyResult.Outputs["RG_NAME"].Value, fmt.Sprintf("rg-%s", infraProvider.env.GetEnvName()))
 }
 
@@ -186,7 +186,7 @@ func TestTerraformState(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, getStateResult.State)
 
-	require.Equal(t, infraProvider.env.Values["AZURE_LOCATION"], getStateResult.State.Outputs["AZURE_LOCATION"].Value)
+	require.Equal(t, infraProvider.env.Dotenv()["AZURE_LOCATION"], getStateResult.State.Outputs["AZURE_LOCATION"].Value)
 	require.Equal(t, fmt.Sprintf("rg-%s", infraProvider.env.GetEnvName()), getStateResult.State.Outputs["RG_NAME"].Value)
 	require.Len(t, getStateResult.State.Resources, 1)
 	require.Regexp(

--- a/cli/azd/pkg/infra/provisioning/test/test_provider.go
+++ b/cli/azd/pkg/infra/provisioning/test/test_provider.go
@@ -56,7 +56,7 @@ func (p *TestProvider) Plan(
 			asyncContext.SetProgress(&DeploymentPlanningProgress{Message: "Planning deployment", Timestamp: time.Now()})
 
 			params := make(map[string]InputParameter)
-			params["location"] = InputParameter{Value: p.env.Values["AZURE_LOCATION"]}
+			params["location"] = InputParameter{Value: p.env.GetLocation()}
 
 			deploymentPlan := DeploymentPlan{
 				Deployment: Deployment{

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -37,7 +37,7 @@ func NewContainerHelper(
 }
 
 func (ch *ContainerHelper) RegistryName(ctx context.Context) (string, error) {
-	loginServer, has := ch.env.Values[environment.ContainerRegistryEndpointEnvVarName]
+	loginServer, has := ch.env.LookupEnv(environment.ContainerRegistryEndpointEnvVarName)
 	if !has {
 		return "", fmt.Errorf(
 			"could not determine container registry endpoint, ensure %s is set as an output of your infrastructure",

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -124,7 +124,7 @@ func (t *aksTarget) Deploy(
 			}
 
 			// Login to AKS cluster
-			clusterName, has := t.env.Values[environment.AksClusterEnvVarName]
+			clusterName, has := t.env.LookupEnv(environment.AksClusterEnvVarName)
 			if !has {
 				task.SetError(fmt.Errorf(
 					"could not determine AKS cluster, ensure %s is set as an output of your infrastructure",
@@ -221,7 +221,7 @@ func (t *aksTarget) Deploy(
 			}
 
 			task.SetProgress(NewServiceProgress("Applying k8s manifests"))
-			t.kubectl.SetEnv(t.env.Values)
+			t.kubectl.SetEnv(t.env.Dotenv())
 			deploymentPath := serviceConfig.K8s.DeploymentPath
 			if deploymentPath == "" {
 				deploymentPath = defaultDeploymentPath

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -105,7 +105,7 @@ func Test_Package_Deploy_HappyPath(t *testing.T) {
 	require.IsType(t, new(kubectl.Deployment), deployResult.Details)
 	require.Greater(t, len(deployResult.Endpoints), 0)
 	// New env variable is created
-	require.Equal(t, "REGISTRY.azurecr.io/test-app/api-test:azd-deploy-0", env.Values["SERVICE_API_IMAGE_NAME"])
+	require.Equal(t, "REGISTRY.azurecr.io/test-app/api-test:azd-deploy-0", env.Dotenv()["SERVICE_API_IMAGE_NAME"])
 }
 
 func Test_Deploy_No_Cluster_Name(t *testing.T) {
@@ -120,7 +120,7 @@ func Test_Deploy_No_Cluster_Name(t *testing.T) {
 	env := createEnv()
 
 	// Simulate AKS cluster name not found in env file
-	delete(env.Values, environment.AksClusterEnvVarName)
+	env.DotenvDelete(environment.AksClusterEnvVarName)
 
 	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env)
 	scope := environment.NewTargetResource("SUB_ID", "RG_ID", "CLUSTER_NAME", string(infra.AzureResourceTypeManagedCluster))

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -115,7 +115,7 @@ func Test_ContainerApp_Deploy(t *testing.T) {
 	require.Equal(t, ContainerAppTarget, deployResult.Kind)
 	require.Greater(t, len(deployResult.Endpoints), 0)
 	// New env variable is created
-	require.Equal(t, "REGISTRY.azurecr.io/test-app/api-test:azd-deploy-0", env.Values["SERVICE_API_IMAGE_NAME"])
+	require.Equal(t, "REGISTRY.azurecr.io/test-app/api-test:azd-deploy-0", env.Dotenv()["SERVICE_API_IMAGE_NAME"])
 }
 
 func createContainerAppServiceTarget(

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -80,7 +80,7 @@ func Test_CLI_InfraCreateAndDelete(t *testing.T) {
 
 	// AZURE_STORAGE_ACCOUNT_NAME is an output of the template, make sure it was added to the .env file.
 	// the name should start with 'st'
-	accountName, ok := env.Values["AZURE_STORAGE_ACCOUNT_NAME"]
+	accountName, ok := env.Dotenv()["AZURE_STORAGE_ACCOUNT_NAME"]
 	require.True(t, ok)
 	require.Regexp(t, `st\S*`, accountName)
 
@@ -141,7 +141,7 @@ func Test_CLI_InfraCreateAndDeleteUpperCase(t *testing.T) {
 
 	// AZURE_STORAGE_ACCOUNT_NAME is an output of the template, make sure it was added to the .env file.
 	// the name should start with 'st'
-	accountName, ok := env.Values["AZURE_STORAGE_ACCOUNT_NAME"]
+	accountName, ok := env.Dotenv()["AZURE_STORAGE_ACCOUNT_NAME"]
 	require.True(t, ok)
 	require.Regexp(t, `st\S*`, accountName)
 
@@ -584,8 +584,8 @@ func assertEnvValuesStored(t *testing.T, env *environment.Environment) {
 	primitives := []string{"STRING", "BOOL", "INT"}
 
 	for k, v := range expectedEnv {
-		assert.Contains(t, env.Values, k)
-		actual := env.Values[k]
+		actual, has := env.Dotenv()[k]
+		assert.True(t, has)
 
 		if slices.Contains(primitives, k) {
 			assert.Equal(t, v, actual)


### PR DESCRIPTION
This allows us to inherit values from the OS Environment which is nice behavior and also supports CI/CD cases where we set values which are normally stored in the .env file as environment variables (because the .env file is not persisted across CI runs).

For folks that care about getting at just the values in the `.env` file stored with the environment, `Environment.Dotenv()` now returns a copy of it. The most common use of this is tests which want to validate that the environment file was updated in someway.

Fixes #2208