### PR TITLE
up: fix follow-up message not displayed

### DIFF
--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -135,7 +135,7 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 	provision.flags = &u.flags.provisionFlags
 	provisionOptions := &middleware.Options{CommandPath: "provision"}
-	_, err = u.runner.RunChildAction(ctx, provisionOptions, provision)
+	provisionResult, err := u.runner.RunChildAction(ctx, provisionOptions, provision)
 	if err != nil {
 		return nil, err
 	}
@@ -164,6 +164,7 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		Message: &actions.ResultMessage{
 			Header: fmt.Sprintf("Your application was provisioned and deployed to Azure in %s.",
 				ux.DurationAsText(since(startTime))),
+			FollowUp: provisionResult.Message.FollowUp,
 		},
 	}, nil
 }


### PR DESCRIPTION
Adding the follow-up message back to `up`. The up command is supposed to print out the final resource group link, which used to work in much older versions. This was regressed awhile back.

After this change: ![image](https://github.com/Azure/azure-dev/assets/2322434/992947d5-6d22-4544-a5d8-410a498c4c0f)
