### PR TITLE
`azd env refresh` - Support for BYOI

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -40,6 +40,7 @@ BOOLSLICE
 BUILDID
 BUILDNUMBER
 buildpacks
+byoi
 cflags
 circleci
 cmdsubst

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -412,8 +412,9 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 		return nil, fmt.Errorf("initializing provisioning manager: %w", err)
 	}
 
-	// If resource group is defined within the project but not in the environment then add it to the environment
-	// to support BYOI lookup scenarios like ADE
+	// If resource group is defined within the project but not in the environment then
+	// add it to the environment to support BYOI lookup scenarios like ADE
+	// Infra providers do not currently have access to project configuration
 	projectResourceGroup, _ := ef.projectConfig.ResourceGroupName.Envsubst(ef.env.Getenv)
 	if _, has := ef.env.LookupEnv(environment.ResourceGroupEnvVarName); !has && projectResourceGroup != "" {
 		ef.env.DotenvSet(environment.ResourceGroupEnvVarName, projectResourceGroup)

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -432,7 +432,7 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 
 	for key := range getStateResult.State.Outputs {
 		ef.console.MessageUxItem(ctx, &ux.DoneMessage{
-			Message: fmt.Sprintf("Setting environment value %s", key),
+			Message: fmt.Sprintf("Setting %s environment variable", key),
 		})
 	}
 

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -430,12 +430,6 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 		return nil, err
 	}
 
-	for key := range getStateResult.State.Outputs {
-		ef.console.MessageUxItem(ctx, &ux.DoneMessage{
-			Message: fmt.Sprintf("Setting %s environment variable", key),
-		})
-	}
-
 	if ef.formatter.Kind() == output.JsonFormat {
 		err = ef.formatter.Format(provisioning.NewEnvRefreshResultFromState(getStateResult.State), ef.writer, nil)
 		if err != nil {
@@ -460,7 +454,7 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
 			Header:   "Environment refresh completed",
-			FollowUp: fmt.Sprintf("View environment variables at %s", output.WithLinkFormat(ef.env.Path())),
+			FollowUp: fmt.Sprintf("View environment variables at %s", output.WithHyperlink(ef.env.Path(), ef.env.Path())),
 		},
 	}, nil
 }

