### PR TITLE
azd package support for user specified output paths

### DIFF
--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -241,7 +241,7 @@ func (da *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 			}
 		} else {
 			//  --from-package not set, package the application
-			packageTask := da.serviceManager.Package(ctx, svc, nil)
+			packageTask := da.serviceManager.Package(ctx, svc, nil, nil)
 			done := make(chan struct{})
 			go func() {
 				for packageProgress := range packageTask.Progress() {

--- a/cli/azd/cmd/package.go
+++ b/cli/azd/cmd/package.go
@@ -218,12 +218,10 @@ func getCmdPackageHelpFooter(*cobra.Command) string {
 		"Packages all services in the current project to Azure.": output.WithHighLightFormat("azd package --all"),
 		"Packages the service named 'api' to Azure.":             output.WithHighLightFormat("azd package api"),
 		"Packages the service named 'web' to Azure.":             output.WithHighLightFormat("azd package web"),
-		//nolint:lll
 		"Packages all services to the specified output path.": output.WithHighLightFormat(
 			"azd package --output-path ./dist",
 		),
-		//nolint:lll
-		"Packages the service name 'api' to the specified output path.": output.WithHighLightFormat(
+		"Packages the service named 'api' to the specified output path.": output.WithHighLightFormat(
 			"azd package api --output-path ./dist/api.zip",
 		),
 	})

--- a/cli/azd/cmd/package.go
+++ b/cli/azd/cmd/package.go
@@ -21,6 +21,7 @@ type packageFlags struct {
 	all    bool
 	global *internal.GlobalCommandOptions
 	*envFlag
+	outputPath string
 }
 
 func newPackageFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *packageFlags {
@@ -42,6 +43,12 @@ func (pf *packageFlags) Bind(local *pflag.FlagSet, global *internal.GlobalComman
 		"all",
 		false,
 		"Deploys all services that are listed in "+azdcontext.ProjectFileName,
+	)
+	local.StringVar(
+		&pf.outputPath,
+		"output-path",
+		"",
+		"File or folder path where the generated packages will be saved.",
 	)
 }
 
@@ -146,7 +153,8 @@ func (pa *packageAction) Run(ctx context.Context) (*actions.ActionResult, error)
 			continue
 		}
 
-		packageTask := pa.serviceManager.Package(ctx, svc, nil)
+		options := &project.PackageOptions{OutputPath: pa.flags.outputPath}
+		packageTask := pa.serviceManager.Package(ctx, svc, nil, options)
 		done := make(chan struct{})
 		go func() {
 			for packageProgress := range packageTask.Progress() {
@@ -210,5 +218,13 @@ func getCmdPackageHelpFooter(*cobra.Command) string {
 		"Packages all services in the current project to Azure.": output.WithHighLightFormat("azd package --all"),
 		"Packages the service named 'api' to Azure.":             output.WithHighLightFormat("azd package api"),
 		"Packages the service named 'web' to Azure.":             output.WithHighLightFormat("azd package web"),
+		//nolint:lll
+		"Packages all services to the specified output path.": output.WithHighLightFormat(
+			"azd package --output-path ./dist",
+		),
+		//nolint:lll
+		"Packages the service name 'api' to the specified output path.": output.WithHighLightFormat(
+			"azd package api --output-path ./dist/api.zip",
+		),
 	})
 }

--- a/cli/azd/cmd/testdata/TestUsage-azd-package.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-package.snap
@@ -13,6 +13,7 @@ Flags
         --docs               	: Opens the documentation for azd package in your web browser.
     -e, --environment string 	: The name of the environment to use.
     -h, --help               	: Gets help for package.
+        --output-path string 	: File or folder path where the generated packages will be saved.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
@@ -23,8 +24,14 @@ Examples
   Packages all services in the current project to Azure.
     azd package --all
 
+  Packages all services to the specified output path.
+    azd package --output-path ./dist
+
   Packages the service named 'api' to Azure.
     azd package api
+
+  Packages the service named 'api' to the specified output path.
+    azd package api --output-path ./dist/api.zip
 
   Packages the service named 'web' to Azure.
     azd package web

--- a/cli/azd/pkg/project/project_utils.go
+++ b/cli/azd/pkg/project/project_utils.go
@@ -6,6 +6,8 @@ package project
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/rzip"
 	"github.com/otiai10/copy"
@@ -13,9 +15,10 @@ import (
 
 // CreateDeployableZip creates a zip file of a folder, recursively.
 // Returns the path to the created zip file or an error if it fails.
-func createDeployableZip(appName string, path string) (string, error) {
+func createDeployableZip(projectName string, appName string, path string) (string, error) {
 	// TODO: should probably avoid picking up files that weren't meant to be deployed (ie, local .env files, etc..)
-	zipFile, err := os.CreateTemp("", "azddeploy*.zip")
+	filePath := filepath.Join(os.TempDir(), fmt.Sprintf("%s-%s-azddeploy-%d.zip", projectName, appName, time.Now().Unix()))
+	zipFile, err := os.Create(filePath)
 	if err != nil {
 		return "", fmt.Errorf("failed when creating zip package to deploy %s: %w", appName, err)
 	}

--- a/cli/azd/pkg/project/service_manager_test.go
+++ b/cli/azd/pkg/project/service_manager_test.go
@@ -170,7 +170,7 @@ func Test_ServiceManager_Package(t *testing.T) {
 	ctx := context.WithValue(*mockContext.Context, frameworkPackageCalled, fakeFrameworkPackageCalled)
 	ctx = context.WithValue(ctx, serviceTargetPackageCalled, fakeServiceTargetPackageCalled)
 
-	packageTask := sm.Package(ctx, serviceConfig, nil)
+	packageTask := sm.Package(ctx, serviceConfig, nil, nil)
 	logProgress(packageTask)
 
 	result, err := packageTask.Await()
@@ -296,7 +296,7 @@ func Test_ServiceManager_Events_With_Errors(t *testing.T) {
 		{
 			name: "package",
 			run: func(ctx context.Context, serviceManager ServiceManager, serviceConfig *ServiceConfig) (any, error) {
-				packageTask := serviceManager.Package(ctx, serviceConfig, nil)
+				packageTask := serviceManager.Package(ctx, serviceConfig, nil, nil)
 				logProgress(packageTask)
 				return packageTask.Await()
 			},

--- a/cli/azd/pkg/project/service_models.go
+++ b/cli/azd/pkg/project/service_models.go
@@ -60,6 +60,10 @@ func (sbr *ServiceBuildResult) MarshalJSON() ([]byte, error) {
 	return json.Marshal(*sbr)
 }
 
+type PackageOptions struct {
+	OutputPath string
+}
+
 // ServicePackageResult is the result of a successful Package operation
 type ServicePackageResult struct {
 	Build       *ServiceBuildResult `json:"build"`

--- a/cli/azd/pkg/project/service_target_appservice.go
+++ b/cli/azd/pkg/project/service_target_appservice.go
@@ -53,7 +53,11 @@ func (st *appServiceTarget) Package(
 	return async.RunTaskWithProgress(
 		func(task *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
 			task.SetProgress(NewServiceProgress("Compressing deployment artifacts"))
-			zipFilePath, err := createDeployableZip(serviceConfig.Name, packageOutput.PackagePath)
+			zipFilePath, err := createDeployableZip(
+				serviceConfig.Project.Name,
+				serviceConfig.Name,
+				packageOutput.PackagePath,
+			)
 			if err != nil {
 				task.SetError(err)
 				return

--- a/cli/azd/pkg/project/service_target_functionapp.go
+++ b/cli/azd/pkg/project/service_target_functionapp.go
@@ -54,7 +54,11 @@ func (f *functionAppTarget) Package(
 	return async.RunTaskWithProgress(
 		func(task *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
 			task.SetProgress(NewServiceProgress("Compressing deployment artifacts"))
-			zipFilePath, err := createDeployableZip(serviceConfig.Name, packageOutput.PackagePath)
+			zipFilePath, err := createDeployableZip(
+				serviceConfig.Project.Name,
+				serviceConfig.Name,
+				packageOutput.PackagePath,
+			)
 			if err != nil {
 				task.SetError(err)
 				return

--- a/cli/azd/test/functional/package_test.go
+++ b/cli/azd/test/functional/package_test.go
@@ -1,0 +1,153 @@
+package cli_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/test/azdcli"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CLI_Package_Err_WorkingDirectory(t *testing.T) {
+	// running this test in parallel is ok as it uses a t.TempDir()
+	t.Parallel()
+	ctx, cancel := newTestContext(t)
+	defer cancel()
+
+	dir := tempDirWithDiagnostics(t)
+	t.Logf("DIR: %s", dir)
+
+	cli := azdcli.NewCLI(t)
+	cli.WorkingDirectory = dir
+	cli.Env = append(os.Environ(), "AZURE_LOCATION=eastus2")
+
+	err := copySample(dir, "webapp")
+	require.NoError(t, err, "failed expanding sample")
+
+	// cd infra
+	err = os.MkdirAll(filepath.Join(dir, "infra"), osutil.PermissionDirectory)
+	require.NoError(t, err)
+	cli.WorkingDirectory = filepath.Join(dir, "infra")
+
+	result, err := cli.RunCommandWithStdIn(ctx, stdinForInit("testenv"), "package")
+	require.Error(t, err, "package should fail in non-project and non-service directory")
+	require.Contains(t, result.Stdout, "current working directory")
+}
+
+func Test_CLI_Package_FromServiceDirectory(t *testing.T) {
+	// running this test in parallel is ok as it uses a t.TempDir()
+	t.Parallel()
+	ctx, cancel := newTestContext(t)
+	defer cancel()
+
+	dir := tempDirWithDiagnostics(t)
+	t.Logf("DIR: %s", dir)
+
+	cli := azdcli.NewCLI(t)
+	cli.WorkingDirectory = dir
+	cli.Env = append(os.Environ(), "AZURE_LOCATION=eastus2")
+
+	err := copySample(dir, "webapp")
+	require.NoError(t, err, "failed expanding sample")
+
+	cli.WorkingDirectory = filepath.Join(dir, "src", "dotnet")
+
+	result, err := cli.RunCommandWithStdIn(ctx, stdinForInit("testenv"), "package")
+	require.NoError(t, err)
+	require.Contains(t, result.Stdout, "Packaging service web")
+}
+
+func Test_CLI_Package_WithOutputPath(t *testing.T) {
+	t.Run("AllServices", func(t *testing.T) {
+		// running this test in parallel is ok as it uses a t.TempDir()
+		t.Parallel()
+		ctx, cancel := newTestContext(t)
+		defer cancel()
+
+		dir := tempDirWithDiagnostics(t)
+		t.Logf("DIR: %s", dir)
+
+		envName := randomEnvName()
+		t.Logf("AZURE_ENV_NAME: %s", envName)
+
+		cli := azdcli.NewCLI(t)
+		cli.WorkingDirectory = dir
+		cli.Env = append(os.Environ(), "AZURE_LOCATION=eastus2")
+
+		err := copySample(dir, "webapp")
+		require.NoError(t, err, "failed expanding sample")
+
+		packageResult, err := cli.RunCommandWithStdIn(
+			ctx,
+			stdinForInit(envName),
+			"package", "--output-path", "./dist",
+		)
+		require.NoError(t, err)
+		require.Contains(t, packageResult.Stdout, "Package Output: dist")
+
+		distPath := filepath.Join(dir, "dist")
+		files, err := os.ReadDir(distPath)
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+	})
+
+	t.Run("SingleService", func(t *testing.T) {
+		// running this test in parallel is ok as it uses a t.TempDir()
+		t.Parallel()
+		ctx, cancel := newTestContext(t)
+		defer cancel()
+
+		dir := tempDirWithDiagnostics(t)
+		t.Logf("DIR: %s", dir)
+
+		envName := randomEnvName()
+		t.Logf("AZURE_ENV_NAME: %s", envName)
+
+		cli := azdcli.NewCLI(t)
+		cli.WorkingDirectory = dir
+		cli.Env = append(os.Environ(), "AZURE_LOCATION=eastus2")
+
+		err := copySample(dir, "webapp")
+		require.NoError(t, err, "failed expanding sample")
+
+		packageResult, err := cli.RunCommandWithStdIn(
+			ctx,
+			stdinForInit(envName),
+			"package", "web", "--output-path", "./dist/web.zip",
+		)
+		require.NoError(t, err)
+		require.Contains(t, packageResult.Stdout, "Package Output: ./dist/web.zip")
+
+		artifactPath := filepath.Join(dir, "dist", "web.zip")
+		info, err := os.Stat(artifactPath)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+	})
+}
+
+func Test_CLI_Package(t *testing.T) {
+	// running this test in parallel is ok as it uses a t.TempDir()
+	t.Parallel()
+	ctx, cancel := newTestContext(t)
+	defer cancel()
+
+	dir := tempDirWithDiagnostics(t)
+	t.Logf("DIR: %s", dir)
+
+	envName := randomEnvName()
+	t.Logf("AZURE_ENV_NAME: %s", envName)
+
+	cli := azdcli.NewCLI(t)
+	cli.WorkingDirectory = dir
+	cli.Env = append(os.Environ(), "AZURE_LOCATION=eastus2")
+
+	err := copySample(dir, "webapp")
+	require.NoError(t, err, "failed expanding sample")
+
+	packageResult, err := cli.RunCommandWithStdIn(ctx, stdinForInit(envName), "package", "web")
+	require.NoError(t, err)
+	require.Contains(t, packageResult.Stdout, fmt.Sprintf("Package Output: %s", os.TempDir()))
+}


### PR DESCRIPTION
Resolves #2543

Adds ability for a user to specify a `--output-path` param to the `azd package` command to control the output location of file based packages.

For top level commands it would be expected that user specify a absolute or relative folder path.  If the path does not exist azd will create it automatically.

### Output multiple services to well known location
`azd package --output-path ./dist`

<img width="433" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/949a2e97-dba4-4d7a-b7bf-4f22342eeb6d">

### Output single service to well known location
`azd package api --output-path ./dist/api-app.zip`

<img width="378" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/bc438155-83a6-4ec1-88b2-2394b59bca31">

### Updates default naming convention for package artifacts

Package artifact naming convention now follows the format of `{project_name}-{service_name}-azddeploy-{timestamp}.zip` to provide more information to the user to more easily find the correct generated artifact and distinguish them from one another.

<img width="614" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/651cd98e-80b7-44fd-826f-c4931b14e13f">

## Use Case: Store package output into some artifact store

When running AZD in CI a common scenario would be to package service artifacts into a well known location that can then be referenced and stored in an artifact store.

User can run the following:
`azd package api --output-path ./dist/api-app.zip`

Since the user now has control of where the artifact will be generated they can easily copy this artifact into an artifact store of their choosing.

## Use Case: Deploy azd package from previously packaged artifact

User now has more control on where the generated artifacts are stored and can easily reference them in other azd commnds such as `azd deploy`

```bash
// Generate service artifact to known path
azd package api --output-path ./dist/api-app.zip

// Use known path in deploy command
azd deploy api --from-package ./dist/api-app.zip
```

TODO: 
- [x] Write functional test to validate behavior
