### PR TITLE
Filters Todo templates for template testing matrix

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.3.0-beta.1 (Unreleased) 
+## 1.3.0-beta.1 (Unreleased)
 
 ### Features Added
 

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.3.0-beta.1 (Unreleased)
+## 1.3.0-beta.1 (Unreleased) 
 
 ### Features Added
 

--- a/eng/pipelines/repoman.yml
+++ b/eng/pipelines/repoman.yml
@@ -111,7 +111,7 @@ stages:
           TemplateBranchName: $[ dependencies.Generate_Repos_For_PR.outputs['DetermineChanged.TemplateBranch'] ]
           # Exclude AKS templates due to internal security policies restricting ingress network traffic
           # That will cause the Playwright tests to fail since the host is not reachable
-          TemplateListFilter: '^(?!\S+-aks)\S+$'
+          TemplateListFilter: '^Azure-Samples/todo-((?!aks).)*$'
           JobCondition: >-
             and(
               succeeded(),

--- a/eng/pipelines/template-tests.yml
+++ b/eng/pipelines/template-tests.yml
@@ -23,7 +23,7 @@ parameters:
   displayName: | 
     Regex filter expression to filter templates. Examples: 'csharp', 'terraform', 'python-mongo'
   type: string
-  default: 'Azure-Samples/todo-.*'
+  default: '^Azure-Samples/todo-((?!aks).)*$'
 
 - name: TemplateBranchName
   displayName: The template repository branch to test against

--- a/eng/pipelines/template-tests.yml
+++ b/eng/pipelines/template-tests.yml
@@ -23,7 +23,7 @@ parameters:
   displayName: | 
     Regex filter expression to filter templates. Examples: 'csharp', 'terraform', 'python-mongo'
   type: string
-  default: '.*'
+  default: 'Azure-Samples/todo-.*'
 
 - name: TemplateBranchName
   displayName: The template repository branch to test against

--- a/eng/pipelines/templates/jobs/run-template-tests.yml
+++ b/eng/pipelines/templates/jobs/run-template-tests.yml
@@ -17,7 +17,7 @@ parameters:
   displayName: | 
     Regex filter expression to filter templates. Examples: 'csharp', 'terraform', 'python-mongo'
   type: string
-  default: '.*'
+  default: 'Azure-Samples/todo-.*'
 
 - name: TemplateBranchName
   displayName: The template repository branch to test against

--- a/eng/pipelines/templates/jobs/run-template-tests.yml
+++ b/eng/pipelines/templates/jobs/run-template-tests.yml
@@ -17,7 +17,7 @@ parameters:
   displayName: | 
     Regex filter expression to filter templates. Examples: 'csharp', 'terraform', 'python-mongo'
   type: string
-  default: 'Azure-Samples/todo-.*'
+  default: '^Azure-Samples/todo-((?!aks).)*$'
 
 - name: TemplateBranchName
   displayName: The template repository branch to test against

--- a/eng/pipelines/templates/steps/template-test-generate-jobs.yml
+++ b/eng/pipelines/templates/steps/template-test-generate-jobs.yml
@@ -9,7 +9,7 @@ parameters:
   displayName: | 
     Regex filter expression to filter templates. Examples: 'csharp', 'terraform', 'python-mongo'
   type: string
-  default: 'Azure-Samples/todo-.*'
+  default: '^Azure-Samples/todo-((?!aks).)*$'
 
 - name: OutputMatrixVariable
   displayName: The output matrix variable to set

--- a/eng/pipelines/templates/steps/template-test-generate-jobs.yml
+++ b/eng/pipelines/templates/steps/template-test-generate-jobs.yml
@@ -9,7 +9,7 @@ parameters:
   displayName: | 
     Regex filter expression to filter templates. Examples: 'csharp', 'terraform', 'python-mongo'
   type: string
-  default: '.*'
+  default: 'Azure-Samples/todo-.*'
 
 - name: OutputMatrixVariable
   displayName: The output matrix variable to set


### PR DESCRIPTION
Since `azd template test` now include all Awesome AZD templates by default we want to filter the testing templates to only the `Azure-Samples/todo-*` templates.