### PR TITLE
Allows prompting for for bicep parameters that reference empty or not set environment variables

### DIFF
--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -1863,7 +1863,7 @@ func (p *BicepProvider) ensureParameters(
 		// If a value is explicitly configured via a parameters file, use it.
 		// unless the parameter value inference is nil/empty
 		if v, has := parameters[key]; has {
-			paramValue := armParameterFileValue(p.mapBicepTypeToInterfaceType(param.Type), v.Value)
+			paramValue := armParameterFileValue(p.mapBicepTypeToInterfaceType(param.Type), v.Value, param.DefaultValue)
 			if paramValue != nil {
 				configuredParameters[key] = azure.ArmParameterValue{
 					Value: paramValue,
@@ -1934,7 +1934,7 @@ func (p *BicepProvider) ensureParameters(
 }
 
 // Convert the ARM parameters file value into a value suitable for deployment
-func armParameterFileValue(paramType ParameterType, value any) any {
+func armParameterFileValue(paramType ParameterType, value any, defaultValue any) any {
 	// Relax the handling of bool and number types to accept convertible strings
 	switch paramType {
 	case ParameterTypeBoolean:
@@ -1950,8 +1950,20 @@ func armParameterFileValue(paramType ParameterType, value any) any {
 			}
 		}
 	case ParameterTypeString:
-		if val, ok := value.(string); ok && val != "" {
-			return val
+		// Use Cases
+		// 1. Non-empty input value, return input value (no prompt)
+		// 2. Empty input value and no default - return nil (prompt user)
+		// 3. Empty input value and non-empty default - return empty input string (no prompt)
+		paramVal, paramValid := value.(string)
+		defaultVal, hasDefault := defaultValue.(string)
+		if hasDefault {
+			if paramValid && paramVal != defaultVal {
+				return paramVal
+			}
+		}
+
+		if paramValid && paramVal != "" {
+			return paramVal
 		}
 	// All other parameter types return the specified value as-is
 	default:

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -1953,6 +1953,9 @@ func armParameterFileValue(paramType ParameterType, value any) any {
 		if val, ok := value.(string); ok && val != "" {
 			return val
 		}
+	// All other parameter types return the specified value as-is
+	default:
+		return value
 	}
 
 	return nil

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -1955,22 +1955,19 @@ func armParameterFileValue(paramType ParameterType, value any, defaultValue any)
 		// 2. Empty input value and no default - return nil (prompt user)
 		// 3. Empty input value and non-empty default - return empty input string (no prompt)
 		paramVal, paramValid := value.(string)
-		defaultVal, hasDefault := defaultValue.(string)
-		if hasDefault {
-			if paramValid && paramVal != defaultVal {
-				return paramVal
-			}
+		if !paramValid {
+			return nil
 		}
 
-		if paramValid && paramVal != "" {
+		defaultVal, hasDefault := defaultValue.(string)
+		if paramValid && paramVal != "" || hasDefault && paramValid && paramVal != defaultVal {
 			return paramVal
 		}
-	// All other parameter types return the specified value as-is
-	default:
-		return value
+
+		return nil
 	}
 
-	return nil
+	return value
 }
 
 func isValueAssignableToParameterType(paramType ParameterType, value any) bool {

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -1024,47 +1024,59 @@ func TestUserDefinedTypes(t *testing.T) {
 
 func Test_armParameterFileValue(t *testing.T) {
 	t.Run("NilValue", func(t *testing.T) {
-		actual := armParameterFileValue(ParameterTypeString, nil)
+		actual := armParameterFileValue(ParameterTypeString, nil, nil)
 		require.Nil(t, actual)
 	})
 
 	t.Run("StringWithValue", func(t *testing.T) {
 		expected := "value"
-		actual := armParameterFileValue(ParameterTypeString, expected)
+		actual := armParameterFileValue(ParameterTypeString, expected, nil)
 		require.Equal(t, expected, actual)
 	})
 
 	t.Run("EmptyString", func(t *testing.T) {
+		input := ""
+		actual := armParameterFileValue(ParameterTypeString, input, nil)
+		require.Nil(t, actual)
+	})
+
+	t.Run("EmptyStringWithNonEmptyDefault", func(t *testing.T) {
 		expected := ""
-		actual := armParameterFileValue(ParameterTypeString, expected)
+		actual := armParameterFileValue(ParameterTypeString, expected, "not-empty")
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("EmptyStringWithEmptyDefault", func(t *testing.T) {
+		input := ""
+		actual := armParameterFileValue(ParameterTypeString, input, "")
 		require.Nil(t, actual)
 	})
 
 	t.Run("ValidBool", func(t *testing.T) {
 		expected := true
-		actual := armParameterFileValue(ParameterTypeBoolean, "true")
+		actual := armParameterFileValue(ParameterTypeBoolean, "true", nil)
 		require.Equal(t, expected, actual)
 	})
 
 	t.Run("InvalidBool", func(t *testing.T) {
-		actual := armParameterFileValue(ParameterTypeBoolean, "NotABool")
+		actual := armParameterFileValue(ParameterTypeBoolean, "NotABool", nil)
 		require.Nil(t, actual)
 	})
 
 	t.Run("ValidInt", func(t *testing.T) {
 		var expected int64 = 42
-		actual := armParameterFileValue(ParameterTypeNumber, "42")
+		actual := armParameterFileValue(ParameterTypeNumber, "42", nil)
 		require.Equal(t, expected, actual)
 	})
 
 	t.Run("InvalidInt", func(t *testing.T) {
-		actual := armParameterFileValue(ParameterTypeNumber, "NotAnInt")
+		actual := armParameterFileValue(ParameterTypeNumber, "NotAnInt", nil)
 		require.Nil(t, actual)
 	})
 
 	t.Run("Array", func(t *testing.T) {
 		expected := []string{"a", "b", "c"}
-		actual := armParameterFileValue(ParameterTypeArray, expected)
+		actual := armParameterFileValue(ParameterTypeArray, expected, nil)
 		require.Equal(t, expected, actual)
 	})
 }

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -1022,6 +1022,53 @@ func TestUserDefinedTypes(t *testing.T) {
 	}, customOutput.Metadata)
 }
 
+func Test_armParameterFileValue(t *testing.T) {
+	t.Run("NilValue", func(t *testing.T) {
+		actual := armParameterFileValue(ParameterTypeString, nil)
+		require.Nil(t, actual)
+	})
+
+	t.Run("StringWithValue", func(t *testing.T) {
+		expected := "value"
+		actual := armParameterFileValue(ParameterTypeString, expected)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("EmptyString", func(t *testing.T) {
+		expected := ""
+		actual := armParameterFileValue(ParameterTypeString, expected)
+		require.Nil(t, actual)
+	})
+
+	t.Run("ValidBool", func(t *testing.T) {
+		expected := true
+		actual := armParameterFileValue(ParameterTypeBoolean, "true")
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("InvalidBool", func(t *testing.T) {
+		actual := armParameterFileValue(ParameterTypeBoolean, "NotABool")
+		require.Nil(t, actual)
+	})
+
+	t.Run("ValidInt", func(t *testing.T) {
+		var expected int64 = 42
+		actual := armParameterFileValue(ParameterTypeNumber, "42")
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("InvalidInt", func(t *testing.T) {
+		actual := armParameterFileValue(ParameterTypeNumber, "NotAnInt")
+		require.Nil(t, actual)
+	})
+
+	t.Run("Array", func(t *testing.T) {
+		expected := []string{"a", "b", "c"}
+		actual := armParameterFileValue(ParameterTypeArray, expected)
+		require.Equal(t, expected, actual)
+	})
+}
+
 const userDefinedParamsSample = `{
 	"$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
 	"languageVersion": "2.0",

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -1054,13 +1054,14 @@ func Test_armParameterFileValue(t *testing.T) {
 
 	t.Run("ValidBool", func(t *testing.T) {
 		expected := true
-		actual := armParameterFileValue(ParameterTypeBoolean, "true", nil)
+		actual := armParameterFileValue(ParameterTypeBoolean, expected, nil)
 		require.Equal(t, expected, actual)
 	})
 
-	t.Run("InvalidBool", func(t *testing.T) {
-		actual := armParameterFileValue(ParameterTypeBoolean, "NotABool", nil)
-		require.Nil(t, actual)
+	t.Run("ActualBool", func(t *testing.T) {
+		expected := true
+		actual := armParameterFileValue(ParameterTypeBoolean, "true", nil)
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("ValidInt", func(t *testing.T) {
@@ -1069,9 +1070,10 @@ func Test_armParameterFileValue(t *testing.T) {
 		require.Equal(t, expected, actual)
 	})
 
-	t.Run("InvalidInt", func(t *testing.T) {
-		actual := armParameterFileValue(ParameterTypeNumber, "NotAnInt", nil)
-		require.Nil(t, actual)
+	t.Run("ActualInt", func(t *testing.T) {
+		var expected int64 = 42
+		actual := armParameterFileValue(ParameterTypeNumber, expected, nil)
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("Array", func(t *testing.T) {

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -1064,6 +1064,11 @@ func Test_armParameterFileValue(t *testing.T) {
 		require.Equal(t, expected, actual)
 	})
 
+	t.Run("InvalidBool", func(t *testing.T) {
+		actual := armParameterFileValue(ParameterTypeBoolean, "NotABool", nil)
+		require.Nil(t, actual)
+	})
+
 	t.Run("ValidInt", func(t *testing.T) {
 		var expected int64 = 42
 		actual := armParameterFileValue(ParameterTypeNumber, "42", nil)
@@ -1074,6 +1079,11 @@ func Test_armParameterFileValue(t *testing.T) {
 		var expected int64 = 42
 		actual := armParameterFileValue(ParameterTypeNumber, expected, nil)
 		require.Equal(t, expected, actual)
+	})
+
+	t.Run("InvalidInt", func(t *testing.T) {
+		actual := armParameterFileValue(ParameterTypeNumber, "NotAnInt", nil)
+		require.Nil(t, actual)
 	})
 
 	t.Run("Array", func(t *testing.T) {


### PR DESCRIPTION
Fixes #2895 & #1910

When `main.parameters.json` references an empty or not set value expression `azd` will prompt the user for a value unless the parameter also defines a default value.

The only edge case scenario I could think of where this would be undesired is if the bicep param does define a non-empty default string value but the user explicitly wants to specify/override with an empty string.

## Use Cases

bicep param | main.paramters.json | env expression | azd result | Suggestion |
| --- | --- | --- | --- | --- |
| No Default | Not defined | N/A | Prompt user for value | N/A |
| No Default | ${ENV_VAR} | Not Defined | Prompt user for value | N/A |
| No Default | ${VAR_1}-${VAR_2} | Any env var not defined | No prompt, rely on bicep validation | User should specify @minlengh in bicep
| No Default | ${ENV_VAR} | Empty string | Prompt user for a value | N/A |
| Has Default | Not defined | N/A | No prompt, use bicep default value | N/A |
| Has Default | ${ENV_VAR} | Not Defined | No prompt, use bicep default value | N/A |
| Has Default | ${ENV_VAR} | Defined value | No prompt, use env var defined value | N/A |
| Has Default | ${ENV_VAR} | Empty string | No prompt, use bicep default value | N/A |