### PR TITLE
Refactor `init.go`

### DIFF
--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -40,7 +40,20 @@ func invalidEnvironmentNameMsg(environmentName string) string {
 
 // ensureValidEnvironmentName ensures the environment name is valid, if it is not, an error is printed
 // and the user is prompted for a new name.
-func ensureValidEnvironmentName(ctx context.Context, environmentName *string, suggest string, console input.Console) error {
+func ensureValidEnvironmentName(
+	ctx context.Context,
+	environmentName *string,
+	examples []string,
+	console input.Console) error {
+	exampleText := ""
+	if len(examples) > 0 {
+		exampleText = "\n\nExamples:"
+	}
+
+	for _, example := range examples {
+		exampleText += fmt.Sprintf("\n  %s", example)
+	}
+
 	for !environment.IsValidEnvironmentName(*environmentName) {
 		userInput, err := console.Prompt(ctx, input.ConsoleOptions{
 			Message: "Enter a new environment name:",
@@ -49,8 +62,7 @@ func ensureValidEnvironmentName(ctx context.Context, environmentName *string, su
 			
 			This value is typically used by the infrastructure as code templates to name the resource group that contains
 			the infrastructure for your application and to generate a unique suffix that is applied to resources to prevent
-			naming collisions.`),
-			DefaultValue: suggest,
+			naming collisions.`) + exampleText,
 		})
 
 		if err != nil {
@@ -71,8 +83,8 @@ type environmentSpec struct {
 	environmentName string
 	subscription    string
 	location        string
-	// suggest is the name that is offered as a suggestion if we need to prompt the user for an environment name.
-	suggest string
+	// examples of environment names to prompt.
+	examples []string
 }
 
 // createEnvironment creates a new named environment. If an environment with this name already
@@ -89,7 +101,7 @@ func createEnvironment(
 		return nil, fmt.Errorf(errMsg)
 	}
 
-	if err := ensureValidEnvironmentName(ctx, &envSpec.environmentName, envSpec.suggest, console); err != nil {
+	if err := ensureValidEnvironmentName(ctx, &envSpec.environmentName, envSpec.examples, console); err != nil {
 		return nil, err
 	}
 
@@ -184,7 +196,7 @@ func loadOrCreateEnvironment(
 				environmentName)
 		}
 
-		if err := ensureValidEnvironmentName(ctx, &environmentName, "", console); err != nil {
+		if err := ensureValidEnvironmentName(ctx, &environmentName, nil, console); err != nil {
 			return nil, false, err
 		}
 

--- a/cli/azd/cmd/util_test.go
+++ b/cli/azd/cmd/util_test.go
@@ -31,7 +31,7 @@ func Test_promptEnvironmentName(t *testing.T) {
 
 		environmentName := "hello"
 
-		err := ensureValidEnvironmentName(*mockContext.Context, &environmentName, "", mockContext.Console)
+		err := ensureValidEnvironmentName(*mockContext.Context, &environmentName, nil, mockContext.Console)
 
 		require.NoError(t, err)
 	})
@@ -44,7 +44,7 @@ func Test_promptEnvironmentName(t *testing.T) {
 			return true
 		}).Respond("someEnv")
 
-		err := ensureValidEnvironmentName(*mockContext.Context, &environmentName, "", mockContext.Console)
+		err := ensureValidEnvironmentName(*mockContext.Context, &environmentName, nil, mockContext.Console)
 
 		require.NoError(t, err)
 		require.Equal(t, "someEnv", environmentName)


### PR DESCRIPTION
Refactor `init.go` to allow the upcoming feature work for fingerprinting to land more cleanly.

Also, environment name prompt now provides examples instead of a default value.