### PR TITLE
Add "brew update" to upgrade message on brew install scenarios

### DIFF
--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -104,7 +104,7 @@ func main() {
 			} else if runtime.GOOS == "darwin" {
 				switch installedBy {
 				case installer.InstallTypeBrew:
-					upgradeText = "run:\nbrew upgrade azd"
+					upgradeText = "run:\nbrew update && brew upgrade azd"
 				case installer.InstallTypeSh:
 					//nolint:lll
 					upgradeText = "run:\ncurl -fsSL https://aka.ms/install-azd.sh | bash\n\nIf the install script was run with custom parameters, ensure that the same parameters are used for the upgrade. For advanced install instructions, see: https://aka.ms/azd/upgrade/mac"


### PR DESCRIPTION
In some mac scenarios brew's internal view of packages may be behind the current state of the azd homebrew tap. Add `brew update` to the command to prevent inaccurate warnings from brew that the latest version is already installed.