### PR TITLE
Update AKS templates to latest Bicep version

### DIFF
--- a/templates/common/infra/bicep/core/host/aks-agent-pool.bicep
+++ b/templates/common/infra/bicep/core/host/aks-agent-pool.bicep
@@ -6,11 +6,11 @@ param name string
 @description('The agent pool configuration')
 param config object
 
-resource aksCluster 'Microsoft.ContainerService/managedClusters@2023-01-02-preview' existing = {
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2023-03-02-preview' existing = {
   name: clusterName
 }
 
-resource nodePool 'Microsoft.ContainerService/managedClusters/agentPools@2023-01-02-preview' = {
+resource nodePool 'Microsoft.ContainerService/managedClusters/agentPools@2023-03-02-preview' = {
   parent: aksCluster
   name: name
   properties: config

--- a/templates/common/infra/bicep/core/host/aks-managed-cluster.bicep
+++ b/templates/common/infra/bicep/core/host/aks-managed-cluster.bicep
@@ -61,7 +61,7 @@ param systemPoolConfig object
 @description('The DNS prefix to associate with the AKS cluster')
 param dnsPrefix string = ''
 
-resource aks 'Microsoft.ContainerService/managedClusters@2023-02-01' = {
+resource aks 'Microsoft.ContainerService/managedClusters@2023-03-02-preview' = {
   name: name
   location: location
   tags: tags


### PR DESCRIPTION
Updates AKS bicep templates to latest version `2023-03-02-preview`
Previous version was not properly enabling ingress which was causing deployment to hang and fail

Resolves #1708 
fix https://github.com/Azure/azure-dev/issues/2172

Resources
- [Microsoft.ContainerService managedClusters](https://learn.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters?pivots=deployment-language-bicep)