### PR TITLE
Feature Clickable Template Links in Terminal `azd template list`

### DIFF
--- a/cli/azd/pkg/github/remote.go
+++ b/cli/azd/pkg/github/remote.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/git"
+	"github.com/savioxavier/termlink"
 )
 
 var ErrRemoteHostIsNotGitHub = errors.New("not a github host")
@@ -38,7 +39,7 @@ func GetSlugForRemote(remoteUrl string) (string, error) {
 	for _, r := range []*regexp.Regexp{gitHubRemoteGitUrlRegex, gitHubRemoteHttpsUrlRegex} {
 		captures := r.FindStringSubmatch(remoteUrl)
 		if captures != nil {
-			return captures[1], nil
+			return termlink.Link(captures[1], remoteUrl), nil
 		}
 	}
 

--- a/cli/azd/pkg/templates/template_manager.go
+++ b/cli/azd/pkg/templates/template_manager.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/savioxavier/termlink"
 	"github.com/theckman/yacspin"
 	"golang.org/x/exp/slices"
 )
@@ -177,8 +178,22 @@ func PromptTemplate(
 	for _, template := range templates {
 		templateChoice := template.Name
 		if isInteractive {
-			repoPath := output.WithGrayFormat("(%s)", template.RepositoryPath)
-			templateChoice += fmt.Sprintf("\n  %s\n", repoPath)
+			if termlink.SupportsHyperlinks() {
+				trimmedPath := strings.Split(
+					strings.TrimRight(
+						strings.TrimLeft(
+							template.RepositoryPath,
+							"\x1b]8;;https://github.com/"),
+						"\x1b]8;;\x07\u001b[0m"),
+					"\x07")
+				repoPath := output.WithGrayFormat("(%s)", trimmedPath[0])
+				templateChoice += fmt.Sprintf("\n  %s\n", repoPath)
+			} else {
+				trimmedPath := strings.SplitN(template.RepositoryPath, " (", 2)
+				repoPath := output.WithGrayFormat("(%s)", trimmedPath[0])
+				templateChoice += fmt.Sprintf("\n  %s\n", repoPath)
+			}
+
 		}
 		choices = append(choices, templateChoice)
 	}

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,10 @@ require (
 
 require github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
 
-require github.com/stretchr/objx v0.5.0 // indirect
+require (
+	github.com/savioxavier/termlink v1.3.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
+)
 
 require (
 	github.com/Azure/azure-pipeline-go v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -444,6 +444,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
+github.com/savioxavier/termlink v1.3.0 h1:3Gl4FzQjUyiHzmoEDfmWEhgIwDiJY4poOQHP+k8ReA4=
+github.com/savioxavier/termlink v1.3.0/go.mod h1:5T5ePUlWbxCHIwyF8/Ez1qufOoGM89RCg9NvG+3G3gc=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sethvargo/go-retry v0.2.3 h1:oYlgvIvsju3jNbottWABtbnoLC+GDtLdBHxKWxQm/iU=
 github.com/sethvargo/go-retry v0.2.3/go.mod h1:1afjQuvh7s4gflMObvjLPaWgluLLyhA1wmVZ6KLpICw=


### PR DESCRIPTION
closes #2731

I have implemented and unimplemented the feature at the same time. 😮‍💨 
The clickable links provided by the library https://github.com/savioxavier/termlink doesn't work in the interactive terminal it displays the whole text without rendering + crashes the whole terminal so, I had to catch the oldText that we were displaying from the formatted text by termlink and display it.

The feature is easy to implement the problem is with the interactive terminal and I thought it would be better to implement it and fix it's implementation error and then work on the init output later.

Screenshot from output of `azd template list`
![image](https://github.com/Azure/azure-dev/assets/64026625/fb2cf68b-5a95-4426-b97b-a7709df2eb3a)


Crashing Terminal for `azd init` [Also Fixed]
![image](https://github.com/Azure/azure-dev/assets/64026625/67dedd48-3ae5-4a54-af6e-f54130e70482)
