### PR TITLE
Add `azd hooks run` command for testing `azd` hooks

### DIFF
--- a/cli/azd/cmd/hooks.go
+++ b/cli/azd/cmd/hooks.go
@@ -1,0 +1,275 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/azure/azure-dev/cli/azd/cmd/actions"
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/ext"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func hooksActions(root *actions.ActionDescriptor) *actions.ActionDescriptor {
+	group := root.Add("hooks", &actions.ActionDescriptorOptions{
+		Command: &cobra.Command{
+			Use:   "hooks",
+			Short: "Manage hooks.",
+		},
+		GroupingOptions: actions.CommandGroupOptions{
+			RootLevelHelp: actions.CmdGroupManage,
+		},
+	})
+
+	group.Add("run", &actions.ActionDescriptorOptions{
+		Command:        newHooksRunCmd(),
+		FlagsResolver:  newHooksRunFlags,
+		ActionResolver: newHooksRunAction,
+	})
+
+	return group
+}
+
+func newHooksRunFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *hooksRunFlags {
+	flags := &hooksRunFlags{}
+	flags.Bind(cmd.Flags(), global)
+
+	return flags
+}
+
+func newHooksRunCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "run <name>",
+		Short: "Runs the specified hook for the project and services",
+		Args:  cobra.ExactArgs(1),
+	}
+}
+
+type hooksRunFlags struct {
+	envFlag
+	global      *internal.GlobalCommandOptions
+	platform    string
+	interactive bool
+	service     string
+}
+
+func (f *hooksRunFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
+	f.envFlag.Bind(local, global)
+	f.global = global
+
+	local.StringVar(&f.platform, "platform", "", "Forces hooks to run for the specified platform.")
+	local.BoolVar(&f.interactive, "interactive", false, "Forces all hooks to run in interactive mode for testing")
+	local.StringVar(&f.service, "service", "", "Only runs hooks for the specified service.")
+}
+
+type hooksRunAction struct {
+	projectConfig *project.ProjectConfig
+	env           *environment.Environment
+	commandRunner exec.CommandRunner
+	console       input.Console
+	flags         *hooksRunFlags
+	args          []string
+}
+
+func newHooksRunAction(
+	projectConfig *project.ProjectConfig,
+	env *environment.Environment,
+	commandRunner exec.CommandRunner,
+	console input.Console,
+	flags *hooksRunFlags,
+	args []string,
+) actions.Action {
+	return &hooksRunAction{
+		projectConfig: projectConfig,
+		env:           env,
+		commandRunner: commandRunner,
+		console:       console,
+		flags:         flags,
+		args:          args,
+	}
+}
+
+const noHookFoundMessage = " (No hook found)"
+
+func (hra *hooksRunAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	hookName := hra.args[0]
+
+	// Command title
+	hra.console.MessageUxItem(ctx, &ux.MessageTitle{
+		Title: "Running hooks (azd hooks run)",
+		TitleNote: fmt.Sprintf(
+			"Finding and executing %s hooks for environment %s",
+			output.WithHighLightFormat(hookName),
+			output.WithHighLightFormat(hra.env.GetEnvName()),
+		),
+	})
+
+	// Validate hook type
+	if _, _, err := ext.InferHookType(hookName); err != nil {
+		return nil, fmt.Errorf("hook name is invalid. Hook names should start with 'pre' or 'post', %w", err)
+	}
+
+	// Validate service name
+	if _, ok := hra.projectConfig.Services[hra.flags.service]; hra.flags.service != "" && !ok {
+		return nil, fmt.Errorf("service name '%s' doesn't exist", hra.flags.service)
+	}
+
+	// Project level hooks
+	projectHooksMessage := "Running command hook for project"
+	if err := hra.processHooks(
+		ctx,
+		hra.projectConfig.Path,
+		hookName,
+		projectHooksMessage,
+		hra.projectConfig.Hooks,
+		false,
+	); err != nil {
+		return nil, err
+	}
+
+	// Service level hooks
+	for serviceName, service := range hra.projectConfig.Services {
+		skip := hra.flags.service != "" && serviceName != hra.flags.service
+
+		serviceHookMessage := fmt.Sprintf("Running service hook for %s", serviceName)
+		if err := hra.processHooks(
+			ctx,
+			service.RelativePath,
+			hookName,
+			serviceHookMessage,
+			service.Hooks,
+			skip,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	return &actions.ActionResult{
+		Message: &actions.ResultMessage{
+			Header: "Your hooks have been run successfully",
+		},
+	}, nil
+}
+
+func (hra *hooksRunAction) processHooks(
+	ctx context.Context,
+	cwd string,
+	hookName string,
+	message string,
+	hooks map[string]*ext.HookConfig,
+	skip bool,
+) error {
+	hra.console.ShowSpinner(ctx, message, input.Step)
+
+	if skip {
+		hra.console.StopSpinner(ctx, message, input.StepSkipped)
+		return nil
+	}
+
+	hook, ok := hooks[hookName]
+	if !ok {
+		hra.console.StopSpinner(ctx, message+noHookFoundMessage, input.StepWarning)
+		return nil
+	}
+
+	hookType, commandName, err := ext.InferHookType(hookName)
+	if err != nil {
+		return err
+	}
+
+	if err := hra.prepareHook(hookName, hook); err != nil {
+		return err
+	}
+
+	if hook.Interactive {
+		hra.console.StopSpinner(ctx, "", input.StepDone)
+		hra.console.Message(ctx, output.WithBold(output.WithUnderline(message)))
+	}
+
+	err = hra.execHook(ctx, cwd, hookType, commandName, hook)
+	if err != nil {
+		hra.console.StopSpinner(ctx, message, input.StepFailed)
+		return fmt.Errorf("failed running hook %s, %w", hookName, err)
+	}
+
+	hra.console.StopSpinner(ctx, message, input.StepDone)
+	return nil
+}
+
+func (hra *hooksRunAction) execHook(
+	ctx context.Context,
+	cwd string,
+	hookType ext.HookType,
+	commandName string,
+	hook *ext.HookConfig,
+) error {
+	hookName := string(hookType) + commandName
+
+	hooks := map[string]*ext.HookConfig{
+		hookName: hook,
+	}
+
+	hooksManager := ext.NewHooksManager(cwd)
+	hooksRunner := ext.NewHooksRunner(hooksManager, hra.commandRunner, hra.console, cwd, hooks, hra.env)
+	err := hooksRunner.RunHooks(ctx, hookType, commandName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Overrides the configured hooks from command line flags
+func (hra *hooksRunAction) prepareHook(name string, hook *ext.HookConfig) error {
+	// Enable testing cross platform
+	if hra.flags.platform != "" {
+		platformType := ext.HookPlatformType(hra.flags.platform)
+		switch platformType {
+		case ext.HookPlatformWindows:
+			if hook.Windows == nil {
+				return fmt.Errorf("hook is not configured for Windows")
+			} else {
+				*hook = *hook.Windows
+			}
+		case ext.HookPlatformPosix:
+			if hook.Posix == nil {
+				return fmt.Errorf("hook is not configured for Posix")
+			} else {
+				*hook = *hook.Posix
+			}
+		default:
+			return fmt.Errorf("platform %s is not valid. Supported values are windows & posix", hra.flags.platform)
+		}
+	}
+
+	hook.Name = name
+
+	// Don't display the 'Executing hook...' messages
+	hook.Quiet = true
+	if hra.flags.interactive {
+		hook.Interactive = true
+	}
+
+	hra.configureHookFlags(hook.Windows)
+	hra.configureHookFlags(hook.Posix)
+
+	return nil
+}
+
+func (hra *hooksRunAction) configureHookFlags(hook *ext.HookConfig) {
+	if hook == nil {
+		return
+	}
+
+	hook.Quiet = true
+	if hra.flags.interactive {
+		hook.Interactive = true
+	}
+}

--- a/cli/azd/cmd/hooks.go
+++ b/cli/azd/cmd/hooks.go
@@ -21,10 +21,10 @@ func hooksActions(root *actions.ActionDescriptor) *actions.ActionDescriptor {
 	group := root.Add("hooks", &actions.ActionDescriptorOptions{
 		Command: &cobra.Command{
 			Use:   "hooks",
-			Short: "Manage hooks.",
+			Short: fmt.Sprintf("Develop, test and run hooks for an application. %s", output.WithWarningFormat("(Beta)")),
 		},
 		GroupingOptions: actions.CommandGroupOptions{
-			RootLevelHelp: actions.CmdGroupManage,
+			RootLevelHelp: actions.CmdGroupConfig,
 		},
 	})
 

--- a/cli/azd/cmd/hooks.go
+++ b/cli/azd/cmd/hooks.go
@@ -111,11 +111,6 @@ func (hra *hooksRunAction) Run(ctx context.Context) (*actions.ActionResult, erro
 		),
 	})
 
-	// Validate hook type
-	if _, _, err := ext.InferHookType(hookName); err != nil {
-		return nil, fmt.Errorf("hook name is invalid. Hook names should start with 'pre' or 'post', %w", err)
-	}
-
 	// Validate service name
 	if _, ok := hra.projectConfig.Services[hra.flags.service]; hra.flags.service != "" && !ok {
 		return nil, fmt.Errorf("service name '%s' doesn't exist", hra.flags.service)
@@ -179,10 +174,7 @@ func (hra *hooksRunAction) processHooks(
 		return nil
 	}
 
-	hookType, commandName, err := ext.InferHookType(hookName)
-	if err != nil {
-		return err
-	}
+	hookType, commandName := ext.InferHookType(hookName)
 
 	if err := hra.prepareHook(hookName, hook); err != nil {
 		return err
@@ -193,7 +185,7 @@ func (hra *hooksRunAction) processHooks(
 		hra.console.Message(ctx, output.WithBold(output.WithUnderline(message)))
 	}
 
-	err = hra.execHook(ctx, cwd, hookType, commandName, hook)
+	err := hra.execHook(ctx, cwd, hookType, commandName, hook)
 	if err != nil {
 		hra.console.StopSpinner(ctx, message, input.StepFailed)
 		return fmt.Errorf("failed running hook %s, %w", hookName, err)

--- a/cli/azd/cmd/middleware/hooks.go
+++ b/cli/azd/cmd/middleware/hooks.go
@@ -145,8 +145,8 @@ func (m *HooksMiddleware) registerServiceHooks(
 			env,
 		)
 
-		for hookName, hookConfig := range service.Hooks {
-			hookType, eventName, err := inferHookType(hookName, hookConfig)
+		for hookName := range service.Hooks {
+			hookType, eventName, err := ext.InferHookType(hookName)
 			if err != nil {
 				return fmt.Errorf(
 					//nolint:lll
@@ -186,19 +186,6 @@ func (m *HooksMiddleware) createServiceEventHandler(
 	return func(ctx context.Context, eventArgs project.ServiceLifecycleEventArgs) error {
 		return hooksRunner.RunHooks(ctx, hookType, hookName)
 	}
-}
-
-func inferHookType(name string, config *ext.HookConfig) (ext.HookType, string, error) {
-	// Validate name length so go doesn't PANIC for string slicing below
-	if len(name) < 4 {
-		return "", "", fmt.Errorf("unable to infer hook '%s'", name)
-	} else if name[:3] == "pre" {
-		return ext.HookTypePre, name[3:], nil
-	} else if name[:4] == "post" {
-		return ext.HookTypePost, name[4:], nil
-	}
-
-	return "", "", fmt.Errorf("unable to infer hook '%s'", name)
 }
 
 // Gets a value that returns whether or not service hooks have already been registered

--- a/cli/azd/cmd/middleware/hooks.go
+++ b/cli/azd/cmd/middleware/hooks.go
@@ -146,14 +146,10 @@ func (m *HooksMiddleware) registerServiceHooks(
 		)
 
 		for hookName := range service.Hooks {
-			hookType, eventName, err := ext.InferHookType(hookName)
-			if err != nil {
-				return fmt.Errorf(
-					//nolint:lll
-					"%w for service '%s'. Hooks must start with 'pre' or 'post' and end in a valid service event name. Examples: restore, package, deploy",
-					err,
-					serviceName,
-				)
+			hookType, eventName := ext.InferHookType(hookName)
+			// If not a pre or post hook we can continue on.
+			if hookType == ext.HookTypeNone {
+				continue
 			}
 
 			if err := service.AddHandler(

--- a/cli/azd/cmd/middleware/hooks.go
+++ b/cli/azd/cmd/middleware/hooks.go
@@ -180,7 +180,7 @@ func (m *HooksMiddleware) createServiceEventHandler(
 	hooksRunner *ext.HooksRunner,
 ) ext.EventHandlerFn[project.ServiceLifecycleEventArgs] {
 	return func(ctx context.Context, eventArgs project.ServiceLifecycleEventArgs) error {
-		return hooksRunner.RunHooks(ctx, hookType, hookName)
+		return hooksRunner.RunHooks(ctx, hookType, nil, hookName)
 	}
 }
 

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -108,6 +108,7 @@ func NewRootCmd(staticHelp bool, middlewareChain []*actions.MiddlewareRegistrati
 	telemetryActions(root)
 	templatesActions(root)
 	authActions(root)
+	hooksActions(root)
 
 	root.Add("version", &actions.ActionDescriptorOptions{
 		Command: &cobra.Command{

--- a/cli/azd/cmd/testdata/TestUsage-azd-hooks-run.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-hooks-run.snap
@@ -5,6 +5,7 @@ Usage
   azd hooks run <name> [flags]
 
 Flags
+        --docs               	: Opens the documentation for azd hooks run in your web browser.
     -e, --environment string 	: The name of the environment to use.
     -h, --help               	: Gets help for run.
         --interactive        	: Forces all hooks to run in interactive mode for testing

--- a/cli/azd/cmd/testdata/TestUsage-azd-hooks-run.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-hooks-run.snap
@@ -1,0 +1,21 @@
+
+Runs the specified hook for the project and services
+
+Usage
+  azd hooks run <name> [flags]
+
+Flags
+    -e, --environment string 	: The name of the environment to use.
+    -h, --help               	: Gets help for run.
+        --interactive        	: Forces all hooks to run in interactive mode for testing
+        --platform string    	: Forces hooks to run for the specified platform.
+        --service string     	: Only runs hooks for the specified service.
+
+Global Flags
+    -C, --cwd string 	: Sets the current working directory.
+        --debug      	: Enables debugging and diagnostics logging.
+        --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
+
+Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.
+
+

--- a/cli/azd/cmd/testdata/TestUsage-azd-hooks-run.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-hooks-run.snap
@@ -8,7 +8,6 @@ Flags
         --docs               	: Opens the documentation for azd hooks run in your web browser.
     -e, --environment string 	: The name of the environment to use.
     -h, --help               	: Gets help for run.
-        --interactive        	: Forces all hooks to run in interactive mode for testing
         --platform string    	: Forces hooks to run for the specified platform.
         --service string     	: Only runs hooks for the specified service.
 

--- a/cli/azd/cmd/testdata/TestUsage-azd-hooks.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-hooks.snap
@@ -8,6 +8,7 @@ Available Commands
   run	: Runs the specified hook for the project and services
 
 Flags
+        --docs 	: Opens the documentation for azd hooks in your web browser.
     -h, --help 	: Gets help for hooks.
 
 Global Flags

--- a/cli/azd/cmd/testdata/TestUsage-azd-hooks.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-hooks.snap
@@ -1,0 +1,22 @@
+
+Develop, test and run hooks for an application. (Beta)
+
+Usage
+  azd hooks [command]
+
+Available Commands
+  run	: Runs the specified hook for the project and services
+
+Flags
+    -h, --help 	: Gets help for hooks.
+
+Global Flags
+    -C, --cwd string 	: Sets the current working directory.
+        --debug      	: Enables debugging and diagnostics logging.
+        --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
+
+Use azd hooks [command] --help to view examples and more information about a specific command.
+
+Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.
+
+

--- a/cli/azd/cmd/testdata/TestUsage-azd.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd.snap
@@ -16,6 +16,7 @@ Commands
     deploy   	: Deploy the application's code to Azure.
     down     	: Delete Azure resources for an application.
     env      	: Manage environments.
+    hooks    	: Manage hooks.
     package  	: Packages the application's code to be deployed to Azure. (Beta)
     provision	: Provision the Azure resources for an application.
     up       	: Provision Azure resources, and deploy your project with a single command.

--- a/cli/azd/cmd/testdata/TestUsage-azd.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd.snap
@@ -8,6 +8,7 @@ Commands
   Configure and develop your app
     auth     	: Authenticate with Azure.
     config   	: Manage azd configurations (ex: default Azure subscription, location).
+    hooks    	: Develop, test and run hooks for an application. (Beta)
     init     	: Initialize a new application.
     restore  	: Restores the application's dependencies. (Beta)
     template 	: Find and view template details. (Beta)
@@ -16,7 +17,6 @@ Commands
     deploy   	: Deploy the application's code to Azure.
     down     	: Delete Azure resources for an application.
     env      	: Manage environments.
-    hooks    	: Manage hooks.
     package  	: Packages the application's code to be deployed to Azure. (Beta)
     provision	: Provision the Azure resources for an application.
     up       	: Provision Azure resources, and deploy your project with a single command.

--- a/cli/azd/pkg/ext/hooks_runner.go
+++ b/cli/azd/pkg/ext/hooks_runner.go
@@ -58,7 +58,7 @@ func NewHooksRunner(
 
 // Invokes an action run runs any registered pre or post script hooks for the specified command.
 func (h *HooksRunner) Invoke(ctx context.Context, commands []string, actionFn InvokeFn) error {
-	err := h.RunHooks(ctx, HookTypePre, commands...)
+	err := h.RunHooks(ctx, HookTypePre, nil, commands...)
 	if err != nil {
 		return fmt.Errorf("failed running pre hooks: %w", err)
 	}
@@ -68,7 +68,7 @@ func (h *HooksRunner) Invoke(ctx context.Context, commands []string, actionFn In
 		return err
 	}
 
-	err = h.RunHooks(ctx, HookTypePost, commands...)
+	err = h.RunHooks(ctx, HookTypePost, nil, commands...)
 	if err != nil {
 		return fmt.Errorf("failed running post hooks: %w", err)
 	}
@@ -77,7 +77,12 @@ func (h *HooksRunner) Invoke(ctx context.Context, commands []string, actionFn In
 }
 
 // Invokes any registered script hooks for the specified hook type and command.
-func (h *HooksRunner) RunHooks(ctx context.Context, hookType HookType, commands ...string) error {
+func (h *HooksRunner) RunHooks(
+	ctx context.Context,
+	hookType HookType,
+	options *tools.ExecOptions,
+	commands ...string,
+) error {
 	hooks, err := h.hooksManager.GetByParams(h.hooks, hookType, commands...)
 	if err != nil {
 		return fmt.Errorf("failed running scripts for hooks '%s', %w", strings.Join(commands, ","), err)
@@ -88,7 +93,7 @@ func (h *HooksRunner) RunHooks(ctx context.Context, hookType HookType, commands 
 			return fmt.Errorf("reloading environment before running hook: %w", err)
 		}
 
-		err := h.execHook(ctx, hookConfig)
+		err := h.execHook(ctx, hookConfig, options)
 		if err != nil {
 			return err
 		}
@@ -121,7 +126,11 @@ func (h *HooksRunner) GetScript(hookConfig *HookConfig) (tools.Script, error) {
 	}
 }
 
-func (h *HooksRunner) execHook(ctx context.Context, hookConfig *HookConfig) error {
+func (h *HooksRunner) execHook(ctx context.Context, hookConfig *HookConfig, options *tools.ExecOptions) error {
+	if options == nil {
+		options = &tools.ExecOptions{}
+	}
+
 	script, err := h.GetScript(hookConfig)
 	if err != nil {
 		return err
@@ -130,6 +139,10 @@ func (h *HooksRunner) execHook(ctx context.Context, hookConfig *HookConfig) erro
 	formatter := h.console.GetFormatter()
 	consoleInteractive := (formatter == nil || formatter.Kind() == output.NoneFormat)
 	scriptInteractive := consoleInteractive && hookConfig.Interactive
+
+	if options.Interactive == nil {
+		options.Interactive = &scriptInteractive
+	}
 
 	// When running in an interactive terminal broadcast a message to the dev to remind them that custom hooks are running.
 	if consoleInteractive && !hookConfig.Quiet {
@@ -146,7 +159,7 @@ func (h *HooksRunner) execHook(ctx context.Context, hookConfig *HookConfig) erro
 	}
 
 	log.Printf("Executing script '%s'\n", hookConfig.path)
-	res, err := script.Execute(ctx, hookConfig.path, scriptInteractive)
+	res, err := script.Execute(ctx, hookConfig.path, *options)
 	if err != nil {
 		execErr := fmt.Errorf(
 			"'%s' hook failed with exit code: '%d', Path: '%s'. : %w",

--- a/cli/azd/pkg/ext/hooks_runner.go
+++ b/cli/azd/pkg/ext/hooks_runner.go
@@ -128,11 +128,11 @@ func (h *HooksRunner) execHook(ctx context.Context, hookConfig *HookConfig) erro
 	}
 
 	formatter := h.console.GetFormatter()
-	consoleInteractive := formatter == nil || formatter.Kind() == output.NoneFormat
+	consoleInteractive := (formatter == nil || formatter.Kind() == output.NoneFormat)
 	scriptInteractive := consoleInteractive && hookConfig.Interactive
 
 	// When running in an interactive terminal broadcast a message to the dev to remind them that custom hooks are running.
-	if consoleInteractive {
+	if consoleInteractive && !hookConfig.Quiet {
 		h.console.Message(
 			ctx,
 			output.WithBold(

--- a/cli/azd/pkg/ext/hooks_runner_test.go
+++ b/cli/azd/pkg/ext/hooks_runner_test.go
@@ -68,7 +68,7 @@ func Test_Hooks_Execute(t *testing.T) {
 
 		hooksManager := NewHooksManager(cwd)
 		runner := NewHooksRunner(hooksManager, mockContext.CommandRunner, mockContext.Console, cwd, hooks, env)
-		err := runner.RunHooks(*mockContext.Context, HookTypePre, "command")
+		err := runner.RunHooks(*mockContext.Context, HookTypePre, nil, "command")
 
 		require.True(t, ranPreHook)
 		require.False(t, ranPostHook)
@@ -94,7 +94,7 @@ func Test_Hooks_Execute(t *testing.T) {
 
 		hooksManager := NewHooksManager(cwd)
 		runner := NewHooksRunner(hooksManager, mockContext.CommandRunner, mockContext.Console, cwd, hooks, env)
-		err := runner.RunHooks(*mockContext.Context, HookTypePost, "command")
+		err := runner.RunHooks(*mockContext.Context, HookTypePost, nil, "command")
 
 		require.False(t, ranPreHook)
 		require.True(t, ranPostHook)
@@ -120,7 +120,7 @@ func Test_Hooks_Execute(t *testing.T) {
 
 		hooksManager := NewHooksManager(cwd)
 		runner := NewHooksRunner(hooksManager, mockContext.CommandRunner, mockContext.Console, cwd, hooks, env)
-		err := runner.RunHooks(*mockContext.Context, HookTypePre, "interactive")
+		err := runner.RunHooks(*mockContext.Context, HookTypePre, nil, "interactive")
 
 		require.False(t, ranPreHook)
 		require.True(t, ranPostHook)
@@ -142,7 +142,7 @@ func Test_Hooks_Execute(t *testing.T) {
 
 		hooksManager := NewHooksManager(cwd)
 		runner := NewHooksRunner(hooksManager, mockContext.CommandRunner, mockContext.Console, cwd, hooks, env)
-		err := runner.RunHooks(*mockContext.Context, HookTypePre, "inline")
+		err := runner.RunHooks(*mockContext.Context, HookTypePre, nil, "inline")
 
 		require.False(t, ranPreHook)
 		require.True(t, ranPostHook)

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -72,7 +72,7 @@ type HookConfig struct {
 	Posix *HookConfig `yaml:"posix,omitempty"`
 	// Hides executing messages printed to the console
 	// This is a temp workaround until we have a better way to handle this
-	Quiet bool
+	Quiet bool `yaml:"-"`
 }
 
 // Validates and normalizes the hook configuration

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -27,6 +27,7 @@ const (
 	HookTypePre HookType = "pre"
 	// Execute post hooks
 	HookTypePost        HookType         = "post"
+	HookTypeNone        HookType         = ""
 	HookPlatformWindows HookPlatformType = "windows"
 	HookPlatformPosix   HookPlatformType = "posix"
 )
@@ -134,17 +135,17 @@ func (hc *HookConfig) validate() error {
 	return nil
 }
 
-func InferHookType(name string) (HookType, string, error) {
+func InferHookType(name string) (HookType, string) {
 	// Validate name length so go doesn't PANIC for string slicing below
 	if len(name) < 4 {
-		return "", "", fmt.Errorf("unable to infer hook '%s'", name)
+		return HookTypeNone, name
 	} else if name[:3] == "pre" {
-		return HookTypePre, name[3:], nil
+		return HookTypePre, name[3:]
 	} else if name[:4] == "post" {
-		return HookTypePost, name[4:], nil
+		return HookTypePost, name[4:]
 	}
 
-	return "", "", fmt.Errorf("unable to infer hook '%s'", name)
+	return HookTypeNone, name
 }
 
 func inferScriptTypeFromFilePath(path string) (ShellType, error) {

--- a/cli/azd/pkg/tools/bash/bash.go
+++ b/cli/azd/pkg/tools/bash/bash.go
@@ -26,7 +26,7 @@ type bashScript struct {
 
 // Executes the specified bash script
 // When interactive is true will attach to stdin, stdout & stderr
-func (bs *bashScript) Execute(ctx context.Context, path string, interactive bool) (exec.RunResult, error) {
+func (bs *bashScript) Execute(ctx context.Context, path string, options tools.ExecOptions) (exec.RunResult, error) {
 	var runArgs exec.RunArgs
 	// Bash likes all path separators in POSIX format
 	path = strings.ReplaceAll(path, "\\", "/")
@@ -40,8 +40,15 @@ func (bs *bashScript) Execute(ctx context.Context, path string, interactive bool
 	runArgs = runArgs.
 		WithCwd(bs.cwd).
 		WithEnv(bs.envVars).
-		WithInteractive(interactive).
 		WithShell(true)
+
+	if options.Interactive != nil {
+		runArgs = runArgs.WithInteractive(*options.Interactive)
+	}
+
+	if options.StdOut != nil {
+		runArgs = runArgs.WithStdOut(options.StdOut)
+	}
 
 	return bs.commandRunner.Run(ctx, runArgs)
 }

--- a/cli/azd/pkg/tools/bash/bash_test.go
+++ b/cli/azd/pkg/tools/bash/bash_test.go
@@ -6,7 +6,9 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
 )
@@ -39,7 +41,11 @@ func Test_Bash_Execute(t *testing.T) {
 		})
 
 		bashScript := NewBashScript(mockContext.CommandRunner, workingDir, env)
-		runResult, err := bashScript.Execute(*mockContext.Context, scriptPath, true)
+		runResult, err := bashScript.Execute(
+			*mockContext.Context,
+			scriptPath,
+			tools.ExecOptions{Interactive: convert.RefOf(true)},
+		)
 
 		require.NotNil(t, runResult)
 		require.NoError(t, err)
@@ -55,7 +61,11 @@ func Test_Bash_Execute(t *testing.T) {
 		})
 
 		bashScript := NewBashScript(mockContext.CommandRunner, workingDir, env)
-		runResult, err := bashScript.Execute(*mockContext.Context, scriptPath, true)
+		runResult, err := bashScript.Execute(
+			*mockContext.Context,
+			scriptPath,
+			tools.ExecOptions{Interactive: convert.RefOf(true)},
+		)
 
 		require.Equal(t, 1, runResult.ExitCode)
 		require.Error(t, err)
@@ -63,10 +73,10 @@ func Test_Bash_Execute(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		value bool
+		value tools.ExecOptions
 	}{
-		{name: "Interactive", value: true},
-		{name: "NonInteractive", value: false},
+		{name: "Interactive", value: tools.ExecOptions{Interactive: convert.RefOf(true)}},
+		{name: "NonInteractive", value: tools.ExecOptions{Interactive: convert.RefOf(false)}},
 	}
 
 	for _, test := range tests {
@@ -76,7 +86,7 @@ func Test_Bash_Execute(t *testing.T) {
 			mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 				return true
 			}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-				require.Equal(t, test.value, args.Interactive)
+				require.Equal(t, *test.value.Interactive, args.Interactive)
 				return exec.NewRunResult(0, "", ""), nil
 			})
 

--- a/cli/azd/pkg/tools/powershell/powershell.go
+++ b/cli/azd/pkg/tools/powershell/powershell.go
@@ -24,12 +24,19 @@ type powershellScript struct {
 
 // Executes the specified powershell script
 // When interactive is true will attach to stdin, stdout & stderr
-func (bs *powershellScript) Execute(ctx context.Context, path string, interactive bool) (exec.RunResult, error) {
+func (bs *powershellScript) Execute(ctx context.Context, path string, options tools.ExecOptions) (exec.RunResult, error) {
 	runArgs := exec.NewRunArgs("pwsh", path).
 		WithCwd(bs.cwd).
 		WithEnv(bs.envVars).
-		WithInteractive(interactive).
 		WithShell(true)
+
+	if options.Interactive != nil {
+		runArgs = runArgs.WithInteractive(*options.Interactive)
+	}
+
+	if options.StdOut != nil {
+		runArgs = runArgs.WithStdOut(options.StdOut)
+	}
 
 	return bs.commandRunner.Run(ctx, runArgs)
 }

--- a/cli/azd/pkg/tools/powershell/powershell_test.go
+++ b/cli/azd/pkg/tools/powershell/powershell_test.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +35,11 @@ func Test_Powershell_Execute(t *testing.T) {
 		})
 
 		PowershellScript := NewPowershellScript(mockContext.CommandRunner, workingDir, env)
-		runResult, err := PowershellScript.Execute(*mockContext.Context, scriptPath, true)
+		runResult, err := PowershellScript.Execute(
+			*mockContext.Context,
+			scriptPath,
+			tools.ExecOptions{Interactive: convert.RefOf(true)},
+		)
 
 		require.NotNil(t, runResult)
 		require.NoError(t, err)
@@ -49,7 +55,11 @@ func Test_Powershell_Execute(t *testing.T) {
 		})
 
 		PowershellScript := NewPowershellScript(mockContext.CommandRunner, workingDir, env)
-		runResult, err := PowershellScript.Execute(*mockContext.Context, scriptPath, true)
+		runResult, err := PowershellScript.Execute(
+			*mockContext.Context,
+			scriptPath,
+			tools.ExecOptions{Interactive: convert.RefOf(true)},
+		)
 
 		require.Equal(t, 1, runResult.ExitCode)
 		require.Error(t, err)
@@ -57,10 +67,10 @@ func Test_Powershell_Execute(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		value bool
+		value tools.ExecOptions
 	}{
-		{name: "Interactive", value: true},
-		{name: "NonInteractive", value: false},
+		{name: "Interactive", value: tools.ExecOptions{Interactive: convert.RefOf(true)}},
+		{name: "NonInteractive", value: tools.ExecOptions{Interactive: convert.RefOf(false)}},
 	}
 
 	for _, test := range tests {
@@ -70,7 +80,7 @@ func Test_Powershell_Execute(t *testing.T) {
 			mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 				return true
 			}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-				require.Equal(t, test.value, args.Interactive)
+				require.Equal(t, *test.value.Interactive, args.Interactive)
 				return exec.NewRunResult(0, "", ""), nil
 			})
 

--- a/cli/azd/pkg/tools/script.go
+++ b/cli/azd/pkg/tools/script.go
@@ -2,11 +2,18 @@ package tools
 
 import (
 	"context"
+	"io"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 )
 
+// ExecOptions provide configuration for how scripts are executed
+type ExecOptions struct {
+	Interactive *bool
+	StdOut      io.Writer
+}
+
 // Utility to easily execute a bash script across platforms
 type Script interface {
-	Execute(ctx context.Context, scriptPath string, interactive bool) (exec.RunResult, error)
+	Execute(ctx context.Context, scriptPath string, options ExecOptions) (exec.RunResult, error)
 }


### PR DESCRIPTION
Adds `azd hooks run <name>` command to help develop, test and run hooks for an azd project & services.

Resolves #1642 

## Features
- An easy way for developers to test and troubleshoot their azd hook scripts without the overhead of waiting for azd commands to run
- Developers can develop a suite of hooks/scripts to support their day to day inner-loop development
- Call into other hook scripts from azd hook lifecycle events

### Example
Dev wants to validate their deployment to run a series of UX smoke test across their services
- Dev creates a `vaildate` hook in each service that they want to test. These tests could run playwright or some other UX test framework
- Dev adds a `postdeploy` hook that calls `azd hooks run validate`
  - This ensures that the `validate` hook would run for each service after deployment completes
- Dev also has a custom hook/script in their toolbox where they could run `azd hooks run validate` at any time.


## Docs and Parameters
<img width="662" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/2071cbc9-7671-4580-844f-c01281914da8">

## Output
Script output is automatically displayed regardless of `interactive` setting

<img width="366" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/cd8e7ef5-303f-4511-a727-32ddf7b14538">

Final output shows a consolidated view of what hooks run for the given command

<img width="433" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/d57474c9-3c15-42c9-b69b-9633b958ba72">

