### PR TITLE
POC: Adds `azd hooks run <name>` command

### DIFF
--- a/cli/azd/cmd/hooks.go
+++ b/cli/azd/cmd/hooks.go
@@ -1,0 +1,275 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/azure/azure-dev/cli/azd/cmd/actions"
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/ext"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func hooksActions(root *actions.ActionDescriptor) *actions.ActionDescriptor {
+	group := root.Add("hooks", &actions.ActionDescriptorOptions{
+		Command: &cobra.Command{
+			Use:   "hooks",
+			Short: "Manage hooks.",
+		},
+		GroupingOptions: actions.CommandGroupOptions{
+			RootLevelHelp: actions.CmdGroupManage,
+		},
+	})
+
+	group.Add("run", &actions.ActionDescriptorOptions{
+		Command:        newHooksRunCmd(),
+		FlagsResolver:  newHooksRunFlags,
+		ActionResolver: newHooksRunAction,
+	})
+
+	return group
+}
+
+func newHooksRunFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *hooksRunFlags {
+	flags := &hooksRunFlags{}
+	flags.Bind(cmd.Flags(), global)
+
+	return flags
+}
+
+func newHooksRunCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "run <name>",
+		Short: "Runs the specified hook for the project and services",
+		Args:  cobra.ExactArgs(1),
+	}
+}
+
+type hooksRunFlags struct {
+	envFlag
+	global      *internal.GlobalCommandOptions
+	platform    string
+	interactive bool
+	service     string
+}
+
+func (f *hooksRunFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
+	f.envFlag.Bind(local, global)
+	f.global = global
+
+	local.StringVar(&f.platform, "platform", "", "Forces hooks to run for the specified platform.")
+	local.BoolVar(&f.interactive, "interactive", false, "Forces all hooks to run in interactive mode for testing")
+	local.StringVar(&f.service, "service", "", "Only runs hooks for the specified service.")
+}
+
+type hooksRunAction struct {
+	projectConfig *project.ProjectConfig
+	env           *environment.Environment
+	commandRunner exec.CommandRunner
+	console       input.Console
+	flags         *hooksRunFlags
+	args          []string
+}
+
+func newHooksRunAction(
+	projectConfig *project.ProjectConfig,
+	env *environment.Environment,
+	commandRunner exec.CommandRunner,
+	console input.Console,
+	flags *hooksRunFlags,
+	args []string,
+) actions.Action {
+	return &hooksRunAction{
+		projectConfig: projectConfig,
+		env:           env,
+		commandRunner: commandRunner,
+		console:       console,
+		flags:         flags,
+		args:          args,
+	}
+}
+
+const noHookFoundMessage = " (No hook found)"
+
+func (hra *hooksRunAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	hookName := hra.args[0]
+
+	// Command title
+	hra.console.MessageUxItem(ctx, &ux.MessageTitle{
+		Title: "Running hooks (azd hooks run)",
+		TitleNote: fmt.Sprintf(
+			"Finding and executing %s hooks for environment %s",
+			output.WithHighLightFormat(hookName),
+			output.WithHighLightFormat(hra.env.GetEnvName()),
+		),
+	})
+
+	// Validate hook type
+	if _, _, err := ext.InferHookType(hookName); err != nil {
+		return nil, fmt.Errorf("hook name is invalid. Hook names should start with 'pre' or 'post', %w", err)
+	}
+
+	// Validate service name
+	if _, ok := hra.projectConfig.Services[hra.flags.service]; hra.flags.service != "" && !ok {
+		return nil, fmt.Errorf("service name '%s' doesn't exist", hra.flags.service)
+	}
+
+	// Project level hooks
+	projectHooksMessage := "Running command hook for project"
+	if err := hra.processHooks(
+		ctx,
+		hra.projectConfig.Path,
+		hookName,
+		projectHooksMessage,
+		hra.projectConfig.Hooks,
+		false,
+	); err != nil {
+		return nil, err
+	}
+
+	// Service level hooks
+	for serviceName, service := range hra.projectConfig.Services {
+		skip := hra.flags.service != "" && serviceName != hra.flags.service
+
+		serviceHookMessage := fmt.Sprintf("Running service hook for %s", serviceName)
+		if err := hra.processHooks(
+			ctx,
+			service.RelativePath,
+			hookName,
+			serviceHookMessage,
+			service.Hooks,
+			skip,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	return &actions.ActionResult{
+		Message: &actions.ResultMessage{
+			Header: "Your hooks have been run successfully",
+		},
+	}, nil
+}
+
+func (hra *hooksRunAction) processHooks(
+	ctx context.Context,
+	cwd string,
+	hookName string,
+	message string,
+	hooks map[string]*ext.HookConfig,
+	skip bool,
+) error {
+	hra.console.ShowSpinner(ctx, message, input.Step)
+
+	if skip {
+		hra.console.StopSpinner(ctx, message, input.StepSkipped)
+		return nil
+	}
+
+	hook, ok := hooks[hookName]
+	if !ok {
+		hra.console.StopSpinner(ctx, message+noHookFoundMessage, input.StepWarning)
+		return nil
+	}
+
+	hookType, commandName, err := ext.InferHookType(hookName)
+	if err != nil {
+		return err
+	}
+
+	if err := hra.prepareHook(hookName, hook); err != nil {
+		return err
+	}
+
+	if hook.Interactive {
+		hra.console.StopSpinner(ctx, "", input.StepDone)
+		hra.console.Message(ctx, output.WithBold(output.WithUnderline(message)))
+	}
+
+	err = hra.execHook(ctx, cwd, hookType, commandName, hook)
+	if err != nil {
+		hra.console.StopSpinner(ctx, message, input.StepFailed)
+		return fmt.Errorf("failed running hook %s, %w", hookName, err)
+	}
+
+	hra.console.StopSpinner(ctx, message, input.StepDone)
+	return nil
+}
+
+func (hra *hooksRunAction) execHook(
+	ctx context.Context,
+	cwd string,
+	hookType ext.HookType,
+	commandName string,
+	hook *ext.HookConfig,
+) error {
+	hookName := string(hookType) + commandName
+
+	hooks := map[string]*ext.HookConfig{
+		hookName: hook,
+	}
+
+	hooksManager := ext.NewHooksManager(cwd)
+	hooksRunner := ext.NewHooksRunner(hooksManager, hra.commandRunner, hra.console, cwd, hooks, hra.env)
+	err := hooksRunner.RunHooks(ctx, hookType, commandName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Overrides the configured hooks from command line flags
+func (hra *hooksRunAction) prepareHook(name string, hook *ext.HookConfig) error {
+	// Enable testing cross platform
+	if hra.flags.platform != "" {
+		platformType := ext.HookPlatformType(hra.flags.platform)
+		switch platformType {
+		case ext.HookPlatformWindows:
+			if hook.Windows == nil {
+				return fmt.Errorf("hook is not configured for Windows")
+			} else {
+				*hook = *hook.Windows
+			}
+		case ext.HookPlatformPosix:
+			if hook.Posix == nil {
+				return fmt.Errorf("hook is not configured for Posix")
+			} else {
+				*hook = *hook.Posix
+			}
+		default:
+			return fmt.Errorf("platform %s is not valid. Supported values are windows & posix", hra.flags.platform)
+		}
+	}
+
+	hook.Name = name
+
+	// Don't display the 'Executing hook...' messages
+	hook.Quiet = true
+	if hra.flags.interactive {
+		hook.Interactive = true
+	}
+
+	hra.configureHookFlags(hook.Windows)
+	hra.configureHookFlags(hook.Posix)
+
+	return nil
+}
+
+func (hra *hooksRunAction) configureHookFlags(hook *ext.HookConfig) {
+	if hook == nil {
+		return
+	}
+
+	hook.Quiet = true
+	if hra.flags.interactive {
+		hook.Interactive = true
+	}
+}

--- a/cli/azd/cmd/hooks.go
+++ b/cli/azd/cmd/hooks.go
@@ -21,10 +21,10 @@ func hooksActions(root *actions.ActionDescriptor) *actions.ActionDescriptor {
 	group := root.Add("hooks", &actions.ActionDescriptorOptions{
 		Command: &cobra.Command{
 			Use:   "hooks",
-			Short: "Manage hooks.",
+			Short: fmt.Sprintf("Develop, test and run hooks for an application. %s", output.WithWarningFormat("(Beta)")),
 		},
 		GroupingOptions: actions.CommandGroupOptions{
-			RootLevelHelp: actions.CmdGroupManage,
+			RootLevelHelp: actions.CmdGroupConfig,
 		},
 	})
 

--- a/cli/azd/cmd/hooks.go
+++ b/cli/azd/cmd/hooks.go
@@ -111,11 +111,6 @@ func (hra *hooksRunAction) Run(ctx context.Context) (*actions.ActionResult, erro
 		),
 	})
 
-	// Validate hook type
-	if _, _, err := ext.InferHookType(hookName); err != nil {
-		return nil, fmt.Errorf("hook name is invalid. Hook names should start with 'pre' or 'post', %w", err)
-	}
-
 	// Validate service name
 	if _, ok := hra.projectConfig.Services[hra.flags.service]; hra.flags.service != "" && !ok {
 		return nil, fmt.Errorf("service name '%s' doesn't exist", hra.flags.service)
@@ -179,10 +174,7 @@ func (hra *hooksRunAction) processHooks(
 		return nil
 	}
 
-	hookType, commandName, err := ext.InferHookType(hookName)
-	if err != nil {
-		return err
-	}
+	hookType, commandName := ext.InferHookType(hookName)
 
 	if err := hra.prepareHook(hookName, hook); err != nil {
 		return err
@@ -193,7 +185,7 @@ func (hra *hooksRunAction) processHooks(
 		hra.console.Message(ctx, output.WithBold(output.WithUnderline(message)))
 	}
 
-	err = hra.execHook(ctx, cwd, hookType, commandName, hook)
+	err := hra.execHook(ctx, cwd, hookType, commandName, hook)
 	if err != nil {
 		hra.console.StopSpinner(ctx, message, input.StepFailed)
 		return fmt.Errorf("failed running hook %s, %w", hookName, err)

--- a/cli/azd/cmd/middleware/hooks.go
+++ b/cli/azd/cmd/middleware/hooks.go
@@ -145,8 +145,8 @@ func (m *HooksMiddleware) registerServiceHooks(
 			env,
 		)
 
-		for hookName, hookConfig := range service.Hooks {
-			hookType, eventName, err := inferHookType(hookName, hookConfig)
+		for hookName := range service.Hooks {
+			hookType, eventName, err := ext.InferHookType(hookName)
 			if err != nil {
 				return fmt.Errorf(
 					//nolint:lll
@@ -186,19 +186,6 @@ func (m *HooksMiddleware) createServiceEventHandler(
 	return func(ctx context.Context, eventArgs project.ServiceLifecycleEventArgs) error {
 		return hooksRunner.RunHooks(ctx, hookType, hookName)
 	}
-}
-
-func inferHookType(name string, config *ext.HookConfig) (ext.HookType, string, error) {
-	// Validate name length so go doesn't PANIC for string slicing below
-	if len(name) < 4 {
-		return "", "", fmt.Errorf("unable to infer hook '%s'", name)
-	} else if name[:3] == "pre" {
-		return ext.HookTypePre, name[3:], nil
-	} else if name[:4] == "post" {
-		return ext.HookTypePost, name[4:], nil
-	}
-
-	return "", "", fmt.Errorf("unable to infer hook '%s'", name)
 }
 
 // Gets a value that returns whether or not service hooks have already been registered

--- a/cli/azd/cmd/middleware/hooks.go
+++ b/cli/azd/cmd/middleware/hooks.go
@@ -146,14 +146,10 @@ func (m *HooksMiddleware) registerServiceHooks(
 		)
 
 		for hookName := range service.Hooks {
-			hookType, eventName, err := ext.InferHookType(hookName)
-			if err != nil {
-				return fmt.Errorf(
-					//nolint:lll
-					"%w for service '%s'. Hooks must start with 'pre' or 'post' and end in a valid service event name. Examples: restore, package, deploy",
-					err,
-					serviceName,
-				)
+			hookType, eventName := ext.InferHookType(hookName)
+			// If not a pre or post hook we can continue on.
+			if hookType == ext.HookTypeNone {
+				continue
 			}
 
 			if err := service.AddHandler(

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -107,6 +107,7 @@ func NewRootCmd(staticHelp bool, middlewareChain []*actions.MiddlewareRegistrati
 	telemetryActions(root)
 	templatesActions(root)
 	authActions(root)
+	hooksActions(root)
 
 	root.Add("version", &actions.ActionDescriptorOptions{
 		Command: &cobra.Command{

--- a/cli/azd/cmd/testdata/TestUsage-azd-hooks-run.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-hooks-run.snap
@@ -1,0 +1,21 @@
+
+Runs the specified hook for the project and services
+
+Usage
+  azd hooks run <name> [flags]
+
+Flags
+    -e, --environment string 	: The name of the environment to use.
+    -h, --help               	: Gets help for run.
+        --interactive        	: Forces all hooks to run in interactive mode for testing
+        --platform string    	: Forces hooks to run for the specified platform.
+        --service string     	: Only runs hooks for the specified service.
+
+Global Flags
+    -C, --cwd string 	: Sets the current working directory.
+        --debug      	: Enables debugging and diagnostics logging.
+        --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
+
+Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.
+
+

--- a/cli/azd/cmd/testdata/TestUsage-azd-hooks.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-hooks.snap
@@ -1,0 +1,22 @@
+
+Develop, test and run hooks for an application. (Beta)
+
+Usage
+  azd hooks [command]
+
+Available Commands
+  run	: Runs the specified hook for the project and services
+
+Flags
+    -h, --help 	: Gets help for hooks.
+
+Global Flags
+    -C, --cwd string 	: Sets the current working directory.
+        --debug      	: Enables debugging and diagnostics logging.
+        --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
+
+Use azd hooks [command] --help to view examples and more information about a specific command.
+
+Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.
+
+

--- a/cli/azd/cmd/testdata/TestUsage-azd.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd.snap
@@ -16,6 +16,7 @@ Commands
     deploy   	: Deploy the application's code to Azure.
     down     	: Delete Azure resources for an application.
     env      	: Manage environments.
+    hooks    	: Manage hooks.
     package  	: Packages the application's code to be deployed to Azure. (Beta)
     provision	: Provision the Azure resources for an application.
     up       	: Provision Azure resources, and deploy your project with a single command.

--- a/cli/azd/cmd/testdata/TestUsage-azd.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd.snap
@@ -8,6 +8,7 @@ Commands
   Configure and develop your app
     auth     	: Authenticate with Azure.
     config   	: Manage azd configurations (ex: default Azure subscription, location).
+    hooks    	: Develop, test and run hooks for an application. (Beta)
     init     	: Initialize a new application.
     restore  	: Restores the application's dependencies. (Beta)
     template 	: Find and view template details. (Beta)
@@ -16,7 +17,6 @@ Commands
     deploy   	: Deploy the application's code to Azure.
     down     	: Delete Azure resources for an application.
     env      	: Manage environments.
-    hooks    	: Manage hooks.
     package  	: Packages the application's code to be deployed to Azure. (Beta)
     provision	: Provision the Azure resources for an application.
     up       	: Provision Azure resources, and deploy your project with a single command.

--- a/cli/azd/pkg/ext/hooks_runner.go
+++ b/cli/azd/pkg/ext/hooks_runner.go
@@ -128,11 +128,11 @@ func (h *HooksRunner) execHook(ctx context.Context, hookConfig *HookConfig) erro
 	}
 
 	formatter := h.console.GetFormatter()
-	consoleInteractive := formatter == nil || formatter.Kind() == output.NoneFormat
+	consoleInteractive := (formatter == nil || formatter.Kind() == output.NoneFormat)
 	scriptInteractive := consoleInteractive && hookConfig.Interactive
 
 	// When running in an interactive terminal broadcast a message to the dev to remind them that custom hooks are running.
-	if consoleInteractive {
+	if consoleInteractive && !hookConfig.Quiet {
 		h.console.Message(
 			ctx,
 			output.WithBold(

--- a/cli/azd/pkg/ext/hooks_runner_test.go
+++ b/cli/azd/pkg/ext/hooks_runner_test.go
@@ -296,7 +296,11 @@ func Test_Hooks_GetScript(t *testing.T) {
 		require.Equal(t, "*powershell.powershellScript", reflect.TypeOf(script).String())
 		require.Equal(t, ScriptLocationInline, hookConfig.location)
 		require.Equal(t, ShellTypePowershell, hookConfig.Shell)
-		require.Contains(t, hookConfig.script, "Invoke-WebRequest -Uri \"https://sample.com/sample.json\" -OutFile \"out.json\"")
+		require.Contains(
+			t,
+			hookConfig.script,
+			"Invoke-WebRequest -Uri \"https://sample.com/sample.json\" -OutFile \"out.json\"",
+		)
 		require.Contains(t, hookConfig.path, os.TempDir())
 		require.Contains(t, hookConfig.path, ".ps1")
 		require.NoError(t, err)

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -27,6 +27,7 @@ const (
 	HookTypePre HookType = "pre"
 	// Execute post hooks
 	HookTypePost        HookType         = "post"
+	HookTypeNone        HookType         = ""
 	HookPlatformWindows HookPlatformType = "windows"
 	HookPlatformPosix   HookPlatformType = "posix"
 )
@@ -134,17 +135,17 @@ func (hc *HookConfig) validate() error {
 	return nil
 }
 
-func InferHookType(name string) (HookType, string, error) {
+func InferHookType(name string) (HookType, string) {
 	// Validate name length so go doesn't PANIC for string slicing below
 	if len(name) < 4 {
-		return "", "", fmt.Errorf("unable to infer hook '%s'", name)
+		return HookTypeNone, name
 	} else if name[:3] == "pre" {
-		return HookTypePre, name[3:], nil
+		return HookTypePre, name[3:]
 	} else if name[:4] == "post" {
-		return HookTypePost, name[4:], nil
+		return HookTypePost, name[4:]
 	}
 
-	return "", "", fmt.Errorf("unable to infer hook '%s'", name)
+	return HookTypeNone, name
 }
 
 func inferScriptTypeFromFilePath(path string) (ShellType, error) {


### PR DESCRIPTION
POC that Adds `azd hooks run <name>` command to help develop, test and run hooks for an azd project & services.

Resolves #1642 

## Features
- An easy way for developers to test and troubleshoot their azd hook scripts without the overhead of waiting for azd commands to run
- Developers can develop a suite of hooks/scripts to support their day to day inner-loop development
- Call into other hook scripts from azd hook lifecycle events

### Example
Dev wants to validate their deployment to run a series of UX smoke test across their services
- Dev creates a `vaildate` hook in each service that they want to test. These tests could run playwright or some other UX test framework
- Dev adds a `postdeploy` hook that calls `azd hooks run validate`
  - This ensures that the `validate` hook would run for each service after deployment completes
- Dev also has a custom hook/script in their toolbox where they could run `azd hooks run validate` at any time.


## Docs and Parameters
<img width="662" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/2071cbc9-7671-4580-844f-c01281914da8">

## Output
<img width="433" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/d57474c9-3c15-42c9-b69b-9633b958ba72">

