### PR TITLE
Rename the binaries inside the compressed files as well

### DIFF
--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -1182,9 +1182,9 @@ stages:
           - pwsh: |
               $urlBase = "$(GenerateUrlBase.UrlBase)"
               $linuxReleaseUrl = "$urlBase/azd-linux-amd64.tar.gz"
-              $linuxReleaseUrlArm64 = "$urlBase/azd-linux-arm64.tar.gz"
+              $linuxReleaseUrlArm64 = "$urlBase/azd-linux-arm64-beta.tar.gz"
               $macosReleaseUrl = "$urlBase/azd-darwin-amd64.zip"
-              $macosReleaseUrlArm64 = "$urlBase/azd-darwin-arm64.zip"
+              $macosReleaseUrlArm64 = "$urlBase/azd-darwin-arm64-beta.zip"
               $windowsReleaseUrl = "$urlBase/azd-windows-amd64.zip"
               $msiReleaseUrl = "$urlBase/azd-windows-amd64.msi"
 

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -22,6 +22,7 @@ pr:
       - go.mod
       - cli/
       - eng/pipelines/release-cli.yml
+      - eng/pipelines/templates/steps/publish-cli.yml
 
 variables:
   - template: /eng/pipelines/templates/variables/globals.yml

--- a/eng/pipelines/templates/steps/publish-cli.yml
+++ b/eng/pipelines/templates/steps/publish-cli.yml
@@ -99,8 +99,8 @@ steps:
 
   - ${{ if eq('true', parameters.PublishArm64Binaries) }}: 
     - pwsh: |
-        Rename-Item release-staging/azd-linux-arm64 release-staging/azd-linux-arm64-beta 
-        Rename-Item signed/mac/azd-darwin-arm64 signed/mac/azd-darwin-arm64-beta
+        Move-Item release-staging/azd-linux-arm64 release-staging/azd-linux-arm64-beta 
+        Move-Item signed/mac/azd-darwin-arm64 signed/mac/azd-darwin-arm64-beta
 
         New-Item -ItemType Directory -Path release -Force
         zip release/azd-darwin-arm64-beta.zip -j signed/mac/azd-darwin-arm64-beta NOTICE.txt

--- a/eng/pipelines/templates/steps/publish-cli.yml
+++ b/eng/pipelines/templates/steps/publish-cli.yml
@@ -99,13 +99,16 @@ steps:
 
   - ${{ if eq('true', parameters.PublishArm64Binaries) }}: 
     - pwsh: |
+        Rename-Item release-staging/azd-linux-arm64 release-staging/azd-linux-arm64-beta 
+        Rename-Item signed/mac/azd-darwin-arm64 signed/mac/azd-darwin-arm64-beta
+
         New-Item -ItemType Directory -Path release -Force
-        zip release/azd-darwin-arm64-beta.zip -j signed/mac/azd-darwin-arm64 NOTICE.txt
+        zip release/azd-darwin-arm64-beta.zip -j signed/mac/azd-darwin-arm64-beta NOTICE.txt
 
         # Must place NOTICE.txt in file tree for tar to pick it up and place it in
         # the same place in the directory structure
         Copy-Item NOTICE.txt ./release-staging/
-        tar -C ./release-staging/ -cvzf release/azd-linux-arm64-beta.tar.gz azd-linux-arm64 NOTICE.txt
+        tar -C ./release-staging/ -cvzf release/azd-linux-arm64-beta.tar.gz azd-linux-arm64-beta NOTICE.txt
       displayName: Compress standalone binary for release (ARM64)
 
 


### PR DESCRIPTION
Finishes fixing #2183... This renames the ARM binaries contained in their compressed files as described in https://github.com/Azure/azure-dev/issues/2183#issuecomment-1545303694