### PR TITLE
Set CWD for telemetry to fix Windows CI issues

### DIFF
--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -357,6 +357,16 @@ func startBackgroundUploadProcess() error {
 	}
 
 	cmd := exec.Command(execPath, cmd.TelemetryCommandFlag, cmd.TelemetryUploadCommandFlag)
+
+	// Use the location of azd as the cwd for the background uploading process.  On windows, when a process is running
+	// the current working directory is considered in use and can not be deleted. If a user runs `azd` in a directory, we
+	// do want that directory to be considered in use and locked while the telemetry upload is happening. One example of
+	// where we see this problem often is in our CI for end to end tests where we run a copy of `azd` that we built in an
+	// ephemeral directory created by (*testing.T).TempDir().  When the test completes, the testing package attempts to
+	// clean up the temporary directory, but if the telemetry upload process is still running, the directory can not be
+	// deleted.
+	cmd.Dir = filepath.Dir(execPath)
+
 	err = cmd.Start()
 	return err
 }


### PR DESCRIPTION
When `azd` is about to exit, if there is telemetry that needs to be
uploaded, we spawn a separate copy of `azd` to go do the uploading and
then exit the current process.  This allows the upload of the
telemetry to happen in the background instead of pausing the
termination of `azd` until it is complete.

Previously, we reused the current working directory that the root
`azd` process was launched in (which, in the common case is whatever
directory the user ran `azd` from).

On Windows, if a process is running with a given CWD, that directory
can not be deleted until the process exits. This means that until the
upload process finishes and the uploader exits, the CWD of the initial
`azd` is in use and can not be deleted.

In CI our end to ends tests run in an ephemeral directory, created by
`(*testing.T).TempDir()`, and `azd` is run from within this
folder. When the test completes, the testing library tries to clean up
this temporary directory, and this can fail (depending on timing)
because the directory is in use, since the uploader is running.

To address this issue, when we launch `azd` to upload telemetry, use
the directory that `azd` is contained in, instead of what our current
working directory is.