### PR TITLE
Fix error in publish-cli.yml

### DIFF
--- a/eng/pipelines/templates/steps/publish-cli.yml
+++ b/eng/pipelines/templates/steps/publish-cli.yml
@@ -233,7 +233,7 @@ steps:
   - ${{ if eq('true', parameters.PublishBrewFormula) }}:
     - pwsh: |
         $submitPackage = eng/scripts/Test-ShouldReleasePackageVersion.ps1 `
-          -CliVersion '${{ parameters.CliVersion }}'
+          -CliVersion '${{ parameters.CliVersion }}' `
           -AllowPrerelease:$${{ parameters.AllowPrerelease }}
 
         if ('$(Skip.ReleaseBrew)' -eq 'true') {


### PR DESCRIPTION
Looking back through releases I found a couple failures which required intervention: 

1. [Jun 14 release build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2846258&view=logs&j=b7097f24-c4f3-5d67-8e4f-7a291a407709&t=5b99ed8b-cb08-5fde-dff1-b89d40c908d6)
2. [Jul 12 release build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2911902&view=logs&j=493e9ff3-1332-590a-730c-4fca05f30c58&t=4c7fa1e3-7572-57b4-94a9-fbe790ecd3ae)

## What happened on June 14th?

As part of the [GA publishing tasks PR](https://github.com/Azure/azure-dev/commit/bfc7050577348db4070f8888676ea24d0b501e03) a [`Set SubmitBrewFormula` task was added](https://github.com/Azure/azure-dev/commit/bfc7050577348db4070f8888676ea24d0b501e03#diff-97440691b051b7593395361d95cba18f367e3e8155c120eff3a00a0c51ecfb18R232) which would determine if we would update the brew formula. 

In that case, we were missing a value for `${{ parameters.CliVersion }}` (which was present in other template files). 

[The fix](https://github.com/Azure/azure-dev/commit/1d406fb76d752dc9106ab078cce8a15c9a23a5e0) for that introduced back on June 15th. 



## What happened on July 12th?

The next release uncovered [another issue introduced in the GA tasks PR](https://github.com/Azure/azure-dev/commit/bfc7050577348db4070f8888676ea24d0b501e03#diff-97440691b051b7593395361d95cba18f367e3e8155c120eff3a00a0c51ecfb18R234). That is, a missing backtick to tell PowerShell to keep parsing the next line as if it were on the same line... a formatting error. 

This PR fixes that backtick formatting error. 


