### PR TITLE
Pipeline Config - Reuse previous service principal when available

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -2,16 +2,15 @@
 
 ## 1.1.1 (Unreleased)
 
-### Bugs Fixed
-
-- [[2569]](https://github.com/Azure/azure-dev/pull/2569) Fix `azd down` so it works after a failed `azd provision`
-
 ### Features Added
 
 - [[2550]](https://github.com/Azure/azure-dev/pull/2550) Add `--preview` to `azd provision` to get the changes
+- [[2521]](https://github.com/Azure/azure-dev/pull/2521) Support `--principal-id` param for azd pipeline config to reuse existing service principal
+- [[2455]](https://github.com/Azure/azure-dev/pull/2455) Adds optional support for text templates in AKS k8s manifests
 
 ### Bugs Fixed
 
+- [[2569]](https://github.com/Azure/azure-dev/pull/2569) Fix `azd down` so it works after a failed `azd provision`
 - [[2367]](https://github.com/Azure/azure-dev/pull/2367) Don't fail AKS deployment for failed environment substitution
 
 ## 1.1.0 (2023-07-12)

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -276,6 +276,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.RegisterSingleton(account.NewSubscriptionsManager)
 	container.RegisterSingleton(account.NewSubscriptionCredentialProvider)
 	container.RegisterSingleton(azcli.NewManagedClustersService)
+	container.RegisterSingleton(azcli.NewAdService)
 	container.RegisterSingleton(azcli.NewContainerRegistryService)
 	container.RegisterSingleton(containerapps.NewContainerAppService)
 	container.RegisterSingleton(project.NewContainerHelper)

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -31,6 +31,12 @@ type pipelineConfigFlags struct {
 
 func (pc *pipelineConfigFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	local.StringVar(
+		&pc.PipelineServicePrincipalId,
+		"principal-id",
+		"",
+		"The client id of the service principal to use to grant access to Azure resources as part of the pipeline.",
+	)
+	local.StringVar(
 		&pc.PipelineServicePrincipalName,
 		"principal-name",
 		"",

--- a/cli/azd/cmd/testdata/TestUsage-azd-pipeline-config.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-pipeline-config.snap
@@ -13,6 +13,7 @@ Flags
         --docs                       	: Opens the documentation for azd pipeline config in your web browser.
     -e, --environment string         	: The name of the environment to use.
     -h, --help                       	: Gets help for config.
+        --principal-id string        	: The client id of the service principal to use to grant access to Azure resources as part of the pipeline.
         --principal-name string      	: The name of the service principal to use to grant access to Azure resources as part of the pipeline.
         --principal-role stringArray 	: The roles to assign to the service principal. By default the service principal will be granted the Contributor and User Access Administrator roles.
         --provider string            	: The pipeline provider to use (github for Github Actions and azdo for Azure Pipelines).

--- a/cli/azd/pkg/graphsdk/application_request_builders.go
+++ b/cli/azd/pkg/graphsdk/application_request_builders.go
@@ -84,6 +84,24 @@ func (c *ApplicationItemRequestBuilder) FederatedIdentityCredentialById(
 	return NewFederatedIdentityCredentialItemRequestBuilder(c.client, c.id, id)
 }
 
+func (c *ApplicationItemRequestBuilder) GetByAppId(ctx context.Context) (*Application, error) {
+	req, err := runtime.NewRequest(ctx, http.MethodGet, fmt.Sprintf("%s/applications(appId='%s')", c.client.host, c.id))
+	if err != nil {
+		return nil, fmt.Errorf("failed creating request: %w", err)
+	}
+
+	res, err := c.client.pipeline.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if !runtime.HasStatusCode(res, http.StatusOK) {
+		return nil, runtime.NewResponseError(res)
+	}
+
+	return httputil.ReadRawResponse[Application](res)
+}
+
 // Gets a Microsoft Graph Application for the specified application identifier
 func (c *ApplicationItemRequestBuilder) Get(ctx context.Context) (*Application, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, fmt.Sprintf("%s/applications/%s", c.client.host, c.id))

--- a/cli/azd/pkg/pipeline/github_provider.go
+++ b/cli/azd/pkg/pipeline/github_provider.go
@@ -591,8 +591,8 @@ func (p *GitHubCiProvider) configureFederatedAuth(
 	}
 
 	for key, value := range map[string]string{
-		environment.TenantIdEnvVarName:  azureCredentials.TenantId,
-		AzurePipelineClientIdEnvVarName: azureCredentials.ClientId,
+		environment.TenantIdEnvVarName: azureCredentials.TenantId,
+		"AZURE_CLIENT_ID":              azureCredentials.ClientId,
 	} {
 		if err := p.ghCli.SetVariable(ctx, repoSlug, key, value); err != nil {
 			return fmt.Errorf("failed setting github variable '%s':  %w", key, err)

--- a/cli/azd/pkg/pipeline/github_provider.go
+++ b/cli/azd/pkg/pipeline/github_provider.go
@@ -591,8 +591,8 @@ func (p *GitHubCiProvider) configureFederatedAuth(
 	}
 
 	for key, value := range map[string]string{
-		environment.TenantIdEnvVarName: azureCredentials.TenantId,
-		"AZURE_CLIENT_ID":              azureCredentials.ClientId,
+		environment.TenantIdEnvVarName:  azureCredentials.TenantId,
+		AzurePipelineClientIdEnvVarName: azureCredentials.ClientId,
 	} {
 		if err := p.ghCli.SetVariable(ctx, repoSlug, key, value); err != nil {
 			return fmt.Errorf("failed setting github variable '%s':  %w", key, err)

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -147,6 +147,11 @@ func (pm *PipelineManager) Configure(ctx context.Context) (result *PipelineConfi
 		return result, fmt.Errorf("ensuring git remote: %w", err)
 	}
 
+	if pm.args.PipelineServicePrincipalName != "" && pm.args.PipelineServicePrincipalId != "" {
+		//nolint:lll
+		return result, fmt.Errorf("you have specified both --principal-id and --principal-name, but only one of these parameters should be used at a time.")
+	}
+
 	// Existing Service Principal Lookup strategy
 	// 1. --principal-id
 	// 2. --principal-name

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -149,7 +149,9 @@ func (pm *PipelineManager) Configure(ctx context.Context) (result *PipelineConfi
 
 	if pm.args.PipelineServicePrincipalName != "" && pm.args.PipelineServicePrincipalId != "" {
 		//nolint:lll
-		return result, fmt.Errorf("you have specified both --principal-id and --principal-name, but only one of these parameters should be used at a time.")
+		return result, fmt.Errorf(
+			"you have specified both --principal-id and --principal-name, but only one of these parameters should be used at a time.",
+		)
 	}
 
 	// Existing Service Principal Lookup strategy

--- a/cli/azd/pkg/pipeline/pipeline_manager_test.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/git"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/github"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
-	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazcli"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -424,7 +424,7 @@ func createPipelineManager(
 
 	return NewPipelineManager(
 		*mockContext.Context,
-		mockazcli.NewAzCliFromMockContext(mockContext),
+		azcli.NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient),
 		git.NewGitCli(mockContext.CommandRunner),
 		azdContext,
 		env,

--- a/cli/azd/pkg/tools/azcli/ad.go
+++ b/cli/azd/pkg/tools/azcli/ad.go
@@ -32,16 +32,15 @@ type AzureCredentials struct {
 type ErrorWithSuggestion struct {
 	Suggestion string
 	Err        error
-
-// AdService provides actions on top of Azure Active Directory (AD)
-type AdService interface {
-	GetServicePrincipal(
 }
 
 func (es *ErrorWithSuggestion) Error() string {
 	return es.Err.Error()
 }
 
+// AdService provides actions on top of Azure Active Directory (AD)
+type AdService interface {
+	GetServicePrincipal(
 		ctx context.Context,
 		subscriptionId string,
 		applicationId string,
@@ -371,14 +370,12 @@ func (ad *adService) applyRoleAssignmentWithRetry(
 
 			// If the response is a 403 then the required role is missing.
 			if errors.As(err, &responseError) && responseError.StatusCode == http.StatusForbidden {
-
 				return &ErrorWithSuggestion{
 					Suggestion: fmt.Sprintf("\nSuggested Action: Ensure you have either the `User Access Administrator`, " +
 						"Owner` or custom azure roles assigned to your subscription to perform action " +
 						"'Microsoft.Authorization/roleAssignments/write', in order to manage role assignments\n"),
 					Err: err,
 				}
-
 			}
 
 			return retry.RetryableError(

--- a/cli/azd/pkg/tools/azcli/ad_test.go
+++ b/cli/azd/pkg/tools/azcli/ad_test.go
@@ -44,7 +44,7 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 	existingApplication := graphsdk.Application{
 		Id:          convert.RefOf("UNIQUE_ID"),
 		AppId:       &expectedServicePrincipalCredential.ClientId,
-		DisplayName: "MY_APP",
+		DisplayName: "APPLICATION_NAME",
 		PasswordCredentials: []*graphsdk.ApplicationPasswordCredential{
 			credential,
 		},
@@ -60,9 +60,9 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 	// Tests the use case for a brand new service principal
 	t.Run("NewServicePrincipal", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
+		mockgraphsdk.RegisterApplicationListMock(mockContext, http.StatusOK, []graphsdk.Application{})
 		mockgraphsdk.RegisterApplicationGetItemByAppIdMock(mockContext, http.StatusNotFound, "APPLICATION_NAME", nil)
 		mockgraphsdk.RegisterApplicationGetItemMock(mockContext, http.StatusNotFound, "APPLICATION_NAME", nil)
-		mockgraphsdk.RegisterApplicationListMock(mockContext, http.StatusOK, []graphsdk.Application{})
 		mockgraphsdk.RegisterServicePrincipalListMock(mockContext, http.StatusOK, []graphsdk.ServicePrincipal{})
 		mockgraphsdk.RegisterApplicationCreateItemMock(mockContext, http.StatusCreated, &newApplication)
 		mockgraphsdk.RegisterServicePrincipalCreateItemMock(mockContext, http.StatusCreated, &servicePrincipal)
@@ -87,9 +87,23 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 	// Tests the use case for updating an existing service principal
 	t.Run("ExistingServicePrincipal", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		mockgraphsdk.RegisterApplicationGetItemByAppIdMock(mockContext, http.StatusOK, existingApplication.DisplayName, &existingApplication)
-		mockgraphsdk.RegisterApplicationGetItemMock(mockContext, http.StatusOK, existingApplication.DisplayName, &existingApplication)
-		mockgraphsdk.RegisterApplicationListMock(mockContext, http.StatusOK, []graphsdk.Application{existingApplication})
+		mockgraphsdk.RegisterApplicationListMock(
+			mockContext,
+			http.StatusOK,
+			[]graphsdk.Application{existingApplication},
+		)
+		mockgraphsdk.RegisterApplicationGetItemByAppIdMock(
+			mockContext,
+			http.StatusOK,
+			existingApplication.DisplayName,
+			&existingApplication,
+		)
+		mockgraphsdk.RegisterApplicationGetItemMock(
+			mockContext,
+			http.StatusOK,
+			existingApplication.DisplayName,
+			&existingApplication,
+		)
 		mockgraphsdk.RegisterServicePrincipalListMock(
 			mockContext,
 			http.StatusOK,
@@ -118,6 +132,18 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 	t.Run("RoleAssignmentExists", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		mockgraphsdk.RegisterApplicationListMock(mockContext, http.StatusOK, []graphsdk.Application{existingApplication})
+		mockgraphsdk.RegisterApplicationGetItemByAppIdMock(
+			mockContext,
+			http.StatusOK,
+			existingApplication.DisplayName,
+			&existingApplication,
+		)
+		mockgraphsdk.RegisterApplicationGetItemMock(
+			mockContext,
+			http.StatusOK,
+			existingApplication.DisplayName,
+			&existingApplication,
+		)
 		mockgraphsdk.RegisterServicePrincipalListMock(
 			mockContext,
 			http.StatusOK,
@@ -146,6 +172,18 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 	t.Run("InvalidRole", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		mockgraphsdk.RegisterApplicationListMock(mockContext, http.StatusOK, []graphsdk.Application{})
+		mockgraphsdk.RegisterApplicationGetItemByAppIdMock(
+			mockContext,
+			http.StatusOK,
+			existingApplication.DisplayName,
+			&existingApplication,
+		)
+		mockgraphsdk.RegisterApplicationGetItemMock(
+			mockContext,
+			http.StatusOK,
+			existingApplication.DisplayName,
+			&existingApplication,
+		)
 		mockgraphsdk.RegisterServicePrincipalListMock(mockContext, http.StatusOK, []graphsdk.ServicePrincipal{})
 		mockgraphsdk.RegisterApplicationCreateItemMock(mockContext, http.StatusCreated, &newApplication)
 		mockgraphsdk.RegisterServicePrincipalCreateItemMock(mockContext, http.StatusCreated, &servicePrincipal)
@@ -168,6 +206,8 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 	t.Run("ErrorCreatingApplication", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		mockgraphsdk.RegisterApplicationListMock(mockContext, http.StatusOK, []graphsdk.Application{})
+		mockgraphsdk.RegisterApplicationGetItemByAppIdMock(mockContext, http.StatusNotFound, "APPLICATION_NAME", nil)
+		mockgraphsdk.RegisterApplicationGetItemMock(mockContext, http.StatusNotFound, "APPLICATION_NAME", nil)
 		mockgraphsdk.RegisterServicePrincipalListMock(mockContext, http.StatusOK, []graphsdk.ServicePrincipal{})
 		// Note that the application creation returns an unauthorized error
 		mockgraphsdk.RegisterApplicationCreateItemMock(mockContext, http.StatusUnauthorized, nil)

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -5,7 +5,6 @@ package azcli
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 
@@ -115,12 +114,6 @@ type AzCli interface {
 	// may be used by tools which understand the `AZURE_CREDENTIALS` format (i.e. the `sdk-auth` format). The service
 	// principal is assigned a given role. If an existing principal exists with the given name,
 	// it is updated in place and its credentials are reset.
-	CreateOrUpdateServicePrincipal(
-		ctx context.Context,
-		subscriptionId string,
-		applicationName string,
-		rolesToAssign []string,
-	) (json.RawMessage, error)
 	GetAppServiceProperties(
 		ctx context.Context,
 		subscriptionId string,

--- a/cli/azd/test/mocks/mockgraphsdk/mocks.go
+++ b/cli/azd/test/mocks/mockgraphsdk/mocks.go
@@ -48,7 +48,8 @@ func RegisterApplicationGetItemByAppIdMock(
 	application *graphsdk.Application,
 ) {
 	mockContext.HttpClient.When(func(request *http.Request) bool {
-		return request.Method == http.MethodGet && strings.Contains(request.URL.Path, fmt.Sprintf("/applications(appId='%s')", appId))
+		return request.Method == http.MethodGet &&
+			strings.Contains(request.URL.Path, fmt.Sprintf("/applications(appId='%s')", appId))
 	}).RespondFn(func(request *http.Request) (*http.Response, error) {
 		if application == nil {
 			return mocks.CreateEmptyHttpResponse(request, statusCode)

--- a/cli/azd/test/mocks/mockgraphsdk/mocks.go
+++ b/cli/azd/test/mocks/mockgraphsdk/mocks.go
@@ -41,6 +41,23 @@ func RegisterApplicationListMock(mockContext *mocks.MockContext, statusCode int,
 	})
 }
 
+func RegisterApplicationGetItemByAppIdMock(
+	mockContext *mocks.MockContext,
+	statusCode int,
+	appId string,
+	application *graphsdk.Application,
+) {
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && strings.Contains(request.URL.Path, fmt.Sprintf("/applications(appId='%s')", appId))
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		if application == nil {
+			return mocks.CreateEmptyHttpResponse(request, statusCode)
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, statusCode, application)
+	})
+}
+
 func RegisterApplicationGetItemMock(
 	mockContext *mocks.MockContext,
 	statusCode int,


### PR DESCRIPTION
Related to #2468 

Today every time a user runs `azd pipeline` config without any arguments a new service principal is created in Azure.  This causes the following issues:

1. Bloats number of service principals created in subscriptions
2. Unintended behavior and users would expect the same service principal to be used when available.

<img width="683" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/994fb6d3-1e8f-483f-9f45-f11bf50eb341">

## What Changes

This PR introduces caching the service principal application client id in the `azd` environment.  On subsequent run of `azd pipeline config` this same service principal will be reused instead of creating a new one.

- [x] New `--principal-id` param to specify the client-id of an existing service principal
- [x] New `AZURE_PIPELINE_CLIENT_ID` env var that can be set to lookup existing service principal
- [x] `AZURE_PIPELINE_CLIENT_ID` is now set in azd environment with new/updated service principal and used for lookups in subsequent calls

## What doesn't change

- When setting `--principal-name` `azd` will continue to create/update the specified service principal name
- When creating new `azd` environment and running `azd pipeline config` a new service principal will still be created

## Use Case: Update pipeline config for new branch

When developing using multiple features branches users will need to run `azd pipeline config` for each branch in order to updated federated credentials (when using GitHub provider).

Prior to this change, if a user ran `azd pipeline config` without a specified `--principal-name` parameter they would need to manually discover the principal name to use in future calls.

1. Login to azure portal
2. Navigate to app registrations
4. Find the auto generated service principal and have understanding of our default naming strategy
5. Click into service principal and copy the name

OR

1. Go to their github repo
2. Find the AZURE_CLIENT_ID variable
3. Manually look up service principal matching the client id and copy the service principal name

```bash
git checkout main
azd pipeline config # Creates initial service principal

git checkout -b dev # Create new dev branch
azd pipeline config # Updates existing service principal with federated credentials for new dev branch
```

### Other Improvements

- [x] Refactors and moves `AD` related funcs out of `AzCli` interface and into new `AdService` interface