### PR TITLE
Assignment for experimentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ test-results/
 **/.terraform
 *.tfstate*
 *.terraform*
+
+# Finder state files
+.DS_Store

--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -87,6 +87,7 @@ overrides:
     words:
       - assignmentcache
       - machineid
+      - azdversion
   - filename: pkg/experimentation/client.go
     words:
       - variantassignment

--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -83,6 +83,13 @@ overrides:
   - filename: pkg/tools/kubectl/kubectl.go
     words:
       - tmpl
+  - filename: pkg/experimentation/assignment.go
+    words:
+      - assignmentcache
+      - machineid
+  - filename: pkg/experimentation/client.go
+    words:
+      - variantassignment
 ignorePaths:
   - "**/*_test.go"
   - "**/mock*.go"

--- a/cli/azd/internal/tracing/fields/fields.go
+++ b/cli/azd/internal/tracing/fields/fields.go
@@ -55,6 +55,12 @@ const (
 	InstalledByKey = attribute.Key("service.installer")
 )
 
+// Fields related to the experimentation platform
+const (
+	// The assignment context as returned by the experimentation platform.
+	ExpAssignmentContextKey = attribute.Key("exp.assignmentContext")
+)
+
 // Context level fields. Availability depends on the command running.
 const (
 	// Object ID of the principal.

--- a/cli/azd/internal/tracing/resource/machine_id.go
+++ b/cli/azd/internal/tracing/resource/machine_id.go
@@ -23,8 +23,8 @@ var invalidMacAddresses = map[string]struct{}{
 	"ac:de:48:00:11:22": {},
 }
 
-// getMachineId returns a unique ID for the machine.
-func getMachineId() string {
+// MachineId returns a unique ID for the machine.
+func MachineId() string {
 	// We store the machine ID on the filesystem not due to performance,
 	// but to increase the stability of the ID to be constant across factors like changing mac addresses, NICs.
 	return loadOrCalculate(calculateMachineId, machineIdCacheFileName)

--- a/cli/azd/internal/tracing/resource/resource.go
+++ b/cli/azd/internal/tracing/resource/resource.go
@@ -28,7 +28,7 @@ func New() *resource.Resource {
 			fields.HostArchKey.String(runtime.GOARCH),
 			fields.ProcessRuntimeVersionKey.String(runtime.Version()),
 			fields.ExecutionEnvironmentKey.String(getExecutionEnvironment()),
-			fields.MachineIdKey.String(getMachineId()),
+			fields.MachineIdKey.String(MachineId()),
 			fields.InstalledByKey.String(getInstalledBy()),
 		),
 	)

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -178,9 +178,6 @@ func main() {
 	}
 }
 
-// azdConfigDir is the name of the folder where `azd` writes user wide configuration data.
-const azdConfigDir = ".azd"
-
 // updateCheckCacheFileName is the name of the file created in the azd configuration directory
 // which is used to cache version information for our up to date check.
 const updateCheckCacheFileName = "update-check.json"

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -207,7 +207,7 @@ func fetchLatestVersion(version chan<- semver.Version) {
 	// of time, in the user's home directory.
 	configDir, err := config.GetUserConfigDir()
 	if err != nil {
-		log.Printf("could not config directory: %v, skipping update check", err)
+		log.Printf("could not determine config directory: %v, skipping update check", err)
 		return
 	}
 

--- a/cli/azd/pkg/experimentation/assignment.go
+++ b/cli/azd/pkg/experimentation/assignment.go
@@ -1,0 +1,186 @@
+package experimentation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/azure/azure-dev/cli/azd/internal/tracing/resource"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+)
+
+// cCacheFileNamePattern is the pattern used to generate the cache file name. It is formatted
+// using the machine ID.
+const cCacheFileNamePattern = "mid-%s.cache"
+
+// MachineIdParameterName is the name of the parameter used to identify the machine ID in the assignment
+// request.
+const MachineIdParameterName = "machineid"
+
+// AssignmentsManager manages interaction with the Assignments service, caching the results for 24 hours.
+type AssignmentsManager struct {
+	cacheRoot string
+	client    *tasClient
+}
+
+// NewAssignmentsManager creates a new AssignmentManager, which will communicate with the TAS service. The
+// AssignmentManager caches the assignment information for 24 hours.
+
+func NewAssignmentsManager(endpoint string, transport policy.Transporter) (*AssignmentsManager, error) {
+	configRoot, err := config.GetUserConfigDir()
+	if err != nil {
+		return nil, err
+	}
+
+	cacheRoot := filepath.Join(configRoot, "experiments")
+	if err := os.MkdirAll(cacheRoot, osutil.PermissionDirectory); err != nil {
+		return nil, err
+	}
+
+	client, err := newTasClient(endpoint, &policy.ClientOptions{
+		Transport: transport,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &AssignmentsManager{
+		cacheRoot: cacheRoot,
+		client:    client,
+	}, nil
+}
+
+// Assignment is a subset of the information returned by the TAS service.
+type Assignment struct {
+	Features          []string
+	Flights           map[string]string
+	Configs           []AssignmentConfig
+	ParameterGroups   []string
+	AssignmentContext string
+}
+
+// AssignmentConfig is information about a specific config in an assignment.
+type AssignmentConfig struct {
+	ID         string
+	Parameters map[string]interface{}
+}
+
+// Assignment gets a the assignment information for this given machine.
+func (am *AssignmentsManager) Assignment(ctx context.Context) (*Assignment, error) {
+	machineId := resource.MachineId()
+
+	cachedAssignment, err := am.readResponseFromCache(machineId)
+	if err != nil {
+		log.Printf("could not read assignment from cache: %v", err)
+	}
+
+	if cachedAssignment == nil {
+		assignment, err := am.client.GetVariantAssignments(ctx, &variantAssignmentRequest{
+			Parameters: map[string]string{
+				MachineIdParameterName: resource.MachineId(),
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		if err := am.cacheResponse(machineId, assignment); err != nil {
+			log.Printf("failed to cache assignment response: %v", err)
+		}
+
+		cachedAssignment = assignment
+	}
+
+	var configs []AssignmentConfig
+
+	if cachedAssignment.Configs != nil {
+		configs = make([]AssignmentConfig, len(cachedAssignment.Configs))
+
+		for i, config := range cachedAssignment.Configs {
+			configs[i] = AssignmentConfig{
+				ID:         config.ID,
+				Parameters: config.Parameters,
+			}
+		}
+	}
+
+	return &Assignment{
+		Features:          cachedAssignment.Features,
+		Flights:           cachedAssignment.Flights,
+		Configs:           configs,
+		ParameterGroups:   cachedAssignment.ParameterGroups,
+		AssignmentContext: cachedAssignment.AssignmentContext,
+	}, nil
+}
+
+// errCacheExpired is returned when the cached data is out of date.
+var errCacheExpired = errors.New("cache expired")
+
+// errUnsupportedCacheVersion is returned with the cache version is not supported
+var errUnsupportedCacheVersion = errors.New("unsupported cache version")
+
+// cacheResponse caches the response from the TAS service for 24 hours, using the machineId as the cache key.
+func (am *AssignmentsManager) cacheResponse(machineId string, response *treatmentAssignmentResponse) error {
+	responseJson, err := json.Marshal(response)
+	if err != nil {
+		return err
+	}
+
+	cacheFile := assignmentCacheFile{
+		Version:   1,
+		Response:  json.RawMessage(responseJson),
+		ExpiresOn: time.Now().UTC().Add(24 * time.Hour),
+	}
+
+	cacheJson, err := json.Marshal(cacheFile)
+	if err != nil {
+		return err
+	}
+
+	cacheFilePath := filepath.Join(am.cacheRoot, fmt.Sprintf(cCacheFileNamePattern, machineId))
+	return os.WriteFile(cacheFilePath, cacheJson, osutil.PermissionFile)
+}
+
+// readResponseFromCache reads the cached response from the TAS service for the given machineId.
+func (am *AssignmentsManager) readResponseFromCache(machineId string) (*treatmentAssignmentResponse, error) {
+	cache, err := os.ReadFile(filepath.Join(am.cacheRoot, fmt.Sprintf(cCacheFileNamePattern, machineId)))
+	if err != nil {
+		return nil, err
+	}
+
+	var cacheFile assignmentCacheFile
+	if err := json.Unmarshal(cache, &cacheFile); err != nil {
+		return nil, err
+	}
+
+	if cacheFile.Version != 1 {
+		return nil, errUnsupportedCacheVersion
+	}
+
+	if time.Now().UTC().After(cacheFile.ExpiresOn) {
+		return nil, errCacheExpired
+	}
+
+	var resp treatmentAssignmentResponse
+
+	if err := json.Unmarshal(cacheFile.Response, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// assignmentCacheFile is the wire format of the cache file we write. The format contains the version (which should
+// be incremented if the format changes, and is currently one), the JSON encoded response from the TAS Service and
+// an expiration time
+type assignmentCacheFile struct {
+	Version   int             `json:"version"`
+	Response  json.RawMessage `json:"response"`
+	ExpiresOn time.Time       `json:"expiresOn"`
+}

--- a/cli/azd/pkg/experimentation/assignment_test.go
+++ b/cli/azd/pkg/experimentation/assignment_test.go
@@ -1,0 +1,178 @@
+package experimentation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/azure/azure-dev/cli/azd/internal/tracing/resource"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockhttp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMachineIdIsSent(t *testing.T) {
+	mockEndpoint := "https://test-exp-s2s.msedge.net/ab"
+	mockHttp := mockhttp.NewMockHttpUtil()
+	mockHttp.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && request.URL.String() == mockEndpoint
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		require.Equal(t, request.Header["X-ExP-Parameters"], []string{fmt.Sprintf("machineid=%s", resource.MachineId())})
+
+		res := treatmentAssignmentResponse{
+			FlightingVersion:  1,
+			AssignmentContext: "context:393182",
+		}
+
+		jsonBytes, _ := json.Marshal(res)
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewBuffer(jsonBytes)),
+		}, nil
+	})
+
+	mgr, err := NewAssignmentsManager(mockEndpoint, mockHttp)
+	require.NoError(t, err)
+
+	// The mock validates that the machineid is passed as a parameter
+	// to the request. No need for us to validate the return value.
+	_, err = mgr.Assignment(context.Background())
+	require.NoError(t, err)
+}
+
+func TestCache(t *testing.T) {
+	mockEndpoint := "https://test-exp-s2s.msedge.net/ab"
+	mockHttp := mockhttp.NewMockHttpUtil()
+	mockHttp.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && request.URL.String() == mockEndpoint
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		res := treatmentAssignmentResponse{
+			FlightingVersion: 1,
+			Configs: []struct {
+				ID         string                 `json:"Id"`
+				Parameters map[string]interface{} `json:"Parameters"`
+			}{
+				{
+					ID: "config1",
+					Parameters: map[string]interface{}{
+						"number":  1,
+						"string":  "hello",
+						"boolean": true,
+					},
+				},
+			},
+			AssignmentContext: "context:393182",
+		}
+
+		jsonBytes, _ := json.Marshal(res)
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewBuffer(jsonBytes)),
+		}, nil
+	})
+
+	configRoot := t.TempDir()
+	t.Setenv("AZD_CONFIG_DIR", configRoot)
+
+	mgr, err := NewAssignmentsManager(mockEndpoint, mockHttp)
+	require.NoError(t, err)
+
+	assignment, err := mgr.Assignment(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, "context:393182", assignment.AssignmentContext)
+
+	// The response should have been cached, so we should have a single entry in the cache folder
+	// under the config root.
+	cacheRoot := filepath.Join(configRoot, "experiments")
+	cacheEntries, err := os.ReadDir(cacheRoot)
+	require.NoError(t, err)
+	require.Len(t, cacheEntries, 1)
+
+	// Create another client and validate that that the cached response is returned and no HTTP request is
+	// made.
+	mockHttp = mockhttp.NewMockHttpUtil()
+
+	mockHttp.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && request.URL.String() == mockEndpoint
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		t.Error("HTTP request should not have been made")
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: http.StatusInternalServerError,
+			Header:     http.Header{},
+		}, nil
+	})
+
+	mgr, err = NewAssignmentsManager(mockEndpoint, mockHttp)
+	require.NoError(t, err)
+
+	assignment, err = mgr.Assignment(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "context:393182", assignment.AssignmentContext)
+
+	// Now, let's expire the cache and validate that a new HTTP request is made.
+	var cacheFile assignmentCacheFile
+	cacheData, err := os.ReadFile(filepath.Join(cacheRoot, cacheEntries[0].Name()))
+	require.NoError(t, err)
+	json.Unmarshal(cacheData, &cacheFile)
+	cacheFile.ExpiresOn = time.Now().UTC().Add(-1 * time.Hour)
+	cacheData, err = json.Marshal(cacheFile)
+	require.NoError(t, err)
+	os.WriteFile(filepath.Join(cacheRoot, cacheEntries[0].Name()), cacheData, os.ModePerm)
+
+	// We'll return a new assigment context from the mock HTTP server, to simulate the
+	// user being assigned to a new experiment.
+	mockHttp = mockhttp.NewMockHttpUtil()
+
+	mockHttp.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && request.URL.String() == mockEndpoint
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		res := treatmentAssignmentResponse{
+			FlightingVersion: 2,
+			Configs: []struct {
+				ID         string                 `json:"Id"`
+				Parameters map[string]interface{} `json:"Parameters"`
+			}{
+				{
+					ID: "config1",
+					Parameters: map[string]interface{}{
+						"number":  1,
+						"string":  "hello",
+						"boolean": true,
+					},
+				},
+			},
+			AssignmentContext: "context:393182;anothercontext:393183",
+		}
+
+		jsonBytes, _ := json.Marshal(res)
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewBuffer(jsonBytes)),
+		}, nil
+	})
+
+	mgr, err = NewAssignmentsManager(mockEndpoint, mockHttp)
+	require.NoError(t, err)
+
+	assignment, err = mgr.Assignment(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "context:393182;anothercontext:393183", assignment.AssignmentContext)
+}

