### PR TITLE
AKS Service Target - Overriding KUBECONFIG handling

### DIFF
--- a/cli/azd/pkg/project/service_config_test.go
+++ b/cli/azd/pkg/project/service_config_test.go
@@ -217,8 +217,9 @@ func createTestServiceConfig(path string, host ServiceTargetKind, language Servi
 		Language:     language,
 		RelativePath: filepath.Join(path),
 		Project: &ProjectConfig{
-			Name: "Test-App",
-			Path: ".",
+			Name:            "Test-App",
+			Path:            ".",
+			EventDispatcher: ext.NewEventDispatcher[ProjectLifecycleEventArgs](),
 		},
 		EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
 	}

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -545,7 +545,7 @@ func (t *aksTarget) getIngressEndpoints(
 		if ingress.Spec.Rules[index].Host == nil {
 			baseUrl = fmt.Sprintf("%s://%s", protocol, resource.Ip)
 		} else {
-			baseUrl = fmt.Sprintf("%s://%s", *ingress.Spec.Rules[index].Host, resource.Ip)
+			baseUrl = fmt.Sprintf("%s://%s", protocol, *ingress.Spec.Rules[index].Host)
 		}
 
 		endpointUrl, err := url.JoinPath(baseUrl, serviceConfig.K8s.Ingress.RelativePath)

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -309,7 +309,7 @@ func (t *aksTarget) ensureClusterContext(
 	}
 
 	log.Printf("getting AKS credentials for cluster '%s'\n", clusterName)
-	clusterCreds, err := t.managedClustersService.GetAdminCredentials(
+	clusterCreds, err := t.managedClustersService.GetUserCredentials(
 		ctx,
 		targetResource.SubscriptionId(),
 		targetResource.ResourceGroupName(),

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
+	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
@@ -521,8 +522,11 @@ func createAksServiceTarget(
 	envManager.On("Save", *mockContext.Context, env).Return(nil)
 
 	azCli := mockazcli.NewAzCliFromMockContext(mockContext)
-	resourceManager := NewResourceManager(env, azCli)
-
+	resourceManager := NewResourceManager(
+		env,
+		azCli,
+		azapi.NewDeploymentOperations(credentialProvider, mockContext.HttpClient),
+	)
 	managedClustersService := azcli.NewManagedClustersService(credentialProvider, mockContext.HttpClient)
 	containerRegistryService := azcli.NewContainerRegistryService(credentialProvider, mockContext.HttpClient, dockerCli)
 	containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), containerRegistryService, dockerCli)

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/kubectl"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockaccount"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazcli"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockenv"
 	"github.com/azure/azure-dev/cli/azd/test/ostest"
@@ -484,6 +485,9 @@ func createAksServiceTarget(
 	envManager := &mockenv.MockEnvManager{}
 	envManager.On("Save", *mockContext.Context, env).Return(nil)
 
+	azCli := mockazcli.NewAzCliFromMockContext(mockContext)
+	resourceManager := NewResourceManager(env, azCli)
+
 	managedClustersService := azcli.NewManagedClustersService(credentialProvider, mockContext.HttpClient)
 	containerRegistryService := azcli.NewContainerRegistryService(credentialProvider, mockContext.HttpClient, dockerCli)
 	containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), containerRegistryService, dockerCli)
@@ -492,6 +496,8 @@ func createAksServiceTarget(
 		env,
 		envManager,
 		managedClustersService,
+		resourceManager,
+		resourceManager,
 		kubeCtl,
 		containerHelper,
 	)

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
@@ -189,23 +188,6 @@ func setupMocksForAksTarget(mockContext *mocks.MockContext) error {
 	setupMocksForAcr(mockContext)
 	setupMocksForKubectl(mockContext)
 	setupMocksForDocker(mockContext)
-
-	mockContext.HttpClient.When(func(request *http.Request) bool {
-		return request.Method == http.MethodGet && strings.Contains(request.URL.String(), "resources?$filter=tagName")
-	}).RespondFn(func(request *http.Request) (*http.Response, error) {
-		result := armresources.ResourceListResult{
-			Value: []*armresources.GenericResourceExpanded{
-				{
-					ID:       convert.RefOf("RESOURCE_ID"),
-					Location: convert.RefOf("eastus2"),
-					Name:     convert.RefOf("Resource"),
-					Type:     convert.RefOf("Microsoft.ContainerService/managedClusters"),
-				},
-			},
-		}
-
-		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, result)
-	})
 
 	return nil
 }

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -536,7 +536,6 @@ func createAksServiceTarget(
 		envManager,
 		managedClustersService,
 		resourceManager,
-		resourceManager,
 		kubeCtl,
 		containerHelper,
 	)

