### PR TITLE
Update cosmos-account.bicep to 4.2

### DIFF
--- a/templates/common/infra/bicep/core/database/cosmos/cosmos-account.bicep
+++ b/templates/common/infra/bicep/core/database/cosmos/cosmos-account.bicep
@@ -26,7 +26,7 @@ resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2022-08-15' = {
     databaseAccountOfferType: 'Standard'
     enableAutomaticFailover: false
     enableMultipleWriteLocations: false
-    apiProperties: (kind == 'MongoDB') ? { serverVersion: '4.0' } : {}
+    apiProperties: (kind == 'MongoDB') ? { serverVersion: '4.2' } : {}
     capabilities: [ { name: 'EnableServerless' } ]
   }
 }


### PR DESCRIPTION
Suggested from @kjaymiller : 4.2 is the most recent version that is currently supported, so its better to use 4.2 than 4.0. We are using 4.2 successful in our cookiecutter-relecloud templates. 