### PR TITLE
Fix flakiness in `TestParametersAreSent`

### DIFF
--- a/cli/azd/pkg/experimentation/assignment_test.go
+++ b/cli/azd/pkg/experimentation/assignment_test.go
@@ -28,7 +28,7 @@ func TestParametersAreSent(t *testing.T) {
 		return request.Method == http.MethodGet && request.URL.String() == mockEndpoint
 	}).RespondFn(func(request *http.Request) (*http.Response, error) {
 		// nolint: staticcheck
-		require.Equal(t, request.Header["X-ExP-Parameters"],
+		require.ElementsMatch(t, request.Header["X-ExP-Parameters"],
 			[]string{
 				fmt.Sprintf("machineid=%s", resource.MachineId()),
 				fmt.Sprintf("azdversion=%s", internal.VersionInfo().Version.String()),


### PR DESCRIPTION
The properties included in the assignment request are built by walking a map of key value pairs. In go, the order of enumeration of a map is non determinsitc, so we need to relax the check from strict equality to just elements match in a test.