--- a/cli/azd/cmd/provision.go
+++ b/cli/azd/cmd/provision.go
@@ -152,7 +152,7 @@ func (p *provisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 
 	if err != nil {
 		if p.formatter.Kind() == output.JsonFormat {
-			stateResult, err := p.provisionManager.State(ctx)
+			stateResult, err := p.provisionManager.State(ctx, nil)
 			if err != nil {
 				return nil, fmt.Errorf(
 					"deployment failed and the deployment result is unavailable: %w",
@@ -200,7 +200,7 @@ func (p *provisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 	}
 
 	if p.formatter.Kind() == output.JsonFormat {
-		stateResult, err := p.provisionManager.State(ctx)
+		stateResult, err := p.provisionManager.State(ctx, nil)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"deployment succeeded but the deployment result is unavailable: %w",

--- a/cli/azd/cmd/testdata/TestUsage-azd-env-refresh.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env-refresh.snap
@@ -8,6 +8,7 @@ Flags
         --docs               	: Opens the documentation for azd env refresh in your web browser.
     -e, --environment string 	: The name of the environment to use.
     -h, --help               	: Gets help for refresh.
+        --hint string        	: Hint to help identify the environment to refresh
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -278,7 +278,7 @@ func (e *Environment) Save() error {
 
 	marshalled = fixupUnquotedDotenv(e.dotenv, marshalled)
 
-	envFile, err := os.Create(filepath.Join(e.Root, azdcontext.DotEnvFileName))
+	envFile, err := os.Create(e.Path())
 	if err != nil {
 		return fmt.Errorf("saving .env: %w", err)
 	}
@@ -295,6 +295,10 @@ func (e *Environment) Save() error {
 
 	tracing.SetUsageAttributes(fields.StringHashed(fields.EnvNameKey, e.GetEnvName()))
 	return nil
+}
+
+func (e *Environment) Path() string {
+	return filepath.Join(e.Root, azdcontext.DotEnvFileName)
 }
 
 // GetEnvName is shorthand for Getenv(EnvNameEnvVarName)

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -201,8 +201,7 @@ func (e *Environment) DotenvSet(key string, value string) {
 // Reloads environment variables and configuration
 func (e *Environment) Reload() error {
 	// Reload env values
-	envPath := filepath.Join(e.Root, azdcontext.DotEnvFileName)
-	if envMap, err := godotenv.Read(envPath); errors.Is(err, os.ErrNotExist) {
+	if envMap, err := godotenv.Read(e.Path()); errors.Is(err, os.ErrNotExist) {
 		e.dotenv = make(map[string]string)
 		e.deletedKeys = make(map[string]struct{})
 	} else if err != nil {
@@ -213,9 +212,8 @@ func (e *Environment) Reload() error {
 	}
 
 	// Reload env config
-	cfgPath := filepath.Join(e.Root, azdcontext.ConfigFileName)
 	cfgMgr := config.NewManager()
-	if cfg, err := cfgMgr.Load(cfgPath); errors.Is(err, os.ErrNotExist) {
+	if cfg, err := cfgMgr.Load(e.ConfigPath()); errors.Is(err, os.ErrNotExist) {
 		e.Config = config.NewEmptyConfig()
 	} else if err != nil {
 		return fmt.Errorf("loading config: %w", err)
@@ -243,7 +241,7 @@ func (e *Environment) Save() error {
 
 	// Update configuration
 	cfgMgr := config.NewManager()
-	if err := cfgMgr.Save(e.Config, filepath.Join(e.Root, azdcontext.ConfigFileName)); err != nil {
+	if err := cfgMgr.Save(e.Config, e.ConfigPath()); err != nil {
 		return fmt.Errorf("saving config: %w", err)
 	}
 
@@ -299,6 +297,10 @@ func (e *Environment) Save() error {
 
 func (e *Environment) Path() string {
 	return filepath.Join(e.Root, azdcontext.DotEnvFileName)
+}
+
+func (e *Environment) ConfigPath() string {
+	return filepath.Join(e.Root, azdcontext.ConfigFileName)
 }
 
 // GetEnvName is shorthand for Getenv(EnvNameEnvVarName)

--- a/cli/azd/pkg/environment/environment_test.go
+++ b/cli/azd/pkg/environment/environment_test.go
@@ -202,3 +202,19 @@ func Test_fixupUnquotedDotenv(t *testing.T) {
 	fixed := fixupUnquotedDotenv(test, dotenv)
 	require.Equal(t, "TEST_SHOULD_NOT_QUOTE=1\nTEST_SHOULD_QUOTE=\"01\"", fixed)
 }
+
+func Test_Environment_Path(t *testing.T) {
+	root := t.TempDir()
+	env := EmptyWithRoot(root)
+
+	path := env.Path()
+	require.Equal(t, filepath.Join(root, azdcontext.DotEnvFileName), path)
+}
+
+func Test_Environment_ConfigPath(t *testing.T) {
+	root := t.TempDir()
+	env := EmptyWithRoot(root)
+
+	path := env.ConfigPath()
+	require.Equal(t, filepath.Join(root, azdcontext.ConfigFileName), path)
+}

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -456,9 +456,18 @@ func (p *BicepProvider) scopeForTemplate(ctx context.Context, t azure.ArmTemplat
 
 func (p *BicepProvider) inferScopeFromEnv(ctx context.Context) (infra.Scope, error) {
 	if resourceGroup, has := p.env.LookupEnv(environment.ResourceGroupEnvVarName); has {
-		return infra.NewResourceGroupScope(p.azCli, p.env.GetSubscriptionId(), resourceGroup), nil
+		return infra.NewResourceGroupScope(
+			p.deploymentsService,
+			p.deploymentOperations,
+			p.env.GetSubscriptionId(),
+			resourceGroup,
+		), nil
 	} else {
-		return infra.NewSubscriptionScope(p.azCli, p.env.GetSubscriptionId()), nil
+		return infra.NewSubscriptionScope(
+			p.deploymentsService,
+			p.deploymentOperations,
+			p.env.GetSubscriptionId(),
+		), nil
 	}
 }
 

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -188,9 +188,9 @@ func (p *BicepProvider) State(ctx context.Context, options *StateOptions) (*Stat
 		}
 
 		outputs = template.Outputs
-	} else {
-		// To support BYOI (bring your own infrastructure), we need to support the case where there template
-		// that exists within the project
+	} else if errors.Is(err, os.ErrNotExist) {
+		// To support BYOI (bring your own infrastructure)
+		// We need to support the case where there template does not contain an `infra` folder.
 		scope, scopeErr = p.inferScopeFromEnv(ctx)
 		if scopeErr != nil {
 			return nil, fmt.Errorf("computing deployment scope: %w", err)

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -156,6 +156,10 @@ func (p *BicepProvider) EnsureEnv(ctx context.Context) error {
 }
 
 func (p *BicepProvider) State(ctx context.Context, options *StateOptions) (*StateResult, error) {
+	if options == nil {
+		options = &StateOptions{}
+	}
+
 	var err error
 	spinnerMessage := "Loading Bicep template"
 	// TODO: Report progress, "Loading Bicep template"

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -118,7 +118,7 @@ func TestBicepState(t *testing.T) {
 
 	infraProvider := createBicepProvider(t, mockContext)
 
-	getDeploymentResult, err := infraProvider.State(*mockContext.Context)
+	getDeploymentResult, err := infraProvider.State(*mockContext.Context, nil)
 
 	require.Nil(t, err)
 	require.NotNil(t, getDeploymentResult.State)

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -42,8 +42,11 @@ func (m *Manager) Initialize(ctx context.Context, projectPath string, options Op
 }
 
 // Gets the latest deployment details for the specified scope
-func (m *Manager) State(ctx context.Context) (*StateResult, error) {
-	result, err := m.provider.State(ctx)
+func (m *Manager) State(ctx context.Context, options *StateOptions) (*StateResult, error) {
+	if options == nil {
+		options = &StateOptions{}
+	}
+	result, err := m.provider.State(ctx, options)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving state: %w", err)
 	}

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -43,9 +43,6 @@ func (m *Manager) Initialize(ctx context.Context, projectPath string, options Op
 
 // Gets the latest deployment details for the specified scope
 func (m *Manager) State(ctx context.Context, options *StateOptions) (*StateResult, error) {
-	if options == nil {
-		options = &StateOptions{}
-	}
 	result, err := m.provider.State(ctx, options)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving state: %w", err)

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -82,7 +82,7 @@ func TestManagerGetState(t *testing.T) {
 	err := mgr.Initialize(*mockContext.Context, "", Options{Provider: "test"})
 	require.NoError(t, err)
 
-	getResult, err := mgr.State(*mockContext.Context)
+	getResult, err := mgr.State(*mockContext.Context, nil)
 
 	require.NotNil(t, getResult)
 	require.Nil(t, err)

--- a/cli/azd/pkg/infra/provisioning/options.go
+++ b/cli/azd/pkg/infra/provisioning/options.go
@@ -36,6 +36,21 @@ type DestroyOptions struct {
 	purge bool
 }
 
+type StateOptions struct {
+	// A value used to lookup the state of a specific deployment
+	hint string
+}
+
+func NewStateOptions(hint string) *StateOptions {
+	return &StateOptions{
+		hint: hint,
+	}
+}
+
+func (o *StateOptions) Hint() string {
+	return o.hint
+}
+
 func (o *DestroyOptions) Purge() bool {
 	return o.purge
 }

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -45,7 +45,7 @@ type StateResult struct {
 type Provider interface {
 	Name() string
 	Initialize(ctx context.Context, projectPath string, options Options) error
-	State(ctx context.Context) (*StateResult, error)
+	State(ctx context.Context, options *StateOptions) (*StateResult, error)
 	Deploy(ctx context.Context) (*DeployResult, error)
 	Preview(ctx context.Context) (*DeployPreviewResult, error)
 	Destroy(ctx context.Context, options DestroyOptions) (*DestroyResult, error)

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -254,7 +254,7 @@ func (t *TerraformProvider) Destroy(ctx context.Context, options DestroyOptions)
 	}, nil
 }
 
-func (t *TerraformProvider) State(ctx context.Context) (*StateResult, error) {
+func (t *TerraformProvider) State(ctx context.Context, options *StateOptions) (*StateResult, error) {
 	isRemoteBackendConfig, err := t.isRemoteBackendConfig()
 	if err != nil {
 		return nil, fmt.Errorf("reading backend config: %w", err)

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
@@ -79,7 +79,7 @@ func TestTerraformState(t *testing.T) {
 	prepareShowMocks(mockContext.CommandRunner)
 
 	infraProvider := createTerraformProvider(t, mockContext)
-	getStateResult, err := infraProvider.State(*mockContext.Context)
+	getStateResult, err := infraProvider.State(*mockContext.Context, nil)
 
 	require.Nil(t, err)
 	require.NotNil(t, getStateResult.State)

--- a/cli/azd/pkg/infra/provisioning/test/test_provider.go
+++ b/cli/azd/pkg/infra/provisioning/test/test_provider.go
@@ -50,7 +50,7 @@ func (t *TestProvider) EnsureEnv(ctx context.Context) error {
 	return EnsureSubscriptionAndLocation(ctx, t.env, t.prompters)
 }
 
-func (p *TestProvider) State(ctx context.Context) (*StateResult, error) {
+func (p *TestProvider) State(ctx context.Context, options *StateOptions) (*StateResult, error) {
 	// TODO: progress, "Looking up deployment"
 
 	state := State{

--- a/cli/azd/pkg/infra/scope.go
+++ b/cli/azd/pkg/infra/scope.go
@@ -24,8 +24,10 @@ type Deployment interface {
 	Scope
 	// Name is the name of this deployment.
 	Name() string
-	// PortalUrl is the URL that may be used to view this deployment in Azure Portal.
+	// PortalUrl is the URL that may be used to view this deployment in the Azure Portal.
 	PortalUrl() string
+	// OutputsUrl is the URL that may be used to view this deployment outputs the in Azure Portal.
+	OutputsUrl() string
 	// Deploy a given template with a set of parameters.
 	Deploy(
 		ctx context.Context,
@@ -97,6 +99,13 @@ func (s *ResourceGroupDeployment) PortalUrl() string {
 		url.PathEscape(azure.ResourceGroupDeploymentRID(s.subscriptionId, s.resourceGroupName, s.name)))
 }
 
+// Gets the url to view deployment outputs
+func (s *ResourceGroupDeployment) OutputsUrl() string {
+	return fmt.Sprintf("%s/%s",
+		cOutputsUrlPrefix,
+		url.PathEscape(azure.ResourceGroupDeploymentRID(s.subscriptionId, s.resourceGroupName, s.name)))
+}
+
 func NewResourceGroupDeployment(
 	deploymentsService azapi.Deployments,
 	deploymentOperations azapi.DeploymentOperations,
@@ -145,7 +154,8 @@ func (s *ResourceGroupScope) ListDeployments(ctx context.Context) ([]*armresourc
 
 // cPortalUrlPrefix is the prefix which can be combined with the RID of a deployment to produce a URL into the Azure Portal
 // that shows information about the deployment.
-const cPortalUrlPrefix = "https://portal.azure.com/#blade/HubsExtension/DeploymentDetailsBlade/overview/id"
+const cPortalUrlPrefix = "https://portal.azure.com/#view/HubsExtension/DeploymentDetailsBlade/~/overview/id"
+const cOutputsUrlPrefix = "https://portal.azure.com/#view/HubsExtension/DeploymentDetailsBlade/~/outputs/id"
 
 type SubscriptionDeployment struct {
 	*SubscriptionScope
@@ -166,6 +176,13 @@ func (s *SubscriptionDeployment) SubscriptionId() string {
 func (s *SubscriptionDeployment) PortalUrl() string {
 	return fmt.Sprintf("%s/%s",
 		cPortalUrlPrefix,
+		url.PathEscape(azure.SubscriptionDeploymentRID(s.subscriptionId, s.name)))
+}
+
+// Gets the url to view deployment outputs
+func (s *SubscriptionDeployment) OutputsUrl() string {
+	return fmt.Sprintf("%s/%s",
+		cOutputsUrlPrefix,
 		url.PathEscape(azure.SubscriptionDeploymentRID(s.subscriptionId, s.name)))
 }
 

--- a/cli/azd/pkg/output/colors.go
+++ b/cli/azd/pkg/output/colors.go
@@ -1,6 +1,8 @@
 package output
 
 import (
+	"fmt"
+
 	"github.com/fatih/color"
 )
 
@@ -43,4 +45,9 @@ func WithUnderline(text string, a ...interface{}) string {
 // WithBackticks wraps text with the backtick (`) character.
 func WithBackticks(text string) string {
 	return "`" + text + "`"
+}
+
+// WithHyperlink wraps text with the colored hyperlink format escape sequence.
+func WithHyperlink(url string, text string) string {
+	return WithLinkFormat(fmt.Sprintf("\033]8;;%s\007%s\033]8;;\007", url, text))
 }


### PR DESCRIPTION
Adds support to use AZD with projects where the underlying Azure infrastructure was provisioned outside of `azd`.

## What's New?
- [x] Adds new `--hint` param to provide a hint for the Azure deployment to use to refresh the environment
  - Supports both subscription and resource group scoped Bicep deployments
- [x] `infra` folder no longer required when using external infrastructure provider (ex. ADE)
- [x] Enhanced UX experience  

## Only one matching deployment found
Use the matching deployment without confirmation. Display the matching deployment with highlight color

<img width="542" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/41c505c6-655d-4c8c-bd7e-a6a14dff66be">

## Multiple matching deployments found
Prompt the user with a list of matching deployments including the name and timestamp of the deployment

<img width="416" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/efdc461c-c6c9-42b7-8e70-6d829943d6b6">

**After Selection**
Display selected deployment and actions performed

<img width="570" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/3dd734c1-500a-4d63-a7e4-0d36c6f74030">

@Austinauth Please let me know if you have any feedback on the updated UX.

## Use Case - Infrastructure provisioned by DevCenter environments (ADE)
Devs were not able to link infra to `azd` when infrastructure is provisioned by DevCenter environments.  `azd env refresh` would fail because the deployment was not matched by the default lookup strategy.

Now a dev can run the following after provisioning infrastructure with ADE:
```bash
azd env set AZURE_RESOURCE_GROUP <RESOURCE_GROUP_NAME> # Name of the resource group provisioned by ADE
azd env refresh --hint <ADE_PROJECT_NAME> # Partial name of the ADE project created
```
 
This will allow for a partial name match to help find and link the ADE resource group deployment to `azd` to support deploy scenarios.