### PR TITLE
Make `pipeline config` work with RG Scoped Deployments

### DIFF
--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -154,6 +154,12 @@ func getDefinitionVariables(
 		"AZURE_SUBSCRIPTION_ID":    createBuildDefinitionVariable(credentials.SubscriptionId, false, false),
 	}
 
+	if provisioningProvider.Provider == provisioning.Bicep {
+		if v, has := env.LookupEnv(environment.ResourceGroupEnvVarName); has {
+			variables[environment.ResourceGroupEnvVarName] = createBuildDefinitionVariable(v, false, false)
+		}
+	}
+
 	if provisioningProvider.Provider == provisioning.Terraform {
 		variables["ARM_TENANT_ID"] = createBuildDefinitionVariable(credentials.TenantId, false, false)
 		variables["ARM_CLIENT_ID"] = createBuildDefinitionVariable(credentials.ClientId, true, false)

--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -155,8 +155,8 @@ func getDefinitionVariables(
 	}
 
 	if provisioningProvider.Provider == provisioning.Bicep {
-		if v, has := env.LookupEnv(environment.ResourceGroupEnvVarName); has {
-			variables[environment.ResourceGroupEnvVarName] = createBuildDefinitionVariable(v, false, false)
+		if rgName, has := env.LookupEnv(environment.ResourceGroupEnvVarName); has {
+			variables[environment.ResourceGroupEnvVarName] = createBuildDefinitionVariable(rgName, false, false)
 		}
 	}
 

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -102,9 +102,54 @@ func (p *BicepProvider) Initialize(ctx context.Context, projectPath string, opti
 // values are unset.
 //
 // An environment is considered to be in a provision-ready state if it contains both an AZURE_SUBSCRIPTION_ID and
-// AZURE_LOCATION value.
+// AZURE_LOCATION value. Additionally, for resource group scoped deployments, an AZURE_RESOURCE_GROUP value is required.
 func (p *BicepProvider) EnsureEnv(ctx context.Context) error {
-	return EnsureSubscriptionAndLocation(ctx, p.env, p.prompters)
+	if err := EnsureSubscriptionAndLocation(ctx, p.env, p.prompters); err != nil {
+		return err
+	}
+
+	modulePath := p.modulePath()
+	if _, err := os.Stat(modulePath); errors.Is(err, os.ErrNotExist) {
+		// If there's not template, just behave as if we are in a subscription scope (and don't ask about
+		// AZURE_RESOURCE_GROUP). Future operations which try to use the infrastructure may fail, but that's ok. These
+		// failures will have reasonable error messages.
+		//
+		// We want to handle the case where the provider can `Initialize` even without a template, because we do this
+		// in a few of our end to end telemetry tests to speed things up.
+		return nil
+	}
+
+	_, template, err := p.compileBicep(ctx, modulePath)
+	if err != nil {
+		return fmt.Errorf("compiling bicep template: %w", err)
+	}
+
+	scope, err := template.TargetScope()
+	if err != nil {
+		return err
+	}
+
+	if scope == azure.DeploymentScopeResourceGroup {
+		if !p.alphaFeatureManager.IsEnabled(ResourceGroupDeploymentFeature) {
+			return ErrResourceGroupScopeNotSupported
+		}
+
+		p.console.WarnForFeature(ctx, ResourceGroupDeploymentFeature)
+
+		if p.env.Getenv(environment.ResourceGroupEnvVarName) == "" {
+			rgName, err := p.prompters.PromptResourceGroup(ctx)
+			if err != nil {
+				return err
+			}
+
+			p.env.DotenvSet(environment.ResourceGroupEnvVarName, rgName)
+			if err := p.env.Save(); err != nil {
+				return fmt.Errorf("saving resource group name: %w", err)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (p *BicepProvider) State(ctx context.Context) (*StateResult, error) {
@@ -206,24 +251,6 @@ func (p *BicepProvider) Plan(ctx context.Context) (*DeploymentPlan, error) {
 			deploymentNameForEnv(p.env.GetEnvName(), p.clock),
 		)
 	} else if deploymentScope == azure.DeploymentScopeResourceGroup {
-		if !p.alphaFeatureManager.IsEnabled(ResourceGroupDeploymentFeature) {
-			return nil, ErrResourceGroupScopeNotSupported
-		}
-
-		p.console.WarnForFeature(ctx, ResourceGroupDeploymentFeature)
-
-		if p.env.Getenv(environment.ResourceGroupEnvVarName) == "" {
-			rgName, err := p.prompters.PromptResourceGroup(ctx)
-			if err != nil {
-				return nil, err
-			}
-
-			p.env.DotenvSet(environment.ResourceGroupEnvVarName, rgName)
-			if err := p.env.Save(); err != nil {
-				return nil, fmt.Errorf("saving environment: %w", err)
-			}
-		}
-
 		target = infra.NewResourceGroupDeployment(
 			p.azCli,
 			p.env.GetSubscriptionId(),
@@ -342,30 +369,11 @@ func (p *BicepProvider) scopeForTemplate(ctx context.Context, t azure.ArmTemplat
 	if deploymentScope == azure.DeploymentScopeSubscription {
 		return infra.NewSubscriptionScope(p.azCli, p.env.GetSubscriptionId()), nil
 	} else if deploymentScope == azure.DeploymentScopeResourceGroup {
-		if !p.alphaFeatureManager.IsEnabled(ResourceGroupDeploymentFeature) {
-			return nil, ErrResourceGroupScopeNotSupported
-		}
-
-		p.console.WarnForFeature(ctx, ResourceGroupDeploymentFeature)
-
-		if p.env.Getenv(environment.ResourceGroupEnvVarName) == "" {
-			rgName, err := p.prompters.PromptResourceGroup(ctx)
-			if err != nil {
-				return nil, err
-			}
-
-			p.env.DotenvSet(environment.ResourceGroupEnvVarName, rgName)
-			if err := p.env.Save(); err != nil {
-				return nil, fmt.Errorf("saving resource group name: %w", err)
-			}
-		}
-
 		return infra.NewResourceGroupScope(
 			p.azCli,
 			p.env.GetSubscriptionId(),
 			p.env.Getenv(environment.ResourceGroupEnvVarName),
 		), nil
-
 	} else {
 		return nil, fmt.Errorf("unsupported deployment scope: %s", deploymentScope)
 	}
@@ -1172,7 +1180,6 @@ func (p *BicepProvider) loadParameters(ctx context.Context) (map[string]azure.Ar
 func (p *BicepProvider) compileBicep(
 	ctx context.Context, modulePath string,
 ) (azure.RawArmTemplate, azure.ArmTemplate, error) {
-
 	compiled, err := p.bicepCli.Build(ctx, modulePath)
 	if err != nil {
 		return nil, azure.ArmTemplate{}, fmt.Errorf("failed to compile bicep template: %w", err)

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -81,7 +81,7 @@ func TestBicepPlanPrompt(t *testing.T) {
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 		return strings.Contains(args.Cmd, "bicep") && args.Args[0] == "--version"
 	}).Respond(exec.RunResult{
-		Stdout: "Bicep CLI version 0.12.40 (41892bd0fb)",
+		Stdout: fmt.Sprintf("Bicep CLI version %s (abcdef0123)", bicep.BicepVersion.String()),
 		Stderr: "",
 	})
 
@@ -435,7 +435,7 @@ func prepareBicepMocks(
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 		return strings.Contains(args.Cmd, "bicep") && args.Args[0] == "--version"
 	}).Respond(exec.RunResult{
-		Stdout: "Bicep CLI version 0.12.40 (41892bd0fb)",
+		Stdout: fmt.Sprintf("Bicep CLI version %s (abcdef0123)", bicep.BicepVersion.String()),
 		Stderr: "",
 	})
 

--- a/cli/azd/pkg/infra/provisioning/bicep/prompt_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
-	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -45,13 +44,7 @@ func TestPromptForParameter(t *testing.T) {
 			t.Parallel()
 
 			mockContext := mocks.NewMockContext(context.Background())
-
-			mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-				return strings.Contains(args.Cmd, "bicep") && args.Args[0] == "--version"
-			}).Respond(exec.RunResult{
-				Stdout: "Bicep CLI version 0.12.40 (41892bd0fb)",
-				Stderr: "",
-			})
+			prepareBicepMocks(mockContext)
 
 			p := createBicepProvider(t, mockContext)
 
@@ -183,13 +176,9 @@ func TestPromptForParameterValidation(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			mockContext := mocks.NewMockContext(context.Background())
+			prepareBicepMocks(mockContext)
 
-			mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-				return strings.Contains(args.Cmd, "bicep") && args.Args[0] == "--version"
-			}).Respond(exec.RunResult{
-				Stdout: "Bicep CLI version 0.12.40 (41892bd0fb)",
-				Stderr: "",
-			})
+			p := createBicepProvider(t, mockContext)
 
 			mockContext.Console.WhenPrompt(func(options input.ConsoleOptions) bool {
 				return strings.Contains(options.Message, "for the 'testParam' infrastructure parameter")
@@ -198,8 +187,6 @@ func TestPromptForParameterValidation(t *testing.T) {
 				tc.provided = tc.provided[1:]
 				return ret, nil
 			})
-
-			p := createBicepProvider(t, mockContext)
 
 			value, err := p.promptForParameter(*mockContext.Context, "testParam", tc.param)
 			require.NoError(t, err)
@@ -255,13 +242,7 @@ func TestPromptForParametersLocation(t *testing.T) {
 	t.Parallel()
 
 	mockContext := mocks.NewMockContext(context.Background())
-
-	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.Contains(args.Cmd, "bicep") && args.Args[0] == "--version"
-	}).Respond(exec.RunResult{
-		Stdout: "Bicep CLI version 0.12.40 (41892bd0fb)",
-		Stderr: "",
-	})
+	prepareBicepMocks(mockContext)
 
 	env := environment.Ephemeral()
 	azCli := mockazcli.NewAzCliFromMockContext(mockContext)

--- a/cli/azd/pkg/pipeline/github_provider.go
+++ b/cli/azd/pkg/pipeline/github_provider.go
@@ -484,8 +484,8 @@ func (p *GitHubCiProvider) setPipelineVariables(
 	}
 
 	if infraOptions.Provider == provisioning.Bicep {
-		if v, has := p.env.LookupEnv(environment.ResourceGroupEnvVarName); has {
-			if err := p.ghCli.SetVariable(ctx, repoSlug, environment.ResourceGroupEnvVarName, v); err != nil {
+		if rgName, has := p.env.LookupEnv(environment.ResourceGroupEnvVarName); has {
+			if err := p.ghCli.SetVariable(ctx, repoSlug, environment.ResourceGroupEnvVarName, rgName); err != nil {
 				return fmt.Errorf("failed setting %s variable: %w", environment.ResourceGroupEnvVarName, err)
 			}
 		}

--- a/cli/azd/pkg/pipeline/github_provider.go
+++ b/cli/azd/pkg/pipeline/github_provider.go
@@ -413,6 +413,10 @@ func (p *GitHubCiProvider) configureConnection(
 		return fmt.Errorf("failed configuring authentication: %w", authErr)
 	}
 
+	if err := p.setPipelineVariables(ctx, repoSlug, infraOptions); err != nil {
+		return fmt.Errorf("failed setting pipeline variables: %w", err)
+	}
+
 	p.console.MessageUxItem(ctx, &ux.MultilineMessage{
 		Lines: []string{
 			"",
@@ -420,6 +424,72 @@ func (p *GitHubCiProvider) configureConnection(
 			output.WithLinkFormat("https://github.com/%s/settings/secrets/actions", repoSlug),
 			""},
 	})
+
+	return nil
+}
+
+// setPipelineVariables sets all the pipeline variables required for the pipeline to run.  This includes the environment
+// variables that the core of AZD uses (AZURE_ENV_NAME) as well as the variables that the provisioning system needs to run
+// (AZURE_SUBSCRIPTION_ID, AZURE_LOCATION) as well as scenario specific variables (AZURE_RESOURCE_GROUP for resource group
+// scoped deployments, a series of RS_ variables for terraform remote state)
+func (p *GitHubCiProvider) setPipelineVariables(
+	ctx context.Context,
+	repoSlug string,
+	infraOptions provisioning.Options,
+) error {
+	for name, value := range map[string]string{
+		environment.EnvNameEnvVarName:        p.env.GetEnvName(),
+		environment.LocationEnvVarName:       p.env.GetLocation(),
+		environment.SubscriptionIdEnvVarName: p.env.GetSubscriptionId(),
+	} {
+		if err := p.ghCli.SetVariable(ctx, repoSlug, name, value); err != nil {
+			return fmt.Errorf("failed setting %s variable: %w", name, err)
+		}
+		p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+			Name: name,
+			Kind: ux.GitHubVariable,
+		})
+	}
+
+	if infraOptions.Provider == provisioning.Terraform {
+		remoteStateKeys := []string{"RS_RESOURCE_GROUP", "RS_STORAGE_ACCOUNT", "RS_CONTAINER_NAME"}
+		for _, key := range remoteStateKeys {
+			value, ok := p.env.LookupEnv(key)
+			if !ok || strings.TrimSpace(value) == "" {
+				p.console.StopSpinner(ctx, "Configuring terraform", input.StepWarning)
+				p.console.MessageUxItem(ctx, &ux.WarningMessage{
+					Description: "Terraform Remote State configuration is invalid",
+					HidePrefix:  true,
+				})
+				p.console.Message(
+					ctx,
+					fmt.Sprintf(
+						"Visit %s for more information on configuring Terraform remote state",
+						output.WithLinkFormat("https://aka.ms/azure-dev/terraform"),
+					),
+				)
+				p.console.Message(ctx, "")
+				return errors.New("terraform remote state is not correctly configured")
+			}
+
+			// env var was found
+			if err := p.ghCli.SetVariable(ctx, repoSlug, key, value); err != nil {
+				return fmt.Errorf("setting terraform remote state variables: %w", err)
+			}
+			p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+				Name: key,
+				Kind: ux.GitHubVariable,
+			})
+		}
+	}
+
+	if infraOptions.Provider == provisioning.Bicep {
+		if v, has := p.env.LookupEnv(environment.ResourceGroupEnvVarName); has {
+			if err := p.ghCli.SetVariable(ctx, repoSlug, environment.ResourceGroupEnvVarName, v); err != nil {
+				return fmt.Errorf("failed setting %s variable: %w", environment.ResourceGroupEnvVarName, err)
+			}
+		}
+	}
 
 	return nil
 }
@@ -453,79 +523,32 @@ func (p *GitHubCiProvider) configureClientCredentialsAuth(
 			return fmt.Errorf("setting terraform env var credentials: %w", e)
 		}
 
-		/* #nosec G101 - Potential hardcoded credentials - false positive */
-		secretName = "ARM_TENANT_ID"
-		if err := p.ghCli.SetVariable(ctx, repoSlug, secretName, values.Tenant); err != nil {
-			return fmt.Errorf("setting terraform %s:: %w", secretName, err)
-		}
-		p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
-			Name: secretName,
-			Kind: ux.GitHubVariable,
-		})
-
-		/* #nosec G101 - Potential hardcoded credentials - false positive */
-		secretName = "ARM_CLIENT_ID"
-		if err := p.ghCli.SetVariable(ctx, repoSlug, secretName, values.ClientId); err != nil {
-			return fmt.Errorf("setting terraform %s:: %w", secretName, err)
-		}
-		p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
-			Name: secretName,
-			Kind: ux.GitHubVariable,
-		})
-
-		/* #nosec G101 - Potential hardcoded credentials - false positive */
-		secretName = "ARM_CLIENT_SECRET"
-		if err := p.ghCli.SetSecret(ctx, repoSlug, secretName, values.ClientSecret); err != nil {
-			return fmt.Errorf("setting terraform %s:: %w", secretName, err)
-		}
-		p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
-			Name: secretName,
-			Kind: ux.GitHubSecret,
-		})
-
-		// Sets the terraform remote state environment variables in github
-		remoteStateKeys := []string{"RS_RESOURCE_GROUP", "RS_STORAGE_ACCOUNT", "RS_CONTAINER_NAME"}
-		for _, key := range remoteStateKeys {
-			value, ok := p.env.LookupEnv(key)
-			if !ok || strings.TrimSpace(value) == "" {
-				p.console.StopSpinner(ctx, "Configuring terraform", input.StepWarning)
-				p.console.MessageUxItem(ctx, &ux.WarningMessage{
-					Description: "Terraform Remote State configuration is invalid",
-					HidePrefix:  true,
+		for key, info := range map[string]struct {
+			value  string
+			secret bool
+		}{
+			"ARM_TENANT_ID":     {values.Tenant, false},
+			"ARM_CLIENT_ID":     {values.ClientId, false},
+			"ARM_CLIENT_SECRET": {values.ClientSecret, true},
+		} {
+			if !info.secret {
+				if err := p.ghCli.SetVariable(ctx, repoSlug, key, info.value); err != nil {
+					return fmt.Errorf("setting github variable %s:: %w", key, err)
+				}
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name: key,
+					Kind: ux.GitHubVariable,
 				})
-				p.console.Message(
-					ctx,
-					fmt.Sprintf(
-						"Visit %s for more information on configuring Terraform remote state",
-						output.WithLinkFormat("https://aka.ms/azure-dev/terraform"),
-					),
-				)
-				p.console.Message(ctx, "")
-				return errors.New("terraform remote state is not correctly configured")
+			} else {
+				if err := p.ghCli.SetSecret(ctx, repoSlug, key, info.value); err != nil {
+					return fmt.Errorf("setting github secret %s:: %w", key, err)
+				}
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name: key,
+					Kind: ux.GitHubSecret,
+				})
 			}
-			// env var was found
-			if err := p.ghCli.SetVariable(ctx, repoSlug, key, value); err != nil {
-				return fmt.Errorf("setting terraform remote state variables: %w", err)
-			}
-			p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
-				Name: key,
-				Kind: ux.GitHubVariable,
-			})
 		}
