### PR TITLE
Remove inherited base policies on custom policy

### DIFF
--- a/templates/common/infra/shared/gateway/apim/apim-api-policy.xml
+++ b/templates/common/infra/shared/gateway/apim/apim-api-policy.xml
@@ -1,7 +1,6 @@
 <!-- Policy configuration for the API. Explore other sample policies at https://learn.microsoft.com/en-us/azure/api-management/policies/ -->
 <policies>
     <inbound>
-        <base />
         <!-- This policy is needed to handle preflight requests using the OPTIONS method. Learn more at https://learn.microsoft.com/en-us/azure/api-management/api-management-cross-domain-policies  -->
         <cors allow-credentials="false">
             <allowed-origins>
@@ -40,7 +39,6 @@
         </limit-concurrency>
     </backend>
     <outbound>
-        <base />
         <!-- Optional policy to validate the response headers. Learn more at https://learn.microsoft.com/en-us/azure/api-management/validation-policies#validate-headers -->
         <validate-headers specified-header-action="ignore" unspecified-header-action="ignore" errors-variable-name="responseHeadersValidation" />
         <!-- Optional policy to to send custom metrics to Application Insights. Learn more at https://learn.microsoft.com/en-us/azure/api-management/api-management-advanced-policies#emit-metrics -->
@@ -65,7 +63,6 @@
         </choose>
     </outbound>
     <on-error>
-        <base />
         <!-- Optional policy to handle errors. Learn more at https://learn.microsoft.com/en-us/azure/api-management/api-management-error-handling-policies -->
         <trace source="@(context.Api.Name)" severity="error">
             <message>Failed to process the @(context.Api.Name)</message>


### PR DESCRIPTION
blgo opened a [pr](https://github.com/Azure-Samples/todo-python-mongo-swa-func/pull/7) to ask for remove base in apim policy xml since "the default base policy (allowed-methods GET, POST, PUT and allowed-origins wildcard) was overriding the custom policies defiled here". 

According to [Policies in Azure API Management](https://learn.microsoft.com/en-us/azure/api-management/api-management-howto-policies), remove `base /` means only policies configured at the API scope will be applied. Neither product nor global scope policies would be applied. 

I wonder do we want to have this included to all templates. If not, we might document it and ask customers to remove base policy if they wanted to.