### PR TITLE
Include external command output in errors in all cases

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -1,5 +1,6 @@
 # hyphen is optional, "re-authentication" and "reauthentication" are equivalent.
 AADSTS
+ABRT
 alphafeatures
 apimanagement
 apims

--- a/cli/azd/pkg/exec/command_runner_test_unix.go
+++ b/cli/azd/pkg/exec/command_runner_test_unix.go
@@ -1,0 +1,21 @@
+// go:build unix
+
+package exec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAbortSignalRetainsOutputError(t *testing.T) {
+	runner := NewCommandRunner(nil)
+
+	// Run a small shell script that prints to stdout, stderr and then aborts and ensure that the returned error
+	// contains the output from both stdout and stderr.
+	_, err := runner.Run(context.Background(), NewRunArgs("/bin/sh", "-c", "echo Hello ; >&2 echo World ; kill -s ABRT $$"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Hello")
+	require.Contains(t, err.Error(), "World")
+}

--- a/cli/azd/pkg/exec/runresult.go
+++ b/cli/azd/pkg/exec/runresult.go
@@ -55,19 +55,21 @@ func NewExitError(
 	}
 }
 
+// Error augments the underlying exec.ExitError's Error with the stdout and stderr output of the command, if available.
 func (e *ExitError) Error() string {
-	if e.err.Exited() {
-		if !e.outputAvailable {
-			return fmt.Sprintf("exit code: %d", e.err.ExitCode())
-		}
+	var errorPrefix string
 
-		return fmt.Sprintf(
-			"exit code: %d, stdout: %s, stderr: %s",
-			e.err.ExitCode(),
-			e.stdOut,
-			e.stdErr)
+	// Handle the case where the underlying error represents an exit code error. In this case we'd rather use "exit code"
+	// and not "exit status" as the error message, to make it easier to find in logs.
+	if e.err.Exited() {
+		errorPrefix = fmt.Sprintf("exit code: %d", e.err.ExitCode())
+	} else {
+		errorPrefix = e.err.Error()
 	}
 
-	// for a non-exit-code error (such as a signal), just return the underlying exec.ExitError message
-	return e.err.Error()
+	if !e.outputAvailable {
+		return errorPrefix
+	}
+
+	return fmt.Sprintf("%s, stdout: %s, stderr: %s", errorPrefix, e.stdOut, e.stdErr)
 }

--- a/cli/azd/pkg/exec/util_test.go
+++ b/cli/azd/pkg/exec/util_test.go
@@ -75,7 +75,7 @@ func TestKillCommand(t *testing.T) {
 		// on Windows terminating the process doesn't register as an error
 		require.NoError(t, err)
 	} else {
-		require.EqualValues(t, "signal: killed", err.Error())
+		require.ErrorContains(t, err, "signal: killed")
 	}
 	// should be pretty much instant since our context was already cancelled
 	// but we'll give a little wiggle room (as long as it's < 10000 seconds, which is
@@ -144,7 +144,7 @@ func TestError(t *testing.T) {
 
 	var exitErr *ExitError
 	require.ErrorAs(t, err, &exitErr)
-	require.Contains(t, exitErr.Error(), "exit code: 2, stdout:")
+	require.ErrorContains(t, exitErr, "exit code: 2, stdout:")
 }
 
 func TestError_Interactive(t *testing.T) {


### PR DESCRIPTION
Previously, we only added the output from standard out and standard error in cases where the command we ran called exit() cleanly. In other cases, we would not include this information.

This did not work well in practice, for example, dotnet applications will exit via a signal (`SIGABRT`) if `libicu` is not installed on a linux machine, after printing very helpful text to standard error, which we would not include.

This changes our logic so that we always include this output, when we have it. So instead of:

```
ERROR: initializing provisioning manager: initializing infrastructure provider: failed resolving IaC provider 'bicep': checking bicep version: signal: aborted
```

To (the much longer, but much more helpful):

```
ERROR: initializing provisioning manager: initializing infrastructure provider: failed resolving IaC provider 'bicep': checking bicep version: signal: aborted, stdout: , stderr: Process terminated. Couldn't find a valid ICU package installed on the system. Please install libicu (or icu-libs) using your package manager and try again. Alternatively you can set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support. Please see https://aka.ms/dotnet-missing-libicu for more information.
   at System.Environment.FailFast(System.String)
   at System.Globalization.GlobalizationMode+Settings..cctor()
   at System.Globalization.GlobalizationMode+Settings.get_Invariant()
   at System.Globalization.GlobalizationMode.get_Invariant()
   at System.Globalization.CultureData.CreateCultureWithInvariantData()
   at System.Globalization.CultureData.get_Invariant()
   at System.Globalization.CultureInfo..cctor()
   at System.Globalization.CultureInfo.get_CurrentCulture()
   at System.Globalization.NumberFormatInfo.get_CurrentInfo()
   at System.Reflection.AssemblyNameParser.ParseVersion(System.String)
   at System.Reflection.AssemblyNameParser.Parse()
   at System.Reflection.AssemblyNameParser.Parse(System.ReadOnlySpan`1<Char>)
   at System.Reflection.AssemblyName.ParseAsAssemblySpec(Char*, Void*)
   at System.RuntimeTypeHandle.<GetTypeByNameUsingCARules>g____PInvoke|80_0(UInt16*, System.Runtime.CompilerServices.QCallModule, System.Runtime.CompilerServices.ObjectHandleOnStack)
   at System.RuntimeTypeHandle.<GetTypeByNameUsingCARules>g____PInvoke|80_0(UInt16*, System.Runtime.CompilerServices.QCallModule, System.Runtime.CompilerServices.ObjectHandleOnStack)
   at System.RuntimeTypeHandle.GetTypeByNameUsingCARules(System.String, System.Runtime.CompilerServices.QCallModule, System.Runtime.CompilerServices.ObjectHandleOnStack)
   at System.RuntimeTypeHandle.GetTypeByNameUsingCARules(System.String, System.Reflection.RuntimeModule)
   at System.Reflection.CustomAttributeTypedArgument.ResolveType(System.Reflection.RuntimeModule, System.String)
   at System.Reflection.CustomAttributeTypedArgument..ctor(System.Reflection.RuntimeModule, System.Reflection.CustomAttributeEncodedArgument)
   at System.Reflection.RuntimeCustomAttributeData.get_ConstructorArguments()
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.GetDynamicallyAccessedMemberTypes(System.Type)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.ValidateTrimmingAnnotations(System.Type, System.Type[], System.Type, System.Type[])
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.Populate()
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory..ctor(System.Collections.Generic.ICollection`1<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>)
   at Microsoft.Extensions.DependencyInjection.ServiceProvider..ctor(System.Collections.Generic.ICollection`1<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, Microsoft.Extensions.DependencyInjection.ServiceProviderOptions)
   at Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions.BuildServiceProvider(Microsoft.Extensions.DependencyInjection.IServiceCollection, Microsoft.Extensions.DependencyInjection.ServiceProviderOptions)
   at Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions.BuildServiceProvider(Microsoft.Extensions.DependencyInjection.IServiceCollection)
   at Microsoft.Extensions.Logging.LoggerFactory.Create(System.Action`1<Microsoft.Extensions.Logging.ILoggingBuilder>)
   at Bicep.Cli.Program.CreateLoggerFactory(Bicep.Cli.IOContext)
   at Bicep.Cli.Program.ConfigureServices(Bicep.Cli.IOContext)
   at Bicep.Cli.Program..ctor(Bicep.Cli.IOContext, System.Action`1<Microsoft.Extensions.DependencyInjection.IServiceCollection>)
   at Bicep.Cli.Program+<Main>d__3.MoveNext()
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[[Bicep.Cli.Program+<Main>d__3, bicep, Version=0.17.0.0, Culture=neutral, PublicKeyToken=null]](<Main>d__3 ByRef)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].Start[[Bicep.Cli.Program+<Main>d__3, bicep, Version=0.17.0.0, Culture=neutral, PublicKeyToken=null]](<Main>d__3 ByRef)
   at Bicep.Cli.Program.Main(System.String[])
   at Bicep.Cli.Program.<Main>(System.String[])
```

Fixes #2197