### PR TITLE
use env-flag as default to override

### DIFF
--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -541,7 +541,14 @@ func newEnvGetValuesAction(
 }
 
 func (eg *envGetValuesAction) Run(ctx context.Context) (*actions.ActionResult, error) {
-	name, _ := eg.azdCtx.GetDefaultEnvironmentName()
+	name, err := eg.azdCtx.GetDefaultEnvironmentName()
+	if err != nil {
+		return nil, err
+	}
+	// Note: if there is not an environment yet, GetDefaultEnvironmentName() returns empty string (not error)
+	// and later, then envManager.Get() is called with the empty string, azd returns an error.
+	// But if there is already an environment (default to be selected), azd must honor the --environment flag
+	// over the default environment.
 	if eg.flags.environmentName != "" {
 		name = eg.flags.environmentName
 	}

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -546,7 +546,7 @@ func (eg *envGetValuesAction) Run(ctx context.Context) (*actions.ActionResult, e
 		return nil, err
 	}
 	// Note: if there is not an environment yet, GetDefaultEnvironmentName() returns empty string (not error)
-	// and later, then envManager.Get() is called with the empty string, azd returns an error.
+	// and later, when envManager.Get() is called with the empty string, azd returns an error.
 	// But if there is already an environment (default to be selected), azd must honor the --environment flag
 	// over the default environment.
 	if eg.flags.environmentName != "" {

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -542,6 +542,9 @@ func newEnvGetValuesAction(
 
 func (eg *envGetValuesAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	name, _ := eg.azdCtx.GetDefaultEnvironmentName()
+	if eg.flags.environmentName != "" {
+		name = eg.flags.environmentName
+	}
 	env, err := eg.envManager.Get(ctx, name)
 	if errors.Is(err, environment.ErrNotFound) {
 		return nil, fmt.Errorf(


### PR DESCRIPTION
Fix regression on `azd env get-values` after https://github.com/Azure/azure-dev/pull/2840/files

Root cause:
  azd is checking if there is a default environment and fail when that's false. But when that is true, azd is using the default environment name and not honoring if there is a flag setting the name of the environment.

This fix makes azd to honor the name of the environment from a flag, when it is provided.