### PR TITLE
Add buildpacks (`pack` cli) integration

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -113,6 +113,7 @@ otlp
 otlpconfig
 otlptrace
 otlptracehttp
+paketobuildpacks
 pflag
 preinit
 proxying

--- a/cli/azd/internal/tracing/events/events.go
+++ b/cli/azd/internal/tracing/events/events.go
@@ -18,6 +18,9 @@ const BicepInstallEvent = "tools.bicep.install"
 // GitHubCliInstallEvent is the name of the event which tracks the overall GitHub cli install operation.
 const GitHubCliInstallEvent = "tools.gh.install"
 
+// PackCliInstallEvent is the name of the event which tracks the overall pack cli install operation.
+const PackCliInstallEvent = "tools.pack.install"
+
 // AccountSubscriptionsListEvent is the name of the event which tracks listing of account subscriptions .
 // See fields.AccountSubscriptionsListTenantsFound for additional event fields.
 const AccountSubscriptionsListEvent = "account.subscriptions.list"

--- a/cli/azd/pkg/alpha/alpha_features.go
+++ b/cli/azd/pkg/alpha/alpha_features.go
@@ -2,4 +2,5 @@ package alpha
 
 const (
 	TerraformId FeatureId = "terraform"
+	Buildpacks  FeatureId = "buildpacks"
 )

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -288,7 +288,6 @@ func (p *dockerProject) packBuild(
 		})
 
 	builder := DefaultBuilderImage
