### PR TITLE
Support Azure Spring Apps consumption dedicated plan

### DIFF
--- a/cli/azd/pkg/tools/azcli/spring_app.go
+++ b/cli/azd/pkg/tools/azcli/spring_app.go
@@ -93,7 +93,8 @@ func (ss *springService) GetSpringAppProperties(
 
 	var fqdn []string
 	if springApp.Properties != nil &&
-		springApp.Properties.Fqdn != nil {
+		springApp.Properties.Fqdn != nil &&
+		*springApp.Properties.Public {
 		fqdn = []string{*springApp.Properties.Fqdn}
 	} else {
 		fqdn = []string{}

--- a/cli/azd/pkg/tools/azcli/spring_app.go
+++ b/cli/azd/pkg/tools/azcli/spring_app.go
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappplatform"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappplatform/v2"
 	"github.com/Azure/azure-storage-file-go/azfile"
 	azdinternal "github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers v1.0.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappplatform v1.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappplatform/v2 v2.0.0-beta.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appconfiguration/armappcon
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appconfiguration/armappconfiguration v1.0.0/go.mod h1:YW819qVTop21KS8LJLEf3Z47LBaRHIaz/IRLZpKqTIU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers v1.0.0 h1:zIQzosd251uW2j2+MIbMDeyqkISOFV88XYE7pvkWIZM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers v1.0.0/go.mod h1:/OjYJjDeOIdCSJmuQH0BDpegn00BI747f5WJseOm26o=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappplatform v1.0.0 h1:wgU84WluDEsqrgw/ZYLcOHN/NNaFAWa6EAUyzxasNeE=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappplatform v1.0.0/go.mod h1:yGK8WOLcIMXyT84rwf1EL3y5QU4XYYwczK70uWfBFmQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappplatform/v2 v2.0.0-beta.1 h1:/0cm1GshkYOYpA9t6W3dU1uGNwBiaTNeGMX4HMD9LBU=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappplatform/v2 v2.0.0-beta.1/go.mod h1:cKYj1VwtPpdhRZDp3eiOIYgx4Q4LiQZvA21I1IiQgpI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice v1.0.0 h1:kRX8I0dWAcpW6Vq0m90CgV+qw4O1vXodgwrhoPr1RWs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice v1.0.0/go.mod h1:avvc5/7qR4taCvAhOM7KFXuEHhAU0Wek9YX7sh9H3EM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization v1.0.0 h1:qtRcg5Y7jNJ4jEzPq4GpWLfTspHdNe2ZK6LjwGcjgmU=


### PR DESCRIPTION
- Update ASA go sdk from `https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappplatform` to `https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappplatform/v2`, the newer one support ASA consumption dedicated plan.
- Add a new condition to extract Azure Spring Apps endpoint.