### PR TITLE
Upgrade v8-compile-cache

### DIFF
--- a/templates/todo/api/js/package-lock.json
+++ b/templates/todo/api/js/package-lock.json
@@ -10893,9 +10893,9 @@
       }
     },
     "node_modules/v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz",
+      "integrity": "sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==",
       "dev": true
     },
     "node_modules/v8-to-istanbul": {
@@ -19329,9 +19329,9 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz",
+      "integrity": "sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==",
       "dev": true
     },
     "v8-to-istanbul": {


### PR DESCRIPTION
Partial #2625 

This PR fixes the build break which appears in the nodejs projects. The version of `v8-compile-cache` used in `package-lock.json` is not compatible with variations in architecture on the same machine. The later version does support. 

This was tested with `Azure-Samples/todo-nodejs-*` templates and works properly. 

The scenario in question: 

1. Install `azd` on an Apple Silicon Mac in x86_64 mode and init a template 
2. Run `azd package` (or some superset command) on the template
3. Upgrade `azd` to a later version using ARM64 binary instead of x86_64 binary
4. Run `azd package` (or some superset command) on the template from step 2

In the past this failed with a segfault during the `npm run lint` step in the `api`. 