### PR TITLE
Allow app settings to be configured in `main.parameters.json` for simplified init apps

### DIFF
--- a/cli/azd/internal/scaffold/funcs.go
+++ b/cli/azd/internal/scaffold/funcs.go
@@ -1,6 +1,10 @@
 package scaffold
 
-import "strings"
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
 
 // BicepName returns a name suitable for use as a bicep variable name.
 //
@@ -105,4 +109,19 @@ func ContainerAppName(name string) string {
 	}
 
 	return sb.String()
+}
+
+// Formats a parameter value for use in a bicep file.
+// If the value is a string, it is quoted.
+// Otherwise, the value is marshaled with indentation specified by prefix and indent.
+func FormatParameter(prefix string, indent string, value any) (string, error) {
+	if valueStr, ok := value.(string); ok {
+		return fmt.Sprintf("\"%s\"", valueStr), nil
+	}
+
+	val, err := json.MarshalIndent(value, prefix, indent)
+	if err != nil {
+		return "", err
+	}
+	return string(val), nil
 }

--- a/cli/azd/internal/scaffold/funcs.go
+++ b/cli/azd/internal/scaffold/funcs.go
@@ -112,7 +112,7 @@ func ContainerAppName(name string) string {
 }
 
 // Formats a parameter value for use in a bicep file.
