### PR TITLE
Add `project.DotNetContainerAppTarget`

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -166,6 +166,7 @@ swacli
 Syncer
 teamcity
 testdata
+tmpl
 tracesdk
 tracetest
 trafficmanager

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -461,13 +461,14 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 
 	// Service Targets
 	serviceTargetMap := map[project.ServiceTargetKind]any{
-		"":                          project.NewAppServiceTarget,
-		project.AppServiceTarget:    project.NewAppServiceTarget,
-		project.AzureFunctionTarget: project.NewFunctionAppTarget,
-		project.ContainerAppTarget:  project.NewContainerAppTarget,
-		project.StaticWebAppTarget:  project.NewStaticWebAppTarget,
-		project.AksTarget:           project.NewAksTarget,
-		project.SpringAppTarget:     project.NewSpringAppTarget,
+		"":                               project.NewAppServiceTarget,
+		project.AppServiceTarget:         project.NewAppServiceTarget,
+		project.AzureFunctionTarget:      project.NewFunctionAppTarget,
+		project.ContainerAppTarget:       project.NewContainerAppTarget,
+		project.StaticWebAppTarget:       project.NewStaticWebAppTarget,
+		project.AksTarget:                project.NewAksTarget,
+		project.SpringAppTarget:          project.NewSpringAppTarget,
+		project.DotNetContainerAppTarget: project.NewDotNetContainerAppTarget,
 	}
 
 	for target, constructor := range serviceTargetMap {

--- a/cli/azd/cmd/package.go
+++ b/cli/azd/cmd/package.go
@@ -149,6 +149,40 @@ func (pa *packageAction) Run(ctx context.Context) (*actions.ActionResult, error)
 	}
 	serviceCount := len(serviceTable)
 	for index, svc := range serviceTable {
+		// TODO(ellismg): We need to figure out what packaging an containerized dotnet app means. For now, just skip it.
+		//  We "package" the app during deploy when we call `dotnet publish /p:PublishProfile=DefaultContainer` to build
+		//  and push the container image.
+		//
+		// Doing this skip here means that during `azd up` we don't show output like:
+		// /* cSpell:disable */
+		//
+		// Packaging services (azd package)
+		//
+		// (✓) Done: Packaging service basketservice
+		// - Package Output: /var/folders/6n/sxbj12js5ksg6ztn0kslqp400000gn/T/azd472091284
+		//
+		// (✓) Done: Packaging service catalogservice
+		// - Package Output: /var/folders/6n/sxbj12js5ksg6ztn0kslqp400000gn/T/azd2265185954
+		//
+		// (✓) Done: Packaging service frontend
+		// - Package Output: /var/folders/6n/sxbj12js5ksg6ztn0kslqp400000gn/T/azd2956031596
+		//
+		// /* cSpell:enable */
+		// Which is nice - since the above is not the package that we publish (instead it's the raw output of
+		// `dotnet publish`, as if you were going to run on App Service.).
+		//
+		// With .NET 8, we'll be able to build just the container image, by setting ContainerArchiveOutputPath
+		// as a property when we run `dotnet publish`.  If we set this to the filepath of a tgz (doesn't need to exist)
+		// the the action will just produce a container image and save it to that tgz, as `docker save` would have. It will
+		// not push the container image.
+		//
+		// It's probably right for us to think about "package" for a containerized application as meaning "produce the tgz"
+		// of the image, as would be done by `docker save` and then do this for both DotNetContainerAppTargets and
+		// ContainerAppTargets.
+		if svc.Host == project.DotNetContainerAppTarget {
+			continue
+		}
+
 		stepMessage := fmt.Sprintf("Packaging service %s", svc.Name)
 		pa.console.ShowSpinner(ctx, stepMessage, input.Step)
 

--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -2,6 +2,7 @@ package containerapps
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v2"
@@ -11,6 +12,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/benbjohnson/clock"
+	"gopkg.in/yaml.v3"
 )
 
 // ContainerAppService exposes operations for managing Azure Container Apps
@@ -22,6 +24,13 @@ type ContainerAppService interface {
 		resourceGroup,
 		appName string,
 	) (*ContainerAppIngressConfiguration, error)
