### PR TITLE
Handle if project is undetected

### DIFF
--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -271,10 +271,6 @@ func (p *dockerProject) Package(
 const DefaultBuilderImage = "mcr.microsoft.com/oryx/builder:debian-bullseye-20231004.1"
 const DefaultDotNetBuilderImage = "mcr.microsoft.com/oryx/builder:debian-buster-20231004.1"
 
-// All buildpacks groups have failed to detect w/o error.
-// See https://buildpacks.io/docs/concepts/components/lifecycle/detect/#exit-codes
-const PackExitCodeUndetected = 20
-
 func (p *dockerProject) packBuild(
 	ctx context.Context,
 	svc *ServiceConfig,

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -320,23 +320,25 @@ func (p *dockerProject) packBuild(
 				return nil, err
 			}
 
-			for _, dep := range prj.Dependencies {
-				if dep == appdetect.PyFastApi {
-					launch, err := appdetect.PyFastApiLaunch(prj.Path)
-					if err != nil {
-						return nil, err
-					}
+			if prj != nil {
+				for _, dep := range prj.Dependencies {
+					if dep == appdetect.PyFastApi {
+						launch, err := appdetect.PyFastApiLaunch(prj.Path)
+						if err != nil {
+							return nil, err
+						}
 
-					// If launch isn't detected, fallback to default Oryx runtime logic, which may recover for scenarios
-					// such as a simple main entrypoint launch.
-					if launch != "" {
-						environ = append(environ,
-							"POST_BUILD_COMMAND=pip install uvicorn",
-							//nolint:lll
-							"ORYX_RUNTIME_SCRIPT=oryx create-script -appPath ./oryx-output -bindPort 80 -userStartupCommand "+
-								"'uvicorn "+launch+" --port $PORT --host $HOST' && ./run.sh")
+						// If launch isn't detected, fallback to default Oryx runtime logic, which may recover for scenarios
+						// such as a simple main entrypoint launch.
+						if launch != "" {
+							environ = append(environ,
+								"POST_BUILD_COMMAND=pip install uvicorn",
+								//nolint:lll
+								"ORYX_RUNTIME_SCRIPT=oryx create-script -appPath ./oryx-output -bindPort 80 -userStartupCommand "+
+									"'uvicorn "+launch+" --port $PORT --host $HOST' && ./run.sh")
+						}
+						break
 					}
-					break
 				}
 			}
 		}


### PR DESCRIPTION
Add a nil-check to handle when a python project is undetected. In this case, the python project will still be attempted to be built by the Oryx builder. This would likely result in a different, but friendlier error message and avoids the panic.

With this change, better error messaging is also provided when building a containerized project fails due to no Dockerfile and failed detection.

Fixes #2961