### PR TITLE
Create an `alpha` version of `azure.yaml` schema

### DIFF
--- a/.vscode/cspell.misc.yaml
+++ b/.vscode/cspell.misc.yaml
@@ -33,6 +33,7 @@ overrides:
           - prodapi
           - appservice
           - containerapp
+          - springapp
           - staticwebapp
           - myapp
           - azdev

--- a/.vscode/cspell.misc.yaml
+++ b/.vscode/cspell.misc.yaml
@@ -28,7 +28,7 @@ overrides:
     - filename: generators/repo/tsconfig.json
       words:
           - tsbuildinfo
-    - filename: schemas/v1.0/azure.yaml.json
+    - filename: schemas/**/azure.yaml.json
       words:
           - prodapi
           - appservice

--- a/cli/azd/test/functional/testdata/samples/springapp/azure.yaml
+++ b/cli/azd/test/functional/testdata/samples/springapp/azure.yaml
@@ -7,7 +7,5 @@ services:
     host: springapp
     language: java
 infra:
-#  provider: terraform
-#  path: infra-terraform
   path: infra-bicep
 

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -88,6 +88,7 @@
                             "appservice",
                             "containerapp",
                             "function",
+                            "springapp",
                             "staticwebapp",
                             "aks"
                         ]

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -1,0 +1,503 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/alpha/azure.yaml.json",
+    "type": "object",
+    "required": [
+        "name"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 2,
+            "title": "Name of the application"
+        },
+        "resourceGroup": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 64,
+            "title": "Name of the Azure resource group",
+            "description": "When specified will override the resource group name used for infrastructure provisioning. Supports environment variable substitution."
+        },
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "template": {
+                    "type": "string",
+                    "title": "Identifier of the template from which the application was created. Optional.",
+                    "examples": [
+                        "todo-nodejs-mongo@0.0.1-beta"
+                    ]
+                }
+            }
+        },
+        "infra": {
+            "type": "object",
+            "title": "The infrastructure configuration used for the application",
+            "description": "Optional. Provides additional configuration for Azure infrastructure provisioning.",
+            "additionalProperties": true,
+            "properties": {
+                "provider": {
+                    "type": "string",
+                    "title": "Type of infrastructure provisioning provider",
+                    "description": "Optional. The infrastructure provisioning provider used to provision the Azure resources for the application. (Default: bicep)",
+                    "enum": [
+                        "bicep",
+                        "terraform"
+                    ]
+                },
+                "path": {
+                    "type": "string",
+                    "title": "Path to the location that contains Azure provisioning templates",
+                    "description": "Optional. The relative folder path to the Azure provisioning templates for the specified provider. (Default: infra)"
+                },
+                "module": {
+                    "type": "string",
+                    "title": "Name of the default module within the Azure provisioning templates",
+                    "description": "Optional. The name of the Azure provisioning module used when provisioning resources. (Default: main)"
+                }
+            }
+        },
+        "services": {
+            "type": "object",
+            "title": "Definition of services that comprise the application",
+            "minProperties": 1,
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "project",
+                    "language"
+                ],
+                "properties": {
+                    "resourceName": {
+                        "type": "string",
+                        "title": "Name of the Azure resource that implements the service",
+                        "description": "By default, the CLI will discover the Azure resource with tag 'azd-service-name' set to the current service's name. When specified, the CLI will instead find the Azure resource with the matching resource name. Supports environment variable substitution."
+                    },
+                    "project": {
+                        "type": "string",
+                        "title": "Path to the service source code directory"
+                    },
+                    "host": {
+                        "type": "string",
+                        "title": "Type of Azure resource used for service implementation",
+                        "description": "If omitted, App Service will be assumed.",
+                        "enum": [
+                            "",
+                            "appservice",
+                            "containerapp",
+                            "function",
+                            "staticwebapp",
+                            "aks"
+                        ]
+                    },
+                    "language": {
+                        "type": "string",
+                        "title": "Service implementation language",
+                        "enum": [
+                            "dotnet",
+                            "csharp",
+                            "fsharp",
+                            "py",
+                            "python",
+                            "js",
+                            "ts",
+                            "java"
+                        ]
+                    },
+                    "module": {
+                        "type": "string",
+                        "title": "(DEPRECATED) Path of the infrastructure module used to deploy the service relative to the root infra folder",
+                        "description": "If omitted, the CLI will assume the module name is the same as the service name. This property will be deprecated in a future release."
+                    },
+                    "dist": {
+                        "type": "string",
+                        "title": "Relative path to service deployment artifacts"
+                    },
+                    "docker": {
+                        "$ref": "#/definitions/docker"
+                    },
+                    "k8s": {
+                        "$ref": "#/definitions/aksOptions"
+                    },
+                    "hooks": {
+                        "type": "object",
+                        "title": "Service level hooks",
+                        "description": "Hooks should match `service` event names prefixed with `pre` or `post` depending on when the script should execute. When specifying paths they should be relative to the service path.",
+                        "additionalProperties": false,
+                        "properties": {
+                            "predeploy": {
+                                "title": "pre deploy hook",
+                                "description": "Runs before the service is deployed to Azure",
+                                "$ref": "#/definitions/hook"
+                            },
+                            "postdeploy": {
+                                "title": "post deploy hook",
+                                "description": "Runs after the service is deployed to Azure",
+                                "$ref": "#/definitions/hook"
+                            },
+                            "prerestore": {
+                                "title": "pre restore hook",
+                                "description": "Runs before the service dependencies are restored",
+                                "$ref": "#/definitions/hook"
+                            },
+                            "postrestore": {
+                                "title": "post restore hook",
+                                "description": "Runs after the service dependencies are restored",
+                                "$ref": "#/definitions/hook"
+                            },
+                            "prepackage": {
+                                "title": "pre package hook",
+                                "description": "Runs before the service is deployment package is created",
+                                "$ref": "#/definitions/hook"
+                            },
+                            "postpackage": {
+                                "title": "post package hook",
+                                "description": "Runs after the service is deployment package is created",
+                                "$ref": "#/definitions/hook"
+                            }
+                        }
+                    }
+                },
+                "allOf": [
+                    {
+                        "if": {
+                            "not": {
+                                "properties": {
+                                    "host": {
+                                        "enum": [
+                                            "containerapp",
+                                            "aks"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "docker": false
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "not": {
+                                "properties": {
+                                    "host": {
+                                        "enum": [
+                                            "aks"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "k8s": false
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "language": {
+                                    "const": "java"
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "dist": {
+                                    "type": "string",
+                                    "description": "Optional. The path to the directory containing a single Java archive file (.jar/.ear/.war), or the path to the specific Java archive file to be included in the deployment artifact. If omitted, the CLI will detect the output directory based on the build system in-use. For maven, the default output directory 'target' is assumed."
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "properties": {
+                            "dist": {
+                                "type": "string",
+                                "description": "Optional. The CLI will use files under this path to create the deployment artifact (ZIP file). If omitted, all files under service project directory will be included."
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "pipeline": {
+            "type": "object",
+            "title": "Definition of continuous integration pipeline",
+            "properties": {
+                "provider": {
+                    "type": "string",
+                    "title": "Type of pipeline provider",
+                    "description": "Optional. The pipeline provider to be used for continuous integration. (Default: github)",
+                    "enum": [
+                        "github",
+                        "azdo"
+                    ]
+                }
+            }
+        },
+        "hooks": {
+            "type": "object",
+            "title": "Command level hooks",
+            "description": "Hooks should match `azd` command names prefixed with `pre` or `post` depending on when the script should execute. When specifying paths they should be relative to the project path.",
+            "additionalProperties": false,
+            "properties": {
+                "preprovision": {
+                    "title": "pre provision hook",
+                    "description": "Runs before the `provision` command",
+                    "$ref": "#/definitions/hook"
+                },
+                "postprovision": {
+                    "title": "post provision hook",
+                    "description": "Runs after the `provision` command",
+                    "$ref": "#/definitions/hook"
+                },
+                "preinfracreate": {
+                    "title": "pre infra create hook",
+                    "description": "Runs before the `infra create` or `provision` commands",
+                    "$ref": "#/definitions/hook"
+                },
+                "postinfracreate": {
+                    "title": "post infra create hook",
+                    "description": "Runs after the `infra create` or `provision` commands",
+                    "$ref": "#/definitions/hook"
+                },
+                "preinfradelete": {
+                    "title": "pre infra delete hook",
+                    "description": "Runs before the `infra delete` or `down` commands",
+                    "$ref": "#/definitions/hook"
+                },
+                "postinfradelete": {
+                    "title": "post infra delete hook",
+                    "description": "Runs after the `infra delete` or `down` commands",
+                    "$ref": "#/definitions/hook"
+                },
+                "predown": {
+                    "title": "pre down hook",
+                    "description": "Runs before the `infra delete` or `down` commands",
+                    "$ref": "#/definitions/hook"
+                },
+                "postdown": {
+                    "title": "post down hook",
+                    "description": "Runs after the `infra delete` or `down` commands",
+                    "$ref": "#/definitions/hook"
+                },
+                "preup": {
+                    "title": "pre up hook",
+                    "description": "Runs before the `up` command",
+                    "$ref": "#/definitions/hook"
+                },
+                "postup": {
+                    "title": "post up hook",
+                    "description": "Runs after the `up` command",
+                    "$ref": "#/definitions/hook"
+                },
+                "prepackage": {
+                    "title": "pre package hook",
+                    "description": "Runs before the `package` command",
+                    "$ref": "#/definitions/hook"
+                },
+                "postpackage": {
+                    "title": "post package hook",
+                    "description": "Runs after the `package` command",
+                    "$ref": "#/definitions/hook"
+                },
+                "predeploy": {
+                    "title": "pre deploy hook",
+                    "description": "Runs before the `deploy` command",
+                    "$ref": "#/definitions/hook"
+                },
+                "postdeploy": {
+                    "title": "post deploy hook",
+                    "description": "Runs after the `deploy` command",
+                    "$ref": "#/definitions/hook"
+                },
+                "prerestore": {
+                    "title": "pre restore hook",
+                    "description": "Runs before the `restore` command",
+                    "$ref": "#/definitions/hook"
+                },
+                "postrestore": {
+                    "title": "post restore hook",
+                    "description": "Runs after the `restore` command",
+                    "$ref": "#/definitions/hook"
+                }
+            }
+        },
+        "requiredVersions": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "azd": {
+                    "type": "string",
+                    "title": "A range of supported versions of `azd` for this project",
+                    "description": "A range of supported versions of `azd` for this project. If the version of `azd` is outside this range, the project will fail to load. Optional (allows all versions if absent).",
+                    "examples": [
+                        ">= 0.6.0-beta.3"
+                    ]
+                }
+            }
+        }
+    },
+    "definitions": {
+        "hook": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shell": {
+                    "type": "string",
+                    "title": "Type of shell to execute scripts",
+                    "description": "Optional. The type of shell to use for the hook. (Default: sh)",
+                    "enum": [
+                        "sh",
+                        "pwsh"
+                    ],
+                    "default": "sh"
+                },
+                "run": {
+                    "type": "string",
+                    "title": "Required. The inline script or relative path of your scripts from the project or service path",
+                    "description": "When specifying an inline script you also must specify the `shell` to use. This is automatically inferred when using paths."
+                },
+                "continueOnError": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "Whether or not a script error will halt the azd command",
+                    "description": "Optional. When set to true will continue to run the command even after a script error has occurred. (Default: false)"
+                },
+                "interactive": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "Whether the script will run in interactive mode",
+                    "description": "Optional. When set to true will bind the script to stdin, stdout & stderr of the running console. (Default: false)"
+                },
+                "windows": {
+                    "title": "The hook configuration used for Windows environments",
+                    "description": "When specified overrides the hook configuration when executed in Windows environments",
+                    "default": null,
+                    "$ref": "#/definitions/hook"
+                },
+                "posix": {
+                    "title": "The hook configuration used for POSIX (Linux & MacOS) environments",
+                    "description": "When specified overrides the hook configuration when executed in POSIX environments",
+                    "default": null,
+                    "$ref": "#/definitions/hook"
+                }
+            },
+            "if": {
+                "not": {
+                    "anyOf": [
+                        {
+                            "required": [
+                                "windows"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "posix"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "then": {
+                "required": [
+                    "run"
+                ]
+            }
+        },
+        "docker": {
+            "type": "object",
+            "description": "This is only applicable when `host` is `containerapp` or `aks`",
+            "additionalProperties": false,
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "title": "The path to the Dockerfile",
+                    "description": "Path to the Dockerfile is relative to your service",
+                    "default": "./Dockerfile"
+                },
+                "context": {
+                    "type": "string",
+                    "title": "The docker build context",
+                    "description": "When specified overrides the default context",
+                    "default": "."
+                },
+                "platform": {
+                    "type": "string",
+                    "title": "The platform target",
+                    "default": "amd64"
+                },
+                "tag": {
+                    "type": "string",
+                    "title": "The tag that will be applied to the built container image.",
+                    "description": "If omitted, a unique tag will be generated based on the format: {appName}/{serviceName}-{environmentName}:azd-deploy-{unix time (seconds)}. Supports environment variable substitution. For example, to generate unique tags for a given release: myapp/myimage:${DOCKER_IMAGE_TAG}"
+                }
+            }
+        },
+        "aksOptions": {
+            "type": "object",
+            "title": "Optional. The Azure Kubernetes Service (AKS) configuration options",
+            "additionalProperties": false,
+            "properties": {
+                "deploymentPath": {
+                    "type": "string",
+                    "title": "Optional. The relative path from the service path to the k8s deployment manifests. (Default: manifests)",
+                    "description": "When set it will override the default deployment path location for k8s deployment manifests.",
+                    "default": "manifests"
+                },
+                "namespace": {
+                    "type": "string",
+                    "title": "Optional. The k8s namespace of the deployed resources. (Default: Project name)",
+                    "description": "When specified a new k8s namespace will be created if it does not already exist"
+                },
+                "deployment": {
+                    "type": "object",
+                    "title": "Optional. The k8s deployment configuration",
+                    "additionalProperties": false,
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "title": "Optional. The name of the k8s deployment resource to use during deployment. (Default: Service name)",
+                            "description": "Used during deployment to ensure if the k8s deployment rollout has been completed. If not set will search for a deployment resource in the same namespace that contains the service name."
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "title": "Optional. The k8s service configuration",
+                    "additionalProperties": false,
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "title": "Optional. The name of the k8s service resource to use as the default service endpoint. (Default: Service name)",
+                            "description": "Used when determining endpoints for the default service resource. If not set will search for a deployment resource in the same namespace that contains the service name."
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "title": "Optional. The k8s ingress configuration",
+                    "additionalProperties": false,
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "title": "Optional. The name of the k8s ingress resource to use as the default service endpoint. (Default: Service name)",
+                            "description": "Used when determining endpoints for the default ingress resource. If not set will search for a deployment resource in the same namespace that contains the service name."
+                        },
+                        "relativePath": {
+                            "type": "string",
+                            "title": "Optional. The relative path to the service from the root of your ingress controller.",
+                            "description": "When set will be appended to the root of your ingress resource path."
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/templates/starter/terraform/azure.yaml
+++ b/templates/starter/terraform/azure.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/alpha/azure.yaml.json
 
 # This is an example starter azure.yaml file containing several example services in comments below.
 # Make changes as needed to describe your application setup.

--- a/templates/todo/projects/java-postgresql/.repo/terraform/azure.yaml
+++ b/templates/todo/projects/java-postgresql/.repo/terraform/azure.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/alpha/azure.yaml.json
 
 name: todo-java-postgresql-terraform
 metadata:

--- a/templates/todo/projects/nodejs-mongo/.repo/terraform/azure.yaml
+++ b/templates/todo/projects/nodejs-mongo/.repo/terraform/azure.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/alpha/azure.yaml.json
 
 name: todo-nodejs-mongo-terraform
 metadata:

--- a/templates/todo/projects/python-mongo/.repo/terraform/azure.yaml
+++ b/templates/todo/projects/python-mongo/.repo/terraform/azure.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/alpha/azure.yaml.json
 
 name: todo-python-mongo-terraform
 metadata:


### PR DESCRIPTION
We don't want to include any values in the schema that are tied to alpha features in the `v1.0` schema, since we may remove or change these values during development.

This change introduces a new copy of this schema and adds "terraform" as a supported member of an enum (this is a new value that is supported behind an alpha feature)

Fixes #1925