### PR TITLE
POC: Container Registry service target

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -470,6 +470,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		project.AksTarget:                project.NewAksTarget,
 		project.SpringAppTarget:          project.NewSpringAppTarget,
 		project.DotNetContainerAppTarget: project.NewDotNetContainerAppTarget,
+		project.RegistryTarget:           project.NewRegistryTarget,
 	}
 
 	for target, constructor := range serviceTargetMap {

--- a/cli/azd/pkg/async/task_context.go
+++ b/cli/azd/pkg/async/task_context.go
@@ -64,7 +64,9 @@ func NewTaskContextWithProgress[R comparable, P comparable](task *TaskWithProgre
 
 // Write a new progress value to the underlying progress channel
 func (c *TaskContextWithProgress[R, P]) SetProgress(progress P) {
-	c.task.progressChannel <- progress
+	if c.task.status == Running {
+		c.task.progressChannel <- progress
+	}
 }
 
 // Task with progress function definition

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -32,6 +32,7 @@ import (
 )
 
 type DockerProjectOptions struct {
+	Registry  string           `yaml:"registry,omitempty"  json:"registry,omitempty"`
 	Path      string           `yaml:"path,omitempty"      json:"path,omitempty"`
 	Context   string           `yaml:"context,omitempty"   json:"context,omitempty"`
 	Platform  string           `yaml:"platform,omitempty"  json:"platform,omitempty"`

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
@@ -554,8 +555,14 @@ func (sm *serviceManager) GetFrameworkService(ctx context.Context, serviceConfig
 		))
 	}
 
+	containerizedAppTargets := []ServiceTargetKind{
+		ContainerAppTarget,
+		AksTarget,
+		RegistryTarget,
+	}
+
 	// For containerized applications we use a composite framework service
-	if serviceConfig.Host == ContainerAppTarget || serviceConfig.Host == AksTarget {
+	if slices.Contains(containerizedAppTargets, serviceConfig.Host) {
 		var compositeFramework CompositeFrameworkService
 		if err := sm.serviceLocator.ResolveNamed(string(ServiceLanguageDocker), &compositeFramework); err != nil {
 			panic(fmt.Errorf(

--- a/cli/azd/pkg/project/service_target.go
+++ b/cli/azd/pkg/project/service_target.go
@@ -125,7 +125,7 @@ func resourceTypeMismatchError(
 // As an example, ContainerAppTarget is able to provision the container app as part of deployment,
 // and thus returns true.
 func (st ServiceTargetKind) SupportsDelayedProvisioning() bool {
-	return st == AksTarget
+	return st == AksTarget || st == RegistryTarget
 }
 
 func checkResourceType(resource *environment.TargetResource, expectedResourceType infra.AzureResourceType) error {

--- a/cli/azd/pkg/project/service_target.go
+++ b/cli/azd/pkg/project/service_target.go
@@ -25,6 +25,7 @@ const (
 	SpringAppTarget          ServiceTargetKind = "springapp"
 	AksTarget                ServiceTargetKind = "aks"
 	DotNetContainerAppTarget ServiceTargetKind = "containerapp-dotnet"
+	RegistryTarget           ServiceTargetKind = "registry"
 )
 
 func parseServiceHost(kind ServiceTargetKind) (ServiceTargetKind, error) {
@@ -38,7 +39,8 @@ func parseServiceHost(kind ServiceTargetKind) (ServiceTargetKind, error) {
 		AzureFunctionTarget,
 		StaticWebAppTarget,
 		SpringAppTarget,
-		AksTarget:
+		AksTarget,
+		RegistryTarget:
 
 		return kind, nil
 	}

--- a/cli/azd/pkg/project/service_target_dotnet_containerapp.go
+++ b/cli/azd/pkg/project/service_target_dotnet_containerapp.go
@@ -97,7 +97,7 @@ func (at *dotnetContainerAppTarget) Deploy(
 			task.SetProgress(NewServiceProgress("Logging in to registry"))
 
 			// Login, tag & push container image to ACR
-			loginServer, err := at.containerHelper.Login(ctx, targetResource)
+			loginServer, err := at.containerHelper.Login(ctx, serviceConfig, targetResource)
 			if err != nil {
 				task.SetError(fmt.Errorf("logging in to registry: %w", err))
 				return

--- a/cli/azd/pkg/project/service_target_registry.go
+++ b/cli/azd/pkg/project/service_target_registry.go
@@ -63,7 +63,7 @@ func (r *registryTarget) Deploy(
 			containerDeployTask := r.containerHelper.Deploy(ctx, serviceConfig, packageOutput, targetResource)
 			syncProgress(task, containerDeployTask.Progress())
 
-			_, err := containerDeployTask.Await()
+			containerDeployResult, err := containerDeployTask.Await()
 			if err != nil {
 				task.SetError(err)
 				return
@@ -83,6 +83,7 @@ func (r *registryTarget) Deploy(
 					targetResource.ResourceGroupName(),
 					targetResource.ResourceName(),
 				),
+				Details:   containerDeployResult.Details,
 				Kind:      RegistryTarget,
 				Endpoints: endpoints,
 			})

--- a/cli/azd/pkg/project/service_target_registry.go
+++ b/cli/azd/pkg/project/service_target_registry.go
@@ -1,0 +1,121 @@
+package project
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/async"
+	"github.com/azure/azure-dev/cli/azd/pkg/azure"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+)
+
+type registryTarget struct {
+	env             *environment.Environment
+	containerHelper *ContainerHelper
+}
+
+func NewRegistryTarget(
+	env *environment.Environment,
+	containerHelper *ContainerHelper,
+) ServiceTarget {
+	return &registryTarget{
+		env:             env,
+		containerHelper: containerHelper,
+	}
+}
+
+func (r *registryTarget) Initialize(ctx context.Context, serviceConfig *ServiceConfig) error {
+	return nil
+}
+
+func (r *registryTarget) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+	return r.containerHelper.RequiredExternalTools(ctx)
+}
+
+func (r *registryTarget) Package(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	packageOutput *ServicePackageResult,
+) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress] {
+	return async.RunTaskWithProgress(
+		func(task *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
+			task.SetResult(packageOutput)
+		},
+	)
+}
+
+func (r *registryTarget) Deploy(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	packageOutput *ServicePackageResult,
+	targetResource *environment.TargetResource,
+) *async.TaskWithProgress[*ServiceDeployResult, ServiceProgress] {
+	return async.RunTaskWithProgress(
+		func(task *async.TaskContextWithProgress[*ServiceDeployResult, ServiceProgress]) {
+			if err := r.validateTargetResource(ctx, serviceConfig, targetResource); err != nil {
+				task.SetError(fmt.Errorf("validating target resource: %w", err))
+				return
+			}
+
+			// Login, tag & push container image to ACR
+			containerDeployTask := r.containerHelper.Deploy(ctx, serviceConfig, packageOutput, targetResource)
+			syncProgress(task, containerDeployTask.Progress())
+
+			deployResult, err := containerDeployTask.Await()
+			if err != nil {
+				task.SetError(err)
+				return
+			}
+
+			task.SetProgress(NewServiceProgress("Fetching endpoints for container app service"))
+			endpoints, err := r.Endpoints(ctx, serviceConfig, targetResource)
+			if err != nil {
+				task.SetError(err)
+				return
+			}
+
+			task.SetResult(&ServiceDeployResult{
+				Package: packageOutput,
+				TargetResourceId: azure.ContainerAppRID(
+					targetResource.SubscriptionId(),
+					targetResource.ResourceGroupName(),
+					targetResource.ResourceName(),
+				),
+				Details:   deployResult,
+				Kind:      RegistryTarget,
+				Endpoints: endpoints,
+			})
+		},
+	)
+}
+
+func (r *registryTarget) Endpoints(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	targetResource *environment.TargetResource,
+) ([]string, error) {
+	registryEndpoint := r.env.Getenv(environment.ContainerRegistryEndpointEnvVarName)
+	imageName := r.env.GetServiceProperty(serviceConfig.Name, "IMAGE_NAME")
+
+	return []string{fmt.Sprintf("%s/%s", registryEndpoint, imageName)}, nil
+}
+
+func (r *registryTarget) validateTargetResource(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	targetResource *environment.TargetResource,
+) error {
+	if targetResource.ResourceGroupName() == "" {
+		return fmt.Errorf("missing resource group name: %s", targetResource.ResourceGroupName())
+	}
+
+	if targetResource.ResourceType() != "" {
+		if err := checkResourceType(targetResource, infra.AzureResourceTypeContainerRegistry); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cli/azd/pkg/project/service_target_registry.go
+++ b/cli/azd/pkg/project/service_target_registry.go
@@ -63,13 +63,13 @@ func (r *registryTarget) Deploy(
 			containerDeployTask := r.containerHelper.Deploy(ctx, serviceConfig, packageOutput, targetResource)
 			syncProgress(task, containerDeployTask.Progress())
 
-			deployResult, err := containerDeployTask.Await()
+			_, err := containerDeployTask.Await()
 			if err != nil {
 				task.SetError(err)
 				return
 			}
 
-			task.SetProgress(NewServiceProgress("Fetching endpoints for container app service"))
+			task.SetProgress(NewServiceProgress("Fetching endpoints for container registry service"))
 			endpoints, err := r.Endpoints(ctx, serviceConfig, targetResource)
 			if err != nil {
 				task.SetError(err)
@@ -83,7 +83,6 @@ func (r *registryTarget) Deploy(
 					targetResource.ResourceGroupName(),
 					targetResource.ResourceName(),
 				),
-				Details:   deployResult,
 				Kind:      RegistryTarget,
 				Endpoints: endpoints,
 			})
@@ -96,10 +95,8 @@ func (r *registryTarget) Endpoints(
 	serviceConfig *ServiceConfig,
 	targetResource *environment.TargetResource,
 ) ([]string, error) {
-	registryEndpoint := r.env.Getenv(environment.ContainerRegistryEndpointEnvVarName)
 	imageName := r.env.GetServiceProperty(serviceConfig.Name, "IMAGE_NAME")
-
-	return []string{fmt.Sprintf("%s/%s", registryEndpoint, imageName)}, nil
+	return []string{imageName}, nil
 }
 
 func (r *registryTarget) validateTargetResource(


### PR DESCRIPTION
This PR adds a new service target `registry` that simply support building, tagging and pushing containers to a configured container registry.

## Use Case: Dev only wants to publish container image

In the use case where a dev only wants to publish a container image then can leverage this new service target `registry`

```yaml
name: todo-nodejs-mongo-aca
metadata:
  template: todo-nodejs-mongo-aca@0.0.1-beta
services:
  web:
    project: ./src/web
    language: js
    host: registry
    docker:
      registry: <registry-endpoint>
```

Container images could then be used as part of other workloads (or gitops) across various service targets (maybe even in different applications)

The registry can be configured by setting the `AZURE_CONTAINER_REGISTRY_ENDPOINT` environment variable or by setting the `docker.registry` node within the service configuration.

## Use Case: Dev wants to publish container apps with sidecar containers

> [!Note]
> Not implemented in this PR

In many micro service implementations it is common to deploy a sidecar along with your main images running in the same pod.  In this scenario the dev has a sidecar image that needs to be built/deployed and then referenced within their container apps.

In the following scenario the `sidecar` service is referenced by multiple other `containerapp` services.  This reference would cause the `sidecar` service to become an implicit dependency of the `containerapp` services and would be packaged and built before the `containerapp` services.

Since the `containerapp` services reference a source `project` it will be used as the main container image and deploy any additional images referenced in the `containers` node of the service configuration.

```yaml
name: todo-nodejs-mongo-aca
metadata:
  template: todo-nodejs-mongo-aca@0.0.1-beta
services:
  # Sidecar image is referenced by multiple micro-services
  sidecar:
    project: ./src/sidecar
    language: js
    host: registry
    docker:
      registry: <registry-endpoint>
  # Products API requires `sidecar` container
  products-api:
    project: ./src/products
    language: js
    host: containerapp
    containers:
      - service: sidecar
  # Inventory API requires `sidecar` container
  inventory-api:
    project: ./src/inventory
    language: js
    host: containerapp
    containers:
      - service: sidecar
```

## Use Case: Dev wants to copy a container image from a public registry to a private container registry

> [!Note]
> Not implemented in this PR

In many production/enterprise scenarios applications can be deployed from private container registries that are managed by centralized IT teams.  

It would be interesting to wire this up via `azure.yaml` to specify a source image and a target registry to automate the process of pulling, tagging & pushing containers into private registries

In this example the public `nginx` image would be copied to the specified container registry as part of `azd deploy`

```yaml
name: todo-nodejs-mongo-aca
metadata:
  template: todo-nodejs-mongo-aca@0.0.1-beta
services:
  web:
    project: ./src/web
    language: js
    host: registry
    docker:
      container: nginx
      registry: <registry-endpoint>
```