### PR TITLE
init: restore old behavior, do not consider parent projects

### DIFF
--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -125,11 +125,8 @@ func (i *initAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		return nil, fmt.Errorf("getting cwd: %w", err)
 	}
 
-	azdCtx, err := i.lazyAzdCtx.GetValue()
-	if err != nil {
-		azdCtx = azdcontext.NewAzdContextWithDirectory(wd)
-		i.lazyAzdCtx.SetValue(azdCtx)
-	}
+	azdCtx := azdcontext.NewAzdContextWithDirectory(wd)
+	i.lazyAzdCtx.SetValue(azdCtx)
 
 	if i.flags.templateBranch != "" && i.flags.templatePath == "" {
 		return nil,


### PR DESCRIPTION
This restores the init behavior prior to 1.4.0 regression. `azd init` simply considers the current working directory when initializing, without attempting to resolve a parent directory project which is counterintuitive.

Fixes #2946