### PR TITLE
WIP: Support fetching credentials from an external process

### DIFF
--- a/cli/azd/cmd/auth_login.go
+++ b/cli/azd/cmd/auth_login.go
@@ -456,20 +456,30 @@ func (la *loginAction) login(ctx context.Context) error {
 		return nil
 	}
 
-	useDevCode, err := parseUseDeviceCode(ctx, la.flags.useDeviceCode, la.commandRunner)
-	if err != nil {
-		return err
-	}
-
-	if useDevCode {
-		_, err := la.authManager.LoginWithDeviceCode(ctx, la.flags.tenantID, la.flags.scopes)
-		if err != nil {
-			return fmt.Errorf("logging in: %w", err)
+	if la.authManager.UseExternalAuth() {
+		// Request a token and assume the external auth system will prompt the user to log in.
+		//
+		// TODO(ellismg): We may want instead to call some explicit `/login` endpoint on the external auth system instead
+		// of abusing the token request in this manner. This would allow the other end to provide a more tailored experience.
+		if _, err := la.verifyLoggedIn(ctx); err != nil {
+			return err
 		}
 	} else {
-		_, err := la.authManager.LoginInteractive(ctx, la.flags.redirectPort, la.flags.tenantID, la.flags.scopes)
+		useDevCode, err := parseUseDeviceCode(ctx, la.flags.useDeviceCode, la.commandRunner)
 		if err != nil {
-			return fmt.Errorf("logging in: %w", err)
+			return err
+		}
+
+		if useDevCode {
+			_, err := la.authManager.LoginWithDeviceCode(ctx, la.flags.tenantID, la.flags.scopes)
+			if err != nil {
+				return fmt.Errorf("logging in: %w", err)
+			}
+		} else {
+			_, err := la.authManager.LoginInteractive(ctx, la.flags.redirectPort, la.flags.tenantID, la.flags.scopes)
+			if err != nil {
+				return fmt.Errorf("logging in: %w", err)
+			}
 		}
 	}
 

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -641,6 +641,13 @@ func (m *Manager) Logout(ctx context.Context) error {
 	return nil
 }
 
+func (m *Manager) UseExternalAuth() bool {
+	_, hasEndpoint := os.LookupEnv(cExternalAuthEndpointEnvVarName)
+	_, hasKey := os.LookupEnv(cExternalAuthKeyEnvVarName)
+
+	return hasEndpoint && hasKey
+}
+
 func (m *Manager) saveLoginForPublicClient(res public.AuthResult) error {
 	if err := m.saveUserProperties(&userProperties{HomeAccountID: &res.Account.HomeAccountID}); err != nil {
 		return err

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -55,6 +55,9 @@ const cDefaultAuthority = "https://login.microsoftonline.com/organizations"
 
 const cUseCloudShellAuthEnvVar = "AZD_IN_CLOUDSHELL"
 
+const cExternalAuthEndpointEnvVarName = "AZD_AUTH_ENDPOINT"
+const cExternalAuthKeyEnvVarName = "AZD_AUTH_KEY"
+
 // The scopes to request when acquiring our token during the login flow or when requesting a token to validate if the client
 // is logged in.
 var LoginScopes = []string{azure.ManagementScope}
@@ -167,6 +170,14 @@ func (m *Manager) CredentialForCurrentUser(
 
 	if options == nil {
 		options = &CredentialForCurrentUserOptions{}
+	}
+
+	if endpoint, hasEndpoint := os.LookupEnv(cExternalAuthEndpointEnvVarName); hasEndpoint {
+		if key, hasKey := os.LookupEnv(cExternalAuthKeyEnvVarName); hasKey {
+			log.Printf("delegating auth to external process since %s and %s are set",
+				cExternalAuthEndpointEnvVarName, cExternalAuthKeyEnvVarName)
+			return newRemoteCredential(endpoint, key, options.TenantID, m.httpClient), nil
+		}
 	}
 
 	userConfig, err := m.userConfigManager.Load()
@@ -287,6 +298,14 @@ func ShouldUseCloudShellAuth() bool {
 // This can be used to determine if the tenant is fixed, and if so short circuit performance intensive tenant-switching
 // for service principals.
 func (m *Manager) GetLoggedInServicePrincipalTenantID(ctx context.Context) (*string, error) {
+
+	if _, hasEndpoint := os.LookupEnv(cExternalAuthEndpointEnvVarName); hasEndpoint {
+		if _, hasKey := os.LookupEnv(cExternalAuthKeyEnvVarName); hasKey {
+			// When delegating to an external system, we have no way to determine what principal was used
+			return nil, nil
+		}
+	}
+
 	cfg, err := m.userConfigManager.Load()
 	if err != nil {
 		return nil, fmt.Errorf("fetching current user: %w", err)

--- a/cli/azd/pkg/auth/remote_credential.go
+++ b/cli/azd/pkg/auth/remote_credential.go
@@ -1,0 +1,101 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
+)
+
+// RemoteCredential implements azcore.TokenCredential by using the remote credential protocol.
+type RemoteCredential struct {
+	// The endpoint of the remote endpoint to authenticate against.
+	endpoint string
+	// The key to use to authenticate against the remote endpoint.
+	key string
+	// Tenant ID to use to authenticate, instead of the default. Optional.
+	tenantID string
+	// The HTTP client to use to make requests.
+	httpClient httputil.HttpClient
+}
+
+func newRemoteCredential(endpoint, key, tenantID string, httpClient httputil.HttpClient) *RemoteCredential {
+	return &RemoteCredential{
+		endpoint:   endpoint,
+		key:        key,
+		tenantID:   tenantID,
+		httpClient: httpClient,
+	}
+}
+
+// GetToken implements azcore.TokenCredential.
+func (rc *RemoteCredential) GetToken(ctx context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	tenantID := rc.tenantID
+	if options.TenantID != "" {
+		tenantID = options.TenantID
+	}
+
+	body, _ := json.Marshal(struct {
+		Scopes   []string `json:"scopes"`
+		TenantId string   `json:"tenantId,omitempty"`
+	}{
+		Scopes:   options.Scopes,
+		TenantId: tenantID,
+	})
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		fmt.Sprintf("%s/token?api-version=2023-07-12-preview", rc.endpoint),
+		bytes.NewReader(body))
+	if err != nil {
+		return azcore.AccessToken{}, fmt.Errorf("building request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", rc.key))
+
+	res, err := rc.httpClient.Do(req)
+	if err != nil {
+		return azcore.AccessToken{}, fmt.Errorf("making request: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return azcore.AccessToken{}, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+
+	var tokenResp struct {
+		Status string `json:"status"`
+
+		// These fields are set when status is "success"
+		Token     *string    `json:"token,omitempty"`
+		ExpiresOn *time.Time `json:"expiresOn,omitempty"`
+
+		// These fields are set when the status "error"
+		Code    *string `json:"code,omitempty"`
+		Message *string `json:"message,omitempty"`
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(&tokenResp); err != nil {
+		return azcore.AccessToken{}, fmt.Errorf("unmarshalling response: %w", err)
+	}
+
+	if tokenResp.Status != "success" {
+		return azcore.AccessToken{}, fmt.Errorf("RemoteCredential: failed to acquire token: code: %s message: %s",
+			*tokenResp.Code,
+			*tokenResp.Message)
+	}
+
+	return azcore.AccessToken{
+		Token:     *tokenResp.Token,
+		ExpiresOn: *tokenResp.ExpiresOn,
+	}, nil
+}
+
+var _ = azcore.TokenCredential(&RemoteCredential{})

--- a/cli/azd/test/functional/auth_test.go
+++ b/cli/azd/test/functional/auth_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cli_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/azure/azure-dev/cli/azd/test/azdcli"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_CLI_Auth_ExternalAuth(t *testing.T) {
+	// running this test in parallel is ok as it uses a t.TempDir()
+	t.Parallel()
+	ctx, cancel := newTestContext(t)
+	defer cancel()
+
+	dir := tempDirWithDiagnostics(t)
+	t.Logf("DIR: %s", dir)
+
+	cli := azdcli.NewCLI(t)
+	cli.WorkingDirectory = dir
+
+	// We spin up a small server here to serve a fixed response to the auth request, and
+	// then observe the returned key from `azd auth token --output=json` to ensure it matches
+	// what we handed back.
+
+	// nolint:gosec
+	expectedToken := "THIS-IS-A-FAKE-TOKEN"
+	expectedExpiresOn := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		if r.URL.Path != "/token" {
+			http.Error(w, "Not found", http.StatusNotFound)
+			return
+		}
+
+		if r.URL.Query().Get("api-version") != "2023-07-12-preview" {
+			http.Error(w, "Bad request", http.StatusBadRequest)
+			return
+		}
+
+		authHeader := r.Header.Get("Authorization")
+		if authHeader != "Bearer a-fake-key" {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		type tokenResponse struct {
+			Status    string `json:"status"`
+			Token     string `json:"token"`
+			ExpiresOn string `json:"expiresOn"`
+		}
+
+		response := tokenResponse{
+			Status:    "success",
+			Token:     expectedToken,
+			ExpiresOn: expectedExpiresOn,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(response)
+		assert.NoError(t, err)
+	}))
+
+	defer server.Close()
+
+	cli.Env = append(os.Environ(),
+		fmt.Sprintf("AZD_AUTH_ENDPOINT=%s", server.URL),
+		fmt.Sprintf("AZD_AUTH_KEY=%s", "a-fake-key"),
+	)
+
+	res, err := cli.RunCommand(ctx, "auth", "token", "--output=json")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, res.ExitCode)
+
+	var token struct {
+		Token     string `json:"token"`
+		ExpiresOn string `json:"expiresOn"`
+	}
+
+	err = json.Unmarshal([]byte(res.Stdout), &token)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedToken, token.Token)
+	assert.Equal(t, expectedExpiresOn, token.ExpiresOn)
+}

--- a/ext/vscode/.vscode/cspell-dictionary.txt
+++ b/ext/vscode/.vscode/cspell-dictionary.txt
@@ -1,4 +1,5 @@
 azuretools
+azureauth
 pseudoterminal
 randomizer
 hostapi

--- a/ext/vscode/package-lock.json
+++ b/ext/vscode/package-lock.json
@@ -18,6 +18,7 @@
                 "yaml": "~2"
             },
             "devDependencies": {
+                "@azure/core-auth": "^1.4",
                 "@types/chai": "~4",
                 "@types/glob": "~7",
                 "@types/mocha": "~10",
@@ -43,13 +44,29 @@
                 "vscode": "^1.76.0"
             }
         },
-        "node_modules/@aashutoshrathi/word-wrap": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+        "node_modules/@azure/abort-controller": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+            "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
             "dev": true,
+            "dependencies": {
+                "tslib": "^2.2.0"
+            },
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@azure/core-auth": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.4.0.tgz",
+            "integrity": "sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==",
+            "dev": true,
+            "dependencies": {
+                "@azure/abort-controller": "^1.0.0",
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/@azure/ms-rest-azure-env": {
@@ -92,14 +109,14 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
-            "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
+            "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.6.0",
+                "espree": "^9.4.0",
                 "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
@@ -114,27 +131,28 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/@eslint/js": {
-            "version": "8.44.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
-            "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.10",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-            "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+            "version": "0.10.7",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
+            "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
             "dev": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.1",
                 "debug": "^4.1.1",
-                "minimatch": "^3.0.5"
+                "minimatch": "^3.0.4"
             },
             "engines": {
                 "node": ">=10.10.0"
+            }
+        },
+        "node_modules/@humanwhocodes/gitignore-to-minimatch": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
+            "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
+            "dev": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -189,9 +207,9 @@
             }
         },
         "node_modules/@jridgewell/source-map": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