--- a/cli/azd/pkg/tools/azcli/managed_clusters.go
+++ b/cli/azd/pkg/tools/azcli/managed_clusters.go
@@ -19,6 +19,13 @@ type ManagedClustersService interface {
 		resourceGroupName string,
 		resourceName string,
 	) (*armcontainerservice.CredentialResults, error)
+	// Gets the user credentials for the specified resource
+	GetUserCredentials(
+		ctx context.Context,
+		subscriptionId string,
+		resourceGroupName string,
+		resourceName string,
+	) (*armcontainerservice.CredentialResults, error)
 }
 
 type managedClustersService struct {
@@ -37,6 +44,26 @@ func NewManagedClustersService(
 		httpClient:         httpClient,
 		userAgent:          azdinternal.UserAgent(),
 	}
+}
+
+// Gets the user credentials for the specified resource
+func (cs *managedClustersService) GetUserCredentials(
+	ctx context.Context,
+	subscriptionId string,
+	resourceGroupName string,
+	resourceName string,
+) (*armcontainerservice.CredentialResults, error) {
+	client, err := cs.createManagedClusterClient(ctx, subscriptionId)
+	if err != nil {
+		return nil, err
+	}
+
+	credResult, err := client.ListClusterUserCredentials(ctx, resourceGroupName, resourceName, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &credResult.CredentialResults, nil
 }
 
 // Gets the admin credentials for the specified resource

--- a/cli/azd/pkg/tools/kubectl/kube_config.go
+++ b/cli/azd/pkg/tools/kubectl/kube_config.go
@@ -41,24 +41,24 @@ func ParseKubeConfig(ctx context.Context, raw []byte) (*KubeConfig, error) {
 }
 
 // Saves the KubeConfig to the kube configuration folder with the specified name
-func (kcm *KubeConfigManager) SaveKubeConfig(ctx context.Context, configName string, config *KubeConfig) error {
+func (kcm *KubeConfigManager) SaveKubeConfig(ctx context.Context, configName string, config *KubeConfig) (string, error) {
 	kubeConfigRaw, err := yaml.Marshal(config)
 	if err != nil {
-		return fmt.Errorf("failed marshalling KubeConfig to yaml: %w", err)
+		return "", fmt.Errorf("failed marshalling KubeConfig to yaml: %w", err)
 	}
 
 	// Create .kube config folder if it doesn't already exist
 	if err := os.MkdirAll(kcm.configPath, osutil.PermissionDirectory); err != nil {
-		return fmt.Errorf("failed creating .kube config directory, %w", err)
+		return "", fmt.Errorf("failed creating .kube config directory, %w", err)
 	}
 
 	outFilePath := filepath.Join(kcm.configPath, configName)
 	err = os.WriteFile(outFilePath, kubeConfigRaw, osutil.PermissionFile)
 	if err != nil {
-		return fmt.Errorf("failed writing kube config file: %w", err)
+		return "", fmt.Errorf("failed writing kube config file: %w", err)
 	}
 
-	return nil
+	return outFilePath, nil
 }
 
 // Deletes the KubeConfig with the specified name
@@ -75,7 +75,7 @@ func (kcm *KubeConfigManager) DeleteKubeConfig(ctx context.Context, configName s
 // Merges the specified kube configs into the kube config
 // This powers the use of the kubectl config set of commands that allow developers to switch between different
 // k8s cluster contexts
-func (kcm *KubeConfigManager) MergeConfigs(ctx context.Context, newConfigName string, path ...string) error {
+func (kcm *KubeConfigManager) MergeConfigs(ctx context.Context, newConfigName string, path ...string) (string, error) {
 	fullConfigPaths := []string{}
 	for _, kubeConfigName := range path {
 		fullConfigPaths = append(fullConfigPaths, filepath.Join(kcm.configPath, kubeConfigName))
@@ -86,32 +86,36 @@ func (kcm *KubeConfigManager) MergeConfigs(ctx context.Context, newConfigName st
 
 	res, err := kcm.cli.ConfigView(ctx, true, true, nil)
 	if err != nil {
-		return fmt.Errorf("kubectl config view failed: %w", err)
+		return "", fmt.Errorf("kubectl config view failed: %w", err)
 	}
 
 	kubeConfigRaw := []byte(res.Stdout)
 	outFilePath := filepath.Join(kcm.configPath, newConfigName)
 	err = os.WriteFile(outFilePath, kubeConfigRaw, osutil.PermissionFile)
 	if err != nil {
-		return fmt.Errorf("failed writing new kube config: %w", err)
+		return "", fmt.Errorf("failed writing new kube config: %w", err)
 	}
 
-	return nil
+	return outFilePath, nil
 }
 
 // Adds a new or updates an existing KubeConfig in the main kube config
-func (kcm *KubeConfigManager) AddOrUpdateContext(ctx context.Context, contextName string, newKubeConfig *KubeConfig) error {
-	err := kcm.SaveKubeConfig(ctx, contextName, newKubeConfig)
+func (kcm *KubeConfigManager) AddOrUpdateContext(
+	ctx context.Context,
+	contextName string,
+	newKubeConfig *KubeConfig,
+) (string, error) {
+	_, err := kcm.SaveKubeConfig(ctx, contextName, newKubeConfig)
 	if err != nil {
-		return fmt.Errorf("failed write new kube context file: %w", err)
+		return "", fmt.Errorf("failed write new kube context file: %w", err)
 	}
 
-	err = kcm.MergeConfigs(ctx, "config", contextName)
+	configPath, err := kcm.MergeConfigs(ctx, "config", contextName)
 	if err != nil {
-		return fmt.Errorf("failed merging KUBE configs: %w", err)
+		return "", fmt.Errorf("failed merging KUBE configs: %w", err)
 	}
 
-	return nil
+	return configPath, nil
 }
 
 func getKubeConfigDir() (string, error) {

--- a/cli/azd/pkg/tools/kubectl/kube_config.go
+++ b/cli/azd/pkg/tools/kubectl/kube_config.go
@@ -81,10 +81,9 @@ func (kcm *KubeConfigManager) MergeConfigs(ctx context.Context, newConfigName st
 		fullConfigPaths = append(fullConfigPaths, filepath.Join(kcm.configPath, kubeConfigName))
 	}
 
-	envValues := map[string]string{
-		"KUBECONFIG": strings.Join(fullConfigPaths, string(os.PathListSeparator)),
-	}
-	kcm.cli.SetEnv(envValues)
+	kubeConfig := strings.Join(fullConfigPaths, string(os.PathListSeparator))
+	kcm.cli.SetKubeConfig(kubeConfig)
+
 	res, err := kcm.cli.ConfigView(ctx, true, true, nil)
 	if err != nil {
 		return fmt.Errorf("kubectl config view failed: %w", err)

--- a/cli/azd/pkg/tools/kubectl/kube_config_test.go
+++ b/cli/azd/pkg/tools/kubectl/kube_config_test.go
@@ -3,6 +3,7 @@ package kubectl
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
@@ -30,15 +31,25 @@ func Test_MergeKubeConfig(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	err = kubeConfigManager.SaveKubeConfig(*mockContext.Context, "config1", config1)
+	kubeConfigPath, err := kubeConfigManager.SaveKubeConfig(*mockContext.Context, "config1", config1)
 	require.NoError(t, err)
-	err = kubeConfigManager.SaveKubeConfig(*mockContext.Context, "config2", config2)
-	require.NoError(t, err)
-	err = kubeConfigManager.SaveKubeConfig(*mockContext.Context, "config3", config3)
-	require.NoError(t, err)
+	require.NotEmpty(t, kubeConfigPath)
+	require.Contains(t, kubeConfigPath, filepath.Join(".kube", "config1"))
 
-	err = kubeConfigManager.MergeConfigs(*mockContext.Context, "config", "config1", "config2", "config3")
+	kubeConfigPath, err = kubeConfigManager.SaveKubeConfig(*mockContext.Context, "config2", config2)
 	require.NoError(t, err)
+	require.NotEmpty(t, kubeConfigPath)
+	require.Contains(t, kubeConfigPath, filepath.Join(".kube", "config2"))
+
+	kubeConfigPath, err = kubeConfigManager.SaveKubeConfig(*mockContext.Context, "config3", config3)
+	require.NoError(t, err)
+	require.NotEmpty(t, kubeConfigPath)
+	require.Contains(t, kubeConfigPath, filepath.Join(".kube", "config3"))
+
+	kubeConfigPath, err = kubeConfigManager.MergeConfigs(*mockContext.Context, "config", "config1", "config2", "config3")
+	require.NoError(t, err)
+	require.NotEmpty(t, kubeConfigPath)
+	require.Contains(t, kubeConfigPath, filepath.Join(".kube", "config"))
 }
 
 func createTestCluster(clusterName, username string) *KubeConfig {

--- a/cli/azd/pkg/tools/kubectl/kubectl.go
+++ b/cli/azd/pkg/tools/kubectl/kubectl.go
@@ -80,7 +80,6 @@ type kubectlCli struct {
 	commandRunner exec.CommandRunner
 	env           map[string]string
 	cwd           string
-	kubeConfig    string
 }
 
 // Creates a new K8s CLI instance
@@ -145,7 +144,7 @@ func (cli *kubectlCli) SetEnv(envValues map[string]string) {
 
 // Sets the KUBECONFIG environment variable
 func (cli *kubectlCli) SetKubeConfig(kubeConfig string) {
-	cli.kubeConfig = kubeConfig
+	cli.env[KubeConfigEnvVarName] = kubeConfig
 }
 
 // Sets the current working directory
@@ -336,12 +335,7 @@ func (cli *kubectlCli) executeCommandWithArgs(
 		args = args.WithCwd(cli.cwd)
 	}
 
-	env := cli.env
-	if cli.kubeConfig != "" {
-		env[KubeConfigEnvVarName] = cli.kubeConfig
-	}
-
-	args = args.WithEnv(environ(env))
+	args = args.WithEnv(environ(cli.env))
 
 	if flags != nil {
 		if flags.DryRun != "" {

--- a/cli/azd/pkg/tools/kubectl/kubectl.go
+++ b/cli/azd/pkg/tools/kubectl/kubectl.go
@@ -139,7 +139,9 @@ func (cli *kubectlCli) Name() string {
 
 // Sets the env vars available to the CLI
 func (cli *kubectlCli) SetEnv(envValues map[string]string) {
-	cli.env = envValues
+	for key, value := range envValues {
+		cli.env[key] = value
+	}
 }
 
 // Sets the KUBECONFIG environment variable

--- a/cli/azd/pkg/tools/kubectl/models.go
+++ b/cli/azd/pkg/tools/kubectl/models.go
@@ -11,6 +11,7 @@ const (
 	ResourceTypeDeployment ResourceType = "deployment"
 	ResourceTypeIngress    ResourceType = "ing"
 	ResourceTypeService    ResourceType = "svc"
+	KubeConfigEnvVarName   string       = "KUBECONFIG"
 )
 
 type Resource struct {
@@ -166,8 +167,9 @@ type KubeContext struct {
 }
 
 type KubeContextData struct {
-	Cluster string `yaml:"cluster"`
-	User    string `yaml:"user"`
+	Cluster   string `yaml:"cluster"`
+	Namespace string `yaml:"namespace"`
+	User      string `yaml:"user"`
 }
 
 type KubeUser struct {

--- a/cli/azd/pkg/tools/kubectl/util.go
+++ b/cli/azd/pkg/tools/kubectl/util.go
@@ -100,7 +100,6 @@ type ResourceFilterFn[T comparable] func(resource T) bool
 func WaitForResource[T comparable](
 	ctx context.Context,
 	cli KubectlCli,
-	namespace string,
 	resourceType ResourceType,
 	resourceFilter ResourceFilterFn[T],
 	readyStatusFilter ResourceFilterFn[T],
@@ -111,9 +110,7 @@ func WaitForResource[T comparable](
 		ctx,
 		retry.WithMaxDuration(time.Minute*10, retry.NewConstant(time.Second*10)),
 		func(ctx context.Context) error {
-			result, err := GetResources[T](ctx, cli, resourceType, &KubeCliFlags{
-				Namespace: namespace,
-			})
+			result, err := GetResources[T](ctx, cli, resourceType, nil)
 
 			if err != nil {
 				return fmt.Errorf("failed waiting for resource, %w", err)


### PR DESCRIPTION
This change builds on smaller set of changes from other open PRs:

- #2455 
- #2464

Additionally this adds support to override behavior of the `KUBECONFIG` environment variable.

## Use Case: Standard `azd` use case

When provisioning is complete `azd` will automatically attempt to authenticate to the cluster with local admin credentials.  A new `KUBECONFIG` is created with the same name as the AKS cluster name and merged into the default `KUBECONFIG`.  

The default context within the `KUBECONFIG` now also includes the default project/service namespace.

> **Note**
> Namespaces can be set within resource yaml definitions.  If not specified `azd` will use the default service namespace. Services can specify namespace name in the `k8s` section of the service yaml.  
> 
> If no namespace has been set for the service the `azd` project name will be used by default.

The k8s current context is set to the new cluster with default project namespace.  At this point any custom `kubectl` commands that exist within `postprovision` or `predeploy` scripts can make `kubectl` commands and it will automatically use the new `KUBECONFIG`.

## Use Case: Overriding `KUBECONFIG` environment variable

If `KUBECONFIG` is set in either the azd `.env` file or in the OS `azd` will use this `KUBECONFIG` as its default.  `azd` will **_NOT_** create a new `KUBECONFIG` or context and the developer must ensure the `KUBECONFIG` is initialized with correct authentication credentials with context and namespace.

Any calls to `kubectl` within `postprovision` or `predeploy` scripts will automatically use the specified `KUBECONFIG`.