### PR TITLE
Update bicep.go (bump bicep to 0.17.1)

### DIFF
--- a/cli/azd/pkg/tools/bicep/bicep.go
+++ b/cli/azd/pkg/tools/bicep/bicep.go
@@ -27,7 +27,7 @@ import (
 
 // cBicepVersion is the minimum version of bicep that we require (and the one we fetch when we fetch bicep on behalf of a
 // user).
-var cBicepVersion semver.Version = semver.MustParse("0.16.1")
+var cBicepVersion semver.Version = semver.MustParse("0.17.1")
 
 type BicepCli interface {
 	Build(ctx context.Context, file string) (string, error)


### PR DESCRIPTION
bump bicep to 0.17.1 which introduces the new `loadYamlContent` file function.