### PR TITLE
Share `httpClient` instance

### DIFF
--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -16,6 +16,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -120,6 +121,7 @@ type pipelineConfigAction struct {
 	env                *environment.Environment
 	console            input.Console
 	commandRunner      exec.CommandRunner
+	httpClient         httputil.HttpClient
 	credentialProvider account.SubscriptionCredentialProvider
 }
 
@@ -133,6 +135,7 @@ func newPipelineConfigAction(
 	console input.Console,
 	flags *pipelineConfigFlags,
 	commandRunner exec.CommandRunner,
+	httpClient httputil.HttpClient,
 ) actions.Action {
 	pca := &pipelineConfigAction{
 		flags:              flags,
@@ -146,6 +149,7 @@ func newPipelineConfigAction(
 		env:            env,
 		console:        console,
 		commandRunner:  commandRunner,
+		httpClient:     httpClient,
 	}
 
 	return pca
@@ -167,7 +171,7 @@ func (p *pipelineConfigAction) Run(ctx context.Context) (*actions.ActionResult, 
 	p.manager.ScmProvider,
 		p.manager.CiProvider,
 		err = pipeline.DetectProviders(
-		ctx, p.azdCtx, p.env, p.manager.PipelineProvider, p.console, credential, p.commandRunner,
+		ctx, p.azdCtx, p.env, p.manager.PipelineProvider, p.console, credential, p.commandRunner, p.httpClient,
 	)
 	if err != nil {
 		return nil, err

--- a/cli/azd/pkg/commands/pipeline/github_provider_test.go
+++ b/cli/azd/pkg/commands/pipeline/github_provider_test.go
@@ -48,7 +48,11 @@ func Test_gitHub_provider_preConfigure_check(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		setupGithubCliMocks(mockContext)
 
-		provider := NewGitHubCiProvider(mockContext.Credentials, mockContext.CommandRunner, mockContext.Console)
+		provider := NewGitHubCiProvider(
+			mockContext.Credentials,
+			mockContext.CommandRunner,
+			mockContext.Console,
+			mockContext.HttpClient)
 		updatedConfig, err := provider.preConfigureCheck(
 			*mockContext.Context,
 			PipelineManagerArgs{},
@@ -75,7 +79,11 @@ func Test_gitHub_provider_preConfigure_check(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		setupGithubCliMocks(mockContext)
 
-		provider := NewGitHubCiProvider(mockContext.Credentials, mockContext.CommandRunner, mockContext.Console)
+		provider := NewGitHubCiProvider(
+			mockContext.Credentials,
+			mockContext.CommandRunner,
+			mockContext.Console,
+			mockContext.HttpClient)
 		updatedConfig, err := provider.preConfigureCheck(
 			*mockContext.Context, pipelineManagerArgs, infraOptions, "")
 		require.Error(t, err)
@@ -95,7 +103,11 @@ func Test_gitHub_provider_preConfigure_check(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		setupGithubCliMocks(mockContext)
 
-		provider := NewGitHubCiProvider(mockContext.Credentials, mockContext.CommandRunner, mockContext.Console)
+		provider := NewGitHubCiProvider(
+			mockContext.Credentials,
+			mockContext.CommandRunner,
+			mockContext.Console,
+			mockContext.HttpClient)
 		updatedConfig, err := provider.preConfigureCheck(
 			*mockContext.Context, pipelineManagerArgs, infraOptions, "")
 		require.NoError(t, err)

--- a/cli/azd/pkg/commands/pipeline/pipeline.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline.go
@@ -16,6 +16,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -188,6 +189,7 @@ func DetectProviders(
 	console input.Console,
 	credential azcore.TokenCredential,
 	commandRunner exec.CommandRunner,
+	httpClient httputil.HttpClient,
 ) (ScmProvider, CiProvider, error) {
 	projectDir := azdContext.ProjectDirectory()
 
@@ -254,7 +256,7 @@ func DetectProviders(
 	_ = savePipelineProviderToEnv(gitHubLabel, env)
 	log.Printf("Using pipeline provider: %s", output.WithHighLightFormat("GitHub"))
 	scmProvider := NewGitHubScmProvider(commandRunner, console)
-	ciProvider := NewGitHubCiProvider(credential, commandRunner, console)
+	ciProvider := NewGitHubCiProvider(credential, commandRunner, console, httpClient)
 	return scmProvider, ciProvider, nil
 }
 

--- a/cli/azd/pkg/commands/pipeline/pipeline_test.go
+++ b/cli/azd/pkg/commands/pipeline/pipeline_test.go
@@ -34,6 +34,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.Nil(t, scmProvider)
 		assert.Nil(t, ciProvider)
@@ -57,6 +58,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.Nil(t, scmProvider)
 		assert.Nil(t, ciProvider)
@@ -89,6 +91,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.Nil(t, scmProvider)
 		assert.Nil(t, ciProvider)
@@ -114,6 +117,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.Nil(t, scmProvider)
 		assert.Nil(t, ciProvider)
@@ -143,6 +147,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.IsType(t, &AzdoScmProvider{}, scmProvider)
 		assert.IsType(t, &AzdoCiProvider{}, ciProvider)
@@ -165,6 +170,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.Nil(t, scmProvider)
 		assert.Nil(t, ciProvider)
@@ -189,6 +195,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.IsType(t, &GitHubScmProvider{}, scmProvider)
 		assert.IsType(t, &GitHubCiProvider{}, ciProvider)
@@ -210,6 +217,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.Nil(t, scmProvider)
 		assert.Nil(t, ciProvider)
@@ -234,6 +242,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.Nil(t, scmProvider)
 		assert.Nil(t, ciProvider)
@@ -257,6 +266,7 @@ func Test_detectProviders(t *testing.T) {
 			"", mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.Nil(t, scmProvider)
 		assert.Nil(t, ciProvider)
@@ -290,6 +300,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.Nil(t, scmProvider)
 		assert.Nil(t, ciProvider)
@@ -324,6 +335,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.Nil(t, scmProvider)
 		assert.Nil(t, ciProvider)
@@ -351,6 +363,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.IsType(t, &GitHubScmProvider{}, scmProvider)
 		assert.IsType(t, &GitHubCiProvider{}, ciProvider)
@@ -371,6 +384,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.IsType(t, &AzdoScmProvider{}, scmProvider)
 		assert.IsType(t, &AzdoCiProvider{}, ciProvider)
@@ -394,6 +408,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.IsType(t, &GitHubScmProvider{}, scmProvider)
 		assert.IsType(t, &GitHubCiProvider{}, ciProvider)
@@ -417,6 +432,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.IsType(t, &AzdoScmProvider{}, scmProvider)
 		assert.IsType(t, &AzdoCiProvider{}, ciProvider)
@@ -434,6 +450,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.IsType(t, &AzdoScmProvider{}, scmProvider)
 		assert.IsType(t, &AzdoCiProvider{}, ciProvider)
@@ -459,6 +476,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.IsType(t, &AzdoScmProvider{}, scmProvider)
 		assert.IsType(t, &AzdoCiProvider{}, ciProvider)
@@ -472,6 +490,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.IsType(t, &AzdoScmProvider{}, scmProvider)
 		assert.IsType(t, &AzdoCiProvider{}, ciProvider)
@@ -490,6 +509,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.IsType(t, &GitHubScmProvider{}, scmProvider)
 		assert.IsType(t, &GitHubCiProvider{}, ciProvider)
@@ -508,6 +528,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.IsType(t, &GitHubScmProvider{}, scmProvider)
 		assert.IsType(t, &GitHubCiProvider{}, ciProvider)
@@ -522,6 +543,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.IsType(t, &AzdoScmProvider{}, scmProvider)
 		assert.IsType(t, &AzdoCiProvider{}, ciProvider)
@@ -541,6 +563,7 @@ func Test_detectProviders(t *testing.T) {
 			mockContext.Console,
 			mockContext.Credentials,
 			mockContext.CommandRunner,
+			mockContext.HttpClient,
 		)
 		assert.IsType(t, &GitHubScmProvider{}, scmProvider)
 		assert.IsType(t, &GitHubCiProvider{}, ciProvider)

--- a/cli/azd/pkg/exec/util_test.go
+++ b/cli/azd/pkg/exec/util_test.go
@@ -64,7 +64,7 @@ func TestKillCommand(t *testing.T) {
 			Cmd: "sh",
 			Args: []string{
 				"-c",
-				"sleep 10s",
+				"sleep 10",
 			},
 		}
 	}

--- a/cli/azd/pkg/exec/util_test.go
+++ b/cli/azd/pkg/exec/util_test.go
@@ -49,14 +49,27 @@ func TestKillCommand(t *testing.T) {
 	s := time.Now()
 
 	runner := NewCommandRunner(nil)
-	_, err := runner.Run(ctx, RunArgs{
-		Cmd: "pwsh",
-		Args: []string{
-			"-c",
-			"sleep",
-			"10000",
-		},
-	})
+	var args RunArgs
+	if runtime.GOOS == "windows" {
+		args = RunArgs{
+			Cmd: "pwsh",
+			Args: []string{
+				"-c",
+				"sleep",
+				"10000",
+			},
+		}
+	} else {
+		args = RunArgs{
+			Cmd: "sh",
+			Args: []string{
+				"-c",
+				"sleep 10s",
+			},
+		}
+	}
+
+	_, err := runner.Run(ctx, args)
 
 	if runtime.GOOS == "windows" {
 		// on Windows terminating the process doesn't register as an error

--- a/cli/azd/pkg/httputil/http_client.go
+++ b/cli/azd/pkg/httputil/http_client.go
@@ -4,33 +4,9 @@
 package httputil
 
 import (
-	"context"
 	"net/http"
 )
 
 type HttpClient interface {
 	Do(req *http.Request) (*http.Response, error)
-}
-
-type contextKey string
-
-const (
-	httpClientContextKey contextKey = "httpclient"
-)
-
-// GetHttpClient attempts to retrieve a HttpUtil instance from the specified context.
-// Will return the context if found or create a new instance
-func GetHttpClient(ctx context.Context) HttpClient {
-	value := ctx.Value(httpClientContextKey)
-	client, ok := value.(HttpClient)
-
-	if !ok {
-		return &http.Client{}
-	}
-
-	return client
-}
-
-func WithHttpClient(ctx context.Context, httpClient HttpClient) context.Context {
-	return context.WithValue(ctx, httpClientContextKey, httpClient)
 }

--- a/cli/azd/pkg/tools/azcli/ad.go
+++ b/cli/azd/pkg/tools/azcli/ad.go
@@ -321,7 +321,7 @@ func (cli *azCli) createGraphClient(
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildCoreClientOptions()
+	options := cli.clientOptionsBuilder(ctx).BuildCoreClientOptions()
 	client, err := graphsdk.NewGraphClient(credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Graph Users client: %w", err)
@@ -340,7 +340,7 @@ func (cli *azCli) createRoleDefinitionsClient(
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
 	client, err := armauthorization.NewRoleDefinitionsClient(credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating ARM Role Definitions client: %w", err)
@@ -359,7 +359,7 @@ func (cli *azCli) createRoleAssignmentsClient(
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
 	client, err := armauthorization.NewRoleAssignmentsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating ARM Role Assignments client: %w", err)

--- a/cli/azd/pkg/tools/azcli/apim.go
+++ b/cli/azd/pkg/tools/azcli/apim.go
@@ -66,7 +66,7 @@ func (cli *azCli) createApimDeletedClient(
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
 	apimClient, err := armapimanagement.NewDeletedServicesClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
@@ -85,7 +85,7 @@ func (cli *azCli) createApimClient(
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
 	apimClient, err := armapimanagement.NewServiceClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)

--- a/cli/azd/pkg/tools/azcli/appconfig.go
+++ b/cli/azd/pkg/tools/azcli/appconfig.go
@@ -74,7 +74,7 @@ func (cli *azCli) createAppConfigClient(
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
 	appConfigStoresClient, err := armappconfiguration.NewConfigurationStoresClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -351,9 +351,9 @@ func (cli *azCli) UserAgent() string {
 	return cli.userAgent
 }
 
-func (cli *azCli) createDefaultClientOptionsBuilder(ctx context.Context) *azsdk.ClientOptionsBuilder {
+func (cli *azCli) clientOptionsBuilder(ctx context.Context) *azsdk.ClientOptionsBuilder {
 	return azsdk.NewClientOptionsBuilder().
-		WithTransport(httputil.GetHttpClient(ctx)).
+		WithTransport(cli.httpClient).
 		WithPerCallPolicy(azsdk.NewUserAgentPolicy(cli.UserAgent())).
 		WithPerCallPolicy(azsdk.NewMsCorrelationPolicy(ctx))
 }

--- a/cli/azd/pkg/tools/azcli/cognitive_service.go
+++ b/cli/azd/pkg/tools/azcli/cognitive_service.go
@@ -54,7 +54,7 @@ func (cli *azCli) createCognitiveAccountClient(
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
 	client, err := armcognitiveservices.NewAccountsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
@@ -70,7 +70,7 @@ func (cli *azCli) createDeletedCognitiveAccountClient(
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
 	client, err := armcognitiveservices.NewDeletedAccountsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)

--- a/cli/azd/pkg/tools/azcli/deployments.go
+++ b/cli/azd/pkg/tools/azcli/deployments.go
@@ -118,7 +118,7 @@ func (cli *azCli) createDeploymentsClient(
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
 	client, err := armresources.NewDeploymentsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating deployments client: %w", err)

--- a/cli/azd/pkg/tools/azcli/deployments_operations.go
+++ b/cli/azd/pkg/tools/azcli/deployments_operations.go
@@ -21,7 +21,7 @@ func (cli *azCli) createDeploymentsOperationsClient(
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
 	client, err := armresources.NewDeploymentOperationsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating deployments client: %w", err)

--- a/cli/azd/pkg/tools/azcli/keyvault.go
+++ b/cli/azd/pkg/tools/azcli/keyvault.go
@@ -117,7 +117,7 @@ func (cli *azCli) createKeyVaultClient(ctx context.Context, subscriptionId strin
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
 	client, err := armkeyvault.NewVaultsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
@@ -138,7 +138,7 @@ func (cli *azCli) createSecretsDataClient(
 		return nil, err
 	}
 
-	coreOptions := cli.createDefaultClientOptionsBuilder(ctx).BuildCoreClientOptions()
+	coreOptions := cli.clientOptionsBuilder(ctx).BuildCoreClientOptions()
 	options := &azsecrets.ClientOptions{
 		ClientOptions:                        *coreOptions,
 		DisableChallengeResourceVerification: false,

--- a/cli/azd/pkg/tools/azcli/resources.go
+++ b/cli/azd/pkg/tools/azcli/resources.go
@@ -142,7 +142,7 @@ func (cli *azCli) createResourcesClient(ctx context.Context, subscriptionId stri
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
 	client, err := armresources.NewClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
@@ -160,7 +160,7 @@ func (cli *azCli) createResourceGroupClient(
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
 	client, err := armresources.NewResourceGroupsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating ResourceGroup client: %w", err)

--- a/cli/azd/pkg/tools/azcli/static_webapp.go
+++ b/cli/azd/pkg/tools/azcli/static_webapp.go
@@ -94,7 +94,7 @@ func (cli *azCli) createStaticSitesClient(
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
 	client, err := armappservice.NewStaticSitesClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Static Sites client: %w", err)

--- a/cli/azd/pkg/tools/azcli/webapp.go
+++ b/cli/azd/pkg/tools/azcli/webapp.go
@@ -61,7 +61,7 @@ func (cli *azCli) createWebAppsClient(ctx context.Context, subscriptionId string
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
 	client, err := armappservice.NewWebAppsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating WebApps client: %w", err)
@@ -76,7 +76,7 @@ func (cli *azCli) createZipDeployClient(ctx context.Context, subscriptionId stri
 		return nil, err
 	}
 
-	options := cli.createDefaultClientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
 	client, err := azsdk.NewZipDeployClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating WebApps client: %w", err)

--- a/cli/azd/test/mocks/mock_context.go
+++ b/cli/azd/test/mocks/mock_context.go
@@ -36,8 +36,6 @@ func NewMockContext(ctx context.Context) *MockContext {
 
 	mockexec.AddAzLoginMocks(commandRunner)
 
-	ctx = httputil.WithHttpClient(ctx, httpClient)
-
 	mockContext := &MockContext{
 		Credentials:                    &MockCredentials{},
 		Context:                        &ctx,


### PR DESCRIPTION
Update instances in the codebase where `httpClient` was created on-demand via `ctx.Context`, to now reference the shared `httpClient`.

Remove unneeded code for storing `httpClient` and retrieving `httpClient` from context as a result.
