### PR TITLE
feat: clickable url for azd template show

### DIFF
--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -138,7 +138,7 @@ func (tl *templateListAction) Run(ctx context.Context) (*actions.ActionResult, e
 			{
 				Heading:       "Repository Path",
 				ValueTemplate: "{{.RepositoryPath}}",
-				Transformer:   templates.ClickableRepositoryPathUrl,
+				Transformer:   templates.Hyperlink,
 			},
 		}
 

--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
@@ -126,16 +125,6 @@ func (tl *templateListAction) Run(ctx context.Context) (*actions.ActionResult, e
 		return nil, err
 	}
 
-	// get clickable link for a repo path
-	clickableUrl := func(text string) string {
-		url, err := templates.Absolute(text)
-		if err != nil {
-			log.Printf("error: getting absolute url from template: %v", err)
-			return text
-		}
-		return output.WithHyperlink(url, text)
-	}
-
 	if tl.formatter.Kind() == output.TableFormat {
 		columns := []output.Column{
 			{
@@ -149,7 +138,7 @@ func (tl *templateListAction) Run(ctx context.Context) (*actions.ActionResult, e
 			{
 				Heading:       "Repository Path",
 				ValueTemplate: "{{.RepositoryPath}}",
-				Transformer:   clickableUrl,
+				Transformer:   templates.ClickableRepositoryPathUrl,
 			},
 		}
 

--- a/cli/azd/pkg/templates/path.go
+++ b/cli/azd/pkg/templates/path.go
@@ -32,7 +32,9 @@ func Absolute(path string) (string, error) {
 	}
 }
 
-func ClickableRepositoryPathUrl(path string) string {
+// Hyperlink returns a hyperlink to the given template path.
+// If the path is cannot be resolved absolutely, it is returned as-is.
+func Hyperlink(path string) string {
 	url, err := Absolute(path)
 	if err != nil {
 		log.Printf("error: getting absolute url from template: %v", err)

--- a/cli/azd/pkg/templates/path.go
+++ b/cli/azd/pkg/templates/path.go
@@ -2,7 +2,10 @@ package templates
 
 import (
 	"fmt"
+	"log"
 	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
 // Absolute returns an absolute template path, given a possibly relative template path. An absolute path also corresponds to
@@ -27,4 +30,13 @@ func Absolute(path string) (string, error) {
 			"template '%s' should either be <owner>/<repo> for GitHub repositories, "+
 				"or <repo> for Azure-Samples GitHub repositories", path)
 	}
+}
+
+func ClickableRepositoryPathUrl(path string) string {
+	url, err := Absolute(path)
+	if err != nil {
+		log.Printf("error: getting absolute url from template: %v", err)
+		return path
+	}
+	return output.WithHyperlink(url, path)
 }

--- a/cli/azd/pkg/templates/template.go
+++ b/cli/azd/pkg/templates/template.go
@@ -26,9 +26,6 @@ type Template struct {
 
 // Display writes a string representation of the template suitable for display.
 func (t *Template) Display(writer io.Writer) error {
-
-	clickableRepositoryPath := ClickableRepositoryPathUrl(t.RepositoryPath)
-
 	tabs := tabwriter.NewWriter(
 		writer,
 		0,
@@ -37,7 +34,7 @@ func (t *Template) Display(writer io.Writer) error {
 		output.TablePadCharacter,
 		output.TableFlags)
 	text := [][]string{
-		{"RepositoryPath", ":", clickableRepositoryPath},
+		{"RepositoryPath", ":", Hyperlink(t.RepositoryPath)},
 		{"Name", ":", t.Name},
 		{"Source", ":", t.Source},
 		{"Description", ":", t.Description},

--- a/cli/azd/pkg/templates/template.go
+++ b/cli/azd/pkg/templates/template.go
@@ -26,6 +26,9 @@ type Template struct {
 
 // Display writes a string representation of the template suitable for display.
 func (t *Template) Display(writer io.Writer) error {
+
+	clickableRepositoryPath := ClickableRepositoryPathUrl(t.RepositoryPath)
+
 	tabs := tabwriter.NewWriter(
 		writer,
 		0,
@@ -34,7 +37,7 @@ func (t *Template) Display(writer io.Writer) error {
 		output.TablePadCharacter,
 		output.TableFlags)
 	text := [][]string{
-		{"RepositoryPath", ":", t.RepositoryPath},
+		{"RepositoryPath", ":", clickableRepositoryPath},
 		{"Name", ":", t.Name},
 		{"Source", ":", t.Source},
 		{"Description", ":", t.Description},


### PR DESCRIPTION
The command `azd template list` gt the feature of clickable repository paths in release 1.4.2. This PR brings this feature also to the command `azd template show xyz` transfering the logic implemented in #2845 to the show command. 

To avoid code duplication the formatting logic is trenafered to the `path.go` file which looks like a good fit for this kind of logic. 

The sequence of the output of the `template show` command was not changed. If this should be aligned with the `template list` command, just comment and I add a commit