### PR TITLE
Enable experimentation-alpha integration

### DIFF
--- a/cli/azd/cmd/middleware/experimentation.go
+++ b/cli/azd/cmd/middleware/experimentation.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -49,23 +48,8 @@ func (m *ExperimentationMiddleware) Run(ctx context.Context, next NextFn) (*acti
 					if strings.HasPrefix(parameter, "alpha_") {
 						featureId := parameter[len("alpha_"):]
 						if enablement, ok := value.(bool); ok {
-							if enablement {
-								// set default enablement for the feature
-								alpha.SetDefaultEnablement(featureId, true)
-							} else {
-								// setting a 'false' value acts as a kill switch,
-								// explicitly override the configuration here
-								err = os.Setenv(
-									fmt.Sprintf("AZD_ALPHA_ENABLE_%s", strings.ToUpper(featureId)),
-									"false")
-
-								if err != nil {
-									log.Printf(
-										"failed to set environment variable for disabling alpha feature '%s': %v",
-										featureId,
-										err)
-								}
-							}
+							// set default enablement for the feature
+							alpha.SetDefaultEnablement(featureId, enablement)
 						} else {
 							log.Printf("could not parse value for alpha feature '%s' as a bool, ignoring", featureId)
 						}

--- a/cli/azd/cmd/middleware/experimentation.go
+++ b/cli/azd/cmd/middleware/experimentation.go
@@ -1,0 +1,65 @@
+package middleware
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/cmd/actions"
+	"github.com/azure/azure-dev/cli/azd/internal/tracing"
+	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
+	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
+	"github.com/azure/azure-dev/cli/azd/pkg/experimentation"
+)
+
+type ExperimentationMiddleware struct {
+}
+
+func NewExperimentationMiddleware() Middleware {
+	return &ExperimentationMiddleware{}
+}
+
+const assignmentEndpoint = "https://default.exp-tas.com/exptas49/b80dfe81-554e-48ec-a7bc-1dd773cd6a54-azdexpws/api/v1/tas"
+
+func (m *ExperimentationMiddleware) Run(ctx context.Context, next NextFn) (*actions.ActionResult, error) {
+	endpoint := assignmentEndpoint
+	// Allow overriding the assignment endpoint, either for local development (where you want to hit a private instance)
+	// or testing (we use this in our end to end tests to control assignment behavior for the CLI under test)/
+	if override := os.Getenv("AZD_DEBUG_EXPERIMENTATION_TAS_ENDPOINT"); override != "" {
+		log.Printf("using override assignment endpoint: %s, from AZD_DEBUG_EXPERIMENTATION_TAS_ENDPOINT", override)
+		endpoint = override
+	}
+
+	if assignmentManager, err := experimentation.NewAssignmentsManager(
+		endpoint,
+		http.DefaultClient,
+	); err == nil {
+		if assignment, err := assignmentManager.Assignment(ctx); err != nil {
+			log.Printf("failed to get variant assignments: %v", err)
+		} else {
+			log.Printf("assignment context: %v", assignment.AssignmentContext)
+			tracing.SetGlobalAttributes(fields.ExpAssignmentContextKey.String(assignment.AssignmentContext))
+
+			for _, feature := range assignment.Configs {
+				for parameter, value := range feature.Parameters {
+					// Apply any alpha feature defaults from the assignment
+					if strings.HasPrefix(parameter, "alpha_") {
+						featureId := parameter[len("alpha_"):]
+
+						if enablement, ok := value.(bool); ok {
+							alpha.SetDefaultEnablement(featureId, enablement)
+						} else {
+							log.Printf("could not parse value for alpha feature '%s' as a bool, ignoring", featureId)
+						}
+					}
+				}
+			}
+		}
+	} else {
+		log.Printf("failed to create assignment manager: %v", err)
+	}
+
+	return next(ctx)
+}

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -303,6 +303,7 @@ func NewRootCmd(staticHelp bool, middlewareChain []*actions.MiddlewareRegistrati
 	// Global middleware registration
 	root.
 		UseMiddleware("debug", middleware.NewDebugMiddleware).
+		UseMiddleware("experimentation", middleware.NewExperimentationMiddleware).
 		UseMiddlewareWhen("telemetry", middleware.NewTelemetryMiddleware, func(descriptor *actions.ActionDescriptor) bool {
 			return !descriptor.Options.DisableTelemetry
 		})

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -26,10 +26,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/cmd"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
-	"github.com/azure/azure-dev/cli/azd/internal/tracing"
-	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
-	"github.com/azure/azure-dev/cli/azd/pkg/experimentation"
 	"github.com/azure/azure-dev/cli/azd/pkg/installer"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -57,29 +54,6 @@ func main() {
 	log.Printf("azd version: %s", internal.Version)
 
 	ts := telemetry.GetTelemetrySystem()
-
-	assignmentEndpoint := "https://default.exp-tas.com/exptas49/b80dfe81-554e-48ec-a7bc-1dd773cd6a54-azdexpws/api/v1/tas"
-
-	// Allow overriding the assignment endpoint, either for local development (where you want to hit a private instance)
-	// or testing (we use this in our end to end tests to control assignment behavior for the CLI under test)/
-	if override := os.Getenv("AZD_DEBUG_EXPERIMENTATION_TAS_ENDPOINT"); override != "" {
-		log.Printf("using override assignment endpoint: %s, from AZD_DEBUG_EXPERIMENTATION_TAS_ENDPOINT", override)
-		assignmentEndpoint = override
-	}
-
-	if assignmentManager, err := experimentation.NewAssignmentsManager(
-		assignmentEndpoint,
-		http.DefaultClient,
-	); err == nil {
-		if assignment, err := assignmentManager.Assignment(ctx); err != nil {
-			log.Printf("failed to get variant assignments: %v", err)
-		} else {
-			log.Printf("assignment context: %v", assignment.AssignmentContext)
-			tracing.SetGlobalAttributes(fields.ExpAssignmentContextKey.String(assignment.AssignmentContext))
-		}
-	} else {
-		log.Printf("failed to create assignment manager: %v", err)
-	}
 
 	latest := make(chan semver.Version)
 	go fetchLatestVersion(latest)

--- a/cli/azd/pkg/alpha/alpha_feature_manager.go
+++ b/cli/azd/pkg/alpha/alpha_feature_manager.go
@@ -96,7 +96,22 @@ func (m *FeatureManager) IsEnabled(featureId FeatureId) bool {
 		return true
 	}
 
+	// check if the feature has been set with a default value internally
+	if val, ok := defaultEnablement[strings.ToLower(string(featureId))]; ok {
+		return val
+	}
+
 	return false
+}
+
+// defaultEnablement is a map of lower-cased feature ids to their default enablement values.
+//
+// This is used to determine if a feature is enabled by default, when no user configuration is specified.
+var defaultEnablement = map[string]bool{}
+
+// SetDefaultEnablement sets the default enablement value for the given feature id.
+func SetDefaultEnablement(id string, val bool) {
+	defaultEnablement[strings.ToLower(id)] = val
 }
 
 func isEnabled(config config.Config, id FeatureId) bool {


### PR DESCRIPTION
Allow experimentation rollouts to control the default alpha feature enablement.

- If a feature flag for `alpha_<featureId>` is set to true, the alpha feature is enabled by default. User config takes precedence over the default.

Also, moving the experimentation initialization to later in app initialization so that initialization only occurs when a command is fully parsed. Error commands should not trigger the flow.

Partially addresses #1260