### PR TITLE
Update cognitiveservices.bicep with networkAcls

### DIFF
--- a/templates/common/infra/bicep/core/ai/cognitiveservices.bicep
+++ b/templates/common/infra/bicep/core/ai/cognitiveservices.bicep
@@ -6,9 +6,19 @@ param tags object = {}
 param customSubDomainName string = name
 param deployments array = []
 param kind string = 'OpenAI'
+
+@allowed([ 'Enabled', 'Disabled' ])
 param publicNetworkAccess string = 'Enabled'
 param sku object = {
   name: 'S0'
+}
+
+param allowedIpRules array = []
+param networkAcls object = empty(allowedIpRules) ? {
+  defaultAction: 'Allow'
+} : {
+  ipRules: allowedIpRules
+  defaultAction: 'Deny'
 }
 
 resource account 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
@@ -19,6 +29,7 @@ resource account 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   properties: {
     customSubDomainName: customSubDomainName
     publicNetworkAccess: publicNetworkAccess
+    networkAcls: networkAcls
   }
   sku: sku
 }


### PR DESCRIPTION
This PR adds networkAcls to cognitiveservices.bicep. It defaults to "Allow" which is not the most secure option but is needed for OpenAI deployments (https://github.com/Azure-Samples/azure-search-openai-demo/issues/133), Azure AI studio usage, etc.

It also permits passing in IPs to specifically allow, which can be used in conjunction with a VNet (as demonstrated in this PR: https://github.com/Azure-Samples/azure-search-openai-demo/pull/864/files#diff-8a64001dc63e4053382af7bbd6519e074e3a637a9e0a50b5b6e8ca136b4224ce), for heightened security.