### PR TITLE
Add correlation for terraform

### DIFF
--- a/cli/azd/cmd/cobra_builder.go
+++ b/cli/azd/cmd/cobra_builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/cmd/middleware"
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -160,12 +161,15 @@ func (cb *CobraBuilder) configureActionResolver(cmd *cobra.Command, descriptor *
 			if err != nil {
 				var respErr *azcore.ResponseError
 				var azureErr *azcli.AzureDeploymentError
+				var toolExitErr *exec.ExitError
 
 				// We only want to show trace ID for server-related errors,
 				// where we have full server logs to troubleshoot from.
 				//
 				// For client errors, we don't want to show the trace ID, as it is not useful to the user currently.
-				if errors.As(err, &respErr) || errors.As(err, &azureErr) {
+				if errors.As(err, &respErr) ||
+					errors.As(err, &azureErr) ||
+					(errors.As(err, &toolExitErr) && toolExitErr.Cmd == "terraform") {
 					if actionResult != nil && actionResult.TraceID != "" {
 						console.Message(
 							ctx,

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
@@ -32,6 +33,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/terraform"
 	"github.com/drone/envsubst"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // TerraformProvider exposes infrastructure provisioning using Azure Terraform templates
@@ -104,6 +106,13 @@ func (t *TerraformProvider) EnsureConfigured(ctx context.Context) error {
 		fmt.Sprintf("ARM_SUBSCRIPTION_ID=%s", t.env.GetSubscriptionId()),
 		fmt.Sprintf("ARM_CLIENT_ID=%s", os.Getenv("ARM_CLIENT_ID")),
 		fmt.Sprintf("ARM_CLIENT_SECRET=%s", os.Getenv("ARM_CLIENT_SECRET")),
+		// Include azd in user agent
+		fmt.Sprintf("TF_APPEND_USER_AGENT=%s", internal.MakeUserAgentString("")),
+	}
+
+	spanCtx := trace.SpanContextFromContext(ctx)
+	if spanCtx.HasTraceID() {
+		envVars = append(envVars, fmt.Sprintf("ARM_CORRELATION_REQUEST_ID=%s", spanCtx.TraceID().String()))
 	}
 
 	t.cli.SetEnv(envVars)

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -495,6 +495,7 @@ func Test_CLI_InfraCreateAndDeleteResourceTerraformRemote(t *testing.T) {
 	// Create storage container
 	runArgs = newRunArgs("az", "storage", "container", "create", "--name", backendContainerName,
 		"--account-name", backendStorageAccountName, "--account-key", storageAccountKey)
+	runArgs.SensitiveData = append(runArgs.SensitiveData, storageAccountKey)
 	result, err := commandRunner.Run(ctx, runArgs)
 	_ = result
 	require.NoError(t, err)


### PR DESCRIPTION
Set the following environment variables: `TF_APPEND_USER_AGENT` and `ARM_CORRELATION_REQUEST_ID` appropriately when invoking the `terraform `CLI.

- `TF_APPEND_USER_AGENT` is a terraform CLI level environment variable, which gets appended to the terraform user agent variable. RM providers that build a user-agent string upon terraform user agent will thus inherit this. `azurerm` is confirmed to work with this model
- `ARM_CORRELATION_REQUEST_ID` is an `azurerm` provider environment variable. If unset, `azurerm` simply generates a UUID per-request. Note that users can explicitly disable this by setting `ARM_DISABLE_CORRELATION_REQUEST_ID` variable or configuring `disable_correlation_request_id` in `.tf`. `azapi` doesn't yet support this. Issue filed: https://github.com/Azure/terraform-provider-azapi/issues/296

Confirmed this is working as expected by examining HTTP requests made, traced by `terraform` when `TF_LOG=debug` is set.

Fixes #2284