### PR TITLE
Fix logout not clearing msal cache

### DIFF
--- a/cli/azd/pkg/auth/cache.go
+++ b/cli/azd/pkg/auth/cache.go
@@ -42,6 +42,7 @@ func (a *msalCacheAdapter) Export(ctx context.Context, cache cache.Marshaler, ca
 type Cache interface {
 	Read(key string) ([]byte, error)
 	Set(key string, value []byte) error
+	UnsetAll() error
 }
 
 var errCacheKeyNotFound = errors.New("key not found")

--- a/cli/azd/pkg/auth/cache_test.go
+++ b/cli/azd/pkg/auth/cache_test.go
@@ -59,12 +59,12 @@ func TestCache(t *testing.T) {
 
 	// read some non-existing data
 	nonExist := fixedMarshaller{
-		val: []byte(""),
+		val: []byte("nonExist data"),
 	}
 	err = c.Replace(ctx, &nonExist, cache.ReplaceHints{PartitionKey: "nonExist"})
 	require.NoError(t, err)
 	// data should not be overwritten when key is not found.
-	require.Equal(t, []byte(""), nonExist.val)
+	require.Equal(t, []byte("nonExist data"), nonExist.val)
 
 	// Unset all values
 	err = cImpl.UnsetAll()
@@ -72,11 +72,11 @@ func TestCache(t *testing.T) {
 
 	err = c.Replace(ctx, &nonExist, cache.ReplaceHints{PartitionKey: "d1"})
 	require.NoError(t, err)
-	require.Equal(t, []byte(""), nonExist.val)
+	require.Equal(t, []byte("nonExist data"), nonExist.val)
 
 	err = c.Replace(ctx, &nonExist, cache.ReplaceHints{PartitionKey: "d2"})
 	require.NoError(t, err)
-	require.Equal(t, []byte(""), nonExist.val)
+	require.Equal(t, []byte("nonExist data"), nonExist.val)
 }
 
 func TestCredentialCache(t *testing.T) {

--- a/cli/azd/pkg/auth/cache_unix.go
+++ b/cli/azd/pkg/auth/cache_unix.go
@@ -10,11 +10,12 @@ import (
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/cache"
 )
 
-// newCache creates a cache implementation that satisfies [cache.ExportReplace] from the MSAL library.
+// newCache creates a cache implementation that satisfies [cache.ExportReplace] from the MSAL library,
+// returning both the [cache.ExportReplace] adapter and the underlying [Cache].
 //
 // root must be created beforehand, and must point to a directory.
-func newCache(root string) cache.ExportReplace {
-	return &msalCacheAdapter{
+func newCache(root string) (cache.ExportReplace, Cache) {
+	adapter := &msalCacheAdapter{
 		cache: &memoryCache{
 			cache: make(map[string][]byte),
 			inner: &fileCache{
@@ -24,6 +25,8 @@ func newCache(root string) cache.ExportReplace {
 			},
 		},
 	}
+
+	return adapter, adapter.cache
 }
 
 // newCredentialCache creates a cache implementation for storing credentials.

--- a/cli/azd/pkg/auth/cache_windows.go
+++ b/cli/azd/pkg/auth/cache_windows.go
@@ -32,8 +32,8 @@ type encryptionType string
 // for more information on these APIs.
 const cCryptProtectDataEncryptionType encryptionType = "CryptProtectData"
 
-func newCache(root string) cache.ExportReplace {
-	return &msalCacheAdapter{
+func newCache(root string) (cache.ExportReplace, Cache) {
+	adapter := &msalCacheAdapter{
 		cache: &memoryCache{
 			cache: make(map[string][]byte),
 			inner: &encryptedCache{
@@ -45,6 +45,8 @@ func newCache(root string) cache.ExportReplace {
 			},
 		},
 	}
+
+	return adapter, adapter.cache
 }
 
 func newCredentialCache(root string) Cache {
@@ -158,4 +160,8 @@ func (c *encryptedCache) Set(key string, val []byte) error {
 	}
 
 	return c.inner.Set(key, toStore)
+}
+
+func (c *encryptedCache) UnsetAll() error {
+	return c.inner.UnsetAll()
 }

--- a/cli/azd/pkg/auth/file_cache.go
+++ b/cli/azd/pkg/auth/file_cache.go
@@ -78,7 +78,7 @@ func (c *fileCache) UnsetAll() error {
 	for _, entry := range entries {
 		if !entry.IsDir() && filepath.Ext(entry.Name()) == ext {
 			err := os.Remove(filepath.Join(c.root, entry.Name()))
-			if err != nil {
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
 				return err
 			}
 		}

--- a/cli/azd/pkg/auth/file_cache.go
+++ b/cli/azd/pkg/auth/file_cache.go
@@ -65,6 +65,28 @@ func (c *fileCache) Set(key string, value []byte) error {
 	return os.WriteFile(cachePath, value, osutil.PermissionFileOwnerOnly)
 }
 
+func (c *fileCache) UnsetAll() error {
+	entries, err := os.ReadDir(c.root)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	ext := "." + c.ext
+	for _, entry := range entries {
+		if !entry.IsDir() && filepath.Ext(entry.Name()) == ext {
+			err := os.Remove(filepath.Join(c.root, entry.Name()))
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
 func (c *fileCache) pathForCache(key string) string {
 	return filepath.Join(c.root, fmt.Sprintf("%s%s.%s", c.prefix, key, c.ext))
 }

--- a/cli/azd/pkg/auth/memory_cache.go
+++ b/cli/azd/pkg/auth/memory_cache.go
@@ -54,3 +54,11 @@ func (c *memoryCache) Set(key string, value []byte) error {
 	c.cache[key] = value
 	return nil
 }
+
+func (c *memoryCache) UnsetAll() error {
+	c.cache = make(map[string][]byte)
+	if c.inner != nil {
+		return c.inner.UnsetAll()
+	}
+	return nil
+}


### PR DESCRIPTION
This change fixes `logout` not clearing the MSAL cache correctly.

Notably:
1. Fix `getSignedInAccount` using an old implementation that only reads from `config.json` and not `auth.json`.
2. Add explicit cache expiration logic, since it is noticed that MSAL does not clear all cached entries by default. Additional follow-up with MSAL library is needed to determine the overall expected working behavior.