### PR TITLE
Update appservice.bicep with gunicorn config

### DIFF
--- a/templates/common/infra/bicep/core/host/appservice.bicep
+++ b/templates/common/infra/bicep/core/host/appservice.bicep
@@ -99,6 +99,7 @@ module config 'appservice-appsettings.bicep' = if (!empty(appSettings)) {
         SCM_DO_BUILD_DURING_DEPLOYMENT: string(scmDoBuildDuringDeployment)
         ENABLE_ORYX_BUILD: string(enableOryxBuild)
       },
+      runtimeName == 'python' ? { PYTHON_ENABLE_GUNICORN_MULTIWORKERS: 'true'} : {},
       !empty(applicationInsightsName) ? { APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.properties.ConnectionString } : {},
       !empty(keyVaultName) ? { AZURE_KEY_VAULT_ENDPOINT: keyVault.properties.vaultUri } : {})
   }


### PR DESCRIPTION
This PR sets PYTHON_ENABLE_GUNICORN_MULTIWORKERS by default on App Service, when python runtime is chosen. When Oryx sees that env variable, it will auto configure the gunicorn server to use a worker count based off the formula of CPU_COUNT * 2 + 1. That's generally better than always using a single worker.

Here's Oryx docs about the config option:
https://github.com/microsoft/Oryx/blob/5239b0416cdddcf5bf0aef6703eb339efa865d67/doc/runtimes/python.md?plain=1#L101

The only reason this isn't default on App Service is for backwards compatibility reasons, but I think it should be default for all our App Service Python apps that dont specify their own appCommandLine.