### PR TITLE
Sample: Using pubsub for progress reporting in azd command

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -25,9 +25,12 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
+	"github.com/azure/azure-dev/cli/azd/pkg/messaging"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/progress"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
+	"github.com/azure/azure-dev/cli/azd/pkg/sample"
 	"github.com/azure/azure-dev/cli/azd/pkg/templates"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/bicep"
@@ -310,6 +313,19 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.RegisterSingleton(python.NewPythonCli)
 	container.RegisterSingleton(swa.NewSwaCli)
 	container.RegisterSingleton(terraform.NewTerraformCli)
+
+	// Messaging
+	container.RegisterSingleton(messaging.NewService)
+	container.RegisterSingleton(func(messageService *messaging.Service) messaging.Publisher {
+		return messageService
+	})
+	container.RegisterSingleton(func(messageService *messaging.Service) messaging.Subscriber {
+		return messageService
+	})
+
+	// Sample
+	container.RegisterSingleton(sample.NewSampler)
+	container.RegisterSingleton(progress.NewPrinter)
 
 	// Provisioning
 	container.RegisterTransient(provisioning.NewManager)

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -108,6 +108,12 @@ func NewRootCmd(staticHelp bool, middlewareChain []*actions.MiddlewareRegistrati
 	templatesActions(root)
 	authActions(root)
 
+	root.Add("sample", &actions.ActionDescriptorOptions{
+		Command:        newSampleCmd(),
+		FlagsResolver:  newSampleFlags,
+		ActionResolver: newSampleAction,
+	})
+
 	root.Add("version", &actions.ActionDescriptorOptions{
 		Command: &cobra.Command{
 			Short: "Print the version number of Azure Developer CLI.",

--- a/cli/azd/cmd/sample.go
+++ b/cli/azd/cmd/sample.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/azure/azure-dev/cli/azd/cmd/actions"
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
+	"github.com/azure/azure-dev/cli/azd/pkg/progress"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
+	"github.com/azure/azure-dev/cli/azd/pkg/sample"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type sampleFlags struct {
+	global *internal.GlobalCommandOptions
+}
+
+func (v *sampleFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
+	v.global = global
+}
+
+func newSampleFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *sampleFlags {
+	flags := &sampleFlags{}
+	flags.Bind(cmd.Flags(), global)
+
+	return flags
+}
+
+func newSampleCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "sample",
+		Short: "Pubsub sample",
+	}
+}
+
+type sampleAction struct {
+	flags           *sampleFlags
+	projectConfig   *project.ProjectConfig
+	sampler         *sample.Sampler
+	progressPrinter *progress.Printer
+	console         input.Console
+	formatter       output.Formatter
+	writer          io.Writer
+}
+
+func newSampleAction(
+	flags *sampleFlags,
+	projectConfig *project.ProjectConfig,
+	sampler *sample.Sampler,
+	projectPrinter *progress.Printer,
+	console input.Console,
+	formatter output.Formatter,
+	writer io.Writer,
+
+) actions.Action {
+	return &sampleAction{
+		flags:           flags,
+		projectConfig:   projectConfig,
+		sampler:         sampler,
+		progressPrinter: projectPrinter,
+		console:         console,
+		formatter:       formatter,
+		writer:          writer,
+	}
+}
+
+func (sa *sampleAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	// Command title
+	sa.console.MessageUxItem(ctx, &ux.MessageTitle{
+		Title: "Sampling services (azd sample)",
+	})
+
+	// Start progress reporting
+	// This could also be moved to a middleware to handle commonly used progress messages
+	subscription, err := sa.progressPrinter.Start(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer subscription.Close(ctx)
+
+	startTime := time.Now()
+
+	// Start your long running / blocking operation
+	_, err = sa.sampler.LongRunningOperation(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure all messages are flushed and handled before writing out success message
+	if err := subscription.Flush(ctx); err != nil {
+		return nil, err
+	}
+
+	return &actions.ActionResult{
+		Message: &actions.ResultMessage{
+			Header: fmt.Sprintf("Your application was sampled for Azure in %s.", ux.DurationAsText(since(startTime))),
+		},
+	}, nil
+}

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -50,14 +50,4 @@ type Provider interface {
 	Plan(ctx context.Context) (*DeploymentPlan, error)
 	Deploy(ctx context.Context, plan *DeploymentPlan) (*DeployResult, error)
 	Destroy(ctx context.Context, options DestroyOptions) (*DestroyResult, error)
-		env,
-		projectPath,
-		infraOptions,
-		console,
-		azCli,
-		commandRunner,
-		prompters,
-		principalProvider,
-		alphaFeatureManager,
-	)
 }

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -50,4 +50,14 @@ type Provider interface {
 	Plan(ctx context.Context) (*DeploymentPlan, error)
 	Deploy(ctx context.Context, plan *DeploymentPlan) (*DeployResult, error)
 	Destroy(ctx context.Context, options DestroyOptions) (*DestroyResult, error)
+		env,
+		projectPath,
+		infraOptions,
+		console,
+		azCli,
+		commandRunner,
+		prompters,
+		principalProvider,
+		alphaFeatureManager,
+	)
 }

--- a/cli/azd/pkg/messaging/message.go
+++ b/cli/azd/pkg/messaging/message.go
@@ -4,12 +4,16 @@ import (
 	"time"
 )
 
+// MessageKind represents the kind of a message.
+// This is used to filter messages.
 type MessageKind string
 
 const (
+	// SimpleMessage is a simple message.
 	SimpleMessage MessageKind = "Simple"
 )
 
+// Message represents a message sent to a topic.
 type Message struct {
 	Timestamp time.Time
 	Type      MessageKind
@@ -17,6 +21,7 @@ type Message struct {
 	Tags      map[string]any
 }
 
+// NewMessage creates a new message with the specified kind and value.
 func NewMessage[T any](kind MessageKind, value T) *Message {
 	return &Message{
 		Type:      kind,

--- a/cli/azd/pkg/messaging/message.go
+++ b/cli/azd/pkg/messaging/message.go
@@ -1,7 +1,6 @@
 package messaging
 
 import (
-	"context"
 	"time"
 )
 
@@ -18,10 +17,6 @@ type Message struct {
 	Tags      map[string]any
 }
 
-func NewSimpleMessage(message string) *Message {
-	return NewMessage(SimpleMessage, message)
-}
-
 func NewMessage[T any](kind MessageKind, value T) *Message {
 	return &Message{
 		Type:      kind,
@@ -29,12 +24,4 @@ func NewMessage[T any](kind MessageKind, value T) *Message {
 		Timestamp: time.Now(),
 		Tags:      map[string]any{},
 	}
-}
-
-type Publisher interface {
-	Send(ctx context.Context, msg *Message)
-}
-
-type Subscriber interface {
-	Subscribe(ctx context.Context, filter MessageFilter, handler MessageHandler) *Subscription
 }

--- a/cli/azd/pkg/messaging/message.go
+++ b/cli/azd/pkg/messaging/message.go
@@ -1,0 +1,40 @@
+package messaging
+
+import (
+	"context"
+	"time"
+)
+
+type MessageKind string
+
+const (
+	SimpleMessage MessageKind = "Simple"
+)
+
+type Message struct {
+	Timestamp time.Time
+	Type      MessageKind
+	Value     any
+	Tags      map[string]any
+}
+
+func NewSimpleMessage(message string) *Message {
+	return NewMessage(SimpleMessage, message)
+}
+
+func NewMessage[T any](kind MessageKind, value T) *Message {
+	return &Message{
+		Type:      kind,
+		Value:     value,
+		Timestamp: time.Now(),
+		Tags:      map[string]any{},
+	}
+}
+
+type Publisher interface {
+	Send(ctx context.Context, msg *Message)
+}
+
+type Subscriber interface {
+	Subscribe(ctx context.Context, filter MessageFilter, handler MessageHandler) *Subscription
+}

--- a/cli/azd/pkg/messaging/service.go
+++ b/cli/azd/pkg/messaging/service.go
@@ -1,0 +1,57 @@
+package messaging
+
+import (
+	"context"
+)
+
+type Service struct {
+	topics map[string]*Topic
+}
+
+func NewService() *Service {
+	return &Service{
+		topics: map[string]*Topic{},
+	}
+}
+
+type contextKey string
+
+const (
+	defaultTopicName string     = "default"
+	topicContextKey  contextKey = "messaging-topic"
+)
+
+func (s *Service) WithTopic(ctx context.Context, topicName string) context.Context {
+	return context.WithValue(ctx, topicContextKey, topicName)
+}
+
+func (s *Service) Send(ctx context.Context, msg *Message) {
+	topic := s.ensureTopic(ctx)
+	topic.Send(ctx, msg)
+}
+
+func (s *Service) Subscribe(ctx context.Context, filter MessageFilter, handler MessageHandler) *Subscription {
+	topic := s.ensureTopic(ctx)
+	return topic.Subscribe(ctx, filter, handler)
+}
+
+func (s *Service) ensureTopic(ctx context.Context) *Topic {
+	topicName := s.getTopicName(ctx)
+	topic, has := s.topics[topicName]
+	if !has {
+		topic = NewTopic(topicName)
+		topic.init(ctx)
+		s.topics[topicName] = topic
+	}
+
+	return topic
+}
+
+func (s *Service) getTopicName(ctx context.Context) string {
+	topicName, ok := ctx.Value(topicContextKey).(string)
+	if !ok {
+		topicName = defaultTopicName
+	}
+
+	return topicName
+}

--- a/cli/azd/pkg/messaging/service.go
+++ b/cli/azd/pkg/messaging/service.go
@@ -4,18 +4,24 @@ import (
 	"context"
 )
 
+// Publisher is an interface for sending messages.
 type Publisher interface {
+	// Send sends a message to the topic specified in the context.
 	Send(ctx context.Context, msg *Message) error
 }
 
+// Subscriber is an interface for receiving messages.
 type Subscriber interface {
+	// Subscribe subscribes to the topic specified in the context with the specified filter and handler.
 	Subscribe(ctx context.Context, filter MessageFilter, handler MessageHandler) (*Subscription, error)
 }
 
+// Service is a messaging service for sending and receiving messages.
 type Service struct {
 	topics map[string]*Topic
 }
 
+// NewService creates a new messaging service.
 func NewService() *Service {
 	return &Service{
 		topics: map[string]*Topic{},
@@ -29,18 +35,25 @@ const (
 	topicContextKey  contextKey = "messaging-topic"
 )
 
+// WithTopic returns a new context with the specified topic name.
+// Calls to Send / Subscribe will use the topic name from the context.
 func (s *Service) WithTopic(ctx context.Context, topicName string) context.Context {
 	return context.WithValue(ctx, topicContextKey, topicName)
 }
 
+// Send sends a message to the topic specified in the context.
 func (s *Service) Send(ctx context.Context, msg *Message) error {
 	return s.Topic(ctx).Send(ctx, msg)
 }
 
+// Subscribe subscribes to the topic specified in the context with the specified filter and handler.
 func (s *Service) Subscribe(ctx context.Context, filter MessageFilter, handler MessageHandler) (*Subscription, error) {
 	return s.Topic(ctx).Subscribe(ctx, filter, handler)
 }
 
+// Topic returns the topic specified in the context.
+// If no topic is specified in the context, the default topic is returned.
+// If the topic does not exist, it is created.
 func (s *Service) Topic(ctx context.Context) *Topic {
 	topicName := s.getTopicName(ctx)
 	topic, has := s.topics[topicName]

--- a/cli/azd/pkg/messaging/service.go
+++ b/cli/azd/pkg/messaging/service.go
@@ -14,6 +14,7 @@ type Publisher interface {
 type Subscriber interface {
 	// Subscribe subscribes to the topic specified in the context with the specified filter and handler.
 	Subscribe(ctx context.Context, filter MessageFilter, handler MessageHandler) (*Subscription, error)
+	Unsubscribe(ctx context.Context, subscription *Subscription)
 }
 
 // Service is a messaging service for sending and receiving messages.
@@ -49,6 +50,10 @@ func (s *Service) Send(ctx context.Context, msg *Message) error {
 // Subscribe subscribes to the topic specified in the context with the specified filter and handler.
 func (s *Service) Subscribe(ctx context.Context, filter MessageFilter, handler MessageHandler) (*Subscription, error) {
 	return s.Topic(ctx).Subscribe(ctx, filter, handler)
+}
+
+func (s *Service) Unsubscribe(ctx context.Context, subscription *Subscription) {
+	s.Topic(ctx).Unsubscribe(ctx, subscription)
 }
 
 // Topic returns the topic specified in the context.

--- a/cli/azd/pkg/messaging/service_test.go
+++ b/cli/azd/pkg/messaging/service_test.go
@@ -1,0 +1,132 @@
+package messaging
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Service_Send_Receive(t *testing.T) {
+	ctx := context.Background()
+	service := NewService()
+
+	t.Run("With_Default_Topic", func(t *testing.T) {
+		recievedMessages := []*Message{}
+
+		subscription, err := service.Subscribe(ctx, nil, func(ctx context.Context, msg *Message) {
+			recievedMessages = append(recievedMessages, msg)
+		})
+		require.NoError(t, err)
+		defer subscription.Close(ctx)
+
+		err = service.Send(ctx, NewMessage(SimpleMessage, "Hello World"))
+		require.NoError(t, err)
+		subscription.Flush(ctx)
+
+		require.Len(t, recievedMessages, 1)
+	})
+
+	t.Run("With_Custom_Topic", func(t *testing.T) {
+		topicCtx := service.WithTopic(ctx, "custom")
+		recievedMessages := []*Message{}
+
+		subscription, err := service.Subscribe(topicCtx, nil, func(ctx context.Context, msg *Message) {
+			recievedMessages = append(recievedMessages, msg)
+		})
+		require.NoError(t, err)
+		defer subscription.Close(topicCtx)
+
+		subscription.Flush(topicCtx)
+
+		err = service.Send(topicCtx, NewMessage(SimpleMessage, "Hello World"))
+		require.NoError(t, err)
+		require.Len(t, recievedMessages, 1)
+	})
+
+	t.Run("With_Multiple_Topics", func(t *testing.T) {
+		topic1Ctx := service.WithTopic(ctx, "topic1")
+		topic2Ctx := service.WithTopic(ctx, "topic2")
+
+		topic1ReceivedMessages := []*Message{}
+		topic2ReceivedMessages := []*Message{}
+
+		subscription1, err := service.Subscribe(topic1Ctx, nil, func(ctx context.Context, msg *Message) {
+			topic1ReceivedMessages = append(topic1ReceivedMessages, msg)
+		})
+		require.NoError(t, err)
+		defer subscription1.Close(topic1Ctx)
+
+		subscription2, err := service.Subscribe(topic2Ctx, nil, func(ctx context.Context, msg *Message) {
+			topic2ReceivedMessages = append(topic2ReceivedMessages, msg)
+		})
+		require.NoError(t, err)
+		defer subscription2.Close(topic2Ctx)
+
+		err = service.Send(topic1Ctx, NewMessage(SimpleMessage, "Hello World"))
+		require.NoError(t, err)
+
+		err = service.Send(topic2Ctx, NewMessage(SimpleMessage, "Hello World"))
+		require.NoError(t, err)
+
+		err = subscription1.Flush(topic1Ctx)
+		require.NoError(t, err)
+
+		err = subscription2.Flush(topic2Ctx)
+		require.NoError(t, err)
+
+		require.Len(t, topic1ReceivedMessages, 1)
+		require.Len(t, topic2ReceivedMessages, 1)
+	})
+
+	t.Run("With_Multiple_Messages", func(t *testing.T) {
+		recievedMessages := []*Message{}
+
+		subscription, err := service.Subscribe(ctx, nil, func(ctx context.Context, msg *Message) {
+			recievedMessages = append(recievedMessages, msg)
+		})
+		require.NoError(t, err)
+		defer subscription.Close(ctx)
+
+		messageCount := 100
+		for i := 0; i < 100; i++ {
+			err = service.Send(ctx, NewMessage(SimpleMessage, fmt.Sprintf("Hello World %d", i)))
+			require.NoError(t, err)
+		}
+
+		err = subscription.Flush(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, recievedMessages, messageCount)
+	})
+
+	t.Run("With_More_Messages_After_Flush", func(t *testing.T) {
+		recievedMessages := []*Message{}
+
+		subscription, err := service.Subscribe(ctx, nil, func(ctx context.Context, msg *Message) {
+			recievedMessages = append(recievedMessages, msg)
+		})
+		require.NoError(t, err)
+		defer subscription.Close(ctx)
+
+		messageCount := 100
+		for i := 0; i < 100; i++ {
+			err = service.Send(ctx, NewMessage(SimpleMessage, fmt.Sprintf("Hello World %d", i)))
+			require.NoError(t, err)
+		}
+
+		err = subscription.Flush(ctx)
+		require.NoError(t, err)
+
+		for i := 0; i < 100; i++ {
+			err = service.Send(ctx, NewMessage(SimpleMessage, fmt.Sprintf("Hello World %d", i)))
+			require.NoError(t, err)
+		}
+
+		err = subscription.Flush(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, recievedMessages, 2*messageCount)
+	})
+}

--- a/cli/azd/pkg/messaging/subscription.go
+++ b/cli/azd/pkg/messaging/subscription.go
@@ -1,0 +1,33 @@
+package messaging
+
+import "context"
+
+type MessageFilter func(ctx context.Context, msg *Message) bool
+
+type MessageHandler func(ctx context.Context, msg *Message)
+
+type Subscription struct {
+	topic   *Topic
+	filter  MessageFilter
+	handler MessageHandler
+}
+
+func NewSubscription(topic *Topic, filter MessageFilter, handler MessageHandler) *Subscription {
+	return &Subscription{
+		topic:   topic,
+		filter:  filter,
+		handler: handler,
+	}
+}
+
+func (s *Subscription) receive(ctx context.Context, msg *Message) {
+	if s.filter != nil && !s.filter(ctx, msg) {
+		return
+	}
+
+	s.handler(ctx, msg)
+}
+
+func (s *Subscription) Close(ctx context.Context) {
+	s.topic.Unsubscribe(ctx, s)
+}

--- a/cli/azd/pkg/messaging/subscription.go
+++ b/cli/azd/pkg/messaging/subscription.go
@@ -5,16 +5,20 @@ import (
 	"fmt"
 )
 
+// MessageFilter is a function that determines whether a message should be handled by a subscription.
 type MessageFilter func(ctx context.Context, msg *Message) bool
 
+// MessageHandler is a function that handles a message.
 type MessageHandler func(ctx context.Context, msg *Message)
 
+// Subscription is a subscription to a topic.
 type Subscription struct {
 	topic   *Topic
 	filter  MessageFilter
 	handler MessageHandler
 }
 
+// NewSubscription creates a new subscription to the specified topic with the specified filter and handler.
 func NewSubscription(topic *Topic, filter MessageFilter, handler MessageHandler) (*Subscription, error) {
 	if handler == nil {
 		return nil, fmt.Errorf("creating subscription: handler is nil")
@@ -27,6 +31,7 @@ func NewSubscription(topic *Topic, filter MessageFilter, handler MessageHandler)
 	}, nil
 }
 
+// Close closes the subscription.
 func (s *Subscription) Close(ctx context.Context) error {
 	err := s.topic.Flush(ctx)
 	if err != nil {
@@ -37,6 +42,7 @@ func (s *Subscription) Close(ctx context.Context) error {
 	return nil
 }
 
+// Flush flushes the subscription.
 func (s *Subscription) Flush(ctx context.Context) error {
 	return s.topic.Flush(ctx)
 }

--- a/cli/azd/pkg/messaging/subscription_test.go
+++ b/cli/azd/pkg/messaging/subscription_test.go
@@ -1,0 +1,82 @@
+package messaging
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Subscription_Receive(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("All_Messages", func(t *testing.T) {
+		messages := []*Message{}
+		topic := NewTopic(ctx, "test")
+		subscription, err := topic.Subscribe(ctx, nil, func(ctx context.Context, msg *Message) {
+			messages = append(messages, msg)
+		})
+		require.NoError(t, err)
+		require.NotNil(t, subscription)
+
+		for i := 0; i < 10; i++ {
+			err := topic.Send(ctx, NewMessage(SimpleMessage, "test"))
+			require.NoError(t, err)
+		}
+
+		err = subscription.Flush(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, messages, 10)
+	})
+
+	t.Run("With_Message_Filter", func(t *testing.T) {
+		messages := []*Message{}
+		topic := NewTopic(ctx, "test")
+		subscription, err := topic.Subscribe(ctx, func(ctx context.Context, msg *Message) bool {
+			return msg.Type == SimpleMessage
+		}, func(ctx context.Context, msg *Message) {
+			messages = append(messages, msg)
+		})
+		require.NoError(t, err)
+		require.NotNil(t, subscription)
+
+		var customMessage MessageKind = "custom"
+
+		for i := 0; i < 10; i++ {
+			err := topic.Send(ctx, NewMessage(SimpleMessage, "test"))
+			require.NoError(t, err)
+
+			err = topic.Send(ctx, NewMessage(customMessage, "custom"))
+			require.NoError(t, err)
+		}
+
+		err = subscription.Flush(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, messages, 10)
+	})
+}
+
+func Test_Subscription_Close(t *testing.T) {
+	ctx := context.Background()
+
+	messages := []*Message{}
+	topic := NewTopic(ctx, "test")
+	subscription, err := topic.Subscribe(ctx, nil, func(ctx context.Context, msg *Message) {
+		messages = append(messages, msg)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+
+	err = subscription.Close(ctx)
+	require.NoError(t, err)
+
+	err = topic.Send(ctx, NewMessage(SimpleMessage, "test"))
+	require.NoError(t, err)
+
+	err = subscription.Flush(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, messages, 0)
+}

--- a/cli/azd/pkg/messaging/topic.go
+++ b/cli/azd/pkg/messaging/topic.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+// Topic receives messages from the messaging system and broadcasts them to subscribers.
 type Topic struct {
 	Name        string
 	channel     chan *Message
@@ -16,6 +17,7 @@ type Topic struct {
 	closed      bool
 }
 
+// NewTopic creates a new topic with the specified name.
 func NewTopic(ctx context.Context, name string) *Topic {
 	topic := &Topic{
 		Name:        name,
@@ -27,6 +29,8 @@ func NewTopic(ctx context.Context, name string) *Topic {
 	return topic
 }
 
+// Subscribe subscribes to the topic with the specified filter and handler.
+// The filter is used to filter messages. If not filter is specified, all messages are received.
 func (t *Topic) Subscribe(ctx context.Context, filter MessageFilter, handler MessageHandler) (*Subscription, error) {
 	if err := t.ensureOpen(); err != nil {
 		return nil, err
@@ -42,6 +46,7 @@ func (t *Topic) Subscribe(ctx context.Context, filter MessageFilter, handler Mes
 	return subscription, nil
 }
 
+// Unsubscribe unsubscribes from the topic.
 func (t *Topic) Unsubscribe(ctx context.Context, subscription *Subscription) {
 	index := slices.IndexFunc(t.subscribers, func(s *Subscription) bool {
 		return s == subscription
@@ -55,6 +60,7 @@ func (t *Topic) Unsubscribe(ctx context.Context, subscription *Subscription) {
 	t.subscribers = append(t.subscribers[:index], t.subscribers[index+1:]...)
 }
 
+// Send sends a message to the topic.
 func (t *Topic) Send(ctx context.Context, msg *Message) error {
 	if err := t.ensureOpen(); err != nil {
 		return err
@@ -68,6 +74,7 @@ func (t *Topic) Send(ctx context.Context, msg *Message) error {
 	return nil
 }
 
+// Close closes the topic.
 func (t *Topic) Close(ctx context.Context) error {
 	if err := t.ensureOpen(); err != nil {
 		return err
@@ -84,6 +91,8 @@ func (t *Topic) Close(ctx context.Context) error {
 	return nil
 }
 
+// Flush flushes the topic.
+// This method blocks until all messages have been delivered to all subscribers.
 func (t *Topic) Flush(ctx context.Context) error {
 	if err := t.ensureOpen(); err != nil {
 		return err

--- a/cli/azd/pkg/messaging/topic.go
+++ b/cli/azd/pkg/messaging/topic.go
@@ -2,6 +2,8 @@ package messaging
 
 import (
 	"context"
+	"fmt"
+	"sync"
 
 	"golang.org/x/exp/slices"
 )
@@ -10,21 +12,34 @@ type Topic struct {
 	Name        string
 	channel     chan *Message
 	subscribers []*Subscription
+	flushLock   sync.Mutex
+	closed      bool
 }
 
-func NewTopic(name string) *Topic {
-	return &Topic{
+func NewTopic(ctx context.Context, name string) *Topic {
+	topic := &Topic{
 		Name:        name,
 		channel:     make(chan *Message),
 		subscribers: []*Subscription{},
 	}
+
+	topic.init(ctx)
+	return topic
 }
 
-func (t *Topic) Subscribe(ctx context.Context, filter MessageFilter, handler MessageHandler) *Subscription {
-	subscription := NewSubscription(t, filter, handler)
+func (t *Topic) Subscribe(ctx context.Context, filter MessageFilter, handler MessageHandler) (*Subscription, error) {
+	if err := t.ensureOpen(); err != nil {
+		return nil, err
+	}
+
+	subscription, err := NewSubscription(t, filter, handler)
+	if err != nil {
+		return nil, err
+	}
+
 	t.subscribers = append(t.subscribers, subscription)
 
-	return subscription
+	return subscription, nil
 }
 
 func (t *Topic) Unsubscribe(ctx context.Context, subscription *Subscription) {
@@ -40,24 +55,84 @@ func (t *Topic) Unsubscribe(ctx context.Context, subscription *Subscription) {
 	t.subscribers = append(t.subscribers[:index], t.subscribers[index+1:]...)
 }
 
-func (t *Topic) Send(ctx context.Context, msg *Message) {
+func (t *Topic) Send(ctx context.Context, msg *Message) error {
+	if err := t.ensureOpen(); err != nil {
+		return err
+	}
+
+	if msg == nil {
+		return fmt.Errorf("sending message: message is nil")
+	}
+
 	t.channel <- msg
+	return nil
 }
 
-func (t *Topic) Close(ctx context.Context) {
+func (t *Topic) Close(ctx context.Context) error {
+	if err := t.ensureOpen(); err != nil {
+		return err
+	}
+
+	close(t.channel)
+	t.Flush(ctx)
+
 	for _, subscriber := range t.subscribers {
 		subscriber.Close(ctx)
 	}
 
-	close(t.channel)
+	t.closed = true
+	return nil
+}
+
+func (t *Topic) Flush(ctx context.Context) error {
+	if err := t.ensureOpen(); err != nil {
+		return err
+	}
+
+	t.flushLock.Lock()
+	defer t.flushLock.Unlock()
+
+	return nil
+}
+
+func (t *Topic) receive(ctx context.Context, msg *Message) {
+	// Attempt to re-lock the flush mutex
+	_ = t.flushLock.TryLock()
+	for i := len(t.subscribers) - 1; i >= 0; i-- {
+		t.subscribers[i].receive(ctx, msg)
+	}
 }
 
 func (t *Topic) init(ctx context.Context) {
 	go func() {
-		for msg := range t.channel {
-			for i := len(t.subscribers) - 1; i >= 0; i-- {
-				t.subscribers[i].receive(ctx, msg)
+		flushed := false
+		t.flushLock.Lock()
+
+		for {
+			select {
+			case <-ctx.Done():
+				t.Close(ctx)
+				if !flushed {
+					t.flushLock.Unlock()
+				}
+				return
+			case msg := <-t.channel:
+				flushed = false
+				t.receive(ctx, msg)
+			default:
+				if !flushed {
+					t.flushLock.Unlock()
+					flushed = true
+				}
 			}
 		}
 	}()
+}
+
+func (t *Topic) ensureOpen() error {
+	if t.closed {
+		return fmt.Errorf("topic has already been closed")
+	}
+
+	return nil
 }

--- a/cli/azd/pkg/messaging/topic.go
+++ b/cli/azd/pkg/messaging/topic.go
@@ -1,0 +1,63 @@
+package messaging
+
+import (
+	"context"
+
+	"golang.org/x/exp/slices"
+)
+
+type Topic struct {
+	Name        string
+	channel     chan *Message
+	subscribers []*Subscription
+}
+
+func NewTopic(name string) *Topic {
+	return &Topic{
+		Name:        name,
+		channel:     make(chan *Message),
+		subscribers: []*Subscription{},
+	}
+}
+
+func (t *Topic) Subscribe(ctx context.Context, filter MessageFilter, handler MessageHandler) *Subscription {
+	subscription := NewSubscription(t, filter, handler)
+	t.subscribers = append(t.subscribers, subscription)
+
+	return subscription
+}
+
+func (t *Topic) Unsubscribe(ctx context.Context, subscription *Subscription) {
+	index := slices.IndexFunc(t.subscribers, func(s *Subscription) bool {
+		return s == subscription
+	})
+
+	if index < 0 {
+		return
+	}
+
+	// Remove subscription from t.subscribers
+	t.subscribers = append(t.subscribers[:index], t.subscribers[index+1:]...)
+}
+
+func (t *Topic) Send(ctx context.Context, msg *Message) {
+	t.channel <- msg
+}
+
+func (t *Topic) Close(ctx context.Context) {
+	for _, subscriber := range t.subscribers {
+		subscriber.Close(ctx)
+	}
+
+	close(t.channel)
+}
+
+func (t *Topic) init(ctx context.Context) {
+	go func() {
+		for msg := range t.channel {
+			for i := len(t.subscribers) - 1; i >= 0; i-- {
+				t.subscribers[i].receive(ctx, msg)
+			}
+		}
+	}()
+}

--- a/cli/azd/pkg/messaging/topic_test.go
+++ b/cli/azd/pkg/messaging/topic_test.go
@@ -1,0 +1,150 @@
+package messaging
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Topic_Send(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Success", func(t *testing.T) {
+		topic := NewTopic(ctx, "test")
+		err := topic.Send(ctx, NewMessage(SimpleMessage, "test"))
+		require.NoError(t, err)
+	})
+
+	t.Run("With_Nil_Message", func(t *testing.T) {
+		topic := NewTopic(ctx, "test")
+		err := topic.Send(ctx, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("After_Send", func(t *testing.T) {
+		topic := NewTopic(ctx, "test")
+		err := topic.Send(ctx, NewMessage(SimpleMessage, "test"))
+		require.NoError(t, err)
+
+		messages := []*Message{}
+		// Subscribe after message is sent
+		subscription, err := topic.Subscribe(ctx, nil, func(ctx context.Context, msg *Message) {
+			messages = append(messages, msg)
+		})
+		require.NoError(t, err)
+		require.NotNil(t, subscription)
+
+		// Subscription expected to be zero
+		// Topics do not replay old messages
+		require.Len(t, messages, 0)
+	})
+
+	t.Run("After_Close", func(t *testing.T) {
+		topic := NewTopic(ctx, "test")
+		topic.Close(ctx)
+
+		err := topic.Send(ctx, NewMessage(SimpleMessage, "test"))
+		require.Error(t, err)
+	})
+
+	t.Run("After_Unsubscribe", func(t *testing.T) {
+		messages := []*Message{}
+		topic := NewTopic(ctx, "test")
+
+		subscription, err := topic.Subscribe(ctx, nil, func(ctx context.Context, msg *Message) {
+			messages = append(messages, msg)
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, subscription)
+
+		topic.Unsubscribe(ctx, subscription)
+
+		err = topic.Send(ctx, NewMessage(SimpleMessage, "test"))
+		require.NoError(t, err)
+		require.Len(t, messages, 0)
+	})
+
+	t.Run("With_Closed_Context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+
+		topic := NewTopic(ctx, "test")
+		cancel()
+		err := topic.Flush(ctx)
+		require.NoError(t, err)
+
+		require.Panics(t, func() {
+			_ = topic.Send(ctx, NewMessage(SimpleMessage, "test"))
+		})
+	})
+}
+
+func Test_Topic_Subscribe(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Success", func(t *testing.T) {
+		topic := NewTopic(ctx, "test")
+		subscription, err := topic.Subscribe(ctx, nil, func(ctx context.Context, msg *Message) {})
+		require.NoError(t, err)
+		require.NotNil(t, subscription)
+	})
+
+	t.Run("With_Nil_Handler", func(t *testing.T) {
+		topic := NewTopic(ctx, "test")
+		_, err := topic.Subscribe(ctx, nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("With_Closed_Topic", func(t *testing.T) {
+		topic := NewTopic(ctx, "test")
+		topic.Close(ctx)
+
+		_, err := topic.Subscribe(ctx, nil, func(ctx context.Context, msg *Message) {})
+		require.Error(t, err)
+	})
+}
+
+func Test_Topic_Unsubscibe(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Success", func(t *testing.T) {
+		topic := NewTopic(ctx, "test")
+		subscription, err := topic.Subscribe(ctx, nil, func(ctx context.Context, msg *Message) {})
+		require.NoError(t, err)
+		require.NotNil(t, subscription)
+
+		topic.Unsubscribe(ctx, subscription)
+		require.NoError(t, err)
+	})
+
+	t.Run("With_Closed_Topic", func(t *testing.T) {
+		topic := NewTopic(ctx, "test")
+		subscription, err := topic.Subscribe(ctx, nil, func(ctx context.Context, msg *Message) {})
+		require.NoError(t, err)
+		require.NotNil(t, subscription)
+
+		err = topic.Close(ctx)
+		require.NoError(t, err)
+		topic.Unsubscribe(ctx, subscription)
+	})
+}
+
+func Test_Topic_Close(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Success", func(t *testing.T) {
+		topic := NewTopic(ctx, "test")
+		err := topic.Close(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("With_Closed_Topic", func(t *testing.T) {
+		topic := NewTopic(ctx, "test")
+		err := topic.Close(ctx)
+		require.NoError(t, err)
+
+		err = topic.Close(ctx)
+		require.Error(t, err)
+	})
+}

--- a/cli/azd/pkg/messaging/topic_test.go
+++ b/cli/azd/pkg/messaging/topic_test.go
@@ -65,19 +65,6 @@ func Test_Topic_Send(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, messages, 0)
 	})
-
-	t.Run("With_Closed_Context", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(ctx)
-
-		topic := NewTopic(ctx, "test")
-		cancel()
-		err := topic.Flush(ctx)
-		require.NoError(t, err)
-
-		require.Panics(t, func() {
-			_ = topic.Send(ctx, NewMessage(SimpleMessage, "test"))
-		})
-	})
 }
 
 func Test_Topic_Subscribe(t *testing.T) {

--- a/cli/azd/pkg/progress/printer.go
+++ b/cli/azd/pkg/progress/printer.go
@@ -1,0 +1,52 @@
+package progress
+
+import (
+	"context"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/messaging"
+)
+
+type Printer struct {
+	// Import subscriber to register handler for message stream
+	subscriber messaging.Subscriber
+	console    input.Console
+}
+
+func NewPrinter(subscriber messaging.Subscriber, console input.Console) *Printer {
+	return &Printer{
+		subscriber: subscriber,
+		console:    console,
+	}
+}
+
+func (p *Printer) Start(ctx context.Context) (*messaging.Subscription, error) {
+	// Create a filter to only receive progress messages
+	filter := func(ctx context.Context, message *messaging.Message) bool {
+		return message.Type == ProgressMessageKind
+	}
+
+	// Subscribe to the topic and handle messages
+	subscription, err := p.subscriber.Subscribe(ctx, filter, func(ctx context.Context, msg *messaging.Message) {
+		// Message payload can contain any value
+		// Cast to appropriate type
+		progressMessage, ok := msg.Value.(*ProgressMessage)
+		if !ok {
+			return
+		}
+
+		// Integrate with existing UX components for writing out to stdout / stderr
+		switch progressMessage.State {
+		case Running:
+			p.console.ShowSpinner(ctx, progressMessage.Message, input.Step)
+		case Success:
+			p.console.StopSpinner(ctx, progressMessage.Message, input.StepDone)
+		}
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return subscription, nil
+}

--- a/cli/azd/pkg/progress/progress.go
+++ b/cli/azd/pkg/progress/progress.go
@@ -1,0 +1,31 @@
+package progress
+
+import "github.com/azure/azure-dev/cli/azd/pkg/messaging"
+
+var ProgressMessageKind messaging.MessageKind = "progress"
+
+type StateKind string
+
+const (
+	Running StateKind = "running"
+	Success StateKind = "success"
+	Error   StateKind = "error"
+)
+
+// ProgressMessage is a sample message payload that contains the message to display and the state of the message
+// This ends up being the payload of the message sent to the topic
+type ProgressMessage struct {
+	Message string
+	State   StateKind
+}
+
+// NewProgressMessage is a helper function to create a new message payload
+// Any message payload can be sent to the topic as long as it is wrapping in the `messaging.Message` struct
+func NewProgressMessage(message string, state StateKind) *messaging.Message {
+	msg := &ProgressMessage{
+		Message: message,
+		State:   state,
+	}
+
+	return messaging.NewMessage(ProgressMessageKind, msg)
+}

--- a/cli/azd/pkg/sample/sampler.go
+++ b/cli/azd/pkg/sample/sampler.go
@@ -1,0 +1,43 @@
+package sample
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/messaging"
+	"github.com/azure/azure-dev/cli/azd/pkg/progress"
+)
+
+type Sampler struct {
+	// Import publisher to enable message sending
+	publisher messaging.Publisher
+}
+
+type SampleResult struct {
+	Value string
+}
+
+func NewSampler(publisher messaging.Publisher) *Sampler {
+	return &Sampler{
+		publisher: publisher,
+	}
+}
+
+func (s *Sampler) LongRunningOperation(ctx context.Context) (*SampleResult, error) {
+	// Send message payloads during long running operation
+	for i := 1; i <= 5; i++ {
+		err := s.publisher.Send(ctx, progress.NewProgressMessage(fmt.Sprintf("Sampling Project %d", i), progress.Running))
+		if err != nil {
+			return nil, err
+		}
+		time.Sleep(2 * time.Second)
+		err = s.publisher.Send(ctx, progress.NewProgressMessage(fmt.Sprintf("Sampling Project %d", i), progress.Success))
+		if err != nil {
+			return nil, err
+		}
+
+	}
+
+	return &SampleResult{}, nil
+}


### PR DESCRIPTION
This sample that demonstrates the pubsub system and how it might be used within an `azd` command:

- Adds `sample` command to azd
- Builds on pubsub system from #2341 

**During Command**
<img width="356" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/3d46b762-9d43-4f3d-a961-281af3d4824f">

**Completed Command**
<img width="379" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/0c013abd-4595-481a-abbb-5c0c594c66a1">


