### PR TITLE
core bicep: apply appsettings by default

### DIFF
--- a/templates/common/infra/bicep/core/host/appservice.bicep
+++ b/templates/common/infra/bicep/core/host/appservice.bicep
@@ -90,7 +90,7 @@ resource appService 'Microsoft.Web/sites@2022-03-01' = {
   }
 }
 
-module config 'appservice-appsettings.bicep' = if (!empty(appSettings)) {
+module config 'appservice-appsettings.bicep' = {
   name: '${name}-appSettings'
   params: {
     name: appService.name


### PR DESCRIPTION
Honor settings from `appInsightsName`, `keyVaultName`, and apply default app settings even when `appSettings` is empty.

Fixes #3025