### PR TITLE
Feature Show Logged in account email or client ID for `azd auth login` and `azd auth login --check-status`

### DIFF
--- a/cli/azd/cmd/auth_login.go
+++ b/cli/azd/cmd/auth_login.go
@@ -26,6 +26,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/oneauth"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/github"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -335,21 +336,11 @@ func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 				return nil, nil
 			}
 
-			switch details.LoginType {
-			case auth.EmailLoginType:
-				fmt.Fprintf(la.console.Handles().Stdout, "%s as %s.", msg, output.WithBold("%s", details.Account))
-				return nil, nil
-			case auth.ClientIdLoginType:
-				fmt.Fprintf(
-					la.console.Handles().Stdout,
-					"%s as (%s).",
-					msg,
-					output.WithGrayFormat("%s", details.Account))
-				return nil, nil
-			default:
-				fmt.Fprintln(la.console.Handles().Stdout, msg+".")
-				return nil, nil
-			}
+			la.console.MessageUxItem(ctx, &ux.LoggedIn{
+				LoggedInAs: details.Account,
+				LoginType:  ux.LoginType(details.LoginType),
+			})
+			return nil, nil
 		}
 	}
 
@@ -386,22 +377,11 @@ func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		la.console.Message(ctx, cLoginSuccessMessage+".")
 		return nil, nil
 	}
-
-	switch details.LoginType {
-	case auth.EmailLoginType:
-		fmt.Fprintf(la.console.Handles().Stdout, "%s as %s.", cLoginSuccessMessage, output.WithBold("%s", details.Account))
-		return nil, nil
-	case auth.ClientIdLoginType:
-		fmt.Fprintf(
-			la.console.Handles().Stdout,
-			"%s as (%s).",
-			cLoginSuccessMessage,
-			output.WithGrayFormat("%s", details.Account))
-		return nil, nil
-	default:
-		la.console.Message(ctx, cLoginSuccessMessage+".")
-		return nil, nil
-	}
+	la.console.MessageUxItem(ctx, &ux.LoggedIn{
+		LoggedInAs: details.Account,
+		LoginType:  ux.LoginType(details.LoginType),
+	})
+	return nil, nil
 }
 
 // Verifies that the user has credentials stored,

--- a/cli/azd/cmd/auth_login.go
+++ b/cli/azd/cmd/auth_login.go
@@ -329,13 +329,14 @@ func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 			// get user account information - login --check-status
 			details, err := la.authManager.LogInDetails(ctx)
 
-			// error getting user account
+			// error getting user account or not logged in
 			if err != nil {
 				log.Printf("error: getting signed in account: %v", err)
-				fmt.Fprintln(la.console.Handles().Stdout, msg+".")
+				fmt.Fprintln(la.console.Handles().Stdout, msg)
 				return nil, nil
 			}
 
+			// only print the message if the user is logged in
 			la.console.MessageUxItem(ctx, &ux.LoggedIn{
 				LoggedInAs: details.Account,
 				LoginType:  ux.LoginType(details.LoginType),
@@ -368,13 +369,12 @@ func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		}
 	}
 
-	const cLoginSuccessMessage = "Logged in to Azure"
 	details, err := la.authManager.LogInDetails(ctx)
 
 	// error getting user account, successful log in
 	if err != nil {
 		log.Printf("error: getting signed in account: %v", err)
-		la.console.Message(ctx, cLoginSuccessMessage+".")
+		la.console.Message(ctx, "Logged in to Azure")
 		return nil, nil
 	}
 	la.console.MessageUxItem(ctx, &ux.LoggedIn{

--- a/cli/azd/pkg/output/ux/logged_in.go
+++ b/cli/azd/pkg/output/ux/logged_in.go
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package ux
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+)
+
+const cLoginSuccessMessage = "Logged in to Azure"
+const (
+	EmailLoginType    LoginType = "email"
+	ClientIdLoginType LoginType = "clientId"
+)
+
+type LoginType string
+
+type LoggedIn struct {
+	LoggedInAs string
+	LoginType  LoginType
+}
+
+func (cr *LoggedIn) ToString(currentIndentation string) string {
+	switch cr.LoginType {
+	case EmailLoginType:
+		return fmt.Sprintf(
+			"%s%s as %s",
+			currentIndentation,
+			cLoginSuccessMessage,
+			output.WithBold("%s", cr.LoggedInAs))
+	case ClientIdLoginType:
+		return fmt.Sprintf(
+			"%s%s as (%s)",
+			currentIndentation,
+			cLoginSuccessMessage,
+			output.WithGrayFormat("%s", cr.LoggedInAs))
+	default:
+	}
+
+	return fmt.Sprintf(
+		"%s%s",
+		currentIndentation,
+		cLoginSuccessMessage)
+}
+
+func (cr *LoggedIn) MarshalJSON() ([]byte, error) {
+	// reusing the same envelope from console messages
+	return json.Marshal(output.EventForMessage(
+		fmt.Sprintf("%s as %s", cLoginSuccessMessage, cr.LoggedInAs)))
+}


### PR DESCRIPTION
This pull request updates to the login functionality in the Azure CLI. The main changes involve improving the login status messaging and adding detailed account information after a successful login.

closes #1745

### `azd auth login` and `azd auth login --check-status` with normal account

<img width="335" alt="image" src="https://github.com/user-attachments/assets/3d66d97b-06b3-408b-af4d-b47618768190" />

![image](https://github.com/user-attachments/assets/93834104-3758-455a-a8b2-c26db58a1afc)


### `azd auth login --check-status` with service principal

<img width="460" alt="image" src="https://github.com/user-attachments/assets/8d22fb50-5921-4492-a6fe-7435916e5ba9" />