-            "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
+            "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.0",
@@ -215,29 +233,29 @@
             }
         },
         "node_modules/@microsoft/1ds-core-js": {
-            "version": "3.2.12",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.12.tgz",
-            "integrity": "sha512-cHpxZZ+pbtOyqFMFB/c1COpaOE3VPFU6phYVHVvOA9DvoeMZfI/Xrxaj7B/vfq4MmkiE7nOAPhv5ZRn+i6OogA==",
+            "version": "3.2.10",
+            "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.10.tgz",
+            "integrity": "sha512-fYzgrVuAK6HH66QJq5gyB+hmql2OTWwvP2520B7vM/idl8+O0yV9/PPTuwTpCWzGcksq5X3LaUX2MugzaRHLHA==",
             "dependencies": {
-                "@microsoft/applicationinsights-core-js": "2.8.14",
+                "@microsoft/applicationinsights-core-js": "2.8.12",
                 "@microsoft/applicationinsights-shims": "^2.0.2",
                 "@microsoft/dynamicproto-js": "^1.1.7"
             }
         },
         "node_modules/@microsoft/1ds-post-js": {
-            "version": "3.2.12",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.12.tgz",
-            "integrity": "sha512-vhIVYg4FzBfwtM8tBqDUq3xU+cFu6SQ7biuJHtQpd5PVjDgvAovVOMRF1khsZE/k2rttRRBpmBgNEqG3Ptoysw==",
+            "version": "3.2.10",
+            "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.10.tgz",
+            "integrity": "sha512-/yUdt1wUQpB0jM3LGwgrkSX2TLc3geHj4RflYYmW20uHN9XDqjSQfPiTm5m1sMcISz7OdQQd/PeqYnybkBOMfQ==",
             "dependencies": {
-                "@microsoft/1ds-core-js": "3.2.12",
+                "@microsoft/1ds-core-js": "3.2.10",
                 "@microsoft/applicationinsights-shims": "^2.0.2",
                 "@microsoft/dynamicproto-js": "^1.1.7"
             }
         },
         "node_modules/@microsoft/applicationinsights-core-js": {
-            "version": "2.8.14",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.14.tgz",
-            "integrity": "sha512-XacWUHdjSHMUwdngMZBp0oiCBifD56CQK2Egu2PiBiF4xu2AO2yNCtWSXsQX2g5OkEhVwaEjfa/aH3WbpYxB1g==",
+            "version": "2.8.12",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.12.tgz",
+            "integrity": "sha512-lA4epwWPBJ4awx07QQVCkoxygsl0qiTNoSYaR63hRE56ybu4kpp3tpYo/AfOI1DZMgKB8H0EwDz4vVmzUT3p/A==",
             "dependencies": {
                 "@microsoft/applicationinsights-shims": "2.0.2",
                 "@microsoft/dynamicproto-js": "^1.1.9"
@@ -257,9 +275,9 @@
             "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.0.1.tgz",
-            "integrity": "sha512-T8PMZPHOpQl86lqpY9ngnAAg99O+vTBWQYJkXzxRzpHqIuF2ecaTAnN2+F/Xev3/O0BoGbMjXMva9rzJ+l+GxQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.0.0.tgz",
+            "integrity": "sha512-I75IMSo1CvrF8J7S/RoHrvl4yQRWufvFGHSdlGfjBPdYFJ7O9J5hjeDCmv9/WIa8+qbSUmFPPyNZIXibbplSUQ==",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.0.4",
                 "@vscode/extension-telemetry": "^0.6.2",
@@ -276,12 +294,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azureresources-api": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-2.1.0.tgz",
-            "integrity": "sha512-dqjLyHl0OJgnjEtMtZEDvA9YovszWnE2k3ktEcHiTHWZ62luYrhOQhMzJjGArSFH3ANRCWgS6A1q4OTjZoBrKQ==",
-            "peerDependencies": {
-                "@azure/ms-rest-azure-env": "^2.0.0"
-            }
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-2.0.4.tgz",
+            "integrity": "sha512-LridV1h2rCydrBzEpwy+pUIUx61GpZNwrK04G7LdlhoxHrzuM/WAoy8jXaSC/FSKSsXD1QXuE6u/YofEfsuKeg=="
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -366,9 +381,9 @@
             "dev": true
         },
         "node_modules/@types/eslint": {
-            "version": "8.44.0",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.0.tgz",
-            "integrity": "sha512-gsF+c/0XOguWgaOgvFs+xnnRqt9GwgTvIks36WpE6ueeI4KCEHHd8K/CKHqhOqrJKsYH8m27kRzQEvWXAwXUTw==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.37.0.tgz",
+            "integrity": "sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -386,9 +401,9 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-            "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+            "version": "0.0.51",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
             "dev": true
         },
         "node_modules/@types/glob": {
@@ -402,9 +417,9 @@
             }
         },
         "node_modules/@types/json-schema": {
-            "version": "7.0.12",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-            "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+            "version": "7.0.11",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
             "dev": true
         },
         "node_modules/@types/minimatch": {
@@ -420,15 +435,15 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "16.18.38",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.38.tgz",
-            "integrity": "sha512-6sfo1qTulpVbkxECP+AVrHV9OoJqhzCsfTNp5NIG+enM4HyM3HvZCO798WShIXBN0+QtDIcutJCjsVYnQP5rIQ==",
+            "version": "16.18.25",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
+            "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==",
             "dev": true
         },
         "node_modules/@types/semver": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-            "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+            "version": "7.3.13",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+            "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
             "dev": true
         },
         "node_modules/@types/vscode": {
@@ -642,9 +657,9 @@
             }
         },
         "node_modules/@vscode/test-electron": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.3.tgz",
