### PR TITLE
Relaxes platform configuration issues

### DIFF
--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -46,7 +46,7 @@ func NewRootCmd(ctx context.Context, staticHelp bool, middlewareChain []*actions
 			// If there was a platform configuration error report it to the user until it is resolved
 			// Using fmt.Printf directly here since we can't leverage our IoC container to resolve a console instance
 			if platform.Error != nil && errors.Is(platform.Error, platform.ErrPlatformNotSupported) {
-				fmt.Printf(output.WithWarningFormat("WARNING: %s\n\n", platform.Error.Error()))
+				fmt.Print(output.WithWarningFormat("WARNING: %s\n\n", platform.Error.Error()))
 			}
 
 			if opts.Cwd != "" {

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -45,7 +45,7 @@ func NewRootCmd(ctx context.Context, staticHelp bool, middlewareChain []*actions
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// If there was a platform configuration error report it to the user until it is resolved
 			// Using fmt.Printf directly here since we can't leverage our IoC container to resolve a console instance
-			if platform.Error != nil && errors.Is(platform.Error, platform.ErrPlatformNotSupported) {
+			if errors.Is(platform.Error, platform.ErrPlatformNotSupported) {
 				fmt.Print(output.WithWarningFormat("WARNING: %s\n\n", platform.Error.Error()))
 			}
 

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -42,6 +43,12 @@ func NewRootCmd(ctx context.Context, staticHelp bool, middlewareChain []*actions
 		Use:   "azd",
 		Short: fmt.Sprintf("%s is an open-source tool that helps onboard and manage your application on Azure", productName),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// If there was a platform configuration error report it to the user until it is resolved
+			// Using fmt.Printf directly here since we can't leverage our IoC container to resolve a console instance
+			if platform.Error != nil && errors.Is(platform.Error, platform.ErrPlatformNotSupported) {
+				fmt.Printf(output.WithWarningFormat("WARNING: %s\n\n", platform.Error.Error()))
+			}
+
 			if opts.Cwd != "" {
 				current, err := os.Getwd()
 
@@ -320,6 +327,8 @@ func NewRootCmd(ctx context.Context, staticHelp bool, middlewareChain []*actions
 	registerCommonDependencies(ioc.Global)
 
 	// Initialize the platform specific components for the IoC container
+	// Only container resolution errors will return an error
+	// Invalid configurations will fall back to default platform
 	if _, err := platform.Initialize(ioc.Global, azd.PlatformKindDefault); err != nil {
 		panic(err)
 	}

--- a/cli/azd/pkg/devcenter/prompter_test.go
+++ b/cli/azd/pkg/devcenter/prompter_test.go
@@ -160,7 +160,11 @@ func Test_Prompt_EnvironmentDefinitions(t *testing.T) {
 		selectedProject := mockProjects[1]
 
 		mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
-		mockdevcentersdk.MockListEnvironmentDefinitions(mockContext, selectedProject.Name, []*devcentersdk.EnvironmentDefinition{})
+		mockdevcentersdk.MockListEnvironmentDefinitions(
+			mockContext,
+			selectedProject.Name,
+			[]*devcentersdk.EnvironmentDefinition{},
+		)
 
 		manager := &mockDevCenterManager{}
 		manager.

--- a/cli/azd/pkg/platform/platform.go
+++ b/cli/azd/pkg/platform/platform.go
@@ -1,13 +1,17 @@
 package platform
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 )
 
-var ErrPlatformNotSupported = fmt.Errorf("unsupported platform")
+var (
+	ErrPlatformNotSupported   = fmt.Errorf("unsupported platform")
+	ErrPlatformConfigNotFound = fmt.Errorf("platform config not found")
+
+	Error error = nil
+)
 
 type PlatformKind string
 
@@ -23,9 +27,8 @@ func Initialize(container *ioc.NestedContainer, defaultPlatform PlatformKind) (P
 	platformType := defaultPlatform
 
 	// Override platform type when specified
-	err := container.Resolve(&platformConfig)
-	if err != nil && errors.Is(err, ErrPlatformNotSupported) {
-		return nil, err
+	if err := container.Resolve(&platformConfig); err != nil {
+		Error = err
 	}
 
 	if platformConfig != nil {


### PR DESCRIPTION
Relaxes platform configuration panics when an invalid platform configuration is detected.

If a platform configuration issue is detected the following warning will be displayed before the output of any command.

<img width="731" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/38875af3-a9c0-455e-b347-da3336c97641">