-	args := []string{}
 	environ := []string{}
 
 	if os.Getenv("AZD_BUILDER_IMAGE") != "" {
@@ -315,7 +314,6 @@ func (p *dockerProject) packBuild(
 		builder,
 		imageName,
 		environ,
-		args,
 		previewer)
 	p.console.StopPreviewer(ctx)
 	if err != nil {

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -280,13 +280,6 @@ func (p *dockerProject) packBuild(
 	if err != nil {
 		return nil, err
 	}
-	previewer := p.console.ShowPreviewer(ctx,
-		&input.ShowPreviewerOptions{
-			Prefix:       "  ",
-			MaxLineCount: 8,
-			Title:        "Docker (pack) Output",
-		})
-
 	builder := DefaultBuilderImage
 	environ := []string{}
 
@@ -308,6 +301,12 @@ func (p *dockerProject) packBuild(
 			"BP_WEB_SERVER_ENABLE_PUSH_STATE=true")
 	}
 
+	previewer := p.console.ShowPreviewer(ctx,
+		&input.ShowPreviewerOptions{
+			Prefix:       "  ",
+			MaxLineCount: 8,
+			Title:        "Docker (pack) Output",
+		})
 	err = pack.Build(
 		ctx,
 		svc.Path(),

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -166,7 +166,13 @@ func (p *dockerProject) Build(
 			path := filepath.Join(serviceConfig.Path(), dockerOptions.Path)
 			_, err := os.Stat(path)
 			packBuildEnabled := p.alphaFeatureManager.IsEnabled(alpha.Buildpacks)
-			if err != nil || !packBuildEnabled && errors.Is(err, os.ErrNotExist) {
+			if packBuildEnabled {
+				if err != nil && !errors.Is(err, os.ErrNotExist) {
+					task.SetError(fmt.Errorf("reading dockerfile: %w", err))
+					return
+				}
+			}
+			if !packBuildEnabled && err != nil {
 				task.SetError(fmt.Errorf("reading dockerfile: %w", err))
 				return
 			}

--- a/cli/azd/pkg/tools/docker/docker.go
+++ b/cli/azd/pkg/tools/docker/docker.go
@@ -33,6 +33,7 @@ type Docker interface {
 	) (string, error)
 	Tag(ctx context.Context, cwd string, imageName string, tag string) error
 	Push(ctx context.Context, cwd string, tag string) error
+	Inspect(ctx context.Context, imageName string, format string) (string, error)
 }
 
 func NewDocker(commandRunner exec.CommandRunner) Docker {
@@ -145,6 +146,15 @@ func (d *docker) Push(ctx context.Context, cwd string, tag string) error {
 	}
 
 	return nil
+}
+
+func (d *docker) Inspect(ctx context.Context, imageName string, format string) (string, error) {
+	out, err := d.executeCommand(ctx, "", "image", "inspect", "--format", format, imageName)
+	if err != nil {
+		return "", fmt.Errorf("inspecting image: %w", err)
+	}
+
+	return out.Stdout, nil
 }
 
 func (d *docker) versionInfo() tools.VersionInfo {

--- a/cli/azd/pkg/tools/pack/pack.go
+++ b/cli/azd/pkg/tools/pack/pack.go
@@ -1,0 +1,412 @@
+package pack
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/azure/azure-dev/cli/azd/internal/tracing"
+	"github.com/azure/azure-dev/cli/azd/internal/tracing/events"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+	"github.com/blang/semver/v4"
+)
+
+// PackVersion is the minimum version of pack that we require (and the one we fetch when we fetch pack on behalf of a
+// user).
+var PackVersion semver.Version = semver.MustParse("0.30.0")
+
+type PackCli interface {
+	Build(
+		ctx context.Context,
+		cwd string,
+		builder string,
+		imageName string,
+		environ []string,
+		args []string,
+		buildProgress io.Writer,
+	) error
+}
+
+// NewPackCli creates a new PackCli. azd manages its own copy of the pack CLI, stored in `$AZD_CONFIG_DIR/bin`. If
+// pack is not present at this location, or if it is present but is older than the minimum supported version, it is
+// downloaded.
+func NewPackCli(
+	ctx context.Context,
+	console input.Console,
+	commandRunner exec.CommandRunner,
+) (PackCli, error) {
+	return newPackCliImpl(
+		ctx,
+		console,
+		commandRunner,
+		http.DefaultClient,
+		extractCli)
+}
+
+func NewPackCliWithPath(
+	commandRunner exec.CommandRunner,
+	cliPath string,
+) PackCli {
+	return &packCli{
+		path:   cliPath,
+		runner: commandRunner,
+	}
+}
+
+// packCliPath returns the path where we store our local copy of pack ($AZD_CONFIG_DIR/bin).
+func packCliPath() (string, error) {
+	configDir, err := config.GetUserConfigDir()
+	if err != nil {
+		return "", err
+	}
+
+	if runtime.GOOS == "windows" {
+		return filepath.Join(configDir, "bin", "pack.exe"), nil
+	}
+
+	return filepath.Join(configDir, "bin", "pack"), nil
+}
+
+func newPackCliImpl(
+	ctx context.Context,
+	console input.Console,
+	commandRunner exec.CommandRunner,
+	transporter policy.Transporter,
+	extract func(string, string) (string, error)) (PackCli, error) {
+	if override := os.Getenv("AZD_PACK_TOOL_PATH"); override != "" {
+		log.Printf("using external pack tool: %s", override)
+
+		return &packCli{
+			path:   override,
+			runner: commandRunner,
+		}, nil
+	}
+
+	cliPath, err := packCliPath()
+	if err != nil {
+		return nil, fmt.Errorf("finding pack: %w", err)
+	}
+	if _, err = os.Stat(cliPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("finding pack: %w", err)
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(filepath.Dir(cliPath), osutil.PermissionDirectory); err != nil {
+			return nil, fmt.Errorf("downloading pack: %w", err)
+		}
+
+		msg := "Acquiring pack cli"
+		console.ShowSpinner(ctx, msg, input.Step)
+		err := downloadPack(ctx, transporter, PackVersion, extract, cliPath)
+		console.StopSpinner(ctx, "", input.Step)
+		if err != nil {
+			return nil, fmt.Errorf("downloading pack: %w", err)
+		}
+	}
+
+	cli := &packCli{
+		path:   cliPath,
+		runner: commandRunner,
+	}
+
+	ver, err := cli.version(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("checking pack version: %w", err)
+	}
+
+	log.Printf("pack version: %s", ver)
+
+	if ver.LT(PackVersion) {
+		log.Printf("installed pack version %s is older than %s; updating.", ver.String(), PackVersion.String())
+
+		msg := "Upgrading pack"
+		console.ShowSpinner(ctx, msg, input.Step)
+		err := downloadPack(ctx, transporter, PackVersion, extract, cliPath)
+		console.StopSpinner(ctx, "", input.Step)
+		if err != nil {
+			return nil, fmt.Errorf("upgrading pack: %w", err)
+		}
+	}
+
+	log.Printf("using local pack: %s", cliPath)
+
+	return cli, nil
+}
+
+type packCli struct {
+	path   string
+	runner exec.CommandRunner
+}
+
+func (cli *packCli) version(ctx context.Context) (semver.Version, error) {
+	packRes, err := cli.runner.Run(ctx, exec.NewRunArgs(cli.path, "--version"))
+	if err != nil {
+		return semver.Version{}, err
+	}
+
+	version, err := tools.ExtractVersion(packRes.Stdout)
+	if err != nil {
+		return semver.Version{}, err
+	}
+
+	return version, nil
+}
+
+func (cli *packCli) enableExperimental(ctx context.Context) error {
+	runArgs := exec.NewRunArgs(cli.path, "config", "experimental", "true")
+	runArgs.Interactive = false
+	_, err := cli.runner.Run(ctx, runArgs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cli *packCli) Build(
+	ctx context.Context,
+	cwd string,
+	builder string,
+	imageName string,
+	environ []string,
+	args []string,
+	buildProgress io.Writer,
+) error {
+	err := cli.enableExperimental(ctx)
+	if err != nil {
+		return err
+	}
+
+	envArgs := make([]string, 0, 2*len(environ))
+	for _, e := range environ {
+		envArgs = append(envArgs, "--env", e)
+	}
+
+	runArgs := exec.NewRunArgs(
+		cli.path, "build", imageName, "--builder", builder, "--path", cwd)
+	runArgs.Args = append(runArgs.Args, envArgs...)
+	if len(args) > 0 {
+		runArgs.Args = append(runArgs.Args, args...)
+	}
+	if buildProgress != nil {
+		runArgs = runArgs.WithStdOut(buildProgress).WithStdErr(buildProgress)
+	}
+
+	_, err = cli.runner.Run(ctx, runArgs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func packName() string {
+	if runtime.GOOS == "windows" {
+		return "pack.exe"
+	} else {
+		return "pack"
+	}
+}
+
+func extractFromZip(
+	zipped string,
+	out string) (string, error) {
+	zipReader, err := zip.OpenReader(zipped)
+	if err != nil {
+		return "", err
+	}
+
+	log.Printf("extract from %s", zipped)
+	defer zipReader.Close()
+
+	var extractedAt string
+	for _, file := range zipReader.File {
+		fileName := file.FileInfo().Name()
+		if !file.FileInfo().IsDir() && fileName == packName() {
+			log.Printf("found cli at: %s", file.Name)
+			fileReader, err := file.Open()
+			if err != nil {
+				return extractedAt, err
+			}
+			filePath := filepath.Join(out, fileName)
+			cliFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
+			if err != nil {
+				return extractedAt, err
+			}
+			defer cliFile.Close()
+			/* #nosec G110 - decompression bomb false positive */
+			_, err = io.Copy(cliFile, fileReader)
+			if err != nil {
+				return extractedAt, err
+			}
+			extractedAt = filePath
+			break
+		}
+	}
+	if extractedAt != "" {
+		log.Printf("extracted to: %s", extractedAt)
+		return extractedAt, nil
+	}
+	return extractedAt, fmt.Errorf("pack cli binary was not found within the zip file")
+}
+func extractFromTar(
+	zipped string,
+	out string) (string, error) {
+	gzFile, err := os.Open(zipped)
+	if err != nil {
+		return "", err
+	}
+	defer gzFile.Close()
+
+	gzReader, err := gzip.NewReader(gzFile)
+	if err != nil {
+		return "", err
+	}
+	defer gzReader.Close()
+
+	var extractedAt string
+	// tarReader doesn't need to be closed as it is closed by the gz reader
+	tarReader := tar.NewReader(gzReader)
+	for {
+		fileHeader, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			return extractedAt, fmt.Errorf("did not find pack cli within tar file")
+		}
+		if fileHeader == nil {
+			continue
+		}
+		if err != nil {
+			return extractedAt, err
+		}
+		// Tha name contains the path, remove it
+		fileNameParts := strings.Split(fileHeader.Name, "/")
+		fileName := fileNameParts[len(fileNameParts)-1]
+		// cspell: disable-next-line `Typeflag` is comming fron *tar.Header
+		if fileHeader.Typeflag == tar.TypeReg && fileName == "pack" {
+			filePath := filepath.Join(out, fileName)
+			packCliFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(fileHeader.Mode))
+			if err != nil {
+				return extractedAt, err
+			}
+			defer packCliFile.Close()
+			/* #nosec G110 - decompression bomb false positive */
+			_, err = io.Copy(packCliFile, tarReader)
+			if err != nil {
+				return extractedAt, err
+			}
+			extractedAt = filePath
+			break
+		}
+	}
+	if extractedAt != "" {
+		return extractedAt, nil
+	}
+	return extractedAt, fmt.Errorf("unable to find pack cli within archive")
+}
+
+// extractCli gets the pack cli from either a zip or a tar.gz
+func extractCli(src, dst string) (string, error) {
+	if strings.HasSuffix(src, ".zip") {
+		return extractFromZip(src, dst)
+	} else if strings.HasSuffix(src, ".tgz") {
+		return extractFromTar(src, dst)
+	}
+	return "", fmt.Errorf("unknown format while trying to extract")
+}
+
+// downloadPack downloads a given version of pack cli from the release site.
+func downloadPack(
+	ctx context.Context,
+	transporter policy.Transporter,
+	version semver.Version,
+	extractFile func(src, dst string) (string, error),
+	path string) error {
+	systemArch := runtime.GOARCH
+	archString := "" // amd64 is the implicit default
+	if systemArch != "amd64" {
+		archString = fmt.Sprintf("-%s", systemArch)
+	}
+
+	var releaseName string
+	switch runtime.GOOS {
+	case "windows":
+		releaseName = fmt.Sprintf("pack-v%s-windows%s.zip", version, archString)
+	case "darwin":
+		releaseName = fmt.Sprintf("pack-v%s-macos%s.tgz", version, archString)
+	case "linux":
+		releaseName = fmt.Sprintf("pack-v%s-linux%s.tgz", version, archString)
+	default:
+		return fmt.Errorf("unsupported platform")
+	}
+
+	// example: https://github.com/buildpacks/pack/releases/download/v0.29.0/pack-v0.29.0-windows.zip
+	ghReleaseUrl := fmt.Sprintf("https://github.com/buildpacks/pack/releases/download/v%s/%s", version, releaseName)
+	log.Printf("downloading pack cli release %s -> %s", ghReleaseUrl, releaseName)
+
+	spanCtx, span := tracing.Start(ctx, events.PackCliInstallEvent)
+	defer span.End()
+
+	req, err := http.NewRequestWithContext(spanCtx, "GET", ghReleaseUrl, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := transporter.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("http error %d", resp.StatusCode)
+	}
+
+	tmpPath := filepath.Dir(path)
+	compressedRelease, err := os.CreateTemp(tmpPath, releaseName)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = compressedRelease.Close()
+		_ = os.Remove(compressedRelease.Name())
+	}()
+
+	if _, err := io.Copy(compressedRelease, resp.Body); err != nil {
+		return err
+	}
+	if err := compressedRelease.Close(); err != nil {
+		return err
+	}
+
+	// change file name from temporal name to the final name, as the download has completed
+	compressedFileName := filepath.Join(tmpPath, releaseName)
+	if err := osutil.Rename(ctx, compressedRelease.Name(), compressedFileName); err != nil {
+		return err
+	}
+	defer func() {
+		log.Printf("delete %s", compressedFileName)
+		_ = os.Remove(compressedFileName)
+	}()
+
+	// unzip downloaded file
+	log.Printf("extracting file %s", compressedFileName)
+	_, err = extractFile(compressedFileName, tmpPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cli/azd/pkg/tools/pack/pack_test.go
+++ b/cli/azd/pkg/tools/pack/pack_test.go
@@ -63,7 +63,7 @@ func Test_extractZip(t *testing.T) {
 			require.NoError(t, err)
 
 			file := filepath.Join(dir, "pack.zip")
-			err = os.WriteFile(file, zip.Bytes(), 0644)
+			err = os.WriteFile(file, zip.Bytes(), 0600)
 			require.NoError(t, err)
 
 			packCli, err := extractCli(file, dir)
@@ -125,7 +125,7 @@ func Test_extractTgz(t *testing.T) {
 			require.NoError(t, err)
 
 			file := filepath.Join(dir, "pack.tgz")
-			err = os.WriteFile(file, zip.Bytes(), 0644)
+			err = os.WriteFile(file, zip.Bytes(), 0600)
 			require.NoError(t, err)
 
 			packCli, err := extractCli(file, dir)

--- a/cli/azd/pkg/tools/pack/pack_test.go
+++ b/cli/azd/pkg/tools/pack/pack_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -31,7 +32,7 @@ func Test_extractZip(t *testing.T) {
 			"found",
 			[]mockzip.File{
 				{
-					Name:    filepath.Join("bin", packName()),
+					Name:    path.Join("bin", packName()),
 					Content: contentZipped,
 				},
 				{
@@ -93,7 +94,7 @@ func Test_extractTgz(t *testing.T) {
 			"found",
 			[]mockzip.File{
 				{
-					Name:    filepath.Join("bin", packName()),
+					Name:    "bin/pack",
 					Content: contentZipped,
 				},
 				{

--- a/cli/azd/pkg/tools/pack/pack_test.go
+++ b/cli/azd/pkg/tools/pack/pack_test.go
@@ -157,7 +157,7 @@ func TestNewPackCliInstall(t *testing.T) {
 	})
 
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.HasSuffix(args.Cmd, "pack") && args.Args[0] == "--version" && len(args.Args) == 1
+		return strings.HasSuffix(args.Cmd, packName()) && args.Args[0] == "--version" && len(args.Args) == 1
 	}).Respond(exec.NewRunResult(
 		0,
 		fmt.Sprintf("%s+git-c38f7da.build-4952", PackVersion.String()),
@@ -211,7 +211,7 @@ func TestNewPackCliUpgrade(t *testing.T) {
 	})
 
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.HasSuffix(args.Cmd, "pack") && args.Args[0] == "--version" && len(args.Args) == 1
+		return strings.HasSuffix(args.Cmd, packName()) && args.Args[0] == "--version" && len(args.Args) == 1
 	}).Respond(exec.NewRunResult(
 		0,
 		fmt.Sprintf("%s+git-c38f7da.build-4952", semver.MustParse("0.0.1").String()),

--- a/cli/azd/pkg/tools/pack/pack_test.go
+++ b/cli/azd/pkg/tools/pack/pack_test.go
@@ -1,0 +1,244 @@
+package pack
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockzip"
+	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_extractZip(t *testing.T) {
+	const contentZipped = "zipped pack"
+
+	tests := []struct {
+		name    string
+		files   []mockzip.File
+		wantErr bool
+	}{
+		{
+			"found",
+			[]mockzip.File{
+				{
+					Name:    filepath.Join("bin", packName()),
+					Content: contentZipped,
+				},
+				{
+					Name: "bin/etc",
+				},
+				{
+					Name: "etc",
+				},
+			},
+			false,
+		},
+		{
+			"not found",
+			[]mockzip.File{
+				{
+					Name: "bin/etc",
+				},
+				{
+					Name: "etc",
+				},
+			},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			zip, err := mockzip.Zip(tt.files)
+			require.NoError(t, err)
+
+			file := filepath.Join(dir, "pack.zip")
+			err = os.WriteFile(file, zip.Bytes(), 0644)
+			require.NoError(t, err)
+
+			packCli, err := extractCli(file, dir)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				content, err := os.ReadFile(packCli)
+
+				require.NoError(t, err)
+				require.EqualValues(t, []byte(contentZipped), content)
+			}
+		})
+	}
+}
+
+func Test_extractTgz(t *testing.T) {
+	const contentZipped = "gzipped pack"
+
+	tests := []struct {
+		name    string
+		files   []mockzip.File
+		wantErr bool
+	}{
+		{
+			"found",
+			[]mockzip.File{
+				{
+					Name:    filepath.Join("bin", packName()),
+					Content: contentZipped,
+				},
+				{
+					Name: "bin/etc",
+				},
+				{
+					Name: "etc",
+				},
+			},
+			false,
+		},
+		{
+			"not found",
+			[]mockzip.File{
+				{
+					Name: "bin/etc",
+				},
+				{
+					Name: "etc",
+				},
+			},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			zip, err := mockzip.GzippedTar(tt.files)
+			require.NoError(t, err)
+
+			file := filepath.Join(dir, "pack.tgz")
+			err = os.WriteFile(file, zip.Bytes(), 0644)
+			require.NoError(t, err)
+
+			packCli, err := extractCli(file, dir)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				content, err := os.ReadFile(packCli)
+
+				require.NoError(t, err)
+				require.EqualValues(t, []byte(contentZipped), content)
+			}
+		})
+	}
+}
+
+func TestNewPackCliInstall(t *testing.T) {
+	configRoot := t.TempDir()
+	t.Setenv("AZD_CONFIG_DIR", configRoot)
+
+	mockContext := mocks.NewMockContext(context.Background())
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && request.URL.Host == "github.com"
+	}).Respond(&http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewBufferString("pack cli")),
+	})
+
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.HasSuffix(args.Cmd, "pack") && args.Args[0] == "--version" && len(args.Args) == 1
+	}).Respond(exec.NewRunResult(
+		0,
+		fmt.Sprintf("%s+git-c38f7da.build-4952", PackVersion.String()),
+		"",
+	))
+
+	mockExtract := func(src, dst string) (string, error) {
+		exp, _ := packCliPath()
+		_ = osutil.Rename(context.Background(), src, exp)
+		return src, nil
+	}
+
+	cli, err := newPackCliImpl(
+		*mockContext.Context,
+		mockContext.Console,
+		mockContext.CommandRunner,
+		mockContext.HttpClient,
+		mockExtract,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, cli)
+
+	packCli, err := packCliPath()
+	require.NoError(t, err)
+
+	contents, err := os.ReadFile(packCli)
+	require.NoError(t, err)
+
+	require.Equal(t, "pack cli", string(contents))
+}
+
+func TestNewPackCliUpgrade(t *testing.T) {
+	configRoot := t.TempDir()
+	t.Setenv("AZD_CONFIG_DIR", configRoot)
+
+	cliPath, err := packCliPath()
+	require.NoError(t, err)
+	err = os.MkdirAll(filepath.Dir(cliPath), 0700)
+	require.NoError(t, err)
+
+	err = os.WriteFile(cliPath, []byte("old pack cli"), 0600)
+	require.NoError(t, err)
+
+	mockContext := mocks.NewMockContext(context.Background())
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && request.URL.Host == "github.com"
+	}).Respond(&http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewBufferString("pack cli")),
+	})
+
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.HasSuffix(args.Cmd, "pack") && args.Args[0] == "--version" && len(args.Args) == 1
+	}).Respond(exec.NewRunResult(
+		0,
+		fmt.Sprintf("%s+git-c38f7da.build-4952", semver.MustParse("0.0.1").String()),
+		"",
+	))
+
+	mockExtract := func(src, dst string) (string, error) {
+		exp, _ := packCliPath()
+		_ = osutil.Rename(context.Background(), src, exp)
+		return src, nil
+	}
+
+	cli, err := newPackCliImpl(
+		*mockContext.Context,
+		mockContext.Console,
+		mockContext.CommandRunner,
+		mockContext.HttpClient,
+		mockExtract,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, cli)
+
+	packCli, err := packCliPath()
+	require.NoError(t, err)
+
+	contents, err := os.ReadFile(packCli)
+	require.NoError(t, err)
+
+	require.Equal(t, "pack cli", string(contents))
+}

