### PR TITLE
Fix spurious test output

### DIFF
--- a/cli/azd/internal/repository/detect_confirm_test.go
+++ b/cli/azd/internal/repository/detect_confirm_test.go
@@ -205,8 +205,12 @@ func Test_detectConfirm_confirm(t *testing.T) {
 			d.Init(tt.detection, dir)
 
 			err = d.Confirm(context.Background())
-			require.NoError(t, err)
 
+			// Print extra newline to avoid mangling `go test -v` final test result output while waiting for final stdin,
+			// which may result in incorrect `gotestsum` reporting
+			fmt.Println()
+
+			require.NoError(t, err)
 			require.Equal(t, tt.want, d.Services)
 		})
 	}

--- a/cli/azd/internal/repository/infra_confirm_test.go
+++ b/cli/azd/internal/repository/infra_confirm_test.go
@@ -2,6 +2,8 @@ package repository
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -205,7 +207,7 @@ func TestInitializer_infraSpecFromDetect(t *testing.T) {
 					false,
 					os.Stdout,
 					input.ConsoleHandles{
-						Stderr: os.Stderr,
+						Stderr: io.Discard,
 						Stdin:  strings.NewReader(strings.Join(tt.interactions, "\n") + "\n"),
 						Stdout: os.Stdout,
 					},
@@ -213,6 +215,11 @@ func TestInitializer_infraSpecFromDetect(t *testing.T) {
 			}
 
 			spec, err := i.infraSpecFromDetect(context.Background(), tt.detect)
+
+			// Print extra newline to avoid mangling `go test -v` final test result output while waiting for final stdin,
+			// which may result in incorrect `gotestsum` reporting
+			fmt.Println()
+
 			require.NoError(t, err)
 			require.Equal(t, tt.want, spec)
 		})

--- a/cli/azd/internal/repository/infra_confirm_test.go
+++ b/cli/azd/internal/repository/infra_confirm_test.go
@@ -3,7 +3,6 @@ package repository
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 	"testing"
@@ -207,7 +206,7 @@ func TestInitializer_infraSpecFromDetect(t *testing.T) {
 					false,
 					os.Stdout,
 					input.ConsoleHandles{
-						Stderr: io.Discard,
+						Stderr: os.Stderr,
 						Stdin:  strings.NewReader(strings.Join(tt.interactions, "\n") + "\n"),
 						Stdout: os.Stdout,
 					},


### PR DESCRIPTION
Fix spurious test output in CI.

In CI, we see these tests reported as FAILED in the log, but not actually failing. The reason is that `gotestsum` is unable to find the actual "PASS" event emitted, but `go test` does succeed correctly. We have trailing output that isn't newline terminated (while waiting for stdin), which results in the behavior.

Example:
```
=== FAIL: cli/azd/internal/repository TestInitializer_infraSpecFromDetect/api_and_web_with_db (unknown)
Input the name of the app database (PostgreSQL) --- PASS: TestInitializer_infraSpecFromDetect (0.00s)
```
