### PR TITLE
Update version.txt in a separate stage

### DIFF
--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -1328,7 +1328,7 @@ stages:
                           --account-key '$(azdev-storage-account-key)' `
                           --auth-mode key `
                           -s release/ `
-                          -d "azd/standalone/$folder/version.txt" `
+                          -d "azd/standalone/$folder" `
                           --overwrite
 
                         if ($LASTEXITCODE) {

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -1282,7 +1282,7 @@ stages:
                       targetType: filePath
                       filePath: eng/scripts/Get-MsiVersion.ps1
                       arguments: >-
-                        -CliVersion '${{ parameters.CliVersion }}'
+                        -CliVersion '$(CLI_VERSION)'
                         -DevOpsOutput
 
                   - task: PowerShell@2

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -1235,6 +1235,109 @@ stages:
                       CommitMsg: Increment CLI version after release
                       PRTitle: Increment CLI version after release
 
+    - stage: PublishVersionTxt
+      dependsOn: PublishCLI
+
+      condition: >-
+        and(
+          succeeded(),
+          ne(variables['Skip.Release'], 'true'),
+          or(
+            eq('Manual', variables['BuildReasonOverride']),
+            and(
+              eq('', variables['BuildReasonOverride']),
+              eq('Manual', variables['Build.Reason'])
+            )
+          )
+        )
+
+      jobs:
+        - deployment: Upload_Version_Txt
+          condition: >-
+            and(
+              succeeded(),
+              ne('true', variables['Skip.Publish'])
+            )
+          environment: azure-dev
+
+          pool:
+            name: azsdk-pool-mms-win-2022-general
+
+          strategy:
+            runOnce:
+              deploy:
+                steps:
+                  - checkout: self
+                  - task: PowerShell@2
+                    inputs:
+                      pwsh: true
+                      targetType: filePath
+                      filePath: eng/scripts/Set-CliVersionVariable.ps1
+                    displayName: Set CLI_VERSION
+
+                  - task: PowerShell@2
+                    displayName: Set MSI_VERSION
+                    inputs:
+                      pwsh: true
+                      targetType: filePath
+                      filePath: eng/scripts/Get-MsiVersion.ps1
+                      arguments: >-
+                        -CliVersion '${{ parameters.CliVersion }}'
+                        -DevOpsOutput
+
+                  - task: PowerShell@2
+                    displayName: Wait for WinGet package
+                    inputs:
+                      pwsh: true
+                      targetType: filePath
+                      filePath: eng/scripts/Wait-WinGetPackage.ps1
+                      arguments: >-
+                        -PackageName 'Microsoft.Azd'
+                        -PackageVersion '$(MSI_VERSION)'
+
+                  - task: PowerShell@2
+                    displayName: Wait for Choco package
+                    inputs:
+                      pwsh: true
+                      targetType: filePath
+                      filePath: eng/scripts/Wait-ChocoPackage.ps1
+                      arguments: >-
+                        -PackageName 'azd'
+                        -PackageVersion '$(MSI_VERSION)'
+
+                  - pwsh: |
+                      New-Item -ItemType Directory -Path release
+                      Write-Output $(CLI_VERSION) | Out-File -Encoding utf8 -FilePath ./release/version.txt
+                    displayName: Write version.txt file for release
+
+                  - pwsh: |
+                      $isPublishingGa = eng/scripts/Test-ShouldReleasePackageVersion.ps1 `
+                        -CliVersion '$(CLI_VERSION)'
+
+                      $publishUploadLocations = @('release/latest')
+                      if ($isPublishingGa) {
+                        $publishUploadLocations += @('release/stable')
+                      }
+
+                      Get-ChildItem release/
+
+                      foreach ($folder in $publishUploadLocations) {
+                        Write-Host "Upload to azd/standalone/$folder"
+                        az storage blob upload-batch `
+                          --account-name '$(azdev-storage-account-name)' `
+                          --account-key '$(azdev-storage-account-key)' `
+                          --auth-mode key `
+                          -s release/ `
+                          -d "azd/standalone/$folder/version.txt" `
+                          --overwrite
+
+                        if ($LASTEXITCODE) {
+                          Write-Error "Upload failed"
+                          exit 1
+                        }
+                      }
+                    displayName: Upload version.txt to storage account
+
   - stage: Publish_Integration
     dependsOn: Sign
     jobs:

--- a/eng/pipelines/templates/steps/publish-cli.yml
+++ b/eng/pipelines/templates/steps/publish-cli.yml
@@ -183,12 +183,6 @@ steps:
       env:
         GH_TOKEN: $(azuresdk-github-pat)
 
