### PR TITLE
Verifies that devcenter prompts have values otherwise return error

### DIFF
--- a/cli/azd/pkg/devcenter/prompter.go
+++ b/cli/azd/pkg/devcenter/prompter.go
@@ -66,6 +66,10 @@ func (p *Prompter) PromptProject(ctx context.Context, devCenterName string) (*de
 		return nil, err
 	}
 
+	if len(writeableProjects) == 0 {
+		return nil, fmt.Errorf("no dev center projects have been found")
+	}
+
 	slices.SortFunc(writeableProjects, func(x, y *devcentersdk.Project) bool {
 		return x.Name < y.Name
 	})
@@ -135,6 +139,10 @@ func (p *Prompter) PromptEnvironmentType(
 		return x.Name < y.Name
 	})
 
+	if len(envTypes) == 0 {
+		return nil, fmt.Errorf("no environment types have been found for '%s'", projectName)
+	}
+
 	envTypeNames := []string{}
 	for _, envType := range envTypesResponse.Value {
 		envTypeNames = append(envTypeNames, envType.Name)
@@ -175,6 +183,10 @@ func (p *Prompter) PromptEnvironmentDefinition(
 	slices.SortFunc(environmentDefinitions, func(x, y *devcentersdk.EnvironmentDefinition) bool {
 		return x.Name < y.Name
 	})
+
+	if len(environmentDefinitions) == 0 {
+		return nil, fmt.Errorf("no environment definitions have been found for '%s'", projectName)
+	}
 
 	duplicateNames := []string{}
 	envDefinitionNames := []string{}

--- a/cli/azd/pkg/devcenter/prompter.go
+++ b/cli/azd/pkg/devcenter/prompter.go
@@ -140,7 +140,7 @@ func (p *Prompter) PromptEnvironmentType(
 	})
 
 	if len(envTypes) == 0 {
-		return nil, fmt.Errorf("no environment types have been found for '%s'", projectName)
+		return nil, fmt.Errorf("no environment types found for '%s'", projectName)
 	}
 
 	envTypeNames := []string{}

--- a/cli/azd/pkg/devcenter/prompter.go
+++ b/cli/azd/pkg/devcenter/prompter.go
@@ -67,7 +67,7 @@ func (p *Prompter) PromptProject(ctx context.Context, devCenterName string) (*de
 	}
 
 	if len(writeableProjects) == 0 {
-		return nil, fmt.Errorf("no dev center projects have been found")
+		return nil, fmt.Errorf("no dev center projects found")
 	}
 
 	slices.SortFunc(writeableProjects, func(x, y *devcentersdk.Project) bool {

--- a/cli/azd/pkg/devcenter/prompter.go
+++ b/cli/azd/pkg/devcenter/prompter.go
@@ -185,7 +185,7 @@ func (p *Prompter) PromptEnvironmentDefinition(
 	})
 
 	if len(environmentDefinitions) == 0 {
-		return nil, fmt.Errorf("no environment definitions have been found for '%s'", projectName)
+		return nil, fmt.Errorf("no environment definitions found for '%s'", projectName)
 	}
 
 	duplicateNames := []string{}

--- a/cli/azd/pkg/devcenter/prompter_test.go
+++ b/cli/azd/pkg/devcenter/prompter_test.go
@@ -16,90 +16,167 @@ import (
 )
 
 func Test_Prompt_Project(t *testing.T) {
-	mockContext := mocks.NewMockContext(context.Background())
-	selectedDevCenter := mockDevCenterList[0]
-	selectedProjectIndex := 1
+	t.Run("Success", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		selectedDevCenter := mockDevCenterList[0]
+		selectedProjectIndex := 1
 
-	manager := &mockDevCenterManager{}
-	manager.
-		On("WritableProjects", *mockContext.Context).
-		Return(mockProjects, nil)
+		manager := &mockDevCenterManager{}
+		manager.
+			On("WritableProjects", *mockContext.Context).
+			Return(mockProjects, nil)
 
-	mockContext.Console.WhenSelect(func(options input.ConsoleOptions) bool {
-		return strings.Contains(options.Message, "Select a project")
-	}).RespondFn(func(options input.ConsoleOptions) (any, error) {
-		return selectedProjectIndex, nil
+		mockContext.Console.WhenSelect(func(options input.ConsoleOptions) bool {
+			return strings.Contains(options.Message, "Select a project")
+		}).RespondFn(func(options input.ConsoleOptions) (any, error) {
+			return selectedProjectIndex, nil
+		})
+
+		prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
+		selectedProject, err := prompter.PromptProject(*mockContext.Context, selectedDevCenter.Name)
+		require.NoError(t, err)
+		require.NotNil(t, selectedProject)
+		require.Equal(t, mockProjects[selectedProjectIndex], selectedProject)
 	})
 
-	prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
-	selectedProject, err := prompter.PromptProject(*mockContext.Context, selectedDevCenter.Name)
-	require.NoError(t, err)
-	require.NotNil(t, selectedProject)
-	require.Equal(t, mockProjects[selectedProjectIndex], selectedProject)
+	t.Run("NoProjects", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+
+		manager := &mockDevCenterManager{}
+		manager.
+			On("WritableProjects", *mockContext.Context).
+			Return([]*devcentersdk.Project{}, nil)
+
+		prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
+		selectedProject, err := prompter.PromptProject(*mockContext.Context, "")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "no dev center projects have been found")
+		require.Nil(t, selectedProject)
+	})
 }
 
 func Test_Prompt_EnvironmentType(t *testing.T) {
-	mockContext := mocks.NewMockContext(context.Background())
-	selectedDevCenter := mockDevCenterList[0]
-	selectedProject := mockProjects[1]
+	t.Run("Success", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		selectedDevCenter := mockDevCenterList[0]
+		selectedProject := mockProjects[1]
 
-	selectedIndex := 3
+		selectedIndex := 3
 
-	mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
-	mockdevcentersdk.MockListEnvironmentTypes(mockContext, selectedProject.Name, mockEnvironmentTypes)
+		mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
+		mockdevcentersdk.MockListEnvironmentTypes(mockContext, selectedProject.Name, mockEnvironmentTypes)
 
-	manager := &mockDevCenterManager{}
-	manager.
-		On("WritableProjects", *mockContext.Context).
-		Return(mockProjects, nil)
+		manager := &mockDevCenterManager{}
+		manager.
+			On("WritableProjects", *mockContext.Context).
+			Return(mockProjects, nil)
 
-	mockContext.Console.WhenSelect(func(options input.ConsoleOptions) bool {
-		return strings.Contains(options.Message, "Select an environment type")
-	}).RespondFn(func(options input.ConsoleOptions) (any, error) {
-		return selectedIndex, nil
+		mockContext.Console.WhenSelect(func(options input.ConsoleOptions) bool {
+			return strings.Contains(options.Message, "Select an environment type")
+		}).RespondFn(func(options input.ConsoleOptions) (any, error) {
+			return selectedIndex, nil
+		})
+
+		prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
+		selectedEnvironmentType, err := prompter.PromptEnvironmentType(
+			*mockContext.Context,
+			selectedDevCenter.Name,
+			selectedProject.Name,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, selectedEnvironmentType)
+		require.Equal(t, mockEnvironmentTypes[selectedIndex], selectedEnvironmentType)
 	})
 
-	prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
-	selectedEnvironmentType, err := prompter.PromptEnvironmentType(
-		*mockContext.Context,
-		selectedDevCenter.Name,
-		selectedProject.Name,
-	)
-	require.NoError(t, err)
-	require.NotNil(t, selectedEnvironmentType)
-	require.Equal(t, mockEnvironmentTypes[selectedIndex], selectedEnvironmentType)
+	t.Run("NoEnvironmentTypes", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		selectedDevCenter := mockDevCenterList[0]
+		selectedProject := mockProjects[1]
+
+		selectedIndex := 3
+
+		mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
+		mockdevcentersdk.MockListEnvironmentTypes(mockContext, selectedProject.Name, []*devcentersdk.EnvironmentType{})
+
+		manager := &mockDevCenterManager{}
+		manager.
+			On("WritableProjects", *mockContext.Context).
+			Return(mockProjects, nil)
+
+		mockContext.Console.WhenSelect(func(options input.ConsoleOptions) bool {
+			return strings.Contains(options.Message, "Select an environment type")
+		}).RespondFn(func(options input.ConsoleOptions) (any, error) {
+			return selectedIndex, nil
+		})
+
+		prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
+		selectedEnvironmentType, err := prompter.PromptEnvironmentType(
+			*mockContext.Context,
+			selectedDevCenter.Name,
+			selectedProject.Name,
+		)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "no environment types have been found")
+		require.Nil(t, selectedEnvironmentType)
+	})
 }
 
 func Test_Prompt_EnvironmentDefinitions(t *testing.T) {
-	mockContext := mocks.NewMockContext(context.Background())
-	selectedDevCenter := mockDevCenterList[0]
-	selectedProject := mockProjects[1]
+	t.Run("Success", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		selectedDevCenter := mockDevCenterList[0]
+		selectedProject := mockProjects[1]
 
-	selectedIndex := 2
+		selectedIndex := 2
 
-	mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
-	mockdevcentersdk.MockListEnvironmentDefinitions(mockContext, selectedProject.Name, mockEnvDefinitions)
+		mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
+		mockdevcentersdk.MockListEnvironmentDefinitions(mockContext, selectedProject.Name, mockEnvDefinitions)
 
-	manager := &mockDevCenterManager{}
-	manager.
-		On("WritableProjects", *mockContext.Context).
-		Return(mockProjects, nil)
+		manager := &mockDevCenterManager{}
+		manager.
+			On("WritableProjects", *mockContext.Context).
+			Return(mockProjects, nil)
 
-	mockContext.Console.WhenSelect(func(options input.ConsoleOptions) bool {
-		return strings.Contains(options.Message, "Select an environment definition")
-	}).RespondFn(func(options input.ConsoleOptions) (any, error) {
-		return selectedIndex, nil
+		mockContext.Console.WhenSelect(func(options input.ConsoleOptions) bool {
+			return strings.Contains(options.Message, "Select an environment definition")
+		}).RespondFn(func(options input.ConsoleOptions) (any, error) {
+			return selectedIndex, nil
+		})
+
+		prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
+		selectedEnvironmentType, err := prompter.PromptEnvironmentDefinition(
+			*mockContext.Context,
+			selectedDevCenter.Name,
+			selectedProject.Name,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, selectedEnvironmentType)
+		require.Equal(t, mockEnvDefinitions[selectedIndex], selectedEnvironmentType)
 	})
 
-	prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
-	selectedEnvironmentType, err := prompter.PromptEnvironmentDefinition(
-		*mockContext.Context,
-		selectedDevCenter.Name,
-		selectedProject.Name,
-	)
-	require.NoError(t, err)
-	require.NotNil(t, selectedEnvironmentType)
-	require.Equal(t, mockEnvDefinitions[selectedIndex], selectedEnvironmentType)
+	t.Run("NoEnvironmentDefinitions", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		selectedDevCenter := mockDevCenterList[0]
+		selectedProject := mockProjects[1]
+
+		mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
+		mockdevcentersdk.MockListEnvironmentDefinitions(mockContext, selectedProject.Name, []*devcentersdk.EnvironmentDefinition{})
+
+		manager := &mockDevCenterManager{}
+		manager.
+			On("WritableProjects", *mockContext.Context).
+			Return(mockProjects, nil)
+
+		prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
+		selectedEnvironmentType, err := prompter.PromptEnvironmentDefinition(
+			*mockContext.Context,
+			selectedDevCenter.Name,
+			selectedProject.Name,
+		)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "no environment definitions have been found")
+		require.Nil(t, selectedEnvironmentType)
+	})
 }
 
 func Test_Prompt_Config(t *testing.T) {

--- a/cli/azd/pkg/devcenter/prompter_test.go
+++ b/cli/azd/pkg/devcenter/prompter_test.go
@@ -50,7 +50,7 @@ func Test_Prompt_Project(t *testing.T) {
 		prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
 		selectedProject, err := prompter.PromptProject(*mockContext.Context, "")
 		require.Error(t, err)
-		require.ErrorContains(t, err, "no dev center projects have been found")
+		require.ErrorContains(t, err, "no dev center projects found")
 		require.Nil(t, selectedProject)
 	})
 }
@@ -116,7 +116,7 @@ func Test_Prompt_EnvironmentType(t *testing.T) {
 			selectedProject.Name,
 		)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "no environment types have been found")
+		require.ErrorContains(t, err, "no environment types found")
 		require.Nil(t, selectedEnvironmentType)
 	})
 }
@@ -174,7 +174,7 @@ func Test_Prompt_EnvironmentDefinitions(t *testing.T) {
 			selectedProject.Name,
 		)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "no environment definitions have been found")
+		require.ErrorContains(t, err, "no environment definitions found")
 		require.Nil(t, selectedEnvironmentType)
 	})
 }


### PR DESCRIPTION
When prompting for devcenter configuration values validate that prompts have available values otherwise throw error.