### PR TITLE
use Debug azd cli as first alternative

### DIFF
--- a/cli/azd/.vscode/launch.json
+++ b/cli/azd/.vscode/launch.json
@@ -3,6 +3,16 @@
     // ignore changes to this file so you don't need to worry about commiting your edits.
     "version": "0.2.0",
     "configurations": [
+        // This will launch azd (starting from main.go), under the debugger.
+        {
+            "name": "Debug azd cli",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}",
+            "args": "${input:cliArgs}",
+            "console": "integratedTerminal",
+        },
         // If you set `AZD_DEBUG=true` in your environment, `azd` will pause early in start up and allow you to attach
         // to it. Use the Attach to Process configuration and pick the corresponding `azd` process.
         {
@@ -12,17 +22,28 @@
             "mode": "local",
             "processId": "${command:pickGoProcess}"
         },
-        // This will launch azd (starting from main.go), under the debugger.
-
+        // Manually set configuration.
+        // Arguments, cwd and env are set before running F5
         {
-            "name": "Debug azd cli",
+            "name": "Manual Process",
             "type": "go",
             "request": "launch",
             "mode": "debug",
             "program": "${workspaceFolder}",
-            "args": "${input:cliArgs}",
             "console": "integratedTerminal",
-        }
+            "args": [
+                "auth", "login"
+                //"pipeline", "config", "--principal-name", "foo", "--provider", "github"
+                //"package", "api", "--debug"
+                //"provision"
+                //"up"
+                //"env", "new"
+            ],
+            //"cwd": "~/workspace/cwd/path",
+            // "env": {
+            //     "INT_TAG_VALUE":"1989"
+            // }
+        },
     ],
     "inputs": [
         {


### PR DESCRIPTION
re-ordering debugging options (as suggested by @Petermarcu ) .

Having `Debug azd cli` with prompt for args with `"${input:cliArgs}"` provides the simplest approach for contributors to run azd with debugger.

Moving the `attach` strategy to the second place as it requires some special considerations when contributors are using Linux (like codespaces or WSL).

Adding one last manual configuration for launching azd where contributors can manually define all the debuging settings.