### PR TITLE
Adds awesome azd as default template source when not defined

### DIFF
--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -461,7 +461,7 @@ func (a *templateSourceRemoveAction) Run(ctx context.Context) (*actions.ActionRe
 	})
 
 	var key = a.args[0]
-	spinnerMessage := "Removing template source"
+	spinnerMessage := fmt.Sprintf("Removing template source (%s)", key)
 	a.console.ShowSpinner(ctx, spinnerMessage, input.Step)
 	err := a.sourceManager.Remove(ctx, key)
 	a.console.StopSpinner(ctx, spinnerMessage, input.GetStepResultFormat(err))
@@ -472,6 +472,10 @@ func (a *templateSourceRemoveAction) Run(ctx context.Context) (*actions.ActionRe
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
 			Header: fmt.Sprintf("Removed azd template source %s", key),
+			FollowUp: fmt.Sprintf(
+				"Add more template sources by running %s",
+				output.WithHighLightFormat("azd template source add <key>"),
+			),
 		},
 	}, nil
 }

--- a/cli/azd/pkg/templates/awesome_source_test.go
+++ b/cli/azd/pkg/templates/awesome_source_test.go
@@ -24,15 +24,10 @@ var testAwesomeAzdTemplates []*awesomeAzdTemplate = []*awesomeAzdTemplate{
 
 func Test_NewAwesomeAzdTemplateSource_ValidUrl(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
+	mockAwesomeAzdTemplateSource(mockContext)
 
 	name := "test"
 	url := "https://aka.ms/awesome-azd/templates.json"
-
-	mockContext.HttpClient.When(func(req *http.Request) bool {
-		return req.Method == http.MethodGet && req.URL.String() == url
-	}).RespondFn(func(req *http.Request) (*http.Response, error) {
-		return mocks.CreateHttpResponseWithBody(req, http.StatusOK, testAwesomeAzdTemplates)
-	})
 
 	source, err := NewAwesomeAzdTemplateSource(context.Background(), name, url, mockContext.HttpClient)
 	require.Nil(t, err)
@@ -72,4 +67,14 @@ func Test_NewAwesomeAzdTemplateSource_InvalidUrl(t *testing.T) {
 	source, err := NewAwesomeAzdTemplateSource(context.Background(), name, url, mockContext.HttpClient)
 	require.Nil(t, source)
 	require.Error(t, err)
+}
+
+func mockAwesomeAzdTemplateSource(mockContext *mocks.MockContext) {
+	const url = "https://aka.ms/awesome-azd/templates.json"
+
+	mockContext.HttpClient.When(func(req *http.Request) bool {
+		return req.Method == http.MethodGet && req.URL.String() == url
+	}).RespondFn(func(req *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(req, http.StatusOK, testAwesomeAzdTemplates)
+	})
 }

--- a/cli/azd/pkg/templates/template_manager_test.go
+++ b/cli/azd/pkg/templates/template_manager_test.go
@@ -13,6 +13,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var defaultTemplateSourceData = map[string]interface{}{
+	"template": map[string]interface{}{
+		"sources": map[string]interface{}{
+			"default": map[string]interface{}{},
+		},
+	},
+}
+
 func Test_Templates_NewTemplateManager(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	templateManager, err := NewTemplateManager(NewSourceManager(config.NewUserConfigManager(), mockContext.HttpClient))
@@ -22,8 +30,10 @@ func Test_Templates_NewTemplateManager(t *testing.T) {
 
 func Test_Templates_ListTemplates(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
+	mockAwesomeAzdTemplateSource(mockContext)
+
 	configManager := &mockUserConfigManager{}
-	configManager.On("Load").Return(config.NewConfig(nil), nil)
+	configManager.On("Load").Return(config.NewConfig(defaultTemplateSourceData), nil)
 
 	templateManager, err := NewTemplateManager(NewSourceManager(configManager, mockContext.HttpClient))
 	require.NoError(t, err)
@@ -75,7 +85,7 @@ func Test_Templates_ListTemplates_SourceError(t *testing.T) {
 func Test_Templates_GetTemplate_WithValidPath(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	configManager := &mockUserConfigManager{}
-	configManager.On("Load").Return(config.NewConfig(nil), nil)
+	configManager.On("Load").Return(config.NewConfig(defaultTemplateSourceData), nil)
 
 	templateManager, err := NewTemplateManager(NewSourceManager(configManager, mockContext.HttpClient))
 	require.NoError(t, err)
@@ -94,7 +104,7 @@ func Test_Templates_GetTemplate_WithValidPath(t *testing.T) {
 func Test_Templates_GetTemplate_WithInvalidPath(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	configManager := &mockUserConfigManager{}
-	configManager.On("Load").Return(config.NewConfig(nil), nil)
+	configManager.On("Load").Return(config.NewConfig(defaultTemplateSourceData), nil)
 
 	templateManager, err := NewTemplateManager(NewSourceManager(configManager, mockContext.HttpClient))
 	require.NoError(t, err)
@@ -109,7 +119,7 @@ func Test_Templates_GetTemplate_WithInvalidPath(t *testing.T) {
 func Test_Templates_GetTemplate_WithNotFoundPath(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	configManager := &mockUserConfigManager{}
-	configManager.On("Load").Return(config.NewConfig(nil), nil)
+	configManager.On("Load").Return(config.NewConfig(defaultTemplateSourceData), nil)
 
 	templateManager, err := NewTemplateManager(NewSourceManager(configManager, mockContext.HttpClient))
 	require.NoError(t, err)


### PR DESCRIPTION
Adds `awesome-azd` as the default template source when template sources has not been defined.

- When `template.sources` is not defined in `config.json` => Add `awesome-azd`
- When `template.sources` is empty => Empty template sources

## Use case: 1st run experience after release

`template.sources` will not be defined, `awesome-azd` will automatically get added and saved

## Use case: User manually removes all templates sources

User has used `azd template source remove <key>` for all registered template sources.  New sources will need to be manually registered for anything to show up in `azd template list` or `azd init` experience.

> [!NOTE] 
> `Minimal` will still show in `azd init` experience with empty template sources.

## Use case: User manually clears `config.json` or `azd config reset`

Fallback to 1st run experience above where template sources have not been defined.