### PR TITLE
Reshare clock implementation for bicep provider

### DIFF
--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -65,6 +65,7 @@ type BicepProvider struct {
 	prompters           prompt.Prompter
 	curPrincipal        CurrentPrincipalIdProvider
 	alphaFeatureManager *alpha.FeatureManager
+	clock               clock.Clock
 }
 
 var ErrResourceGroupScopeNotSupported = fmt.Errorf(
@@ -193,7 +194,7 @@ func (p *BicepProvider) Plan(ctx context.Context) (*DeploymentPlan, error) {
 			p.azCli,
 			p.env.GetLocation(),
 			p.env.GetSubscriptionId(),
-			deploymentNameForEnv(p.env.GetEnvName(), clock.New()),
+			deploymentNameForEnv(p.env.GetEnvName(), p.clock),
 		)
 	} else if deploymentScope == azure.DeploymentScopeResourceGroup {
 		if !p.alphaFeatureManager.IsEnabled(ResourceGroupDeploymentFeature) {
@@ -218,7 +219,7 @@ func (p *BicepProvider) Plan(ctx context.Context) (*DeploymentPlan, error) {
 			p.azCli,
 			p.env.GetSubscriptionId(),
 			p.env.Getenv(environment.ResourceGroupEnvVarName),
-			deploymentNameForEnv(p.env.GetEnvName(), clock.New()),
+			deploymentNameForEnv(p.env.GetEnvName(), p.clock),
 		)
 	} else {
 		return nil, fmt.Errorf("unsupported scope: %s", deploymentScope)
@@ -1382,6 +1383,7 @@ func NewBicepProvider(
 	prompters prompt.Prompter,
 	curPrincipal CurrentPrincipalIdProvider,
 	alphaFeatureManager *alpha.FeatureManager,
+	clock clock.Clock,
 ) Provider {
 	return &BicepProvider{
 		env:                 env,
@@ -1391,5 +1393,6 @@ func NewBicepProvider(
 		prompters:           prompters,
 		curPrincipal:        curPrincipal,
 		alphaFeatureManager: alphaFeatureManager,
+		clock:               clock,
 	}
 }

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -406,6 +406,7 @@ func createBicepProvider(t *testing.T, mockContext *mocks.MockContext) *BicepPro
 		prompt.NewDefaultPrompter(env, mockContext.Console, accountManager, azCli),
 		&mockCurrentPrincipal{},
 		mockContext.AlphaFeaturesManager,
+		clock.NewMock(),
 	)
 
 	err = provider.Initialize(*mockContext.Context, projectDir, options)

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockaccount"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazcli"
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -184,5 +185,9 @@ func registerContainerDependencies(mockContext *mocks.MockContext, env *environm
 	})
 	mockContext.Container.RegisterSingleton(func() azcli.AzCli {
 		return mockazcli.NewAzCliFromMockContext(mockContext)
+	})
+
+	mockContext.Container.RegisterSingleton(func() clock.Clock {
+		return clock.NewMock()
 	})
 }


### PR DESCRIPTION
Allow bicep_provider to take in a `clock.Clock` instance, which is already injected [here](https://github.com/Azure/azure-dev/blob/9a995a2584fbee25441f52941bc56c9f7523008e/cli/azd/cmd/container.go#L332). This is the shared instance throughout the application.