### PR TITLE
Remove `httputil.HandleRequestError`

### DIFF
--- a/cli/azd/pkg/azsdk/zip_deploy_client.go
+++ b/cli/azd/pkg/azsdk/zip_deploy_client.go
@@ -95,7 +95,7 @@ func (c *ZipDeployClient) BeginDeploy(
 
 	response, err := c.pipeline.Do(request)
 	if err != nil {
-		return nil, httputil.HandleRequestError(response, err)
+		return nil, err
 	}
 
 	defer response.Body.Close()
@@ -187,7 +187,7 @@ func (h *deployPollingHandler) Poll(ctx context.Context) (*http.Response, error)
 
 	response, err := h.pipeline.Do(req)
 	if err != nil {
-		return nil, httputil.HandleRequestError(response, err)
+		return nil, err
 	}
 
 	if !runtime.HasStatusCode(response, http.StatusAccepted) && !runtime.HasStatusCode(response, http.StatusOK) {

--- a/cli/azd/pkg/graphsdk/application_request_builders.go
+++ b/cli/azd/pkg/graphsdk/application_request_builders.go
@@ -30,7 +30,7 @@ func (c *ApplicationListRequestBuilder) Get(ctx context.Context) (*ApplicationLi
 
 	res, err := c.client.pipeline.Do(req)
 	if err != nil {
-		return nil, httputil.HandleRequestError(res, err)
+		return nil, err
 	}
 
 	if !runtime.HasStatusCode(res, http.StatusOK) {
@@ -53,7 +53,7 @@ func (c *ApplicationListRequestBuilder) Post(ctx context.Context, application *A
 
 	res, err := c.client.pipeline.Do(req)
 	if err != nil {
-		return nil, httputil.HandleRequestError(res, err)
+		return nil, err
 	}
 
 	if !runtime.HasStatusCode(res, http.StatusCreated) {
@@ -93,7 +93,7 @@ func (c *ApplicationItemRequestBuilder) Get(ctx context.Context) (*Application, 
 
 	res, err := c.client.pipeline.Do(req)
 	if err != nil {
-		return nil, httputil.HandleRequestError(res, err)
+		return nil, err
 	}
 
 	if !runtime.HasStatusCode(res, http.StatusOK) {
@@ -112,7 +112,7 @@ func (c *ApplicationItemRequestBuilder) Delete(ctx context.Context) error {
 
 	res, err := c.client.pipeline.Do(req)
 	if err != nil {
-		return httputil.HandleRequestError(res, err)
+		return err
 	}
 
 	if !runtime.HasStatusCode(res, http.StatusNoContent) {
@@ -143,7 +143,7 @@ func (c *ApplicationItemRequestBuilder) RemovePassword(ctx context.Context, keyI
 
 	res, err := c.client.pipeline.Do(req)
 	if err != nil {
-		return httputil.HandleRequestError(res, err)
+		return err
 	}
 
 	if !runtime.HasStatusCode(res, http.StatusNoContent) {
@@ -172,7 +172,7 @@ func (c *ApplicationItemRequestBuilder) AddPassword(ctx context.Context) (*Appli
 
 	res, err := c.client.pipeline.Do(req)
 	if err != nil {
-		return nil, httputil.HandleRequestError(res, err)
+		return nil, err
 	}
 
 	if !runtime.HasStatusCode(res, http.StatusOK) {

--- a/cli/azd/pkg/graphsdk/fic_request_builders.go
+++ b/cli/azd/pkg/graphsdk/fic_request_builders.go
@@ -41,7 +41,7 @@ func (c *FederatedIdentityCredentialListRequestBuilder) Get(
 
 	res, err := c.client.pipeline.Do(req)
 	if err != nil {
-		return nil, httputil.HandleRequestError(res, err)
+		return nil, err
 	}
 
 	if !runtime.HasStatusCode(res, http.StatusOK) {
@@ -71,7 +71,7 @@ func (c *FederatedIdentityCredentialListRequestBuilder) Post(
 
 	res, err := c.client.pipeline.Do(req)
 	if err != nil {
-		return nil, httputil.HandleRequestError(res, err)
+		return nil, err
 	}
 
 	if !runtime.HasStatusCode(res, http.StatusCreated) {
@@ -112,7 +112,7 @@ func (c *FederatedIdentityCredentialItemRequestBuilder) Get(ctx context.Context)
 
 	res, err := c.client.pipeline.Do(req)
 	if err != nil {
-		return nil, httputil.HandleRequestError(res, err)
+		return nil, err
 	}
 
 	if !runtime.HasStatusCode(res, http.StatusOK) {
@@ -142,7 +142,7 @@ func (c *FederatedIdentityCredentialItemRequestBuilder) Update(
 
 	res, err := c.client.pipeline.Do(req)
 	if err != nil {
-		return httputil.HandleRequestError(res, err)
+		return err
 	}
 
 	if !runtime.HasStatusCode(res, http.StatusNoContent) {
@@ -165,7 +165,7 @@ func (c *FederatedIdentityCredentialItemRequestBuilder) Delete(ctx context.Conte
 
 	res, err := c.client.pipeline.Do(req)
 	if err != nil {
-		return httputil.HandleRequestError(res, err)
+		return err
 	}
 
 	if !runtime.HasStatusCode(res, http.StatusNoContent) {

--- a/cli/azd/pkg/graphsdk/me_request_builder.go
+++ b/cli/azd/pkg/graphsdk/me_request_builder.go
@@ -29,7 +29,7 @@ func (b *MeItemRequestBuilder) Get(ctx context.Context) (*UserProfile, error) {
 
 	res, err := b.client.pipeline.Do(req)
 	if err != nil {
-		return nil, httputil.HandleRequestError(res, err)
+		return nil, err
 	}
 
 	if !runtime.HasStatusCode(res, http.StatusOK) {

--- a/cli/azd/pkg/graphsdk/service_principal_request_builders.go
+++ b/cli/azd/pkg/graphsdk/service_principal_request_builders.go
@@ -29,7 +29,7 @@ func (c *ServicePrincipalListRequestBuilder) Get(ctx context.Context) (*ServiceP
 
 	res, err := c.client.pipeline.Do(req)
 	if err != nil {
-		return nil, httputil.HandleRequestError(res, err)
+		return nil, err
 	}
 
 	if !runtime.HasStatusCode(res, http.StatusOK) {
@@ -59,7 +59,7 @@ func (c *ServicePrincipalListRequestBuilder) Post(
 
 	res, err := c.client.pipeline.Do(req)
 	if err != nil {
-		return nil, httputil.HandleRequestError(res, err)
+		return nil, err
 	}
 
 	if !runtime.HasStatusCode(res, http.StatusCreated) {
@@ -89,7 +89,7 @@ func (b *ServicePrincipalItemRequestBuilder) Get(ctx context.Context) (*ServiceP
 
 	res, err := b.client.pipeline.Do(req)
 	if err != nil {
-		return nil, httputil.HandleRequestError(res, err)
+		return nil, err
 	}
 
 	if !runtime.HasStatusCode(res, http.StatusOK) {
@@ -107,7 +107,7 @@ func (b *ServicePrincipalItemRequestBuilder) Delete(ctx context.Context) error {
 
 	res, err := b.client.pipeline.Do(req)
 	if err != nil {
-		return httputil.HandleRequestError(res, err)
+		return err
 	}
 
 	if !runtime.HasStatusCode(res, http.StatusNoContent) {

--- a/cli/azd/pkg/httputil/util.go
+++ b/cli/azd/pkg/httputil/util.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
 // Reads the raw HTTP response and attempt to convert it into the specified type
@@ -26,13 +24,4 @@ func ReadRawResponse[T any](response *http.Response) (*T, error) {
 	}
 
 	return instance, nil
-}
-
-// Handles and errors executing the http request
-func HandleRequestError(response *http.Response, err error) error {
-	if response == nil {
-		return err
-	}
-
-	return runtime.NewResponseError(response)
 }

--- a/cli/azd/pkg/tools/azcli/container_registry.go
+++ b/cli/azd/pkg/tools/azcli/container_registry.go
@@ -245,7 +245,7 @@ func (crs *containerRegistryService) getAcrToken(
 
 	response, err := pipeline.Do(req)
 	if err != nil {
-		return nil, httputil.HandleRequestError(response, err)
+		return nil, err
 	}
 
 	if !azruntime.HasStatusCode(response, http.StatusOK) {


### PR DESCRIPTION
Remove `httputil.HandleRequestError` and its usage as it may be more correct to return the underlying `err` when `err != nil && response != nil`.

Reasoning is as follows: suppose that the transport, or an executor of the pipeline, had returned an `err` for some reason, with `resp` intact. The executing code has made a decision that the request should be considered an error. The server response, in this case, is not the cause of the error. Instead, something else has occurred.

For example, it is documented in [http.Client.Do](https://pkg.go.dev/net/http#Client.Do):

> On error, any Response can be ignored. A non-nil Response with a non-nil error only occurs when CheckRedirect fails, and even then the returned Response.Body is already closed.

In this case, it is more correct to attribute the error to the maximum redirects reached, and not the HTTP response with StatusCode 307/308 from the server.