### PR TITLE
Move `EnsureEnv` from `prompt.Prompter` to `provisioning.Provider`

### DIFF
--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -12,10 +12,12 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	"github.com/azure/azure-dev/cli/azd/pkg/pipeline"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -108,11 +110,13 @@ func newPipelineConfigCmd() *cobra.Command {
 
 // pipelineConfigAction defines the action for pipeline config command
 type pipelineConfigAction struct {
-	flags     *pipelineConfigFlags
-	manager   *pipeline.PipelineManager
-	env       *environment.Environment
-	console   input.Console
-	prompters prompt.Prompter
+	flags               *pipelineConfigFlags
+	manager             *pipeline.PipelineManager
+	provisioningManager *provisioning.Manager
+	env                 *environment.Environment
+	console             input.Console
+	prompters           prompt.Prompter
+	projectConfig       *project.ProjectConfig
 }
 
 func newPipelineConfigAction(
@@ -122,13 +126,17 @@ func newPipelineConfigAction(
 	flags *pipelineConfigFlags,
 	prompters prompt.Prompter,
 	manager *pipeline.PipelineManager,
+	provisioningManager *provisioning.Manager,
+	projectConfig *project.ProjectConfig,
 ) actions.Action {
 	pca := &pipelineConfigAction{
-		flags:     flags,
-		manager:   manager,
-		env:       env,
-		console:   console,
-		prompters: prompters,
+		flags:               flags,
+		manager:             manager,
+		env:                 env,
+		console:             console,
+		prompters:           prompters,
+		provisioningManager: provisioningManager,
+		projectConfig:       projectConfig,
 	}
 
 	return pca
@@ -136,7 +144,7 @@ func newPipelineConfigAction(
 
 // Run implements action interface
 func (p *pipelineConfigAction) Run(ctx context.Context) (*actions.ActionResult, error) {
-	err := p.prompters.EnsureEnv(ctx)
+	err := p.provisioningManager.Initialize(ctx, p.projectConfig.Path, p.projectConfig.Infra)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -10,6 +10,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
@@ -60,6 +61,7 @@ type upAction struct {
 	console                    input.Console
 	runner                     middleware.MiddlewareContext
 	prompters                  prompt.Prompter
+	provisioningManager        *provisioning.Manager
 }
 
 func newUpAction(
@@ -73,6 +75,7 @@ func newUpAction(
 	console input.Console,
 	runner middleware.MiddlewareContext,
 	prompters prompt.Prompter,
+	provisioningManager *provisioning.Manager,
 ) actions.Action {
 	return &upAction{
 		flags:                      flags,
@@ -84,6 +87,7 @@ func newUpAction(
 		console:                    console,
 		runner:                     runner,
 		prompters:                  prompters,
+		provisioningManager:        provisioningManager,
 	}
 }
 
@@ -107,7 +111,7 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 			output.WithWarningFormat("WARNING: The '--service' flag is deprecated and will be removed in a future release."))
 	}
 
-	err := u.prompters.EnsureEnv(ctx)
+	err := u.provisioningManager.Initialize(ctx, u.projectConfig.Path, u.projectConfig.Infra)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -95,7 +95,16 @@ func (p *BicepProvider) Initialize(ctx context.Context, projectPath string, opti
 		return err
 	}
 
-	return p.prompters.EnsureEnv(ctx)
+	return p.EnsureEnv(ctx)
+}
+
+// EnsureEnv ensures that the environment is in a provision-ready state with required values set, prompting the user if
+// values are unset.
+//
+// An environment is considered to be in a provision-ready state if it contains both an AZURE_SUBSCRIPTION_ID and
+// AZURE_LOCATION value.
+func (p *BicepProvider) EnsureEnv(ctx context.Context) error {
+	return EnsureSubscriptionAndLocation(ctx, p.env, p.prompters)
 }
 
 func (p *BicepProvider) State(ctx context.Context) (*StateResult, error) {

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -42,7 +42,7 @@ func TestProvisionInitializesEnvironment(t *testing.T) {
 
 	registerContainerDependencies(mockContext, env)
 
-	mgr := NewManager(mockContext.Container, env, mockContext.Console, mockContext.AlphaFeaturesManager)
+	mgr := NewManager(mockContext.Container, env, mockContext.Console, mockContext.AlphaFeaturesManager, nil)
 	err := mgr.Initialize(*mockContext.Context, "", Options{Provider: "test"})
 	require.NoError(t, err)
 
@@ -59,7 +59,7 @@ func TestManagerPlan(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	registerContainerDependencies(mockContext, env)
 
-	mgr := NewManager(mockContext.Container, env, mockContext.Console, mockContext.AlphaFeaturesManager)
+	mgr := NewManager(mockContext.Container, env, mockContext.Console, mockContext.AlphaFeaturesManager, nil)
 	err := mgr.Initialize(*mockContext.Context, "", Options{Provider: "test"})
 	require.NoError(t, err)
 
@@ -79,7 +79,7 @@ func TestManagerGetState(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	registerContainerDependencies(mockContext, env)
 
-	mgr := NewManager(mockContext.Container, env, mockContext.Console, mockContext.AlphaFeaturesManager)
+	mgr := NewManager(mockContext.Container, env, mockContext.Console, mockContext.AlphaFeaturesManager, nil)
 	err := mgr.Initialize(*mockContext.Context, "", Options{Provider: "test"})
 	require.NoError(t, err)
 
@@ -98,7 +98,7 @@ func TestManagerDeploy(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	registerContainerDependencies(mockContext, env)
 
-	mgr := NewManager(mockContext.Container, env, mockContext.Console, mockContext.AlphaFeaturesManager)
+	mgr := NewManager(mockContext.Container, env, mockContext.Console, mockContext.AlphaFeaturesManager, nil)
 	err := mgr.Initialize(*mockContext.Context, "", Options{Provider: "test"})
 	require.NoError(t, err)
 
@@ -122,7 +122,7 @@ func TestManagerDestroyWithPositiveConfirmation(t *testing.T) {
 
 	registerContainerDependencies(mockContext, env)
 
-	mgr := NewManager(mockContext.Container, env, mockContext.Console, mockContext.AlphaFeaturesManager)
+	mgr := NewManager(mockContext.Container, env, mockContext.Console, mockContext.AlphaFeaturesManager, nil)
 	err := mgr.Initialize(*mockContext.Context, "", Options{Provider: "test"})
 	require.NoError(t, err)
 
@@ -148,7 +148,7 @@ func TestManagerDestroyWithNegativeConfirmation(t *testing.T) {
 
 	registerContainerDependencies(mockContext, env)
 
-	mgr := NewManager(mockContext.Container, env, mockContext.Console, mockContext.AlphaFeaturesManager)
+	mgr := NewManager(mockContext.Container, env, mockContext.Console, mockContext.AlphaFeaturesManager, nil)
 	err := mgr.Initialize(*mockContext.Context, "", Options{Provider: "test"})
 	require.NoError(t, err)
 

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -50,4 +50,5 @@ type Provider interface {
 	Plan(ctx context.Context) (*DeploymentPlan, error)
 	Deploy(ctx context.Context, plan *DeploymentPlan) (*DeployResult, error)
 	Destroy(ctx context.Context, options DestroyOptions) (*DestroyResult, error)
+	EnsureEnv(ctx context.Context) error
 }

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -80,7 +80,7 @@ func (t *TerraformProvider) Initialize(ctx context.Context, projectPath string, 
 		return err
 	}
 
-	if err := t.prompters.EnsureEnv(ctx); err != nil {
+	if err := t.EnsureEnv(ctx); err != nil {
 		return err
 	}
 
@@ -103,6 +103,15 @@ func (t *TerraformProvider) Initialize(ctx context.Context, projectPath string, 
 
 	t.cli.SetEnv(envVars)
 	return nil
+}
+
+// EnsureEnv ensures that the environment is in a provision-ready state with required values set, prompting the user if
+// values are unset.
+//
+// An environment is considered to be in a provision-ready state if it contains both an AZURE_SUBSCRIPTION_ID and
+// AZURE_LOCATION value.
+func (t *TerraformProvider) EnsureEnv(ctx context.Context) error {
+	return EnsureSubscriptionAndLocation(ctx, t.env, t.prompters)
 }
 
 // Previews the infrastructure through terraform plan

--- a/cli/azd/pkg/infra/provisioning/test/test_provider.go
+++ b/cli/azd/pkg/infra/provisioning/test/test_provider.go
@@ -38,7 +38,16 @@ func (p *TestProvider) Initialize(ctx context.Context, projectPath string, optio
 	p.projectPath = projectPath
 	p.options = options
 
-	return p.prompters.EnsureEnv(ctx)
+	return p.EnsureEnv(ctx)
+}
+
+// EnsureEnv ensures that the environment is in a provision-ready state with required values set, prompting the user if
+// values are unset.
+//
+// An environment is considered to be in a provision-ready state if it contains both an AZURE_SUBSCRIPTION_ID and
+// AZURE_LOCATION value.
+func (t *TestProvider) EnsureEnv(ctx context.Context) error {
+	return EnsureSubscriptionAndLocation(ctx, t.env, t.prompters)
 }
 
 func (p *TestProvider) Plan(ctx context.Context) (*DeploymentPlan, error) {


### PR DESCRIPTION
Different provisioning providers may require different values to be set in the environment to be able to do a provision operation.  For example, when using the bicep provider and doing a resource group scoped deployment, in addition to a subscription and a location, we need `AZURE_RESOURCE_GROUP` defined to name the target resource group to deploy to.

This change prepares us to have providers require different values to be set in the environment by moving `EnsureEnv` from `prompt.Prompter` and to the providers themselves.  `provisioning.Manager` also gains an `EnsureEnv` method which simply calls `EnsureEnv` on the underlying provider.

There should be no functional impact of this change, it is simply code motion to help with some future changes.