### PR TITLE
Validate container app revision during `azd deploy` command

### DIFF
--- a/cli/azd/pkg/containerapps/container_app_test.go
+++ b/cli/azd/pkg/containerapps/container_app_test.go
@@ -114,7 +114,7 @@ func Test_ContainerApp_Get(t *testing.T) {
 	)
 
 	cas := NewContainerAppService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, clock.NewMock())
-	containerApp, err := cas.Get(*mockContext.Context, subscriptionId, resourceGroup, appName)
+	containerApp, err := cas.App(*mockContext.Context, subscriptionId, resourceGroup, appName)
 	require.NotNil(t, expected)
 	require.NoError(t, err)
 	require.Equal(t, expected, containerApp)

--- a/cli/azd/pkg/containerapps/container_app_test.go
+++ b/cli/azd/pkg/containerapps/container_app_test.go
@@ -105,7 +105,13 @@ func Test_ContainerApp_Get(t *testing.T) {
 	}
 
 	mockContext := mocks.NewMockContext(context.Background())
-	mockGetContainerAppRequest := mockazsdk.MockContainerAppGet(mockContext, subscriptionId, resourceGroup, appName, expected)
+	mockGetContainerAppRequest := mockazsdk.MockContainerAppGet(
+		mockContext,
+		subscriptionId,
+		resourceGroup,
+		appName,
+		expected,
+	)
 
 	cas := NewContainerAppService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, clock.NewMock())
 	containerApp, err := cas.Get(*mockContext.Context, subscriptionId, resourceGroup, appName)

