### PR TITLE
Add msal cache 1.0 -> 1.1 upgrade 

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -115,6 +115,7 @@ pyapp
 pyvenv
 reauthentication
 relogin
+remarshal
 restoreapp
 retriable
 rzip


### PR DESCRIPTION
When retrieving cache entries, automatically upgrade cache entries that were saved in msal cache v1.0 format to v1.1 format to avoid stale cache entries causing random auth failures.

Related to https://github.com/AzureAD/microsoft-authentication-library-for-go/issues/453

Fixes #2659