### PR TITLE
Cloud Shell auth error logging

### DIFF
--- a/cli/azd/pkg/auth/cloudshell_credential.go
+++ b/cli/azd/pkg/auth/cloudshell_credential.go
@@ -66,13 +66,13 @@ func (t CloudShellCredential) GetToken(ctx context.Context, options policy.Token
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		return azcore.AccessToken{}, fmt.Errorf("invalid CloudShell token API response code: %d", resp.StatusCode)
-	}
-
 	responseBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return azcore.AccessToken{}, err
+	}
+
+	if resp.StatusCode != 200 {
+		return azcore.AccessToken{}, fmt.Errorf("invalid CloudShell token API response code: %d, content: %s", resp.StatusCode, responseBytes)
 	}
 
 	var tokenObject TokenFromCloudShell

--- a/cli/azd/pkg/auth/cloudshell_credential.go
+++ b/cli/azd/pkg/auth/cloudshell_credential.go
@@ -72,7 +72,10 @@ func (t CloudShellCredential) GetToken(ctx context.Context, options policy.Token
 	}
 
 	if resp.StatusCode != 200 {
-		return azcore.AccessToken{}, fmt.Errorf("invalid CloudShell token API response code: %d, content: %s", resp.StatusCode, responseBytes)
+		return azcore.AccessToken{}, fmt.Errorf(
+			"invalid CloudShell token API response code: %d, content: %s",
+			resp.StatusCode,
+			responseBytes)
 	}
 
 	var tokenObject TokenFromCloudShell


### PR DESCRIPTION
Adds logs to console. Fixes https://github.com/Azure/azure-dev/issues/2410 by adding details to error logs in the console. 

Example error using a contrived audience URL (error messages will vary based on the user's situation): 

![image](https://github.com/Azure/azure-dev/assets/2158838/997e85df-c0ed-4d63-b2df-1ca5caa6f21e)

This error is expected to only occur in scenarios like those described in https://github.com/Azure/azure-dev/issues/2410 where a browser or machine is not fully permitted by policy to perform certain interactions. In those cases the user may also see an error in their browser indicating that they need to ensure that their device is properly authenticated.

I also explored using a pipeline to log the requests and using `AZURE_SDK_GO_LOGGING=all` and `--debug` to get more detail on a request. The resulting logs did not include the response body which renders the additional logging by the pipeline useless for debugging purposes. 

@Austinauth, @savannahostrowski -- UX changes here. We're logging the response body when a user in Cloud Shell encounters an authentication error. The only such case of these errors happening is the above linked bug where the user has logged into the Azure Portal with a machine that is not fully trusted and certain operations are restricted by policy. (Error message above is not from this scenario as I haven't been able to consistently replicate the above linked bug). 