### PR TITLE
Add `project.ImportManager` infrastructure

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -387,6 +387,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		})
 	})
 	container.RegisterSingleton(project.NewProjectManager)
+	container.RegisterSingleton(project.NewImportManager)
 	container.RegisterSingleton(project.NewServiceManager)
 	container.RegisterSingleton(func() *lazy.Lazy[project.ServiceManager] {
 		return lazy.NewLazy(func() (project.ServiceManager, error) {

--- a/cli/azd/cmd/down.go
+++ b/cli/azd/cmd/down.go
@@ -55,6 +55,7 @@ func newDownCmd() *cobra.Command {
 type downAction struct {
 	flags            *downFlags
 	provisionManager *provisioning.Manager
+	importManager    *project.ImportManager
 	env              *environment.Environment
 	console          input.Console
 	projectConfig    *project.ProjectConfig
@@ -67,6 +68,7 @@ func newDownAction(
 	projectConfig *project.ProjectConfig,
 	console input.Console,
 	alphaFeatureManager *alpha.FeatureManager,
+	importManager *project.ImportManager,
 ) actions.Action {
 	return &downAction{
 		flags:            flags,
@@ -74,6 +76,7 @@ func newDownAction(
 		env:              env,
 		console:          console,
 		projectConfig:    projectConfig,
+		importManager:    importManager,
 	}
 }
 
@@ -86,7 +89,13 @@ func (a *downAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 	startTime := time.Now()
 
-	if err := a.provisionManager.Initialize(ctx, a.projectConfig.Path, a.projectConfig.Infra); err != nil {
+	infra, err := a.importManager.ProjectInfrastructure(ctx, a.projectConfig)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = infra.Cleanup() }()
+
+	if err := a.provisionManager.Initialize(ctx, a.projectConfig.Path, infra.Options); err != nil {
 		return nil, fmt.Errorf("initializing provisioning manager: %w", err)
 	}
 

--- a/cli/azd/cmd/middleware/hooks_test.go
+++ b/cli/azd/cmd/middleware/hooks_test.go
@@ -344,6 +344,7 @@ func runMiddleware(
 		lazyEnvManager,
 		lazyEnv,
 		lazyProjectConfig,
+		project.NewImportManager(),
 		mockContext.CommandRunner,
 		mockContext.Console,
 		runOptions,

--- a/cli/azd/cmd/restore.go
+++ b/cli/azd/cmd/restore.go
@@ -75,6 +75,7 @@ type restoreAction struct {
 	env            *environment.Environment
 	projectConfig  *project.ProjectConfig
 	projectManager project.ProjectManager
+	importManager  *project.ImportManager
 	serviceManager project.ServiceManager
 	commandRunner  exec.CommandRunner
 }
@@ -130,6 +131,7 @@ func (ra *restoreAction) Run(ctx context.Context) (*actions.ActionResult, error)
 	targetServiceName, err := getTargetServiceName(
 		ctx,
 		ra.projectManager,
+		ra.importManager,
 		ra.projectConfig,
 		string(project.ServiceEventRestore),
 		targetServiceName,
@@ -150,8 +152,12 @@ func (ra *restoreAction) Run(ctx context.Context) (*actions.ActionResult, error)
 	}
 
 	restoreResults := map[string]*project.ServiceRestoreResult{}
+	stableServices, err := ra.importManager.ServiceStable(ctx, ra.projectConfig)
+	if err != nil {
+		return nil, err
+	}
 
-	for _, svc := range ra.projectConfig.GetServicesStable() {
+	for _, svc := range stableServices {
 		stepMessage := fmt.Sprintf("Restoring service %s", svc.Name)
 		ra.console.ShowSpinner(ctx, stepMessage, input.Step)
 

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -98,6 +98,7 @@ func serviceNameWarningCheck(console input.Console, serviceNameFlag string, comm
 func getTargetServiceName(
 	ctx context.Context,
 	projectManager project.ProjectManager,
+	importManager *project.ImportManager,
 	projectConfig *project.ProjectConfig,
 	commandName string,
 	targetServiceName string,
@@ -125,8 +126,12 @@ func getTargetServiceName(
 		}
 	}
 
-	if targetServiceName != "" && !projectConfig.HasService(targetServiceName) {
-		return "", fmt.Errorf("service name '%s' doesn't exist", targetServiceName)
+	if targetServiceName != "" {
+		if has, err := importManager.HasService(ctx, projectConfig, targetServiceName); err != nil {
+			return "", err
+		} else if !has {
+			return "", fmt.Errorf("service name '%s' doesn't exist", targetServiceName)
+		}
 	}
 
 	return targetServiceName, nil

--- a/cli/azd/pkg/devcentersdk/developer_client_test.go
+++ b/cli/azd/pkg/devcentersdk/developer_client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
@@ -17,9 +16,7 @@ import (
 )
 
 func Test_DevCenter_Client(t *testing.T) {
-	if os.Getenv("CI") != "" {
-		t.Skip("Skipping DevCenter tests in CI")
-	}
+	t.Skip("azure/azure-dev#2944")
 
 	mockContext := mocks.NewMockContext(context.Background())
 	fileConfigManager := config.NewFileConfigManager(config.NewManager())

--- a/cli/azd/pkg/pipeline/pipeline_manager_test.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/git"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/github"
@@ -442,5 +443,6 @@ func createPipelineManager(
 		mockContext.Console,
 		args,
 		mockContext.Container,
+		project.NewImportManager(),
 	)
 }

--- a/cli/azd/pkg/project/importer.go
+++ b/cli/azd/pkg/project/importer.go
@@ -1,0 +1,90 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
+)
+
+type ImportManager struct {
+}
+
+func NewImportManager() *ImportManager {
+	return &ImportManager{}
+}
+
+func (im *ImportManager) HasService(ctx context.Context, projectConfig *ProjectConfig, name string) (bool, error) {
+	services, err := im.ServiceStable(ctx, projectConfig)
+	if err != nil {
+		return false, err
+	}
+
+	for _, svc := range services {
+		if svc.Name == name {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// Retrieves the list of services in the project, in a stable ordering that is deterministic.
+func (im *ImportManager) ServiceStable(ctx context.Context, projectConfig *ProjectConfig) ([]*ServiceConfig, error) {
+	allServices := make(map[string]*ServiceConfig)
+
+	for name, svcConfig := range projectConfig.Services {
+		allServices[name] = svcConfig
+	}
+
+	// Collect all the services and then sort the resulting list by name. This provides a stable ordering of services.
+	allServicesSlice := make([]*ServiceConfig, 0, len(allServices))
+	for _, v := range allServices {
+		allServicesSlice = append(allServicesSlice, v)
+	}
+
+	slices.SortFunc(allServicesSlice, func(x, y *ServiceConfig) int {
+		return strings.Compare(x.Name, y.Name)
+	})
+
+	return allServicesSlice, nil
+}
+
+func (im *ImportManager) ProjectInfrastructure(ctx context.Context, projectConfig *ProjectConfig) (*Infra, error) {
+	infraRoot := projectConfig.Infra.Path
+	if !filepath.IsAbs(infraRoot) {
+		infraRoot = filepath.Join(projectConfig.Path, infraRoot)
+	}
+
+	// Allow overriding the infrastructure by placing an `infra` folder in the location that would be expected based
+	// on azure.yaml
+	if _, err := os.Stat(infraRoot); err == nil {
+		log.Printf("using infrastructure from %s directory", infraRoot)
+		return &Infra{
+			Options: projectConfig.Infra,
+		}, nil
+	}
+
+	return nil, fmt.Errorf(
+		"this project does not contain any infrastructure, have you created an '%s' folder?", filepath.Base(infraRoot))
+}
+
+// Infra represents the (possibly temporarily generated) infrastructure. Call [Cleanup] when done with infrastructure,
+// which will cause any temporarily generated files to be removed.
+type Infra struct {
+	Options    provisioning.Options
+	cleanupDir string
+}
+
+func (i *Infra) Cleanup() error {
+	if i.cleanupDir != "" {
+		return os.RemoveAll(i.cleanupDir)
+	}
+
+	return nil
+}

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -78,6 +78,10 @@ func Parse(ctx context.Context, yamlContent string) (*ProjectConfig, error) {
 		return nil, fmt.Errorf("parsing project %s: %w", projectConfig.Name, err)
 	}
 
+	if projectConfig.Infra.Path == "" {
+		projectConfig.Infra.Path = "infra"
+	}
+
 	for key, svc := range projectConfig.Services {
 		svc.Name = key
 		svc.Project = &projectConfig

--- a/cli/azd/pkg/project/project_config.go
+++ b/cli/azd/pkg/project/project_config.go
@@ -2,7 +2,6 @@ package project
 
 import (
 	"context"
-	"sort"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
@@ -55,31 +54,4 @@ type ProjectMetadata struct {
 	// in every template that we ship.
 	// ex: todo-python-mongo@version
 	Template string
-}
-
-// HasService checks if the project contains a service with a given name.
-func (p *ProjectConfig) HasService(name string) bool {
-	for key, svc := range p.Services {
-		if key == name && svc != nil {
-			return true
-		}
-	}
-
-	return false
-}
-
-// Retrieves the list of services in the project, in a stable ordering that is deterministic.
-func (p *ProjectConfig) GetServicesStable() []*ServiceConfig {
-	// Sort services by friendly name an then collect them into a list. This provides a stable ordering of services.
-	serviceKeys := make([]string, 0, len(p.Services))
-	for k := range p.Services {
-		serviceKeys = append(serviceKeys, k)
-	}
-	sort.Strings(serviceKeys)
-
-	services := make([]*ServiceConfig, 0, len(p.Services))
-	for _, key := range serviceKeys {
-		services = append(services, p.Services[key])
-	}
-	return services
 }

--- a/cli/azd/pkg/project/project_config_test.go
+++ b/cli/azd/pkg/project/project_config_test.go
@@ -94,32 +94,6 @@ services:
 	}
 }
 
-func TestProjectConfigHasService(t *testing.T) {
-	const testProj = `
-name: test-proj
-metadata:
-  template: test-proj-template
-resourceGroup: rg-test
-services:
-  web:
-    project: src/web
-    language: js
-    host: appservice
-  api:
-    project: src/api
-    language: js
-    host: appservice
-`
-
-	mockContext := mocks.NewMockContext(context.Background())
-	projectConfig, err := Parse(*mockContext.Context, testProj)
-	require.Nil(t, err)
-
-	require.True(t, projectConfig.HasService("web"))
-	require.True(t, projectConfig.HasService("api"))
-	require.False(t, projectConfig.HasService("foobar"))
-}
-
 func TestProjectWithCustomDockerOptions(t *testing.T) {
 	const testProj = `
 name: test-proj

--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -260,7 +260,7 @@ func Test_Invalid_Project_File(t *testing.T) {
 }
 
 func TestMinimalYaml(t *testing.T) {
-	prj := ProjectConfig{
+	prj := &ProjectConfig{
 		Name:     "minimal",
 		Services: map[string]*ServiceConfig{},
 	}

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/test/azdcli"
 	"github.com/google/uuid"
@@ -251,6 +252,9 @@ func Test_CLI_Telemetry_NestedCommands(t *testing.T) {
 	// Remove infra folder to avoid lengthy Azure operations while asserting the intended telemetry behavior.
 	// The current behavior is that `azd provision` will fail when trying to read the nonexistent bicep folder.
 	require.NoError(t, os.RemoveAll(filepath.Join(dir, "infra")))
+
+	// We do require that infra folder exist, however, so put it back (empty).
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "infra"), osutil.PermissionDirectoryOwnerOnly))
 
 	_, err = cli.RunCommandWithStdIn(ctx, stdinForProvision(), "up", "--trace-log-file", traceFilePath)
 	require.Error(t, err)


### PR DESCRIPTION
We are going to be adding support for services to contribute auto-generated infrastructure as well as sub services in a future set of changes.

This means that direct access to both the `.Infra` and `.Services` property of a `*ProjectConfig` may be incomplete. To address this, a new (somewhat poorly named) `ImportManager` is introduced. The `ImportManager` is tasked with getting the complete set of services or a `provisioning.Options` for the infrastructure.

For now, we have no Importers, so this change is a no-op. However, it lays the groundwork for future changes and will make follow on commits easier to review.

Longer term, we should look at not directly exporting `Infra` and `Services` from the `ProjectConfig` and force other packages to consume these via the `ImportManager`. For now, I've pushed off a little of that work because it would expand the diff.  The remaining places we touch these members directly it is safe to do so (either we are in tests where there will be no projects that have imports) or it is clear by construction that there will be no imports resloved.