--- a/cli/azd/pkg/experimentation/assignment_test.go
+++ b/cli/azd/pkg/experimentation/assignment_test.go
@@ -23,6 +23,7 @@ func TestMachineIdIsSent(t *testing.T) {
 	mockHttp.When(func(request *http.Request) bool {
 		return request.Method == http.MethodGet && request.URL.String() == mockEndpoint
 	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		// nolint: staticcheck
 		require.Equal(t, request.Header["X-ExP-Parameters"], []string{fmt.Sprintf("machineid=%s", resource.MachineId())})
 
 		res := treatmentAssignmentResponse{
@@ -128,11 +129,13 @@ func TestCache(t *testing.T) {
 	var cacheFile assignmentCacheFile
 	cacheData, err := os.ReadFile(filepath.Join(cacheRoot, cacheEntries[0].Name()))
 	require.NoError(t, err)
-	json.Unmarshal(cacheData, &cacheFile)
+	err = json.Unmarshal(cacheData, &cacheFile)
+	require.NoError(t, err)
 	cacheFile.ExpiresOn = time.Now().UTC().Add(-1 * time.Hour)
 	cacheData, err = json.Marshal(cacheFile)
 	require.NoError(t, err)
-	os.WriteFile(filepath.Join(cacheRoot, cacheEntries[0].Name()), cacheData, os.ModePerm)
+	err = os.WriteFile(filepath.Join(cacheRoot, cacheEntries[0].Name()), cacheData, os.ModePerm)
+	require.NoError(t, err)
 
 	// We'll return a new assigment context from the mock HTTP server, to simulate the
 	// user being assigned to a new experiment.

--- a/cli/azd/pkg/experimentation/assignment_test.go
+++ b/cli/azd/pkg/experimentation/assignment_test.go
@@ -97,7 +97,7 @@ func TestCache(t *testing.T) {
 
 	// The response should have been cached, so we should have a single entry in the cache folder
 	// under the config root.
-	cacheRoot := filepath.Join(configRoot, "experiments")
+	cacheRoot := filepath.Join(configRoot, cCacheDirectoryName)
 	cacheEntries, err := os.ReadDir(cacheRoot)
 	require.NoError(t, err)
 	require.Len(t, cacheEntries, 1)

--- a/cli/azd/pkg/experimentation/client.go
+++ b/cli/azd/pkg/experimentation/client.go
@@ -1,0 +1,132 @@
+package experimentation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+var clientVersion string = "0.0.1"
+
+type tasClient struct {
+	tasEndpoint string
+	pipeline    runtime.Pipeline
+}
+
+type variantAssignmentRequest struct {
+	Parameters       map[string]string
+	AssignmentScopes []string
+	RequiredVariants []string
+	BlockedVariants  []string
+}
+
+type treatmentAssignmentResponse struct {
+	Features []string          `json:"Features"`
+	Flights  map[string]string `json:"Flights"`
+	Configs  []struct {
+		ID         string                 `json:"Id"`
+		Parameters map[string]interface{} `json:"Parameters"`
+	} `json:"Configs"`
+	ParameterGroups   []string `json:"ParameterGroups"`
+	FlightingVersion  int64    `json:"FlightingVersion"`
+	ImpressionID      string   `json:"ImpressionId"`
+	AssignmentContext string   `json:"AssignmentContext"`
+}
+
+// newTasClient creates a new instance of the treatment assignments client.
+func newTasClient(tasEndpoint string, options *azcore.ClientOptions) (*tasClient, error) {
+	if tasEndpoint == "" {
+		return nil, fmt.Errorf("invalid argument, tasEndpoint and pipeline cannot be nil")
+	}
+
+	if options == nil {
+		options = &azcore.ClientOptions{}
+	}
+
+	pipeline := runtime.NewPipeline("variantassignment", clientVersion, runtime.PipelineOptions{}, options)
+
+	return &tasClient{
+		tasEndpoint: tasEndpoint,
+		pipeline:    pipeline,
+	}, nil
+}
+
+// GetVariantAssignments gets the variant assignments for the given request.
+func (c *tasClient) GetVariantAssignments(
+	ctx context.Context,
+	request *variantAssignmentRequest,
+) (*treatmentAssignmentResponse, error) {
+	req, err := runtime.NewRequest(ctx, http.MethodGet, c.tasEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add sdk headers
+	req.Raw().Header.Add("Accept", "application/json")
+	req.Raw().Header.Add("X-ExP-SDK-Version", clientVersion)
+
+	setHeaderValues(req.Raw(), "X-ExP-Parameters", escapeParameterStrings(request.Parameters))
+	setHeaderValues(req.Raw(), "X-ExP-AssignmentScopes", escapeDataStrings(request.AssignmentScopes))
+	setHeaderValues(req.Raw(), "X-ExP-RequiredVariants", escapeDataStrings(request.RequiredVariants))
+	setHeaderValues(req.Raw(), "X-ExP-BlockedVariants", escapeDataStrings(request.BlockedVariants))
+
+	resp, err := c.pipeline.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status code: %d", resp.StatusCode)
+	}
+
+	var response treatmentAssignmentResponse
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+// setHeaderValues sets the values of the given header if the values are not empty.
+func setHeaderValues(request *http.Request, headerName string, values []string) {
+	if len(values) > 0 {
+		request.Header[headerName] = values
+	}
+}
+
+// escapeParameterStrings returns a slice of query escaped parameter strings.
+func escapeParameterStrings(values map[string]string) []string {
+	if values == nil {
+		return nil
+	}
+	escapedValues := make([]string, 0, len(values))
+	for key, value := range values {
+		if key == "" || value == "" {
+			continue
+		}
+		encodedParameter := url.QueryEscape(key) + "=" + url.QueryEscape(value)
+		escapedValues = append(escapedValues, encodedParameter)
+	}
+	return escapedValues
+}
+
+// escapeDataStrings returns a copy of values, after [url.QueryEscape]ing each element.
+func escapeDataStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	escapedValues := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != "" {
+			escapedValues = append(escapedValues, url.QueryEscape(value))
+		}
+	}
+	return escapedValues
+}

--- a/cli/azd/pkg/experimentation/client.go
+++ b/cli/azd/pkg/experimentation/client.go
@@ -41,7 +41,7 @@ type treatmentAssignmentResponse struct {
 // newTasClient creates a new instance of the treatment assignments client.
 func newTasClient(tasEndpoint string, options *azcore.ClientOptions) (*tasClient, error) {
 	if tasEndpoint == "" {
-		return nil, fmt.Errorf("invalid argument, tasEndpoint and pipeline cannot be nil")
+		return nil, fmt.Errorf("tasEndpoint must be set")
 	}
 
 	if options == nil {

--- a/cli/azd/pkg/experimentation/client_test.go
+++ b/cli/azd/pkg/experimentation/client_test.go
@@ -22,9 +22,13 @@ func TestGetVariantAssignments(t *testing.T) {
 		return request.Method == http.MethodGet && request.URL.String() == endpoint
 	}).RespondFn(
 		func(request *http.Request) (*http.Response, error) {
+			// nolint: staticcheck
 			require.ElementsMatch(t, request.Header["X-ExP-Parameters"], []string{"key1=value1", "key2=value2"})
+			// nolint: staticcheck
 			require.Equal(t, request.Header["X-ExP-RequiredVariants"], []string{"variant1", "variant2"})
+			// nolint: staticcheck
 			require.Equal(t, request.Header["X-ExP-BlockedVariants"], []string{"variant3", "variant4"})
+			// nolint: staticcheck
 			require.Equal(t, request.Header["X-ExP-AssignmentScopes"], []string(nil))
 
 			res := treatmentAssignmentResponse{

--- a/cli/azd/pkg/experimentation/client_test.go
+++ b/cli/azd/pkg/experimentation/client_test.go
@@ -1,0 +1,94 @@
+package experimentation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockhttp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetVariantAssignments(t *testing.T) {
+	endpoint := "https://test-exp-s2s.msedge.net/ab"
+
+	mockHttp := mockhttp.NewMockHttpUtil()
+	mockHttp.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && request.URL.String() == endpoint
+	}).RespondFn(
+		func(request *http.Request) (*http.Response, error) {
+			require.ElementsMatch(t, request.Header["X-ExP-Parameters"], []string{"key1=value1", "key2=value2"})
+			require.Equal(t, request.Header["X-ExP-RequiredVariants"], []string{"variant1", "variant2"})
+			require.Equal(t, request.Header["X-ExP-BlockedVariants"], []string{"variant3", "variant4"})
+			require.Equal(t, request.Header["X-ExP-AssignmentScopes"], []string(nil))
+
+			res := treatmentAssignmentResponse{
+				FlightingVersion:  1,
+				AssignmentContext: "context:393182",
+			}
+
+			jsonBytes, _ := json.Marshal(res)
+
+			return &http.Response{
+				Request:    request,
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       io.NopCloser(bytes.NewBuffer(jsonBytes)),
+			}, nil
+		},
+	)
+	client, err := newTasClient("https://test-exp-s2s.msedge.net/ab", &azcore.ClientOptions{
+		Transport: mockHttp,
+	})
+	require.NoError(t, err)
+
+	request := variantAssignmentRequest{
+		Parameters: map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		},
+		AssignmentScopes: []string{""},
+		RequiredVariants: []string{"variant1", "variant2"},
+		BlockedVariants:  []string{"variant3", "variant4"},
+	}
+	resp, err := client.GetVariantAssignments(context.Background(), &request)
+	require.NoError(t, err)
+	require.Equal(t, "context:393182", resp.AssignmentContext)
+	require.Equal(t, int64(1), resp.FlightingVersion)
+}
+
+func TestGetEscapedParameterStrings(t *testing.T) {
+	parameterValues := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+	escapedValues := escapeParameterStrings(parameterValues)
+	if len(escapedValues) != 2 {
+		t.Errorf("Expected 2 escaped values, got %d", len(escapedValues))
+	}
+	// Try with null value
+	escapedValues = escapeParameterStrings(nil)
+	if escapedValues != nil {
+		t.Errorf("Expected 0 escaped values, got %d", len(escapedValues))
+	}
+	fmt.Println("get escaped parameter strings test passed")
+}
+
+func TestGetEscapedDataStrings(t *testing.T) {
+	inputValues := []string{"value1", "value2"}
+	escapedValues := escapeDataStrings(inputValues)
+	if len(escapedValues) != 2 {
+		t.Errorf("Expected 2 escaped values, got %d", len(escapedValues))
+	}
+	// Try with null value
+	escapedValues = escapeDataStrings(nil)
+	if escapedValues != nil {
+		t.Errorf("Expected 0 escaped values, got %d", len(escapedValues))
+	}
+	fmt.Println("get escaped data strings test passed")
+}

--- a/cli/azd/pkg/experimentation/client_test.go
+++ b/cli/azd/pkg/experimentation/client_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -67,32 +66,81 @@ func TestGetVariantAssignments(t *testing.T) {
 }
 
 func TestGetEscapedParameterStrings(t *testing.T) {
-	parameterValues := map[string]string{
-		"key1": "value1",
-		"key2": "value2",
+	tests := []struct {
+		name            string
+		parameterValues map[string]string
+		expectedEscaped []string
+	}{
+		{
+			name: "valid parameters",
+			parameterValues: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			expectedEscaped: []string{"key1=value1", "key2=value2"},
+		},
+		{
+			name: "escaped parameters",
+			parameterValues: map[string]string{
+				"ke&y1": "val&ue1",
+				"ke&y2": "val&ue2",
+			},
+			expectedEscaped: []string{"ke%26y1=val%26ue1", "ke%26y2=val%26ue2"},
+		},
+		{
+			name:            "nil parameters",
+			parameterValues: nil,
+			expectedEscaped: nil,
+		},
 	}
-	escapedValues := escapeParameterStrings(parameterValues)
-	if len(escapedValues) != 2 {
-		t.Errorf("Expected 2 escaped values, got %d", len(escapedValues))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			escapedValues := escapeParameterStrings(tt.parameterValues)
+			require.Equal(t, tt.expectedEscaped, escapedValues)
+		})
 	}
-	// Try with null value
-	escapedValues = escapeParameterStrings(nil)
-	if escapedValues != nil {
-		t.Errorf("Expected 0 escaped values, got %d", len(escapedValues))
-	}
-	fmt.Println("get escaped parameter strings test passed")
 }
 
 func TestGetEscapedDataStrings(t *testing.T) {
-	inputValues := []string{"value1", "value2"}
-	escapedValues := escapeDataStrings(inputValues)
-	if len(escapedValues) != 2 {
-		t.Errorf("Expected 2 escaped values, got %d", len(escapedValues))
+	tests := []struct {
+		name            string
+		inputValues     []string
+		expectedEscaped []string
+	}{
+		{
+			name: "valid data",
+			inputValues: []string{
+				"value1",
+				"value2",
+			},
+			expectedEscaped: []string{
+				"value1",
+				"value2",
+			},
+		},
+		{
+			name: "escaped data",
+			inputValues: []string{
+				"val&ue1",
+				"val&ue2",
+			},
+			expectedEscaped: []string{
+				"val%26ue1",
+				"val%26ue2",
+			},
+		},
+		{
+			name:            "nil data",
+			inputValues:     nil,
+			expectedEscaped: nil,
+		},
 	}
-	// Try with null value
-	escapedValues = escapeDataStrings(nil)
-	if escapedValues != nil {
-		t.Errorf("Expected 0 escaped values, got %d", len(escapedValues))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			escapedValues := escapeDataStrings(tt.inputValues)
+			require.Equal(t, tt.expectedEscaped, escapedValues)
+		})
 	}
-	fmt.Println("get escaped data strings test passed")
 }

--- a/cli/azd/pkg/experimentation/client_test.go
+++ b/cli/azd/pkg/experimentation/client_test.go
@@ -97,7 +97,7 @@ func TestGetEscapedParameterStrings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			escapedValues := escapeParameterStrings(tt.parameterValues)
-			require.Equal(t, tt.expectedEscaped, escapedValues)
+			require.ElementsMatch(t, tt.expectedEscaped, escapedValues)
 		})
 	}
 }
@@ -140,7 +140,7 @@ func TestGetEscapedDataStrings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			escapedValues := escapeDataStrings(tt.inputValues)
-			require.Equal(t, tt.expectedEscaped, escapedValues)
+			require.ElementsMatch(t, tt.expectedEscaped, escapedValues)
 		})
 	}
 }

