### PR TITLE
Adopt go 1.21

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -21,12 +21,12 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "^1.20.0"
+          go-version: "^1.21.0"
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.54.1
           args: -v --timeout 10m0s
           working-directory: cli/azd
 

--- a/cli/azd/cmd/cmd_help.go
+++ b/cli/azd/cmd/cmd_help.go
@@ -5,12 +5,12 @@ package cmd
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/cli/azd/cmd/cobra_builder.go
+++ b/cli/azd/cmd/cobra_builder.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -19,7 +20,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 )
 
 const cDocsFlagName = "docs"

--- a/cli/azd/internal/repository/initializer_test.go
+++ b/cli/azd/internal/repository/initializer_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -21,7 +22,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func Test_Initializer_Initialize(t *testing.T) {

--- a/cli/azd/internal/telemetry/storage_test.go
+++ b/cli/azd/internal/telemetry/storage_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 // The tests in this file intentionally interacts with the filesystem (important implementation detail).

--- a/cli/azd/internal/telemetry/uploader_test.go
+++ b/cli/azd/internal/telemetry/uploader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -11,7 +12,6 @@ import (
 	appinsightsexporter "github.com/azure/azure-dev/cli/azd/internal/telemetry/appinsights-exporter"
 	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/slices"
 )
 
 type InMemoryItem struct {

--- a/cli/azd/internal/tracing/baggage/baggage.go
+++ b/cli/azd/internal/tracing/baggage/baggage.go
@@ -4,8 +4,9 @@
 package baggage
 
 import (
-	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/exp/maps"
+
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // An immutable object safe for concurrent use.

--- a/cli/azd/pkg/account/manager.go
+++ b/cli/azd/pkg/account/manager.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"slices"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
-	"golang.org/x/exp/slices"
 )
 
 // JSON document path locations for default subscription & location

--- a/cli/azd/pkg/account/manager_test.go
+++ b/cli/azd/pkg/account/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"slices"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
@@ -15,7 +16,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockhttp"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func Test_GetAccountDefaults(t *testing.T) {

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"slices"
 
 	msal "github.com/AzureAD/microsoft-authentication-library-for-go/apps/errors"
-	"golang.org/x/exp/slices"
 )
 
 const cLoginCmd = "azd auth login"

--- a/cli/azd/pkg/azureutil/location.go
+++ b/cli/azd/pkg/azureutil/location.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
-	"golang.org/x/exp/slices"
 )
 
 // PromptLocation asks the user to select a location from a list of supported azure locations for a given subscription.
@@ -48,9 +48,9 @@ func PromptLocationWithFilter(
 		}
 	}
 
-	slices.SortFunc(locations, func(a, b account.Location) bool {
+	slices.SortFunc(locations, func(a, b account.Location) int {
 		return strings.Compare(
-			strings.ToLower(a.RegionalDisplayName), strings.ToLower(b.RegionalDisplayName)) < 0
+			strings.ToLower(a.RegionalDisplayName), strings.ToLower(b.RegionalDisplayName))
 	})
 
 	// Allow the environment variable `AZURE_LOCATION` to control the default value for the location

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -11,13 +11,14 @@ import (
 	"regexp"
 	"strings"
 
+	"maps"
+
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/joho/godotenv"
-	"golang.org/x/exp/maps"
 )
 
 // EnvNameEnvVarName is the name of the key used to store the envname property in the environment.

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -38,7 +39,6 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/drone/envsubst"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 const DefaultModule = "main"
@@ -715,8 +715,8 @@ func (p *BicepProvider) findCompletedDeployments(
 		return nil, err
 	}
 
-	slices.SortFunc(deployments, func(x, y *armresources.DeploymentExtended) bool {
-		return x.Properties.Timestamp.After(*y.Properties.Timestamp)
+	slices.SortFunc(deployments, func(x, y *armresources.DeploymentExtended) int {
+		return x.Properties.Timestamp.Compare(*y.Properties.Timestamp)
 	})
 
 	// If hint is not provided, use the environment name as the hint

--- a/cli/azd/pkg/infra/provisioning/bicep/prompt.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strconv"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
-	"golang.org/x/exp/slices"
 
 	. "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 )

--- a/cli/azd/pkg/pipeline/github_provider.go
+++ b/cli/azd/pkg/pipeline/github_provider.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -31,7 +32,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/git"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/github"
-	"golang.org/x/exp/slices"
 )
 
 // GitHubScmProvider implements ScmProvider using GitHub as the provider

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -25,7 +26,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/git"
 	"github.com/sethvargo/go-retry"
-	"golang.org/x/exp/slices"
 )
 
 type PipelineAuthType string

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
@@ -16,7 +17,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/blang/semver/v4"
-	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
 

--- a/cli/azd/pkg/prompt/prompter.go
+++ b/cli/azd/pkg/prompt/prompter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -15,7 +16,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
-	"golang.org/x/exp/slices"
 )
 
 type LocationFilterPredicate func(loc account.Location) bool