-// If the value is a string, it is quoted.
+// If the value is a string, it is quoted inline with no indentation.
 // Otherwise, the value is marshaled with indentation specified by prefix and indent.
 func FormatParameter(prefix string, indent string, value any) (string, error) {
 	if valueStr, ok := value.(string); ok {

--- a/cli/azd/internal/scaffold/scaffold.go
+++ b/cli/azd/internal/scaffold/scaffold.go
@@ -58,6 +58,7 @@ func Load() (*template.Template, error) {
 		"containerAppName": ContainerAppName,
 		"upper":            strings.ToUpper,
 		"lower":            strings.ToLower,
+		"formatParam":      FormatParameter,
 	}
 
 	t, err := template.New("templates").
@@ -164,5 +165,7 @@ func preExecExpand(spec *InfraSpec) {
 		// containerapp requires a global '_exist' parameter for each service
 		spec.Parameters = append(spec.Parameters,
 			containerAppExistsParameter(svc.Name))
+		spec.Parameters = append(spec.Parameters,
+			serviceDefPlaceholder(svc.Name))
 	}
 }

--- a/cli/azd/internal/scaffold/spec.go
+++ b/cli/azd/internal/scaffold/spec.go
@@ -16,7 +16,7 @@ type InfraSpec struct {
 
 type Parameter struct {
 	Name   string
-	Value  string
+	Value  any
 	Type   string
 	Secret bool
 }
@@ -67,5 +67,45 @@ func containerAppExistsParameter(serviceName string) Parameter {
 		Value: fmt.Sprintf("${SERVICE_%s_RESOURCE_EXISTS=false}",
 			strings.ReplaceAll(strings.ToUpper(serviceName), "-", "_")),
 		Type: "bool",
+	}
+}
+
+type serviceDef struct {
+	Settings []serviceDefSettings `json:"settings"`
+}
+
+type serviceDefSettings struct {
+	Name         string `json:"name"`
+	Value        string `json:"value"`
+	Secret       bool   `json:"secret,omitempty"`
+	SecretRef    string `json:"secretRef,omitempty"`
+	CommentName  string `json:"_comment_name,omitempty"`
+	CommentValue string `json:"_comment_value,omitempty"`
+}
+
+func serviceDefPlaceholder(serviceName string) Parameter {
+	return Parameter{
+		Name: BicepName(serviceName) + "Definition",
+		Value: serviceDef{
+			Settings: []serviceDefSettings{
+				{
+					Name:        "",
+					Value:       "${VAR}",
+					CommentName: "The name of the environment variable when running in Azure. If empty, ignored.",
+					//nolint:lll
+					CommentValue: "The value to provide. This can be a fixed literal, or an expression like ${VAR} to use the value of 'VAR' from the current environment.",
+				},
+				{
+					Name:        "",
+					Value:       "${VAR_S}",
+					Secret:      true,
+					CommentName: "The name of the environment variable when running in Azure. If empty, ignored.",
+					//nolint:lll
+					CommentValue: "The value to provide. This can be a fixed literal, or an expression like ${VAR_S} to use the value of 'VAR_S' from the current environment.",
+				},
+			},
+		},
+		Type:   "object",
+		Secret: true,
 	}
 }

--- a/cli/azd/resources/scaffold/templates/host-containerapp.bicept
+++ b/cli/azd/resources/scaffold/templates/host-containerapp.bicept
@@ -28,7 +28,7 @@ param exists bool
 @secure()
 param appDefinition object
 
-var appSettingsArray = filter(array(appDefinition.settings), i => i.name != null)
+var appSettingsArray = filter(array(appDefinition.settings), i => i.name != '')
 var secrets = map(filter(appSettingsArray, i => i.?secret != null), i => {
   name: i.name
   value: i.value

--- a/cli/azd/resources/scaffold/templates/host-containerapp.bicept
+++ b/cli/azd/resources/scaffold/templates/host-containerapp.bicept
@@ -34,7 +34,10 @@ var secrets = map(filter(appSettingsArray, i => i.?secret != null), i => {
   value: i.value
   secretRef: i.?secretRef ?? take(replace(replace(toLower(i.name), '_', '-'), '.', '-'), 32)
 })
-var env = filter(appSettingsArray, i => i.?secret == null)
+var env = map(filter(appSettingsArray, i => i.?secret == null), i => {
+  name: i.name
+  value: i.value
+})
 
 resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: identityName

--- a/cli/azd/resources/scaffold/templates/host-containerapp.bicept
+++ b/cli/azd/resources/scaffold/templates/host-containerapp.bicept
@@ -25,6 +25,16 @@ param apiUrls array
 param allowedOrigins array
 {{- end}}
 param exists bool
+@secure()
+param appDefinition object
+
+var appSettingsArray = filter(array(appDefinition.settings), i => i.name != null)
+var secrets = map(filter(appSettingsArray, i => i.?secret != null), i => {
+  name: i.name
+  value: i.value
+  secretRef: i.?secretRef ?? take(replace(replace(toLower(i.name), '_', '-'), '.', '-'), 32)
+})
+var env = filter(appSettingsArray, i => i.?secret == null)
 
 resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: identityName
@@ -94,7 +104,7 @@ resource app 'Microsoft.App/containerApps@2023-04-01-preview' = {
           identity: identity.id
         }
       ]
-      secrets: [
+      secrets: union([
         {{- if .DbCosmosMongo}}
         {
           name: 'azure-cosmos-connection-string'
@@ -107,14 +117,18 @@ resource app 'Microsoft.App/containerApps@2023-04-01-preview' = {
           value: databasePassword
         }
         {{- end}}
-      ]
+      ],
+      map(secrets, secret => {
+        name: secret.secretRef
+        value: secret.value
+      }))
     }
     template: {
       containers: [
         {
           image: fetchLatestImage.outputs.?containers[?0].?image ?? 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
           name: 'main'
-          env: [
+          env: union([
             {
               name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
               value: applicationInsights.properties.ConnectionString
@@ -161,7 +175,12 @@ resource app 'Microsoft.App/containerApps@2023-04-01-preview' = {
               value: '{{ .Port }}'
             }
             {{- end}}
-          ]
+          ],
+          env,
+          map(secrets, secret => {
+            name: secret.name
+            secretRef: secret.secretRef
+          }))
           resources: {
             cpu: json('1.0')
             memory: '2.0Gi'

--- a/cli/azd/resources/scaffold/templates/main.bicept
+++ b/cli/azd/resources/scaffold/templates/main.bicept
@@ -139,6 +139,7 @@ module {{bicepName .Name}} './app/{{.Name}}.bicep' = {
     containerAppsEnvironmentName: appsEnv.outputs.name
     containerRegistryName: registry.outputs.name
     exists: {{bicepName .Name}}Exists
+    appDefinition: {{bicepName .Name}}Definition
     {{- if .DbCosmosMongo}}
     cosmosDbConnectionString: vault.getSecret(cosmosDb.outputs.connectionStringKey)
     {{- end}}

--- a/cli/azd/resources/scaffold/templates/main.parameters.jsont
+++ b/cli/azd/resources/scaffold/templates/main.parameters.jsont
@@ -11,7 +11,7 @@
       },
       {{- range .Parameters}}
       "{{.Name}}": {
-        "value": "{{.Value}}"
+        "value": {{formatParam "        " "  " .Value}}
       },
       {{- end}}
       "principalId": {

--- a/cli/azd/resources/scaffold/templates/next-steps.mdt
+++ b/cli/azd/resources/scaffold/templates/next-steps.mdt
@@ -12,12 +12,11 @@
 
 ### Define environment variables for running services
 
-1. Modify or add environment variables to configure the running application. Environment variables can be configured by modifying the `env` node in the following files:
+1. Modify or add environment variables to configure the running application. Environment variables can be configured by updating the `settings` node(s) for each service in [main.parameters.json](./infra/main.parameters.json).
+2. For services using a database, environment variables have been pre-configured under the `env` node in the following files to allow connection to the database. Modify the name of these variables as needed to match your application.
 {{- range .Services}}
     - [app/{{.Name}}.bicep](./infra/app/{{.Name}}.bicep)
 {{- end}}
-2. For services using a database, environment variables have been pre-configured under `env` to allow connection to the database. Modify the name of these variables as needed to match your application.
-3. To set a secret or API key as an environment variable under `env`, the variable should be added with a `secretRef` pointing to a `secrets` entry or a stored KeyVault secret.
 
 ### Provision infrastructure and deploy application code
 


### PR DESCRIPTION
Allow app settings to be configured in `main.parameters.json` for simplified init apps.

To this end, the bicep files in simplified init apps has been updated to allow flowing of any required app settings to the container app host, which enables configuration to be done simply as the following:
**main.parameters.json**
```json
    "apiDefinition": {
      "value": {
        "settings": [
          {
            "name": "AZURE_ENV_NAME",
            "value": "${AZURE_ENV_NAME}",
          },
          {
            "name": "OPENAI_API_KEY",
            "value": "${OPENAI_API_KEY}",
            "secret": true
          }
        ]
      }
  }
```

To ease discovery, the generated `main.parameters.json` includes placeholder values and documentation. `next-steps.md` has also been updated to include the information.

<img width="983" alt="image" src="https://github.com/Azure/azure-dev/assets/2322434/d45ee22d-2c73-4f7b-849c-1d72fbffae68">


Fixes #2739