### PR TITLE
Fetch k8s GPG key from alternate location

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -38,7 +38,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
      # kubectl CLI
      && apt-get update \
      && mkdir -p /etc/apt/keyrings \
-     && curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+     && curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg \
      && echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list \
      && apt-get update \
      && apt-get install -y kubectl \


### PR DESCRIPTION
Currently running into some issues when building the docker container:

```
W: GPG error: https://packages.cloud.google.com/apt kubernetes-xenial InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
E: The repository 'https://apt.kubernetes.io kubernetes-xenial InRelease' is not signed.
```

In https://github.com/kubernetes/release/issues/2862 there were similar issues (at the time the URL that served the key was 500'ing) and there was a link to an alternate location for this key file, published by the k8s team.

Pick up that key, as others on the thread have today when they hit issues as well.