### PR TITLE
Disabled ACR admin user by default

### DIFF
--- a/templates/common/infra/bicep/core/host/container-registry.bicep
+++ b/templates/common/infra/bicep/core/host/container-registry.bicep
@@ -2,7 +2,7 @@ param name string
 param location string = resourceGroup().location
 param tags object = {}
 
-param adminUserEnabled bool = true
+param adminUserEnabled bool = false
 param anonymousPullEnabled bool = false
 param dataEndpointEnabled bool = false
 param encryption object = {


### PR DESCRIPTION
With the change from #2245 we are now able to disable the ACR admin user by default.

This is a security best practice. More information available in [azure docs](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#admin-account)

> The admin account is designed for a single user to access the registry, mainly for testing purposes. We do not recommend sharing the admin account credentials among multiple users. All users authenticating with the admin account appear as a single user with push and pull access to the registry. Changing or disabling this account disables registry access for all users who use its credentials. Individual identity is recommended for users and service principals for headless scenarios.