--- a/cli/azd/resources/alpha_features.yaml
+++ b/cli/azd/resources/alpha_features.yaml
@@ -2,3 +2,5 @@
   description: "Provision Azure resources from terraform files."
 - id: resourceGroupDeployments
   description: "Support infrastructure deployments at resource group scope."
+- id: buildpacks
+  description: "Enables Cloud Native Buildpacks that can transform your source code into container images."

--- a/cli/azd/test/mocks/mockzip/mockzip.go
+++ b/cli/azd/test/mocks/mockzip/mockzip.go
@@ -1,0 +1,86 @@
+package mockzip
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"io"
+)
+
+type File struct {
+	// Name of the path in the archive. Forward slash should be the path separator.
+	Name string
+
+	// Content of the file.
+	Content string
+}
+
+func CreateTar(files []File) (*bytes.Buffer, error) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+
+	for _, file := range files {
+		hdr := &tar.Header{
+			Name: file.Name,
+			Mode: 0644,
+			Size: int64(len(file.Content)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, err
+		}
+		if _, err := tw.Write([]byte(file.Content)); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+
+	return &buf, nil
+}
+
+func CompressGzip(content *bytes.Buffer) (*bytes.Buffer, error) {
+	var compressedBuffer bytes.Buffer
+	gzipWriter := gzip.NewWriter(&compressedBuffer)
+	defer gzipWriter.Close()
+
+	_, err := io.Copy(gzipWriter, content)
+	if err != nil {
+		return nil, err
+	}
+
+	return &compressedBuffer, nil
+}
+
+func GzippedTar(files []File) (*bytes.Buffer, error) {
+	bytes, err := CreateTar(files)
+	if err != nil {
+		return nil, err
+	}
+
+	return CompressGzip(bytes)
+}
+
+func Zip(files []File) (*bytes.Buffer, error) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	for _, file := range files {
+		f, err := zw.Create(file.Name)
+		if err != nil {
+			return nil, err
+		}
+		_, err = f.Write([]byte(file.Content))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+
+	return &buf, nil
+}


### PR DESCRIPTION
Buildpacks allows source to container image transformation without Dockerfiles. When a `Dockerfile` isn't found in `azure.yaml`, and the alpha feature `buildpacks` isn't enabled, `azd` will use [pack](https://buildpacks.io/docs/tools/pack/) CLI to invoke the dockerization build.

Limited build customization is provided with this initial release. The only allowed customization is the builder image to use.

Closes #2677