### PR TITLE
GitHub CI Provider: Include current git branch in federated authentication

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs Fixed
 
 - [[2402]](https://github.com/Azure/azure-dev/pull/2279) Support for workload profiles in Azure Container Apps
+- [[2428, 2040]](https://github.com/Azure/azure-dev/pull/2468) Include current git branch in GitHub federated credentials
 
 ## 1.0.2 (2023-06-14)
 

--- a/cli/azd/pkg/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/pipeline/azdo_provider.go
@@ -568,7 +568,6 @@ func gitInsteadOfConfig(
 // Push code and queue pipeline
 func (p *AzdoScmProvider) GitPush(
 	ctx context.Context,
-	gitCli git.GitCli,
 	gitRepo *gitRepositoryDetails,
 	remoteName string,
 	branchName string) error {

--- a/cli/azd/pkg/pipeline/pipeline.go
+++ b/cli/azd/pkg/pipeline/pipeline.go
@@ -12,7 +12,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
-	"github.com/azure/azure-dev/cli/azd/pkg/tools/git"
 )
 
 // subareaProvider defines the base behavior from any pipeline provider
@@ -47,6 +46,8 @@ type gitRepositoryDetails struct {
 	pushStatus bool
 	// remote
 	remote string
+	// branch
+	branch string
 
 	details interface{}
 }
@@ -70,7 +71,6 @@ type ScmProvider interface {
 		branchName string) (bool, error)
 	//Hook function to allow SCM providers to handle scenarios after the git push is complete
 	GitPush(ctx context.Context,
-		gitCli git.GitCli,
 		gitRepo *gitRepositoryDetails,
 		remoteName string,
 		branchName string) error

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -189,11 +189,6 @@ func (pm *PipelineManager) Configure(ctx context.Context) (result *PipelineConfi
 		return result, fmt.Errorf("prompting to push: %w", err)
 	}
 
-	currentBranch, err := pm.gitCli.GetCurrentBranch(ctx, pm.azdCtx.ProjectDirectory())
-	if err != nil {
-		return result, fmt.Errorf("getting current branch: %w", err)
-	}
-
 	// scm provider can prevent from pushing changes and/or use the
 	// interactive console for setting up any missing details.
 	// For example, GitHub provider would check if GH-actions are disabled.
@@ -202,7 +197,7 @@ func (pm *PipelineManager) Configure(ctx context.Context) (result *PipelineConfi
 			ctx,
 			gitRepoInfo,
 			pm.args.PipelineRemoteName,
-			currentBranch)
+			gitRepoInfo.branch)
 		if err != nil {
 			return result, fmt.Errorf("check git push prevent: %w", err)
 		}
@@ -211,7 +206,7 @@ func (pm *PipelineManager) Configure(ctx context.Context) (result *PipelineConfi
 	}
 
 	if doPush {
-		err = pm.pushGitRepo(ctx, gitRepoInfo, currentBranch)
+		err = pm.pushGitRepo(ctx, gitRepoInfo, gitRepoInfo.branch)
 		if err != nil {
 			return result, fmt.Errorf("git push: %w", err)
 		}
@@ -231,7 +226,7 @@ func (pm *PipelineManager) Configure(ctx context.Context) (result *PipelineConfi
 			fmt.Sprintf(
 				"To fully enable pipeline you need to push this repo to the upstream using 'git push --set-upstream %s %s'.\n",
 				pm.args.PipelineRemoteName,
-				currentBranch))
+				gitRepoInfo.branch))
 	}
 
 	return &PipelineConfigResult{


### PR DESCRIPTION
Fixes #2428, #2040

Includes the current git branch name when setting up federated credentials for GitHub.