### PR TITLE
Don't create blob storage containers

### DIFF
--- a/cli/azd/resources/apphost/templates/resources.bicept
+++ b/cli/azd/resources/apphost/templates/resources.bicept
@@ -170,15 +170,6 @@ resource {{bicepName $name}} 'Microsoft.Storage/storageAccounts@2022-05-01' = {
 
   resource blobs 'blobServices@2022-05-01' = {
     name: 'default'
-{{range $cname := $value.Containers}}
-
-    resource {{bicepName $cname}} 'containers@2022-05-01' = {
-      name: '{{bicepName $cname}}'
-      properties: {
-        publicAccess: 'None'
-      }
-    }
-{{- end}}
   }
 }
 


### PR DESCRIPTION
Instead of having `azd` provision the container, the consumer of the blob storage account will hanlde this at runtime.