### PR TITLE
GA publishing tasks part 1

### DIFF
--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -986,12 +986,42 @@ stages:
                     filePath: eng/scripts/Set-CliVersionVariable.ps1
                   displayName: Set CLI_VERSION
 
+                - pwsh: |
+                    # Initial upload locations
+                    $publishUploadLocations = 'release/$(CLI_VERSION);release/latest'
+
+                    $isPublishingGa = eng/scripts/Test-ShouldReleasePackageVersion.ps1 `
+                      -CliVersion '$(CLI_VERSION)'
+
+                    if ($isPublishingGa) {
+                      $publishUploadLocations += ";release/GA"
+                    }
+
+                    Write-Host "Setting StorageUploadLocations to $publishUploadLocations"
+                    Write-Host "###vso[task.setvariable variable=StorageUploadLocations]$publishUploadLocations"
+                  displayName: Set StorageUploadLocations
+
+                - pwsh: |
+                    # Initial tag
+                    $dockerTags = '$(CLI_VERSION)'
+
+                    $isPublishingGa = eng/scripts/Test-ShouldReleasePackageVersion.ps1 `
+                      -CliVersion '$(CLI_VERSION)'
+
+                    if ($isPublishingGa) {
+                      $dockerTags += ";latest"
+                    }
+
+                    Write-Host "Setting DockerImageTags to $dockerTags"
+                    Write-Host "###vso[task.setvariable variable=DockerImageTags]$dockerTags"
+                  displayName: Set DockerImageTags
+
                 - template: /eng/pipelines/templates/steps/publish-cli.yml
                   parameters:
                     CreateGitHubRelease: true
-                    PublishUploadLocations: release/$(CLI_VERSION);release/latest
+                    PublishUploadLocations: $(StorageUploadLocations)
                     PublishShield: true
-                    DockerImageTags: $(CLI_VERSION);latest
+                    DockerImageTags: $(DockerImageTags)
                     ReleaseSyndicatedDockerContainer: true
                     PublishUpdatedDocs: true
                     UploadMsi: true

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -1024,8 +1024,6 @@ stages:
 
                 - template: /eng/pipelines/templates/steps/publish-cli-choco.yml
                   parameters:
-                    # Set to false after GA (https://github.com/Azure/azure-dev/issues/1485)
-                    AllowPrerelease: true
                     CliVersion: $(CLI_VERSION)
 
       - deployment: Publish_WinGet
@@ -1054,8 +1052,6 @@ stages:
 
                 - template: /eng/pipelines/templates/steps/publish-cli-winget.yml
                   parameters:
-                    # Set to false after GA (https://github.com/Azure/azure-dev/issues/1485)
-                    AllowPrerelease: true
                     CliVersion: $(CLI_VERSION)
 
       - deployment: Increment_Version

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -994,7 +994,7 @@ stages:
                       -CliVersion '$(CLI_VERSION)'
 
                     if ($isPublishingGa) {
-                      $publishUploadLocations += ";release/GA"
+                      $publishUploadLocations += ";release/stable"
                     }
 
                     Write-Host "Setting StorageUploadLocations to $publishUploadLocations"

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -1116,7 +1116,7 @@ stages:
                     CommitMsg: Increment CLI version after release
                     PRTitle: Increment CLI version after release
 
-  - stage: PublishIntegration
+  - stage: Publish_Integration
     dependsOn: Sign
     jobs:
       - job: Publish_Continuous_Deployment

--- a/eng/pipelines/templates/steps/publish-cli-choco.yml
+++ b/eng/pipelines/templates/steps/publish-cli-choco.yml
@@ -28,10 +28,10 @@ steps:
 
   - pwsh: |
       $submitPackage = eng/scripts/Test-ShouldReleasePackageVersion.ps1 `
-        -Version '$(MSI_VERSION)' `
+        -CliVersion '${{ parameters.CliVersion }}' `
         -AllowPrerelease:$${{ parameters.AllowPrerelease }}
 
-      if ('$(Skip.ReleaseWinGet)' -eq 'true') {
+      if ('$(Skip.ReleaseChoco)' -eq 'true') {
         $submitPackage = 'false'
       }
       Write-Host "Setting SubmitChocoPackage to $submitPackage"

--- a/eng/pipelines/templates/steps/publish-cli-winget.yml
+++ b/eng/pipelines/templates/steps/publish-cli-winget.yml
@@ -25,7 +25,7 @@ steps:
 
   - pwsh: |
       $submitPackage = eng/scripts/Test-ShouldReleasePackageVersion.ps1 `
-        -Version '$(MSI_VERSION)' `
+        -CliVersion '${{ parameters.CliVersion }}' `
         -AllowPrerelease:$${{ parameters.AllowPrerelease }}
 
       if ('$(Skip.ReleaseWinGet)' -eq 'true') {

--- a/eng/pipelines/templates/steps/publish-cli.yml
+++ b/eng/pipelines/templates/steps/publish-cli.yml
@@ -229,10 +229,23 @@ steps:
       displayName: Push container tags (syndicated release)
 
   - ${{ if eq('true', parameters.PublishBrewFormula) }}:
+    - pwsh: |
+        $submitPackage = eng/scripts/Test-ShouldReleasePackageVersion.ps1 `
+          -CliVersion '${{ parameters.CliVersion }}'
+          -AllowPrerelease:$${{ parameters.AllowPrerelease }}
+
+        if ('$(Skip.ReleaseBrew)' -eq 'true') {
+          $submitPackage = 'false'
+        }
+        Write-Host "Setting SubmitBrewFormula to $submitPackage"
+        Write-Host "##vso[task.setvariable variable=SubmitBrewFormula]$submitPackage"
+      displayName: Set SubmitBrewFormula
+
     - pwsh: git clone https://github.com/Azure/homebrew-azd
       displayName: Clone Azure/homebrew-azd
 
     - task: PowerShell@2
+      condition: eq(variables['SubmitBrewFormula'], 'true')
       displayName: Update brew formula
       inputs:
         targetType: filePath


### PR DESCRIPTION
Partial: https://github.com/Azure/azure-dev/issues/2239

* Releases to `GA` in storage account when releasing a GA version (install script still uses `latest`)
* Disable publishing preview releases on WinGet, Choco (only releases GA releases to those channels now)
* Only release to latest tag on MCR when releasing GA

Another PR will contain the default installer switch to the GA channel. 