+	DeployYaml(
+		ctx context.Context,
+		subscriptionId string,
+		resourceGroupName string,
+		appName string,
+		containerAppYaml []byte,
+	) error
 	// Adds and activates a new revision to the specified container app
 	AddRevision(
 		ctx context.Context,
@@ -82,6 +91,46 @@ func (cas *containerAppService) GetIngressConfiguration(
 	return &ContainerAppIngressConfiguration{
 		HostNames: hostNames,
 	}, nil
+}
+
+func (cas *containerAppService) DeployYaml(
+	ctx context.Context,
+	subscriptionId string,
+	resourceGroupName string,
+	appName string,
+	containerAppYaml []byte,
+) error {
+	appClient, err := cas.createContainerAppsClient(ctx, subscriptionId)
+	if err != nil {
+		return err
+	}
+
+	var obj map[string]any
+	if err := yaml.Unmarshal(containerAppYaml, &obj); err != nil {
+		return fmt.Errorf("decoding yaml: %w", err)
+	}
+
+	containerAppJson, err := json.Marshal(obj)
+	if err != nil {
+		panic("should not have failed")
+	}
+
+	var containerApp armappcontainers.ContainerApp
+	if err := json.Unmarshal(containerAppJson, &containerApp); err != nil {
+		return fmt.Errorf("converting to container app type: %w", err)
+	}
+
+	poller, err := appClient.BeginCreateOrUpdate(ctx, resourceGroupName, appName, containerApp, nil)
+	if err != nil {
+		return fmt.Errorf("applying manifest: %w", err)
+	}
+
+	_, err = poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("polling for container app update completion: %w", err)
+	}
+
+	return nil
 }
 
 // Adds and activates a new revision to the specified container app

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -90,6 +90,20 @@ func (ch *ContainerHelper) RequiredExternalTools(context.Context) []tools.Extern
 	return []tools.ExternalTool{ch.docker}
 }
 
