### PR TITLE
Fix subscription ID saving

### DIFF
--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -191,6 +191,12 @@ func (e *Environment) Dotenv() map[string]string {
 	return maps.Clone(e.dotenv)
 }
 
+// DotenvGet returns the value named by the given key stored in the .env file in the environment.
+// If the key does not exist, an empty string is returned.
+func (e *Environment) DotenvGet(key string) string {
+	return e.dotenv[key]
+}
+
 // DotenvSet sets the value of [key] to [value] in the .env file associated with the environment. [Save] should be
 // called to ensure this change is persisted.
 func (e *Environment) DotenvSet(key string, value string) {

--- a/cli/azd/pkg/prompt/prompter.go
+++ b/cli/azd/pkg/prompt/prompter.go
@@ -53,20 +53,20 @@ func NewDefaultPrompter(
 //
 // This currently means that subscription (AZURE_SUBSCRIPTION_ID) and location (AZURE_LOCATION) variables are set.
 func (p *DefaultPrompter) EnsureEnv(ctx context.Context) error {
-	if p.env.GetSubscriptionId() == "" {
+	if p.env.DotenvGet(environment.SubscriptionIdEnvVarName) == "" {
 		subscriptionId, err := p.PromptSubscription(ctx, "Select an Azure Subscription to use:")
 		if err != nil {
 			return err
 		}
 
-		p.env.SetSubscriptionId(subscriptionId)
+		p.env.DotenvSet(environment.SubscriptionIdEnvVarName, subscriptionId)
 
 		if err := p.env.Save(); err != nil {
 			return err
 		}
 	}
 
-	if p.env.GetLocation() == "" {
+	if p.env.DotenvGet(environment.LocationEnvVarName) == "" {
 		location, err := p.PromptLocation(
 			ctx,
 			p.env.GetSubscriptionId(),
@@ -77,7 +77,7 @@ func (p *DefaultPrompter) EnsureEnv(ctx context.Context) error {
 			return err
 		}
 
-		p.env.SetLocation(location)
+		p.env.DotenvSet(environment.LocationEnvVarName, location)
 
 		if err := p.env.Save(); err != nil {
 			return err


### PR DESCRIPTION
Ensure that after provisioning, `AZURE_SUBSCRIPTION_ID` and `AZURE_LOCATION` are always saved in the environment.

Fixes #2423 