### PR TITLE
Default supportsHttpsTrafficOnly in storage accounts to true

### DIFF
--- a/templates/common/infra/bicep/core/storage/storage-account.bicep
+++ b/templates/common/infra/bicep/core/storage/storage-account.bicep
@@ -18,6 +18,7 @@ param deleteRetentionPolicy object = {}
 param dnsEndpointType string = 'Standard'
 param kind string = 'StorageV2'
 param minimumTlsVersion string = 'TLS1_2'
+param supportsHttpsTrafficOnly bool = true
 param networkAcls object = {
   bypass: 'AzureServices'
   defaultAction: 'Allow'
@@ -42,6 +43,7 @@ resource storage 'Microsoft.Storage/storageAccounts@2022-05-01' = {
     minimumTlsVersion: minimumTlsVersion
     networkAcls: networkAcls
     publicNetworkAccess: publicNetworkAccess
+    supportsHttpsTrafficOnly: supportsHttpsTrafficOnly
   }
 
   resource blobServices 'blobServices' = if (!empty(containers)) {


### PR DESCRIPTION
See AZR rule https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.Storage.SecureTransfer/

Removes a false-positive for rule analyser security issues on the storage account (true is already the default value from 2019-04-01)