### PR TITLE
fix quickstart commands on the README in the todo projects

### DIFF
--- a/templates/todo/projects/csharp-sql-swa-func/README.md
+++ b/templates/todo/projects/csharp-sql-swa-func/README.md
@@ -54,7 +54,7 @@ This quickstart will show you how to authenticate on Azure, initialize using a t
 azd auth login
 
 # First-time project setup. Initialize a project in the current directory, using this template. 
-azd init --template Azure-Samples/todo-csharp-cosmos-sql
+azd init --template Azure-Samples/todo-csharp-sql-swa-func
 
 # Provision and deploy to Azure
 azd up

--- a/templates/todo/projects/csharp-sql/README.md
+++ b/templates/todo/projects/csharp-sql/README.md
@@ -52,7 +52,7 @@ This quickstart will show you how to authenticate on Azure, initialize using a t
 azd auth login
 
 # First-time project setup. Initialize a project in the current directory, using this template. 
-azd init --template Azure-Samples/todo-csharp-cosmos-sql
+azd init --template Azure-Samples/todo-csharp-sql
 
 # Provision and deploy to Azure
 azd up

--- a/templates/todo/projects/java-mongo-aca/README.md
+++ b/templates/todo/projects/java-mongo-aca/README.md
@@ -53,7 +53,7 @@ This quickstart will show you how to authenticate on Azure, initialize using a t
 azd auth login
 
 # First-time project setup. Initialize a project in the current directory, using this template. 
-azd init --template Azure-Samples/todo-csharp-cosmos-sql
+azd init --template Azure-Samples/todo-java-mongo-aca
 
 # Provision and deploy to Azure
 azd up

--- a/templates/todo/projects/java-mongo/README.md
+++ b/templates/todo/projects/java-mongo/README.md
@@ -51,7 +51,7 @@ This quickstart will show you how to authenticate on Azure, initialize using a t
 azd auth login
 
 # First-time project setup. Initialize a project in the current directory, using this template. 
-azd init --template Azure-Samples/todo-csharp-cosmos-sql
+azd init --template Azure-Samples/todo-java-mongo
 
 # Provision and deploy to Azure
 azd up

--- a/templates/todo/projects/java-postgresql/README.md
+++ b/templates/todo/projects/java-postgresql/README.md
@@ -34,7 +34,7 @@ This quickstart will show you how to authenticate on Azure, initialize using a t
 azd auth login
 
 # First-time project setup. Initialize a project in the current directory, using this template. 
-azd init --template Azure-Samples/todo-csharp-cosmos-sql
+azd init --template Azure-Samples/todo-java-postgresql-terraform
 
 # Provision and deploy to Azure
 azd up

--- a/templates/todo/projects/nodejs-mongo-aca/README.md
+++ b/templates/todo/projects/nodejs-mongo-aca/README.md
@@ -51,7 +51,7 @@ This quickstart will show you how to authenticate on Azure, initialize using a t
 azd auth login
 
 # First-time project setup. Initialize a project in the current directory, using this template. 
-azd init --template Azure-Samples/todo-csharp-cosmos-sql
+azd init --template Azure-Samples/todo-nodejs-mongo-aca
 
 # Provision and deploy to Azure
 azd up

--- a/templates/todo/projects/nodejs-mongo-aks/README.md
+++ b/templates/todo/projects/nodejs-mongo-aks/README.md
@@ -51,7 +51,7 @@ This quickstart will show you how to authenticate on Azure, initialize using a t
 azd auth login
 
 # First-time project setup. Initialize a project in the current directory, using this template. 
-azd init --template Azure-Samples/todo-csharp-cosmos-sql
+azd init --template Azure-Samples/todo-nodejs-mongo-aks
 
 # Provision and deploy to Azure
 azd up

--- a/templates/todo/projects/nodejs-mongo-swa-func/README.md
+++ b/templates/todo/projects/nodejs-mongo-swa-func/README.md
@@ -50,7 +50,7 @@ This quickstart will show you how to authenticate on Azure, initialize using a t
 azd auth login
 
 # First-time project setup. Initialize a project in the current directory, using this template. 
-azd init --template Azure-Samples/todo-csharp-cosmos-sql
+azd init --template Azure-Samples/todo-nodejs-mongo-swa-func
 
 # Provision and deploy to Azure
 azd up

--- a/templates/todo/projects/python-mongo-aca/README.md
+++ b/templates/todo/projects/python-mongo-aca/README.md
@@ -52,7 +52,7 @@ This quickstart will show you how to authenticate on Azure, initialize using a t
 azd auth login
 
 # First-time project setup. Initialize a project in the current directory, using this template. 
-azd init --template Azure-Samples/todo-csharp-cosmos-sql
+azd init --template Azure-Samples/todo-python-mongo-aca
 
 # Provision and deploy to Azure
 azd up

--- a/templates/todo/projects/python-mongo-swa-func/README.md
+++ b/templates/todo/projects/python-mongo-swa-func/README.md
@@ -50,7 +50,7 @@ This quickstart will show you how to authenticate on Azure, initialize using a t
 azd auth login
 
 # First-time project setup. Initialize a project in the current directory, using this template. 
-azd init --template Azure-Samples/todo-csharp-cosmos-sql
+azd init --template Azure-Samples/todo-python-mongo-swa-func
 
 # Provision and deploy to Azure
 azd up


### PR DESCRIPTION
This PR fixes the README quickstart guide commands.

I have replaced `Azure-Samples/todo-csharp-cosmos-sql` in each command with the correct template reference that is mentioned a few lines above in each README where this was present.

I raised this with @savannahostrowski 