-  # Write a version.txt file into the `release` folder which we upload to blob storage. The CLI uses
-  # this file to detect if there is a newer version to use
-  - pwsh: |
-      Write-Output $(CLI_VERSION) | Out-File -Encoding utf8 -FilePath ./release/version.txt
-    displayName: Write version.txt file for release
-
   - pwsh: |
       $uploadLocations = "${{ parameters.PublishUploadLocations }}" -split ';'
 

--- a/eng/scripts/Wait-ChocoPackage.ps1
+++ b/eng/scripts/Wait-ChocoPackage.ps1
@@ -1,0 +1,20 @@
+param(
+    $PackageName,
+    $PackageVersion,
+    $TimeoutInSeconds = 300
+)
+
+$startTime = Get-Date
+
+while (((Get-Date) - $startTime).TotalSeconds -lt $TimeoutInSeconds) {
+    if (choco info $PackageName --version=$PackageVersion --limit-output) { 
+        Write-Host "Package $PackageName $PackageVersion is available"
+        exit 0
+    }
+
+    Write-Host "$PackageName $PackageVersion is not available yet. Waiting..."
+    Start-Sleep -Seconds 10
+}
+
+Write-Host "Package not found before expiration."
+exit 1

--- a/eng/scripts/Wait-WinGetPackage.ps1
+++ b/eng/scripts/Wait-WinGetPackage.ps1
@@ -4,10 +4,14 @@ param(
     $TimeoutInSeconds = 300
 )
 
+if (!(Test-Path wingetcreate.exe)) {
+    Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+}
+
 $startTime = Get-Date
 
 while (((Get-Date) - $startTime).TotalSeconds -lt $TimeoutInSeconds) {
-    if ((winget show $PackageName --versions) -contains $PackageVersion) {
+    if ((.\wingetcreate.exe show $PackageName --version-manifest) -contains "PackageVersion: $PackageVersion") {
         Write-Host "Package $PackageName $PackageVersion is available"
         exit 0
     }

--- a/eng/scripts/Wait-WinGetPackage.ps1
+++ b/eng/scripts/Wait-WinGetPackage.ps1
@@ -1,0 +1,20 @@
+param(
+    $PackageName,
+    $PackageVersion,
+    $TimeoutInSeconds = 300
+)
+
+$startTime = Get-Date
+
+while (((Get-Date) - $startTime).TotalSeconds -lt $TimeoutInSeconds) {
+    if ((winget show $PackageName --versions) -contains $PackageVersion) {
+        Write-Host "Package $PackageName $PackageVersion is available"
+        exit 0
+    }
+
+    Write-Host "$PackageName $PackageVersion is not available yet. Waiting..."
+    Start-Sleep -Seconds 10
+}
+
+Write-Host "Package not found before expiration."
+exit 1


### PR DESCRIPTION
Temporary fix for #2864. The long term fix here should be [azd upgrade](https://github.com/Azure/azure-dev/issues/2003).

This adds a stage which runs after release of the CLI. The stage checks for expected versions in winget and choco. If the expected versions aren't found the job fails and can be re-run. If the expected versions are found then `version.txt` is updated in the CDN. To complete the release this stage must run successfully.


Example test of the job when the version is not available (failure expected): https://dev.azure.com/azure-sdk/playground/_build/results?buildId=3173181&view=results

Example test of the job when the version is available: https://dev.azure.com/azure-sdk/playground/_build/results?buildId=3173178&view=results


Release steps:

Here's an example of the relevant publish stages (red x's are because I did not approve the publish): 
![image](https://github.com/Azure/azure-dev/assets/2158838/900039b8-c92c-49ff-897f-c0ac3fdcf4eb)


1. Release as normal approving the `PublishCLI` stage. 
2. Once that succeeds, packages are submitted to Choco and WinGet. Check that the packages have successfully published: 
    1. WinGet -- Look for an [open PR from the `azure-sdk`](https://github.com/microsoft/winget-pkgs/pulls/azure-sdk) user and follow its progress. See [historic PRs](https://github.com/microsoft/winget-pkgs/pulls?q=+is%3Apr+author%3Aazure-sdk+) for approvers to follow up with if things stall.
    2. Choco -- Look for a new entry in the [version table for azd](https://community.chocolatey.org/packages/azd#versionhistory). The scanning and approval process can take on the order of ~1-6 hours to complete.
3. Now that all packages have published, approve the `PublishVersionTxt` stage to update the version.txt file. 


The stage has guardrails built in to ensure that the package IS present in both WinGet and Choco at the released version. If the package is not updated on WinGet or Choco the job will fail. Wait until the publishing has succeeded and then re-run the failed job (this will require another signoff)   