### PR TITLE
Add tracking for user interaction time

### DIFF
--- a/cli/azd/cmd/build.go
+++ b/cli/azd/cmd/build.go
@@ -200,7 +200,7 @@ func (ba *buildAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header: fmt.Sprintf("Your application was built for Azure in %s.", ux.DurationAsText(time.Since(startTime))),
+			Header: fmt.Sprintf("Your application was built for Azure in %s.", ux.DurationAsText(since(startTime))),
 		},
 	}, nil
 }

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -290,7 +290,7 @@ func (da *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header:   fmt.Sprintf("Your application was deployed to Azure in %s.", ux.DurationAsText(time.Since(startTime))),
+			Header:   fmt.Sprintf("Your application was deployed to Azure in %s.", ux.DurationAsText(since(startTime))),
 			FollowUp: getResourceGroupFollowUp(ctx, da.formatter, da.projectConfig, da.resourceManager, da.env),
 		},
 	}, nil

--- a/cli/azd/cmd/down.go
+++ b/cli/azd/cmd/down.go
@@ -120,7 +120,7 @@ func (a *downAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header: fmt.Sprintf("Your application was removed from Azure in %s.", ux.DurationAsText(time.Since(startTime))),
+			Header: fmt.Sprintf("Your application was removed from Azure in %s.", ux.DurationAsText(since(startTime))),
 		},
 	}, nil
 }

--- a/cli/azd/cmd/middleware/telemetry.go
+++ b/cli/azd/cmd/middleware/telemetry.go
@@ -67,6 +67,7 @@ func (m *TelemetryMiddleware) Run(ctx context.Context, next NextFn) (*actions.Ac
 	defer func() {
 		// Include any usage attributes set
 		span.SetAttributes(tracing.GetUsageAttributes()...)
+		span.SetAttributes(fields.PerfInteractTime.Int64(tracing.InteractTimeMs.Load()))
 		span.End()
 	}()
 

--- a/cli/azd/cmd/package.go
+++ b/cli/azd/cmd/package.go
@@ -178,7 +178,7 @@ func (pa *packageAction) Run(ctx context.Context) (*actions.ActionResult, error)
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header: fmt.Sprintf("Your application was packaged for Azure in %s.", ux.DurationAsText(time.Since(startTime))),
+			Header: fmt.Sprintf("Your application was packaged for Azure in %s.", ux.DurationAsText(since(startTime))),
 		},
 	}, nil
 }

--- a/cli/azd/cmd/provision.go
+++ b/cli/azd/cmd/provision.go
@@ -233,7 +233,7 @@ func (p *provisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
 			Header: fmt.Sprintf(
-				"Your application was provisioned in Azure in %s.", ux.DurationAsText(time.Since(startTime))),
+				"Your application was provisioned in Azure in %s.", ux.DurationAsText(since(startTime))),
 			FollowUp: getResourceGroupFollowUp(
 				ctx, p.formatter, p.projectConfig, p.resourceManager, p.env),
 		},

--- a/cli/azd/cmd/restore.go
+++ b/cli/azd/cmd/restore.go
@@ -195,7 +195,7 @@ func (ra *restoreAction) Run(ctx context.Context) (*actions.ActionResult, error)
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
 			Header: fmt.Sprintf(
-				"Your applications dependencies were restored in %s.", ux.DurationAsText(time.Since(startTime))),
+				"Your applications dependencies were restored in %s.", ux.DurationAsText(since(startTime))),
 		},
 	}, nil
 }

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -160,7 +160,7 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
 			Header: fmt.Sprintf("Your application was provisioned and deployed to Azure in %s.",
-				ux.DurationAsText(time.Since(startTime))),
+				ux.DurationAsText(since(startTime))),
 		},
 	}, nil
 }

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -8,10 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/internal/tracing"
+	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -294,4 +297,16 @@ func getTargetServiceName(
 	}
 
 	return targetServiceName, nil
+}
+
+// Calculate the total time since t, excluding user interaction time.
+func since(t time.Time) time.Duration {
+	usage := tracing.GetUsageAttributes()
+	for _, kv := range usage {
+		if kv.Key == fields.PerfInteractTime {
+			return time.Since(t) - time.Duration(kv.Value.AsInt64())*time.Millisecond
+		}
+	}
+
+	return time.Since(t)
 }

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -14,7 +14,6 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
-	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -301,12 +300,6 @@ func getTargetServiceName(
 
 // Calculate the total time since t, excluding user interaction time.
 func since(t time.Time) time.Duration {
-	usage := tracing.GetUsageAttributes()
-	for _, kv := range usage {
-		if kv.Key == fields.PerfInteractTime {
-			return time.Since(t) - time.Duration(kv.Value.AsInt64())*time.Millisecond
-		}
-	}
-
-	return time.Since(t)
+	userInteractTime := tracing.InteractTimeMs.Load()
+	return time.Since(t) - time.Duration(userInteractTime)*time.Millisecond
 }

--- a/cli/azd/internal/tracing/attributes.go
+++ b/cli/azd/internal/tracing/attributes.go
@@ -106,3 +106,6 @@ func GetUsageAttributes() []attribute.KeyValue {
 func AppendUsageAttribute(attr attribute.KeyValue) {
 	appendTo(&usageVal, attr)
 }
+
+// InteractTimeMs is the time spent waiting on user interaction in milliseconds.
+var InteractTimeMs = atomic.NewInt64(0)

--- a/cli/azd/internal/tracing/fields/fields.go
+++ b/cli/azd/internal/tracing/fields/fields.go
@@ -204,3 +204,9 @@ const (
 	// The exit code of the tool after invocation.
 	ToolExitCode = attribute.Key("tool.exitCode")
 )
+
+// Performance related fields
+const (
+	// The time spent waiting on user interaction in milliseconds.
+	PerfInteractTime = attribute.Key("perf.interact_time")
+)


### PR DESCRIPTION
Track time waiting for user. This currently only includes prompts generated by the CLI, and not indirectly by a tool.

Fixes #598