### PR TITLE
Fixes azd package tests that fail when running in parallel

### DIFF
--- a/cli/azd/test/functional/package_test.go
+++ b/cli/azd/test/functional/package_test.go
@@ -62,8 +62,6 @@ func Test_CLI_Package_FromServiceDirectory(t *testing.T) {
 
 func Test_CLI_Package_WithOutputPath(t *testing.T) {
 	t.Run("AllServices", func(t *testing.T) {
-		// running this test in parallel is ok as it uses a t.TempDir()
-		t.Parallel()
 		ctx, cancel := newTestContext(t)
 		defer cancel()
 
@@ -95,8 +93,6 @@ func Test_CLI_Package_WithOutputPath(t *testing.T) {
 	})
 
 	t.Run("SingleService", func(t *testing.T) {
-		// running this test in parallel is ok as it uses a t.TempDir()
-		t.Parallel()
 		ctx, cancel := newTestContext(t)
 		defer cancel()
 


### PR DESCRIPTION
Fixes azd package tests that fail when running in parallel.

Based on recent temp file naming for package command there is an opportunity that if multiple package commands are run at the same time that it can generate the same package name which causes the tests to clash.

This case doesn't exist in user scenarios since the temp file name is a combination of project name, service name and current unix timestamp.