-            "integrity": "sha512-hgXCkDP0ibboF1K6seqQYyHAzCURgTwHS/6QU7slhwznDLwsRwg9bhfw1CZdyUEw8vvCmlrKWnd7BlQnI0BC4w==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.0.tgz",
+            "integrity": "sha512-fwzA9RtazH1GT/sckYlbxu6t5e4VaMXwCVtyLv4UAG0hP6NTfnMaaG25XCfWqlVwFhBMcQXHBCy5dmz2eLUnkw==",
             "dev": true,
             "dependencies": {
                 "http-proxy-agent": "^4.0.1",
@@ -714,157 +729,157 @@
             }
         },
         "node_modules/@vscode/vsce/node_modules/semver": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver"
             }
         },
         "node_modules/@webassemblyjs/ast": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
-            "integrity": "sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+            "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/helper-numbers": "1.11.6",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+                "@webassemblyjs/helper-numbers": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
             }
         },
         "node_modules/@webassemblyjs/floating-point-hex-parser": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
-            "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
             "dev": true
         },
         "node_modules/@webassemblyjs/helper-api-error": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
-            "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
             "dev": true
         },
         "node_modules/@webassemblyjs/helper-buffer": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz",
-            "integrity": "sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
             "dev": true
         },
         "node_modules/@webassemblyjs/helper-numbers": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
-            "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+            "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/floating-point-hex-parser": "1.11.6",
-                "@webassemblyjs/helper-api-error": "1.11.6",
+                "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
-            "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
             "dev": true
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz",
-            "integrity": "sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+            "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.6",
-                "@webassemblyjs/helper-buffer": "1.11.6",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-                "@webassemblyjs/wasm-gen": "1.11.6"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1"
             }
         },
         "node_modules/@webassemblyjs/ieee754": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
-            "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+            "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
             "dev": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
         },
         "node_modules/@webassemblyjs/leb128": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
-            "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+            "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
             "dev": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@webassemblyjs/utf8": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
