### PR TITLE
Change AKS service spec 'targetPort' from int to string

### DIFF
--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -354,7 +354,7 @@ func setupMocksForKubectl(mockContext *mocks.MockContext) {
 				Ports: []kubectl.Port{
 					{
 						Port:       80,
-						TargetPort: "3000",
+						TargetPort: 3000,
 						Protocol:   "http",
 					},
 				},

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -354,7 +354,7 @@ func setupMocksForKubectl(mockContext *mocks.MockContext) {
 				Ports: []kubectl.Port{
 					{
 						Port:       80,
-						TargetPort: 3000,
+						TargetPort: "3000",
 						Protocol:   "http",
 					},
 				},

--- a/cli/azd/pkg/tools/kubectl/models.go
+++ b/cli/azd/pkg/tools/kubectl/models.go
@@ -107,7 +107,7 @@ type ServiceStatus struct {
 
 type Port struct {
 	Port       int    `json:"port"`
-	TargetPort int    `json:"targetPort"`
+	TargetPort string `json:"targetPort"`
 	Protocol   string `json:"protocol"`
 }
 

--- a/cli/azd/pkg/tools/kubectl/models.go
+++ b/cli/azd/pkg/tools/kubectl/models.go
@@ -107,7 +107,7 @@ type ServiceStatus struct {
 
 type Port struct {
 	Port       int    `json:"port"`
-	TargetPort string `json:"targetPort"`
+	TargetPort any    `json:"targetPort"`
 	Protocol   string `json:"protocol"`
 }
 

--- a/cli/azd/pkg/tools/kubectl/models.go
+++ b/cli/azd/pkg/tools/kubectl/models.go
@@ -1,5 +1,10 @@
 package kubectl
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 type ResourceType string
 
 const (
@@ -106,9 +111,32 @@ type ServiceStatus struct {
 }
 
 type Port struct {
-	Port       int    `json:"port"`
-	TargetPort any    `json:"targetPort"`
-	Protocol   string `json:"protocol"`
+	Port       int         `json:"port"`
+	TargetPort interface{} `json:"targetPort"`
+	Protocol   string      `json:"protocol"`
+}
+
+func (p *Port) UnmarshalJSON(data []byte) error {
+	var aux struct {
+		Port       int         `json:"port"`
+		TargetPort interface{} `json:"targetPort"`
+		Protocol   string      `json:"protocol"`
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	p.Port = aux.Port
+	p.Protocol = aux.Protocol
+
+	switch v := aux.TargetPort.(type) {
+	case string, int, float64:
+		p.TargetPort = v
+		return nil
+	default:
+		return fmt.Errorf("unsupported type for TargetPort")
+	}
 }
 
 type KubeConfig struct {

--- a/cli/azd/pkg/tools/kubectl/models.go
+++ b/cli/azd/pkg/tools/kubectl/models.go
@@ -111,16 +111,17 @@ type ServiceStatus struct {
 }
 
 type Port struct {
-	Port       int         `json:"port"`
-	TargetPort interface{} `json:"targetPort"`
-	Protocol   string      `json:"protocol"`
+	Port int `json:"port"`
+	// The target port can be a valid port number or well known service name like 'redis'
+	TargetPort any    `json:"targetPort"`
+	Protocol   string `json:"protocol"`
 }
 
 func (p *Port) UnmarshalJSON(data []byte) error {
 	var aux struct {
-		Port       int         `json:"port"`
-		TargetPort interface{} `json:"targetPort"`
-		Protocol   string      `json:"protocol"`
+		Port       int    `json:"port"`
+		TargetPort any    `json:"targetPort"`
+		Protocol   string `json:"protocol"`
 	}
 
 	if err := json.Unmarshal(data, &aux); err != nil {

--- a/cli/azd/pkg/tools/kubectl/models_test.go
+++ b/cli/azd/pkg/tools/kubectl/models_test.go
@@ -1,0 +1,34 @@
+package kubectl
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Port_TargetPort_Unmarshalling(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected string
+	}{
+		"StringValue": {
+			input:    "{ \"port\": 80, \"protocol\": \"http\", \"targetPort\": \"redis\" }",
+			expected: "redis",
+		},
+		"IntValue": {
+			input:    "{ \"port\": 80, \"protocol\": \"http\", \"targetPort\": 6379 }",
+			expected: "6379",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var port Port
+			err := json.Unmarshal([]byte(test.input), &port)
+			require.NoError(t, err)
+			require.Equal(t, test.expected, fmt.Sprint(port.TargetPort))
+		})
+	}
+}

--- a/cli/azd/pkg/tools/kubectl/models_test.go
+++ b/cli/azd/pkg/tools/kubectl/models_test.go
@@ -10,8 +10,9 @@ import (
 
 func Test_Port_TargetPort_Unmarshalling(t *testing.T) {
 	tests := map[string]struct {
-		input    string
-		expected string
+		input       string
+		expected    string
+		expectError bool
 	}{
 		"StringValue": {
 			input:    "{ \"port\": 80, \"protocol\": \"http\", \"targetPort\": \"redis\" }",
@@ -21,14 +22,25 @@ func Test_Port_TargetPort_Unmarshalling(t *testing.T) {
 			input:    "{ \"port\": 80, \"protocol\": \"http\", \"targetPort\": 6379 }",
 			expected: "6379",
 		},
+		"InvalidType": {
+			input:       "{ \"port\": 80, \"protocol\": \"http\", \"targetPort\": { \"foo\": \"bar\" } }",
+			expectError: true,
+		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			var port Port
 			err := json.Unmarshal([]byte(test.input), &port)
+			if test.expectError {
+				require.Error(t, err)
+				return
+			}
+
 			require.NoError(t, err)
 			require.Equal(t, test.expected, fmt.Sprint(port.TargetPort))
+			require.Equal(t, 80, port.Port)
+			require.Equal(t, "http", port.Protocol)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #2270

`targetPort` can reference a port or well known service name

**From the docs**
Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. 

https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service