### PR TITLE
Fixes issue with running Tasks that relay on environment configuration path

### DIFF
--- a/cli/azd/pkg/environment/manager.go
+++ b/cli/azd/pkg/environment/manager.go
@@ -16,11 +16,17 @@ import (
 
 // Description is a metadata description of an environment returned for the `azd env list` command
 type Description struct {
-	Name       string
+	// The name of the environment
+	Name string
+	// The path to the local .env file for the environment
+	// This path is used by the VS Code extension to load the current environment variables when using VS code tasks
 	DotEnvPath string
-	HasLocal   bool
-	HasRemote  bool
-	IsDefault  bool
+	// Specifies when the environment exists locally
+	HasLocal bool
+	// Specifies when the environment exists remotely
+	HasRemote bool
+	// Specifies when the environment is the default environment
+	IsDefault bool
 }
 
 // Spec is the specification for creating a new environment

--- a/cli/azd/pkg/environment/manager.go
+++ b/cli/azd/pkg/environment/manager.go
@@ -16,10 +16,11 @@ import (
 
 // Description is a metadata description of an environment returned for the `azd env list` command
 type Description struct {
-	Name      string
-	HasLocal  bool
-	HasRemote bool
-	IsDefault bool
+	Name       string
+	DotEnvPath string
+	HasLocal   bool
+	HasRemote  bool
+	IsDefault  bool
 }
 
 // Spec is the specification for creating a new environment
@@ -243,8 +244,9 @@ func (m *manager) List(ctx context.Context) ([]*Description, error) {
 
 	for _, env := range localEnvs {
 		envMap[env.Name] = &Description{
-			Name:     env.Name,
-			HasLocal: true,
+			Name:       env.Name,
+			HasLocal:   true,
+			DotEnvPath: env.DotEnvPath,
 		}
 	}
 

--- a/cli/azd/pkg/environment/manager_test.go
+++ b/cli/azd/pkg/environment/manager_test.go
@@ -25,12 +25,14 @@ var (
 	emptyEnvList []*contracts.EnvListEnvironment = []*contracts.EnvListEnvironment{}
 	localEnvList []*contracts.EnvListEnvironment = []*contracts.EnvListEnvironment{
 		{
-			Name:      "env1",
-			IsDefault: true,
+			Name:       "env1",
+			IsDefault:  true,
+			DotEnvPath: ".azure/env1/.env",
 		},
 		{
-			Name:      "env2",
-			IsDefault: false,
+			Name:       "env2",
+			IsDefault:  false,
+			DotEnvPath: ".azure/env1/.env",
 		},
 	}
 	remoteEnvList []*contracts.EnvListEnvironment = []*contracts.EnvListEnvironment{
@@ -151,6 +153,7 @@ func Test_EnvManager_List(t *testing.T) {
 		require.Equal(t, "env1", envList[0].Name)
 		require.Equal(t, true, envList[1].HasLocal)
 		require.Equal(t, false, envList[1].HasRemote)
+		require.Equal(t, ".azure/env1/.env", envList[1].DotEnvPath)
 	})
 
 	t.Run("RemoteOnly", func(t *testing.T) {
@@ -169,6 +172,7 @@ func Test_EnvManager_List(t *testing.T) {
 		require.Equal(t, "env1", envList[0].Name)
 		require.Equal(t, false, envList[1].HasLocal)
 		require.Equal(t, true, envList[1].HasRemote)
+		require.Equal(t, "", envList[1].DotEnvPath)
 	})
 
 	t.Run("LocalAndRemote", func(t *testing.T) {
@@ -187,6 +191,7 @@ func Test_EnvManager_List(t *testing.T) {
 		require.Equal(t, "env1", envList[0].Name)
 		require.Equal(t, true, envList[1].HasLocal)
 		require.Equal(t, true, envList[1].HasRemote)
+		require.Equal(t, ".azure/env1/.env", envList[1].DotEnvPath)
 	})
 }
 

--- a/cli/azd/pkg/environment/manager_test.go
+++ b/cli/azd/pkg/environment/manager_test.go
@@ -151,9 +151,9 @@ func Test_EnvManager_List(t *testing.T) {
 
 		require.Equal(t, 2, len(envList))
 		require.Equal(t, "env1", envList[0].Name)
-		require.Equal(t, true, envList[1].HasLocal)
-		require.Equal(t, false, envList[1].HasRemote)
-		require.Equal(t, ".azure/env1/.env", envList[1].DotEnvPath)
+		require.Equal(t, true, envList[0].HasLocal)
+		require.Equal(t, false, envList[0].HasRemote)
+		require.Equal(t, ".azure/env1/.env", envList[0].DotEnvPath)
 	})
 
 	t.Run("RemoteOnly", func(t *testing.T) {
@@ -170,9 +170,9 @@ func Test_EnvManager_List(t *testing.T) {
 
 		require.Equal(t, 3, len(envList))
 		require.Equal(t, "env1", envList[0].Name)
-		require.Equal(t, false, envList[1].HasLocal)
-		require.Equal(t, true, envList[1].HasRemote)
-		require.Equal(t, "", envList[1].DotEnvPath)
+		require.Equal(t, false, envList[0].HasLocal)
+		require.Equal(t, true, envList[0].HasRemote)
+		require.Equal(t, "", envList[0].DotEnvPath)
 	})
 
 	t.Run("LocalAndRemote", func(t *testing.T) {
@@ -189,9 +189,9 @@ func Test_EnvManager_List(t *testing.T) {
 
 		require.Equal(t, 3, len(envList))
 		require.Equal(t, "env1", envList[0].Name)
-		require.Equal(t, true, envList[1].HasLocal)
-		require.Equal(t, true, envList[1].HasRemote)
-		require.Equal(t, ".azure/env1/.env", envList[1].DotEnvPath)
+		require.Equal(t, true, envList[0].HasLocal)
+		require.Equal(t, true, envList[0].HasRemote)
+		require.Equal(t, ".azure/env1/.env", envList[0].DotEnvPath)
 	})
 }
 


### PR DESCRIPTION
Resolves #2852, #2797
Fixes the issue where `DotEnvPath` was unintentionally removed from the `azd env list --output json`