-            "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
             "dev": true
         },
         "node_modules/@webassemblyjs/wasm-edit": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz",
-            "integrity": "sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+            "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.6",
-                "@webassemblyjs/helper-buffer": "1.11.6",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-                "@webassemblyjs/helper-wasm-section": "1.11.6",
-                "@webassemblyjs/wasm-gen": "1.11.6",
-                "@webassemblyjs/wasm-opt": "1.11.6",
-                "@webassemblyjs/wasm-parser": "1.11.6",
-                "@webassemblyjs/wast-printer": "1.11.6"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/helper-wasm-section": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-opt": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "@webassemblyjs/wast-printer": "1.11.1"
             }
         },
         "node_modules/@webassemblyjs/wasm-gen": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz",
-            "integrity": "sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+            "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.6",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-                "@webassemblyjs/ieee754": "1.11.6",
-                "@webassemblyjs/leb128": "1.11.6",
-                "@webassemblyjs/utf8": "1.11.6"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
             }
         },
         "node_modules/@webassemblyjs/wasm-opt": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz",
-            "integrity": "sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+            "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.6",
-                "@webassemblyjs/helper-buffer": "1.11.6",
-                "@webassemblyjs/wasm-gen": "1.11.6",
-                "@webassemblyjs/wasm-parser": "1.11.6"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1"
             }
         },
         "node_modules/@webassemblyjs/wasm-parser": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz",
-            "integrity": "sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+            "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.6",
-                "@webassemblyjs/helper-api-error": "1.11.6",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-                "@webassemblyjs/ieee754": "1.11.6",
-                "@webassemblyjs/leb128": "1.11.6",
-                "@webassemblyjs/utf8": "1.11.6"
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
             }
         },
         "node_modules/@webassemblyjs/wast-printer": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz",
-            "integrity": "sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+            "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.6",
+                "@webassemblyjs/ast": "1.11.1",
                 "@xtuc/long": "4.2.2"
             }
         },
@@ -925,9 +940,9 @@
             "dev": true
         },
         "node_modules/acorn": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-            "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+            "version": "8.8.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+            "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -937,9 +952,9 @@
             }
         },
         "node_modules/acorn-import-assertions": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-            "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+            "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
             "dev": true,
             "peerDependencies": {
                 "acorn": "^8"
@@ -1192,9 +1207,9 @@
             "dev": true
         },
         "node_modules/browserslist": {
-            "version": "4.21.9",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-            "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+            "version": "4.21.5",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+            "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
             "dev": true,
             "funding": [
                 {
@@ -1204,17 +1219,13 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/browserslist"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001503",
-                "electron-to-chromium": "^1.4.431",
-                "node-releases": "^2.0.12",
-                "update-browserslist-db": "^1.0.11"
+                "caniuse-lite": "^1.0.30001449",
+                "electron-to-chromium": "^1.4.284",
+                "node-releases": "^2.0.8",
+                "update-browserslist-db": "^1.0.10"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -1298,9 +1309,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001515",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
-            "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
+            "version": "1.0.30001481",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
+            "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==",
             "dev": true,
             "funding": [
                 {
@@ -1471,76 +1482,6 @@
                 "wrap-ansi": "^7.0.0"
             }
         },
-        "node_modules/cliui/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/cliui/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/cliui/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/cliui/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
-        },
-        "node_modules/cliui/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
         "node_modules/clone-deep": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -1640,9 +1581,9 @@
             }
         },
         "node_modules/dayjs": {
-            "version": "1.11.9",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
-            "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA=="
+            "version": "1.11.7",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+            "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
         },
         "node_modules/debug": {
             "version": "4.3.4",
@@ -1828,14 +1769,11 @@
             }
         },
         "node_modules/dotenv": {
-            "version": "16.3.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-            "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+            "version": "16.0.3",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+            "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
             "engines": {
                 "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/motdotla/dotenv?sponsor=1"
             }
         },
         "node_modules/duplexer": {
@@ -1845,9 +1783,15 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.459",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.459.tgz",
-            "integrity": "sha512-XXRS5NFv8nCrBL74Rm3qhJjA2VCsRFx0OjHKBMPI0otij56aun8UWiKTDABmd5/7GTR021pA4wivs+Ri6XCElg==",
+            "version": "1.4.378",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.378.tgz",
+            "integrity": "sha512-RfCD26kGStl6+XalfX3DGgt3z2DNwJS5DKRHCpkPq5T/PqpZMPB1moSRXuK9xhkt/sF57LlpzJgNoYl7mO7Z6w==",
+            "dev": true
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
         },
         "node_modules/emojis-list": {
@@ -1870,9 +1814,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.15.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
-            "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
+            "version": "5.13.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.13.0.tgz",
+            "integrity": "sha512-eyV8f0y1+bzyfh8xAwW/WTSZpLbjhqc4ne9eGSH4Zo2ejdyiNG9pU6mf9DG8a7+Auk6MFTlNOT4Y2y/9k8GKVg==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -1907,9 +1851,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
-            "integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
             "dev": true
         },
         "node_modules/escalade": {
@@ -1930,47 +1874,47 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.44.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
-            "integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
+            "version": "8.23.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
+            "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
             "dev": true,
             "dependencies": {
-                "@eslint-community/eslint-utils": "^4.2.0",
-                "@eslint-community/regexpp": "^4.4.0",
-                "@eslint/eslintrc": "^2.1.0",
-                "@eslint/js": "8.44.0",
-                "@humanwhocodes/config-array": "^0.11.10",
+                "@eslint/eslintrc": "^1.3.2",
+                "@humanwhocodes/config-array": "^0.10.4",
+                "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
                 "@humanwhocodes/module-importer": "^1.0.1",
-                "@nodelib/fs.walk": "^1.2.8",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.3.2",
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.2.0",
-                "eslint-visitor-keys": "^3.4.1",
-                "espree": "^9.6.0",
-                "esquery": "^1.4.2",
+                "eslint-scope": "^7.1.1",
+                "eslint-utils": "^3.0.0",
+                "eslint-visitor-keys": "^3.3.0",
+                "espree": "^9.4.0",
+                "esquery": "^1.4.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
                 "find-up": "^5.0.0",
-                "glob-parent": "^6.0.2",
-                "globals": "^13.19.0",
-                "graphemer": "^1.4.0",
+                "glob-parent": "^6.0.1",
+                "globals": "^13.15.0",
+                "globby": "^11.1.0",
+                "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
-                "is-path-inside": "^3.0.3",
+                "js-sdsl": "^4.1.4",
                 "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.9.3",
+                "optionator": "^0.9.1",
+                "regexpp": "^3.2.0",
                 "strip-ansi": "^6.0.1",
                 "strip-json-comments": "^3.1.0",
                 "text-table": "^0.2.0"
@@ -1996,6 +1940,33 @@
             },
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/eslint-utils": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+            "dev": true,
+            "dependencies": {
+                "eslint-visitor-keys": "^2.0.0"
+            },
+            "engines": {
+                "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mysticatea"
+            },
+            "peerDependencies": {
+                "eslint": ">=5"
+            }
+        },
+        "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/eslint-visitor-keys": {
@@ -2118,14 +2089,14 @@
             }
         },
         "node_modules/espree": {
-            "version": "9.6.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-            "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
+            "version": "9.5.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
+            "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
             "dev": true,
             "dependencies": {
-                "acorn": "^8.9.0",
+                "acorn": "^8.8.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.4.1"
+                "eslint-visitor-keys": "^3.4.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2220,9 +2191,9 @@
             "dev": true
         },
         "node_modules/fast-glob": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-            "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+            "version": "3.2.12",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+            "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
             "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -2425,14 +2396,13 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-            "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+            "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
             "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
-                "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3"
             },
             "funding": {
@@ -2447,9 +2417,9 @@
             "optional": true
         },
         "node_modules/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+            "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
             "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -2591,18 +2561,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/has-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/has-symbols": {
@@ -2943,15 +2901,6 @@
                 "node": ">=0.12.0"
             }
         },
