### PR TITLE
Add suggested action message when create service principal failed due to lack of permission

### DIFF
--- a/cli/azd/cmd/cobra_builder.go
+++ b/cli/azd/cmd/cobra_builder.go
@@ -17,6 +17,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 )

--- a/cli/azd/pkg/tools/azcli/ad.go
+++ b/cli/azd/pkg/tools/azcli/ad.go
@@ -276,8 +276,9 @@ func (cli *azCli) applyRoleAssignmentWithRetry(
 			if errors.As(err, &responseError) && responseError.StatusCode == http.StatusForbidden {
 
 				return &ErrorWithSuggestion{
-					Suggestion: fmt.Sprintf("\nSuggested Action: Ensure you have either the `User Access Administrator`, `Owner` or custom azure roles assigned" +
-						" to your subscription to perform action 'Microsoft.Authorization/roleAssignments/write', in order to manage role assignments\n"),
+					Suggestion: fmt.Sprintf("\nSuggested Action: Ensure you have either the `User Access Administrator`, " +
+						"Owner` or custom azure roles assigned to your subscription to perform action " +
+						"'Microsoft.Authorization/roleAssignments/write', in order to manage role assignments\n"),
 					Err: err,
 				}
 


### PR DESCRIPTION
fix #1954
Add suggested action to ask users to add admin or owner role assignment to their subscription when they run into permission 403 error during creation of service principal. 

We will update the workflow to check role assignments permission before create service principal once issue https://github.com/Azure/azure-dev/issues/2327 is updated on SDK side. 