### PR TITLE
Mitigate winget upgrade issue

### DIFF
--- a/cli/installer/windows/azd.wxs
+++ b/cli/installer/windows/azd.wxs
@@ -90,7 +90,9 @@
             </Component>
 
             <!-- Override ARP to display full UI during uninstall. -->
-            <Component Directory="INSTALLDIR">
+            <!-- Uncomment this block to restore displaying full UI on uninstall (which includes a notice to clean ~/.azd/bin) -->
+            <!-- See https://github.com/Azure/azure-dev/issues/3012 -->
+            <!-- <Component Directory="INSTALLDIR">
                 <RegistryKey Root="HKCU" Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(var.BaseProductName)">
                     <RegistryValue Name="DisplayName" Value="$(var.BaseProductName)" Type="string" />
                     <RegistryValue Name="DisplayVersion" Value="[ProductVersion]" Type="string" />
@@ -100,11 +102,13 @@
                     <RegistryValue Name="Publisher" Value="[Manufacturer]" Type="string" />
                     <RegistryValue Name="UninstallString" Value="msiexec.exe /X[ProductCode] /qf" Type="string" />
                 </RegistryKey>
-            </Component>
+            </Component> -->
         </Feature>
 
         <!-- Override ARP to display full UI during uninstall. -->
-        <Property Id="ARPSYSTEMCOMPONENT" Value="1" />
+        <!-- Uncomment this line to restore displaying full UI on uninstall (which includes a notice to clean ~/.azd/bin) -->
+        <!-- See https://github.com/Azure/azure-dev/issues/3012 -->
+        <!-- <Property Id="ARPSYSTEMCOMPONENT" Value="1" /> -->
 
         <!-- Broadcast environment variable changes even if a reboot is pending -->
         <CustomActionRef Id="WixBroadcastEnvironmentChange" />


### PR DESCRIPTION
Mitigate [winget issue](https://github.com/microsoft/winget-cli/issues/3825) with MSI upgrade by removing default display of the custom uninstall UI. 

Users of 1.5.0 (N) upgrading to the next version (N+1) using winget will still have to use the uninstall/install workaround. However, once the N+1 version is installed, subsequent versions will upgrade properly. 

@heaths -- Please have a look. 

## Testing 

1. Create MSI with hypothetical version 1.6.0 
2. Create MSI with hypothetical version 1.7.0 
3. Create winget manifests for MSIs 
4. `winget install` 1.6.0 from manifest
5. `winget upgrade` to 1.7.0 from manifest

Upgrades work as expected. Uninstallation from `winget uninstall Microsoft.Azd` or ARP dialog does not result in display of warning. Running uninstall with `/qf` does display UI. 