### PR TITLE
[Refactoring] Merging provisioning provider Plan()->Preview()

### DIFF
--- a/cli/azd/cmd/provision.go
+++ b/cli/azd/cmd/provision.go
@@ -114,7 +114,7 @@ func (p *provisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 	defaultTitle := "Provisioning Azure resources (azd provision)"
 	defaultTitleNote := "Provisioning Azure resources can take some time"
 	if previewMode {
-		defaultTitle = "Previewing Azure resource changes (azd provision --what-if)"
+		defaultTitle = "Previewing Azure resource changes (azd provision --preview)"
 		defaultTitleNote = "This is a preview. No changes will be applied to your Azure resources."
 	}
 
@@ -141,17 +141,12 @@ func (p *provisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 	}
 
 	err := p.projectConfig.Invoke(ctx, project.ProjectEventProvision, projectEventArgs, func() error {
-		deploymentPlan, err := p.provisionManager.Plan(ctx)
-		if err != nil {
-			return fmt.Errorf("planning deployment: %w", err)
-		}
-
+		var err error
 		if previewMode {
-			deployPreviewResult, err = p.provisionManager.WhatIfDeploy(ctx, deploymentPlan)
+			deployPreviewResult, err = p.provisionManager.Preview(ctx)
 		} else {
-			deployResult, err = p.provisionManager.Deploy(ctx, deploymentPlan)
+			deployResult, err = p.provisionManager.Deploy(ctx)
 		}
-
 		return err
 	})
 

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -291,11 +291,10 @@ func deploymentNameForEnv(envName string, clock clock.Clock) string {
 
 // Provisioning the infrastructure within the specified template
 func (p *BicepProvider) Deploy(ctx context.Context) (*DeployResult, error) {
-	deployment, plan, err := p.plan(ctx)
+	deployment, bicepDeploymentData, err := p.plan(ctx)
 	if err != nil {
 		return nil, err
 	}
-	bicepDeploymentData := plan
 
 	cancelProgress := make(chan bool)
 	defer func() { cancelProgress <- true }()

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -43,7 +43,7 @@ import (
 
 const DefaultModule = "main"
 
-type BicepDeploymentDetails struct {
+type bicepDeploymentDetails struct {
 	// Template is the template to deploy during the deployment operation.
 	Template azure.RawArmTemplate
 	// Parameters are the values to provide to the template during the deployment operation.
@@ -213,7 +213,7 @@ func (p *BicepProvider) State(ctx context.Context) (*StateResult, error) {
 var ResourceGroupDeploymentFeature = alpha.MustFeatureKey("resourceGroupDeployments")
 
 // Plans the infrastructure provisioning
-func (p *BicepProvider) plan(ctx context.Context) (*Deployment, *BicepDeploymentDetails, error) {
+func (p *BicepProvider) plan(ctx context.Context) (*Deployment, *bicepDeploymentDetails, error) {
 	p.console.ShowSpinner(ctx, "Creating a deployment plan", input.Step)
 	// TODO: Report progress, "Generating Bicep parameters file"
 
@@ -266,7 +266,7 @@ func (p *BicepProvider) plan(ctx context.Context) (*Deployment, *BicepDeployment
 		return nil, nil, fmt.Errorf("unsupported scope: %s", deploymentScope)
 	}
 
-	return deployment, &BicepDeploymentDetails{
+	return deployment, &bicepDeploymentDetails{
 		Template:        rawTemplate,
 		TemplateOutputs: template.Outputs,
 		Parameters:      configuredParameters,

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -44,13 +44,13 @@ func TestBicepPlan(t *testing.T) {
 	prepareBicepMocks(mockContext)
 	infraProvider := createBicepProvider(t, mockContext)
 
-	deploymentPlan, err := infraProvider.Plan(*mockContext.Context)
+	deployment, deploymentPlan, err := infraProvider.plan(*mockContext.Context)
 
 	require.Nil(t, err)
-	require.NotNil(t, deploymentPlan.Deployment)
+	require.NotNil(t, deployment)
 
-	require.IsType(t, BicepDeploymentDetails{}, deploymentPlan.Details)
-	configuredParameters := deploymentPlan.Details.(BicepDeploymentDetails).Parameters
+	require.IsType(t, &BicepDeploymentDetails{}, deploymentPlan)
+	configuredParameters := deploymentPlan.Parameters
 
 	require.Equal(t, infraProvider.env.GetLocation(), configuredParameters["location"].Value)
 	require.Equal(
@@ -101,13 +101,11 @@ func TestBicepPlanPrompt(t *testing.T) {
 	}).Respond(false)
 
 	infraProvider := createBicepProvider(t, mockContext)
-	plan, err := infraProvider.Plan(*mockContext.Context)
+	_, plan, err := infraProvider.plan(*mockContext.Context)
 
 	require.NoError(t, err)
 
-	bicepDetails := plan.Details.(BicepDeploymentDetails)
-
-	require.Equal(t, "value", bicepDetails.Parameters["stringParam"].Value)
+	require.Equal(t, "value", plan.Parameters["stringParam"].Value)
 }
 
 func TestBicepState(t *testing.T) {
@@ -124,39 +122,6 @@ func TestBicepState(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, getDeploymentResult.State)
 	require.Equal(t, getDeploymentResult.State.Outputs["WEBSITE_URL"].Value, expectedWebsiteUrl)
-}
-
-func TestBicepDeploy(t *testing.T) {
-	expectedWebsiteUrl := "http://myapp.azurewebsites.net"
-	mockContext := mocks.NewMockContext(context.Background())
-	prepareBicepMocks(mockContext)
-	prepareStateMocks(mockContext)
-	prepareDeployMocks(mockContext)
-	depOpService := mockazcli.NewDeploymentOperationsServiceFromMockContext(mockContext)
-	depService := mockazcli.NewDeploymentsServiceFromMockContext(mockContext)
-
-	infraProvider := createBicepProvider(t, mockContext)
-
-	deploymentPlan := DeploymentPlan{
-		Deployment: Deployment{},
-		Details: BicepDeploymentDetails{
-			Template:   azure.RawArmTemplate("{}"),
-			Parameters: testArmParameters,
-			Target: infra.NewSubscriptionDeployment(
-				depService,
-				depOpService,
-				infraProvider.env.GetLocation(),
-				infraProvider.env.GetSubscriptionId(),
-				infraProvider.env.GetEnvName(),
-			),
-		},
-	}
-
-	deployResult, err := infraProvider.Deploy(*mockContext.Context, &deploymentPlan)
-
-	require.Nil(t, err)
-	require.NotNil(t, deployResult)
-	require.Equal(t, deployResult.Deployment.Outputs["WEBSITE_URL"].Value, expectedWebsiteUrl)
 }
 
 func TestBicepDestroy(t *testing.T) {
@@ -335,11 +300,11 @@ func TestPlanForResourceGroup(t *testing.T) {
 	require.NoError(t, err)
 	// The computed plan should target the resource group we picked.
 
-	planResult, err := infraProvider.Plan(*mockContext.Context)
+	_, planResult, err := infraProvider.plan(*mockContext.Context)
 	require.Nil(t, err)
 	require.NotNil(t, planResult)
 	require.Equal(t, "rg-test-env",
-		planResult.Details.(BicepDeploymentDetails).Target.(*infra.ResourceGroupDeployment).ResourceGroupName())
+		planResult.Target.(*infra.ResourceGroupDeployment).ResourceGroupName())
 }
 
 func TestIsValueAssignableToParameterType(t *testing.T) {
@@ -468,46 +433,6 @@ var cTestEnvDeployment armresources.DeploymentExtended = armresources.Deployment
 		ProvisioningState: to.Ptr(armresources.ProvisioningStateSucceeded),
 		Timestamp:         to.Ptr(time.Now()),
 	},
-}
-
-func prepareDeployMocks(mockContext *mocks.MockContext) {
-	deployResultBytes, _ := json.Marshal(cTestEnvDeployment)
-
-	// Create deployment at subscription scope
-	mockContext.HttpClient.When(func(request *http.Request) bool {
-		return request.Method == http.MethodPut && strings.HasSuffix(
-			request.URL.Path,
-			"/subscriptions/SUBSCRIPTION_ID/providers/Microsoft.Resources/deployments/test-env",
-		)
-	}).RespondFn(func(request *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(bytes.NewBuffer(deployResultBytes)),
-			Request: &http.Request{
-				Method: http.MethodGet,
-			},
-		}, nil
-	})
-
-	deploymentsPage := &armresources.DeploymentListResult{
-		Value: []*armresources.DeploymentExtended{
-			&cTestEnvDeployment,
-		},
-	}
-
-	deploymentsPageResultBytes, _ := json.Marshal(deploymentsPage)
-
-	mockContext.HttpClient.When(func(request *http.Request) bool {
-		return request.Method == http.MethodGet && strings.HasSuffix(
-			request.URL.Path,
-			"/SUBSCRIPTION_ID/providers/Microsoft.Resources/deployments/",
-		)
-	}).RespondFn(func(request *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(bytes.NewBuffer(deploymentsPageResultBytes)),
-		}, nil
-	})
 }
 
 func prepareStateMocks(mockContext *mocks.MockContext) {
@@ -660,12 +585,6 @@ func prepareDestroyMocks(mockContext *mocks.MockContext) {
 		response.Header.Add("location", mockPollingUrl)
 		return response, err
 	})
-}
-
-var testArmParameters = azure.ArmParameters{
-	"location": {
-		Value: "West US",
-	},
 }
 
 func getKeyVaultMock(mockContext *mocks.MockContext, keyVaultString string, name string, location string) {

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -49,7 +49,7 @@ func TestBicepPlan(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, deployment)
 
-	require.IsType(t, &BicepDeploymentDetails{}, deploymentPlan)
+	require.IsType(t, &bicepDeploymentDetails{}, deploymentPlan)
 	configuredParameters := deploymentPlan.Parameters
 
 	require.Equal(t, infraProvider.env.GetLocation(), configuredParameters["location"].Value)

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -41,16 +41,6 @@ func (m *Manager) Initialize(ctx context.Context, projectPath string, options Op
 	return m.provider.Initialize(ctx, projectPath, options)
 }
 
-// Prepares for an infrastructure provision operation
-func (m *Manager) Plan(ctx context.Context) (*DeploymentPlan, error) {
-	deploymentPlan, err := m.provider.Plan(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("planning infrastructure provisioning: %w", err)
-	}
-
-	return deploymentPlan, nil
-}
-
 // Gets the latest deployment details for the specified scope
 func (m *Manager) State(ctx context.Context) (*StateResult, error) {
 	result, err := m.provider.State(ctx)
@@ -62,9 +52,9 @@ func (m *Manager) State(ctx context.Context) (*StateResult, error) {
 }
 
 // Deploys the Azure infrastructure for the specified project
-func (m *Manager) Deploy(ctx context.Context, plan *DeploymentPlan) (*DeployResult, error) {
+func (m *Manager) Deploy(ctx context.Context) (*DeployResult, error) {
 	// Apply the infrastructure deployment
-	deployResult, err := m.provider.Deploy(ctx, plan)
+	deployResult, err := m.provider.Deploy(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error deploying infrastructure: %w", err)
 	}
@@ -79,10 +69,10 @@ func (m *Manager) Deploy(ctx context.Context, plan *DeploymentPlan) (*DeployResu
 	return deployResult, nil
 }
 
-// WhatIfDeploy generates a deployment preview.
-func (m *Manager) WhatIfDeploy(ctx context.Context, plan *DeploymentPlan) (*DeployPreviewResult, error) {
+// Preview generates the list of changes to be applied as part of the provisioning.
+func (m *Manager) Preview(ctx context.Context) (*DeployPreviewResult, error) {
 	// Apply the infrastructure deployment
-	deployResult, err := m.provider.WhatIfDeploy(ctx, plan)
+	deployResult, err := m.provider.Preview(ctx)
 
 	if err != nil {
 		return nil, fmt.Errorf("error deploying infrastructure: %w", err)

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -50,7 +50,7 @@ func TestProvisionInitializesEnvironment(t *testing.T) {
 	require.Equal(t, "location", env.GetLocation())
 }
 
-func TestManagerPlan(t *testing.T) {
+func TestManagerPreview(t *testing.T) {
 	env := environment.EphemeralWithValues("test-env", map[string]string{
 		"AZURE_SUBSCRIPTION_ID": "SUBSCRIPTION_ID",
 		"AZURE_LOCATION":        "eastus2",
@@ -63,11 +63,10 @@ func TestManagerPlan(t *testing.T) {
 	err := mgr.Initialize(*mockContext.Context, "", Options{Provider: "test"})
 	require.NoError(t, err)
 
-	deploymentPlan, err := mgr.Plan(*mockContext.Context)
+	deploymentPlan, err := mgr.Preview(*mockContext.Context)
 
 	require.NotNil(t, deploymentPlan)
 	require.Nil(t, err)
-	require.Equal(t, deploymentPlan.Deployment.Parameters["location"].Value, env.Dotenv()["AZURE_LOCATION"])
 }
 
 func TestManagerGetState(t *testing.T) {
@@ -102,8 +101,7 @@ func TestManagerDeploy(t *testing.T) {
 	err := mgr.Initialize(*mockContext.Context, "", Options{Provider: "test"})
 	require.NoError(t, err)
 
-	deploymentPlan, _ := mgr.Plan(*mockContext.Context)
-	deployResult, err := mgr.Deploy(*mockContext.Context, deploymentPlan)
+	deployResult, err := mgr.Deploy(*mockContext.Context)
 
 	require.NotNil(t, deployResult)
 	require.Nil(t, err)

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -23,13 +23,6 @@ type Options struct {
 	Module   string       `yaml:"module"`
 }
 
-type DeploymentPlan struct {
-	Deployment Deployment
-
-	// Additional information about deployment, provider-specific.
-	Details interface{}
-}
-
 type DeployResult struct {
 	Deployment *Deployment
 }
@@ -53,9 +46,9 @@ type Provider interface {
 	Name() string
 	Initialize(ctx context.Context, projectPath string, options Options) error
 	State(ctx context.Context) (*StateResult, error)
-	Plan(ctx context.Context) (*DeploymentPlan, error)
-	Deploy(ctx context.Context, plan *DeploymentPlan) (*DeployResult, error)
-	WhatIfDeploy(ctx context.Context, plan *DeploymentPlan) (*DeployPreviewResult, error)
+	//Plan(ctx context.Context) (*DeploymentPlan, error)
+	Deploy(ctx context.Context) (*DeployResult, error)
+	Preview(ctx context.Context) (*DeployPreviewResult, error)
 	Destroy(ctx context.Context, options DestroyOptions) (*DestroyResult, error)
 	EnsureEnv(ctx context.Context) error
 }

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -46,7 +46,6 @@ type Provider interface {
 	Name() string
 	Initialize(ctx context.Context, projectPath string, options Options) error
 	State(ctx context.Context) (*StateResult, error)
-	//Plan(ctx context.Context) (*DeploymentPlan, error)
 	Deploy(ctx context.Context) (*DeployResult, error)
 	Preview(ctx context.Context) (*DeployPreviewResult, error)
 	Destroy(ctx context.Context, options DestroyOptions) (*DestroyResult, error)

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -33,7 +33,7 @@ type TerraformProvider struct {
 	options      Options
 }
 
-type TerraformDeploymentDetails struct {
+type terraformDeploymentDetails struct {
 	ParameterFilePath  string
 	PlanFilePath       string
 	localStateFilePath string
@@ -115,7 +115,7 @@ func (t *TerraformProvider) EnsureEnv(ctx context.Context) error {
 }
 
 // Previews the infrastructure through terraform plan
-func (t *TerraformProvider) plan(ctx context.Context) (*Deployment, *TerraformDeploymentDetails, error) {
+func (t *TerraformProvider) plan(ctx context.Context) (*Deployment, *terraformDeploymentDetails, error) {
 	isRemoteBackendConfig, err := t.isRemoteBackendConfig()
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading backend config: %w", err)
@@ -154,7 +154,7 @@ func (t *TerraformProvider) plan(ctx context.Context) (*Deployment, *TerraformDe
 		return nil, nil, fmt.Errorf("create terraform template failed: %w", err)
 	}
 
-	deploymentDetails := TerraformDeploymentDetails{
+	deploymentDetails := terraformDeploymentDetails{
 		ParameterFilePath: t.parametersFilePath(),
 		PlanFilePath:      t.planFilePath(),
 	}
@@ -291,7 +291,7 @@ func (t *TerraformProvider) createPlanArgs(isRemoteBackendConfig bool) []string 
 
 // Creates the terraform apply CLI arguments
 func (t *TerraformProvider) createApplyArgs(
-	isRemoteBackendConfig bool, data TerraformDeploymentDetails) ([]string, error) {
+	isRemoteBackendConfig bool, data terraformDeploymentDetails) ([]string, error) {
 	args := []string{}
 	if !isRemoteBackendConfig {
 		args = append(args, fmt.Sprintf("-state=%s", data.localStateFilePath))

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -115,43 +115,43 @@ func (t *TerraformProvider) EnsureEnv(ctx context.Context) error {
 }
 
 // Previews the infrastructure through terraform plan
-func (t *TerraformProvider) Plan(ctx context.Context) (*DeploymentPlan, error) {
+func (t *TerraformProvider) plan(ctx context.Context) (*Deployment, *TerraformDeploymentDetails, error) {
 	isRemoteBackendConfig, err := t.isRemoteBackendConfig()
 	if err != nil {
-		return nil, fmt.Errorf("reading backend config: %w", err)
+		return nil, nil, fmt.Errorf("reading backend config: %w", err)
 	}
 
 	modulePath := t.modulePath()
 
 	initRes, err := t.init(ctx, isRemoteBackendConfig)
 	if err != nil {
-		return nil, fmt.Errorf("terraform init failed: %s , err: %w", initRes, err)
+		return nil, nil, fmt.Errorf("terraform init failed: %s , err: %w", initRes, err)
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	err = t.createInputParametersFile(ctx, t.parametersTemplateFilePath(), t.parametersFilePath())
 	if err != nil {
-		return nil, fmt.Errorf("creating parameters file: %w", err)
+		return nil, nil, fmt.Errorf("creating parameters file: %w", err)
 	}
 
 	validated, err := t.cli.Validate(ctx, modulePath)
 	if err != nil {
-		return nil, fmt.Errorf("terraform validate failed: %s, err %w", validated, err)
+		return nil, nil, fmt.Errorf("terraform validate failed: %s, err %w", validated, err)
 	}
 
 	planArgs := t.createPlanArgs(isRemoteBackendConfig)
 	runResult, err := t.cli.Plan(ctx, modulePath, t.planFilePath(), planArgs...)
 	if err != nil {
-		return nil, fmt.Errorf("terraform plan failed:%s err %w", runResult, err)
+		return nil, nil, fmt.Errorf("terraform plan failed:%s err %w", runResult, err)
 	}
 
 	//create deployment plan
 	deployment, err := t.createDeployment(ctx, modulePath)
 	if err != nil {
-		return nil, fmt.Errorf("create terraform template failed: %w", err)
+		return nil, nil, fmt.Errorf("create terraform template failed: %w", err)
 	}
 
 	deploymentDetails := TerraformDeploymentDetails{
@@ -162,24 +162,25 @@ func (t *TerraformProvider) Plan(ctx context.Context) (*DeploymentPlan, error) {
 		deploymentDetails.localStateFilePath = t.localStateFilePath()
 	}
 
-	return &DeploymentPlan{
-		Deployment: *deployment,
-		Details:    deploymentDetails,
-	}, nil
+	return deployment, &deploymentDetails, nil
 }
 
 // Deploy the infrastructure within the specified template through terraform apply
-func (t *TerraformProvider) Deploy(ctx context.Context, deployment *DeploymentPlan) (*DeployResult, error) {
+func (t *TerraformProvider) Deploy(ctx context.Context) (*DeployResult, error) {
 	t.console.Message(ctx, "Locating plan file...")
 
 	modulePath := t.modulePath()
-	terraformDeploymentData := deployment.Details.(TerraformDeploymentDetails)
+	deployment, terraformDeploymentData, err := t.plan(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	isRemoteBackendConfig, err := t.isRemoteBackendConfig()
 	if err != nil {
 		return nil, fmt.Errorf("reading backend config: %w", err)
 	}
 
-	applyArgs, err := t.createApplyArgs(isRemoteBackendConfig, terraformDeploymentData)
+	applyArgs, err := t.createApplyArgs(isRemoteBackendConfig, *terraformDeploymentData)
 	if err != nil {
 		return nil, err
 	}
@@ -195,16 +196,20 @@ func (t *TerraformProvider) Deploy(ctx context.Context, deployment *DeploymentPl
 		return nil, fmt.Errorf("create terraform template failed: %w", err)
 	}
 
-	currentDeployment := deployment.Deployment
-	currentDeployment.Outputs = outputs
+	deployment.Outputs = outputs
 	return &DeployResult{
-		Deployment: &currentDeployment,
+		Deployment: deployment,
 	}, nil
 }
 
-func (t *TerraformProvider) WhatIfDeploy(ctx context.Context, deployment *DeploymentPlan) (*DeployPreviewResult, error) {
+func (t *TerraformProvider) Preview(ctx context.Context) (*DeployPreviewResult, error) {
 	// terraform uses plan() to display the what-if output
 	// no changes are added to the properties
+	_, _, err := t.plan(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	return &DeployPreviewResult{
 		Preview: &DeploymentPreview{
 			Status:     "done",

--- a/cli/azd/pkg/infra/provisioning/test/test_provider.go
+++ b/cli/azd/pkg/infra/provisioning/test/test_provider.go
@@ -50,20 +50,6 @@ func (t *TestProvider) EnsureEnv(ctx context.Context) error {
 	return EnsureSubscriptionAndLocation(ctx, t.env, t.prompters)
 }
 
-func (p *TestProvider) Plan(ctx context.Context) (*DeploymentPlan, error) {
-	// TODO: progress "Planning deployment"
-
-	params := make(map[string]InputParameter)
-	params["location"] = InputParameter{Value: p.env.GetLocation()}
-
-	return &DeploymentPlan{
-		Deployment: Deployment{
-			Parameters: params,
-			Outputs:    make(map[string]OutputParameter),
-		},
-	}, nil
-}
-
 func (p *TestProvider) State(ctx context.Context) (*StateResult, error) {
 	// TODO: progress, "Looking up deployment"
 
@@ -91,7 +77,7 @@ func (p *TestProvider) GetDeployment(ctx context.Context) (*DeployResult, error)
 }
 
 // Provisioning the infrastructure within the specified template
-func (p *TestProvider) Deploy(ctx context.Context, pd *DeploymentPlan) (*DeployResult, error) {
+func (p *TestProvider) Deploy(ctx context.Context) (*DeployResult, error) {
 	// TODO: progress, "Deploying azure resources"
 
 	deployment := Deployment{
@@ -105,7 +91,7 @@ func (p *TestProvider) Deploy(ctx context.Context, pd *DeploymentPlan) (*DeployR
 }
 
 // Provisioning the infrastructure within the specified template
-func (p *TestProvider) WhatIfDeploy(ctx context.Context, pd *DeploymentPlan) (*DeployPreviewResult, error) {
+func (p *TestProvider) Preview(ctx context.Context) (*DeployPreviewResult, error) {
 	return &DeployPreviewResult{}, nil
 }
 

--- a/cli/azd/pkg/infra/provisioning/test/test_provider.go
+++ b/cli/azd/pkg/infra/provisioning/test/test_provider.go
@@ -92,7 +92,12 @@ func (p *TestProvider) Deploy(ctx context.Context) (*DeployResult, error) {
 
 // Provisioning the infrastructure within the specified template
 func (p *TestProvider) Preview(ctx context.Context) (*DeployPreviewResult, error) {
-	return &DeployPreviewResult{}, nil
+	return &DeployPreviewResult{
+		Preview: &DeploymentPreview{
+			Status:     "Completed",
+			Properties: &DeploymentPreviewProperties{},
+		},
+	}, nil
 }
 
 func (p *TestProvider) Destroy(ctx context.Context, options DestroyOptions) (*DestroyResult, error) {


### PR DESCRIPTION
Updating the Provisioning provider to:
 - Removing `plan()`
 - Adding `Preview()` as the way to generate a provisioning preview
 - Moving the current logic from `plan()` to be called by `Deploy()`
 - Remove `DeploymentPlan` and do not make `Deploy()` to require a plan.  Deploy auto-generates a plan.
 - Remove `WhatIf()`.   Move its logic to be called by `Preview()`
