### PR TITLE
Anonymize host domains 

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -104,6 +104,7 @@ securestring
 semconv
 serverfarms
 setenvs
+servicebus
 snapshotter
 sstore
 staticcheck
@@ -118,6 +119,7 @@ teamcity
 testdata
 tracesdk
 tracetest
+trafficmanager
 Truef
 typeflag
 unmarshalling

--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -30,6 +30,15 @@ dictionaryDefinitions:
 dictionaries:
   - azdProjectDictionary
 overrides:
+  - filename: internal/tracing/fields/domains.go
+    words:
+      - azmk
+      - azurecontainerapps
+      - azureedge
+      - azurefd
+      - cloudapp
+      - mediaservices
+      - msecnd
   - filename: docs/docgen.go
     words:
       - alexwolf

--- a/cli/azd/cmd/middleware/telemetry.go
+++ b/cli/azd/cmd/middleware/telemetry.go
@@ -15,10 +15,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/events"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
-	"github.com/azure/azure-dev/cli/azd/pkg/azdo"
-	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
-	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/spf13/pflag"
 
@@ -218,52 +215,13 @@ func collectCode(lines []*azcli.DeploymentErrorLine, frame int) *deploymentError
 // and corresponding anonymized domain is returned. If the domain name is unrecognized,
 // it is returned as "other", "other".
 func mapService(host string) (service string, hostDomain string) {
-	for _, domain := range knownSubDomains {
+	for _, domain := range fields.Domains {
 		if strings.HasSuffix(host, domain.Name) {
 			return domain.Service, domain.Name
 		}
 	}
 
 	return "other", "other"
-}
-
-type subDomain struct {
-	Name    string
-	Service string
-}
-
-// Taken from https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-domains.
-// Order determines evaluation precedence with short-circuiting
-var knownSubDomains = []subDomain{
-	{azdo.AzDoHostName, "azdo"},
-	{azure.ManagementHostName, "arm"},
-	{graphsdk.HostName, "graph"},
-	{"graph.windows.net", "graph"},
-	{"azmk8s.io", "aks"},
-	{"azure-api.net", "apim"},
-	{"azure-mobile.net", "mobile"},
-	{"azurecontainerapps.io", "aca"},
-	{"azurecr.io", "acr"},
-	{"azureedge.net", "edge"},
-	{"azurefd.net", "frontdoor"},
-	{"scm.azurewebsites.net", "kudu"},
-	{"azurewebsites.net", "websites"},
-	{"blob.core.windows.net", "blob"},
-	{"cloudapp.azure.com", "vm"},
-	{"cloudapp.net", "vm"},
-	{"cosmos.azure.com", "cosmos"},
-	{"database.windows.net", "sql"},
-	{"documents.azure.com", "cosmos"},
-	{"file.core.windows.net", "files"},
-	{"management.core.windows.net", "arm"},
-	{"origin.mediaservices.windows.net", "media"},
-	{"queue.core.windows.net", "queue"},
-	{"servicebus.windows.net", "servicebus"},
-	{"table.core.windows.net", "table"},
-	{"trafficmanager.net", "trafficmanager"},
-	{"vault.azure.net", "keyvault"},
-	{"visualstudio.com", "vs"},
-	{"vo.msecnd.net", "cdn"},
 }
 
 func cmdAsName(cmd string) string {

--- a/cli/azd/internal/tracing/fields/domains.go
+++ b/cli/azd/internal/tracing/fields/domains.go
@@ -1,0 +1,44 @@
+package fields
+
+type Domain struct {
+	// The domain name.
+	Name string
+	// The name of the service that owns the domain name.
+	Service string
+}
+
+// Well-known domains. Domains can also be subdomains, thus should be evaluated as such.
+//
+// Taken from https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-domains.
+var Domains = []Domain{
+	// Order here likely determines evaluation precedence due to short-circuiting.
+	{"dev.azure.com", "azdo"},
+	{"management.azure.com", "arm"},
+	{"management.core.windows.net", "arm"},
+	{"graph.microsoft.com", "graph"},
+	{"graph.windows.net", "graph"},
+	{"azmk8s.io", "aks"},
+	{"azure-api.net", "apim"},
+	{"azure-mobile.net", "mobile"},
+	{"azurecontainerapps.io", "aca"},
+	{"azurecr.io", "acr"},
+	{"azureedge.net", "edge"},
+	{"azurefd.net", "frontdoor"},
+	{"scm.azurewebsites.net", "kudu"},
+	{"azurewebsites.net", "websites"},
+	{"blob.core.windows.net", "blob"},
+	{"cloudapp.azure.com", "vm"},
+	{"cloudapp.net", "vm"},
+	{"cosmos.azure.com", "cosmos"},
+	{"database.windows.net", "sql"},
+	{"documents.azure.com", "cosmos"},
+	{"file.core.windows.net", "files"},
+	{"origin.mediaservices.windows.net", "media"},
+	{"queue.core.windows.net", "queue"},
+	{"servicebus.windows.net", "servicebus"},
+	{"table.core.windows.net", "table"},
+	{"trafficmanager.net", "trafficmanager"},
+	{"vault.azure.net", "keyvault"},
+	{"visualstudio.com", "vs"},
+	{"vo.msecnd.net", "cdn"},
+}

--- a/cli/azd/internal/tracing/fields/domains.go
+++ b/cli/azd/internal/tracing/fields/domains.go
@@ -3,7 +3,7 @@ package fields
 type Domain struct {
 	// The domain name.
 	Name string
-	// The name of the service that owns the domain name.
+	// The name of the service that is responsible for the domain name.
 	Service string
 }
 
@@ -11,7 +11,7 @@ type Domain struct {
 //
 // Taken from https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-domains.
 var Domains = []Domain{
-	// Order here likely determines evaluation precedence due to short-circuiting.
+	// Order here matters, as it likely determines evaluation precedence due to short-circuiting.
 	{"dev.azure.com", "azdo"},
 	{"management.azure.com", "arm"},
 	{"management.core.windows.net", "arm"},

--- a/cli/azd/internal/tracing/fields/fields.go
+++ b/cli/azd/internal/tracing/fields/fields.go
@@ -164,9 +164,6 @@ const (
 	// Error code that describes an error.
 	ErrCode = attribute.Key("error.code")
 
-	// Details of an error.
-	ErrDetails = attribute.Key("error.details")
-
 	// Inner error.
 	ErrInner = attribute.Key("error.inner")
 

--- a/cli/azd/internal/tracing/fields/fields.go
+++ b/cli/azd/internal/tracing/fields/fields.go
@@ -174,6 +174,7 @@ const (
 // Service related fields.
 const (
 	// Hostname of the service.
+	// The list of allowed values can be found in [Domains].
 	ServiceHost = attribute.Key("service.host")
 
 	// Name of the service.

--- a/cli/azd/internal/tracing/fields/key.go
+++ b/cli/azd/internal/tracing/fields/key.go
@@ -41,3 +41,8 @@ func Sha256Hash(val string) string {
 	hash := hex.EncodeToString(sha[:])
 	return hash
 }
+
+// ErrorKey returns a new Key with "error." prefix appended.
+func ErrorKey(k attribute.Key) attribute.Key {
+	return attribute.Key("error." + string(k))
+}


### PR DESCRIPTION
With this change, only well-known domains are mapped and shown in error reporting data. Other domains are simply mapped to the value `other`.

Also, flatten the `error` schema instead of nesting data under `error.details`. This means reporting data that looks like `error.service.name` instead of `error.details` containing a JSON with `service.name`. This better suits azd's telemetry platform needs as data-processing happens at a field level.