### PR TITLE
update spring-boot-starter-parent to 3.0.6

### DIFF
--- a/cli/azd/test/functional/testdata/samples/springapp/pom.xml
+++ b/cli/azd/test/functional/testdata/samples/springapp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.10</version>
+		<version>3.0.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.microsoft.azure</groupId>

--- a/templates/todo/api/java-postgresql/pom.xml
+++ b/templates/todo/api/java-postgresql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.5</version>
+    <version>3.0.6</version>
     <relativePath/>
     <!-- lookup parent from repository -->
   </parent>

--- a/templates/todo/api/java/pom.xml
+++ b/templates/todo/api/java/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.5</version>
+    <version>3.0.6</version>
     <relativePath/>
     <!-- lookup parent from repository -->
   </parent>


### PR DESCRIPTION
Security warning ask for update org.springframework:spring-core from 6.0.7 to 6.0.8. spring-boot-starter-parent 3.0.6 uses org.springframework:spring-core 6.0.8