### PR TITLE
[asker] Fix asker prompting indefinitely due to invalid choice selection on non-tty mode

### DIFF
--- a/cli/azd/pkg/input/asker.go
+++ b/cli/azd/pkg/input/asker.go
@@ -73,19 +73,23 @@ func withShowCursor(o *survey.AskOptions) error {
 
 func askOnePrompt(p survey.Prompt, response interface{}, isTerminal bool, stdout io.Writer, stdin io.Reader) error {
 	// Like (*bufio.Reader).ReadString(byte) except that it does not buffer input from the input stream.
-	// instead, it reads a byte at a time until a delimiter is found, without consuming any extra characters.
+	// Instead, it reads a byte at a time until a delimiter is found or EOF is encountered,
+	// returning bytes read with no extra characters consumed.
 	readStringNoBuffer := func(r io.Reader, delim byte) (string, error) {
 		strBuf := bytes.Buffer{}
 		readBuf := make([]byte, 1)
 		for {
-			if _, err := r.Read(readBuf); err != nil {
+			bytesRead, err := r.Read(readBuf)
+			if err != nil && !errors.Is(err, io.EOF) {
 				return strBuf.String(), err
 			}
 
-			// discard err, per documentation, WriteByte always succeeds.
-			_ = strBuf.WriteByte(readBuf[0])
+			if bytesRead > 0 {
+				// discard err, per documentation, WriteByte always succeeds.
+				_ = strBuf.WriteByte(readBuf[0])
+			}
 
-			if readBuf[0] == delim {
+			if readBuf[0] == delim || errors.Is(err, io.EOF) {
 				return strBuf.String(), nil
 			}
 		}
@@ -127,36 +131,34 @@ func askOnePrompt(p survey.Prompt, response interface{}, isTerminal bool, stdout
 		*pResponse = result
 		return nil
 	case *survey.Select:
-		for {
-			fmt.Fprintf(stdout, "%s", v.Message[0:len(v.Message)-1])
-			if v.Default != nil {
-				fmt.Fprintf(stdout, " (or hit enter to use the default %v)", v.Default)
-			}
-			fmt.Fprintf(stdout, "%s ", v.Message[len(v.Message)-1:])
-			result, err := readStringNoBuffer(stdin, '\n')
-			if err != nil && !errors.Is(err, io.EOF) {
-				return fmt.Errorf("reading response: %w", err)
-			}
-			result = strings.TrimSpace(result)
-			if result == "" && v.Default != nil {
-				result = v.Default.(string)
-			}
-			for idx, val := range v.Options {
-				if val == result {
-					switch ptr := response.(type) {
-					case *string:
-						*ptr = val
-					case *int:
-						*ptr = idx
-					default:
-						return fmt.Errorf("bad type %T for result, should be (*int or *string)", response)
-					}
-
-					return nil
-				}
-			}
-			fmt.Fprintf(stdout, "error: %s is not an allowed choice\n", result)
+		fmt.Fprintf(stdout, "%s", v.Message[0:len(v.Message)-1])
+		if v.Default != nil {
+			fmt.Fprintf(stdout, " (or hit enter to use the default %v)", v.Default)
 		}
+		fmt.Fprintf(stdout, "%s ", v.Message[len(v.Message)-1:])
+		result, err := readStringNoBuffer(stdin, '\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("reading response: %w", err)
+		}
+		result = strings.TrimSpace(result)
+		if result == "" && v.Default != nil {
+			result = v.Default.(string)
+		}
+		for idx, val := range v.Options {
+			if val == result {
+				switch ptr := response.(type) {
+				case *string:
+					*ptr = val
+				case *int:
+					*ptr = idx
+				default:
+					return fmt.Errorf("bad type %T for result, should be (*int or *string)", response)
+				}
+
+				return nil
+			}
+		}
+		return fmt.Errorf("'%s' is not an allowed choice", result)
 	case *survey.Confirm:
 		var pResponse = response.(*bool)
 

--- a/cli/azd/pkg/input/asker.go
+++ b/cli/azd/pkg/input/asker.go
@@ -80,16 +80,16 @@ func askOnePrompt(p survey.Prompt, response interface{}, isTerminal bool, stdout
 		readBuf := make([]byte, 1)
 		for {
 			bytesRead, err := r.Read(readBuf)
-			if err != nil && !errors.Is(err, io.EOF) {
-				return strBuf.String(), err
-			}
-
 			if bytesRead > 0 {
 				// discard err, per documentation, WriteByte always succeeds.
 				_ = strBuf.WriteByte(readBuf[0])
 			}
 
-			if readBuf[0] == delim || errors.Is(err, io.EOF) {
+			if err != nil {
+				return strBuf.String(), err
+			}
+
+			if readBuf[0] == delim {
 				return strBuf.String(), nil
 			}
 		}


### PR DESCRIPTION
While reading a `survey.Select` prompt choice from a non-tty `stdin` (such as a file, or `strings.Reader` in tests), an invalid choice causes the application to stall indefinitely. This is due to the use of a for-loop, where our `asker` implementation was re-prompting for invalid input instead of erroring out.

This change fixes the behavior to error out if an invalid choice is provided while reading in non-tty mode. Other prompt modes did not have the same issue.

Example output:
```
2023-07-24T20:39:31.0014647Z === FAIL: cli/azd/test/functional Test_CLI_Telemetry_NestedCommands (unknown)
2023-07-24T20:39:31.0032809Z     telemetry_test.go:228: DIR: /tmp/Test_CLI_Telemetry_NestedCommands4125947061/001
2023-07-24T20:39:31.0038932Z     cli.go:218: 10ms [stdout] 
2023-07-24T20:39:31.0041844Z     cli.go:218: 10ms [stdout] Initializing a new project (azd init)
2023-07-24T20:39:31.0044565Z     cli.go:218: 10ms [stdout] 
2023-07-24T20:39:31.0047301Z     cli.go:218: 10ms [stdout] How do you want to initialize your app? error:  is not an allowed choice
2023-07-24T20:39:31.0169668Z     cli.go:218: 10ms [stdout] How do you want to initialize your app? error: azdtest-l2453e1 is not an allowed choice
2023-07-24T20:39:31.0170828Z     cli.go:218: 10ms [stdout] How do you want to initialize your app? error:  is not an allowed choice
2023-07-24T20:39:31.0181036Z     cli.go:218: 10ms [stdout] How do you want to initialize your app? error:  is not an allowed choice
2023-07-24T20:39:31.0201108Z     cli.go:218: 10ms [stdout] How do you want to initialize your app? error:  is not an allowed choice
2023-07-24T20:39:31.0210643Z     cli.go:218: 10ms [stdout] How do you want to initialize your app? error:  is not an allowed choice
2023-07-24T20:39:31.0213474Z     cli.go:218: 10ms [stdout] How do you want to initialize your app? error:  is not an allowed choice
2023-07-24T20:39:31.0217357Z     cli.go:218: 10ms [stdout] How do you want to initialize your app? error:  is not an allowed choice
2023-07-24T20:39:31.0220051Z     cli.go:218: 10ms [stdout] How do you want to initialize your app? error:  is not an allowed choice
...
```

Also, fix the `readStringNoBuffer` implementation to handle a non-zero byte read with io.EOF encountered, which is possible as described by the io.Reader [docs](https://pkg.go.dev/io#Reader).