### PR TITLE
contributors devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,0 @@
-ARG IMAGE=bullseye
-FROM mcr.microsoft.com/devcontainers/go
-
-RUN export DEBIAN_FRONTEND=noninteractive \
-     && apt-get update && apt-get install -y xdg-utils \
-     && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,18 +1,36 @@
 {
-    "name": "Azure Developer CLI",
-    "build": {
-        "dockerfile": "Dockerfile",
-        "args": {
-            "IMAGE": "bullseye"
-        }
+    "name": "Azure Developer CLI - Contributor",
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "ghcr.io/devcontainers/features/go:1": {
+            "version": "1.21"
+        },
+        "ghcr.io/devcontainers/features/docker-in-docker:1": {
+            "version": "latest",
+            "moby": true
+        },
+        "ghcr.io/devcontainers/features/azure-cli:1": {},
+        "ghcr.io/devcontainers/features/dotnet:2": {},
+        "ghcr.io/devcontainers/features/java:1": {},
+        "ghcr.io/devcontainers/features/node:1": {},
+        "ghcr.io/devcontainers/features/python:1": {},
+        "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
+        "ghcr.io/devcontainers/features/git:1": {},
+        "ghcr.io/devcontainers/features/github-cli:1": {},
+        "ghcr.io/devcontainers/features/terraform:1": {}
+        
     },
     "customizations": {
         "vscode": {
             "extensions": [
                 "redhat.vscode-yaml",
                 "streetsidesoftware.code-spell-checker",
-                "golang.go"
+                "golang.go",
+                "ms-azuretools.vscode-bicep",
+                "eamodio.gitlens",
+                "hashicorp.terraform"
             ]
         }
-    }
+    },
+    "postAttachCommand": "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
         "ghcr.io/devcontainers/features/go:1": {
             "version": "1.21"
         },
+        "ghcr.io/guiyomh/features/golangci-lint:0":{},
         "ghcr.io/devcontainers/features/docker-in-docker:1": {
             "version": "latest",
             "moby": true
@@ -31,6 +32,5 @@
                 "hashicorp.terraform"
             ]
         }
-    },
-    "postAttachCommand": "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2"
+    }
 }


### PR DESCRIPTION
This PR updates the Azure-dev devcontainer for a better experience to contributors.

- The golangci-lint cli is automatically installed after running the devcontainer. This ensures to run the latest version all the time.
- Java, Node, Python and .Net are all integrated to the container. This makes it easier to a contributor to run any template.
- gh, terraform, az and kubectl cli are included as well.

After this PR, a contributor can create a new Codespace or WSL instance, cd to `cli/azd` and start hacking. For example:
- Run azd with debuger.
- Run linter `golangci-lint run ./...` 
- Run and deploy any template (languages already installed). // might require some logging-in