### PR TITLE
fix: devcontainer setup for terraform - activate alpha feature

### DIFF
--- a/templates/common/.devcontainer/devcontainer.json/java/terraform/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/java/terraform/devcontainer.json
@@ -29,7 +29,7 @@
         3000,
         3100
     ],
-    "postCreateCommand": "",
+    "postCreateCommand": "azd config set alpha.terraform on",
     "remoteUser": "node",
     "hostRequirements": {
         "memory": "8gb"

--- a/templates/common/.devcontainer/devcontainer.json/nodejs/terraform/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/nodejs/terraform/devcontainer.json
@@ -30,7 +30,7 @@
         3000,
         3100
     ],
-    "postCreateCommand": "",
+    "postCreateCommand": "azd config set alpha.terraform on",
     "remoteUser": "node",
     "hostRequirements": {
         "memory": "8gb"

--- a/templates/common/.devcontainer/devcontainer.json/python/terraform/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/terraform/devcontainer.json
@@ -32,7 +32,7 @@
         3000,
         3100
     ],
-    "postCreateCommand": "",
+    "postCreateCommand": "azd config set alpha.terraform on",
     "remoteUser": "vscode",
     "hostRequirements": {
         "memory": "8gb"

--- a/templates/common/.devcontainer/devcontainer.json/terraform-starter/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/terraform-starter/devcontainer.json
@@ -29,7 +29,7 @@
     "forwardPorts": [
         // Forward ports if needed for local development
     ],
-    "postCreateCommand": "",
+    "postCreateCommand": "azd config set alpha.terraform on",
     "remoteUser": "vscode",
     "hostRequirements": {
         "memory": "8gb"


### PR DESCRIPTION
The support for Teraform in `azd` is currently in the alpha stage and must be explicitly activated via `azd config set alpha.terraform on`. This should be done automatically in the devcontainer setup if a Terraform-based template is used. 

This PR contains the fix for the devcontainer definition to activate this alpha feature in the `postCreateCommand` of the devcontainer setup.