-        "node_modules/is-path-inside": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/is-plain-obj": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -3042,6 +2991,16 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/js-sdsl": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+            "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
+            "dev": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/js-sdsl"
             }
         },
         "node_modules/js-yaml": {
@@ -3573,6 +3532,15 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
         },
+        "node_modules/mocha/node_modules/serialize-javascript": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+            "dev": true,
+            "dependencies": {
+                "randombytes": "^2.1.0"
+            }
+        },
         "node_modules/mocha/node_modules/supports-color": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -3678,9 +3646,9 @@
             "dev": true
         },
         "node_modules/node-abi": {
-            "version": "3.45.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.45.0.tgz",
-            "integrity": "sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==",
+            "version": "3.40.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.40.0.tgz",
+            "integrity": "sha512-zNy02qivjjRosswoYmPi8hIKJRr8MpQyeKT6qlcq/OnOgA3Rhoae+IYOqsM9V5+JnHWmxKnWOT2GxvtqdtOCXA==",
             "dev": true,
             "optional": true,
             "dependencies": {
@@ -3717,9 +3685,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.13",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-            "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+            "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
             "dev": true
         },
         "node_modules/normalize-path": {
@@ -3771,17 +3739,17 @@
             }
         },
         "node_modules/optionator": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-            "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
             "dev": true,
             "dependencies": {
-                "@aashutoshrathi/word-wrap": "^1.2.3",
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0"
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.3"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -3854,9 +3822,9 @@
             }
         },
         "node_modules/parse-semver/node_modules/semver": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver"
@@ -4101,9 +4069,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.11.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
-            "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+            "version": "6.11.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
+            "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
             "dev": true,
             "dependencies": {
                 "side-channel": "^1.0.4"
@@ -4236,6 +4204,18 @@
             },
             "engines": {
                 "node": ">= 10.13.0"
+            }
+        },
+        "node_modules/regexpp": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mysticatea"
             }
         },
         "node_modules/require-directory": {
@@ -4371,9 +4351,9 @@
             }
         },
         "node_modules/rxjs": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.6.0.tgz",
+            "integrity": "sha512-DDa7d8TFNUalGC9VqXvQ1euWNN7sc63TrUCuM9J998+ViviahMIjKSOU7rfcgFOF+FCD71BhDRv4hrFz+ImDLQ==",
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -4390,24 +4370,6 @@
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
             "dev": true
         },
-        "node_modules/schema-utils": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-            "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-            "dev": true,
-            "dependencies": {
-                "@types/json-schema": "^7.0.8",
-                "ajv": "^6.12.5",
-                "ajv-keywords": "^3.5.2"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
         "node_modules/selderee": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.6.0.tgz",
@@ -4420,9 +4382,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+            "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -4434,9 +4396,9 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+            "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
             "dev": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
@@ -4593,6 +4555,20 @@
                 "safe-buffer": "~5.1.0"
             }
         },
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -4704,13 +4680,13 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.0.tgz",
-            "integrity": "sha512-JpcpGOQLOXm2jsomozdMDpd5f8ZHh1rR48OFgWUH3QsyZcfPgv2qDCYbcDEAYNd4OZRj2bWYKpwdll/udZCk/Q==",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.1.tgz",
+            "integrity": "sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/source-map": "^0.3.3",
-                "acorn": "^8.8.2",
+                "@jridgewell/source-map": "^0.3.2",
+                "acorn": "^8.5.0",
                 "commander": "^2.20.0",
                 "source-map-support": "~0.5.20"
             },
@@ -4722,16 +4698,16 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.9",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
-            "integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
+            "version": "5.3.7",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz",
+            "integrity": "sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.1",
-                "terser": "^5.16.8"
+                "terser": "^5.16.5"
             },
             "engines": {
                 "node": ">= 10.13.0"
@@ -4755,13 +4731,22 @@
                 }
             }
         },
