### PR TITLE
sync az and azd for terraform pipeline definition

### DIFF
--- a/templates/common/.github/workflows/java/terraform/azure-dev.yml
+++ b/templates/common/.github/workflows/java/terraform/azure-dev.yml
@@ -42,9 +42,7 @@ jobs:
         uses: azure/CLI@v1
         with:
           inlineScript: |
-            az account show
             az account set --subscription ${{vars.AZURE_SUBSCRIPTION_ID}}
-            az account show
 
       - name: Log in with Azure
         run: |

--- a/templates/common/.github/workflows/java/terraform/azure-dev.yml
+++ b/templates/common/.github/workflows/java/terraform/azure-dev.yml
@@ -28,6 +28,24 @@ jobs:
       - run: |
           chmod +x ${GITHUB_WORKSPACE}/src/api/mvnw
 
+      - name: Install Nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Login az
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Set az account
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az account show
+            az account set --subscription ${{vars.AZURE_SUBSCRIPTION_ID}}
+            az account show
+
       - name: Log in with Azure
         run: |
           $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;

--- a/templates/common/.github/workflows/nodejs/terraform/azure-dev.yml
+++ b/templates/common/.github/workflows/nodejs/terraform/azure-dev.yml
@@ -34,9 +34,7 @@ jobs:
         uses: azure/CLI@v1
         with:
           inlineScript: |
-            az account show
             az account set --subscription ${{vars.AZURE_SUBSCRIPTION_ID}}
-            az account show          
 
       - name: Log in with Azure
         run: |

--- a/templates/common/.github/workflows/nodejs/terraform/azure-dev.yml
+++ b/templates/common/.github/workflows/nodejs/terraform/azure-dev.yml
@@ -25,6 +25,19 @@ jobs:
         with:
           node-version: 16
 
+      - name: Login az
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Set az account
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az account show
+            az account set --subscription ${{vars.AZURE_SUBSCRIPTION_ID}}
+            az account show          
+
       - name: Log in with Azure
         run: |
           $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;

--- a/templates/common/.github/workflows/terraform/azure-dev.yml
+++ b/templates/common/.github/workflows/terraform/azure-dev.yml
@@ -34,9 +34,7 @@ jobs:
         uses: azure/CLI@v1
         with:
           inlineScript: |
-            az account show
             az account set --subscription ${{vars.AZURE_SUBSCRIPTION_ID}}
-            az account show
 
       - name: Log in with Azure
         run: |

--- a/templates/common/.github/workflows/terraform/azure-dev.yml
+++ b/templates/common/.github/workflows/terraform/azure-dev.yml
@@ -20,6 +20,24 @@ jobs:
       - name: Install azd
         uses: Azure/setup-azd@v0.1.0
 
+      - name: Install Nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Login az
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Set az account
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az account show
+            az account set --subscription ${{vars.AZURE_SUBSCRIPTION_ID}}
+            az account show
+
       - name: Log in with Azure
         run: |
           $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;


### PR DESCRIPTION
fix: https://github.com/Azure/azure-dev/issues/2231

Adding `az` login and account setup for terraform's pipeline definitions.
This is required after we added `az` commands to the end of `azd provision` for terraform templates to set up basic auth.

This was not catch during CI because we did add the az and az account sync to test-templates CI.  However, we also need this fix for the GitHub pipeline definition.

We don't need to do this for the Azure DevOps pipeline definition because it still uses az-cli auth and automatically sets the az-account based on the connection.