### PR TITLE
React to changes to DevCenterMode

### DIFF
--- a/ext/vscode/.vscode/cspell-dictionary.txt
+++ b/ext/vscode/.vscode/cspell-dictionary.txt
@@ -11,3 +11,4 @@ DEBUGTELEMETRY
 appservice
 containerapp
 staticwebapp
+devcenter

--- a/ext/vscode/package.nls.json
+++ b/ext/vscode/package.nls.json
@@ -20,8 +20,8 @@
     "azure-dev.commands.cli.login.title": "Sign in with Azure Developer CLI",
     "azure-dev.commands.azureWorkspace.revealAzureResource.title": "Show Azure Resource",
     "azure-dev.commands.azureWorkspace.revealAzureResourceGroup.title": "Show Azure Resource Group",
-    "azure-dev.commands.enableDevCenterMode.title": "Enable Dev Center Mode (config set devCenterMode on)",
-    "azure-dev.commands.disableDevCenterMode.title": "Disable Dev Center Mode (config set devCenterMode off)",
+    "azure-dev.commands.enableDevCenterMode.title": "Enable Dev Center Mode (config set platform.type devcenter)",
+    "azure-dev.commands.disableDevCenterMode.title": "Disable Dev Center Mode (config unset platform.type)",
     "azure-dev.commands.getDotEnvFilePath.title": "Get Azure developer environment's .env file path",
 
     "azure-dev.maximumAppsToDisplay.description": "Maximum number of Azure Developer CLI apps to display in the Workspace Resource view",

--- a/ext/vscode/src/commands/devCenterMode.ts
+++ b/ext/vscode/src/commands/devCenterMode.ts
@@ -6,22 +6,25 @@ import * as vscode from 'vscode';
 import { createAzureDevCli } from '../utils/azureDevCli';
 import { execAsync } from '../utils/process';
 
-export function enableDevCenterMode(context: IActionContext): Promise<void> {
-    return setDevCenterMode(context, true);
-}
-
-export async function disableDevCenterMode(context: IActionContext): Promise<void> {
-    return setDevCenterMode(context, false);
-}
-
-async function setDevCenterMode(context: IActionContext, enable: boolean): Promise<void> {
+export async function enableDevCenterMode(context: IActionContext): Promise<void> {
     const azureCli = await createAzureDevCli(context);
     const command = azureCli.commandBuilder
         .withArg('config')
         .withArg('set')
-        .withArg('devCenterMode')
-        .withArg(enable ? 'on' : 'off');
+        .withArg('platform.type')
+        .withArg('devcenter');
 
     await execAsync(command.build(), azureCli.spawnOptions());
-    void vscode.window.showInformationMessage(vscode.l10n.t('Azure Developer CLI\'s Dev Center mode has been {0}.', enable ? vscode.l10n.t('enabled') : vscode.l10n.t('disabled')));
+    void vscode.window.showInformationMessage(vscode.l10n.t('Azure Developer CLI\'s Dev Center mode has been enabled.'));
+}
+
+export async function disableDevCenterMode(context: IActionContext): Promise<void> {
+    const azureCli = await createAzureDevCli(context);
+    const command = azureCli.commandBuilder
+        .withArg('config')
+        .withArg('unset')
+        .withArg('platform.type');
+
+    await execAsync(command.build(), azureCli.spawnOptions());
+    void vscode.window.showInformationMessage(vscode.l10n.t('Azure Developer CLI\'s Dev Center mode has been disabled.'));
 }


### PR DESCRIPTION
@wbreza FYI

Instead of the old way we now set dev center mode with
`azd config set platform.type devcenter`

and unset with
`azd config unset platform.type`