### PR TITLE
Fix coloring for `OperationTypeIgnore` in `--preview`

### DIFF
--- a/cli/azd/pkg/output/ux/preview_provision.go
+++ b/cli/azd/pkg/output/ux/preview_provision.go
@@ -55,7 +55,8 @@ func colorType(opType OperationType) func(string, ...interface{}) string {
 	var final func(format string, a ...interface{}) string
 	switch opType {
 	case OperationTypeCreate,
-		OperationTypeNoChange:
+		OperationTypeNoChange,
+		OperationTypeIgnore:
 		final = output.WithGrayFormat
 	case OperationTypeDelete:
 		final = color.RedString


### PR DESCRIPTION
The `OperationTypeIgnore` should be rendered in grey instead of yellow, since no action will be taken on the resource.

Something I noticed while getting content ready for this week's community call.

Before:

<img width="644" alt="image" src="https://github.com/Azure/azure-dev/assets/9602953/3a8862d2-1fe8-4aa8-8e48-bbee0b540d37">

After:

<img width="647" alt="image" src="https://github.com/Azure/azure-dev/assets/9602953/efc60c20-fc60-4a5d-a6af-eaa72a483ee9">


Note how the "Skip" color for the Web App resource has changed from yellow to grey.

/cc @Austinauth @savannahostrowski 