### PR TITLE
Update usage text for pipeline config

### DIFF
--- a/cli/azd/cmd/cmd_help.go
+++ b/cli/azd/cmd/cmd_help.go
@@ -141,20 +141,6 @@ func getCmdHelpAvailableCommands(commands string) string {
 	return getCmdHelpCommands("Available Commands", commands)
 }
 
-// getCmdHelpDescriptionNoteForInit produces help - description - notes for commands which initialize azd (i.e. up, init)
-func getCmdHelpDescriptionNoteForInit(c *cobra.Command) (notes []string) {
-	notes = append(notes, formatHelpNote(
-		fmt.Sprintf("Running %s without a template will prompt "+
-			"you to start with a minimal template or select from a curated list of presets.",
-			output.WithHighLightFormat(c.CommandPath()),
-		)))
-	notes = append(notes, formatHelpNote(
-		fmt.Sprintf("To view all currently available sample templates visit: %s.",
-			output.WithHighLightFormat(c.CommandPath()),
-		)))
-	return notes
-}
-
 // getFlagsDetails produces the command - flags - details in the form of `-F, --flag [type] : description`
 func getFlagsDetails(flagSet *pflag.FlagSet) (result string) {
 	var lines []string

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -214,9 +214,8 @@ func getCmdInitHelpDescription(*cobra.Command) string {
 					output.WithHighLightFormat("init"),
 				)),
 			formatHelpNote(
-				output.WithGrayFormat("To view available templates run `azd template list` or visit: ") +
-					output.WithLinkFormat("https://azure.github.io/awesome-azd"),
-			),
+				"To view all available sample templates, including those submitted by the azd community, visit: " +
+					output.WithLinkFormat("https://azure.github.io/awesome-azd") + "."),
 		})
 }
 

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -205,9 +205,19 @@ func (i *initAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	}, nil
 }
 
