### PR TITLE
Add support to login to ACR with current identity

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -20,6 +20,7 @@ azdinternal
 azdtempl
 azdtempl
 azdtest
+azruntime
 azsdk
 AZURECLI
 azurestaticapps

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -129,7 +129,7 @@ func (ch *ContainerHelper) Deploy(
 
 			log.Printf("logging into container registry '%s'\n", loginServer)
 			task.SetProgress(NewServiceProgress("Logging into container registry"))
-			err = ch.containerRegistryService.LoginAcr(ctx, targetResource.SubscriptionId(), loginServer)
+			err = ch.containerRegistryService.Login(ctx, targetResource.SubscriptionId(), loginServer)
 			if err != nil {
 				task.SetError(err)
 				return

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -213,4 +213,5 @@ func setupMocksForContainerApps(mockContext *mocks.MockContext) {
 	)
 	mockazsdk.MockContainerAppSecretsList(mockContext, subscriptionId, resourceGroup, appName, secrets)
 	mockazsdk.MockContainerAppUpdate(mockContext, subscriptionId, resourceGroup, appName, containerApp)
+	mockazsdk.MockContainerRegistryTokenExchange(mockContext, subscriptionId, subscriptionId, "REFRESH_TOKEN")
 }

--- a/cli/azd/pkg/tools/azcli/container_registry.go
+++ b/cli/azd/pkg/tools/azcli/container_registry.go
@@ -260,10 +260,8 @@ func (crs *containerRegistryService) getAcrToken(
 	return acrTokenBody, nil
 }
 
-func setHttpRequestBody(req *policy.Request, formData url.Values) error {
+func setHttpRequestBody(req *policy.Request, formData url.Values) {
 	raw := req.Raw()
 	raw.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	raw.Body = io.NopCloser(strings.NewReader(formData.Encode()))
-
-	return nil
 }

--- a/cli/azd/pkg/tools/azcli/container_registry.go
+++ b/cli/azd/pkg/tools/azcli/container_registry.go
@@ -210,6 +210,7 @@ func (crs *containerRegistryService) createRegistriesClient(
 	return client, nil
 }
 
+// Exchanges an AAD token for an ACR refresh token
 func (crs *containerRegistryService) getAcrToken(
 	ctx context.Context,
 	subscriptionId string,
@@ -225,6 +226,7 @@ func (crs *containerRegistryService) getAcrToken(
 		return nil, fmt.Errorf("getting token for subscription '%s': %w", subscriptionId, err)
 	}
 
+	// Implementation based on docs @ https://azure.github.io/acr/AAD-OAuth.html
 	options := clientOptionsBuilder(ctx, crs.httpClient, crs.userAgent).BuildCoreClientOptions()
 	pipeline := azruntime.NewPipeline("azd-acr", internal.Version, azruntime.PipelineOptions{}, options)
 

--- a/cli/azd/pkg/tools/azcli/container_registry.go
+++ b/cli/azd/pkg/tools/azcli/container_registry.go
@@ -2,22 +2,38 @@ package azcli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
 	azdinternal "github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
+	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
 	"golang.org/x/exp/slices"
 )
 
+type dockerCredentials struct {
+	Username    string
+	Password    string
+	LoginServer string
+}
+
+type acrToken struct {
+	RefreshToken string `json:"refresh_token"`
+}
+
 // ContainerRegistryService provides access to query and login to Azure Container Registries (ACR)
 type ContainerRegistryService interface {
 	// Logs into the specified container registry
-	LoginAcr(ctx context.Context, subscriptionId string, loginServer string) error
+	Login(ctx context.Context, subscriptionId string, loginServer string) error
 	// Gets a list of container registries for the specified subscription
 	GetContainerRegistries(ctx context.Context, subscriptionId string) ([]*armcontainerregistry.Registry, error)
 }
@@ -68,12 +84,56 @@ func (crs *containerRegistryService) GetContainerRegistries(
 	return results, nil
 }
 
+func (crs *containerRegistryService) Login(ctx context.Context, subscriptionId string, loginServer string) error {
+	// First attempt to get ACR credentials from the logged in user
+	dockerCreds, tokenErr := crs.getTokenCredentials(ctx, subscriptionId, loginServer)
+	if tokenErr != nil {
+		// If that fails, attempt to get ACR credentials from the admin user
+		adminCreds, adminErr := crs.getAdminUserCredentials(ctx, subscriptionId, loginServer)
+		if adminErr != nil {
+			return fmt.Errorf("failed logging into container registry: %w, %w", tokenErr, adminErr)
+		}
+
+		dockerCreds = adminCreds
+	}
+
+	err := crs.docker.Login(ctx, dockerCreds.LoginServer, dockerCreds.Username, dockerCreds.Password)
+	if err != nil {
+		return fmt.Errorf(
+			"failed logging into docker registry %s: %w",
+			loginServer,
+			err)
+	}
+
+	return nil
+}
+
+func (crs *containerRegistryService) getTokenCredentials(
+	ctx context.Context,
+	subscriptionId string,
+	loginServer string,
+) (*dockerCredentials, error) {
+	acrToken, err := crs.getAcrToken(ctx, subscriptionId, loginServer)
+	if err != nil {
+		return nil, fmt.Errorf("failed getting ACR token: %w", err)
+	}
+
+	return &dockerCredentials{
+		Username:    "00000000-0000-0000-0000-000000000000",
+		Password:    acrToken.RefreshToken,
+		LoginServer: loginServer,
+	}, nil
+}
+
 // Logs into the specified container registry
-func (crs *containerRegistryService) LoginAcr(ctx context.Context, subscriptionId string, loginServer string,
-) error {
+func (crs *containerRegistryService) getAdminUserCredentials(
+	ctx context.Context,
+	subscriptionId string,
+	loginServer string,
+) (*dockerCredentials, error) {
 	client, err := crs.createRegistriesClient(ctx, subscriptionId)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	parts := strings.Split(loginServer, ".")
@@ -82,24 +142,20 @@ func (crs *containerRegistryService) LoginAcr(ctx context.Context, subscriptionI
 	// Find the registry and resource group
 	_, resourceGroup, err := crs.findContainerRegistryByName(ctx, subscriptionId, registryName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Retrieve the registry credentials
 	credResponse, err := client.ListCredentials(ctx, resourceGroup, registryName, nil)
 	if err != nil {
-		return fmt.Errorf("getting container registry credentials: %w", err)
+		return nil, fmt.Errorf("getting container registry credentials: %w", err)
 	}
 
-	username := *credResponse.Username
-
-	// Login to docker with ACR credentials to allow push operations
-	err = crs.docker.Login(ctx, loginServer, username, *credResponse.Passwords[0].Value)
-	if err != nil {
-		return fmt.Errorf("failed logging into docker for username '%s' and server %s: %w", loginServer, username, err)
-	}
-
-	return nil
+	return &dockerCredentials{
+		Username:    *credResponse.Username,
+		Password:    *credResponse.Passwords[0].Value,
+		LoginServer: loginServer,
+	}, nil
 }
 
 func (crs *containerRegistryService) findContainerRegistryByName(
@@ -149,4 +205,57 @@ func (crs *containerRegistryService) createRegistriesClient(
 	}
 
 	return client, nil
+}
+
+func (crs *containerRegistryService) getAcrToken(
+	ctx context.Context,
+	subscriptionId string,
+	loginServer string,
+) (*acrToken, error) {
+	creds, err := crs.credentialProvider.CredentialForSubscription(ctx, subscriptionId)
+	if err != nil {
+		return nil, fmt.Errorf("getting credentials for subscription '%s': %w", subscriptionId, err)
+	}
+
+	token, err := creds.GetToken(ctx, policy.TokenRequestOptions{Scopes: auth.LoginScopes})
+	if err != nil {
+		return nil, fmt.Errorf("getting token for subscription '%s': %w", subscriptionId, err)
+	}
+
+	formData := url.Values{}
+	formData.Set("grant_type", "access_token")
+	formData.Set("service", loginServer)
+	formData.Set("access_token", token.Token)
+
+	tokenUrl := fmt.Sprintf("https://%s/oauth2/exchange", loginServer)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenUrl, strings.NewReader(formData.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := crs.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("getting token: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("getting token: unexpected status code %d, %s", resp.StatusCode, string(body))
+	}
+
+	var acrResponse acrToken
+	err = json.Unmarshal(body, &acrResponse)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshalling response body: %w", err)
+	}
+
+	return &acrResponse, nil
 }

--- a/cli/azd/pkg/tools/docker/docker.go
+++ b/cli/azd/pkg/tools/docker/docker.go
@@ -41,11 +41,14 @@ type docker struct {
 }
 
 func (d *docker) Login(ctx context.Context, loginServer string, username string, password string) error {
-	_, err := d.executeCommand(ctx, ".", "login",
+	runArgs := exec.NewRunArgs(
+		"docker", "login",
 		"--username", username,
-		"--password", password,
-		loginServer)
+		"--password-stdin",
+		loginServer,
+	).WithCwd(".").WithStdIn(strings.NewReader(password))
 
+	_, err := d.commandRunner.Run(ctx, runArgs)
 	if err != nil {
 		return fmt.Errorf("failed logging into docker: %w", err)
 	}

--- a/cli/azd/pkg/tools/docker/docker.go
+++ b/cli/azd/pkg/tools/docker/docker.go
@@ -46,7 +46,7 @@ func (d *docker) Login(ctx context.Context, loginServer string, username string,
 		"--username", username,
 		"--password-stdin",
 		loginServer,
-	).WithCwd(".").WithStdIn(strings.NewReader(password))
+	).WithStdIn(strings.NewReader(password))
 
 	_, err := d.commandRunner.Run(ctx, runArgs)
 	if err != nil {

--- a/cli/azd/pkg/tools/docker/docker_test.go
+++ b/cli/azd/pkg/tools/docker/docker_test.go
@@ -309,7 +309,7 @@ func Test_DockerLogin(t *testing.T) {
 			require.Equal(t, []string{
 				"login",
 				"--username", "USERNAME",
-				"--password", "PASSWORD",
+				"--password-stdin",
 				"LOGIN_SERVER",
 			}, args.Args)
 
@@ -344,7 +344,7 @@ func Test_DockerLogin(t *testing.T) {
 			require.Equal(t, []string{
 				"login",
 				"--username", "USERNAME",
-				"--password", "PASSWORD",
+				"--password-stdin",
 				"LOGIN_SERVER",
 			}, args.Args)
 

--- a/cli/azd/pkg/tools/docker/docker_test.go
+++ b/cli/azd/pkg/tools/docker/docker_test.go
@@ -291,8 +291,6 @@ func Test_DockerPush(t *testing.T) {
 }
 
 func Test_DockerLogin(t *testing.T) {
-	cwd := "."
-
 	t.Run("NoError", func(t *testing.T) {
 		ran := false
 
@@ -305,7 +303,6 @@ func Test_DockerLogin(t *testing.T) {
 			ran = true
 
 			require.Equal(t, "docker", args.Cmd)
-			require.Equal(t, cwd, args.Cwd)
 			require.Equal(t, []string{
 				"login",
 				"--username", "USERNAME",
@@ -340,7 +337,6 @@ func Test_DockerLogin(t *testing.T) {
 			ran = true
 
 			require.Equal(t, "docker", args.Cmd)
-			require.Equal(t, cwd, args.Cwd)
 			require.Equal(t, []string{
 				"login",
 				"--username", "USERNAME",

--- a/cli/azd/test/mocks/mockazsdk/container_registry.go
+++ b/cli/azd/test/mocks/mockazsdk/container_registry.go
@@ -1,0 +1,71 @@
+package mockazsdk
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+)
+
+func MockContainerRegistryTokenExchange(
+	mockContext *mocks.MockContext,
+	subscriptionId string,
+	loginServer string,
+	refreshToken string,
+) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodPost && strings.Contains(request.URL.Path, "oauth2/exchange")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		response := struct {
+			RefreshToken string `json:"refresh_token"`
+		}{
+			RefreshToken: refreshToken,
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}
+
+func MockContainerRegistryList(mockContext *mocks.MockContext, registries []*armcontainerregistry.Registry) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet &&
+			strings.Contains(request.URL.Path, "Microsoft.ContainerRegistry/registries")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		result := armcontainerregistry.RegistryListResult{
+			NextLink: nil,
+			Value:    registries,
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, result)
+	})
+
+	return mockRequest
+}
+
+func MockContainerRegistryCredentials(
+	mockContext *mocks.MockContext,
+	credentials *armcontainerregistry.RegistryListCredentialsResult,
+) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodPost && strings.Contains(request.URL.Path, "listCredentials")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, credentials)
+	})
+
+	return mockRequest
+}


### PR DESCRIPTION
Today `azd` only support logging in with ACR admin user.  This is a bad practice and a security vulnerability.  
This PR addresses this issue by using the current identity to push containers.

This approach leverages exchanging an AAD token for an ACR refresh token based on the published [ACR docs](https://azure.github.io/acr/AAD-OAuth.html#calling-post-oauth2-exchange-to-get-an-acr-refresh-token)

**Other enhancements**
- Uses `--password-stdin` instead of using `--password` param on docker CLI

Resolves #2244 