### PR TITLE
make state to be valid only when deployment did not fail

### DIFF
--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -418,6 +418,11 @@ func (p *BicepProvider) deploymentState(
 		return nil, fmt.Errorf("deployment state error: %w", err)
 	}
 
+	// state is valid if the last deployment failed
+	if *prevDeploymentResult.Properties.ProvisioningState == armresources.ProvisioningStateFailed {
+		return nil, fmt.Errorf("last deployment failed.")
+	}
+
 	var templateHash string
 	createHashResult, err := p.deploymentsService.CalculateTemplateHash(
 		ctx, p.env.GetSubscriptionId(), deploymentData.CompiledBicep.RawArmTemplate)

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -418,8 +418,10 @@ func (p *BicepProvider) deploymentState(
 		return nil, fmt.Errorf("deployment state error: %w", err)
 	}
 
-	// state is valid if the last deployment failed
-	if *prevDeploymentResult.Properties.ProvisioningState == armresources.ProvisioningStateFailed {
+	// State is invalid if the last deployment was not succeeded
+	// This is currently safe because we rely on latestDeploymentResult which
+	// relies on findCompletedDeployments which filters to only Failed and Succeeded
+	if *prevDeploymentResult.Properties.ProvisioningState != armresources.ProvisioningStateSucceeded {
 		return nil, fmt.Errorf("last deployment failed.")
 	}
 


### PR DESCRIPTION
As I was doing some more validations for `provision-state`, I found that azd was using the state from the last deployment even if the deployment was failed.

This change makes sure to ignore the state if the last deployment was failed.