-func getCmdInitHelpDescription(c *cobra.Command) string {
+func getCmdInitHelpDescription(*cobra.Command) string {
 	return generateCmdHelpDescription("Initialize a new application in your current directory.",
-		getCmdHelpDescriptionNoteForInit(c))
+		[]string{
+			formatHelpNote(
+				fmt.Sprintf("Running %s without a template will prompt "+
+					"you to start with a minimal template or select from a curated list of presets.",
+					output.WithHighLightFormat("init"),
+				)),
+			formatHelpNote(
+				output.WithGrayFormat("To view available templates run `azd template list` or visit: ") +
+					output.WithLinkFormat("https://azure.github.io/awesome-azd"),
+			),
+		})
 }
 
 func getCmdInitHelpFooter(*cobra.Command) string {

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -228,7 +228,7 @@ func getCmdPipelineConfigHelpDescription(*cobra.Command) string {
 		"Configure your deployment pipeline to connect securely to Azure",
 		[]string{
 			formatHelpNote(
-				"Supports GitHub Actions and Azure Pipelines. To set the pipeline provider to be configured, " +
+				"Supports GitHub Actions and Azure Pipelines. To configure using a specific pipeline provider, " +
 					"provide a value for the '--provider' flag."),
 			formatHelpNote(
 				output.WithHighLightFormat("pipeline config") +
@@ -237,7 +237,7 @@ func getCmdPipelineConfigHelpDescription(*cobra.Command) string {
 			formatHelpNote("By default, " +
 				output.WithHighLightFormat("pipeline config") +
 				" will set deployment pipeline variables and secrets using the current environment. " +
-				"To configure for a new or a different existing environment, provide a value for the '-e' flag."),
+				"To configure for a new or an existing environment, provide a value for the '-e' flag."),
 		})
 }
 

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -105,7 +105,7 @@ func newPipelineConfigCmd() *cobra.Command {
 	return &cobra.Command{
 		Use: "config",
 		Short: fmt.Sprintf(
-			"Create and configure your deployment pipeline by using GitHub or Azure Pipelines. %s",
+			"Configure your deployment pipeline to connect securely to Azure. %s",
 			output.WithWarningFormat("(Beta)")),
 	}
 }
@@ -199,12 +199,19 @@ func (p *pipelineConfigAction) Run(ctx context.Context) (*actions.ActionResult, 
 
 func getCmdPipelineHelpDescription(*cobra.Command) string {
 	return generateCmdHelpDescription(
-		fmt.Sprintf("Manage integrating your application with build pipelines. %s", output.WithWarningFormat("(Beta)")),
+		fmt.Sprintf("Manage integrating your application with deployment pipelines. %s", output.WithWarningFormat("(Beta)")),
 		[]string{
-			formatHelpNote(fmt.Sprintf("The Azure Developer CLI template includes a GitHub Actions pipeline"+
-				" configuration file (in the %s folder) that deploys your application whenever code is pushed"+
-				" to the main branch.", output.WithLinkFormat(".github/workflows"))),
-			formatHelpNote(fmt.Sprintf("For more information, go to: %s.",
+			formatHelpNote(
+				"azd commands (e.g. " +
+					output.WithHighLightFormat("provision") + ", " +
+					output.WithHighLightFormat("deploy") + ") " +
+					"can be used within GitHub Actions and Azure Pipelines to test your code against real Azure resources " +
+					"and facilitate deployments."),
+			formatHelpNote(
+				"After creating a pipeline definition file, running " +
+					output.WithHighLightFormat("pipeline config") +
+					" will help configure your deployment pipeline to connect securely to Azure."),
+			formatHelpNote(fmt.Sprintf("For more information on how to use azd in your pipeline, go to: %s.",
 				output.WithLinkFormat("https://aka.ms/azure-dev/pipeline"))),
 		})
 }
@@ -218,22 +225,33 @@ func getCmdPipelineHelpFooter(c *cobra.Command) string {
 
 func getCmdPipelineConfigHelpDescription(*cobra.Command) string {
 	return generateCmdHelpDescription(
-		"Create and configure your deployment pipeline by using GitHub or Azure Pipelines.",
+		"Configure your deployment pipeline to connect securely to Azure",
 		[]string{
+			formatHelpNote(
+				"Supports GitHub Actions and Azure Pipelines. To set the pipeline provider to be configured, " +
+					"provide a value for the '--provider' flag."),
+			formatHelpNote(
+				output.WithHighLightFormat("pipeline config") +
+					" creates or uses a service principal on the Azure subscription to create a secure connection between" +
+					" your deployment pipeline and Azure."),
 			formatHelpNote("By default, " +
 				output.WithHighLightFormat("pipeline config") +
-				" will configure and set deployment pipeline variables using the current environment. " +
-				"To configure for a new or a different existing environment, use the '-e' flag."),
+				" will set deployment pipeline variables and secrets using the current environment. " +
+				"To configure for a new or a different existing environment, provide a value for the '-e' flag."),
 		})
 }
 
 func getCmdPipelineConfigHelpFooter(c *cobra.Command) string {
 	return generateCmdHelpSamplesBlock(map[string]string{
-		"Set up a deployment pipeline for 'app-test' environment": fmt.Sprintf("%s %s",
+		"Configure a deployment pipeline using an existing service principal": fmt.Sprintf("%s %s",
+			output.WithHighLightFormat("azd pipeline config --principal-name"),
+			output.WithWarningFormat("[Principal name]"),
+		),
+		"Configure a deployment pipeline for 'app-test' environment": fmt.Sprintf("%s %s",
 			output.WithHighLightFormat("azd pipeline config -e"),
 			output.WithWarningFormat("app-test"),
 		),
-		"Set up a deployment pipeline for 'app-test' environment on Azure Pipelines.": fmt.Sprintf("%s %s %s",
+		"Configure a deployment pipeline for 'app-test' environment on Azure Pipelines.": fmt.Sprintf("%s %s %s",
 			output.WithHighLightFormat("azd pipeline config -e"),
 			output.WithWarningFormat("app-test"),
 			output.WithHighLightFormat("--provider azdo"),

--- a/cli/azd/cmd/provision.go
+++ b/cli/azd/cmd/provision.go
@@ -62,15 +62,6 @@ func newProvisionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "provision",
 		Short: "Provision the Azure resources for an application.",
-		//nolint:lll
-		Long: `Provision the Azure resources for an application.
-
-The command prompts you for the following values:
-- Environment name: The name of your environment.
-- Azure location: The Azure location where your resources will be deployed.
-- Azure subscription: The Azure subscription where your resources will be deployed.
-
-Depending on what Azure resources are created, running this command might take a while. To view progress, go to the Azure portal and search for the resource group that contains your environment name.`,
 	}
 }
 
@@ -256,7 +247,6 @@ func getCmdProvisionHelpDescription(c *cobra.Command) string {
 			" You should run %s any time you update your Bicep or Terraform file."+
 			"\n\nThis command prompts you to input the following:",
 		output.WithHighLightFormat(c.CommandPath())), []string{
-		formatHelpNote("Environment name: The name of your environment (ex: dev, test, prod)."),
 		formatHelpNote("Azure location: The Azure location where your resources will be deployed."),
 		formatHelpNote("Azure subscription: The Azure subscription where your resources will be deployed."),
 	})

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -333,8 +333,10 @@ func getCmdRootHelpFooter(cmd *cobra.Command) string {
 			output.WithHighLightFormat("azd init --template ")+
 			output.WithWarningFormat("[%s]", "template name")+" command in an empty directory.",
 		"Then, run "+output.WithHighLightFormat("azd up")+" to get the application up-and-running in Azure.",
-		output.WithGrayFormat("To view available templates run `azd template list` or visit: ")+
-			output.WithLinkFormat("https://azure.github.io/awesome-azd"),
+		"To view a curated list of sample templates, run "+
+			output.WithHighLightFormat("azd template list")+".\n"+
+			"To view all available sample templates, including those submitted by the azd community, visit: "+
+			output.WithLinkFormat("https://azure.github.io/awesome-azd")+".",
 		getCmdHelpDefaultFooter(cmd),
 	)
 }

--- a/cli/azd/cmd/testdata/TestUsage-azd-init.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-init.snap
@@ -2,7 +2,7 @@
 Initialize a new application in your current directory.
 
   • Running init without a template will prompt you to start with a minimal template or select from a curated list of presets.
-  • To view available templates run `azd template list` or visit: https://azure.github.io/awesome-azd
+  • To view all available sample templates, including those submitted by the azd community, visit: https://azure.github.io/awesome-azd.
 
 Usage
   azd init [flags]

--- a/cli/azd/cmd/testdata/TestUsage-azd-init.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-init.snap
@@ -1,8 +1,8 @@
 
 Initialize a new application in your current directory.
 
-  • Running azd init without a template will prompt you to start with a minimal template or select from a curated list of presets.
-  • To view all currently available sample templates visit: azd init.
+  • Running init without a template will prompt you to start with a minimal template or select from a curated list of presets.
+  • To view available templates run `azd template list` or visit: https://azure.github.io/awesome-azd
 
 Usage
   azd init [flags]

--- a/cli/azd/cmd/testdata/TestUsage-azd-pipeline-config.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-pipeline-config.snap
@@ -1,9 +1,9 @@
 
 Configure your deployment pipeline to connect securely to Azure
 
-  • Supports GitHub Actions and Azure Pipelines. To set the pipeline provider to be configured, provide a value for the '--provider' flag.
+  • Supports GitHub Actions and Azure Pipelines. To configure using a specific pipeline provider, provide a value for the '--provider' flag.
   • pipeline config creates or uses a service principal on the Azure subscription to create a secure connection between your deployment pipeline and Azure.
-  • By default, pipeline config will set deployment pipeline variables and secrets using the current environment. To configure for a new or a different existing environment, provide a value for the '-e' flag.
+  • By default, pipeline config will set deployment pipeline variables and secrets using the current environment. To configure for a new or an existing environment, provide a value for the '-e' flag.
 
 Usage
   azd pipeline config [flags]

--- a/cli/azd/cmd/testdata/TestUsage-azd-pipeline-config.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-pipeline-config.snap
@@ -1,7 +1,9 @@
 
-Create and configure your deployment pipeline by using GitHub or Azure Pipelines.
+Configure your deployment pipeline to connect securely to Azure
 
-  • By default, pipeline config will configure and set deployment pipeline variables using the current environment. To configure for a new or a different existing environment, use the '-e' flag.
+  • Supports GitHub Actions and Azure Pipelines. To set the pipeline provider to be configured, provide a value for the '--provider' flag.
+  • pipeline config creates or uses a service principal on the Azure subscription to create a secure connection between your deployment pipeline and Azure.
+  • By default, pipeline config will set deployment pipeline variables and secrets using the current environment. To configure for a new or a different existing environment, provide a value for the '-e' flag.
 
 Usage
   azd pipeline config [flags]
@@ -21,10 +23,13 @@ Global Flags
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Examples
-  Set up a deployment pipeline for 'app-test' environment
+  Configure a deployment pipeline for 'app-test' environment
     azd pipeline config -e app-test
 
-  Set up a deployment pipeline for 'app-test' environment on Azure Pipelines.
+  Configure a deployment pipeline for 'app-test' environment on Azure Pipelines.
     azd pipeline config -e app-test --provider azdo
+
+  Configure a deployment pipeline using an existing service principal
+    azd pipeline config --principal-name [Principal name]
 
 

--- a/cli/azd/cmd/testdata/TestUsage-azd-pipeline.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-pipeline.snap
@@ -1,14 +1,15 @@
 
-Manage integrating your application with build pipelines. (Beta)
+Manage integrating your application with deployment pipelines. (Beta)
 
-  • The Azure Developer CLI template includes a GitHub Actions pipeline configuration file (in the .github/workflows folder) that deploys your application whenever code is pushed to the main branch.
-  • For more information, go to: https://aka.ms/azure-dev/pipeline.
+  • azd commands (e.g. provision, deploy) can be used within GitHub Actions and Azure Pipelines to test your code against real Azure resources and facilitate deployments.
+  • After creating a pipeline definition file, running pipeline config will help configure your deployment pipeline to connect securely to Azure.
+  • For more information on how to use azd in your pipeline, go to: https://aka.ms/azure-dev/pipeline.
 
 Usage
   azd pipeline [command]
 
 Available Commands
-  config	: Create and configure your deployment pipeline by using GitHub or Azure Pipelines. (Beta)
+  config	: Configure your deployment pipeline to connect securely to Azure. (Beta)
 
 Flags
     -h, --help 	: Gets help for pipeline.

--- a/cli/azd/cmd/testdata/TestUsage-azd-provision.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-provision.snap
@@ -3,7 +3,6 @@ Provision the Azure resources for an application. This step may take a while dep
 
 This command prompts you to input the following:
 
-  • Environment name: The name of your environment (ex: dev, test, prod).
   • Azure location: The Azure location where your resources will be deployed.
   • Azure subscription: The Azure subscription where your resources will be deployed.
 

--- a/cli/azd/cmd/testdata/TestUsage-azd.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd.snap
@@ -39,7 +39,8 @@ Deploying a sample application
 Initialize from a sample application by running the azd init --template [template name] command in an empty directory.
 Then, run azd up to get the application up-and-running in Azure.
 
-To view available templates run `azd template list` or visit: https://azure.github.io/awesome-azd
+To view a curated list of sample templates, run azd template list.
+To view all available sample templates, including those submitted by the azd community, visit: https://azure.github.io/awesome-azd.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.
 

--- a/cli/azd/pkg/commands/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline_manager.go
@@ -416,7 +416,7 @@ func (manager *PipelineManager) Configure(ctx context.Context) (
 	}
 
 	return &PipelineConfigResult{
-		RepositoryLink: gitRepoInfo.remote,
-		PipelineLink:   ciPipeline.remote,
+		RepositoryLink: strings.TrimSuffix(gitRepoInfo.remote, ".git"),
+		PipelineLink:   strings.TrimSuffix(ciPipeline.remote, ".git"),
 	}, nil
 }


### PR DESCRIPTION
Make it clear that user needs to create their pipeline definition or use one provided by an azd template.

While looking at other usage text, the other changes brought in:
- Remove env name prompt from `azd provision` as that is no longer true
- Fix `azd init` link to all templates
- Remove `.git` suffix from links

Fixes #2131, #2236 