### PR TITLE
Validate environment exists when running `azd env select`

### DIFF
--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -161,7 +161,7 @@ func newEnvSelectAction(azdCtx *azdcontext.AzdContext, args []string) actions.Ac
 func (e *envSelectAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	_, err := environment.GetEnvironment(e.azdCtx, e.args[0])
 	if errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf(`environment '%s' does not exist. You can create it with "azd env init %s"`,
+		return nil, fmt.Errorf(`environment '%s' does not exist. You can create it with "azd env new %s"`,
 			e.args[0], e.args[0])
 	} else if err != nil {
 		return nil, fmt.Errorf("ensuring environment exists: %w", err)

--- a/cli/azd/cmd/testdata/TestUsage-azd-env-new.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env-new.snap
@@ -1,5 +1,5 @@
 
-Create a new environment.
+Create a new environment and set it as the default.
 
 Usage
   azd env new <environment> [flags]

--- a/cli/azd/cmd/testdata/TestUsage-azd-env.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env.snap
@@ -12,7 +12,7 @@ Usage
 Available Commands
   get-values	: Get all environment values.
   list      	: List environments.
-  new       	: Create a new environment.
+  new       	: Create a new environment and set it as the default.
   refresh   	: Refresh environment settings by using information from a previous infrastructure provision.
   select    	: Set the default environment.
   set       	: Manage your environment settings.

--- a/cli/azd/test/functional/env_test.go
+++ b/cli/azd/test/functional/env_test.go
@@ -100,6 +100,11 @@ func Test_CLI_Env_Management(t *testing.T) {
 	require.Len(t, environmentList, 2)
 	requireIsDefault(t, environmentList, envName)
 
+	// Verify that trying to select an environment which does not exist fails.
+	res, err := cli.RunCommand(ctx, "env", "select", "does-not-exist")
+	require.Error(t, err)
+	require.Contains(t, res.Stdout, "environment 'does-not-exist' does not exist")
+
 	// Verify that running refresh with an explicit env name from an argument and from a flag leads to an error.
 	_, err = cli.RunCommand(context.Background(), "env", "refresh", "-e", "from-flag", "from-arg")
 	require.Error(t, err)


### PR DESCRIPTION
Also, update the help text for `azd env new` to call out that the new enviromnet is set as the default environment once it is created.

Fixes #2306