--- a/cli/azd/pkg/containerapps/container_app_test.go
+++ b/cli/azd/pkg/containerapps/container_app_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v2"
@@ -51,6 +53,138 @@ func Test_ContainerApp_GetIngressConfiguration(t *testing.T) {
 
 	require.Equal(t, expectedPath, mockRequest.URL.Path)
 	require.Equal(t, hostName, ingressConfig.HostNames[0])
+}
+
+func Test_ContainerApp_ValidateRevision(t *testing.T) {
+	subscriptionId := "SUBSCRIPTION_ID"
+	resourceGroup := "RESOURCE_GROUP"
+	appName := "APP_NAME"
+	revisionName := "NEW_REVISION"
+	expectedRevision := &armappcontainers.Revision{
+		Name: &revisionName,
+		Properties: &armappcontainers.RevisionProperties{
+			ProvisioningState: convert.RefOf(armappcontainers.RevisionProvisioningStateProvisioned),
+			HealthState:       convert.RefOf(armappcontainers.RevisionHealthStateHealthy),
+		},
+	}
+
+	mockContext := mocks.NewMockContext(context.Background())
+	mockGetRevisionRequest := mockazsdk.MockContainerAppRevisionGet(
+		mockContext,
+		subscriptionId,
+		resourceGroup,
+		appName,
+		revisionName,
+		expectedRevision,
+	)
+
+	cas := NewContainerAppService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, clock.NewMock())
+	revision, err := cas.ValidateRevision(*mockContext.Context, subscriptionId, resourceGroup, appName, revisionName)
+	require.NotNil(t, revision)
+	require.NoError(t, err)
+	require.Equal(t, expectedRevision, revision)
+
+	expectedGetRevisionPath := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/containerApps/%s/revisions/%s",
+		subscriptionId,
+		resourceGroup,
+		appName,
+		revisionName,
+	)
+
+	require.Equal(t, expectedGetRevisionPath, mockGetRevisionRequest.URL.Path)
+}
+
+func Test_ContainerApp_Get(t *testing.T) {
+	subscriptionId := "SUBSCRIPTION_ID"
+	resourceGroup := "RESOURCE_GROUP"
+	appName := "APP_NAME"
+
+	expected := &armappcontainers.ContainerApp{
+		Name: &appName,
+	}
+
+	mockContext := mocks.NewMockContext(context.Background())
+	mockGetContainerAppRequest := mockazsdk.MockContainerAppGet(mockContext, subscriptionId, resourceGroup, appName, expected)
+
+	cas := NewContainerAppService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, clock.NewMock())
+	containerApp, err := cas.Get(*mockContext.Context, subscriptionId, resourceGroup, appName)
+	require.NotNil(t, expected)
+	require.NoError(t, err)
+	require.Equal(t, expected, containerApp)
+
+	expectedGetContainerAppPath := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/containerApps/%s",
+		subscriptionId,
+		resourceGroup,
+		appName,
+	)
+
+	require.Equal(t, expectedGetContainerAppPath, mockGetContainerAppRequest.URL.Path)
+}
+
+func Test_ContainerApp_ShiftTraffic(t *testing.T) {
+	subscriptionId := "SUBSCRIPTION_ID"
+	resourceGroup := "RESOURCE_GROUP"
+	appName := "APP_NAME"
+	revisionName := "NEW_REVISION"
+
+	containerApp := &armappcontainers.ContainerApp{
+		Name: &appName,
+		Properties: &armappcontainers.ContainerAppProperties{
+			Configuration: &armappcontainers.Configuration{
+				Ingress: &armappcontainers.Ingress{},
+			},
+		},
+	}
+
+	mockContext := mocks.NewMockContext(context.Background())
+	_ = mockazsdk.MockContainerAppGet(
+		mockContext,
+		subscriptionId,
+		resourceGroup,
+		appName,
+		containerApp,
+	)
+
+	mockContainerAppUpdateRequest := mockazsdk.MockContainerAppUpdate(
+		mockContext,
+		subscriptionId,
+		resourceGroup,
+		appName,
+		containerApp,
+	)
+
+	cas := NewContainerAppService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, clock.NewMock())
+	err := cas.ShiftTrafficToRevision(
+		*mockContext.Context,
+		subscriptionId,
+		resourceGroup,
+		appName,
+		revisionName,
+	)
+	require.NoError(t, err)
+
+	expectedUpdatePath := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/containerApps/%s",
+		subscriptionId,
+		resourceGroup,
+		appName,
+	)
+
+	requestContainerApp, err := readRawBody[armappcontainers.ContainerApp](mockContainerAppUpdateRequest.Body)
+	require.NoError(t, err)
+
+	expectedTrafficWeights := []*armappcontainers.TrafficWeight{
+		{
+			RevisionName: &revisionName,
+			Weight:       convert.RefOf[int32](100),
+		},
+	}
+
+	require.Equal(t, expectedTrafficWeights, requestContainerApp.Properties.Configuration.Ingress.Traffic)
+	require.Equal(t, expectedUpdatePath, mockContainerAppUpdateRequest.URL.Path)
+	require.Equal(t, http.MethodPatch, mockContainerAppUpdateRequest.Method)
 }
 
 func Test_ContainerApp_AddRevision(t *testing.T) {
@@ -128,7 +262,8 @@ func Test_ContainerApp_AddRevision(t *testing.T) {
 	)
 
 	cas := NewContainerAppService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, clock.NewMock())
-	err := cas.AddRevision(*mockContext.Context, subscriptionId, resourceGroup, appName, updatedImageName)
+	revision, err := cas.AddRevision(*mockContext.Context, subscriptionId, resourceGroup, appName, updatedImageName)
+	require.NotNil(t, revision)
 	require.NoError(t, err)
 
 	// Verify lastest revision is read
@@ -149,4 +284,20 @@ func Test_ContainerApp_AddRevision(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, updatedImageName, *updatedContainerApp.Properties.Template.Containers[0].Image)
 	require.Equal(t, "azd-0", *updatedContainerApp.Properties.Template.RevisionSuffix)
