### PR TITLE
Add `Context` parameter to `DetectProject`

### DIFF
--- a/cli/azd/appdetect/main.go
+++ b/cli/azd/appdetect/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -19,6 +20,7 @@ func init() {
 
 func main() {
 	flag.Parse()
+	ctx := context.Background()
 
 	if directory == "" && projectDirectory == "" {
 		fmt.Println("must set one of 'proj', or 'dir'")
@@ -29,12 +31,12 @@ func main() {
 	var err error
 
 	if directory != "" {
-		projects, err = appdetect.Detect(directory)
+		projects, err = appdetect.Detect(ctx, directory)
 	}
 
 	if projectDirectory != "" {
 		var project *appdetect.Project
-		project, err = appdetect.DetectDirectory(projectDirectory)
+		project, err = appdetect.DetectDirectory(ctx, projectDirectory)
 
 		if err == nil && project != nil {
 			projects = append(projects, *project)

--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -4,6 +4,7 @@
 package appdetect
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -158,7 +159,7 @@ type Docker struct {
 
 type projectDetector interface {
 	Language() Language
-	DetectProject(path string, entries []fs.DirEntry) (*Project, error)
+	DetectProject(ctx context.Context, path string, entries []fs.DirEntry) (*Project, error)
 }
 
 var allDetectors = []projectDetector{
@@ -171,23 +172,23 @@ var allDetectors = []projectDetector{
 }
 
 // Detect detects projects located under a directory.
-func Detect(root string, options ...DetectOption) ([]Project, error) {
+func Detect(ctx context.Context, root string, options ...DetectOption) ([]Project, error) {
 	config := newConfig(options...)
-	return detectUnder(root, config)
+	return detectUnder(ctx, root, config)
 }
 
 // DetectDirectory detects the project located in a directory.
-func DetectDirectory(directory string, options ...DetectDirectoryOption) (*Project, error) {
+func DetectDirectory(ctx context.Context, directory string, options ...DetectDirectoryOption) (*Project, error) {
 	config := newDirectoryConfig(options...)
 	entries, err := os.ReadDir(directory)
 	if err != nil {
 		return nil, fmt.Errorf("reading directory: %w", err)
 	}
 
-	return detectAny(config.detectors, directory, entries)
+	return detectAny(ctx, config.detectors, directory, entries)
 }
 
-func detectUnder(root string, config detectConfig) ([]Project, error) {
+func detectUnder(ctx context.Context, root string, config detectConfig) ([]Project, error) {
 	projects := []Project{}
 
 	walkFunc := func(path string, entries []fs.DirEntry) error {
@@ -209,7 +210,7 @@ func detectUnder(root string, config detectConfig) ([]Project, error) {
 			}
 		}
 
-		project, err := detectAny(config.detectors, path, entries)
+		project, err := detectAny(ctx, config.detectors, path, entries)
 		if err != nil {
 			return err
 		}
@@ -232,10 +233,10 @@ func detectUnder(root string, config detectConfig) ([]Project, error) {
 }
 
 // Detects if a directory belongs to any projects.
-func detectAny(detectors []projectDetector, path string, entries []fs.DirEntry) (*Project, error) {
+func detectAny(ctx context.Context, detectors []projectDetector, path string, entries []fs.DirEntry) (*Project, error) {
 	log.Printf("Detecting projects in directory: %s", path)
 	for _, detector := range detectors {
-		project, err := detector.DetectProject(path, entries)
+		project, err := detector.DetectProject(ctx, path, entries)
 		if err != nil {
 			return nil, fmt.Errorf("detecting %s project: %w", string(detector.Language()), err)
 		}

--- a/cli/azd/internal/appdetect/appdetect_test.go
+++ b/cli/azd/internal/appdetect/appdetect_test.go
@@ -1,6 +1,7 @@
 package appdetect
 
 import (
+	"context"
 	"embed"
 	"io/fs"
 	"os"
@@ -161,7 +162,7 @@ func TestDetect(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			projects, err := Detect(dir, tt.options...)
+			projects, err := Detect(context.Background(), dir, tt.options...)
 			require.NoError(t, err)
 
 			// Convert relative to absolute paths
@@ -183,7 +184,7 @@ func TestDetectDocker(t *testing.T) {
 	err = os.WriteFile(filepath.Join(dir, "dotnet", "Dockerfile"), []byte{}, 0600)
 	require.NoError(t, err)
 
-	projects, err := Detect(dir)
+	projects, err := Detect(context.Background(), dir)
 	require.NoError(t, err)
 
 	require.Len(t, projects, 1)
@@ -210,7 +211,7 @@ func TestDetectNested(t *testing.T) {
 	err = copyTestDataDir(t, "**/javascript/**", filepath.Join(src, "dotnet"))
 	require.NoError(t, err)
 
-	projects, err := Detect(dir)
+	projects, err := Detect(context.Background(), dir)
 	require.NoError(t, err)
 
 	require.Len(t, projects, 1)

--- a/cli/azd/internal/appdetect/dotnet.go
+++ b/cli/azd/internal/appdetect/dotnet.go
@@ -1,6 +1,7 @@
 package appdetect
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"path/filepath"
@@ -14,7 +15,7 @@ func (dd *dotNetDetector) Language() Language {
 	return DotNet
 }
 
-func (dd *dotNetDetector) DetectProject(path string, entries []fs.DirEntry) (*Project, error) {
+func (dd *dotNetDetector) DetectProject(ctx context.Context, path string, entries []fs.DirEntry) (*Project, error) {
 	var hasProjectFile bool
 	var hasStartupFile bool
 	var projFileName string

--- a/cli/azd/internal/appdetect/java.go
+++ b/cli/azd/internal/appdetect/java.go
@@ -1,6 +1,7 @@
 package appdetect
 
 import (
+	"context"
 	"io/fs"
 	"strings"
 )
@@ -12,7 +13,7 @@ func (jd *javaDetector) Language() Language {
 	return Java
 }
 
-func (jd *javaDetector) DetectProject(path string, entries []fs.DirEntry) (*Project, error) {
+func (jd *javaDetector) DetectProject(ctx context.Context, path string, entries []fs.DirEntry) (*Project, error) {
 	for _, entry := range entries {
 		if strings.ToLower(entry.Name()) == "pom.xml" {
 			return &Project{

--- a/cli/azd/internal/appdetect/javascript.go
+++ b/cli/azd/internal/appdetect/javascript.go
@@ -1,6 +1,7 @@
 package appdetect
 
 import (
+	"context"
 	"encoding/json"
 	"io/fs"
 	"os"
@@ -22,7 +23,7 @@ func (nd *javaScriptDetector) Language() Language {
 	return JavaScript
 }
 
-func (nd *javaScriptDetector) DetectProject(path string, entries []fs.DirEntry) (*Project, error) {
+func (nd *javaScriptDetector) DetectProject(ctx context.Context, path string, entries []fs.DirEntry) (*Project, error) {
 	for _, entry := range entries {
 		if strings.ToLower(entry.Name()) == "package.json" {
 			project := &Project{

--- a/cli/azd/internal/appdetect/python.go
+++ b/cli/azd/internal/appdetect/python.go
@@ -2,6 +2,7 @@ package appdetect
 
 import (
 	"bufio"
+	"context"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -18,7 +19,7 @@ func (pd *pythonDetector) Language() Language {
 	return Python
 }
 
-func (pd *pythonDetector) DetectProject(path string, entries []fs.DirEntry) (*Project, error) {
+func (pd *pythonDetector) DetectProject(ctx context.Context, path string, entries []fs.DirEntry) (*Project, error) {
 	for _, entry := range entries {
 		// entry.Name() == "pyproject.toml" when azd supports pyproject files
 		if strings.ToLower(entry.Name()) == "requirements.txt" {

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -54,14 +54,14 @@ func (i *Initializer) InitFromApp(
 	tracing.SetUsageAttributes(fields.AppInitLastStep.String("detect"))
 	// Prioritize src directory if it exists
 	if ent, err := os.Stat(sourceDir); err == nil && ent.IsDir() {
-		prj, err := appdetect.Detect(sourceDir)
+		prj, err := appdetect.Detect(ctx, sourceDir)
 		if err == nil && len(prj) > 0 {
 			projects = prj
 		}
 	}
 
 	if len(projects) == 0 {
-		prj, err := appdetect.Detect(wd, appdetect.WithExcludePatterns([]string{
+		prj, err := appdetect.Detect(ctx, wd, appdetect.WithExcludePatterns([]string{
 			"**/eng",
 			"**/tool",
 			"**/tools"},


### PR DESCRIPTION
Detection logic may want to preform operations which take a context, so let's introduce one in the API and pass a context along.