### PR TITLE
Updating all templates to use the devconatiner feature

### DIFF
--- a/templates/common/.devcontainer/Dockerfile/base/Dockerfile
+++ b/templates/common/.devcontainer/Dockerfile/base/Dockerfile
@@ -3,4 +3,3 @@ FROM --platform=amd64 mcr.microsoft.com/devcontainers/${IMAGE}
 RUN export DEBIAN_FRONTEND=noninteractive \
      && apt-get update && apt-get install -y xdg-utils \
      && apt-get clean -y && rm -rf /var/lib/apt/lists/*
-RUN curl -fsSL https://aka.ms/install-azd.sh | bash

--- a/templates/common/.devcontainer/Dockerfile/func/Dockerfile
+++ b/templates/common/.devcontainer/Dockerfile/func/Dockerfile
@@ -6,4 +6,3 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > mic
     && apt-get update && apt-get install -y xdg-utils \
     && apt-get update && apt-get install -y azure-functions-core-tools-4 \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
-RUN curl -fsSL https://aka.ms/install-azd.sh | bash

--- a/templates/common/.devcontainer/Dockerfile/java/Dockerfile
+++ b/templates/common/.devcontainer/Dockerfile/java/Dockerfile
@@ -4,4 +4,3 @@ RUN export DEBIAN_FRONTEND=noninteractive \
      && apt-get update && apt-get install -y xdg-utils \
      && apt-get update && apt-get install --yes --no-install-recommends postgresql-client \
      && apt-get clean -y && rm -rf /var/lib/apt/lists/*
-RUN curl -fsSL https://aka.ms/install-azd.sh | bash

--- a/templates/common/.devcontainer/devcontainer.json/aks/nodejs/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/aks/nodejs/devcontainer.json
@@ -13,6 +13,9 @@
             "version": "latest",
             "helm": "latest",
             "minikube": "none"
+        },
+        "ghcr.io/azure/azure-dev/azd:1": {
+            "version": "stable"
         }
     },
     "customizations": {

--- a/templates/common/.devcontainer/devcontainer.json/bicep-starter/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/bicep-starter/devcontainer.json
@@ -10,6 +10,9 @@
     "features": {
         // See https://containers.dev/features for list of features
         "ghcr.io/devcontainers/features/docker-in-docker:2": {
+        },
+        "ghcr.io/azure/azure-dev/azd:1": {
+            "version": "stable"
         }
     },
     "customizations": {

--- a/templates/common/.devcontainer/devcontainer.json/csharp/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/csharp/devcontainer.json
@@ -12,6 +12,9 @@
         "ghcr.io/devcontainers/features/node:1": {
             "version": "16",
             "nodeGypDependencies": false
+        },
+        "ghcr.io/azure/azure-dev/azd:1": {
+            "version": "stable"
         }
     },
     "customizations": {

--- a/templates/common/.devcontainer/devcontainer.json/java/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/java/devcontainer.json
@@ -9,7 +9,10 @@
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:2": {
         },
-        "ghcr.io/devcontainers/features/java:1": {}
+        "ghcr.io/devcontainers/features/java:1": {},
+        "ghcr.io/azure/azure-dev/azd:1": {
+            "version": "stable"
+        }
     },
     "customizations": {
         "vscode": {

--- a/templates/common/.devcontainer/devcontainer.json/java/terraform/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/java/terraform/devcontainer.json
@@ -14,7 +14,10 @@
         "ghcr.io/devcontainers/features/terraform:1": {
             "version": "latest"
         },
-        "ghcr.io/devcontainers/features/java:1": {}
+        "ghcr.io/devcontainers/features/java:1": {},
+        "ghcr.io/azure/azure-dev/azd:1": {
+            "version": "stable"
+        }
     },
     "customizations": {
         "vscode": {

--- a/templates/common/.devcontainer/devcontainer.json/nodejs/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/nodejs/devcontainer.json
@@ -8,6 +8,9 @@
     },
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:2": {
+        },
+        "ghcr.io/azure/azure-dev/azd:1": {
+            "version": "stable"
         }
     },
     "customizations": {

--- a/templates/common/.devcontainer/devcontainer.json/nodejs/terraform/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/nodejs/terraform/devcontainer.json
@@ -13,6 +13,9 @@
         },
         "ghcr.io/devcontainers/features/terraform:1": {
             "version": "latest"
+        },
+        "ghcr.io/azure/azure-dev/azd:1": {
+            "version": "stable"
         }
     },
     "customizations": {

--- a/templates/common/.devcontainer/devcontainer.json/python/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/devcontainer.json
@@ -12,6 +12,9 @@
         "ghcr.io/devcontainers/features/node:1": {
             "version": "16",
             "nodeGypDependencies": false
+        },
+        "ghcr.io/azure/azure-dev/azd:1": {
+            "version": "stable"
         }
     },
     "customizations": {

--- a/templates/common/.devcontainer/devcontainer.json/python/terraform/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/terraform/devcontainer.json
@@ -17,6 +17,9 @@
         },
         "ghcr.io/devcontainers/features/terraform:1": {
             "version": "latest"
+        },
+        "ghcr.io/azure/azure-dev/azd:1": {
+            "version": "stable"
         }
     },
     "customizations": {

--- a/templates/common/.devcontainer/devcontainer.json/terraform-starter/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/terraform-starter/devcontainer.json
@@ -16,6 +16,9 @@
         },
         "ghcr.io/devcontainers/features/terraform:1": {
             "version": "latest"
+        },
+        "ghcr.io/azure/azure-dev/azd:1": {
+            "version": "stable"
         }
     },
     "customizations": {


### PR DESCRIPTION
With #1118 merged, this PR updates all the templates to use the feature rather than installing the azd cli within the Dockerfile.

This PR is pending the publishing of the feature to the agreed container registry.