### PR TITLE
Show up text `AZD_CONFIG_DIR` for `azd config --help`

### DIFF
--- a/cli/azd/cmd/cmd_help.go
+++ b/cli/azd/cmd/cmd_help.go
@@ -258,10 +258,17 @@ func getPreFooter(c *cobra.Command) string {
 }
 
 // generateCmdHelpDescription construct a help text block from a title and description notes.
-func generateCmdHelpDescription(title string, notes []string) string {
+func generateCmdHelpDescription(title string, notes []string, options ...string) string {
 	var note string
 	if len(notes) > 0 {
 		note = fmt.Sprintf("%s\n\n", strings.Join(notes, "\n"))
+	}
+	if len(options) > 0 {
+		var item string
+		for _, opt := range options {
+			item = opt
+		}
+		return fmt.Sprintf("%s\n\n%s%s\n\n", title, note, item)
 	}
 	return fmt.Sprintf("%s\n\n%s", title, note)
 }

--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -392,7 +392,7 @@ func getCmdConfigHelpDescription(*cobra.Command) string {
 				output.WithBackticks(defaultConfigPath),
 			)),
 		},
-		`The configuration directory can be overridden by specifying a path in the AZD_CONFIG_DIR environment variable.`,
+		"The configuration directory can be overridden by specifying a path in the AZD_CONFIG_DIR environment variable.",
 	)
 }
 

--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -20,6 +20,7 @@ import (
 )
 
 var userConfigPath string
+var defaultConfigPath string
 
 // Setup account command category
 func configActions(root *actions.ActionDescriptor, rootOptions *internal.GlobalCommandOptions) *actions.ActionDescriptor {
@@ -38,7 +39,6 @@ func configActions(root *actions.ActionDescriptor, rootOptions *internal.GlobalC
 		userConfigPath = output.WithBackticks(filepath.Join(userConfigDir, "config.json"))
 	}
 
-	var defaultConfigPath string
 	if runtime.GOOS == "windows" {
 		defaultConfigPath = filepath.Join("%USERPROFILE%", ".azd")
 	} else {
@@ -386,12 +386,14 @@ func getCmdConfigHelpDescription(*cobra.Command) string {
 				output.WithHighLightFormat("azd init"),
 			)),
 			formatHelpNote(fmt.Sprintf("The subscription and location you select will be stored at: %s.",
-				output.WithLinkFormat("%HOME/.azd/config.json"),
+				userConfigPath,
 			)),
 			formatHelpNote(fmt.Sprintf("The default configuration path is: %s.",
-				output.WithLinkFormat("%HOME/.azd"),
+				output.WithBackticks(defaultConfigPath),
 			)),
-		})
+		},
+		`The configuration directory can be overridden by specifying a path in the AZD_CONFIG_DIR environment variable.`,
+	)
 }
 
 func getCmdConfigHelpFooter(c *cobra.Command) string {

--- a/cli/azd/cmd/testdata/TestUsage-azd-config.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-config.snap
@@ -4,6 +4,8 @@ Manage the Azure Developer CLI user configuration, which includes your default A
   • Applications are initially configured when you run azd init.
   • The subscription and location you select will be stored at: %HOME/.azd/config.json.
   • The default configuration path is: %HOME/.azd.
+  
+The configuration directory can be overridden by specifying a path in the AZD_CONFIG_DIR environment variable.
 
 Usage
   azd config [command]


### PR DESCRIPTION
Fix #2302 

For example, running `azd config --help` in `Windows` environment, as shown below:

![image](https://github.com/Azure/azure-dev/assets/80496810/f382cc44-cf9a-4683-9b33-5a8b1d82f6a7)

@rajeshkamal5050 , @weikanglim for notification.