### PR TITLE
add daprEnabled param to container-apps bicep

### DIFF
--- a/templates/common/infra/bicep/core/host/container-app.bicep
+++ b/templates/common/infra/bicep/core/host/container-app.bicep
@@ -127,5 +127,5 @@ resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2022-03-01'
 output defaultDomain string = containerAppsEnvironment.properties.defaultDomain
 output imageName string = imageName
 output name string = app.name
-output uri string = 'https://${app.properties.configuration.ingress.fqdn}'
+output uri string = ingressEnabled ? 'https://${app.properties.configuration.ingress.fqdn}' : ''
 output identityPrincipalId string = normalizedIdentityType == 'None' ? '' : (empty(identityName) ? app.identity.principalId : userIdentity.properties.principalId)

--- a/templates/common/infra/bicep/core/host/container-apps.bicep
+++ b/templates/common/infra/bicep/core/host/container-apps.bicep
@@ -6,6 +6,7 @@ param containerAppsEnvironmentName string
 param containerRegistryName string
 param logAnalyticsWorkspaceName string
 param applicationInsightsName string = ''
+param daprEnabled bool = false
 
 module containerAppsEnvironment 'container-apps-environment.bicep' = {
   name: '${name}-container-apps-environment'
@@ -15,6 +16,7 @@ module containerAppsEnvironment 'container-apps-environment.bicep' = {
     tags: tags
     logAnalyticsWorkspaceName: logAnalyticsWorkspaceName
     applicationInsightsName: applicationInsightsName
+    daprEnabled: daprEnabled
   }
 }
 


### PR DESCRIPTION
Allow to pass in `daprEnabled` field as a parameter in `container-apps.bicep` module. 
Fix `URI` parsing in output in `container-app.bicep` file to only be done when `ingressEnabled` is true.