+// Login logs into the container registry specified by AZURE_CONTAINER_REGISTRY_ENDPOINT in the environment. On success,
+// it returns the name of the container registry that was logged into.
+func (ch *ContainerHelper) Login(
+	ctx context.Context,
+	targetResource *environment.TargetResource,
+) (string, error) {
+	loginServer, err := ch.RegistryName(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return loginServer, ch.containerRegistryService.Login(ctx, targetResource.SubscriptionId(), loginServer)
+}
+
 func (ch *ContainerHelper) Deploy(
 	ctx context.Context,
 	serviceConfig *ServiceConfig,

--- a/cli/azd/pkg/project/service_target.go
+++ b/cli/azd/pkg/project/service_target.go
@@ -18,16 +18,21 @@ import (
 type ServiceTargetKind string
 
 const (
-	AppServiceTarget    ServiceTargetKind = "appservice"
-	ContainerAppTarget  ServiceTargetKind = "containerapp"
-	AzureFunctionTarget ServiceTargetKind = "function"
-	StaticWebAppTarget  ServiceTargetKind = "staticwebapp"
-	SpringAppTarget     ServiceTargetKind = "springapp"
-	AksTarget           ServiceTargetKind = "aks"
+	AppServiceTarget         ServiceTargetKind = "appservice"
+	ContainerAppTarget       ServiceTargetKind = "containerapp"
+	AzureFunctionTarget      ServiceTargetKind = "function"
+	StaticWebAppTarget       ServiceTargetKind = "staticwebapp"
+	SpringAppTarget          ServiceTargetKind = "springapp"
+	AksTarget                ServiceTargetKind = "aks"
+	DotNetContainerAppTarget ServiceTargetKind = "containerapp-dotnet"
 )
 
 func parseServiceHost(kind ServiceTargetKind) (ServiceTargetKind, error) {
 	switch kind {
+
+	// NOTE: We do not support DotNetContainerAppTarget as a listed service host type in azure.yaml, hence
+	// it not include in this switch statement. We should think about if we should support this in azure.yaml because
+	// presently it's the only service target that is tied to a language.
 	case AppServiceTarget,
 		ContainerAppTarget,
 		AzureFunctionTarget,

--- a/cli/azd/pkg/project/service_target_dotnet_containerapp.go
+++ b/cli/azd/pkg/project/service_target_dotnet_containerapp.go
@@ -1,0 +1,225 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/async"
+	"github.com/azure/azure-dev/cli/azd/pkg/azure"
+	"github.com/azure/azure-dev/cli/azd/pkg/containerapps"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
+)
+
+type dotnetContainerAppTarget struct {
+	env                 *environment.Environment
+	containerHelper     *ContainerHelper
+	containerAppService containerapps.ContainerAppService
+	resourceManager     ResourceManager
+	dotNetCli           dotnet.DotNetCli
+}
+
+// NewDotNetContainerAppTarget creates the Service Target for a Container App that is written in .NET. Unlike
+// [ContainerAppTarget], this target does not require a Dockerfile to be present in the project. Instead, it uses the built
+// in support in .NET 8 for publishing containers using `dotnet publish`. In addition, it uses a different deployment
+// strategy built on a yaml manifest file, using the same format `az containerapp create --yaml`, with additional support
+// for using text/template to do replacements, similar to tools like Helm.
+//
+// Note that unlike [ContainerAppTarget] this target does not add SERVICE_<XYZ>_IMAGE_NAME values to the environment,
+// instead, the image name is present on the context object used when rendering the template.
+func NewDotNetContainerAppTarget(
+	env *environment.Environment,
+	containerHelper *ContainerHelper,
+	containerAppService containerapps.ContainerAppService,
+	resourceManager ResourceManager,
+	dotNetCli dotnet.DotNetCli,
+) ServiceTarget {
+	return &dotnetContainerAppTarget{
+		env:                 env,
+		containerHelper:     containerHelper,
+		containerAppService: containerAppService,
+		resourceManager:     resourceManager,
+		dotNetCli:           dotNetCli,
+	}
+}
+
+// Gets the required external tools
+func (at *dotnetContainerAppTarget) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+	return tools.Unique(append(at.containerHelper.RequiredExternalTools(ctx), at.dotNetCli))
+}
+
+// Initializes the Container App target
+func (at *dotnetContainerAppTarget) Initialize(ctx context.Context, serviceConfig *ServiceConfig) error {
+	return nil
+}
+
+// Prepares and tags the container image from the build output based on the specified service configuration
+func (at *dotnetContainerAppTarget) Package(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	packageOutput *ServicePackageResult,
+) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress] {
+	return async.RunTaskWithProgress(
+		func(task *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
+			task.SetResult(packageOutput)
+		},
+	)
+}
+
+// Deploys service container images to ACR and provisions the container app service.
+func (at *dotnetContainerAppTarget) Deploy(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	packageOutput *ServicePackageResult,
+	targetResource *environment.TargetResource,
+) *async.TaskWithProgress[*ServiceDeployResult, ServiceProgress] {
+	return async.RunTaskWithProgress(
+		func(task *async.TaskContextWithProgress[*ServiceDeployResult, ServiceProgress]) {
+			if err := at.validateTargetResource(ctx, serviceConfig, targetResource); err != nil {
+				task.SetError(fmt.Errorf("validating target resource: %w", err))
+				return
+			}
+
+			task.SetProgress(NewServiceProgress("Logging in to registry"))
+
+			// Login, tag & push container image to ACR
+			loginServer, err := at.containerHelper.Login(ctx, targetResource)
+			if err != nil {
+				task.SetError(fmt.Errorf("logging in to registry: %w", err))
+				return
+			}
+
+			task.SetProgress(NewServiceProgress("Pushing container image"))
+
+			imageName := fmt.Sprintf("azd-deploy-%s-%d", serviceConfig.Name, time.Now().Unix())
+
+			err = at.dotNetCli.PublishContainer(ctx, serviceConfig.Path(), "Debug", imageName, loginServer)
+			if err != nil {
+				task.SetError(fmt.Errorf("publishing container: %w", err))
+				return
+			}
+
+			task.SetProgress(NewServiceProgress("Updating container app"))
+
+			projectRoot := serviceConfig.Path()
+			if f, err := os.Stat(projectRoot); err == nil && !f.IsDir() {
+				projectRoot = filepath.Dir(projectRoot)
+			}
+
+			manifest, err := os.ReadFile(filepath.Join(projectRoot, "manifests", "containerApp.tmpl.yaml"))
+			if err != nil {
+				task.SetError(fmt.Errorf("reading container app manifest: %w", err))
+				return
+			}
+
+			tmpl, err := template.New("containerApp.tmpl.yaml").
+				Option("missingkey=error").
+				Parse(string(manifest))
+			if err != nil {
+				task.SetError(fmt.Errorf("failing parsing containerApp.tmpl.yaml: %w", err))
+				return
+			}
+
+			builder := strings.Builder{}
+			err = tmpl.Execute(&builder, struct {
+				Env   map[string]string
+				Image string
+			}{
+				Env:   at.env.Dotenv(),
+				Image: fmt.Sprintf("%s/%s", loginServer, imageName),
+			})
+			if err != nil {
+				task.SetError(fmt.Errorf("failed executing template file: %w", err))
+				return
+			}
+
+			err = at.containerAppService.DeployYaml(
+				ctx,
+				targetResource.SubscriptionId(),
+				targetResource.ResourceGroupName(),
+				serviceConfig.Name,
+				[]byte(builder.String()),
+			)
+			if err != nil {
+				task.SetError(fmt.Errorf("updating container app service: %w", err))
+				return
+			}
+
+			task.SetProgress(NewServiceProgress("Fetching endpoints for container app service"))
+
+			containerAppTarget := environment.NewTargetResource(
+				targetResource.SubscriptionId(),
+				targetResource.ResourceGroupName(),
+				serviceConfig.Name,
+				string(infra.AzureResourceTypeContainerApp))
+
+			endpoints, err := at.Endpoints(ctx, serviceConfig, containerAppTarget)
+			if err != nil {
+				task.SetError(err)
+				return
+			}
+
+			task.SetResult(&ServiceDeployResult{
+				Package: packageOutput,
+				TargetResourceId: azure.ContainerAppRID(
+					targetResource.SubscriptionId(),
+					targetResource.ResourceGroupName(),
+					serviceConfig.Name,
+				),
+				Kind:      ContainerAppTarget,
+				Endpoints: endpoints,
+			})
+		},
+	)
+}
+
+// Gets endpoint for the container app service
+func (at *dotnetContainerAppTarget) Endpoints(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	targetResource *environment.TargetResource,
+) ([]string, error) {
+	if ingressConfig, err := at.containerAppService.GetIngressConfiguration(
+		ctx,
+		targetResource.SubscriptionId(),
+		targetResource.ResourceGroupName(),
+		targetResource.ResourceName(),
+	); err != nil {
+		return nil, fmt.Errorf("fetching service properties: %w", err)
+	} else {
+		endpoints := make([]string, len(ingressConfig.HostNames))
+		for idx, hostName := range ingressConfig.HostNames {
+			endpoints[idx] = fmt.Sprintf("https://%s/", hostName)
+		}
+
+		return endpoints, nil
+	}
+}
+
+func (at *dotnetContainerAppTarget) validateTargetResource(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	targetResource *environment.TargetResource,
+) error {
+	if targetResource.ResourceGroupName() == "" {
+		return fmt.Errorf("missing resource group name: %s", targetResource.ResourceGroupName())
+	}
+
+	if targetResource.ResourceType() != "" {
+		if err := checkResourceType(targetResource, infra.AzureResourceTypeContainerAppEnvironment); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This adds support for a new (presently internal) service target, which is a containerized dotnet application, running on ACA. There are two major differences between this target type and the existing container app type:

1. Instead of using `docker build` and `docker push` to build and push the container, we use `dotnet package` and the new container building support that is in .NET 7 (and being improved in .NET 8) to build and push the ccontainer. This experience is like Oryx in that it does not require a Dockerfile.

2. We use a deployment strategy for the container that looks more like AKS. We expect a `containerApp.tmpl.yaml` file in a `manifests` folder in the root of the service. We use go text templating (as we do in AKS) and then deploy this yaml in the same manner as `az containerapp [create|update] --yaml`. The format of the file is the same between us an `az` (it is just the YAML rendering of what would be sent to the management plane to create or update a container app)

We do not allow this type service target type to appear as a host in `azure.yaml` today. Instead, it will be returned by a custom importer in a later change.

We will explore extending this support to other languages and at that point consider exposing this via `azure.yaml`.