### PR TITLE
Skip update check in test that ensures `--help` is well formed

### DIFF
--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -311,8 +311,10 @@ func Test_CLI_ProvisionIsNeeded(t *testing.T) {
 	}
 }
 
+// Test_CLI_NoDebugSpewWhenHelpPassedWithoutDebug ensures that no debug spew is written to stderr when --help is passed
 func Test_CLI_NoDebugSpewWhenHelpPassedWithoutDebug(t *testing.T) {
 	cli := azdcli.NewCLI(t)
+	// Update checks are one of the things that can write to stderr. Disable it since it's not relevant to this test.
 	cli.Env = append(cli.Env, "AZD_SKIP_UPDATE_CHECK=true")
 	ctx := context.Background()
 	result, err := cli.RunCommand(ctx, "--help")

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -315,6 +315,7 @@ func Test_CLI_ProvisionIsNeeded(t *testing.T) {
 func Test_CLI_NoDebugSpewWhenHelpPassedWithoutDebug(t *testing.T) {
 	cli := azdcli.NewCLI(t)
 	// Update checks are one of the things that can write to stderr. Disable it since it's not relevant to this test.
+	cli.Env = append(cli.Env, os.Environ()...)
 	cli.Env = append(cli.Env, "AZD_SKIP_UPDATE_CHECK=true")
 	ctx := context.Background()
 	result, err := cli.RunCommand(ctx, "--help")

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -313,6 +313,7 @@ func Test_CLI_ProvisionIsNeeded(t *testing.T) {
 
 func Test_CLI_NoDebugSpewWhenHelpPassedWithoutDebug(t *testing.T) {
 	cli := azdcli.NewCLI(t)
+	cli.Env = append(cli.Env, "AZD_SKIP_UPDATE_CHECK=true")
 	ctx := context.Background()
 	result, err := cli.RunCommand(ctx, "--help")
 	require.NoError(t, err)


### PR DESCRIPTION
Skip update check in `Test_CLI_NoDebugSpewWhenHelpPassedWithoutDebug` that ensures `--help` is well formed. The test is asserting that `stderr` isn't polluted by unexpected debug spew when a simple `--help` is passed. The version update check is one of the things that could write to `stderr` but is outside the purpose of the test.