### PR TITLE
Updates for pipeline config credential flows

### DIFF
--- a/cli/azd/pkg/azdo/azdo.go
+++ b/cli/azd/pkg/azdo/azdo.go
@@ -44,13 +44,6 @@ var (
 	ServiceConnectionName = "azconnection"
 )
 
-type AzureServicePrincipalCredentials struct {
-	TenantId       string `json:"tenantId"`
-	ClientId       string `json:"clientId"`
-	ClientSecret   string `json:"clientSecret"`
-	SubscriptionId string `json:"subscriptionId"`
-}
-
 // helper method to return an Azure DevOps connection used the AzDo go sdk
 func GetConnection(
 	ctx context.Context, organization string, personalAccessToken string) (*azuredevops.Connection, error) {

--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -13,6 +13,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/build"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/taskagent"
@@ -89,7 +90,7 @@ func CreatePipeline(
 	name string,
 	repoName string,
 	connection *azuredevops.Connection,
-	credentials AzureServicePrincipalCredentials,
+	credentials *azcli.AzureCredentials,
 	env *environment.Environment,
 	console input.Console,
 	provisioningProvider provisioning.Options) (*build.BuildDefinition, error) {
@@ -146,7 +147,7 @@ func CreatePipeline(
 
 func getDefinitionVariables(
 	env *environment.Environment,
-	credentials AzureServicePrincipalCredentials,
+	credentials *azcli.AzureCredentials,
 	provisioningProvider provisioning.Options) (*map[string]build.BuildDefinitionVariable, error) {
 	rawCredential, err := json.Marshal(credentials)
 	if err != nil {
@@ -192,7 +193,7 @@ func createAzureDevPipelineArgs(
 	projectId string,
 	name string,
 	repoName string,
-	credentials AzureServicePrincipalCredentials,
+	credentials *azcli.AzureCredentials,
 	env *environment.Environment,
 	queue *taskagent.TaskAgentQueue,
 	provisioningProvider provisioning.Options,

--- a/cli/azd/pkg/azdo/service_connection.go
+++ b/cli/azd/pkg/azdo/service_connection.go
@@ -10,6 +10,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/build"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/serviceendpoint"
@@ -82,7 +83,7 @@ func CreateServiceConnection(
 	connection *azuredevops.Connection,
 	projectId string,
 	azdEnvironment environment.Environment,
-	credentials AzureServicePrincipalCredentials,
+	credentials *azcli.AzureCredentials,
 	console input.Console) error {
 
 	client, err := serviceendpoint.NewClient(ctx, connection)
@@ -141,7 +142,7 @@ func CreateServiceConnection(
 func createAzureRMServiceEndPointArgs(
 	ctx context.Context,
 	projectId *string,
-	credentials AzureServicePrincipalCredentials,
+	credentials *azcli.AzureCredentials,
 ) (serviceendpoint.CreateServiceEndpointArgs, error) {
 	endpointType := "azurerm"
 	endpointOwner := "library"

--- a/cli/azd/pkg/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/pipeline/azdo_provider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -32,8 +33,8 @@ import (
 type AzdoScmProvider struct {
 	envManager     environment.Manager
 	repoDetails    *AzdoRepositoryDetails
-	Env            *environment.Environment
-	AzdContext     *azdcontext.AzdContext
+	env            *environment.Environment
+	azdContext     *azdcontext.AzdContext
 	azdoConnection *azuredevops.Connection
 	commandRunner  exec.CommandRunner
 	console        input.Console
@@ -50,8 +51,8 @@ func NewAzdoScmProvider(
 ) ScmProvider {
 	return &AzdoScmProvider{
 		envManager:    envManager,
-		Env:           env,
-		AzdContext:    azdContext,
+		env:           env,
+		azdContext:    azdContext,
 		commandRunner: commandRunner,
 		console:       console,
 		gitCli:        gitCli,
@@ -88,19 +89,19 @@ func (p *AzdoScmProvider) preConfigureCheck(
 	infraOptions provisioning.Options,
 	projectPath string,
 ) (bool, error) {
-	_, updatedPat, err := azdo.EnsurePatExists(ctx, p.Env, p.console)
+	_, updatedPat, err := azdo.EnsurePatExists(ctx, p.env, p.console)
 	if err != nil {
 		return updatedPat, err
 	}
 
-	_, updatedOrg, err := azdo.EnsureOrgNameExists(ctx, p.envManager, p.Env, p.console)
+	_, updatedOrg, err := azdo.EnsureOrgNameExists(ctx, p.envManager, p.env, p.console)
 	return (updatedPat || updatedOrg), err
 }
 
 // helper function to save configuration values to .env file
 func (p *AzdoScmProvider) saveEnvironmentConfig(ctx context.Context, key string, value string) error {
-	p.Env.DotenvSet(key, value)
-	err := p.envManager.Save(ctx, p.Env)
+	p.env.DotenvSet(key, value)
+	err := p.envManager.Save(ctx, p.env)
 	if err != nil {
 		return err
 	}
@@ -227,7 +228,7 @@ func (p *AzdoScmProvider) getAzdoConnection(ctx context.Context) (*azuredevops.C
 		return p.azdoConnection, nil
 	}
 
-	org, _, err := azdo.EnsureOrgNameExists(ctx, p.envManager, p.Env, p.console)
+	org, _, err := azdo.EnsureOrgNameExists(ctx, p.envManager, p.env, p.console)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +236,7 @@ func (p *AzdoScmProvider) getAzdoConnection(ctx context.Context) (*azuredevops.C
 	repoDetails := p.getRepoDetails()
 	repoDetails.orgName = org
 
-	pat, _, err := azdo.EnsurePatExists(ctx, p.Env, p.console)
+	pat, _, err := azdo.EnsurePatExists(ctx, p.env, p.console)
 	if err != nil {
 		return nil, err
 	}
@@ -284,9 +285,9 @@ func (p *AzdoScmProvider) ensureProjectExists(ctx context.Context, console input
 	case 1:
 		projectName, projectId, err = azdo.GetProjectFromNew(
 			ctx,
-			p.AzdContext.ProjectDirectory(),
+			p.azdContext.ProjectDirectory(),
 			connection,
-			p.Env,
+			p.env,
 			console,
 		)
 		newProject = true
@@ -473,22 +474,22 @@ func (p *AzdoScmProvider) gitRepoDetails(ctx context.Context, remoteUrl string) 
 	// While using the same .env file, the outputs from creating a project and repository
 	// are memorized in .env file
 	if repoDetails.orgName == "" {
-		repoDetails.orgName = p.Env.Getenv(azdo.AzDoEnvironmentOrgName)
+		repoDetails.orgName = p.env.Getenv(azdo.AzDoEnvironmentOrgName)
 	}
 	if repoDetails.projectName == "" {
-		repoDetails.projectName = p.Env.Getenv(azdo.AzDoEnvironmentProjectName)
+		repoDetails.projectName = p.env.Getenv(azdo.AzDoEnvironmentProjectName)
 	}
 	if repoDetails.projectId == "" {
-		repoDetails.projectId = p.Env.Getenv(azdo.AzDoEnvironmentProjectIdName)
+		repoDetails.projectId = p.env.Getenv(azdo.AzDoEnvironmentProjectIdName)
 	}
 	if repoDetails.repoName == "" {
-		repoDetails.repoName = p.Env.Getenv(azdo.AzDoEnvironmentRepoName)
+		repoDetails.repoName = p.env.Getenv(azdo.AzDoEnvironmentRepoName)
 	}
 	if repoDetails.repoId == "" {
-		repoDetails.repoId = p.Env.Getenv(azdo.AzDoEnvironmentRepoIdName)
+		repoDetails.repoId = p.env.Getenv(azdo.AzDoEnvironmentRepoIdName)
 	}
 	if repoDetails.repoWebUrl == "" {
-		repoDetails.repoWebUrl = p.Env.Getenv(azdo.AzDoEnvironmentRepoWebUrl)
+		repoDetails.repoWebUrl = p.env.Getenv(azdo.AzDoEnvironmentRepoWebUrl)
 	}
 	if repoDetails.remoteUrl == "" {
 		repoDetails.remoteUrl = remoteUrl
@@ -504,9 +505,9 @@ func (p *AzdoScmProvider) gitRepoDetails(ctx context.Context, remoteUrl string) 
 		// azdoSlug => Org/Project/_git/repoName
 		parts := strings.Split(azdoSlug, "_git/")
 		repoDetails.projectName = strings.Split(parts[0], "/")[1]
-		p.Env.DotenvSet(azdo.AzDoEnvironmentProjectName, repoDetails.projectName)
+		p.env.DotenvSet(azdo.AzDoEnvironmentProjectName, repoDetails.projectName)
 		repoDetails.repoName = parts[1]
-		p.Env.DotenvSet(azdo.AzDoEnvironmentRepoName, repoDetails.repoName)
+		p.env.DotenvSet(azdo.AzDoEnvironmentRepoName, repoDetails.repoName)
 
 		connection, err := p.getAzdoConnection(ctx)
 		if err != nil {
@@ -518,18 +519,18 @@ func (p *AzdoScmProvider) gitRepoDetails(ctx context.Context, remoteUrl string) 
 			return nil, fmt.Errorf("Looking for repository: %w", err)
 		}
 		repoDetails.repoId = repo.Id.String()
-		p.Env.DotenvSet(azdo.AzDoEnvironmentRepoIdName, repoDetails.repoId)
+		p.env.DotenvSet(azdo.AzDoEnvironmentRepoIdName, repoDetails.repoId)
 		repoDetails.repoWebUrl = *repo.WebUrl
-		p.Env.DotenvSet(azdo.AzDoEnvironmentRepoWebUrl, repoDetails.repoWebUrl)
+		p.env.DotenvSet(azdo.AzDoEnvironmentRepoWebUrl, repoDetails.repoWebUrl)
 
 		proj, err := azdo.GetProjectByName(ctx, connection, repoDetails.projectName)
 		if err != nil {
 			return nil, fmt.Errorf("Looking for project: %w", err)
 		}
 		repoDetails.projectId = proj.Id.String()
-		p.Env.DotenvSet(azdo.AzDoEnvironmentProjectIdName, repoDetails.projectId)
+		p.env.DotenvSet(azdo.AzDoEnvironmentProjectIdName, repoDetails.projectId)
 
-		if err := p.envManager.Save(ctx, p.Env); err != nil {
+		if err := p.envManager.Save(ctx, p.env); err != nil {
 			return nil, fmt.Errorf("saving environment: %w", err)
 		}
 	}
@@ -581,7 +582,7 @@ func (p *AzdoScmProvider) GitPush(
 	// ** Push code with PAT
 	// This is the same as gitCli.PushUpstream(), but it adds `-c url.PAT+HostName.insteadOf=HostName` to execute
 	// git push with the PAT to authenticate
-	pat := azdoPat(ctx, p.Env, p.console)
+	pat := azdoPat(ctx, p.env, p.console)
 	remoteAndPatUrl, originalUrl := gitInsteadOfConfig(ctx, pat, gitRepo)
 	runArgs := exec.NewRunArgsWithSensitiveData("git",
 		[]string{
@@ -615,7 +616,7 @@ func (p *AzdoScmProvider) GitPush(
 		p.repoDetails.projectId,
 		p.repoDetails.repoId,
 		p.repoDetails.buildDefinition,
-		p.Env,
+		p.env,
 	)
 	if err != nil {
 		return err
@@ -632,6 +633,7 @@ func (p *AzdoScmProvider) GitPush(
 // AzdoCiProvider implements a CiProvider using Azure DevOps to manage CI with azdo pipelines.
 type AzdoCiProvider struct {
 	envManager    environment.Manager
+	adService     azcli.AdService
 	Env           *environment.Environment
 	AzdContext    *azdcontext.AzdContext
 	credentials   *azcli.AzureCredentials
@@ -641,6 +643,7 @@ type AzdoCiProvider struct {
 
 func NewAzdoCiProvider(
 	envManager environment.Manager,
+	adService azcli.AdService,
 	env *environment.Environment,
 	azdContext *azdcontext.AzdContext,
 	console input.Console,
@@ -648,6 +651,7 @@ func NewAzdoCiProvider(
 ) CiProvider {
 	return &AzdoCiProvider{
 		envManager:    envManager,
+		adService:     adService,
 		Env:           env,
 		AzdContext:    azdContext,
 		console:       console,
@@ -701,9 +705,22 @@ func (p *AzdoCiProvider) configureConnection(
 	ctx context.Context,
 	repoDetails *gitRepositoryDetails,
 	provisioningProvider provisioning.Options,
-	credentials *azcli.AzureCredentials,
+	servicePrincipal *graphsdk.ServicePrincipal,
 	authType PipelineAuthType,
 ) error {
+	credentials, err := p.adService.ResetPasswordCredentials(ctx, p.Env.GetSubscriptionId(), servicePrincipal.AppId)
+	if err != nil {
+		return err
+	}
+
+	p.console.MessageUxItem(
+		ctx,
+		&ux.DisplayedResource{
+			Type: "Configuring client credentials for service principal",
+			Name: servicePrincipal.DisplayName,
+		},
+	)
+
 	p.credentials = credentials
 	details := repoDetails.details.(*AzdoRepositoryDetails)
 	org, _, err := azdo.EnsureOrgNameExists(ctx, p.envManager, p.Env, p.console)

--- a/cli/azd/pkg/pipeline/azdo_provider_test.go
+++ b/cli/azd/pkg/pipeline/azdo_provider_test.go
@@ -24,8 +24,8 @@ func Test_azdo_provider_getRepoDetails(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		// arrange
 		provider := getAzdoScmProviderTestHarness(mockinput.NewMockConsole())
-		testOrgName := provider.Env.Dotenv()[azdo.AzDoEnvironmentOrgName]
-		testRepoName := provider.Env.Dotenv()[azdo.AzDoEnvironmentRepoName]
+		testOrgName := provider.env.Dotenv()[azdo.AzDoEnvironmentOrgName]
+		testRepoName := provider.env.Dotenv()[azdo.AzDoEnvironmentRepoName]
 		ctx := context.Background()
 
 		// act
@@ -115,7 +115,7 @@ func Test_azdo_scm_provider_preConfigureCheck(t *testing.T) {
 		// assert
 		require.Nil(t, e)
 		// PAT is not persisted to .env
-		require.EqualValues(t, "", provider.Env.Dotenv()[azdo.AzDoPatName])
+		require.EqualValues(t, "", provider.env.Dotenv()[azdo.AzDoPatName])
 		require.True(t, updatedConfig)
 	})
 }
@@ -167,7 +167,7 @@ func Test_saveEnvironmentConfig(t *testing.T) {
 		envManager.On("Save", mock.Anything, env).Return(nil)
 
 		provider := getEmptyAzdoScmProviderTestHarness(envManager, mockinput.NewMockConsole())
-		provider.Env = env
+		provider.env = env
 		// act
 		e := provider.saveEnvironmentConfig(*mockContext.Context, key, value)
 		// assert
@@ -183,14 +183,14 @@ func Test_saveEnvironmentConfig(t *testing.T) {
 func getEmptyAzdoScmProviderTestHarness(envManager environment.Manager, console input.Console) *AzdoScmProvider {
 	return &AzdoScmProvider{
 		envManager: envManager,
-		Env:        environment.New("test"),
+		env:        environment.New("test"),
 		console:    console,
 	}
 }
 
 func getAzdoScmProviderTestHarness(console input.Console) *AzdoScmProvider {
 	return &AzdoScmProvider{
-		Env: environment.NewWithValues(
+		env: environment.NewWithValues(
 			"test-env",
 			map[string]string{
 				azdo.AzDoEnvironmentOrgName:       "fake_org",

--- a/cli/azd/pkg/pipeline/github_provider_test.go
+++ b/cli/azd/pkg/pipeline/github_provider_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/git"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/github"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -120,6 +121,7 @@ func createGitHubCiProvider(t *testing.T, mockContext *mocks.MockContext) CiProv
 	return NewGitHubCiProvider(
 		env,
 		mockContext.SubscriptionCredentialProvider,
+		azcli.NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient),
 		ghCli,
 		git.NewGitCli(mockContext.CommandRunner),
 		mockContext.Console,

--- a/cli/azd/pkg/pipeline/pipeline.go
+++ b/cli/azd/pkg/pipeline/pipeline.go
@@ -11,6 +11,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 )
 
 // subareaProvider defines the base behavior from any pipeline provider
@@ -104,7 +105,15 @@ type CiProvider interface {
 		provisioningProvider provisioning.Options,
 		servicePrincipal *graphsdk.ServicePrincipal,
 		authType PipelineAuthType,
+		credentials *azcli.AzureCredentials,
 	) error
+	// Gets the credential options that should be configured for the provider
+	credentialOptions(
+		ctx context.Context,
+		repoDetails *gitRepositoryDetails,
+		infraOptions provisioning.Options,
+		authType PipelineAuthType,
+	) *CredentialOptions
 }
 
 func folderExists(folderPath string) bool {

--- a/cli/azd/pkg/pipeline/pipeline.go
+++ b/cli/azd/pkg/pipeline/pipeline.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
-	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 )
 
 // subareaProvider defines the base behavior from any pipeline provider
@@ -102,7 +102,7 @@ type CiProvider interface {
 		ctx context.Context,
 		gitRepo *gitRepositoryDetails,
 		provisioningProvider provisioning.Options,
-		credentials *azcli.AzureCredentials,
+		servicePrincipal *graphsdk.ServicePrincipal,
 		authType PipelineAuthType,
 	) error
 }

--- a/cli/azd/pkg/pipeline/pipeline.go
+++ b/cli/azd/pkg/pipeline/pipeline.go
@@ -5,12 +5,12 @@ package pipeline
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 )
 
 // subareaProvider defines the base behavior from any pipeline provider
@@ -102,7 +102,7 @@ type CiProvider interface {
 		ctx context.Context,
 		gitRepo *gitRepositoryDetails,
 		provisioningProvider provisioning.Options,
-		credential json.RawMessage,
+		credentials *azcli.AzureCredentials,
 		authType PipelineAuthType,
 	) error
 }

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -225,29 +225,6 @@ func (pm *PipelineManager) Configure(ctx context.Context) (result *PipelineConfi
 		appIdOrName,
 		pm.args.PipelineRoleNames)
 
-	var credentials *azcli.AzureCredentials
-
-	if PipelineAuthType(pm.args.PipelineAuthTypeName) == AuthTypeClientCredentials {
-		updatedCreds, err := pm.adService.ResetPasswordCredentials(
-			ctx,
-			pm.env.GetSubscriptionId(),
-			servicePrincipal.AppId,
-		)
-		if err != nil {
-			return result, fmt.Errorf("failed to reset password credentials: %w", err)
-		}
-
-		credentials = updatedCreds
-	}
-
-	if credentials == nil {
-		credentials = &azcli.AzureCredentials{
-			ClientId:       servicePrincipal.AppId,
-			SubscriptionId: pm.env.GetSubscriptionId(),
-			TenantId:       *servicePrincipal.AppOwnerOrganizationId,
-		}
-	}
-
 	// Update new service principal to include client id
 	if !strings.Contains(displayMsg, servicePrincipal.AppId) {
 		displayMsg += fmt.Sprintf(" (%s)", servicePrincipal.AppId)
@@ -273,7 +250,7 @@ func (pm *PipelineManager) Configure(ctx context.Context) (result *PipelineConfi
 		ctx,
 		gitRepoInfo,
 		prj.Infra,
-		credentials,
+		servicePrincipal,
 		PipelineAuthType(pm.args.PipelineAuthTypeName))
 	pm.console.StopSpinner(ctx, "", input.GetStepResultFormat(err))
 	if err != nil {

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -47,6 +47,7 @@ var (
 	DefaultRoleNames    = []string{"Contributor", "User Access Administrator"}
 )
 
+// PipelineManagerArgs represents the arguments passed to the pipeline manager from Azd CLI
 type PipelineManagerArgs struct {
 	PipelineServicePrincipalId   string
 	PipelineServicePrincipalName string
@@ -56,6 +57,7 @@ type PipelineManagerArgs struct {
 	PipelineAuthTypeName         string
 }
 
+// CredentialOptions represents the options for configuring credentials for a pipeline.
 type CredentialOptions struct {
 	EnableClientCredentials    bool
 	EnableFederatedCredentials bool

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -235,11 +235,9 @@ func (pm *PipelineManager) Configure(ctx context.Context) (result *PipelineConfi
 	}
 
 	// Set in .env to be retrieved for any additional runs
-	if servicePrincipal.AppId != "" {
-		pm.env.DotenvSet(AzurePipelineClientIdEnvVarName, servicePrincipal.AppId)
-		if err := pm.envManager.Save(ctx, pm.env); err != nil {
-			return result, fmt.Errorf("failed to save environment: %w", err)
-		}
+	pm.env.DotenvSet(AzurePipelineClientIdEnvVarName, servicePrincipal.AppId)
+	if err := pm.envManager.Save(ctx, pm.env); err != nil {
+		return result, fmt.Errorf("failed to save environment: %w", err)
 	}
 
 	repoSlug := gitRepoInfo.owner + "/" + gitRepoInfo.repoName

--- a/cli/azd/pkg/pipeline/pipeline_manager_test.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/git"
@@ -21,6 +22,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_PipelineManager_Initialize(t *testing.T) {
@@ -385,6 +387,21 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 	})
 }
 
+func Test_PipelineManager_Configure(t *testing.T) {
+	tempDir := t.TempDir()
+	azdContext := azdcontext.NewAzdContextWithDirectory(tempDir)
+	mockContext := mocks.NewMockContext(context.Background())
+	env := environment.New("test")
+	args := &PipelineManagerArgs{}
+
+	pipelineManager, err := createPipelineManager(t, mockContext, azdContext, env, args)
+	require.NoError(t, err)
+
+	result, err := pipelineManager.Configure(*mockContext.Context)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
 func createPipelineManager(
 	t *testing.T,
 	mockContext *mocks.MockContext,
@@ -403,16 +420,20 @@ func createPipelineManager(
 	envManager := &mockenv.MockEnvManager{}
 	envManager.On("Save", mock.Anything, env).Return(nil)
 
+	adService := azcli.NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient)
+
 	// Singletons
-	mockContext.Container.RegisterSingleton(func() context.Context { return *mockContext.Context })
-	mockContext.Container.RegisterSingleton(func() *azdcontext.AzdContext { return azdContext })
-	mockContext.Container.RegisterSingleton(func() environment.Manager { return envManager })
-	mockContext.Container.RegisterSingleton(func() *environment.Environment { return env })
+	ioc.RegisterInstance(mockContext.Container, *mockContext.Context)
+	ioc.RegisterInstance(mockContext.Container, azdContext)
+	ioc.RegisterInstance[environment.Manager](mockContext.Container, envManager)
+	ioc.RegisterInstance(mockContext.Container, env)
+	ioc.RegisterInstance(mockContext.Container, adService)
+	ioc.RegisterInstance[account.SubscriptionCredentialProvider](
+		mockContext.Container,
+		mockContext.SubscriptionCredentialProvider,
+	)
 	mockContext.Container.RegisterSingleton(github.NewGitHubCli)
 	mockContext.Container.RegisterSingleton(git.NewGitCli)
-	mockContext.Container.RegisterSingleton(func() account.SubscriptionCredentialProvider {
-		return mockContext.SubscriptionCredentialProvider
-	})
 
 	// Pipeline providers
 	pipelineProviderMap := map[string]any{
@@ -430,7 +451,7 @@ func createPipelineManager(
 	return NewPipelineManager(
 		*mockContext.Context,
 		envManager,
-		azcli.NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient),
+		adService,
 		git.NewGitCli(mockContext.CommandRunner),
 		azdContext,
 		env,

--- a/cli/azd/pkg/pipeline/pipeline_manager_test.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_PipelineManager_Initialize(t *testing.T) {
@@ -385,21 +384,6 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 		os.Remove(azdoFolder)
 		os.Remove(ghFolder)
 	})
-}
-
-func Test_PipelineManager_Configure(t *testing.T) {
-	tempDir := t.TempDir()
-	azdContext := azdcontext.NewAzdContextWithDirectory(tempDir)
-	mockContext := mocks.NewMockContext(context.Background())
-	env := environment.New("test")
-	args := &PipelineManagerArgs{}
-
-	pipelineManager, err := createPipelineManager(t, mockContext, azdContext, env, args)
-	require.NoError(t, err)
-
-	result, err := pipelineManager.Configure(*mockContext.Context)
-	require.NoError(t, err)
-	require.NotNil(t, result)
 }
 
 func createPipelineManager(

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -316,7 +316,8 @@ func (p *dockerProject) packBuild(
 						"nginx -g 'daemon off;'",
 					inDockerOutputPath,
 					svc.OutputPath,
-					inDockerOutputPath))
+					inDockerOutputPath,
+				))
 		}
 	}
 

--- a/cli/azd/pkg/tools/azcli/ad_test.go
+++ b/cli/azd/pkg/tools/azcli/ad_test.go
@@ -230,8 +230,7 @@ func Test_ApplyFederatedCredentials(t *testing.T) {
 			*mockContext.Context,
 			"SUBSCRIPTION_ID",
 			*mockApplication.AppId,
-			"owner/repo",
-			[]string{"main"},
+			nil,
 		)
 
 		require.Error(t, err)
@@ -240,6 +239,25 @@ func Test_ApplyFederatedCredentials(t *testing.T) {
 	})
 	t.Run("SingleBranch", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
+		mockCredentials := []graphsdk.FederatedIdentityCredential{
+			{
+				Id:          convert.RefOf("CREDENTIAL_ID"),
+				Name:        "owner-repo-pull_request",
+				Issuer:      federatedIdentityIssuer,
+				Subject:     "repo:owner/repo:pull_request",
+				Description: convert.RefOf("DESCRIPTION"),
+				Audiences:   []string{federatedIdentityAudience},
+			},
+			{
+				Id:          convert.RefOf("CREDENTIAL_ID"),
+				Name:        "owner-repo-main",
+				Issuer:      federatedIdentityIssuer,
+				Subject:     "repo:owner/repo:ref:refs/heads/main",
+				Description: convert.RefOf("DESCRIPTION"),
+				Audiences:   []string{federatedIdentityAudience},
+			},
+		}
+
 		mockgraphsdk.RegisterApplicationGetItemByAppIdMock(
 			mockContext,
 			http.StatusOK,
@@ -264,8 +282,7 @@ func Test_ApplyFederatedCredentials(t *testing.T) {
 			*mockContext.Context,
 			"SUBSCRIPTION_ID",
 			*mockApplication.AppId,
-			"owner/repo",
-			[]string{"main"},
+			[]*graphsdk.FederatedIdentityCredential{&mockCredentials[0], &mockCredentials[1]},
 		)
 
 		require.NoError(t, err)
@@ -275,6 +292,33 @@ func Test_ApplyFederatedCredentials(t *testing.T) {
 
 	t.Run("MultipleBranches", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
+		mockCredentials := []graphsdk.FederatedIdentityCredential{
+			{
+				Id:          convert.RefOf("CREDENTIAL_ID"),
+				Name:        "owner-repo-pull_request",
+				Issuer:      federatedIdentityIssuer,
+				Subject:     "repo:owner/repo:pull_request",
+				Description: convert.RefOf("DESCRIPTION"),
+				Audiences:   []string{federatedIdentityAudience},
+			},
+			{
+				Id:          convert.RefOf("CREDENTIAL_ID"),
+				Name:        "owner-repo-main",
+				Issuer:      federatedIdentityIssuer,
+				Subject:     "repo:owner/repo:ref:refs/heads/main",
+				Description: convert.RefOf("DESCRIPTION"),
+				Audiences:   []string{federatedIdentityAudience},
+			},
+			{
+				Id:          convert.RefOf("CREDENTIAL_ID"),
+				Name:        "owner-repo-dev",
+				Issuer:      federatedIdentityIssuer,
+				Subject:     "repo:owner/repo:ref:refs/heads/dev",
+				Description: convert.RefOf("DESCRIPTION"),
+				Audiences:   []string{federatedIdentityAudience},
+			},
+		}
+
 		mockgraphsdk.RegisterApplicationGetItemByAppIdMock(
 			mockContext,
 			http.StatusOK,
@@ -299,8 +343,7 @@ func Test_ApplyFederatedCredentials(t *testing.T) {
 			*mockContext.Context,
 			"SUBSCRIPTION_ID",
 			*mockApplication.AppId,
-			"owner/repo",
-			[]string{"main", "dev"},
+			[]*graphsdk.FederatedIdentityCredential{&mockCredentials[0], &mockCredentials[1], &mockCredentials[2]},
 		)
 
 		require.NoError(t, err)
@@ -342,8 +385,7 @@ func Test_ApplyFederatedCredentials(t *testing.T) {
 			*mockContext.Context,
 			"SUBSCRIPTION_ID",
 			*mockApplication.AppId,
-			"owner/repo",
-			[]string{"main"},
+			[]*graphsdk.FederatedIdentityCredential{&mockCredentials[0], &mockCredentials[1]},
 		)
 
 		require.NoError(t, err)


### PR DESCRIPTION
Fixes #2883 

Updates pipeline config to only set client credential app passwords when `--auth-type client-credentials` is explicitly specified.

TODO:
- [x] Write unit tests
- [x] Test Github pipeline config flows
  - [x] With Federated credentials
  - [x] With client credentials 
- [x] Test AzDo pipeline config flows  
  - [x] With client credentials 