### PR TITLE
Fix `azd down` after a failed `azd provision`

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.1.1 (Unreleased)
 
+### Bugs Fixed
+
+- [[????]](https://github.com/Azure/azure-dev/pull/????) Fix `azd down` so it works after a failed `azd provision`
+
 ### Features Added
 
 - [[2550]](https://github.com/Azure/azure-dev/pull/2550) Add `--preview` to `azd provision` to get the changes 

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs Fixed
 
-- [[????]](https://github.com/Azure/azure-dev/pull/????) Fix `azd down` so it works after a failed `azd provision`
+- [[2569]](https://github.com/Azure/azure-dev/pull/2569) Fix `azd down` so it works after a failed `azd provision`
 
 ### Features Added
 

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -680,19 +680,6 @@ func resourceGroupsToDelete(deployment *armresources.DeploymentExtended) []strin
 		}
 	}
 
-	if deployment.Properties.OutputResources != nil {
-	} else {
-		// We have seen
-
-		for _, dependency := range deployment.Properties.Dependencies {
-			for _, dependent := range dependency.DependsOn {
-				if *dependent.ResourceType == arm.ResourceGroupResourceType.String() {
-					resourceGroups[*dependent.ResourceName] = struct{}{}
-				}
-			}
-		}
-	}
-
 	return maps.Keys(resourceGroups)
 }
 

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -449,7 +449,7 @@ func (p *BicepProvider) Destroy(ctx context.Context, options DestroyOptions) (*D
 		return nil, err
 	}
 
-	rgsFromDeployment := resourceGroupsFromDeployment(deployment)
+	rgsFromDeployment := resourceGroupsToDelete(deployment)
 
 	// TODO: Report progress, "Fetching resources"
 	groupedResources, err := p.getAllResourcesToDelete(ctx, rgsFromDeployment)
@@ -645,31 +645,55 @@ func latestCompletedDeployment(
 	return nil, fmt.Errorf("no deployments found for environment %s", envName)
 }
 
-// resourceGroupsFromDeployment returns the names of all the unique set of resource group name names resource groups from
-//
-//	the OutputResources section of a ARM deployment.
-func resourceGroupsFromDeployment(deployment *armresources.DeploymentExtended) []string {
-
+// resourceGroupsToDelete collects the resource groups from an existing deployment which should be removed as part of a
+// destroy operation.
+func resourceGroupsToDelete(deployment *armresources.DeploymentExtended) []string {
 	// NOTE: it's possible for a deployment to list a resource group more than once. We're only interested in the
 	// unique set.
 	resourceGroups := map[string]struct{}{}
 
-	for _, resourceId := range deployment.Properties.OutputResources {
-		if resourceId != nil && resourceId.ID != nil {
-			resId, err := arm.ParseResourceID(*resourceId.ID)
-			if err == nil && resId.ResourceGroupName != "" {
-				resourceGroups[resId.ResourceGroupName] = struct{}{}
+	if *deployment.Properties.ProvisioningState == armresources.ProvisioningStateSucceeded {
+		// For a successful deployment, we can use the output resources property to see the resource groups that were
+		// provisioned from this.
+		for _, resourceId := range deployment.Properties.OutputResources {
+			if resourceId != nil && resourceId.ID != nil {
+				resId, err := arm.ParseResourceID(*resourceId.ID)
+				if err == nil && resId.ResourceGroupName != "" {
+					resourceGroups[resId.ResourceGroupName] = struct{}{}
+				}
+			}
+		}
+	} else {
+		// For a failed deployment, the `outputResources` field is not populated. Instead, we assume that any resource
+		// groups which this deployment itself deployed into should be deleted. This matches what a deployment likes
+		// for the common pattern of having a subscription level deployment which allocates a set of resource groups
+		// and then does nested deployments into them.
+		for _, dependency := range deployment.Properties.Dependencies {
+			if *dependency.ResourceType == string(infra.AzureResourceTypeDeployment) {
+				for _, dependent := range dependency.DependsOn {
+					if *dependent.ResourceType == arm.ResourceGroupResourceType.String() {
+						resourceGroups[*dependent.ResourceName] = struct{}{}
+					}
+				}
+			}
+
+		}
+	}
+
+	if deployment.Properties.OutputResources != nil {
+	} else {
+		// We have seen
+
+		for _, dependency := range deployment.Properties.Dependencies {
+			for _, dependent := range dependency.DependsOn {
+				if *dependent.ResourceType == arm.ResourceGroupResourceType.String() {
+					resourceGroups[*dependent.ResourceName] = struct{}{}
+				}
 			}
 		}
 	}
 
-	var resourceGroupNames []string
-
-	for k := range resourceGroups {
-		resourceGroupNames = append(resourceGroupNames, k)
-	}
-
-	return resourceGroupNames
+	return maps.Keys(resourceGroups)
 }
 
 func (p *BicepProvider) getAllResourcesToDelete(

--- a/cli/azd/pkg/infra/provisioning/bicep/testdata/failed-subscription-deployment.json
+++ b/cli/azd/pkg/infra/provisioning/bicep/testdata/failed-subscription-deployment.json
@@ -1,0 +1,109 @@
+{
+  "id": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/matell-2508-1689982746",
+  "location": "eastus2",
+  "name": "matell-2508-1689982746",
+  "properties": {
+    "correlationId": "84c13af8bdb9709a44dda61f93cce798",
+    "debugSetting": null,
+    "dependencies": [
+      {
+        "dependsOn": [
+          {
+            "id": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/matell-2508-rg",
+            "resourceName": "matell-2508-rg",
+            "resourceType": "Microsoft.Resources/resourceGroups"
+          }
+        ],
+        "id": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/matell-2508-rg/providers/Microsoft.Resources/deployments/resources",
+        "resourceGroup": "matell-2508-rg",
+        "resourceName": "resources",
+        "resourceType": "Microsoft.Resources/deployments"
+      }
+    ],
+    "duration": "PT1M39.7689131S",
+    "error": {
+      "additionalInfo": null,
+      "code": "DeploymentFailed",
+      "details": [
+        {
+          "additionalInfo": null,
+          "code": "DeploymentFailed",
+          "details": null,
+          "message": "At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.",
+          "target": null
+        }
+      ],
+      "message": "At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.",
+      "target": null
+    },
+    "mode": "Incremental",
+    "onErrorDeployment": null,
+    "outputResources": null,
+    "outputs": null,
+    "parameters": {
+      "databasePassword": {
+        "type": "SecureString"
+      },
+      "location": {
+        "type": "String",
+        "value": "eastus2"
+      },
+      "name": {
+        "type": "String",
+        "value": "matell-2508"
+      },
+      "secretKey": {
+        "type": "SecureString"
+      }
+    },
+    "parametersLink": null,
+    "providers": [
+      {
+        "id": null,
+        "namespace": "Microsoft.Resources",
+        "providerAuthorizationConsentState": null,
+        "registrationPolicy": null,
+        "registrationState": null,
+        "resourceTypes": [
+          {
+            "aliases": null,
+            "apiProfiles": null,
+            "apiVersions": null,
+            "capabilities": null,
+            "defaultApiVersion": null,
+            "locationMappings": null,
+            "locations": [
+              "eastus2"
+            ],
+            "properties": null,
+            "resourceType": "resourceGroups",
+            "zoneMappings": null
+          },
+          {
+            "aliases": null,
+            "apiProfiles": null,
+            "apiVersions": null,
+            "capabilities": null,
+            "defaultApiVersion": null,
+            "locationMappings": null,
+            "locations": [
+              null
+            ],
+            "properties": null,
+            "resourceType": "deployments",
+            "zoneMappings": null
+          }
+        ]
+      }
+    ],
+    "provisioningState": "Failed",
+    "templateHash": "11208209120649888667",
+    "templateLink": null,
+    "timestamp": "2023-07-21T23:40:49.234299+00:00",
+    "validatedResources": null
+  },
+  "tags": {
+    "azd-env-name": "matell-2508"
+  },
+  "type": "Microsoft.Resources/deployments"
+}


### PR DESCRIPTION
For subscription level deployments, `azd down` needs to discover the set of resource groups from the previous deployment, so it can go delete each one. We were using the `outputResources` property of an ARM Deployment to compute this, which is not populated for failed deployments.

In the failed deployments case, we revert back to trying to infer this information (as before d8863e44c25bad9e52a5c6a1c0b042a52b81edde) from the `dependsOn` portion of the deployment. This can miss some cases (e.g. empty resouce groups, which is why we moved away from this in failure cases (where often you really do want to tear down everything and start over)

Fixes #2508