-	}
-
-	for _, envName := range []string{
-		environment.EnvNameEnvVarName,
-		environment.LocationEnvVarName,
-		environment.SubscriptionIdEnvVarName} {
-
-		if err := p.ghCli.SetVariable(ctx, repoSlug, envName, p.env.Getenv(envName)); err != nil {
-			return fmt.Errorf("failed setting %s variable: %w", envName, err)
-		}
-		p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
-			Name: envName,
-			Kind: ux.GitHubVariable,
-		})
 	}
 
 	return nil
@@ -553,15 +576,10 @@ func (p *GitHubCiProvider) configureFederatedAuth(
 		return err
 	}
 
-	githubVariables := map[string]string{
-		environment.EnvNameEnvVarName:        p.env.GetEnvName(),
-		environment.LocationEnvVarName:       p.env.GetLocation(),
-		environment.TenantIdEnvVarName:       azureCredentials.TenantId,
-		environment.SubscriptionIdEnvVarName: azureCredentials.SubscriptionId,
-		"AZURE_CLIENT_ID":                    azureCredentials.ClientId,
-	}
-
-	for key, value := range githubVariables {
+	for key, value := range map[string]string{
+		environment.TenantIdEnvVarName: azureCredentials.TenantId,
+		"AZURE_CLIENT_ID":              azureCredentials.ClientId,
+	} {
 		if err := p.ghCli.SetVariable(ctx, repoSlug, key, value); err != nil {
 			return fmt.Errorf("failed setting github variable '%s':  %w", key, err)
 		}


### PR DESCRIPTION
When running `azd pipeline configure` we will now set an
`AZURE_RESOURCE_GROUP` variable, when the infrastructure targets
resource group scope.

Pipelines can then be configured to include this variable when running
`azd` commands where it will be respected.

These changes only impact new runs of `pipeline config`. There is no
requirement to have an updated version of `azd` in CI.  The existing
released version (1.0.2) will correctly use these values when set.

As an example, here's the diff to `azure-dev.yml` from the
todo-nodejs-mongo template showing the modifications needed.

The `AZD_ALPHA_ENABLE_RESOURCEGROUPDEPLOYMENTS` env var is used to
enable the alpha feature in CI. It will no longer be needed once the
feature is out of alpha.

```patch
diff --git a/.github/workflows/azure-dev.yml b/.github/workflows/azure-dev.yml
index 3816c95..785aaac 100644
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -26,6 +26,7 @@ jobs:
       AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+      AZD_ALPHA_ENABLE_RESOURCEGROUPDEPLOYMENTS: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -59,6 +60,7 @@ jobs:
           AZURE_ENV_NAME: ${{ vars.AZURE_ENV_NAME }}
           AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}

       - name: Deploy Application
         run: azd deploy --no-prompt
@@ -66,3 +68,4 @@ jobs:
           AZURE_ENV_NAME: ${{ vars.AZURE_ENV_NAME }}
           AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
```