### PR TITLE
Support .NET App Host Projects

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -7,6 +7,7 @@ apimanagement
 apims
 appconfiguration
 appdetect
+apphost
 appinit
 appinsights
 appinsightsexporter
@@ -102,6 +103,7 @@ LASTEXITCODE
 ldflags
 lechnerc77
 libc
+memfs
 mergo
 mgmt
 mgutz
@@ -130,14 +132,17 @@ otlptrace
 otlptracehttp
 paketobuildpacks
 pflag
+posix
 preinit
 proxying
+psanford
 psycopg
 psycopgbinary
 pulumi
 pyapp
 pyproject
 pyvenv
+rabbitmq
 reauthentication
 relogin
 remarshal
@@ -145,6 +150,7 @@ repourl
 resourcegraph
 restoreapp
 retriable
+requirepass
 rzip
 secureobject
 securestring

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -387,6 +387,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		})
 	})
 	container.RegisterSingleton(project.NewProjectManager)
+	container.RegisterSingleton(project.NewDotNetImporter)
 	container.RegisterSingleton(project.NewImportManager)
 	container.RegisterSingleton(project.NewServiceManager)
 	container.RegisterSingleton(func() *lazy.Lazy[project.ServiceManager] {

--- a/cli/azd/cmd/infra.go
+++ b/cli/azd/cmd/infra.go
@@ -39,5 +39,14 @@ func infraActions(root *actions.ActionDescriptor) *actions.ActionDescriptor {
 		}).
 		UseMiddleware("hooks", middleware.NewHooksMiddleware)
 
+	group.
+		Add("synth", &actions.ActionDescriptorOptions{
+			Command:        newInfraSynthCmd(),
+			FlagsResolver:  newInfraSynthFlags,
+			ActionResolver: newInfraSynthAction,
+			OutputFormats:  []output.Format{output.NoneFormat},
+			DefaultFormat:  output.NoneFormat,
+		})
+
 	return group
 }