@@ -112,8 +112,8 @@ func (p *DefaultPrompter) PromptResourceGroup(ctx context.Context) (string, erro
 		return "", fmt.Errorf("listing resource groups: %w", err)
 	}
 
-	slices.SortFunc(groups, func(a, b azcli.AzCliResource) bool {
-		return strings.Compare(a.Name, b.Name) < 0
+	slices.SortFunc(groups, func(a, b azcli.AzCliResource) int {
+		return strings.Compare(a.Name, b.Name)
 	})
 
 	choices := make([]string, len(groups)+1)

--- a/cli/azd/pkg/tools/azcli/container_registry.go
+++ b/cli/azd/pkg/tools/azcli/container_registry.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -17,7 +18,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
-	"golang.org/x/exp/slices"
 )
 
 type dockerCredentials struct {

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -43,7 +44,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
-	"golang.org/x/exp/slices"
 )
 
 // The current running configuration for the test suite.

--- a/cli/azd/test/recording/proxy.go
+++ b/cli/azd/test/recording/proxy.go
@@ -11,12 +11,12 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
 
-	"golang.org/x/exp/slog"
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
 )
 

--- a/cli/azd/test/recording/recording.go
+++ b/cli/azd/test/recording/recording.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -24,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/exp/slog"
 	"gopkg.in/dnaeon/go-vcr.v3/cassette"
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
 	"gopkg.in/yaml.v3"

--- a/eng/pipelines/templates/steps/setup-go.yml
+++ b/eng/pipelines/templates/steps/setup-go.yml
@@ -1,5 +1,5 @@
 parameters:
-  GoVersion: 1.20.3
+  GoVersion: 1.21.0
   Condition: succeeded()
 
 steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/azure/azure-dev
 
-go 1.20
+go 1.21
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.2

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,7 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armconta
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.2.0 h1:3L+gX5ssCABAToH0VQ64/oNz7rr+ShW+2sB+sonzIlY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.2.0/go.mod h1:4gUds0dEPFIld6DwHfbo0cLBljyIyI5E5ciPb5MLi3Q=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.0.0 h1:lMW1lD/17LUA5z1XTURo7LcVG2ICBPlyMHjIUrcFZNQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.0.0/go.mod h1:ceIuwmxDWptoW3eCqSXlnPsZFKh4X+R38dWPv7GS9Vs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.0.0 h1:Jc2KcpCDMu7wJfkrzn7fs/53QMDXH78GuqnH4HOd7zs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.0.0/go.mod h1:PFVgFsclKzPqYRT/BiwpfUN22cab0C7FlgXR3iWpwMo=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0 h1:ECsQtyERDVz3NP3kvDOTLvbQhqWp/x9EsGKtb4ogUr8=
@@ -154,6 +155,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
+github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/drone/envsubst v1.0.3 h1:PCIBwNDYjs50AsLZPYdfhSATKaRg/FJmDc2D6+C2x8g=
 github.com/drone/envsubst v1.0.3/go.mod h1:N2jZmlMufstn1KEqvbHjw40h1KyTmnVzHcSc9bFiJ2g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -195,6 +197,7 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
 github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -249,6 +252,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=


### PR DESCRIPTION
This change moves us to use Go 1.21 for building `azd`.

As part of go 1.21, the `maps`, `slices` and `slog` packages, previously in `golang.org/x/exp` have been moved into the standard libary. As part of this change, I've moved to use these versions of the packages instead of using the experimental versions.

However, there were a few places where we were using `maps.Keys`, which was not added to the standard
library. https://go-review.googlesource.com/c/go/+/513715 explains the rationale here, they may want `Keys` to return an iterator, and were not comfortable locking the name at this time. This functionality will be added to the `maps` package in a future release, it seems, likely under a name like `KeysSlice`.  For now, I just kept the existing use of the the experimental package. We can update the import path and move to the stdlib version when it lands later.

This change also updates `go.mod` to declare that we need at least go 1.21 to build `azd`. Developers which haven't upgraded will see build errors due to references of `maps`, `slices` and `log/slog` which do not exist in earlier versions of the standard libary.

I've also enabled the loopvar experiment for our CI builds and tests. https://github.com/golang/go/wiki/LoopvarExperiment gives more information on what this does, but the long and short of it is that this behavior is likely to become the default in a future version of go, and the semantics of it more closely match what developers expect, so I would like us to just lock in the changes now (we are presently clean on this, so there are no changes, I just don't want us to introduce any new bad uses).