-        "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-            "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+        "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
+            "integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
             "dev": true,
             "dependencies": {
-                "randombytes": "^2.1.0"
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/terser/node_modules/commander": {
@@ -4822,9 +4807,9 @@
             }
         },
         "node_modules/ts-loader": {
-            "version": "9.4.4",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.4.tgz",
-            "integrity": "sha512-MLukxDHBl8OJ5Dk3y69IsKVFRA/6MwzEqBgh+OXMPB/OD01KQuWPFd1WAQP8a5PeSCAxfnkhiuWqfmFJzJQt9w==",
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.3.1.tgz",
+            "integrity": "sha512-OkyShkcZTsTwyS3Kt7a4rsT/t2qvEVQuKCTg4LJmpj9fhFR7ukGdZwV6Qq3tRUkqcXtfGpPR7+hFKHCG/0d3Lw==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.1.0",
@@ -4911,9 +4896,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
         },
         "node_modules/tunnel": {
             "version": "0.0.6",
@@ -4971,9 +4956,9 @@
             }
         },
         "node_modules/typed-rest-client": {
-            "version": "1.8.11",
-            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
-            "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
+            "version": "1.8.9",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
+            "integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
             "dev": true,
             "dependencies": {
                 "qs": "^6.9.1",
@@ -5095,22 +5080,22 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.88.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
-            "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
+            "version": "5.76.3",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+            "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
-                "@types/estree": "^1.0.0",
-                "@webassemblyjs/ast": "^1.11.5",
-                "@webassemblyjs/wasm-edit": "^1.11.5",
-                "@webassemblyjs/wasm-parser": "^1.11.5",
+                "@types/estree": "^0.0.51",
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/wasm-edit": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
                 "acorn": "^8.7.1",
-                "acorn-import-assertions": "^1.9.0",
+                "acorn-import-assertions": "^1.7.6",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.15.0",
-                "es-module-lexer": "^1.2.1",
+                "enhanced-resolve": "^5.10.0",
+                "es-module-lexer": "^0.9.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
@@ -5119,9 +5104,9 @@
                 "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
-                "schema-utils": "^3.2.0",
+                "schema-utils": "^3.1.0",
                 "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.3.7",
+                "terser-webpack-plugin": "^5.1.3",
                 "watchpack": "^2.4.0",
                 "webpack-sources": "^3.2.3"
             },
@@ -5142,12 +5127,11 @@
             }
         },
         "node_modules/webpack-bundle-analyzer": {
-            "version": "4.9.0",
-            "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.9.0.tgz",
-            "integrity": "sha512-+bXGmO1LyiNx0i9enBu3H8mv42sj/BJWhZNFwjz92tVnBa9J3JMGo2an2IXlEleoDOPn/Hofl5hr/xCpObUDtw==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.6.1.tgz",
+            "integrity": "sha512-oKz9Oz9j3rUciLNfpGFjOb49/jEpXNmWdVH8Ls//zNcnLlQdTGXQQMsBbb/gR7Zl8WNLxVCq+0Hqbx3zv6twBw==",
             "dev": true,
             "dependencies": {
-                "@discoveryjs/json-ext": "0.5.7",
                 "acorn": "^8.0.4",
                 "acorn-walk": "^8.0.0",
                 "chalk": "^4.1.0",
@@ -5299,9 +5283,9 @@
             }
         },
         "node_modules/webpack-merge": {
-            "version": "5.9.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.9.0.tgz",
-            "integrity": "sha512-6NbRQw4+Sy50vYNTw7EyOn41OZItPiXB8GNv3INSoe3PSFaHJEz3SHTrYVaRm2LilNGnFUzh0FAwqPEmU/CwDg==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+            "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
             "dev": true,
             "dependencies": {
                 "clone-deep": "^4.0.1",
@@ -5318,6 +5302,24 @@
             "dev": true,
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/webpack/node_modules/schema-utils": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
+            "integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
+            "dev": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/which": {
@@ -5341,10 +5343,69 @@
             "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
             "dev": true
         },
+        "node_modules/word-wrap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/workerpool": {
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
             "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+            "dev": true
+        },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
         "node_modules/wrappy": {
@@ -5458,26 +5519,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/yargs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
-        },
-        "node_modules/yargs/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/yauzl": {

--- a/ext/vscode/package.json
+++ b/ext/vscode/package.json
@@ -140,6 +140,11 @@
                     "type": "number",
                     "default": 5,
                     "description": "%azure-dev.maximumAppsToDisplay.description%"
+                },
+                "azure-dev.auth.useIntegratedAuth": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%azure-dev.auth.useIntegratedAuth.description%"
                 }
             }
         },
