### PR TITLE
semi-manual login for codespaces browser

### DIFF
--- a/cli/azd/cmd/auth_login.go
+++ b/cli/azd/cmd/auth_login.go
@@ -454,10 +454,7 @@ func (la *loginAction) login(ctx context.Context) error {
 
 		var loginError error
 		if !codespacesInBrowser {
-			_, err := la.authManager.LoginInteractive(ctx, la.flags.redirectPort, la.flags.tenantID, la.flags.scopes)
-			if err != nil {
-				return err
-			}
+			_, loginError = la.authManager.LoginInteractive(ctx, la.flags.redirectPort, la.flags.tenantID, la.flags.scopes)
 		} else {
 			loginError = semiManualLogin(
 				ctx, la.console, la.flags.redirectPort, func(port int) (azcore.TokenCredential, error) {

--- a/cli/azd/cmd/auth_login.go
+++ b/cli/azd/cmd/auth_login.go
@@ -575,8 +575,5 @@ func semiManualLogin(
 	}
 
 	_, err = interactiveLogin.Await()
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }


### PR DESCRIPTION
Introducing a new login flow for azd based on the interactive login called semi-manual.

This flow improves the login experience when users are running azd on some remote machine/VM/Container and using their local browser for interactive login.

To activate this method, users can set env var `AZD_SEMI_MANUAL_LOGIN`. Or, when running con codespaces from a web-browser, this login flow is automatically set up.

When user runs `azd auth login`, azd will display the next prompt:
![image](https://github.com/Azure/azure-dev/assets/24213737/42cb18fd-3b8c-4de8-ab0a-85d2afa82cff)

( **text/label are not final...)

Then, the local web-browser is opened to complete the interactive-login, which is expected to fail and show a 404 not-found error in the browser. 
User is asked to copy the url and paste it within the terminal to complete the login process...

Then the url is pasted in the terminal, azd will complete the login:

![image](https://github.com/Azure/azure-dev/assets/24213737/a73344ad-c577-46fb-b9ea-d1d9bb1f72a1)

![image](https://github.com/Azure/azure-dev/assets/24213737/9d5d7af3-7cc1-4638-9ca9-fa4afc4eefbb)


This approach removes the need for:
- using `curl` to complete login
- using `device code` login flow