### PR TITLE
Updates hook output to use previewer

### DIFF
--- a/cli/azd/cmd/hooks.go
+++ b/cli/azd/cmd/hooks.go
@@ -217,14 +217,13 @@ func (hra *hooksRunAction) execHook(
 		Title:        previewMessage,
 		MaxLineCount: 8,
 	})
+	defer hra.console.StopPreviewer(ctx)
 
 	runOptions := &tools.ExecOptions{StdOut: previewer}
 	err := hooksRunner.RunHooks(ctx, hookType, runOptions, commandName)
 	if err != nil {
 		return err
 	}
-
-	hra.console.StopPreviewer(ctx)
 
 	return nil
 }

--- a/cli/azd/pkg/ext/hooks_runner.go
+++ b/cli/azd/pkg/ext/hooks_runner.go
@@ -144,18 +144,16 @@ func (h *HooksRunner) execHook(ctx context.Context, hookConfig *HookConfig, opti
 		options.Interactive = &scriptInteractive
 	}
 
-	// When running in an interactive terminal broadcast a message to the dev to remind them that custom hooks are running.
-	if consoleInteractive && !hookConfig.Quiet {
-		h.console.Message(
-			ctx,
-			output.WithBold(
-				fmt.Sprintf(
-					"Executing %s hook => %s",
-					output.WithHighLightFormat(hookConfig.Name),
-					output.WithHighLightFormat(hookConfig.path),
-				),
-			),
-		)
+	// When the hook is not configured to run in interactive mode and no stdout has been configured
+	// Then show the hook execution output within the console previewer pane
+	if !*options.Interactive && options.StdOut == nil {
+		previewer := h.console.ShowPreviewer(ctx, &input.ShowPreviewerOptions{
+			Prefix:       "  ",
+			Title:        fmt.Sprintf("%s Hook Output", hookConfig.Name),
+			MaxLineCount: 8,
+		})
+		options.StdOut = previewer
+		defer h.console.StopPreviewer(ctx)
 	}
 
 	log.Printf("Executing script '%s'\n", hookConfig.path)

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -70,9 +70,6 @@ type HookConfig struct {
 	Windows *HookConfig `yaml:"windows,omitempty"`
 	// When running on linux/macos use this override config
 	Posix *HookConfig `yaml:"posix,omitempty"`
-	// Hides executing messages printed to the console
-	// This is a temp workaround until we have a better way to handle this
-	Quiet bool `yaml:"-"`
 }
 
 // Validates and normalizes the hook configuration

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -256,7 +256,7 @@ func (c *AskerConsole) ShowPreviewer(ctx context.Context, options *ShowPreviewer
 	// Pause any active spinner
 	currentMsg := c.currentSpinnerMessage
 	if c.spinner != nil {
-		c.spinner.Pause()
+		_ = c.spinner.Pause()
 	}
 
 	if options == nil {
@@ -277,7 +277,7 @@ func (c *AskerConsole) StopPreviewer(ctx context.Context) {
 	c.writer = c.initialWriter
 
 	if c.spinner != nil {
-		c.spinner.Unpause()
+		_ = c.spinner.Unpause()
 	}
 }
 

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -253,9 +253,11 @@ func (c *AskerConsole) ShowPreviewer(ctx context.Context, options *ShowPreviewer
 	c.writeControlMutex.Lock()
 	defer c.writeControlMutex.Unlock()
 
-	// auto-stop any spinner
+	// Pause any active spinner
 	currentMsg := c.currentSpinnerMessage
-	c.StopSpinner(ctx, "", Step)
+	if c.spinner != nil {
+		c.spinner.Pause()
+	}
 
 	if options == nil {
 		options = defaultShowPreviewerOptions()
@@ -273,6 +275,10 @@ func (c *AskerConsole) StopPreviewer(ctx context.Context) {
 	c.previewer.Stop()
 	c.previewer = nil
 	c.writer = c.initialWriter
+
+	if c.spinner != nil {
+		c.spinner.Unpause()
+	}
 }
 
 const cPostfix = "..."


### PR DESCRIPTION
Updates all hook output to use the new previewer when not running in interactive mode.

Fixes #2213 

**Project level command hooks:**

<img width="354" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/c6b218a7-0eac-4bc4-8925-41ea3fd26d65">

**Service level command hooks:**

<img width="382" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/b5c1c76a-080a-4114-b8c0-856f8cbcc662">

<img width="584" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/64f2e80a-790d-49a1-9037-9ab57f966a25">


