### PR TITLE
Fix asa url fetched from consumption plan incorrect

### DIFF
--- a/cli/azd/pkg/project/service_target_springapp.go
+++ b/cli/azd/pkg/project/service_target_springapp.go
@@ -199,10 +199,7 @@ func (st *springAppTarget) Endpoints(
 		return nil, fmt.Errorf("fetching service properties: %w", err)
 	}
 
-	endpoints := make([]string, len(springAppProperties.Url))
-	copy(endpoints, springAppProperties.Url)
-
-	return endpoints, nil
+	return springAppProperties.Url, nil
 }
 
 func (st *springAppTarget) validateTargetResource(

--- a/cli/azd/pkg/project/service_target_springapp.go
+++ b/cli/azd/pkg/project/service_target_springapp.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/azure/azure-dev/cli/azd/pkg/azure"
-
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
+	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"

--- a/cli/azd/pkg/project/service_target_springapp.go
+++ b/cli/azd/pkg/project/service_target_springapp.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"os"
 	"path/filepath"
-	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
@@ -200,10 +200,8 @@ func (st *springAppTarget) Endpoints(
 		return nil, fmt.Errorf("fetching service properties: %w", err)
 	}
 
-	endpoints := make([]string, len(springAppProperties.Fqdn))
-	for idx, fqdn := range springAppProperties.Fqdn {
-		endpoints[idx] = fmt.Sprintf("https://%s/", st.extractEndpoint(fqdn, serviceConfig.Name))
-	}
+	endpoints := make([]string, len(springAppProperties.Url))
+	copy(endpoints, springAppProperties.Url)
 
 	return endpoints, nil
 }
@@ -224,9 +222,4 @@ func (st *springAppTarget) validateTargetResource(
 	}
 
 	return nil
-}
-
-func (st *springAppTarget) extractEndpoint(fqdn string, appName string) string {
-	index := strings.IndexRune(fqdn, '.')
-	return fqdn[0:index] + "-" + appName + fqdn[index:]
 }

--- a/cli/azd/pkg/project/service_target_springapp_test.go
+++ b/cli/azd/pkg/project/service_target_springapp_test.go
@@ -5,7 +5,6 @@ package project
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 
@@ -57,14 +56,4 @@ func TestNewSpringAppTargetTypeValidation(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestExtractEndpoint(t *testing.T) {
-	serviceTarget := &springAppTarget{}
-
-	assert.Equal(t, "https://mock-appname.azuremicroservices.io",
-		serviceTarget.extractEndpoint("https://mock.azuremicroservices.io", "appname"))
-
-	assert.NotEqual(t, "https://mock.azuremicroservices.io",
-		serviceTarget.extractEndpoint("https://mock.azuremicroservices.io", "appname"))
 }

--- a/cli/azd/pkg/tools/azcli/spring_app.go
+++ b/cli/azd/pkg/tools/azcli/spring_app.go
@@ -74,7 +74,7 @@ func NewSpringService(
 }
 
 type SpringAppProperties struct {
-	Fqdn []string
+	Url []string
 }
 
 func (ss *springService) GetSpringAppProperties(
@@ -91,17 +91,17 @@ func (ss *springService) GetSpringAppProperties(
 		return nil, fmt.Errorf("failed retrieving spring app properties: %w", err)
 	}
 
-	var fqdn []string
+	var url []string
 	if springApp.Properties != nil &&
-		springApp.Properties.Fqdn != nil &&
+		springApp.Properties.URL != nil &&
 		*springApp.Properties.Public {
-		fqdn = []string{*springApp.Properties.Fqdn}
+		url = []string{*springApp.Properties.URL}
 	} else {
-		fqdn = []string{}
+		url = []string{}
 	}
 
 	return &SpringAppProperties{
-		Fqdn: fqdn,
+		Url: url,
 	}, nil
 }
 


### PR DESCRIPTION
As subject, this pr is to fix the application url fetched from ASA consumption plan is wrong:
![MicrosoftTeams-image (2)](https://github.com/Azure/azure-dev/assets/63028776/d2dd988f-c917-4cd7-9bc3-a350b51efac8)

This is caused by when getting the public endpoint of spring apps, azd used ASA app fqdn to constuct the app url, which is not applicable to consumption tier. Instead, we should use the url property of spring apps, which could fetch the application url for all of the basic/standard/consumption plan tiers.