### PR TITLE
Add handling for non-existing cache file

### DIFF
--- a/cli/azd/pkg/auth/cache_test.go
+++ b/cli/azd/pkg/auth/cache_test.go
@@ -56,6 +56,14 @@ func TestCache(t *testing.T) {
 	require.NotNil(t, r2.val)
 	require.Equal(t, d1.val, r1.val)
 	require.Equal(t, d2.val, r2.val)
+
+	// read some non-existing data, ensure nil is returned.
+	nonExist := fixedMarshaller{
+		val: []byte("some data"),
+	}
+	err = c.Replace(ctx, &nonExist, cache.ReplaceHints{PartitionKey: "nonExist"})
+	require.NoError(t, err)
+	require.Nil(t, nonExist.val)
 }
 
 func TestCredentialCache(t *testing.T) {
@@ -96,4 +104,9 @@ func TestCredentialCache(t *testing.T) {
 	require.NotNil(t, r2)
 	require.Equal(t, d1, r1)
 	require.Equal(t, d2, r2)
+
+	// read some non-existing data, ensure nil is returned.
+	val, err := c.Read("nonExist")
+	require.NoError(t, err)
+	require.Nil(t, val)
 }

--- a/cli/azd/pkg/auth/cache_unix.go
+++ b/cli/azd/pkg/auth/cache_unix.go
@@ -10,6 +10,9 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/cache"
 )
 
+// newCache creates a cache implementation that satisfies [cache.ExportReplace] from the MSAL library.
+//
+// root must be created beforehand, and must point to a directory.
 func newCache(root string) cache.ExportReplace {
 	return &msalCacheAdapter{
 		cache: &memoryCache{
@@ -23,6 +26,9 @@ func newCache(root string) cache.ExportReplace {
 	}
 }
 
+// newCredentialCache creates a cache implementation for storing credentials.
+//
+// root must be created beforehand, and must point to a directory.
 func newCredentialCache(root string) Cache {
 	return &memoryCache{
 		cache: make(map[string][]byte),

--- a/cli/azd/pkg/auth/file_cache.go
+++ b/cli/azd/pkg/auth/file_cache.go
@@ -4,6 +4,7 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -15,6 +16,8 @@ import (
 
 // fileCache implements Cache by storing the data to disk. The cache key is used as part of the
 // filename for the stored object. Files are stored in [root] and are named [prefix][key].[ext].
+//
+// [root] is the root directory for the cache, and must be created beforehand.
 type fileCache struct {
 	prefix string
 	root   string
@@ -36,7 +39,12 @@ func (c *fileCache) Read(key string) ([]byte, error) {
 		}
 	}()
 
-	return os.ReadFile(cachePath)
+	contents, err := os.ReadFile(cachePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+
+	return contents, err
 }
 
 func (c *fileCache) Set(key string, value []byte) error {


### PR DESCRIPTION
Add handling for file-not-exist errors in file_cache, and return `nil` for the cached value appropriately.

Add a failing unit test that verifies the fix.

Fixes #2258