--- a/cli/azd/pkg/experimentation/doc.go
+++ b/cli/azd/pkg/experimentation/doc.go
@@ -1,0 +1,3 @@
+// Package experimentation provides functionality for experimentation in azd. The [AssignmentsManager] can
+// be used to retrieve the current assignment for the current machine.
+package experimentation

--- a/cli/azd/test/functional/experiment_test.go
+++ b/cli/azd/test/functional/experiment_test.go
@@ -1,0 +1,89 @@
+package cli_test
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
+	"github.com/azure/azure-dev/cli/azd/test/azdcli"
+	"github.com/stretchr/testify/require"
+)
+
+// Verifies that the assignment context returned is included in the telemetry events we capture.
+func Test_CLI_Experiment_AssignmentContextInTelemetry(t *testing.T) {
+	// CLI process and working directory are isolated
+	t.Parallel()
+	ctx, cancel := newTestContext(t)
+	defer cancel()
+
+	dir := tempDirWithDiagnostics(t)
+	t.Logf("DIR: %s", dir)
+
+	// Use a random config root so we don't get cached assigments from the real `azd` CLI.
+	configRoot := tempDirWithDiagnostics(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/tas" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"assignmentContext":"context:393182;"}`))
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}))
+	defer server.Close()
+
+	cli := azdcli.NewCLI(t)
+	// Always set telemetry opt-inn setting to avoid influence from user settings
+	cli.Env = append(
+		os.Environ(),
+		"AZURE_DEV_COLLECT_TELEMETRY=yes",
+		"AZD_CONFIG_DIR="+configRoot,
+		"AZD_DEBUG_EXPERIMENTATION_TAS_ENDPOINT="+fmt.Sprintf("%s/api/v1/tas", server.URL))
+	cli.WorkingDirectory = dir
+
+	envName := randomEnvName()
+
+	err := copySample(dir, "storage")
+	require.NoError(t, err, "failed expanding sample")
+
+	traceFilePath := filepath.Join(dir, "trace.json")
+
+	_, err = cli.RunCommand(ctx, "env", "new", envName, "--trace-log-file", traceFilePath)
+	require.NoError(t, err)
+	fmt.Printf("envName: %s\n", envName)
+
+	traceContent, err := os.ReadFile(traceFilePath)
+	require.NoError(t, err)
+
+	scanner := bufio.NewScanner(bytes.NewReader(traceContent))
+	usageCmdFound := false
+	for scanner.Scan() {
+		if scanner.Text() == "" {
+			continue
+		}
+
+		var span Span
+		err = json.Unmarshal(scanner.Bytes(), &span)
+		require.NoError(t, err)
+
+		verifyResource(t, cli.Env, span.Resource)
+		if strings.HasPrefix(span.Name, "cmd.") {
+			usageCmdFound = true
+			m := attributesMap(span.Attributes)
+			require.Contains(t, m, fields.ExpAssignmentContextKey)
+			require.Equal(t, "context:393182;", m[fields.ExpAssignmentContextKey])
+		}
+	}
+
+	require.True(t, usageCmdFound)
+}