--- a/cli/azd/cmd/infra_synth.go
+++ b/cli/azd/cmd/infra_synth.go
@@ -1,0 +1,241 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/azure/azure-dev/cli/azd/cmd/actions"
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
+	"github.com/otiai10/copy"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type infraSynthFlags struct {
+	global *internal.GlobalCommandOptions
+	*envFlag
+	force bool
+}
+
+func newInfraSynthFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *infraSynthFlags {
+	flags := &infraSynthFlags{
+		envFlag: &envFlag{},
+	}
+	flags.Bind(cmd.Flags(), global)
+
+	return flags
+}
+
+func (f *infraSynthFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
+	f.global = global
+	f.envFlag.Bind(local, global)
+	local.BoolVar(&f.force, "force", false, "Overwrite any existing files without prompting")
+}
+
+func newInfraSynthCmd() *cobra.Command {
+	return &cobra.Command{
+		Use: "synth",
+		Short: fmt.Sprintf(
+			"Write IaC for your project to disk, allowing you to manage it by hand. %s", output.WithWarningFormat("(Beta)")),
+	}
+}
+
+type infraSynthAction struct {
+	projectConfig *project.ProjectConfig
+	importManager *project.ImportManager
+	console       input.Console
+	azdCtx        *azdcontext.AzdContext
+	flags         *infraSynthFlags
+	alphaManager  *alpha.FeatureManager
+}
+
+func newInfraSynthAction(
+	projectConfig *project.ProjectConfig,
+	importManager *project.ImportManager,
+	flags *infraSynthFlags,
+	console input.Console,
+	azdCtx *azdcontext.AzdContext,
+	alphaManager *alpha.FeatureManager,
+) actions.Action {
+	return &infraSynthAction{
+		projectConfig: projectConfig,
+		importManager: importManager,
+		flags:         flags,
+		console:       console,
+		azdCtx:        azdCtx,
+		alphaManager:  alphaManager,
+	}
+}
+
+var infraSynthFeature = alpha.MustFeatureKey("infraSynth")
+
+func (a *infraSynthAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	if !a.alphaManager.IsEnabled(infraSynthFeature) {
+		return nil, fmt.Errorf(
+			"infrastructure synthesis is currently under alpha support and must be explicitly enabled."+
+				" Run `%s` to enable this feature.", alpha.GetEnableCommand(infraSynthFeature),
+		)
+	}
+
+	a.console.WarnForFeature(ctx, infraSynthFeature)
+
+	spinnerMessage := "Synthesizing infrastructure"
+
+	a.console.ShowSpinner(ctx, spinnerMessage, input.Step)
+	synthFS, err := a.importManager.SynthAllInfrastructure(ctx, a.projectConfig)
+	if err != nil {
+		a.console.StopSpinner(ctx, spinnerMessage, input.StepFailed)
+		return nil, err
+	}
+	a.console.StopSpinner(ctx, spinnerMessage, input.StepDone)
+
+	staging, err := os.MkdirTemp("", "infra-synth")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(staging)
+
+	err = fs.WalkDir(synthFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		contents, err := fs.ReadFile(synthFS, path)
+		if err != nil {
+			return err
+		}
+
+		err = os.MkdirAll(filepath.Join(staging, filepath.Dir(path)), osutil.PermissionDirectoryOwnerOnly)
+		if err != nil {
+			return err
+		}
+
+		return os.WriteFile(filepath.Join(staging, path), contents, d.Type().Perm())
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	options := copy.Options{}
+
+	if a.flags.force {
+		options.Skip = func(fileInfo os.FileInfo, src, dest string) (bool, error) {
+			return false, nil
+		}
+
+	} else {
+		skipStagingFiles, err := a.promptForDuplicates(ctx, staging, a.azdCtx.ProjectDirectory())
+		if err != nil {
+			return nil, err
+		}
+
+		if skipStagingFiles != nil {
+			options.Skip = func(fileInfo os.FileInfo, src, dest string) (bool, error) {
+				_, skip := skipStagingFiles[src]
+				return skip, nil
+			}
+		}
+	}
+
+	if err := copy.Copy(staging, a.azdCtx.ProjectDirectory(), options); err != nil {
+		return nil, fmt.Errorf("copying contents from temp staging directory: %w", err)
+	}
+
+	return nil, nil
+}
+
+func (a *infraSynthAction) promptForDuplicates(
+	ctx context.Context, staging string, target string) (skipSourceFiles map[string]struct{}, err error) {
+	log.Printf(
+		"infrastructure synth, checking for duplicates. source: %s target: %s",
+		staging,
+		target,
+	)
+
+	duplicateFiles, err := determineDuplicates(staging, target)
+	if err != nil {
+		return nil, fmt.Errorf("checking for overwrites: %w", err)
+	}
+
+	if len(duplicateFiles) > 0 {
+		a.console.StopSpinner(ctx, "", input.StepDone)
+		a.console.MessageUxItem(ctx, &ux.WarningMessage{
+			Description: "The following files would be overwritten by synthesized versions:",
+		})
+
+		for _, file := range duplicateFiles {
+			a.console.Message(ctx, fmt.Sprintf(" * %s", file))
+		}
+
+		selection, err := a.console.Select(ctx, input.ConsoleOptions{
+			Message: "What would you like to do with these files?",
+			Options: []string{
+				"Overwrite with the synthesized versions",
+				"Keep my existing files unchanged",
+			},
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("prompting to overwrite: %w", err)
+		}
+
+		switch selection {
+		case 0: // overwrite
+			return nil, nil
+		case 1: // keep
+			skipSourceFiles = make(map[string]struct{}, len(duplicateFiles))
+			for _, file := range duplicateFiles {
+				// this also cleans the result, which is important for matching
+				sourceFile := filepath.Join(staging, file)
+				skipSourceFiles[sourceFile] = struct{}{}
+			}
+			return skipSourceFiles, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// Returns files that are both present in source and target.
+// The files returned are expressed in their relative paths to source/target.
+func determineDuplicates(source string, target string) ([]string, error) {
+	var duplicateFiles []string
+	if err := filepath.WalkDir(source, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		partial, err := filepath.Rel(source, path)
+		if err != nil {
+			return fmt.Errorf("computing relative path: %w", err)
+		}
+
+		if _, err := os.Stat(filepath.Join(target, partial)); err == nil {
+			duplicateFiles = append(duplicateFiles, partial)
+		}
+
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("enumerating template files: %w", err)
+	}
+	return duplicateFiles, nil
+}

--- a/cli/azd/cmd/middleware/hooks_test.go
+++ b/cli/azd/cmd/middleware/hooks_test.go
@@ -344,7 +344,7 @@ func runMiddleware(
 		lazyEnvManager,
 		lazyEnv,
 		lazyProjectConfig,
-		project.NewImportManager(),
+		project.NewImportManager(nil),
 		mockContext.CommandRunner,
 		mockContext.Console,
 		runOptions,

--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -12,23 +12,28 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
 	"github.com/bmatcuk/doublestar/v4"
 )
 
 type Language string
 
 const (
-	DotNet     Language = "dotnet"
-	Java       Language = "java"
-	JavaScript Language = "js"
-	TypeScript Language = "ts"
-	Python     Language = "python"
+	DotNet        Language = "dotnet"
+	DotNetAppHost Language = "dotnet-apphost"
+	Java          Language = "java"
+	JavaScript    Language = "js"
+	TypeScript    Language = "ts"
+	Python        Language = "python"
 )
 
 func (pt Language) Display() string {
 	switch pt {
 	case DotNet:
 		return ".NET"
+	case DotNetAppHost:
+		return ".NET (Aspire)"
 	case Java:
 		return "Java"
 	case JavaScript:
@@ -166,6 +171,10 @@ var allDetectors = []projectDetector{
 	// Order here determines precedence when two projects are in the same directory.
 	// This is unlikely to occur in practice, but reordering could help to break the tie in these cases.
 	&javaDetector{},
+	&dotNetAppHostDetector{
+		// TODO(ellismg): Remove ambient authority.
+		dotnetCli: dotnet.NewDotNetCli(exec.NewCommandRunner(nil)),
+	},
 	&dotNetDetector{},
 	&pythonDetector{},
 	&javaScriptDetector{},

--- a/cli/azd/internal/appdetect/dotnet_apphost.go
+++ b/cli/azd/internal/appdetect/dotnet_apphost.go
@@ -1,0 +1,53 @@
+package appdetect
+
+import (
+	"context"
+	"io/fs"
+	"log"
+	"path/filepath"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
+)
+
+type dotNetAppHostDetector struct {
+	dotnetCli dotnet.DotNetCli
+}
+
+func (ad *dotNetAppHostDetector) Language() Language {
+	return DotNetAppHost
+}
+
+func (ad *dotNetAppHostDetector) DetectProject(ctx context.Context, path string, entries []fs.DirEntry) (*Project, error) {
+	for _, entry := range entries {
+		name := entry.Name()
+		ext := filepath.Ext(name)
+
+		switch ext {
+		case ".csproj", ".fsproj", ".vbproj":
+			projectPath := filepath.Join(path, name)
+			if isAppHost, err := ad.isAppHostProject(ctx, filepath.Join(projectPath)); err != nil {
+				log.Printf("error checking if %s is an app host project: %v", projectPath, err)
+			} else if isAppHost {
+				return &Project{
+					Language:      DotNetAppHost,
+					Path:          projectPath,
+					DetectionRule: "Inferred by presence of: " + projectPath,
+				}, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+// isAppHostProject returns true if the project at the given path has an MS Build Property named "IsAspireHost" which is
+// set to "true".
+func (ad *dotNetAppHostDetector) isAppHostProject(ctx context.Context, projectPath string) (bool, error) {
+	value, err := ad.dotnetCli.GetMsBuildProperty(ctx, projectPath, "IsAspireHost")
+	if err != nil {
+		return false, err
+	}
+
+	return strings.TrimSpace(value) == "true", nil
+}

--- a/cli/azd/internal/repository/detect_confirm_apphost.go
+++ b/cli/azd/internal/repository/detect_confirm_apphost.go
@@ -1,0 +1,84 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/azure/azure-dev/cli/azd/internal/appdetect"
+	"github.com/azure/azure-dev/cli/azd/internal/tracing"
+	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/fatih/color"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// detectConfirmAppHost handles prompting for confirming the detected project with an app host.
+type detectConfirmAppHost struct {
+	// The app host we found
+	AppHost appdetect.Project
+
+	// the root directory of the project
+	root string
+
+	// internal state and components
+	console input.Console
+}
+
+// Init initializes state from initial detection output
+func (d *detectConfirmAppHost) Init(appHost appdetect.Project, root string) {
+	d.AppHost = appHost
+
+	d.captureUsage(
+		fields.AppInitDetectedServices)
+}
+
+func (d *detectConfirmAppHost) captureUsage(
+	services attribute.Key) {
+
+	tracing.SetUsageAttributes(
+		services.StringSlice([]string{string(d.AppHost.Language)}),
+	)
+}
+
+// Confirm prompts the user to confirm the detected services and databases,
+// providing modifications to the detected services and databases.
+func (d *detectConfirmAppHost) Confirm(ctx context.Context) error {
+	for {
+		if err := d.render(ctx); err != nil {
+			return err
+		}
+
+		continueOption, err := d.console.Select(ctx, input.ConsoleOptions{
+			Message: "Select an option",
+			Options: []string{
+				"Confirm and continue initializing my app",
+				"Cancel and exit",
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		switch continueOption {
+		case 0:
+			d.captureUsage(
+				fields.AppInitConfirmedServices)
+			return nil
+		case 1:
+			return fmt.Errorf("cancelled due to user input")
+		}
+	}
+}
+
+func (d *detectConfirmAppHost) render(ctx context.Context) error {
+	d.console.Message(ctx, "\n"+output.WithBold("Detected services:")+"\n")
+
+	d.console.Message(ctx, "  "+color.BlueString(projectDisplayName(d.AppHost)))
+	d.console.Message(ctx, "  "+"Detected in: "+output.WithHighLightFormat(relSafe(d.root, d.AppHost.Path)))
+	d.console.Message(ctx, "")
+	d.console.Message(ctx,
+		"azd will generate the files necessary to host your app on Azure using "+color.MagentaString("Azure Container Apps")+".\n")
+
+	return nil
+}

--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -12,14 +12,17 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/bicep"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/pkg/templates"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/git"
 	"github.com/azure/azure-dev/cli/azd/resources"
 	"github.com/otiai10/copy"
@@ -27,16 +30,23 @@ import (
 
 // Initializer handles the initialization of a local repository.
 type Initializer struct {
-	console input.Console
-	gitCli  git.GitCli
+	console        input.Console
+	gitCli         git.GitCli
+	dotnetCli      dotnet.DotNetCli
+	lazyEnvManager *lazy.Lazy[environment.Manager]
 }
 
 func NewInitializer(
 	console input.Console,
-	gitCli git.GitCli) *Initializer {
+	gitCli git.GitCli,
+	dotnetCli dotnet.DotNetCli,
+	lazyEnvManager *lazy.Lazy[environment.Manager],
+) *Initializer {
 	return &Initializer{
-		console: console,
-		gitCli:  gitCli,
+		console:        console,
+		gitCli:         gitCli,
+		lazyEnvManager: lazyEnvManager,
+		dotnetCli:      dotnetCli,
 	}
 }
 

--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -1,0 +1,600 @@
+package apphost
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/template"
+
+	"github.com/azure/azure-dev/cli/azd/internal/scaffold"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/resources"
+	"github.com/psanford/memfs"
+)
+
+// genTemplates is the collection of templates that are used when generating infrastructure files from a manifest.
+var genTemplates *template.Template
+
+func init() {
+	tmpl, err := template.New("templates").
+		Option("missingkey=error").
+		Funcs(
+			template.FuncMap{
+				"bicepName":        scaffold.BicepName,
+				"alphaSnakeUpper":  scaffold.AlphaSnakeUpper,
+				"containerAppName": scaffold.ContainerAppName,
+			},
+		).
+		ParseFS(resources.AppHostTemplates, "apphost/templates/*")
+	if err != nil {
+		panic("failed to parse generator templates: " + err.Error())
+	}
+
+	genTemplates = tmpl
+}
+
+type ContentsAndMode struct {
+	Contents string
+	Mode     fs.FileMode
+}
+
+// ProjectPaths returns a map of project names to their paths.
+func ProjectPaths(manifest *Manifest) map[string]string {
+	res := make(map[string]string)
+
+	for name, comp := range manifest.Resources {
+		switch comp.Type {
+		case "project.v0":
+			res[name] = *comp.Path
+		}
+	}
+
+	return res
+}
+
+// ContainerAppManifestTemplateForProject returns the container app manifest template for a given project.
+// It can be used (after evaluation) to deploy the service to a container app environment.
+func ContainerAppManifestTemplateForProject(manifest *Manifest, projectName string) (string, error) {
+	generator := newInfraGenerator()
+
+	if err := generator.LoadManifest(manifest); err != nil {
+		return "", err
+	}
+
+	if err := generator.Compile(); err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+
+	err := genTemplates.ExecuteTemplate(&buf, "containerApp.tmpl.yaml", generator.containerAppTemplateContexts[projectName])
+	if err != nil {
+		return "", fmt.Errorf("executing template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// BicepTemplate returns a filesystem containing the generated bicep files for the given manifest. These files represent
+// the shared infrastructure that would normally be under the `infra/` folder for the given manifest.
+func BicepTemplate(manifest *Manifest) (fs.FS, error) {
+	generator := newInfraGenerator()
+
+	if err := generator.LoadManifest(manifest); err != nil {
+		return nil, err
+	}
+
+	if err := generator.Compile(); err != nil {
+		return nil, err
+	}
+
+	fs := memfs.New()
+
+	if err := executeToFS(fs, genTemplates, "main.bicep", "main.bicep", generator.bicepContext); err != nil {
+		return nil, fmt.Errorf("generating infra/main.bicep: %w", err)
+	}
+
+	if err := executeToFS(fs, genTemplates, "resources.bicep", "resources.bicep", generator.bicepContext); err != nil {
+		return nil, fmt.Errorf("generating infra/resources.bicep: %w", err)
+	}
+
+	if err := executeToFS(fs, genTemplates, "main.parameters.json", "main.parameters.json", nil); err != nil {
+		return nil, fmt.Errorf("generating infra/resources.bicep: %w", err)
+	}
+
+	return fs, nil
+}
+
+// GenerateProjectArtifacts generates all the artifacts to manage a project with `azd`. Te azure.yaml file as well as
+// a helpful next-steps.md file.
+func GenerateProjectArtifacts(
+	ctx context.Context, projectDir string, projectName string, manifest *Manifest, appHostProject string,
+) (map[string]ContentsAndMode, error) {
+	appHostRel, err := filepath.Rel(projectDir, appHostProject)
+	if err != nil {
+		return nil, err
+	}
+
+	generator := newInfraGenerator()
+
+	if err := generator.LoadManifest(manifest); err != nil {
+		return nil, err
+	}
+
+	if err := generator.Compile(); err != nil {
+		return nil, err
+	}
+
+	generatedFS := memfs.New()
+
+	projectFileContext := genProjectFileContext{
+		Name: projectName,
+		Services: map[string]string{
+			"app": fmt.Sprintf(".%s%s", string(filepath.Separator), appHostRel),
+		},
+	}
+
+	if err := executeToFS(generatedFS, genTemplates, "azure.yaml", "azure.yaml", projectFileContext); err != nil {
+		return nil, fmt.Errorf("generating azure.yaml: %w", err)
+	}
+
+	if err := executeToFS(generatedFS, genTemplates, "next-steps.md", "next-steps.md", nil); err != nil {
+		return nil, fmt.Errorf("generating next-steps.md: %w", err)
+	}
+
+	files := make(map[string]ContentsAndMode)
+
+	err = fs.WalkDir(generatedFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		contents, err := fs.ReadFile(generatedFS, path)
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		files[path] = ContentsAndMode{
+			Contents: string(contents),
+			Mode:     info.Mode(),
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}
+
+type infraGenerator struct {
+	containers        map[string]genContainer
+	projects          map[string]genProject
+	connectionStrings map[string]string
+	resourceTypes     map[string]string
+
+	bicepContext                 genBicepTemplateContext
+	containerAppTemplateContexts map[string]genContainerAppManifestTemplateContext
+}
+
+func newInfraGenerator() *infraGenerator {
+	return &infraGenerator{
+		bicepContext: genBicepTemplateContext{
+			AppInsights:                     make(map[string]genAppInsight),
+			ContainerAppEnvironmentServices: make(map[string]genContainerAppEnvironmentServices),
+			ServiceBuses:                    make(map[string]genServiceBus),
+			StorageAccounts:                 make(map[string]genStorageAccount),
+			KeyVaults:                       make(map[string]genKeyVault),
+			ContainerApps:                   make(map[string]genContainerApp),
+		},
+		containers:                   make(map[string]genContainer),
+		projects:                     make(map[string]genProject),
+		connectionStrings:            make(map[string]string),
+		resourceTypes:                make(map[string]string),
+		containerAppTemplateContexts: make(map[string]genContainerAppManifestTemplateContext),
+	}
+}
+
+// LoadManifest loads the given manifest into the generator. It should be called before [Compile].
+func (b *infraGenerator) LoadManifest(m *Manifest) error {
+	for name, comp := range m.Resources {
+		b.resourceTypes[name] = comp.Type
+
+		switch comp.Type {
+		case "azure.servicebus.v0":
+			b.addServiceBus(name, comp.Queues, comp.Topics)
+		case "azure.appinsights.v0":
+			b.addAppInsights(name)
+		case "project.v0":
+			b.addProject(name, *comp.Path, comp.Env, comp.Bindings)
+		case "container.v0":
+			b.addContainer(name, *comp.Image, comp.Env, comp.Bindings)
+		case "redis.v0":
+			b.addContainerAppService(name, "redis")
+		case "azure.keyvault.v0":
+			b.addKeyVault(name)
+		case "azure.storage.v0":
+			b.addStorageAccount(name)
+		case "azure.storage.blob.v0":
+			b.addStorageBlobContainer(*comp.Parent, name)
+		case "postgres.server.v0":
+			// We currently use a ACA Postgres Service per database. Because of this, we don't need to retain any
+			// information from the server resource.
+			//
+			// We have the case statement here to ensure we don't error out on the resource type by treating it as an unknown
+			// resource type.
+		case "postgres.database.v0":
+			b.addContainerAppService(name, "postgres")
+		case "postgres.connection.v0":
+			b.connectionStrings[name] = *comp.ConnectionString
+		case "rabbitmq.connection.v0":
+			b.connectionStrings[name] = *comp.ConnectionString
+		case "azure.cosmosdb.connection.v0":
+			b.connectionStrings[name] = *comp.ConnectionString
+		default:
+			ignore, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES"))
+			if err == nil && ignore {
+				log.Printf(
+					"ignoring resource of type %s since AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES is set",
+					comp.Type)
+				continue
+			}
+			return fmt.Errorf("unsupported resource type: %s", comp.Type)
+		}
+	}
+
+	return nil
+}
+
+func (b *infraGenerator) requireCluster() {
+	b.bicepContext.HasContainerEnvironment = true
+}
+
+func (b *infraGenerator) requireContainerRegistry() {
+	b.requireLogAnalyticsWorkspace()
+	b.bicepContext.HasContainerRegistry = true
+}
+
+func (b *infraGenerator) requireLogAnalyticsWorkspace() {
+	b.bicepContext.HasLogAnalyticsWorkspace = true
+}
+
+func (b *infraGenerator) addServiceBus(name string, queues, topics *[]string) {
+	if queues == nil {
+		queues = &[]string{}
+	}
+
+	if topics == nil {
+		topics = &[]string{}
+	}
+	b.bicepContext.ServiceBuses[name] = genServiceBus{Queues: *queues, Topics: *topics}
+}
+
+func (b *infraGenerator) addAppInsights(name string) {
+	b.requireLogAnalyticsWorkspace()
+	b.bicepContext.AppInsights[name] = genAppInsight{}
+}
+
+func (b *infraGenerator) addProject(
+	name string, path string, env map[string]string, bindings map[string]*Binding,
+) {
+	b.requireCluster()
+	b.requireContainerRegistry()
+
+	b.projects[name] = genProject{
+		Path:     path,
+		Env:      env,
+		Bindings: bindings,
+	}
+}
+
+func (b *infraGenerator) addContainerAppService(name string, serviceType string) {
+	b.requireCluster()
+
+	b.bicepContext.ContainerAppEnvironmentServices[name] = genContainerAppEnvironmentServices{
+		Type: serviceType,
+	}
+}
+
+func (b *infraGenerator) addStorageAccount(name string) {
+	b.bicepContext.StorageAccounts[name] = genStorageAccount{}
+}
+
+func (b *infraGenerator) addKeyVault(name string) {
+	b.bicepContext.KeyVaults[name] = genKeyVault{}
+}
+
+func (b *infraGenerator) addStorageBlobContainer(storageAccount, containerName string) {
+	// TODO(ellismg): We have to handle the case where we may visit the blob resource before the storage account resource.
+	// But this implementation means that if the parent storage account is not in the manifest, we will not detect that
+	// as an error.  We probably should.
+
+	account := b.bicepContext.StorageAccounts[storageAccount]
+	account.Containers = append(account.Containers, containerName)
+	b.bicepContext.StorageAccounts[storageAccount] = account
+}
+
+func (b *infraGenerator) addContainer(name string, image string, env map[string]string, bindings map[string]*Binding) {
+	b.requireCluster()
+
+	b.containers[name] = genContainer{
+		Image:    image,
+		Env:      env,
+		Bindings: bindings,
+	}
+}
+
+func validateAndMergeBindings(bindings map[string]*Binding) (*Binding, error) {
+	if len(bindings) == 0 {
+		return nil, nil
+	}
+
+	if len(bindings) == 1 {
+		for _, binding := range bindings {
+			return binding, nil
+		}
+	}
+
+	var validatedBinding *Binding
+
+	for _, binding := range bindings {
+		if validatedBinding == nil {
+			validatedBinding = binding
+			continue
+		}
+
+		if validatedBinding.External != binding.External {
+			return nil, fmt.Errorf("the external property of all bindings should match")
+		}
+
+		if validatedBinding.Transport != binding.Transport {
+			return nil, fmt.Errorf("the transport property of all bindings should match")
+		}
+
+		if validatedBinding.Protocol != binding.Protocol {
+			return nil, fmt.Errorf("the protocol property of all bindings should match")
+		}
+
+		if validatedBinding.Protocol != binding.Protocol {
+			return nil, fmt.Errorf("the protocol property of all bindings should match")
+		}
+
+		if (validatedBinding.ContainerPort == nil && binding.ContainerPort != nil) ||
+			(validatedBinding.ContainerPort != nil && binding.ContainerPort == nil) {
+			return nil, fmt.Errorf("the container port property of all bindings should match")
+		}
+
+		if validatedBinding.ContainerPort != nil && binding.ContainerPort != nil &&
+			*validatedBinding.ContainerPort != *binding.ContainerPort {
+			return nil, fmt.Errorf("the container port property of all bindings should match")
+		}
+	}
+
+	return validatedBinding, nil
+}
+
+// Compile compiles the loaded manifest into the internal representation used to generate the infrastructure files. Once
+// called the context objects on the infraGenerator can be passed to the text templates to generate the required
+// infrastructure.
+func (b *infraGenerator) Compile() error {
+	for name, container := range b.containers {
+		binding, err := validateAndMergeBindings(container.Bindings)
+		if err != nil {
+			return fmt.Errorf("validating binding for %s resource: %w", name, err)
+		}
+
+		cs := genContainerApp{
+			Image: container.Image,
+		}
+
+		if binding != nil {
+			cs.Ingress = &genContainerServiceIngress{
+				External:      binding.External,
+				TargetPort:    *binding.ContainerPort,
+				Transport:     binding.Transport,
+				AllowInsecure: strings.ToLower(binding.Transport) == "http2",
+			}
+		}
+
+		b.bicepContext.ContainerApps[name] = cs
+	}
+
+	for projectName, project := range b.projects {
+		projectTemplateCtx := genContainerAppManifestTemplateContext{
+			Name: projectName,
+			Env:  make(map[string]string),
+		}
+
+		binding, err := validateAndMergeBindings(project.Bindings)
+		if err != nil {
+			return fmt.Errorf("configuring ingress for project %s: %w", projectName, err)
+		}
+
+		if binding != nil {
+			projectTemplateCtx.Ingress = &genContainerAppManifestTemplateContextIngress{
+				External:  binding.External,
+				Transport: binding.Transport,
+
+				// TODO(ellismg): We need to inspect the target container and determine this from the exposed ports (or ask
+				// MSBuild to tell us this value when it builds the container image). For now we just assume 8080.
+				//
+				// We can get this by running `dotnet publish` and using the `--getProperty:GeneratedContainerConfiguration`
+				// flag to get the generated docker configuration.  That's a JSON object, from that we pluck off
+				// Config.ExposedPorts, which is an object that would look like:
+				//
+				// {
+				//    "8080/tcp": {}
+				// }
+				//
+				// Note that the protocol type is apparently optional.
+				TargetPort:    8080,
+				AllowInsecure: strings.ToLower(binding.Transport) == "http2",
+			}
+		}
+
+		for k, v := range project.Env {
+			if !strings.HasPrefix(v, "{") || !strings.HasSuffix(v, "}") {
+				// We want to ensure that we render these values in the YAML as strings.  If `v` was the string "false"
+				// (without the quotes), we would naturally create a value directive in yaml that looks like this:
+				//
+				// - name: OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES
+				//   value: true
+				//
+				// And YAML rules would treat the above as the value being a boolean instead of a string, which the container
+				// app service expects.
+				//
+				// JSON marshalling the string value will give us something like `"true"` (with the quotes, and any escaping
+				// that needs to be done), which is what we want here.
+				jsonStr, err := json.Marshal(v)
+				if err != nil {
+					return fmt.Errorf("marshalling env value: %w", err)
+				}
+
+				projectTemplateCtx.Env[k] = string(jsonStr)
+				continue
+			}
+
+			parts := strings.SplitN(v[1:len(v)-1], ".", 2)
+			if len(parts) != 2 {
+				return fmt.Errorf("malformed binding expression, expected <resourceName>.<propertyPath> but was: %s", v)
+			}
+
+			resource, prop := parts[0], parts[1]
+			targetType, ok := b.resourceTypes[resource]
+			if !ok {
+				return fmt.Errorf("unknown resource referenced in binding expression: %s", resource)
+			}
+
+			switch {
+			case targetType == "project.v0" || targetType == "container.v0":
+				if !strings.HasPrefix(prop, "bindings.") {
+					return fmt.Errorf("unsupported property referenced in binding expression: %s for %s", prop, targetType)
+				}
+
+				parts := strings.Split(prop[len("bindings."):], ".")
+				if len(parts) != 2 || parts[1] != "url" {
+					return fmt.Errorf("malformed binding expression, expected bindings.<binding-name>.url but was: %s", v)
+				}
+
+				var binding *Binding
+				var has bool
+
+				if targetType == "project.v0" {
+					binding, has = b.projects[resource].Bindings[parts[0]]
+				} else if targetType == "container.v0" {
+					binding, has = b.containers[resource].Bindings[parts[0]]
+				}
+
+				if !has {
+					return fmt.Errorf(
+						"unknown binding referenced in binding expression: %s for resource %s", parts[0], resource)
+				}
+
+				if binding.External {
+					projectTemplateCtx.Env[k] = fmt.Sprintf(
+						"%s://%s.{{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN }}", binding.Scheme, resource)
+				} else {
+					projectTemplateCtx.Env[k] = fmt.Sprintf(
+						"%s://%s.internal.{{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN }}", binding.Scheme, resource)
+				}
+			case targetType == "postgres.database.v0" || targetType == "redis.v0":
+				switch prop {
+				case "connectionString":
+					projectTemplateCtx.Env[k] = fmt.Sprintf(`{{ connectionString "%s" }}`, resource)
+				default:
+					return errUnsupportedProperty(targetType, prop)
+				}
+			case targetType == "azure.servicebus.v0":
+				switch prop {
+				case "connectionString":
+					projectTemplateCtx.Env[k] = fmt.Sprintf(
+						"{{ urlHost .Env.SERVICE_BINDING_%s_ENDPOINT }}", scaffold.AlphaSnakeUpper(resource))
+				default:
+					return errUnsupportedProperty("azure.servicebus.v0", prop)
+				}
+			case targetType == "azure.appinsights.v0":
+				switch prop {
+				case "connectionString":
+					projectTemplateCtx.Env[k] = fmt.Sprintf(
+						"{{ .Env.SERVICE_BINDING_%s_CONNECTION_STRING }}", scaffold.AlphaSnakeUpper(resource))
+				default:
+					return errUnsupportedProperty("azure.appinsights.v0", prop)
+				}
+			case targetType == "azure.cosmosdb.connection.v0" ||
+				targetType == "postgres.connection.v0" ||
+				targetType == "rabbitmq.connection.v0":
+
+				switch prop {
+				case "connectionString":
+					projectTemplateCtx.Env[k] = b.connectionStrings[resource]
+				default:
+					return errUnsupportedProperty(targetType, prop)
+				}
+			case targetType == "azure.keyvault.v0" || targetType == "azure.storage.blob.v0":
+				switch prop {
+				case "connectionString":
+					projectTemplateCtx.Env[k] = fmt.Sprintf(
+						"{{ .Env.SERVICE_BINDING_%s_ENDPOINT }}", scaffold.AlphaSnakeUpper(resource))
+				default:
+					return errUnsupportedProperty(targetType, prop)
+				}
+			default:
+				ignore, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES"))
+				if err == nil && ignore {
+					log.Printf("ignoring binding reference to resource of type %s since "+
+						"AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES is set", targetType)
+
+					projectTemplateCtx.Env[k] = fmt.Sprintf(
+						"!!! expression '%s' to type '%s' unsupported by azd !!!", v, targetType)
+					continue
+				}
+
+				return fmt.Errorf("unsupported resource type %s referenced in binding expression", targetType)
+			}
+		}
+
+		b.containerAppTemplateContexts[projectName] = projectTemplateCtx
+	}
+
+	return nil
+}
+
+// errUnsupportedProperty returns an error indicating that the given property is not supported for the given resource.
+func errUnsupportedProperty(resourceType, propertyName string) error {
+	return fmt.Errorf("unsupported property referenced in binding expression: %s for %s", propertyName, resourceType)
+}
+
+// executeToFS executes the given template with the given name and context, and writes the result to the given path in
+// the given target filesystem.
+func executeToFS(targetFS *memfs.FS, tmpl *template.Template, name string, path string, context any) error {
+	buf := bytes.NewBufferString("")
+	if err := tmpl.ExecuteTemplate(buf, name, context); err != nil {
+		return fmt.Errorf("executing template: %w", err)
+	}
+
+	if err := targetFS.MkdirAll(filepath.Dir(path), osutil.PermissionDirectory); err != nil {
+		return fmt.Errorf("creating directory: %w", err)
+	}
+
+	if err := targetFS.WriteFile(path, buf.Bytes(), osutil.PermissionFile); err != nil {
+		return fmt.Errorf("writing file: %w", err)
+	}
+
+	return nil
+}

--- a/cli/azd/pkg/apphost/generate_types.go
+++ b/cli/azd/pkg/apphost/generate_types.go
@@ -1,0 +1,72 @@
+package apphost
+
+type genAppInsight struct{}
+
+type genStorageAccount struct {
+	Containers []string
+}
+
+type genServiceBus struct {
+	Queues []string
+	Topics []string
+}
+
+type genContainerAppEnvironmentServices struct {
+	Type string
+}
+
+type genKeyVault struct{}
+
+type genContainerApp struct {
+	Image   string
+	Ingress *genContainerServiceIngress
+}
+
+type genContainerServiceIngress struct {
+	External      bool
+	TargetPort    int
+	Transport     string
+	AllowInsecure bool
+}
+
+type genContainer struct {
+	Image    string
+	Env      map[string]string
+	Bindings map[string]*Binding
+}
+
+type genProject struct {
+	Path     string
+	Env      map[string]string
+	Bindings map[string]*Binding
+}
+
+type genBicepTemplateContext struct {
+	HasContainerRegistry            bool
+	HasContainerEnvironment         bool
+	HasLogAnalyticsWorkspace        bool
+	AppInsights                     map[string]genAppInsight
+	ServiceBuses                    map[string]genServiceBus
+	StorageAccounts                 map[string]genStorageAccount
+	KeyVaults                       map[string]genKeyVault
+	ContainerAppEnvironmentServices map[string]genContainerAppEnvironmentServices
+	ContainerApps                   map[string]genContainerApp
+}
+
+type genContainerAppManifestTemplateContext struct {
+	Name    string
+	Ingress *genContainerAppManifestTemplateContextIngress
+	Env     map[string]string
+}
+
+type genProjectFileContext struct {
+	Name     string
+	Services map[string]string
+}
+
+type genContainerAppManifestTemplateContextIngress struct {
+	External      bool
+	Transport     string
+	TargetPort    int
+	AllowInsecure bool
+}

--- a/cli/azd/pkg/apphost/manifest.go
+++ b/cli/azd/pkg/apphost/manifest.go
@@ -1,0 +1,108 @@
+package apphost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
+)
+
+type Manifest struct {
+	Schema    string               `json:"$schema"`
+	Resources map[string]*Resource `json:"resources"`
+}
+
+type Resource struct {
+	// Type is present on all resource types
+	Type string `json:"type"`
+
+	// Path is present on a project.v0 resource and is the full path to the project file.
+	Path *string `json:"path,omitempty"`
+
+	// Parent is present on a resource which is a child of another. It is the name of the parent resource. For example, a
+	// postgres.database.v0 is a child of a postgres.server.v0, and so it would have a parent of which is the name of
+	// the server resource.
+	Parent *string `json:"parent,omitempty"`
+
+	// Image is present on a container.v0 resource and is the image to use for the container.
+	Image *string `json:"image,omitempty"`
+
+	// Bindings is present on container.v0 and project.v0 resources, and is a map of binding names to binding details.
+	Bindings map[string]*Binding `json:"bindings,omitempty"`
+
+	// Env is present on a project.v0 and container.v0 resource, and is a map of environment variable names to value
+	// expressions. The value expressions are simple expressions like "{redis.connectionString}" or "{postgres.port}" to
+	// allow referencing properties of other resources. The set of properties supported in these expressions
+	// depends on the type of resource you are referencing.
+	Env map[string]string `json:"env,omitempty"`
+
+	// Queues is optionally present on a azure.servicebus.v0 resource, and is a list of queue names to create.
+	Queues *[]string `json:"queues,omitempty"`
+
+	// Topics is optionally present on a azure.servicebus.v0 resource, and is a list of topic names to create.
+	Topics *[]string `json:"topics,omitempty"`
+
+	// Some resources just represent connections to existing resources that need not be provisioned.  These resources have
+	// a "connectionString" property which is the connection string that should be used during binding.
+	ConnectionString *string `json:"connectionString,omitempty"`
+}
+
+type Reference struct {
+	Bindings []string `json:"bindings,omitempty"`
+}
+
+type Binding struct {
+	ContainerPort *int   `json:"containerPort,omitempty"`
+	Scheme        string `json:"scheme"`
+	Protocol      string `json:"protocol"`
+	Transport     string `json:"transport"`
+	External      bool   `json:"external"`
+}
+
+// ManifestFromAppHost returns the Manifest from the given app host.
+func ManifestFromAppHost(ctx context.Context, appHostProject string, dotnetCli dotnet.DotNetCli) (*Manifest, error) {
+	tempDir, err := os.MkdirTemp("", "azd-provision")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp directory for apphost-manifest.json: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	manifestPath := filepath.Join(tempDir, "apphost-manifest.json")
+
+	if err := dotnetCli.PublishAppHostManifest(ctx, appHostProject, manifestPath); err != nil {
+		return nil, fmt.Errorf("generating app host manifest: %w", err)
+	}
+
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var manifest Manifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		return nil, fmt.Errorf("unmarshalling manifest: %w", err)
+	}
+
+	// Make all paths absolute, to simplify logic for consumers.
+	manifestDir := filepath.Dir(manifestPath)
+
+	// The manifest writer writes paths relative to the manifest file. When we use a fixed manifest, the manifest is
+	// located SxS with the appHostProject.
+	if enabled, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_DOTNET_APPHOST_USE_FIXED_MANIFEST")); err == nil && enabled {
+		manifestDir = filepath.Dir(appHostProject)
+	}
+
+	for _, res := range manifest.Resources {
+		if res.Path != nil {
+			if !filepath.IsAbs(*res.Path) {
+				*res.Path = filepath.Join(manifestDir, *res.Path)
+			}
+		}
+	}
+
+	return &manifest, nil
+}

--- a/cli/azd/pkg/apphost/service_ingress_configurer.go
+++ b/cli/azd/pkg/apphost/service_ingress_configurer.go
@@ -1,0 +1,48 @@
+package apphost
+
+import (
+	"context"
+	"slices"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+)
+
+type IngressSelector struct {
+	manifest *Manifest
+	console  input.Console
+}
+
+func NewIngressSelector(manifest *Manifest, console input.Console) *IngressSelector {
+	return &IngressSelector{
+		manifest: manifest,
+		console:  console,
+	}
+}
+
+func (adc *IngressSelector) SelectPublicServices(ctx context.Context) ([]string, error) {
+	var services []string
+	for name, res := range adc.manifest.Resources {
+		if (res.Type == "container.v0" || res.Type == "project.v0") && len(res.Bindings) > 0 {
+			services = append(services, name)
+		}
+	}
+
+	if len(services) == 0 {
+		return nil, nil
+	}
+
+	slices.Sort(services)
+
+	adc.console.Message(ctx, "By default, a service can only be reached from inside the Azure Container Apps environment "+
+		"it is running in. Selecting a service here will also allow it to be reached from the Internet.")
+
+	exposed, err := adc.console.MultiSelect(ctx, input.ConsoleOptions{
+		Message: "Select which services to expose to the Internet",
+		Options: services,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return exposed, nil
+}

--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -39,6 +39,11 @@ type ContainerAppService interface {
 		appName string,
 		imageName string,
 	) error
+	ListSecrets(ctx context.Context,
+		subscriptionId string,
+		resourceGroupName string,
+		appName string,
+	) ([]*armappcontainers.ContainerAppSecret, error)
 }
 
 // NewContainerAppService creates a new ContainerAppService
@@ -186,6 +191,25 @@ func (cas *containerAppService) AddRevision(
 	}
 
 	return nil
+}
+
+func (cas *containerAppService) ListSecrets(
+	ctx context.Context,
+	subscriptionId string,
+	resourceGroupName string,
+	appName string,
+) ([]*armappcontainers.ContainerAppSecret, error) {
+	appClient, err := cas.createContainerAppsClient(ctx, subscriptionId)
+	if err != nil {
+		return nil, err
+	}
+
+	secretsResponse, err := appClient.ListSecrets(ctx, resourceGroupName, appName, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing secrets: %w", err)
+	}
+
+	return secretsResponse.Value, nil
 }
 
 func (cas *containerAppService) syncSecrets(

--- a/cli/azd/pkg/pipeline/pipeline_manager_test.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager_test.go
@@ -443,6 +443,6 @@ func createPipelineManager(
 		mockContext.Console,
 		args,
 		mockContext.Container,
-		project.NewImportManager(),
+		project.NewImportManager(nil),
 	)
 }

--- a/cli/azd/pkg/project/dotnet_importer.go
+++ b/cli/azd/pkg/project/dotnet_importer.go
@@ -1,0 +1,321 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/apphost"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/ext"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
+	"github.com/psanford/memfs"
+)
+
+type hostCheckResult struct {
+	is  bool
+	err error
+}
+
+// DotNetImporter is an importer that is able to import projects and infrastructure from a manifest produced by a .NET App.
+type DotNetImporter struct {
+	dotnetCli      dotnet.DotNetCli
+	console        input.Console
+	lazyEnv        *lazy.Lazy[*environment.Environment]
+	lazyEnvManager *lazy.Lazy[environment.Manager]
+
+	// TODO(ellismg): This cache exists because we end up needing the same manifest multiple times for a single logical
+	// operation and it is expensive to generate. We should consider if this is the correct location for the cache or if
+	// it should be in some higher level component. Right now the lifetime issues are not too large of a deal, since
+	// `azd` processes are short lived.
+	cache   map[string]*apphost.Manifest
+	cacheMu sync.Mutex
+
+	hostCheck   map[string]hostCheckResult
+	hostCheckMu sync.Mutex
+}
+
+func NewDotNetImporter(
+	dotnetCli dotnet.DotNetCli,
+	console input.Console,
+	lazyEnv *lazy.Lazy[*environment.Environment],
+	lazyEnvManager *lazy.Lazy[environment.Manager],
+) *DotNetImporter {
+	return &DotNetImporter{
+		dotnetCli:      dotnetCli,
+		console:        console,
+		lazyEnv:        lazyEnv,
+		lazyEnvManager: lazyEnvManager,
+		cache:          make(map[string]*apphost.Manifest),
+		hostCheck:      make(map[string]hostCheckResult),
+	}
+}
+
+// CanImport returns true when the given project can be imported by this importer. Only some .NET Apps are able
+// to produce the manifest that importer expects.
+func (ai *DotNetImporter) CanImport(ctx context.Context, projectPath string) (bool, error) {
+	ai.hostCheckMu.Lock()
+	defer ai.hostCheckMu.Unlock()
+
+	if v, has := ai.hostCheck[projectPath]; has {
+		return v.is, v.err
+	}
+
+	value, err := ai.dotnetCli.GetMsBuildProperty(ctx, projectPath, "IsAspireHost")
+	if err != nil {
+		ai.hostCheck[projectPath] = hostCheckResult{
+			is:  false,
+			err: err,
+		}
+
+		return false, err
+	}
+
+	ai.hostCheck[projectPath] = hostCheckResult{
+		is:  strings.TrimSpace(value) == "true",
+		err: nil,
+	}
+
+	return strings.TrimSpace(value) == "true", nil
+}
+
+func (ai *DotNetImporter) ProjectInfrastructure(ctx context.Context, svcConfig *ServiceConfig) (*Infra, error) {
+	manifest, err := ai.readManifest(ctx, svcConfig)
+	if err != nil {
+		return nil, fmt.Errorf("generating app host manifest: %w", err)
+	}
+
+	files, err := apphost.BicepTemplate(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("generating bicep from manifest: %w", err)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "azd-infra")
+	if err != nil {
+		return nil, fmt.Errorf("creating temporary directory: %w", err)
+	}
+
+	err = fs.WalkDir(files, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		target := filepath.Join(tmpDir, path)
+		if err := os.MkdirAll(filepath.Dir(target), osutil.PermissionDirectoryOwnerOnly); err != nil {
+			return err
+		}
+
+		contents, err := fs.ReadFile(files, path)
+		if err != nil {
+			return err
+		}
+
+		return os.WriteFile(target, contents, d.Type().Perm())
+	})
+	if err != nil {
+		return nil, fmt.Errorf("writing infrastructure: %w", err)
+	}
+
+	return &Infra{
+		Options: provisioning.Options{
+			Provider: provisioning.Bicep,
+			Path:     tmpDir,
+			Module:   "main",
+		},
+		cleanupDir: tmpDir,
+	}, nil
+}
+
+func (ai *DotNetImporter) Services(
+	ctx context.Context, p *ProjectConfig, svcConfig *ServiceConfig,
+) (map[string]*ServiceConfig, error) {
+	services := make(map[string]*ServiceConfig)
+
+	manifest, err := ai.readManifest(ctx, svcConfig)
+	if err != nil {
+		return nil, fmt.Errorf("generating app host manifest: %w", err)
+	}
+
+	projects := apphost.ProjectPaths(manifest)
+	for name, path := range projects {
+		relPath, err := filepath.Rel(p.Path, path)
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO(ellismg): Some of this code is duplicated from project.Parse, we should centralize this logic long term.
+		svc := &ServiceConfig{
+			RelativePath: relPath,
+			Language:     ServiceLanguageDotNet,
+			Host:         DotNetContainerAppTarget,
+		}
+
+		svc.Name = name
+		svc.Project = p
+		svc.EventDispatcher = ext.NewEventDispatcher[ServiceLifecycleEventArgs]()
+
+		svc.Infra.Provider, err = provisioning.ParseProvider(svc.Infra.Provider)
+		if err != nil {
+			return nil, fmt.Errorf("parsing service %s: %w", svc.Name, err)
+		}
+
+		svc.DotNetContainerApp = &DotNetContainerAppOptions{
+			Manifest:    manifest,
+			ProjectName: name,
+			ProjectPath: svcConfig.Path(),
+		}
+
+		services[svc.Name] = svc
+	}
+	return services, nil
+}
+
+func (ai *DotNetImporter) SynthAllInfrastructure(
+	ctx context.Context, p *ProjectConfig, svcConfig *ServiceConfig,
+) (fs.FS, error) {
+	manifest, err := ai.readManifest(ctx, svcConfig)
+	if err != nil {
+		return nil, fmt.Errorf("generating apphost manifest: %w", err)
+	}
+
+	generatedFS := memfs.New()
+
+	infraFS, err := apphost.BicepTemplate(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("generating infra/ folder: %w", err)
+	}
+
+	err = fs.WalkDir(infraFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		err = generatedFS.MkdirAll(filepath.Join("infra", filepath.Dir(path)), osutil.PermissionDirectoryOwnerOnly)
+		if err != nil {
+			return err
+		}
+
+		contents, err := fs.ReadFile(infraFS, path)
+		if err != nil {
+			return err
+		}
+
+		return generatedFS.WriteFile(filepath.Join("infra", path), contents, d.Type().Perm())
+
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for name, path := range apphost.ProjectPaths(manifest) {
+		containerAppManifest, err := apphost.ContainerAppManifestTemplateForProject(manifest, name)
+		if err != nil {
+			return nil, fmt.Errorf("generating containerApp.tmpl.yaml for project %s: %w", name, err)
+		}
+
+		projectRelPath, err := filepath.Rel(p.Path, path)
+		if err != nil {
+			return nil, err
+		}
+
+		manifestPath := filepath.Join(filepath.Dir(projectRelPath), "manifests", "containerApp.tmpl.yaml")
+
+		if err := generatedFS.MkdirAll(filepath.Dir(manifestPath), osutil.PermissionDirectoryOwnerOnly); err != nil {
+			return nil, err
+		}
+
+		if err := generatedFS.WriteFile(manifestPath, []byte(containerAppManifest), osutil.PermissionFileOwnerOnly); err != nil {
+			return nil, err
+		}
+	}
+
+	return generatedFS, nil
+}
+
+// readManifest reads the manifest for the given app host service, and caches the result. It also reads the value of
+// the `services.<name>.config.exposedServices` property from the environment and sets the `External` property on
+// each binding for the exposed services. If this key does not exist in the config for the environment, the user
+// is prompted to select which services should be exposed. This can happen after an environment is created with
+// `azd env new`.
+func (ai *DotNetImporter) readManifest(ctx context.Context, svcConfig *ServiceConfig) (*apphost.Manifest, error) {
+	ai.cacheMu.Lock()
+	defer ai.cacheMu.Unlock()
+
+	if cached, has := ai.cache[svcConfig.Path()]; has {
+		return cached, nil
+	}
+
+	manifest, err := apphost.ManifestFromAppHost(ctx, svcConfig.Path(), ai.dotnetCli)
+	if err != nil {
+		return nil, err
+	}
+
+	env, err := ai.lazyEnv.GetValue()
+	if err == nil {
+		if cfgValue, has := env.Config.Get(fmt.Sprintf("services.%s.config.exposedServices", svcConfig.Name)); has {
+			if exposedServices, is := cfgValue.([]interface{}); !is {
+				log.Printf("services.%s.config.exposedServices is not an array, ignoring setting.", svcConfig.Name)
+			} else {
+				for idx, name := range exposedServices {
+					if strName, ok := name.(string); !ok {
+						log.Printf("services.%s.config.exposedServices[%d] is not a string, ignoring value.",
+							svcConfig.Name, idx)
+					} else {
+						for _, binding := range manifest.Resources[strName].Bindings {
+							binding.External = true
+						}
+					}
+				}
+			}
+		} else {
+			selector := apphost.NewIngressSelector(manifest, ai.console)
+			exposed, err := selector.SelectPublicServices(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("selecting public services: %w", err)
+			}
+
+			for _, name := range exposed {
+				for _, binding := range manifest.Resources[name].Bindings {
+					binding.External = true
+				}
+			}
+
+			err = env.Config.Set(fmt.Sprintf("services.%s.config.exposedServices", svcConfig.Name), exposed)
+			if err != nil {
+				return nil, err
+			}
+
+			envManager, err := ai.lazyEnvManager.GetValue()
+			if err != nil {
+				return nil, err
+			}
+
+			if err := envManager.Save(ctx, env); err != nil {
+				return nil, err
+			}
+
+		}
+	} else {
+		log.Printf("unexpected error fetching environment: %s, exposed services may not be correct", err)
+	}
+
+	ai.cache[svcConfig.Path()] = manifest
+	return manifest, nil
+}

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -3,6 +3,7 @@ package project
 import (
 	"path/filepath"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/apphost"
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 )
@@ -32,13 +33,25 @@ type ServiceConfig struct {
 	Infra provisioning.Options `yaml:"infra,omitempty"`
 	// Hook configuration for service
 	Hooks map[string]*ext.HookConfig `yaml:"hooks,omitempty"`
+	// Options specific to the DotNetContainerApp target. These are set by the importer and
+	// can not be controlled via the project file today.
+	DotNetContainerApp *DotNetContainerAppOptions `yaml:"-,omitempty"`
 
 	*ext.EventDispatcher[ServiceLifecycleEventArgs] `yaml:"-"`
 
 	initialized bool
 }
 
+type DotNetContainerAppOptions struct {
+	Manifest    *apphost.Manifest
+	ProjectName string
+	ProjectPath string
+}
+
 // Path returns the fully qualified path to the project
 func (sc *ServiceConfig) Path() string {
+	if filepath.IsAbs(sc.RelativePath) {
+		return sc.RelativePath
+	}
 	return filepath.Join(sc.Project.Path, sc.RelativePath)
 }

--- a/cli/azd/pkg/project/service_target.go
+++ b/cli/azd/pkg/project/service_target.go
@@ -39,6 +39,7 @@ func parseServiceHost(kind ServiceTargetKind) (ServiceTargetKind, error) {
 		StaticWebAppTarget,
 		SpringAppTarget,
 		AksTarget:
+
 		return kind, nil
 	}
 

--- a/cli/azd/resources/alpha_features.yaml
+++ b/cli/azd/resources/alpha_features.yaml
@@ -1,2 +1,4 @@
 - id: resourceGroupDeployments
   description: "Support infrastructure deployments at resource group scope."
+- id: infraSynth
+  description: "Enable the `infra synth` command to write generated infrastructure to disk."

--- a/cli/azd/resources/apphost/templates/azure.yamlt
+++ b/cli/azd/resources/apphost/templates/azure.yamlt
@@ -1,0 +1,14 @@
+{{define "azure.yaml" -}}
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+name: {{ .Name }}
+{{- if .Services}}
+services:
+{{- range $name, $value := .Services}}  
+  {{$name}}:
+    language: dotnet
+    project: {{$value}}
+    host: containerapp
+{{- end}}
+{{- end}}
+{{ end}}

--- a/cli/azd/resources/apphost/templates/containerApp.tmpl.yamlt
+++ b/cli/azd/resources/apphost/templates/containerApp.tmpl.yamlt
@@ -1,0 +1,38 @@
+{{define "containerApp.tmpl.yaml" -}}
+location: {{ "{{ .Env.AZURE_LOCATION }}" }}
+identity:
+  type: UserAssigned
+  userAssignedIdentities:
+    ? {{ `"{{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}"` }}
+    : {}
+properties:
+  environmentId: {{ "{{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_ID }}" }}
+  configuration:
+    activeRevisionsMode: single
+{{- if .Ingress}}
+    ingress:
+      external: {{ .Ingress.External }}
+      targetPort: {{ .Ingress.TargetPort }}
+      transport: {{ .Ingress.Transport }}
+      allowInsecure: {{ .Ingress.AllowInsecure }}
+{{- end}}
+    registries:
+    - server: {{ "{{ .Env.AZURE_CONTAINER_REGISTRY_ENDPOINT }}" }}
+      identity: {{ "{{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}" }}
+  template:
+    containers:
+    - image: {{ "{{ .Image }}" }}
+      name: {{ .Name }}
+      env:
+      - name: AZURE_CLIENT_ID
+        value: {{ "{{ .Env.MANAGED_IDENTITY_CLIENT_ID }}" }}
+{{- range $name, $value := .Env}}
+      - name: {{$name}}
+        value: {{$value}}
+{{- end}}
+    scale:
+      minReplicas: 1
+tags:
+  azd-service-name: {{ .Name }}
+  aspire-resource-name: {{ .Name }}
+{{ end}}

--- a/cli/azd/resources/apphost/templates/main.bicept
+++ b/cli/azd/resources/apphost/templates/main.bicept
@@ -1,0 +1,55 @@
+{{define "main.bicep" -}}
+targetScope = 'subscription'
+
+@minLength(1)
+@maxLength(64)
+@description('Name of the environment that can be used as part of naming resource convention, the name of the resource group for your application will use this name, prefixed with rg-')
+param environmentName string
+
+@minLength(1)
+@description('The location used for all deployed resources')
+param location string
+
+var tags = {
+  'azd-env-name': environmentName
+}
+
+resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module resources 'resources.bicep' = {
+  scope: rg
+  name: 'resources'
+  params: {
+    location: location
+    tags: tags
+  }
+}
+
+output MANAGED_IDENTITY_CLIENT_ID string = resources.outputs.MANAGED_IDENTITY_CLIENT_ID
+{{if .HasContainerRegistry -}}
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = resources.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = resources.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID
+{{end -}}
+{{if .HasContainerEnvironment -}}
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = resources.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = resources.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN
+{{end -}}
+{{range $name, $value := .ServiceBuses -}}
+output SERVICE_BINDING_{{alphaSnakeUpper $name}}_ENDPOINT string = resources.outputs.SERVICE_BINDING_{{alphaSnakeUpper $name}}_ENDPOINT
+{{end -}}
+{{range $name, $value := .AppInsights -}}
+output SERVICE_BINDING_{{alphaSnakeUpper $name}}_CONNECTION_STRING string = resources.outputs.SERVICE_BINDING_{{alphaSnakeUpper $name}}_CONNECTION_STRING
+{{end -}}
+{{range $name, $value := .StorageAccounts -}}
+{{range $cname := $value.Containers -}}
+output SERVICE_BINDING_{{alphaSnakeUpper $cname}}_ENDPOINT string = resources.outputs.SERVICE_BINDING_{{alphaSnakeUpper $cname}}_ENDPOINT
+{{end -}}
+{{end -}}
+{{range $name, $value := .KeyVaults -}}
+output SERVICE_BINDING_{{alphaSnakeUpper $name}}_ENDPOINT string =resources.outputs.SERVICE_BINDING_{{alphaSnakeUpper $name}}_ENDPOINT
+{{end -}}
+{{ end}}

--- a/cli/azd/resources/apphost/templates/main.parameters.jsont
+++ b/cli/azd/resources/apphost/templates/main.parameters.jsont
@@ -1,0 +1,14 @@
+{{define "main.parameters.json" -}}
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "environmentName": {
+        "value": "${AZURE_ENV_NAME}"
+      },
+      "location": {
+        "value": "${AZURE_LOCATION}"
+      }
+    }
+  }
+  {{ end}}

--- a/cli/azd/resources/apphost/templates/next-steps.mdt
+++ b/cli/azd/resources/apphost/templates/next-steps.mdt
@@ -1,0 +1,71 @@
+{{define "next-steps.md" -}}
+# Next Steps after `azd init`
+
+## Table of Contents
+
+1. [Next Steps](#next-steps)
+2. [What was added](#what-was-added)
+3. [Billing](#billing)
+4. [Troubleshooting](#troubleshooting)
+
+## Next Steps
+
+### Provision infrastructure and deploy application code
+
+Run `azd up` to provision your infrastructure and deploy to Azure in one step (or run `azd provision` then `azd deploy` to accomplish the tasks separately). Visit the service endpoints listed to see your application up-and-running!
+
+To troubleshoot any issues, see [troubleshooting](#troubleshooting).
+
+### Configure CI/CD pipeline
+
+1. Create a workflow pipeline file locally. The following starters are available:
+   - [Deploy with GitHub Actions](https://github.com/Azure-Samples/azd-starter-bicep/blob/main/.github/workflows/azure-dev.yml)
+   - [Deploy with Azure Pipelines](https://github.com/Azure-Samples/azd-starter-bicep/blob/main/.azdo/pipelines/azure-dev.yml)
+2. Run `azd pipeline config -e <environment name>` to configure the deployment pipeline to connect securely to Azure. An environment name is specified here to configure the pipeline with a different environment for isolation purposes. Run `azd env list` and `azd env set` to reselect the default environment after this step.
+
+## What was added
+
+### Infrastructure configuration
+
+To describe the infrastructure and application and `azure.yaml` was added with the following directory structure:
+
+```yaml
+- azure.yaml     # azd project configuration
+```
+
+This file contains a single service, which references your project's App Host. When needed, `azd` generates the required infrastructure as code in memory and uses it.
+
+If you would like to see or modify the infrastructure that `azd` uses, run `azd infra synth` to persist it to disk.
+
+If you do this, some additional directories will be created:
+
+```yaml
+- infra/            # Infrastructure as Code (bicep) files
+  - main.bicep      # main deployment module
+  - resources.bicep # resources shared across your application's services
+```
+
+In addition, for each project resource referenced by your app host, a `containerApp.tmpl.yaml` file will be created in a directory named `manifests` next the project file. This file contains the infrastructure as code for running the project on Azure Container Apps.
+
+*Note*: Once you have synthesized your infrastructure to disk, changes made to your App Host will not be reflected in the infrastructure. You can re-generate the infrastructure by running `azd infra synth` again. It will prompt you before overwriting files. You can pass `--force` to force `azd infra synth` to overwrite the files without prompting.
+
+*Note*: `azd infra synth` is currently an alpha feature and must be explicitly enabled by running `azd config set alpha.infraSynth on`. You only need to do this once.
+
+## Billing
+
+Visit the *Cost Management + Billing* page in Azure Portal to track current spend. For more information about how you're billed, and how you can monitor the costs incurred in your Azure subscriptions, visit [billing overview](https://learn.microsoft.com/en-us/azure/developer/intro/azure-developer-billing).
+
+## Troubleshooting
+
+Q: I visited the service endpoint listed, and I'm seeing a blank or error page.
+
+A: Your service may have failed to start or misconfigured. To investigate further:
+
+1. Click on the resource group link shown to visit Azure Portal.
+2. Navigate to the specific Azure Container App resource for the service.
+3. Select *Monitoring -> Log stream* under the navigation pane.
+4. Observe the log output to identify any errors.
+5. If logs are written to disk, examine the local logs or debug the application by using the *Console* to connect to a shell within the running container.
+
+For additional information about setting up your `azd` project, visit our official [docs](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/make-azd-compatible?pivots=azd-convert).
+{{ end}}

--- a/cli/azd/resources/apphost/templates/resources.bicept
+++ b/cli/azd/resources/apphost/templates/resources.bicept
@@ -1,0 +1,244 @@
+{{define "resources.bicep" -}}
+@description('The location used for all deployed resources')
+param location string = resourceGroup().location
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+var resourceToken = uniqueString(resourceGroup().id)
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: 'mi-${resourceToken}'
+  location: location
+  tags: tags
+}
+{{if .HasContainerRegistry}}
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+  name: replace('acr-${resourceToken}', '-', '')
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  tags: tags
+}
+
+resource caeMiRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(containerRegistry.id, managedIdentity.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+  scope: containerRegistry
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId:  subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+  }
+}
+{{end -}}
+{{if .HasLogAnalyticsWorkspace}}
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: 'law-${resourceToken}'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+  }
+  tags: tags
+}
+{{end -}}
+{{if .HasContainerEnvironment}}
+resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' = {
+  name: 'cae-${resourceToken}'
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalyticsWorkspace.properties.customerId
+        sharedKey: logAnalyticsWorkspace.listKeys().primarySharedKey
+      }
+    }
+  }
+  tags: tags
+}
+{{end -}}
+{{range $name, $value := .ContainerAppEnvironmentServices}}
+resource {{bicepName $name}} 'Microsoft.App/containerApps@2023-05-02-preview' = {
+  name: '{{containerAppName $name}}'
+  location: location
+  properties: {
+    environmentId: containerAppEnvironment.id
+    configuration: {
+      service: {
+        type: '{{$value.Type}}'
+      }
+    }
+    template: {
+      containers: [
+        {
+          image: '{{$value.Type}}'
+          name: '{{$value.Type}}'
+        }
+      ]
+    }
+  }
+  tags: union(tags, {'aspire-resource-name': '{{$name}}'})
+}
+{{end -}}
+{{range $name, $value := .ContainerApps}}
+resource {{bicepName $name}} 'Microsoft.App/containerApps@2023-05-02-preview' = {
+  name: '{{containerAppName $name}}'
+  location: location
+  properties: {
+    environmentId: containerAppEnvironment.id
+    configuration: {
+      activeRevisionsMode: 'Single'
+{{if $value.Ingress}}      
+      ingress: {
+        external: {{$value.Ingress.External}}
+        targetPort: {{$value.Ingress.TargetPort}}
+        transport: '{{$value.Ingress.Transport}}'
+        allowInsecure: {{$value.Ingress.AllowInsecure}}
+      }
+{{end}}      
+    }
+    template: {
+      containers: [
+        {
+          image: '{{$value.Image}}'
+          name: '{{$name}}'
+        }
+      ]
+    }
+  }
+  tags: union(tags, {'aspire-resource-name': '{{$name}}'})
+}
+{{end -}}
+{{range $name, $value := .ServiceBuses}}
+resource {{bicepName $name}} 'Microsoft.ServiceBus/namespaces@2022-10-01-preview' = {
+  name: '{{$name}}-${resourceToken}'
+  location: location
+  sku: {
+    name: 'Standard'   
+  }
+  properties: {
+    minimumTlsVersion: '1.2'
+  }
+  tags: union(tags, {'aspire-resource-name': '{{$name}}'})
+{{- range $name := $value.Queues}}
+
+  resource {{bicepName $name}} 'queues@2022-10-01-preview' = {
+    name: '{{$name}}'
+  }
+{{end -}}  
+{{range $name := $value.Topics}}
+
+  resource {{bicepName $name}} 'topics@2022-10-01-preview' = {
+    name: '{{$name}}'
+  }
+{{end -}}  
+}
+
+resource {{bicepName $name}}MiRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid({{bicepName $name}}.id, managedIdentity.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '090c5cfd-751d-490a-894a-3ce6f1109419'))
+  scope: {{bicepName $name}}
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '090c5cfd-751d-490a-894a-3ce6f1109419')
+  }
+}
+{{end -}}
+{{range $name, $value := .AppInsights}}
+resource {{bicepName $name}} 'Microsoft.Insights/components@2020-02-02-preview' = {
+  name: '{{$name}}'
+  location: location
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: logAnalyticsWorkspace.id
+  }
+  tags: union(tags, {'aspire-resource-name': '{{$name}}'})
+}
+{{end -}}
+{{range $name, $value := .StorageAccounts}}
+resource {{bicepName $name}} 'Microsoft.Storage/storageAccounts@2022-05-01' = {
+  name: replace('{{$name}}-${resourceToken}', '-', '')
+  location: location
+  kind: 'Storage'
+  sku: {
+    name: 'Standard_GRS'
+  }
+  tags: union(tags, {'aspire-resource-name': '{{$name}}'})
+
+  resource blobs 'blobServices@2022-05-01' = {
+    name: 'default'
+{{range $cname := $value.Containers}}
+
+    resource {{bicepName $cname}} 'containers@2022-05-01' = {
+      name: '{{bicepName $cname}}'
+      properties: {
+        publicAccess: 'None'
+      }
+    }
+{{- end}}
+  }
+}
+
+resource {{bicepName $name}}RoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid({{bicepName $name}}.id, managedIdentity.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88'))
+  scope: {{bicepName $name}}
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId:  subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88')
+  }
+}
+{{end -}}
+{{range $name, $value := .KeyVaults}}
+resource {{bicepName $name}} 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: replace('{{$name}}-${resourceToken}', '-', '')
+  location: location
+  properties: {
+    sku: {
+      name: 'standard'
+      family: 'A'
+    }
+    tenantId: subscription().tenantId
+    enableRbacAuthorization: true
+  }
+  tags: union(tags, {'aspire-resource-name': '{{$name}}'})
+}
+
+resource {{bicepName $name}}RoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid({{bicepName $name}}.id, managedIdentity.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483'))
+  scope: {{bicepName $name}}
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId:  subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')
+  }
+}
+{{- end}}
+
+output MANAGED_IDENTITY_CLIENT_ID string = managedIdentity.properties.clientId
+{{if .HasContainerRegistry -}}
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.properties.loginServer
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = managedIdentity.id
+{{end -}}
+{{if .HasContainerEnvironment -}}
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = containerAppEnvironment.id
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = containerAppEnvironment.properties.defaultDomain
+{{end -}}
+{{range $name, $value := .ServiceBuses -}}
+output SERVICE_BINDING_{{alphaSnakeUpper $name}}_ENDPOINT string = {{bicepName $name}}.properties.serviceBusEndpoint
+{{end -}}
+{{range $name, $value := .AppInsights -}}
+output SERVICE_BINDING_{{alphaSnakeUpper $name}}_CONNECTION_STRING string = {{bicepName $name}}.properties.ConnectionString
+{{end -}}
+{{range $name, $value := .StorageAccounts -}}
+{{range $cname := $value.Containers -}}
+output SERVICE_BINDING_{{alphaSnakeUpper $cname}}_ENDPOINT string = {{bicepName $name}}.properties.primaryEndpoints.blob
+{{end -}}
+{{end -}}
+{{range $name, $value := .KeyVaults -}}
+output SERVICE_BINDING_{{alphaSnakeUpper $name}}_ENDPOINT string = {{bicepName $name}}.properties.vaultUri
+{{end -}}
+{{ end}}

--- a/cli/azd/resources/resources.go
+++ b/cli/azd/resources/resources.go
@@ -21,3 +21,6 @@ var ScaffoldBase embed.FS
 
 //go:embed scaffold/templates/*
 var ScaffoldTemplates embed.FS
+
+//go:embed apphost/templates/*
+var AppHostTemplates embed.FS

--- a/go.mod
+++ b/go.mod
@@ -3,25 +3,33 @@ module github.com/azure/azure-dev
 go 1.21
 
 require (
+	dario.cat/mergo v1.0.0
 	github.com/AlecAivazis/survey/v2 v2.3.2
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v2 v2.0.0-beta.3
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappplatform/v2 v2.0.0-beta.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization v1.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.1.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.4.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v0.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.7.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v0.13.0
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0
 	github.com/Azure/azure-storage-file-go v0.8.0
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.1.0
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
+	github.com/adam-lavrik/go-imath v0.0.0-20210910152346-265a42a96f0b
 	github.com/benbjohnson/clock v1.3.0
 	github.com/blang/semver/v4 v4.0.0
+	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/bradleyjkemp/cupaloy/v2 v2.8.0
+	github.com/buger/goterm v1.0.4
 	github.com/drone/envsubst v1.0.3
 	github.com/fatih/color v1.13.0
 	github.com/gofrs/flock v0.8.1
@@ -35,6 +43,7 @@ require (
 	github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5
 	github.com/nathan-fiscaletti/consolesize-go v0.0.0-20220204101620-317176b6684d
 	github.com/otiai10/copy v1.9.0
+	github.com/psanford/memfs v0.0.0-20230130182539-4dbf7e3e865e
 	github.com/sethvargo/go-retry v0.2.3
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
@@ -49,28 +58,9 @@ require (
 	go.uber.org/multierr v1.8.0
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/sys v0.13.0
+	gopkg.in/dnaeon/go-vcr.v3 v3.1.2
 	gopkg.in/yaml.v3 v3.0.1
 )
-
-require github.com/buger/goterm v1.0.4
-
-require gopkg.in/dnaeon/go-vcr.v3 v3.1.2
-
-require github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v2 v2.0.0-beta.3
-
-require github.com/bmatcuk/doublestar/v4 v4.6.0
-
-require (
-	dario.cat/mergo v1.0.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.1.1
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.7.1
-	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0
-	github.com/adam-lavrik/go-imath v0.0.0-20210910152346-265a42a96f0b
-)
-
-require github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
-
-require github.com/stretchr/objx v0.5.0 // indirect
 
 require (
 	github.com/Azure/azure-pipeline-go v0.2.1 // indirect
@@ -83,6 +73,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
@@ -95,6 +86,7 @@ require (
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.8.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.8.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -445,6 +445,8 @@ github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8b
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
+github.com/psanford/memfs v0.0.0-20230130182539-4dbf7e3e865e h1:51xcRlSMBU5rhM9KahnJGfEsBPVPz3182TgFRowA8yY=
+github.com/psanford/memfs v0.0.0-20230130182539-4dbf7e3e865e/go.mod h1:tcaRap0jS3eifrEEllL6ZMd9dg8IlDpi2S1oARrQ+NI=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=


### PR DESCRIPTION
.NET App Host projects can produce a manifest which `azd` can use instead of our existing huristics to determine what resources an application needs.

This change adds support for these projects to our "initialized from an existing codebase flow".

In addition, this feature uses the new support in `azd` for not persisting IaC to disk by default. A new `azd infra synth` command (presently in alpha) is added for folks that want to persist the infrastructure to disk, either to look at it or modify it if there are issues.