### PR TITLE
fix using build args from docker

### DIFF
--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -25,7 +25,7 @@ type DockerProjectOptions struct {
 	Context   string           `json:"context"`
 	Platform  string           `json:"platform"`
 	Tag       ExpandableString `json:"tag"`
-	BuildArgs []string         `json:"buildArgs"`
+	BuildArgs []string         `json:"buildArgs" yaml:"buildArgs"`
 }
 
 type dockerBuildResult struct {

--- a/cli/azd/pkg/project/project_config_test.go
+++ b/cli/azd/pkg/project/project_config_test.go
@@ -134,6 +134,9 @@ services:
     docker:
       path: ./Dockerfile.dev
       context: ../
+      buildArgs:
+        - 'foo'
+        - 'bar'
 `
 
 	mockContext := mocks.NewMockContext(context.Background())
@@ -146,6 +149,7 @@ services:
 
 	require.Equal(t, "./Dockerfile.dev", service.Docker.Path)
 	require.Equal(t, "../", service.Docker.Context)
+	require.Equal(t, []string{"foo", "bar"}, service.Docker.BuildArgs)
 }
 
 func TestProjectConfigAddHandler(t *testing.T) {


### PR DESCRIPTION
Noticed that `buildArgs` was not actually working when setting the args on `azure.yaml`

This quick change makes it work as expected.