### PR TITLE
fix: Updates `azd up` inline docs and `azd deploy` output

### DIFF
--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -226,11 +226,13 @@ func (da *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 
 	for _, svc := range stableServices {
 		stepMessage := fmt.Sprintf("Deploying service %s", svc.Name)
+		da.console.ShowSpinner(ctx, stepMessage, input.Step)
 
 		// Skip this service if both cases are true:
 		// 1. The user specified a service name
 		// 2. This service is not the one the user specified
 		if targetServiceName != "" && targetServiceName != svc.Name {
+			da.console.StopSpinner(ctx, stepMessage, input.StepSkipped)
 			continue
 		}
 
@@ -240,7 +242,6 @@ func (da *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 			da.console.WarnForFeature(ctx, alphaFeatureId)
 		}
 
-		da.console.ShowSpinner(ctx, stepMessage, input.Step)
 		var packageResult *project.ServicePackageResult
 		if da.flags.fromPackage != "" {
 			// --from-package set, skip packaging

--- a/cli/azd/cmd/testdata/TestUsage-azd-up.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-up.snap
@@ -1,5 +1,5 @@
 
-Executes the azd provision and azd deploy commands in a single step.
+Executes the azd package, azd provision and azd deploy commands in a single step.
 
 Usage
   azd up [flags]

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -180,7 +180,8 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 func getCmdUpHelpDescription(c *cobra.Command) string {
 	return generateCmdHelpDescription(
-		fmt.Sprintf("Executes the %s and %s commands in a single step.",
+		fmt.Sprintf("Executes the %s, %s and %s commands in a single step.",
+			output.WithHighLightFormat("azd package"),
 			output.WithHighLightFormat("azd provision"),
 			output.WithHighLightFormat("azd deploy")), nil)
 }


### PR DESCRIPTION
Adds the following minor updates:

### Updates help text for `azd up`
Updates the help description to make it clear that current implementation of `azd up` calls package, provision & deploy.

<img width="721" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/76d01b37-1f6e-4390-9f6e-e52e87ba847e">

### Display `Skipped` in `azd deploy`
Displays skipped services in calls to `azd deploy <service-name>` when a service name is specified. 
This change brings `azd deploy` inline with conventions used in other command that target multiple services including restore, build & package.

<img width="731" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/8c20781c-f01b-4444-bd8f-a41e2eca8f72">
