### PR TITLE
set AZURE_CREDENTIALS on pipeline for azd auth

### DIFF
--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -5,6 +5,7 @@ package azdo
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -147,11 +148,16 @@ func getDefinitionVariables(
 	env *environment.Environment,
 	credentials AzureServicePrincipalCredentials,
 	provisioningProvider provisioning.Options) (*map[string]build.BuildDefinitionVariable, error) {
+	rawCredential, err := json.Marshal(credentials)
+	if err != nil {
+		return nil, err
+	}
 	variables := map[string]build.BuildDefinitionVariable{
 		"AZURE_LOCATION":           createBuildDefinitionVariable(env.GetLocation(), false, false),
 		"AZURE_ENV_NAME":           createBuildDefinitionVariable(env.GetEnvName(), false, false),
 		"AZURE_SERVICE_CONNECTION": createBuildDefinitionVariable(ServiceConnectionName, false, false),
 		"AZURE_SUBSCRIPTION_ID":    createBuildDefinitionVariable(credentials.SubscriptionId, false, false),
+		"AZURE_CREDENTIALS":        createBuildDefinitionVariable(string(rawCredential), true, false),
 	}
 
 	if provisioningProvider.Provider == provisioning.Bicep {


### PR DESCRIPTION
This is required for migrating azdo-pipelines to use `azd auth login` the same way as github actions.

Before this change, azdo-pipelines were relying on `az cli` task with a `service-connection` on azdo to authenticate.
The `service-connection` will still be created, as it will be used by `terraform` pipeline (still req az-cli).