@@ -478,6 +483,7 @@
         "ci-package": "npm run ci-build && vsce package"
     },
     "devDependencies": {
+        "@azure/core-auth": "^1.4",
         "@types/chai": "~4",
         "@types/glob": "~7",
         "@types/mocha": "~10",

--- a/ext/vscode/package.nls.json
+++ b/ext/vscode/package.nls.json
@@ -22,6 +22,7 @@
     "azure-dev.commands.getDotEnvFilePath.title": "Get Azure developer environment's .env file path",
 
     "azure-dev.maximumAppsToDisplay.description": "Maximum number of Azure Developer CLI apps to display in the Workspace Resource view",
+    "azure-dev.auth.useIntegratedAuth.description": "Use the VS Code integrated authentication with the Azure Developer CLI, instead of its own authentication. Note: This feature is currently in alpha and active under development, and requires a version of the Azure Development CLI that supports it.",
 
     "azure-dev.tasks.dotenv.properties.file": "The .env file to use to populate the target task environment",
     "azure-dev.tasks.dotenv.properties.targetTasks": "Name of the task(s) that will be launched with environment populated from the .env file",

--- a/ext/vscode/src/commands/loginCli.ts
+++ b/ext/vscode/src/commands/loginCli.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { TelemetryId } from '../telemetry/telemetryId';
 import { createAzureDevCli, onAzdLoginAttempted } from '../utils/azureDevCli';

--- a/ext/vscode/src/utils/VsCodeAuthenticationCredential.ts
+++ b/ext/vscode/src/utils/VsCodeAuthenticationCredential.ts
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as vscode from 'vscode';
+import { AccessToken, GetTokenOptions, TokenCredential } from '@azure/core-auth';
+
+// TODO(ellismg): This code is more or less lifted from @microsoft/vscode-azext-azureauth. It would be ideal
+// to share more of it if we can.
+//
+// We need to consider cases where a user's account is in multiple tenants and only some of them are signed in.  Today,
+// in this case `VSCodeAzureSubscriptionProvider`'s getSubscriptions() method will throw `NotSignedInError` because some
+// the tenants are not signed in and it can not return a complete response.
+//
+// I think the thing we want to do is subclass VSCodeAzureSubscriptionProvider and override `getTenantFilters()` such that
+// we only request sessions for the tenant that the user requested.  However, in the case where an explicit tenant ID is not
+// passed, we need a way to say: "filter to exclude everything except the user's default tenant", which is less clear.
+
+/**
+ * An error indicating the user is not signed in.
+ */
+export class NotSignedInError extends Error {
+    public readonly isNotSignedInError = true;
+
+    constructor() {
+        super(vscode.l10n.t('You are not signed in to an Azure account. Please sign in.'));
+    }
+}
+
+/**
+ * Tests if an object is a `NotSignedInError`. This should be used instead of `instanceof`.
+ *
+ * @param error The object to test
+ *
+ * @returns True if the object is a NotSignedInError, false otherwise
+ */
+export function isNotSignedInError(error: unknown): error is NotSignedInError {
+    return !!error && typeof error === 'object' && (error as NotSignedInError).isNotSignedInError === true;
+}
+
+/**
+ *
+ * A TokenCredential that uses the VS Code Authentication API to get tokens.
+ *
+ */
+export class VsCodeAuthenticationCredential implements TokenCredential {
+    async getToken(scopes: string | string[], options?: GetTokenOptions | undefined): Promise<AccessToken | null> {
+        const scopeSet = new Set<string>(scopes);
+
+        if (typeof scopes === 'string') {
+            scopeSet.add(scopes);
+        } else if (Array.isArray(scopes)) {
+            scopes.forEach(scope => scopeSet.add(scope));
+        }
+
+        // getSession recognizes this special scope and uses it to set the tenant ID that is used when
+        // requesting a token. This scope is not actually included in the request that is sent to get
+        // the token, getSession removes it from the list of scopes before sending the request.
+        if (options?.tenantId) {
+            scopeSet.add(`VSCODE_TENANT:${options.tenantId}`);
+        }
+
+        let session = await vscode.authentication.getSession('microsoft', Array.from(scopeSet), { silent: true });
+        if (!session) {
+            // If we couldn't get a sessions silently, the user may not be logged in, so try prompting them.
+            session = await vscode.authentication.getSession('microsoft', Array.from(scopeSet), { createIfNone: true, clearSessionPreference: true });
+            if (!session) {
+                throw new NotSignedInError();
+            }
+        }
+
+        // The object returned by getSession does not have an expiration time associated with it, but the GetToken response
+        // needs one.
+        //
+        // We can pull the `exp` claim from the token and use it. If for some reason, we can't find find the claim, we'll
+        // just set the expiration time to 0. This will mean that the token appears to be expired, however in practice the
+        // `getSession` API handles refreshing the token if it was close to expiring before returning it to us, and the Azure
+        // SDKs will not fail if the token appears to be expired (they may end up requesting a token for each operation instead
+        // of being able to cache it themselves in the client, but that's not a big deal, since `getSession` will be able to
+        // elide the refresh if it is not needed.
+        let expiresOnTimestamp = 0;
+        try {
+             const expClaim = JSON.parse(Buffer.from(session.accessToken.split('.')[1], 'base64').toString()).exp;
+             if (typeof expClaim === 'number') {
+                // The exp claim in the JWT is the number of seconds since the Unix Epoch, but the `expiresOnTimestamp` property
+                // is the number of milliseconds since the Unix Epoch, so we need to multiply by 1000.
+                expiresOnTimestamp = expClaim * 1000;
+             }
+        } catch {
+            // Some issue parsing the token, so not much we can do here, just leave the expiration time as 0 (the Unix Epoch).
+        }
+
+        return {
+            token: session.accessToken,
+            expiresOnTimestamp: expiresOnTimestamp
+        };
+    }
+}

--- a/ext/vscode/src/utils/authServer.ts
+++ b/ext/vscode/src/utils/authServer.ts
@@ -1,0 +1,103 @@
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as http from 'http';
+import { randomBytes } from 'crypto';
+import { AccessToken, TokenCredential } from '@azure/core-auth';
+import { isNotSignedInError } from './VsCodeAuthenticationCredential';
+import { AddressInfo } from 'net';
+
+// startAuthServer creates a locally running server that will respond to Azure Dev CLI authentication requests and
+// starts listening for requests.  Requests must be authenticated with a key that is returned from this function.
+// The provided credential is used to fetch tokens for auth requests.
+export function startAuthServer(credential: TokenCredential): Promise<{ server: http.Server, endpoint: string, key: string }> {
+    const key = randomBytes(32).toString('hex');
+
+    const server = http.createServer(async (req, res) => {
+        if (req.headers['content-type'] !== 'application/json' || req.method !== 'POST' || req.url !== '/token?api-version=2023-07-12-preview') {
+            res.writeHead(400).end();
+            return;
+        }
+
+        if (req.headers['authorization'] !== `Bearer ${key}`) {
+            res.writeHead(401).end();
+            return;
+        }
+
+        const body: Buffer[] = [];
+        req.on('data', (chunk) => { body.push(chunk); });
+        req.on('end', async () => {
+            try {
+                const reqBody = JSON.parse(Buffer.concat(body).toString());
+                if (typeof reqBody !== 'object') {
+                    res.writeHead(400).end();
+                    return;
+                }
+
+                if (!reqBody.scopes ||
+                    !Array.isArray(reqBody.scopes) ||
+                    reqBody.scopes.length === 0 ||
+                    reqBody.scopes.some((a: unknown) => typeof a !== 'string') ||
+                    reqBody.tenantId && typeof reqBody.tenantId !== 'string') {
+                    res.writeHead(400).end();
+                    return;
+                }
+
+                res.setHeader('Content-Type', 'application/json');
+
+                let token: AccessToken | null;
+
+                try {
+                    token = await credential.getToken(reqBody.scopes, {
+                        tenantId: reqBody.tenantId,
+                    });
+                } catch (e: unknown) {
+                    // If getToken Fails, we want to return 200 OK, but with an error status. This lets
+                    // the client observe the failure of fetching a token differently from the failure of
+                    // the auth server.
+
+                    let message = (e instanceof Error) ? e.message : 'unknown error';
+                    let code = "GetTokenError";
+
+                    if (isNotSignedInError(e)) {
+                        code = "NotSignedInError";
+                        message = 'You are not signed in to an Azure account. Please sign in.';
+                    }
+
+                    res.writeHead(200).end(
+                        JSON.stringify({
+                            status: 'error',
+                            code: code,
+                            message: message,
+                        })
+                    );
+                    return;
+                }
+
+                if (!token) {
+                    res.writeHead(500).end();
+                    return;
+                }
+
+                res.writeHead(200).end(
+                    JSON.stringify({
+                        status: 'success',
+                        token: token.token,
+                        expiresOn: new Date(token.expiresOnTimestamp).toISOString(),
+                    })
+                );
+            } catch {
+                res.writeHead(500).end();
+                return;
+            }
+        });
+    });
+
+    return new Promise<{server: http.Server, endpoint: string, key: string}>((resolve) => {
+        server.listen({
+            host: '127.0.0.1',
+            port: 0,
+        }, () => resolve({ server, endpoint: `http://127.0.0.1:${(server.address() as AddressInfo).port}`, key }));
+    });
+}

--- a/ext/vscode/src/utils/azureDevCli.ts
+++ b/ext/vscode/src/utils/azureDevCli.ts
@@ -245,5 +245,5 @@ function azdNotInstalledUserChoices(): AzExtErrorButton[] {
 
 // isAzdCommand returns true if this is the command to run azd.
 export function isAzdCommand(command: string): boolean {
-    return command === getAzDevInvocation()[0];
+    return command === getAzDevInvocation()[0] || command.startsWith(`${getAzDevInvocation()[0]} `);
 }

--- a/ext/vscode/src/utils/azureDevCli.ts
+++ b/ext/vscode/src/utils/azureDevCli.ts
@@ -54,7 +54,7 @@ export function scheduleAzdVersionCheck(): void {
     const oneSecond = 1 * 1000;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const minimumSupportedVersion = semver.coerce('0.8.0')!;
-    
+
     setTimeout(async () => {
         const versionResult = await getAzdVersion();
 
@@ -241,4 +241,9 @@ function azdNotInstalledUserChoices(): AzExtErrorButton[] {
         }
     ];
     return choices;
+}
+
+// isAzdCommand returns true if this is the command to run azd.
+export function isAzdCommand(command: string): boolean {
+    return command === getAzDevInvocation()[0];
 }

--- a/ext/vscode/src/utils/executeAsTask.ts
+++ b/ext/vscode/src/utils/executeAsTask.ts
@@ -1,10 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import * as http from 'http';
 import * as os from 'os';
 import * as vscode from 'vscode';
 import { TelemetryId } from '../telemetry/telemetryId';
 import { callWithTelemetryAndErrorHandling, IActionContext } from '@microsoft/vscode-azext-utils';
+import { startAuthServer } from './authServer';
+import { isAzdCommand } from './azureDevCli';
+import { VsCodeAuthenticationCredential } from './VsCodeAuthenticationCredential';
 
 type ExecuteAsTaskOptions = {
     workspaceFolder?: vscode.WorkspaceFolder;
@@ -16,41 +20,60 @@ type ExecuteAsTaskOptions = {
 };
 
 export function executeAsTask(command: string, name: string, options?: ExecuteAsTaskOptions, telemetryId?: TelemetryId): Promise<void> {
-    options = options ?? {};
-
-    const task = new vscode.Task(
-        { type: 'shell' },
-        options.workspaceFolder ?? vscode.TaskScope.Workspace,
-        name,
-        'Azure Developer',
-        new vscode.ShellExecution(
-            command, 
-            { 
-                cwd: options.cwd || options.workspaceFolder?.uri?.fsPath || os.homedir(),
-                env: options.env
-            }
-        ),
-        [] // problemMatchers
-    );
-
-    if (options.alwaysRunNew) {
-        // If the command should always run in a new task (even if an identical command is still running), add a random value to the definition
-        // This will cause a new task to be run even if one with an identical command line is already running
-        task.definition.idRandomizer = Math.random();
-    }
-
-    if (options.focus) {
-        task.presentationOptions = {
-            focus: true,
-        };
-    }
-
     const runTask = async () => {
+        options ??= {};
+
+        const env = {...options.env};
+
+        let useIntegratedAuth = vscode.workspace.getConfiguration('azure-dev').get<boolean>('auth.useIntegratedAuth', false);
+
+        if (!isAzdCommand(command)) {
+            useIntegratedAuth = false;
+        }
+
+        let authServer: http.Server | undefined;
+
+        if (useIntegratedAuth) {
+            const { server, endpoint, key } = await startAuthServer(new VsCodeAuthenticationCredential());
+
+            env['AZD_AUTH_ENDPOINT'] = endpoint;
+            env['AZD_AUTH_KEY'] = key;
+            authServer = server;
+        }
+
+        const task = new vscode.Task(
+            { type: 'shell' },
+            options.workspaceFolder ?? vscode.TaskScope.Workspace,
+            name,
+            'Azure Developer',
+            new vscode.ShellExecution(
+                command,
+                {
+                    cwd: options.cwd || options.workspaceFolder?.uri?.fsPath || os.homedir(),
+                    env: env,
+                }
+            ),
+            [] // problemMatchers
+        );
+
+        if (options.alwaysRunNew) {
+            // If the command should always run in a new task (even if an identical command is still running), add a random value to the definition
+            // This will cause a new task to be run even if one with an identical command line is already running
+            task.definition.idRandomizer = Math.random();
+        }
+
+        if (options.focus) {
+            task.presentationOptions = {
+                focus: true,
+            };
+        }
+
         const taskExecution = await vscode.tasks.executeTask(task);
 
         const taskEndPromise = new Promise<void>((resolve, reject) => {
             const disposable = vscode.tasks.onDidEndTaskProcess(e => {
                 if (e.execution === taskExecution) {
+                    authServer?.close();
                     disposable.dispose();
 
                     if (e.exitCode && !(options?.suppressErrors)) {
@@ -69,11 +92,10 @@ export function executeAsTask(command: string, name: string, options?: ExecuteAs
         return callWithTelemetryAndErrorHandling(telemetryId, (ctx: IActionContext) => {
             // Errors will be displayed in the task pane; no need to show them again in a popup.
             ctx.errorHandling.suppressDisplay = true;
-            
+
             return runTask();
         });
     } else {
         return runTask();
     }
-    
 }


### PR DESCRIPTION
This change sketches out a possible way for `azd` to delegate
authentication to an external process and teaches the VS Code
extension to use this strategy to provide authentication for `azd`
based on the credential associated with the Azure Account extension.

This works by introducing a new "Remote Credential" type in `azd`, is
used when `AZD_AUTH_ENDPOINT` and `AZD_AUTH_KEY` are defined in the
system environment.  When these values are set and `azd` needs to
request a token, it makes a request to
`${AZD_AUTH_ENDPOINT/token?api-version=2023-07-12-preview` using
`${AZD_AUTH_KEY}` as an bearer token to secure the request.

The body of the request body contains a serialized version of the
`TokenRequestOptions` struct:

```
{
   scopes: []string
   tenantId: string?
}
```

The server is expected to respond with 200 OK and a body that
represents the result of trying to fetch a token (either success or
failure).  One of the two following shapes is expected for the
response:

```
{
  status: "success"
  token: string
  expiresOn: string // (RFC3339 format)
}
```

or

```
{
  status: "error"
  code: "GetTokenError" | "NotLoggedInError"
  message: string // Suitable for display to a human.
}
```

This behavior is currently controlled by a setting
`azure-dev.auth.useIntegratedAuth` which defaults to false. You need
both the updated extension and a version of `azd` which supports this.

Contributes To: #1741