--- a/cli/azd/test/functional/experiment_test.go
+++ b/cli/azd/test/functional/experiment_test.go
@@ -33,12 +33,11 @@ func Test_CLI_Experiment_AssignmentContextInTelemetry(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/tas" {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"assignmentContext":"context:393182;"}`))
+			_, _ = w.Write([]byte(`{"assignmentContext":"context:393182;"}`))
 			return
 		}
 
-		w.WriteHeader(http.StatusNotFound)
-		return
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer server.Close()
 


### PR DESCRIPTION
This change adds support for using the Azure Experimentation service to compute assignment information, which will be used to allow us to do experimental A/B testing in `azd`.  This change introduces the machinery to fetch an assignment, based on the machine ID of the current machine.  This assignment contains information about what experiments have been enabled as well as an assignment context, which needs to be included in the telemetry events that we emit.  This assignment context allows us to compute what experiments the user is running against, which we use to understand if the experiment is a success or not.

There is not an existing SDK for the Azure Experimentation service for Golang.  The team did a small spike of one, which I had intended to vendor here as is, but I instead made a few changes to bring it more in line with other Azure SDK for Go clients (using our pipeline, for example), similar to what we did with the Graph SDK. However, the client is an internal implementation detail of the new `experimentation` package which exposes an `AssignmentManager`.  This type wraps the underlying client and caches assignment data in `AZD_CONFIG_DIR/experiments/` for 24 hours to reduce load on the remote assignment service.

A small end to end test ensures that the assignment context information is propagated in our telemetry events.