+}
+
+func readRawBody[T any](body io.ReadCloser) (*T, error) {
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return nil, err
+	}
+
+	instance := new(T)
+
+	err = json.Unmarshal(data, instance)
+	if err != nil {
+		return nil, fmt.Errorf("failed unmarshalling JSON from response: %w", err)
+	}
+
+	return instance, nil
 }

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v2"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/containerapps"
@@ -120,7 +120,7 @@ func (at *containerAppTarget) Deploy(
 				return
 			}
 
-			containerApp, err := at.containerAppService.Get(
+			containerApp, err := at.containerAppService.App(
 				ctx,
 				targetResource.SubscriptionId(),
 				targetResource.ResourceGroupName(),

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -131,8 +131,13 @@ func (at *containerAppTarget) Deploy(
 				return
 			}
 
-			// If the container app is in multiple revision mode, update the traffic to point to the new revision
-			if *containerApp.Properties.Configuration.ActiveRevisionsMode == armappcontainers.ActiveRevisionsModeMultiple {
+			ingressEnabled := containerApp.Properties.Configuration.Ingress != nil
+			//nolint:lll
+			supportsMultipleRevisions := *containerApp.Properties.Configuration.ActiveRevisionsMode == armappcontainers.ActiveRevisionsModeMultiple
+
+			// If the container app has ingress enabled and supports multiple revisions
+			// then update the traffic to point to the new revision
+			if ingressEnabled && supportsMultipleRevisions {
 				task.SetProgress(NewServiceProgress("Shifting traffic to new revision"))
 				err = at.containerAppService.ShiftTrafficToRevision(ctx,
 					targetResource.SubscriptionId(),

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -156,7 +156,7 @@ func setupMocksForContainerApps(mockContext *mocks.MockContext) {
 	appName := "CONTAINER_APP"
 	originalImageName := "ORIGINAL_IMAGE_NAME"
 	originalRevisionName := "ORIGINAL_REVISION_NAME"
-	updatedRevisionName := "UPDATED_REVISION_NAME"
+	updatedRevisionName := "CONTAINER_APP--azd-0"
 	hostName := fmt.Sprintf("%s.%s.azurecontainerapps.io", appName, location)
 
 	containerApp := &armappcontainers.ContainerApp{
@@ -187,7 +187,10 @@ func setupMocksForContainerApps(mockContext *mocks.MockContext) {
 	}
 
 	revision := &armappcontainers.Revision{
+		Name: convert.RefOf(updatedRevisionName),
 		Properties: &armappcontainers.RevisionProperties{
+			ProvisioningState: convert.RefOf(armappcontainers.RevisionProvisioningStateProvisioned),
+			HealthState:       convert.RefOf(armappcontainers.RevisionHealthStateNone),
 			Template: &armappcontainers.Template{
 				Containers: []*armappcontainers.Container{
 					{
@@ -209,6 +212,14 @@ func setupMocksForContainerApps(mockContext *mocks.MockContext) {
 		resourceGroup,
 		appName,
 		originalRevisionName,
+		revision,
+	)
+	mockazsdk.MockContainerAppRevisionGet(
+		mockContext,
+		subscriptionId,
+		resourceGroup,
+		appName,
+		updatedRevisionName,
 		revision,
 	)
 	mockazsdk.MockContainerAppSecretsList(mockContext, subscriptionId, resourceGroup, appName, secrets)

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -190,7 +190,7 @@ func setupMocksForContainerApps(mockContext *mocks.MockContext) {
 		Name: convert.RefOf(updatedRevisionName),
 		Properties: &armappcontainers.RevisionProperties{
 			ProvisioningState: convert.RefOf(armappcontainers.RevisionProvisioningStateProvisioned),
-			HealthState:       convert.RefOf(armappcontainers.RevisionHealthStateNone),
+			HealthState:       convert.RefOf(armappcontainers.RevisionHealthStateHealthy),
 			Template: &armappcontainers.Template{
 				Containers: []*armappcontainers.Container{
 					{


### PR DESCRIPTION
Validates that the container app revision is in a valid state during deployment.

Fixes #2398