### PR TITLE
Removes unsupported -o pipefail for inline hooks

### DIFF
--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -156,7 +156,7 @@ func createTempScript(hookConfig *HookConfig) (string, error) {
 		ext = "sh"
 		scriptHeader = []string{
 			"#!/bin/sh",
-			"set -eo pipefail",
+			"set -e",
 		}
 	case ShellTypePowershell:
 		ext = "ps1"


### PR DESCRIPTION
The `-o pipefail` is not supported in `sh` and requires `bash`.  
Removing this so we only set `set -e` by default and we can add official `bash` support later.