### PR TITLE
handle user-defined type as outputs

### DIFF
--- a/cli/azd/pkg/azure/arm_template.go
+++ b/cli/azd/pkg/azure/arm_template.go
@@ -60,17 +60,27 @@ type ArmTemplateParameterDefinitions map[string]ArmTemplateParameterDefinition
 
 type ArmTemplateOutputs map[string]ArmTemplateOutput
 
+type ArmTemplateParameterAdditionalProperties struct {
+	Type      string                     `json:"type"`
+	MinValue  *int                       `json:"minValue,omitempty"`
+	MaxValue  *int                       `json:"maxValue,omitempty"`
+	MinLength *int                       `json:"minLength,omitempty"`
+	MaxLength *int                       `json:"maxLength,omitempty"`
+	Metadata  map[string]json.RawMessage `json:"metadata"`
+}
+
 type ArmTemplateParameterDefinition struct {
-	Type          string                          `json:"type"`
-	DefaultValue  any                             `json:"defaultValue"`
-	AllowedValues *[]any                          `json:"allowedValues,omitempty"`
-	MinValue      *int                            `json:"minValue,omitempty"`
-	MaxValue      *int                            `json:"maxValue,omitempty"`
-	MinLength     *int                            `json:"minLength,omitempty"`
-	MaxLength     *int                            `json:"maxLength,omitempty"`
-	Metadata      map[string]json.RawMessage      `json:"metadata"`
-	Ref           string                          `json:"$ref"`
-	Properties    ArmTemplateParameterDefinitions `json:"properties,omitempty"`
+	Type                 string                                   `json:"type"`
+	DefaultValue         any                                      `json:"defaultValue"`
+	AllowedValues        *[]any                                   `json:"allowedValues,omitempty"`
+	MinValue             *int                                     `json:"minValue,omitempty"`
+	MaxValue             *int                                     `json:"maxValue,omitempty"`
+	MinLength            *int                                     `json:"minLength,omitempty"`
+	MaxLength            *int                                     `json:"maxLength,omitempty"`
+	Metadata             map[string]json.RawMessage               `json:"metadata"`
+	Ref                  string                                   `json:"$ref"`
+	Properties           ArmTemplateParameterDefinitions          `json:"properties,omitempty"`
+	AdditionalProperties ArmTemplateParameterAdditionalProperties `json:"additionalProperties,omitempty"`
 }
 
 func (d *ArmTemplateParameterDefinition) Secure() bool {

--- a/cli/azd/pkg/azure/arm_template.go
+++ b/cli/azd/pkg/azure/arm_template.go
@@ -109,4 +109,5 @@ type ArmTemplateOutput struct {
 	Type     string         `json:"type"`
 	Value    any            `json:"value"`
 	Metadata map[string]any `json:"metadata"`
+	Ref      string         `json:"$ref"`
 }

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -1718,6 +1718,8 @@ func combineMetadata(base map[string]json.RawMessage, override map[string]json.R
 }
 
 func definitionName(typeDefinitionRef string) (string, error) {
+	// We typically expect `#/definitions/<name>` or `/definitions/<name>`, but loosely, we simply take
+	// `<name>` as the value of the last separated element.
 	definitionKeyNameTokens := strings.Split(typeDefinitionRef, "/")
 	definitionKeyNameTokensLen := len(definitionKeyNameTokens)
 	if definitionKeyNameTokensLen < 1 {

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -1703,7 +1703,7 @@ func combineMetadata(base map[string]json.RawMessage, override map[string]json.R
 		return base
 	}
 
-	// final map is expected to be at lease the same size as the base
+	// final map is expected to be at least the same size as the base
 	finalMetadata := make(map[string]json.RawMessage, len(base))
 
 	for key, data := range base {

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -975,6 +975,14 @@ func TestUserDefinedTypes(t *testing.T) {
 		},
 		objectParam.Properties)
 
+	// output resolves just the type. Value and Metadata should persist
+	customOutput, exists := template.Outputs["customOutput"]
+	require.True(t, exists)
+	require.Equal(t, "string", customOutput.Type)
+	require.Equal(t, "[parameters('stringLimitedParam')]", customOutput.Value)
+	require.Equal(t, map[string]interface{}{
+		"foo": "bar",
+	}, customOutput.Metadata)
 }
 
 const userDefinedParamsSample = `{
@@ -1067,5 +1075,14 @@ const userDefinedParamsSample = `{
 		"$ref": "#/definitions/objectType"
 	  }
 	},
-	"resources": {}
+	"resources": {},
+	"outputs": {
+		"customOutput": {
+			"$ref": "#/definitions/stringLimitedType",
+			"metadata": {
+				"foo": "bar"
+			},
+			"value": "[parameters('stringLimitedParam')]"
+		}
+	}
 }`

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -982,8 +982,8 @@ func TestUserDefinedTypes(t *testing.T) {
 			Type:      "string",
 			MinLength: to.Ptr(10),
 			Metadata: map[string]json.RawMessage{
-				"fromDefinitionFoo": []byte("\"foo\""),
-				"fromDefinitionBar": []byte("\"bar\""),
+				"fromDefinitionFoo": []byte(`"foo"`),
+				"fromDefinitionBar": []byte(`"bar"`),
 			},
 		},
 		objectParam.AdditionalProperties)
@@ -994,9 +994,9 @@ func TestUserDefinedTypes(t *testing.T) {
 			// Note: Validating the metadata combining and override here.
 			// The parameter definition contains metadata that is automatically added to the parameter.
 			// Then the parameter also has metadata and overrides one of the values from the definition.
-			"fromDefinitionFoo": []byte("\"foo\""),
-			"fromDefinitionBar": []byte("\"override\""),
-			"fromParameter":     []byte("\"parameter\""),
+			"fromDefinitionFoo": []byte(`"foo"`),
+			"fromDefinitionBar": []byte(`"override"`),
+			"fromParameter":     []byte(`"parameter"`),
 		},
 		objectParam.Metadata)
 


### PR DESCRIPTION
Continuation of: https://github.com/Azure/azure-dev/pull/2793

As I was testing the new provision-state with `.bicepparam` files, I also used some user-defined types and got an error when using the types for the outputs.

This PR applies the same patch to outputs as we did before for input parameters.
The only difference is that for `outputs` we only need to resolve the `type`, while keeping the value and metadata.

This PR also adds a few more update to the input parameters:
- Combining `metadata` from user-defined type and parameter. This is required to allow folks to use `azd` metadata from user-defined types, like

```bicep
@metadata({
   azd: "location"
})
type userDefinedLocation = 'eastus' | 'centralus'

param someLocationA userDefinedLocation
param someLocationB userDefinedLocation
```

In this example, both `someLocationA` and `someLocationB` will have the azd metadata for prompting for location in azd-way. 
Then, on parameter can add more metadata or override values from the user-defined type like

```bicep
@metadata({
   azd: "location"
})
type userDefinedLocation = 'eastus' | 'centralus'

@metadata({
   foo: "bar"
})
param someLocationA userDefinedLocation

@metadata({
   azd: "something-else"
})
param someLocationB userDefinedLocation
```

In this case, `someLocationA` is just appending one more field to the metadata, while `someLocationB` is overriding one of the fields.