### PR TITLE
docs: fix --all option description for azd package command

### DIFF
--- a/cli/azd/cmd/package.go
+++ b/cli/azd/cmd/package.go
@@ -42,7 +42,7 @@ func (pf *packageFlags) Bind(local *pflag.FlagSet, global *internal.GlobalComman
 		&pf.all,
 		"all",
 		false,
-		"Deploys all services that are listed in "+azdcontext.ProjectFileName,
+		"Packages all services that are listed in "+azdcontext.ProjectFileName,
 	)
 	local.StringVar(
 		&pf.outputPath,

--- a/cli/azd/cmd/testdata/TestUsage-azd-package.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-package.snap
@@ -9,7 +9,7 @@ Usage
   azd package <service> [flags]
 
 Flags
-        --all                	: Deploys all services that are listed in azure.yaml
+        --all                	: Packages all services that are listed in azure.yaml
         --docs               	: Opens the documentation for azd package in your web browser.
     -e, --environment string 	: The name of the environment to use.
     -h, --help               	: Gets help for package.


### PR DESCRIPTION
This PR contains a minor fix for the output of the metadata of `azd package --help`. It changes the description for the `--all` option from `Deploys` to `Packages`.

Remark: The footer already contained the right description.