### PR TITLE
Remove infrastructure outputs from `.env` on `azd down`

### DIFF
--- a/cli/azd/cmd/down.go
+++ b/cli/azd/cmd/down.go
@@ -114,19 +114,8 @@ func (a *downAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	startTime := time.Now()
 
 	destroyOptions := provisioning.NewDestroyOptions(a.flags.forceDelete, a.flags.purgeDelete)
-	destroyResult, err := infraManager.Destroy(ctx, destroyOptions)
-	if err != nil {
+	if _, err = infraManager.Destroy(ctx, destroyOptions); err != nil {
 		return nil, fmt.Errorf("deleting infrastructure: %w", err)
-	}
-
-	// Remove any outputs from the template from the environment since destroying the infrastructure
-	// invalidated them all.
-	for outputName := range destroyResult.Outputs {
-		a.env.DotenvDelete(outputName)
-	}
-
-	if err := a.env.Save(); err != nil {
-		return nil, fmt.Errorf("saving environment: %w", err)
 	}
 
 	return &actions.ActionResult{

--- a/cli/azd/pkg/environment/environment_test.go
+++ b/cli/azd/pkg/environment/environment_test.go
@@ -148,6 +148,15 @@ func Test_SaveAndReload(t *testing.T) {
 	require.Equal(t, env.dotenv["SERVICE_API_ENDPOINT_URL"], "http://api.example.com")
 	require.Equal(t, "SUBSCRIPTION_ID", env.GetSubscriptionId())
 	require.Equal(t, "eastus2", env.GetLocation())
+
+	// Delete the newly added property
+	env.DotenvDelete("SERVICE_WEB_ENDPOINT_URL")
+	err = env.Save()
+	require.NoError(t, err)
+
+	// Verify the property is deleted
+	_, ok := env.LookupEnv("SERVICE_WEB_ENDPOINT_URL")
+	require.False(t, ok)
 }
 
 func TestCleanName(t *testing.T) {

--- a/cli/azd/pkg/environment/environment_test.go
+++ b/cli/azd/pkg/environment/environment_test.go
@@ -157,6 +157,19 @@ func Test_SaveAndReload(t *testing.T) {
 	// Verify the property is deleted
 	_, ok := env.LookupEnv("SERVICE_WEB_ENDPOINT_URL")
 	require.False(t, ok)
+
+	// Delete an existing key, then add it with a different value and save the environment, to ensure we
+	// don't drop the existing key even though it was deleted in an earlier operation.
+	env.DotenvDelete("SERVICE_API_ENDPOINT_URL")
+	env.DotenvSet("SERVICE_API_ENDPOINT_URL", "http://api.example.com/updated")
+
+	err = env.Save()
+	require.NoError(t, err)
+
+	// Verify the property still exists, and has the updated value.
+	value, ok := env.LookupEnv("SERVICE_API_ENDPOINT_URL")
+	require.True(t, ok)
+	require.Equal(t, "http://api.example.com/updated", value)
 }
 
 func TestCleanName(t *testing.T) {

--- a/cli/azd/test/functional/up_test.go
+++ b/cli/azd/test/functional/up_test.go
@@ -260,6 +260,14 @@ func Test_CLI_Up_Down_ContainerApp(t *testing.T) {
 
 	_, err = cli.RunCommand(ctx, "infra", "delete", "--force", "--purge")
 	require.NoError(t, err)
+
+	// As part of deleting the infrastructure, outputs of the infrastructure such as "WEBSITE_URL" should
+	// have been removed from the environment.
+	env, err = godotenv.Read(filepath.Join(dir, azdcontext.EnvironmentDirectoryName, envName, ".env"))
+	require.NoError(t, err)
+
+	_, has = env["WEBSITE_URL"]
+	require.False(t, has, "WEBSITE_URL should have been removed from the environment as part of infrastructure removal")
 }
 
 func Test_CLI_Up_ResourceGroupScope(t *testing.T) {


### PR DESCRIPTION
The tool had logic to this, but it had been broken for a while due to
a change in how `Environment.Save()` worked. In #1667 we made a change
such that when you save an environment, we would merge in new values
from the existing .env file into the file we were saving, in case the
.env file had been modified by an external hook.

However, that logic did not take into account that we may have
intentionally removed some values (to explicitly delete them) and if
they already existed in the `.env` files, they should be removed as
part of the save operation.

To address this, we now track the deletes that we have preformed so we
can replay them during saving.

To prevent regressing again we also add an end to end test.

Fixes #2217