### PR TITLE
Prefer glibc based Bicep when both musl and glibc are installed

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -90,6 +90,7 @@ keychain
 LASTEXITCODE
 ldflags
 lechnerc77
+libc
 mgmt
 mgutz
 microsoftonline


### PR DESCRIPTION
This matches the behavior of the `az` CLI, which uses this same logic. When we orginally implemented this, `az` did not have this special case, it was added later.

Fixes #2683