### PR TITLE
Support Aspire journey for pipeline config

### DIFF
--- a/cli/azd/pkg/apphost/service_ingress_configurer.go
+++ b/cli/azd/pkg/apphost/service_ingress_configurer.go
@@ -37,8 +37,9 @@ func (adc *IngressSelector) SelectPublicServices(ctx context.Context) ([]string,
 		"it is running in. Selecting a service here will also allow it to be reached from the Internet.")
 
 	exposed, err := adc.console.MultiSelect(ctx, input.ConsoleOptions{
-		Message: "Select which services to expose to the Internet",
-		Options: services,
+		Message:      "Select which services to expose to the Internet",
+		Options:      services,
+		DefaultValue: []string{},
 	})
 	if err != nil {
 		return nil, err

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -5,7 +5,9 @@ package environment
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"regexp"
 	"strings"
@@ -57,17 +59,34 @@ type Environment struct {
 	Config config.Config
 }
 
+const AzureInitialEnvironmentConfigName = "AZURE_INITIAL_ENVIRONMENT_CONFIG"
+
 // New returns a new environment with the specified name.
 func New(name string) *Environment {
 	env := &Environment{
 		name:        name,
 		dotenv:      make(map[string]string),
 		deletedKeys: make(map[string]struct{}),
-		Config:      config.NewEmptyConfig(),
+		Config:      getInitialConfig(),
 	}
 
 	env.SetEnvName(name)
 	return env
+}
+
+func getInitialConfig() config.Config {
+	initialConfig := os.Getenv(AzureInitialEnvironmentConfigName)
+	if initialConfig == "" {
+		return config.NewEmptyConfig()
+	}
+
+	var initConfig map[string]any
+	if err := json.Unmarshal([]byte(initialConfig), &initConfig); err != nil {
+		log.Panicln("Failed to unmarshal initial config", err, "Using empty config.")
+		return config.NewEmptyConfig()
+	}
+
+	return config.NewConfig(initConfig)
 }
 
 // NewWithValues returns an ephemeral environment (i.e. not backed by a data store) with a set

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -59,7 +59,7 @@ type Environment struct {
 	Config config.Config
 }
 
-const AzureInitialEnvironmentConfigName = "AZURE_INITIAL_ENVIRONMENT_CONFIG"
+const AzdInitialEnvironmentConfigName = "AZD_INITIAL_ENVIRONMENT_CONFIG"
 
 // New returns a new environment with the specified name.
 func New(name string) *Environment {
@@ -75,14 +75,14 @@ func New(name string) *Environment {
 }
 
 func getInitialConfig() config.Config {
-	initialConfig := os.Getenv(AzureInitialEnvironmentConfigName)
+	initialConfig := os.Getenv(AzdInitialEnvironmentConfigName)
 	if initialConfig == "" {
 		return config.NewEmptyConfig()
 	}
 
 	var initConfig map[string]any
 	if err := json.Unmarshal([]byte(initialConfig), &initConfig); err != nil {
-		log.Panicln("Failed to unmarshal initial config", err, "Using empty config.")
+		log.Println("Failed to unmarshal initial config", err, "Using empty config.")
 		return config.NewEmptyConfig()
 	}
 

--- a/cli/azd/pkg/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/pipeline/azdo_provider.go
@@ -757,6 +757,7 @@ func (p *AzdoCiProvider) configurePipeline(
 	ctx context.Context,
 	repoDetails *gitRepositoryDetails,
 	provisioningProvider provisioning.Options,
+	additionalSecrets map[string]string,
 ) (CiPipeline, error) {
 	details := repoDetails.details.(*AzdoRepositoryDetails)
 
@@ -782,6 +783,7 @@ func (p *AzdoCiProvider) configurePipeline(
 		p.Env,
 		p.console,
 		provisioningProvider,
+		additionalSecrets,
 	)
 	if err != nil {
 		return nil, err

--- a/cli/azd/pkg/pipeline/github_provider.go
+++ b/cli/azd/pkg/pipeline/github_provider.go
@@ -625,7 +625,16 @@ func (p *GitHubCiProvider) configurePipeline(
 	ctx context.Context,
 	repoDetails *gitRepositoryDetails,
 	provisioningProvider provisioning.Options,
+	additionalSecrets map[string]string,
 ) (CiPipeline, error) {
+
+	repoSlug := repoDetails.owner + "/" + repoDetails.repoName
+	for key, value := range additionalSecrets {
+		if err := p.ghCli.SetSecret(ctx, repoSlug, key, value); err != nil {
+			return nil, fmt.Errorf("failed setting %s secret: %w", key, err)
+		}
+	}
+
 	return &workflow{
 		repoDetails: repoDetails,
 	}, nil

--- a/cli/azd/pkg/pipeline/pipeline.go
+++ b/cli/azd/pkg/pipeline/pipeline.go
@@ -96,6 +96,7 @@ type CiProvider interface {
 		ctx context.Context,
 		repoDetails *gitRepositoryDetails,
 		provisioningProvider provisioning.Options,
+		additionalSecrets map[string]string,
 	) (CiPipeline, error)
 	// configureConnection use the credential to set up the connection from the pipeline
 	// to Azure

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -341,7 +340,7 @@ func (pm *PipelineManager) Configure(ctx context.Context) (result *PipelineConfi
 	}
 
 	additionalSecrets := map[string]string{
-		environment.AzureInitialEnvironmentConfigName: strconv.Quote(string(localEnvConfig)),
+		environment.AzdInitialEnvironmentConfigName: string(localEnvConfig),
 	}
 
 	// config pipeline handles setting or creating the provider pipeline to be used

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -331,7 +331,7 @@ func (pm *PipelineManager) Configure(ctx context.Context) (result *PipelineConfi
 		return result, err
 	}
 
-	// Adding environment.AzureInitialEnvironmentConfigName as a secret to the pipeline as the base configuration for
+	// Adding environment.AzdInitialEnvironmentConfigName as a secret to the pipeline as the base configuration for
 	// whenever a new environment is created. This means loading the local environment config into a pipeline secret which
 	// azd will use to restore the the config on CI
 	localEnvConfig, err := json.Marshal(pm.env.Config.Raw())

--- a/cli/azd/pkg/project/dotnet_importer.go
+++ b/cli/azd/pkg/project/dotnet_importer.go
@@ -262,7 +262,9 @@ func (ai *DotNetImporter) readManifest(ctx context.Context, svcConfig *ServiceCo
 		return cached, nil
 	}
 
+	ai.console.ShowSpinner(ctx, "Generating app host manifest", input.Step)
 	manifest, err := apphost.ManifestFromAppHost(ctx, svcConfig.Path(), ai.dotnetCli)
+	ai.console.StopSpinner(ctx, "", input.Step)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/pkg/project/dotnet_importer.go
+++ b/cli/azd/pkg/project/dotnet_importer.go
@@ -262,7 +262,7 @@ func (ai *DotNetImporter) readManifest(ctx context.Context, svcConfig *ServiceCo
 		return cached, nil
 	}
 
-	ai.console.ShowSpinner(ctx, "Generating app host manifest", input.Step)
+	ai.console.ShowSpinner(ctx, "Analyzing Aspire Application (this might take a moment...)", input.Step)
 	manifest, err := apphost.ManifestFromAppHost(ctx, svcConfig.Path(), ai.dotnetCli)
 	ai.console.StopSpinner(ctx, "", input.Step)
 	if err != nil {


### PR DESCRIPTION
fix: https://github.com/Azure/azure-dev/issues/3027

Implementing a bootstrapping strategy to azd-environment creation. By using env-var `AZURE_INITIAL_ENVIRONMENT_CONFIG`, azd would parse the value (when it exists) when a new environment is created to define the initial env-config (instead of an empty config).

This strategy enables `azd pipeline config` to create a string out of the env-config and set AZURE_INITIAL_ENVIRONMENT_CONFIG as a pipeline secret.  

A pipeline definition can use the secret as a way to bootstrap the env-config.

As a side effect, the settings persisted in env-config at the moment of running `azd pipeline config` would be restored during CI, fixing the aspire pipelines use case and also the bicep-input saved-params.