### PR TITLE
Make `appSettings` a secure object by default

### DIFF
--- a/templates/common/infra/bicep/core/host/appservice-appsettings.bicep
+++ b/templates/common/infra/bicep/core/host/appservice-appsettings.bicep
@@ -2,6 +2,7 @@
 param name string
 
 @description('The app settings to be applied to the app service')
+@secure()
 param appSettings object
 
 resource appService 'Microsoft.Web/sites@2022-03-01' existing = {

--- a/templates/common/infra/bicep/core/host/appservice.bicep
+++ b/templates/common/infra/bicep/core/host/appservice.bicep
@@ -23,6 +23,7 @@ param kind string = 'app,linux'
 param allowedOrigins array = []
 param alwaysOn bool = true
 param appCommandLine string = ''
+@secure()
 param appSettings object = {}
 param clientAffinityEnabled bool = false
 param enableOryxBuild bool = contains(kind, 'linux')

--- a/templates/common/infra/bicep/core/host/functions.bicep
+++ b/templates/common/infra/bicep/core/host/functions.bicep
@@ -30,6 +30,7 @@ param kind string = 'functionapp,linux'
 param allowedOrigins array = []
 param alwaysOn bool = true
 param appCommandLine string = ''
+@secure()
 param appSettings object = {}
 param clientAffinityEnabled bool = false
 param enableOryxBuild bool = contains(kind, 'linux')

--- a/templates/todo/common/infra/bicep/app/api-appservice-dotnet.bicep
+++ b/templates/todo/common/infra/bicep/app/api-appservice-dotnet.bicep
@@ -6,6 +6,7 @@ param allowedOrigins array = []
 param appCommandLine string = ''
 param applicationInsightsName string = ''
 param appServicePlanId string
+@secure()
 param appSettings object = {}
 param keyVaultName string
 param serviceName string = 'api'

--- a/templates/todo/common/infra/bicep/app/api-appservice-java.bicep
+++ b/templates/todo/common/infra/bicep/app/api-appservice-java.bicep
@@ -6,6 +6,7 @@ param allowedOrigins array = []
 param appCommandLine string = ''
 param applicationInsightsName string = ''
 param appServicePlanId string
+@secure()
 param appSettings object = {}
 param keyVaultName string
 param serviceName string = 'api'

--- a/templates/todo/common/infra/bicep/app/api-appservice-node.bicep
+++ b/templates/todo/common/infra/bicep/app/api-appservice-node.bicep
@@ -6,6 +6,7 @@ param allowedOrigins array = []
 param appCommandLine string = ''
 param applicationInsightsName string = ''
 param appServicePlanId string
+@secure()
 param appSettings object = {}
 param keyVaultName string
 param serviceName string = 'api'

--- a/templates/todo/common/infra/bicep/app/api-appservice-python.bicep
+++ b/templates/todo/common/infra/bicep/app/api-appservice-python.bicep
@@ -6,6 +6,7 @@ param allowedOrigins array = []
 param appCommandLine string = 'gunicorn --workers 4 --threads 2 --timeout 60 --access-logfile "-" --error-logfile "-" --bind=0.0.0.0:8000 -k uvicorn.workers.UvicornWorker todo.app:app'
 param applicationInsightsName string = ''
 param appServicePlanId string
+@secure()
 param appSettings object = {}
 param keyVaultName string
 param serviceName string = 'api'

--- a/templates/todo/common/infra/bicep/app/api-functions-dotnet-isolated.bicep
+++ b/templates/todo/common/infra/bicep/app/api-functions-dotnet-isolated.bicep
@@ -5,6 +5,7 @@ param tags object = {}
 param allowedOrigins array = []
 param applicationInsightsName string = ''
 param appServicePlanId string
+@secure()
 param appSettings object = {}
 param keyVaultName string
 param serviceName string = 'api'

--- a/templates/todo/common/infra/bicep/app/api-functions-node.bicep
+++ b/templates/todo/common/infra/bicep/app/api-functions-node.bicep
@@ -5,6 +5,7 @@ param tags object = {}
 param allowedOrigins array = []
 param applicationInsightsName string = ''
 param appServicePlanId string
+@secure()
 param appSettings object = {}
 param keyVaultName string
 param serviceName string = 'api'

--- a/templates/todo/common/infra/bicep/app/api-functions-python.bicep
+++ b/templates/todo/common/infra/bicep/app/api-functions-python.bicep
@@ -5,6 +5,7 @@ param tags object = {}
 param allowedOrigins array = []
 param applicationInsightsName string = ''
 param appServicePlanId string
+@secure()
 param appSettings object = {}
 param keyVaultName string
 param serviceName string = 'api'


### PR DESCRIPTION
This allows users to set secret values as app settings for `appservice`, `function` host services. App service handle secrets in [app settings](https://learn.microsoft.com/en-us/azure/app-service/configure-common?tabs=portal#configure-app-settings) by defaults, so there isn't any additional configuration there.

Fixes https://github.com/Azure/azure-dev-pr/issues/1563