### PR TITLE
Fix typos in `config --help` and `restore --help`

### DIFF
--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -323,7 +323,7 @@ func getCmdConfigHelpDescription(*cobra.Command) string {
 	return generateCmdHelpDescription(
 		"Manage the Azure Developer CLI user configuration, which includes your default Azure subscription and location.",
 		[]string{
-			formatHelpNote(fmt.Sprintf("Applications are initially configures when you run %s.",
+			formatHelpNote(fmt.Sprintf("Applications are initially configured when you run %s.",
 				output.WithHighLightFormat("azd init"),
 			)),
 			formatHelpNote(fmt.Sprintf("The subscription and location you select will be stored at: %s.",

--- a/cli/azd/cmd/restore.go
+++ b/cli/azd/cmd/restore.go
@@ -203,7 +203,7 @@ func getCmdRestoreHelpDescription(*cobra.Command) string {
 		[]string{
 			formatHelpNote("Run this command to download and install all required dependencies so that you can build," +
 				" run, and debug the application locally."),
-			formatHelpNote(fmt.Sprintf("For the best local rn and debug experience, go to %s to learn how "+
+			formatHelpNote(fmt.Sprintf("For the best local run and debug experience, go to %s to learn how "+
 				"to use the Visual Studio Code extension.",
 				output.WithLinkFormat("https://aka.ms/azure-dev/vscode"),
 			)),

--- a/cli/azd/cmd/testdata/TestUsage-azd-config.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-config.snap
@@ -1,7 +1,7 @@
 
 Manage the Azure Developer CLI user configuration, which includes your default Azure subscription and location.
 
-  • Applications are initially configures when you run azd init.
+  • Applications are initially configured when you run azd init.
   • The subscription and location you select will be stored at: %HOME/.azd/config.json.
   • The default configuration path is: %HOME/.azd.
 

--- a/cli/azd/cmd/testdata/TestUsage-azd-restore.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-restore.snap
@@ -2,7 +2,7 @@
 Restore application dependencies.
 
   • Run this command to download and install all required dependencies so that you can build, run, and debug the application locally.
-  • For the best local rn and debug experience, go to https://aka.ms/azure-dev/vscode to learn how to use the Visual Studio Code extension.
+  • For the best local run and debug experience, go to https://aka.ms/azure-dev/vscode to learn how to use the Visual Studio Code extension.
 
 Usage
   azd restore <service> [flags]


### PR DESCRIPTION
adding a couple missing letters in the help text for `config` and `restore`