### PR TITLE
Add parameters for AllowPrerelease and CliVersion with defaults

### DIFF
--- a/eng/pipelines/templates/steps/publish-cli.yml
+++ b/eng/pipelines/templates/steps/publish-cli.yml
@@ -18,6 +18,8 @@ parameters:
   SyndicatedAcrPassword: $(azdev-acr-syndicated-password)
   PublishBrewFormula: false
   PublishArm64Binaries: false
+  AllowPrerelease: false
+  CliVersion: $(CLI_VERSION)
 
 steps:
   - ${{ if eq('true', parameters.CreateGitHubRelease) }}:


### PR DESCRIPTION
There was a [failure in the release](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2846258&view=results) because a couple of parameterized variables were not provided properly. This sets up safe defaults for those. 

In the long term we should refactor the releases to use separate jobs and run in parallel when appropriate to minimize problems from intermittent failures and occasional syntax problems that are hard to test for. https://github.com/Azure/azure-dev/issues/2418