### PR TITLE
Return failed error when logging in

### DIFF
--- a/cli/azd/cmd/auth_login.go
+++ b/cli/azd/cmd/auth_login.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
@@ -239,6 +240,8 @@ func newLoginAction(
 	}
 }
 
+const cLoginSuccessMessage = "Logged in to Azure."
+
 func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	if len(la.flags.scopes) == 0 {
 		la.flags.scopes = auth.LoginScopes
@@ -254,81 +257,103 @@ func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 			"Next time use `azd auth login`.")
 	}
 
-	if !la.flags.onlyCheckStatus {
-		if err := la.accountSubManager.ClearSubscriptions(ctx); err != nil {
-			log.Printf("failed clearing subscriptions: %v", err)
+	if la.flags.onlyCheckStatus {
+		// In check status mode, we always print the final status to stdout.
+		// We print any non-setup related errors to stderr.
+		// We always return a zero exit code.
+		token, err := la.verifyLoggedIn(ctx)
+		var loginExpiryError *auth.ReLoginRequiredError
+		if err != nil &&
+			!errors.Is(err, auth.ErrNoCurrentUser) &&
+			!errors.As(err, &loginExpiryError) {
+			fmt.Fprintln(la.console.Handles().Stderr, err.Error())
 		}
 
-		if err := la.login(ctx); err != nil {
-			return nil, err
+		if la.formatter.Kind() == output.NoneFormat {
+			if err != nil {
+				fmt.Fprintln(la.console.Handles().Stdout, "Not logged in, run `azd auth login` to login to Azure.")
+			} else {
+				fmt.Fprintln(la.console.Handles().Stdout, cLoginSuccessMessage)
+			}
+
+			return nil, nil
+		} else {
+			res := contracts.LoginResult{}
+			if err != nil {
+				res.Status = contracts.LoginStatusUnauthenticated
+			} else {
+				res.Status = contracts.LoginStatusSuccess
+				res.ExpiresOn = &token.ExpiresOn
+			}
+			return nil, la.formatter.Format(res, la.writer, nil)
 		}
 	}
 
-	res := contracts.LoginResult{}
+	if err := la.accountSubManager.ClearSubscriptions(ctx); err != nil {
+		log.Printf("failed clearing subscriptions: %v", err)
+	}
 
+	if err := la.login(ctx); err != nil {
+		return nil, err
+	}
+
+	if _, err := la.verifyLoggedIn(ctx); err != nil {
+		return nil, err
+	}
+
+	// Rehydrate or clear the account's subscriptions cache.
+	// The caching is done here to increase responsiveness of listing subscriptions (during azd init).
+	// It also allows an implicit command for the user to refresh cached subscriptions.
+	if la.flags.clientID == "" {
+		// Deleting subscriptions on file is very unlikely to fail, unless there are serious filesystem issues.
+		// If this does fail, we want the user to be aware of this. Like other stored azd account data,
+		// stored subscriptions are currently tied to the OS user, and not the individual account being logged in,
+		// this means cross-contamination is possible.
+		if err := la.accountSubManager.ClearSubscriptions(ctx); err != nil {
+			return nil, err
+		}
+
+		err := la.accountSubManager.RefreshSubscriptions(ctx)
+		if err != nil {
+			// If this fails, the subscriptions will still be loaded on-demand.
+			// erroring out when the user interacts with subscriptions is much more user-friendly.
+			log.Printf("failed retrieving subscriptions: %v", err)
+		}
+	} else {
+		// Service principals do not typically require subscription caching (running in CI scenarios)
+		// We simply clear the cache, which is much faster than rehydrating.
+		err := la.accountSubManager.ClearSubscriptions(ctx)
+		if err != nil {
+			log.Printf("failed clearing subscriptions: %v", err)
+		}
+	}
+
+	la.console.Message(ctx, cLoginSuccessMessage)
+	return nil, nil
+}
+
+// Verifies that the user has credentials stored,
+// and that the credentials stored is accepted by the identity server (can be exchanged for access token).
+func (la *loginAction) verifyLoggedIn(ctx context.Context) (*azcore.AccessToken, error) {
 	credOptions := auth.CredentialForCurrentUserOptions{
 		TenantID: la.flags.tenantID,
 	}
 
-	if cred, err := la.authManager.CredentialForCurrentUser(ctx, &credOptions); errors.Is(err, auth.ErrNoCurrentUser) {
-		res.Status = contracts.LoginStatusUnauthenticated
-	} else if err != nil {
-		return nil, fmt.Errorf("checking auth status: %w", err)
-	} else {
-		// Ensure ID token is valid, and can be exchanged for an access token
-		token, err := cred.GetToken(ctx, policy.TokenRequestOptions{
-			Scopes: la.flags.scopes,
-		})
-
-		if err != nil {
-			log.Printf("failed to check auth status: %s", err.Error())
-			res.Status = contracts.LoginStatusUnauthenticated
-		} else {
-			res.Status = contracts.LoginStatusSuccess
-			res.ExpiresOn = &token.ExpiresOn
-		}
+	cred, err := la.authManager.CredentialForCurrentUser(ctx, &credOptions)
+	if err != nil {
+		return nil, err
 	}
 
-	if !la.flags.onlyCheckStatus && res.Status == contracts.LoginStatusSuccess {
-		// Rehydrate or clear the account's subscriptions cache.
-		// The caching is done here to increase responsiveness of listing subscriptions (during azd init).
-		// It also allows an implicit command for the user to refresh cached subscriptions.
-		if la.flags.clientID == "" {
-			// Deleting subscriptions on file is very unlikely to fail, unless there are serious filesystem issues.
-			// If this does fail, we want the user to be aware of this. Like other stored azd account data,
-			// stored subscriptions are currently tied to the OS user, and not the individual account being logged in,
-			// this means cross-contamination is possible.
-			if err := la.accountSubManager.ClearSubscriptions(ctx); err != nil {
-				return nil, err
-			}
+	// Ensure credential is valid, and can be exchanged for an access token
+	token, err := cred.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: la.flags.scopes,
+	})
 
-			err := la.accountSubManager.RefreshSubscriptions(ctx)
-			if err != nil {
-				// If this fails, the subscriptions will still be loaded on-demand.
-				// erroring out when the user interacts with subscriptions is much more user-friendly.
-				log.Printf("failed retrieving subscriptions: %v", err)
-			}
-		} else {
-			// Service principals do not typically require subscription caching (running in CI scenarios)
-			// We simply clear the cache, which is much faster than rehydrating.
-			err := la.accountSubManager.ClearSubscriptions(ctx)
-			if err != nil {
-				log.Printf("failed clearing subscriptions: %v", err)
-			}
-		}
+	if err != nil {
+		return nil, err
 	}
 
-	if la.formatter.Kind() == output.NoneFormat {
-		if res.Status == contracts.LoginStatusSuccess {
-			fmt.Fprintln(la.console.Handles().Stdout, "Logged in to Azure.")
-		} else {
-			fmt.Fprintln(la.console.Handles().Stdout, "Not logged in, run `azd auth login` to login to Azure.")
-		}
-
-		return nil, nil
-	}
-
-	return nil, la.formatter.Format(res, la.writer, nil)
+	return &token, nil
 }
 
 func countTrue(elms ...bool) int {

--- a/cli/azd/test/functional/deploy_test.go
+++ b/cli/azd/test/functional/deploy_test.go
@@ -31,7 +31,7 @@ func Test_CLI_Deploy_Err_WorkingDirectory(t *testing.T) {
 	require.NoError(t, err)
 
 	// Otherwise, deploy with 'infrastructure has not been provisioned. Please run `azd provision`'
-	_, err = cli.RunCommand(ctx, "env", "set", "AZURE_SUBSCRIPTION_ID", testSubscriptionId)
+	_, err = cli.RunCommand(ctx, "env", "set", "AZURE_SUBSCRIPTION_ID", cfg.SubscriptionID)
 	require.NoError(t, err)
 
 	// cd infra
@@ -68,7 +68,7 @@ func Test_CLI_DeployInvalidFlags(t *testing.T) {
 	require.NoError(t, err)
 
 	// Otherwise, deploy with 'infrastructure has not been provisioned. Please run `azd provision`'
-	_, err = cli.RunCommand(ctx, "env", "set", "AZURE_SUBSCRIPTION_ID", testSubscriptionId)
+	_, err = cli.RunCommand(ctx, "env", "set", "AZURE_SUBSCRIPTION_ID", cfg.SubscriptionID)
 	require.NoError(t, err)
 
 	// invalid service name

--- a/cli/azd/test/functional/env_test.go
+++ b/cli/azd/test/functional/env_test.go
@@ -199,7 +199,7 @@ func envNew(ctx context.Context, t *testing.T, cli *azdcli.CLI, envName string, 
 		_, err := cli.RunCommandWithStdIn(ctx, stdinForInit(envName), runArgs...)
 		require.NoError(t, err)
 	} else {
-		runArgs := append(defaultArgs, envName, "--subscription", testSubscriptionId, "-l", defaultLocation)
+		runArgs := append(defaultArgs, envName, "--subscription", cfg.SubscriptionID, "-l", cfg.Location)
 		runArgs = append(runArgs, args...)
 		_, err := cli.RunCommand(ctx, runArgs...)
 		require.NoError(t, err)

--- a/cli/azd/test/functional/initialize_test.go
+++ b/cli/azd/test/functional/initialize_test.go
@@ -46,8 +46,8 @@ func Test_CommandsAndActions_Initialize(t *testing.T) {
 	require.NoError(t, err)
 
 	env, _ := environment.GetEnvironment(azdCtx, envName)
-	env.SetSubscriptionId(testSubscriptionId)
-	env.SetLocation(defaultLocation)
+	env.SetSubscriptionId(cfg.SubscriptionID)
+	env.SetLocation(cfg.Location)
 	err = env.Save()
 	require.NoError(t, err)
 

--- a/cli/azd/test/functional/login_test.go
+++ b/cli/azd/test/functional/login_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -40,12 +41,7 @@ func Test_CLI_AuthLoginStatus(t *testing.T) {
 	defer cancel()
 
 	cli := azdcli.NewCLI(t)
-	result, err := cli.RunCommand(ctx, "auth", "login", "--check-status", "--output", "json")
-	require.NoError(t, err)
-
-	loginResult := contracts.LoginResult{}
-	err = json.Unmarshal([]byte(result.Stdout), &loginResult)
-	require.NoError(t, err, "failed to deserialize login result")
+	loginResult := loginStatus(t, ctx, cli)
 
 	switch loginResult.Status {
 	case contracts.LoginStatusUnauthenticated:
@@ -55,4 +51,54 @@ func Test_CLI_AuthLoginStatus(t *testing.T) {
 	default:
 		require.Fail(t, "Unexpected login status: %s", loginResult.Status)
 	}
+}
+
+func Test_CLI_LoginServicePrincipal(t *testing.T) {
+	ctx, cancel := newTestContext(t)
+	defer cancel()
+
+	dir := t.TempDir()
+
+	cli := azdcli.NewCLI(t)
+	// Isolate login to a separate configuration directory
+	cli.Env = append(cli.Env, "AZD_CONFIG_DIR="+dir)
+	if cfg.ClientID == "" || cfg.TenantID == "" || cfg.ClientSecret == "" {
+		if cfg.CI {
+			panic("Service principal is not configured. AZD_TEST_* variables are required to be set for live testing.")
+		}
+
+		t.Skip("Skipping test because service principal is not configured. " +
+			"Set the relevant AZD_TEST_* variables to run this test.")
+		return
+	}
+
+	loginState := loginStatus(t, ctx, cli)
+	require.Equal(t, contracts.LoginStatusUnauthenticated, loginState.Status)
+
+	_, err := cli.RunCommand(ctx,
+		"auth", "login",
+		"--client-id", cfg.ClientID,
+		"--client-secret", cfg.ClientSecret,
+		"--tenant-id", cfg.TenantID)
+	require.NoError(t, err)
+
+	loginState = loginStatus(t, ctx, cli)
+	require.Equal(t, contracts.LoginStatusSuccess, loginState.Status)
+
+	_, err = cli.RunCommand(ctx, "auth", "logout")
+	require.NoError(t, err)
+
+	loginState = loginStatus(t, ctx, cli)
+	require.Equal(t, contracts.LoginStatusUnauthenticated, loginState.Status)
+}
+
+func loginStatus(t *testing.T, ctx context.Context, cli *azdcli.CLI) contracts.LoginResult {
+	result, err := cli.RunCommand(ctx, "auth", "login", "--check-status", "--output", "json")
+	require.NoError(t, err)
+
+	loginResult := contracts.LoginResult{}
+	err = json.Unmarshal([]byte(result.Stdout), &loginResult)
+	require.NoError(t, err, "failed to deserialize login result")
+
+	return loginResult
 }

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -150,7 +150,7 @@ func Test_CLI_Telemetry_UsageData_EnvProjectLoad(t *testing.T) {
 	_, err = cli.RunCommandWithStdIn(ctx, stdinForInit(envName), "init")
 	require.NoError(t, err)
 
-	_, err = cli.RunCommand(ctx, "env", "set", "AZURE_SUBSCRIPTION_ID", testSubscriptionId)
+	_, err = cli.RunCommand(ctx, "env", "set", "AZURE_SUBSCRIPTION_ID", cfg.SubscriptionID)
 	require.NoError(t, err)
 
 	_, err = cli.RunCommand(ctx, "restore", "csharpapptest", "--trace-log-file", traceFilePath)

--- a/cli/azd/test/functional/up_test.go
+++ b/cli/azd/test/functional/up_test.go
@@ -279,7 +279,7 @@ func Test_CLI_Up_ResourceGroupScope(t *testing.T) {
 	cred, err := azidentity.NewAzureCLICredential(nil)
 	require.NoError(t, err)
 
-	rgClient, err := armresources.NewResourceGroupsClient(testSubscriptionId, cred, nil)
+	rgClient, err := armresources.NewResourceGroupsClient(cfg.SubscriptionID, cred, nil)
 	require.NoError(t, err)
 
 	_, err = rgClient.CreateOrUpdate(context.Background(), resourceGroupName, armresources.ResourceGroup{

--- a/cli/azd/test/functional/version_test.go
+++ b/cli/azd/test/functional/version_test.go
@@ -18,16 +18,17 @@ import (
 
 // Returns the expected version number of `azd`.
 //
-//   - When running in CI, the version specified by the CI pipeline.
-//   - When running locally, the version specified in source.
+//   - If AZD_TEST_CLI_VERSION is set, the version specified by the variable. This is used as an end-to-end
+//     test that the version matches what is generated explicitly in CI.
+//   - Otherwise, the version specified in source.
 func getExpectedVersion(t *testing.T) string {
 	expected := internal.VersionInfo().Version.String()
 
-	if os.Getenv("GITHUB_RUN_NUMBER") != "" {
-		// By using CLI_VERSION, we validate that azd was built with the correct version.
-		expected = os.Getenv("CLI_VERSION")
-		require.NotEmpty(t, expected)
+	versionVar, ok := os.LookupEnv("AZD_TEST_CLI_VERSION")
+	if ok {
+		expected = versionVar
 	}
+	require.NotEmpty(t, expected)
 
 	return expected
 }

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -135,15 +135,20 @@ stages:
               workingDirectory: cli/azd
             displayName: Test Go Binary
             env:
-              # Set GITHUB_RUN_NUMBER because cli_test.go is coupled to that
-              # environment variable.
-              GITHUB_RUN_NUMBER: $(Build.BuildId)
-              # Generate junit report to publish results
-              GOTESTSUM_JUNITFILE: junitTestReport.xml
-              # Required for Terraform service principal authentication
+              # AZD live test setup variables
+              CI: true
+              AZD_TEST_CLI_VERSION: $(CLI_VERSION)
+              AZD_TEST_CLIENT_ID: $(arm-client-id)
+              AZD_TEST_CLIENT_SECRET: $(arm-client-secret)
+              AZD_TEST_TENANT_ID: $(arm-tenant-id)
+              AZD_TEST_AZURE_SUBSCRIPTION_ID: $(SubscriptionId)
+              AZD_TEST_AZURE_LOCATION: eastus2
+              # AZD Live Test: Terraform service principal authentication
               ARM_CLIENT_ID: $(arm-client-id)
               ARM_CLIENT_SECRET: $(arm-client-secret)
               ARM_TENANT_ID: $(arm-tenant-id)
+              # Code Coverage: Generate junit report to publish results
+              GOTESTSUM_JUNITFILE: junitTestReport.xml
 
           - task: PublishTestResults@2
             inputs:


### PR DESCRIPTION
Previously, when `login` fails, there are cases where "Not logged in, run 'azd auth login' to login" would be printed out, but the returned exit code is zero. This is a problem in CI situations when auth isn't setup correctly, and yet `login` is deemed successful, the CI pipeline proceeds as normal, resulting in user confusion.

This change updates `login` to always exit with non-zero exit code if `login` fails. The code has been refactored so that `--check-status` plays nicely with this implementation.

Fixes #2221