### PR TITLE
Ensure azd env name is synchronized to .env file

### DIFF
--- a/cli/azd/cmd/auth_token.go
+++ b/cli/azd/cmd/auth_token.go
@@ -97,7 +97,7 @@ func getTenantIdFromAzdEnv(
 	if err != nil {
 		return tenantId, fmt.Errorf(
 			"resolving the Azure Directory from azd environment (%s): %w",
-			azdEnv.GetEnvName(),
+			azdEnv.Name(),
 			err)
 	}
 

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -327,7 +327,7 @@ func (en *envNewAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 		return nil, fmt.Errorf("creating new environment: %w", err)
 	}
 
-	if err := en.azdCtx.SetDefaultEnvironmentName(env.GetEnvName()); err != nil {
+	if err := en.azdCtx.SetDefaultEnvironmentName(env.Name()); err != nil {
 		return nil, fmt.Errorf("saving default environment: %w", err)
 	}
 
@@ -432,7 +432,7 @@ func newEnvRefreshAction(
 func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	// Command title
 	ef.console.MessageUxItem(ctx, &ux.MessageTitle{
-		Title: fmt.Sprintf("Refreshing environment %s (azd env refresh)", ef.env.GetEnvName()),
+		Title: fmt.Sprintf("Refreshing environment %s (azd env refresh)", ef.env.Name()),
 	})
 
 	if err := ef.projectManager.Initialize(ctx, ef.projectConfig); err != nil {

--- a/cli/azd/cmd/hooks.go
+++ b/cli/azd/cmd/hooks.go
@@ -112,7 +112,7 @@ func (hra *hooksRunAction) Run(ctx context.Context) (*actions.ActionResult, erro
 		TitleNote: fmt.Sprintf(
 			"Finding and executing %s hooks for environment %s",
 			output.WithHighLightFormat(hookName),
-			output.WithHighLightFormat(hra.env.GetEnvName()),
+			output.WithHighLightFormat(hra.env.Name()),
 		),
 	})
 

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -359,7 +359,7 @@ func (i *initAction) initializeEnv(
 		return nil, fmt.Errorf("loading environment: %w", err)
 	}
 
-	if err := azdCtx.SetDefaultEnvironmentName(env.GetEnvName()); err != nil {
+	if err := azdCtx.SetDefaultEnvironmentName(env.Name()); err != nil {
 		return nil, fmt.Errorf("saving default environment: %w", err)
 	}
 

--- a/cli/azd/cmd/monitor.go
+++ b/cli/azd/cmd/monitor.go
@@ -101,7 +101,7 @@ func (m *monitorAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 
 	resourceManager := infra.NewAzureResourceManager(m.azCli, m.deploymentOperations)
 	resourceGroups, err := resourceManager.GetResourceGroupsForEnvironment(
-		ctx, m.env.GetSubscriptionId(), m.env.GetEnvName())
+		ctx, m.env.GetSubscriptionId(), m.env.Name())
 	if err != nil {
 		return nil, fmt.Errorf("discovering resource groups from deployment: %w", err)
 	}

--- a/cli/azd/cmd/show.go
+++ b/cli/azd/cmd/show.go
@@ -159,7 +159,7 @@ func (s *showAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		} else {
 			azureResourceManager := infra.NewAzureResourceManager(s.azCli, s.deploymentOperations)
 			resourceManager := project.NewResourceManager(env, s.azCli, s.deploymentOperations)
-			envName := env.GetEnvName()
+			envName := env.Name()
 
 			rgName, err = azureResourceManager.FindResourceGroupForEnvironment(ctx, subId, envName)
 			if err == nil {
@@ -185,7 +185,7 @@ func (s *showAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 			} else {
 				log.Printf(
 					"ignoring error determining resource group for environment %s, resource ids will not be available: %v",
-					env.GetEnvName(),
+					env.Name(),
 					err)
 			}
 		}

--- a/cli/azd/internal/repository/detect_confirm_apphost.go
+++ b/cli/azd/internal/repository/detect_confirm_apphost.go
@@ -77,8 +77,12 @@ func (d *detectConfirmAppHost) render(ctx context.Context) error {
 	d.console.Message(ctx, "  "+color.BlueString(projectDisplayName(d.AppHost)))
 	d.console.Message(ctx, "  "+"Detected in: "+output.WithHighLightFormat(relSafe(d.root, d.AppHost.Path)))
 	d.console.Message(ctx, "")
-	d.console.Message(ctx,
-		"azd will generate the files necessary to host your app on Azure using "+color.MagentaString("Azure Container Apps")+".\n")
+	d.console.Message(
+		ctx,
+		"azd will generate the files necessary to host your app on Azure using "+color.MagentaString(
+			"Azure Container Apps",
+		)+".\n",
+	)
 
 	return nil
 }

--- a/cli/azd/pkg/azdo/build_policy.go
+++ b/cli/azd/pkg/azdo/build_policy.go
@@ -69,7 +69,7 @@ func CreateBuildPolicy(
 
 	policySettings := map[string]interface{}{
 		"buildDefinitionId":       buildDefinition.Id,
-		"displayName":             fmt.Sprintf("Azure Dev Deploy PR - %s", env.GetEnvName()),
+		"displayName":             fmt.Sprintf("Azure Dev Deploy PR - %s", env.Name()),
 		"manualQueueOnly":         false,
 		"queueOnSourceUpdateOnly": true,
 		"validDuration":           720,

--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -155,7 +155,7 @@ func getDefinitionVariables(
 	}
 	variables := map[string]build.BuildDefinitionVariable{
 		"AZURE_LOCATION":           createBuildDefinitionVariable(env.GetLocation(), false, false),
-		"AZURE_ENV_NAME":           createBuildDefinitionVariable(env.GetEnvName(), false, false),
+		"AZURE_ENV_NAME":           createBuildDefinitionVariable(env.Name(), false, false),
 		"AZURE_SERVICE_CONNECTION": createBuildDefinitionVariable(ServiceConnectionName, false, false),
 		"AZURE_SUBSCRIPTION_ID":    createBuildDefinitionVariable(credentials.SubscriptionId, false, false),
 		"AZURE_CREDENTIALS":        createBuildDefinitionVariable(string(rawCredential), true, false),

--- a/cli/azd/pkg/devcenter/environment_store.go
+++ b/cli/azd/pkg/devcenter/environment_store.go
@@ -40,7 +40,7 @@ func NewEnvironmentStore(
 
 // EnvPath returns the path for the environment
 func (s *EnvironmentStore) EnvPath(env *environment.Environment) string {
-	return fmt.Sprintf("projects/%s/users/me/environments/%s", s.config.Project, env.GetEnvName())
+	return fmt.Sprintf("projects/%s/users/me/environments/%s", s.config.Project, env.Name())
 }
 
 // ConfigPath returns the path for the environment configuration
@@ -106,7 +106,7 @@ func (s *EnvironmentStore) Get(ctx context.Context, name string) (*environment.E
 // Reload reloads the environment from the remote data store
 func (s *EnvironmentStore) Reload(ctx context.Context, env *environment.Environment) error {
 	filter := func(e *devcentersdk.Environment) bool {
-		return s.envDefFilter(e) && strings.EqualFold(e.Name, env.GetEnvName())
+		return s.envDefFilter(e) && strings.EqualFold(e.Name, env.Name())
 	}
 
 	envList, err := s.matchingEnvironments(ctx, filter)
@@ -122,7 +122,7 @@ func (s *EnvironmentStore) Reload(ctx context.Context, env *environment.Environm
 		DevCenterByName(s.config.Name).
 		ProjectByName(s.config.Project).
 		EnvironmentsByUser(envList[0].User).
-		EnvironmentByName(env.GetEnvName()).
+		EnvironmentByName(env.Name()).
 		Get(ctx)
 
 	if err != nil {

--- a/cli/azd/pkg/devcenter/environment_store_test.go
+++ b/cli/azd/pkg/devcenter/environment_store_test.go
@@ -155,7 +155,7 @@ func Test_EnvironmentStore_Get(t *testing.T) {
 		env, err := store.Get(*mockContext.Context, mockEnvironments[0].Name)
 		require.NoError(t, err)
 		require.NotNil(t, env)
-		require.Equal(t, mockEnvironments[0].Name, env.GetEnvName())
+		require.Equal(t, mockEnvironments[0].Name, env.Name())
 		require.Equal(t, "value1", env.Getenv("KEY1"))
 		require.Equal(t, "value2", env.Getenv("KEY2"))
 
@@ -206,7 +206,7 @@ func Test_EnvironmentStore_GetEnvPath(t *testing.T) {
 	store := newEnvironmentStoreForTest(t, mockContext, config, nil)
 	env := environment.New(mockEnvironments[0].Name)
 	path := store.EnvPath(env)
-	require.Equal(t, fmt.Sprintf("projects/%s/users/me/environments/%s", config.Project, env.GetEnvName()), path)
+	require.Equal(t, fmt.Sprintf("projects/%s/users/me/environments/%s", config.Project, env.Name()), path)
 }
 
 func Test_EnvironmentStore_Save(t *testing.T) {

--- a/cli/azd/pkg/devcenter/prompter.go
+++ b/cli/azd/pkg/devcenter/prompter.go
@@ -235,7 +235,7 @@ func (p *Prompter) PromptParameters(
 		// Only prompt for parameter values when it has not already been set in the environment configuration
 		if !exists {
 			if param.Name == "environmentName" {
-				paramValues[param.Id] = env.GetEnvName()
+				paramValues[param.Id] = env.Name()
 				continue
 			}
 

--- a/cli/azd/pkg/devcenter/provision_provider.go
+++ b/cli/azd/pkg/devcenter/provision_provider.go
@@ -89,7 +89,7 @@ func (p *ProvisionProvider) State(
 		return nil, fmt.Errorf("invalid devcenter configuration, %w", err)
 	}
 
-	envName := p.env.GetEnvName()
+	envName := p.env.Name()
 	environment, err := p.devCenterClient.
 		DevCenterByName(p.config.Name).
 		ProjectByName(p.config.Project).
@@ -159,7 +159,7 @@ func (p *ProvisionProvider) Deploy(ctx context.Context) (*provisioning.DeployRes
 		return nil, fmt.Errorf("failed saving environment: %w", err)
 	}
 
-	envName := p.env.GetEnvName()
+	envName := p.env.Name()
 
 	// Check to see if an existing devcenter environment already exists
 	existingEnv, _ := p.devCenterClient.
@@ -256,7 +256,7 @@ func (p *ProvisionProvider) Destroy(
 		return nil, fmt.Errorf("invalid devcenter configuration, %w", err)
 	}
 
-	envName := p.env.GetEnvName()
+	envName := p.env.Name()
 	spinnerMessage := fmt.Sprintf("Deleting devcenter environment %s", output.WithHighLightFormat(envName))
 
 	if !options.Force() {

--- a/cli/azd/pkg/devcenter/provision_provider_test.go
+++ b/cli/azd/pkg/devcenter/provision_provider_test.go
@@ -111,12 +111,12 @@ func Test_ProvisionProvider_Deploy(t *testing.T) {
 			config.EnvironmentDefinition,
 			mockEnvDefinitions[0],
 		)
-		mockdevcentersdk.MockGetEnvironment(mockContext, config.Project, config.User, env.GetEnvName(), mockEnvironments[0])
+		mockdevcentersdk.MockGetEnvironment(mockContext, config.Project, config.User, env.Name(), mockEnvironments[0])
 		mockdevcentersdk.MockPutEnvironment(
 			mockContext,
 			config.Project,
 			config.User,
-			env.GetEnvName(),
+			env.Name(),
 			&devcentersdk.OperationStatus{
 				Id:        "id",
 				Name:      mockEnvironments[0].Name,
@@ -177,12 +177,12 @@ func Test_ProvisionProvider_Deploy(t *testing.T) {
 			config.EnvironmentDefinition,
 			mockEnvDefinitions[3],
 		)
-		mockdevcentersdk.MockGetEnvironment(mockContext, config.Project, config.User, env.GetEnvName(), mockEnvironments[0])
+		mockdevcentersdk.MockGetEnvironment(mockContext, config.Project, config.User, env.Name(), mockEnvironments[0])
 		mockdevcentersdk.MockPutEnvironment(
 			mockContext,
 			config.Project,
 			config.User,
-			env.GetEnvName(),
+			env.Name(),
 			&devcentersdk.OperationStatus{
 				Id:        "id",
 				Name:      mockEnvironments[0].Name,
@@ -229,12 +229,12 @@ func Test_ProvisionProvider_Deploy(t *testing.T) {
 			config.EnvironmentDefinition,
 			mockEnvDefinitions[0],
 		)
-		mockdevcentersdk.MockGetEnvironment(mockContext, config.Project, config.User, env.GetEnvName(), nil)
+		mockdevcentersdk.MockGetEnvironment(mockContext, config.Project, config.User, env.Name(), nil)
 		mockdevcentersdk.MockPutEnvironment(
 			mockContext,
 			config.Project,
 			config.User,
-			env.GetEnvName(),
+			env.Name(),
 			&devcentersdk.OperationStatus{
 				Id:        "id",
 				Name:      mockEnvironments[0].Name,
@@ -276,7 +276,7 @@ func Test_ProvisionProvider_State(t *testing.T) {
 			Return(outputParams, nil)
 
 		mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
-		mockdevcentersdk.MockGetEnvironment(mockContext, config.Project, config.User, env.GetEnvName(), mockEnvironments[0])
+		mockdevcentersdk.MockGetEnvironment(mockContext, config.Project, config.User, env.Name(), mockEnvironments[0])
 
 		provider := newProvisionProviderForTest(t, mockContext, config, env, manager)
 		result, err := provider.State(*mockContext.Context, &provisioning.StateOptions{})
@@ -298,7 +298,7 @@ func Test_ProvisionProvider_State(t *testing.T) {
 		env := environment.New("test")
 
 		mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
-		mockdevcentersdk.MockGetEnvironment(mockContext, config.Project, config.User, env.GetEnvName(), nil)
+		mockdevcentersdk.MockGetEnvironment(mockContext, config.Project, config.User, env.Name(), nil)
 
 		provider := newProvisionProviderForTest(t, mockContext, config, env, nil)
 		result, err := provider.State(*mockContext.Context, &provisioning.StateOptions{})
@@ -324,7 +324,7 @@ func Test_ProvisionProvider_State(t *testing.T) {
 			Return(nil, errors.New("no outputs"))
 
 		mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
-		mockdevcentersdk.MockGetEnvironment(mockContext, config.Project, config.User, env.GetEnvName(), mockEnvironments[0])
+		mockdevcentersdk.MockGetEnvironment(mockContext, config.Project, config.User, env.Name(), mockEnvironments[0])
 
 		provider := newProvisionProviderForTest(t, mockContext, config, env, manager)
 		result, err := provider.State(*mockContext.Context, &provisioning.StateOptions{})
@@ -347,12 +347,12 @@ func Test_ProvisionProvider_Destroy(t *testing.T) {
 		env := environment.New("test")
 
 		mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
-		mockdevcentersdk.MockGetEnvironment(mockContext, config.Project, config.User, env.GetEnvName(), mockEnvironments[0])
+		mockdevcentersdk.MockGetEnvironment(mockContext, config.Project, config.User, env.Name(), mockEnvironments[0])
 		mockdevcentersdk.MockDeleteEnvironment(
 			mockContext,
 			config.Project,
 			config.User,
-			env.GetEnvName(),
+			env.Name(),
 			&devcentersdk.OperationStatus{
 				Id:        "id",
 				Name:      mockEnvironments[0].Name,
@@ -398,8 +398,8 @@ func Test_ProvisionProvider_Destroy(t *testing.T) {
 		env := environment.New("test")
 
 		mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
-		mockdevcentersdk.MockGetEnvironment(mockContext, config.Project, config.User, env.GetEnvName(), nil)
-		mockdevcentersdk.MockDeleteEnvironment(mockContext, config.Project, config.User, env.GetEnvName(), nil)
+		mockdevcentersdk.MockGetEnvironment(mockContext, config.Project, config.User, env.Name(), nil)
+		mockdevcentersdk.MockDeleteEnvironment(mockContext, config.Project, config.User, env.Name(), nil)
 
 		provider := newProvisionProviderForTest(t, mockContext, config, env, nil)
 		destroyOptions := provisioning.NewDestroyOptions(true, true)

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -66,7 +66,8 @@ func New(name string) *Environment {
 		Config:      config.NewEmptyConfig(),
 	}
 
-	env.SetEnvName(name)
+	env.DotenvSet(EnvNameEnvVarName, name)
+
 	return env
 }
 
@@ -81,7 +82,6 @@ func NewWithValues(name string, values map[string]string) *Environment {
 		env.dotenv = values
 	}
 
-	env.SetEnvName(name)
 	return env
 }
 
@@ -160,14 +160,14 @@ func (e *Environment) DotenvSet(key string, value string) {
 	delete(e.deletedKeys, key)
 }
 
-// GetEnvName is shorthand for Getenv(EnvNameEnvVarName)
-func (e *Environment) GetEnvName() string {
-	return e.Getenv(EnvNameEnvVarName)
-}
+// Name gets the name of the environment
+// If empty will fallback to the value of the AZURE_ENV_NAME environment variable
+func (e *Environment) Name() string {
+	if e.name == "" {
+		e.name = e.Getenv(EnvNameEnvVarName)
+	}
 
-// SetEnvName is shorthand for DotenvSet(EnvNameEnvVarName, envname)
-func (e *Environment) SetEnvName(envname string) {
-	e.DotenvSet(EnvNameEnvVarName, envname)
+	return e.name
 }
 
 // GetSubscriptionId is shorthand for Getenv(SubscriptionIdEnvVarName)

--- a/cli/azd/pkg/environment/local_file_data_store.go
+++ b/cli/azd/pkg/environment/local_file_data_store.go
@@ -115,8 +115,8 @@ func (fs *LocalFileDataStore) Reload(ctx context.Context, env *Environment) erro
 		env.Config = cfg
 	}
 
-	if env.GetEnvName() != "" {
-		tracing.SetUsageAttributes(fields.StringHashed(fields.EnvNameKey, env.GetEnvName()))
+	if env.Name() != "" {
+		tracing.SetUsageAttributes(fields.StringHashed(fields.EnvNameKey, env.Name()))
 	}
 
 	if _, err := uuid.Parse(env.GetSubscriptionId()); err == nil {
@@ -172,6 +172,6 @@ func (fs *LocalFileDataStore) Save(ctx context.Context, env *Environment) error 
 		return fmt.Errorf("saving .env: %w", err)
 	}
 
-	tracing.SetUsageAttributes(fields.StringHashed(fields.EnvNameKey, env.GetEnvName()))
+	tracing.SetUsageAttributes(fields.StringHashed(fields.EnvNameKey, env.Name()))
 	return nil
 }

--- a/cli/azd/pkg/environment/manager_test.go
+++ b/cli/azd/pkg/environment/manager_test.go
@@ -51,7 +51,8 @@ var (
 	}
 
 	getEnv *Environment = NewWithValues("env1", map[string]string{
-		"key1": "value1",
+		"key1":            "value1",
+		EnvNameEnvVarName: "env1",
 	})
 )
 
@@ -85,7 +86,7 @@ func Test_EnvManager_PromptEnvironmentName(t *testing.T) {
 		env, err := envManager.LoadOrCreateInteractive(*mockContext.Context, expected)
 		require.NoError(t, err)
 		require.NotNil(t, env)
-		require.Equal(t, expected, env.GetEnvName())
+		require.Equal(t, expected, env.Name())
 	})
 
 	t.Run("empty name gets prompted", func(t *testing.T) {
@@ -105,7 +106,7 @@ func Test_EnvManager_PromptEnvironmentName(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, env)
-		require.Equal(t, expected, env.GetEnvName())
+		require.Equal(t, expected, env.Name())
 	})
 }
 

--- a/cli/azd/pkg/environment/storage_blob_data_store.go
+++ b/cli/azd/pkg/environment/storage_blob_data_store.go
@@ -139,7 +139,7 @@ func (sbd *StorageBlobDataStore) Save(ctx context.Context, env *Environment) err
 		return fmt.Errorf("uploading .env: %w", describeError(err))
 	}
 
-	tracing.SetUsageAttributes(fields.StringHashed(fields.EnvNameKey, env.GetEnvName()))
+	tracing.SetUsageAttributes(fields.StringHashed(fields.EnvNameKey, env.Name()))
 	return nil
 }
 
@@ -177,8 +177,8 @@ func (sbd *StorageBlobDataStore) Reload(ctx context.Context, env *Environment) e
 		env.Config = cfg
 	}
 
-	if env.GetEnvName() != "" {
-		tracing.SetUsageAttributes(fields.StringHashed(fields.EnvNameKey, env.GetEnvName()))
+	if env.Name() != "" {
+		tracing.SetUsageAttributes(fields.StringHashed(fields.EnvNameKey, env.Name()))
 	}
 
 	if _, err := uuid.Parse(env.GetSubscriptionId()); err == nil {

--- a/cli/azd/pkg/infra/azure_resource_manager_test.go
+++ b/cli/azd/pkg/infra/azure_resource_manager_test.go
@@ -467,7 +467,7 @@ func TestFindResourceGroupForEnvironment(t *testing.T) {
 
 			arm := NewAzureResourceManager(azCli, depOpService)
 			rgName, err := arm.FindResourceGroupForEnvironment(
-				*mockContext.Context, env.GetSubscriptionId(), env.GetEnvName())
+				*mockContext.Context, env.GetSubscriptionId(), env.Name())
 
 			if tt.expectedErrorText == "" {
 				require.NoError(t, err)

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -231,7 +231,7 @@ func (p *BicepProvider) State(ctx context.Context, options *StateOptions) (*Stat
 
 	var deployment *armresources.DeploymentExtended
 
-	deployments, err := p.findCompletedDeployments(ctx, p.env.GetEnvName(), scope, options.Hint())
+	deployments, err := p.findCompletedDeployments(ctx, p.env.Name(), scope, options.Hint())
 	p.console.StopSpinner(ctx, "", input.StepDone)
 
 	if err != nil {
@@ -386,7 +386,7 @@ func (p *BicepProvider) deploymentScope(deploymentScope azure.DeploymentScope) (
 			p.deploymentOperations,
 			p.env.GetLocation(),
 			p.env.GetSubscriptionId(),
-			deploymentNameForEnv(p.env.GetEnvName(), p.clock),
+			deploymentNameForEnv(p.env.Name(), p.clock),
 		), nil
 	} else if deploymentScope == azure.DeploymentScopeResourceGroup {
 		return infra.NewResourceGroupDeployment(
@@ -394,7 +394,7 @@ func (p *BicepProvider) deploymentScope(deploymentScope azure.DeploymentScope) (
 			p.deploymentOperations,
 			p.env.GetSubscriptionId(),
 			p.env.Getenv(environment.ResourceGroupEnvVarName),
-			deploymentNameForEnv(p.env.GetEnvName(), p.clock),
+			deploymentNameForEnv(p.env.Name(), p.clock),
 		), nil
 	}
 	return nil, fmt.Errorf("unsupported scope: %s", deploymentScope)
@@ -458,7 +458,7 @@ func (p *BicepProvider) latestDeploymentResult(
 	ctx context.Context,
 	scope infra.Scope,
 ) (*armresources.DeploymentExtended, error) {
-	deployments, err := p.findCompletedDeployments(ctx, p.env.GetEnvName(), scope, "")
+	deployments, err := p.findCompletedDeployments(ctx, p.env.Name(), scope, "")
 	// findCompletedDeployments returns error if no deployments are found
 	// No need to check for empty list
 	if err != nil {
@@ -618,7 +618,7 @@ func (p *BicepProvider) Deploy(ctx context.Context) (*DeployResult, error) {
 	p.console.ShowSpinner(ctx, "Creating/Updating resources", input.Step)
 
 	deploymentTags := map[string]*string{
-		azure.TagKeyAzdEnvName: to.Ptr(p.env.GetEnvName()),
+		azure.TagKeyAzdEnvName: to.Ptr(p.env.Name()),
 	}
 	if parametersHashErr == nil {
 		deploymentTags[azure.TagKeyAzdDeploymentStateParamHashName] = to.Ptr(currentParamsHash)
@@ -797,7 +797,7 @@ func (p *BicepProvider) Destroy(ctx context.Context, options DestroyOptions) (*D
 	}
 
 	// TODO: Report progress, "Fetching resource groups"
-	deployments, err := p.findCompletedDeployments(ctx, p.env.GetEnvName(), scope, "")
+	deployments, err := p.findCompletedDeployments(ctx, p.env.Name(), scope, "")
 	if err != nil {
 		return nil, err
 	}
@@ -932,7 +932,7 @@ func (p *BicepProvider) Destroy(ctx context.Context, options DestroyOptions) (*D
 		emptyTemplate,
 		azure.ArmParameters{},
 		map[string]*string{
-			azure.TagKeyAzdEnvName: to.Ptr(p.env.GetEnvName()),
+			azure.TagKeyAzdEnvName: to.Ptr(p.env.Name()),
 			"azd-deploy-reason":    to.Ptr("down"),
 		}); err != nil {
 		log.Println("failed creating new empty deployment after destroy")

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -57,7 +57,7 @@ func TestBicepPlan(t *testing.T) {
 	require.Equal(t, infraProvider.env.GetLocation(), configuredParameters["location"].Value)
 	require.Equal(
 		t,
-		infraProvider.env.GetEnvName(),
+		infraProvider.env.Name(),
 		configuredParameters["environmentName"].Value,
 	)
 }

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -613,29 +613,29 @@ func (t *TerraformProvider) modulePath() string {
 // Gets the path to the staging .azure terraform plan file path
 func (t *TerraformProvider) planFilePath() string {
 	planFilename := fmt.Sprintf("%s.tfplan", t.options.Module)
-	return filepath.Join(t.projectPath, ".azure", t.env.GetEnvName(), t.options.Path, planFilename)
+	return filepath.Join(t.projectPath, ".azure", t.env.Name(), t.options.Path, planFilename)
 }
 
 // Gets the path to the staging .azure terraform local state file path
 func (t *TerraformProvider) localStateFilePath() string {
-	return filepath.Join(t.projectPath, ".azure", t.env.GetEnvName(), t.options.Path, "terraform.tfstate")
+	return filepath.Join(t.projectPath, ".azure", t.env.Name(), t.options.Path, "terraform.tfstate")
 }
 
 // Gets the path to the staging .azure parameters file path
 func (t *TerraformProvider) backendConfigFilePath() string {
-	backendConfigFilename := fmt.Sprintf("%s.conf.json", t.env.GetEnvName())
-	return filepath.Join(t.projectPath, ".azure", t.env.GetEnvName(), t.options.Path, backendConfigFilename)
+	backendConfigFilename := fmt.Sprintf("%s.conf.json", t.env.Name())
+	return filepath.Join(t.projectPath, ".azure", t.env.Name(), t.options.Path, backendConfigFilename)
 }
 
 // Gets the path to the staging .azure backend config file path
 func (t *TerraformProvider) parametersFilePath() string {
 	parametersFilename := fmt.Sprintf("%s.tfvars.json", t.options.Module)
-	return filepath.Join(t.projectPath, ".azure", t.env.GetEnvName(), t.options.Path, parametersFilename)
+	return filepath.Join(t.projectPath, ".azure", t.env.Name(), t.options.Path, parametersFilename)
 }
 
 // Gets the path to the current env.
 func (t *TerraformProvider) dataDirPath() string {
-	return filepath.Join(t.projectPath, ".azure", t.env.GetEnvName(), t.options.Path, ".terraform")
+	return filepath.Join(t.projectPath, ".azure", t.env.Name(), t.options.Path, ".terraform")
 }
 
 // Check terraform file for remote backend provider

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
@@ -87,7 +87,7 @@ func TestTerraformState(t *testing.T) {
 	require.NotNil(t, getStateResult.State)
 
 	require.Equal(t, infraProvider.env.Dotenv()["AZURE_LOCATION"], getStateResult.State.Outputs["AZURE_LOCATION"].Value)
-	require.Equal(t, fmt.Sprintf("rg-%s", infraProvider.env.GetEnvName()), getStateResult.State.Outputs["RG_NAME"].Value)
+	require.Equal(t, fmt.Sprintf("rg-%s", infraProvider.env.Name()), getStateResult.State.Outputs["RG_NAME"].Value)
 	require.Len(t, getStateResult.State.Resources, 1)
 	require.Regexp(
 		t,

--- a/cli/azd/pkg/pipeline/github_provider.go
+++ b/cli/azd/pkg/pipeline/github_provider.go
@@ -506,7 +506,7 @@ func (p *GitHubCiProvider) setPipelineVariables(
 	servicePrincipal *graphsdk.ServicePrincipal,
 ) error {
 	for name, value := range map[string]string{
-		environment.EnvNameEnvVarName:        p.env.GetEnvName(),
+		environment.EnvNameEnvVarName:        p.env.Name(),
 		environment.LocationEnvVarName:       p.env.GetLocation(),
 		environment.SubscriptionIdEnvVarName: p.env.GetSubscriptionId(),
 		environment.TenantIdEnvVarName:       *servicePrincipal.AppOwnerOrganizationId,

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -81,7 +81,7 @@ func (ch *ContainerHelper) LocalImageTag(ctx context.Context, serviceConfig *Ser
 	return fmt.Sprintf("%s/%s-%s:azd-deploy-%d",
 		strings.ToLower(serviceConfig.Project.Name),
 		strings.ToLower(serviceConfig.Name),
-		strings.ToLower(ch.env.GetEnvName()),
+		strings.ToLower(ch.env.Name()),
 		ch.clock.Now().Unix(),
 	), nil
 }

--- a/cli/azd/pkg/project/project_config_test.go
+++ b/cli/azd/pkg/project/project_config_test.go
@@ -85,7 +85,7 @@ services:
 
 	require.Equal(t, "test-proj", projectConfig.Name)
 	require.Equal(t, "test-proj-template", projectConfig.Metadata.Template)
-	require.Equal(t, fmt.Sprintf("rg-%s", e.GetEnvName()), projectConfig.ResourceGroupName.MustEnvsubst(e.Getenv))
+	require.Equal(t, fmt.Sprintf("rg-%s", e.Name()), projectConfig.ResourceGroupName.MustEnvsubst(e.Getenv))
 	require.Equal(t, 2, len(projectConfig.Services))
 
 	for key, svc := range projectConfig.Services {

--- a/cli/azd/pkg/project/resource_manager.go
+++ b/cli/azd/pkg/project/resource_manager.go
@@ -86,7 +86,7 @@ func (rm *resourceManager) GetResourceGroupName(
 	}
 
 	resourceManager := infra.NewAzureResourceManager(rm.azCli, rm.deploymentOperations)
-	resourceGroupName, err := resourceManager.FindResourceGroupForEnvironment(ctx, subscriptionId, rm.env.GetEnvName())
+	resourceGroupName, err := resourceManager.FindResourceGroupForEnvironment(ctx, subscriptionId, rm.env.Name())
 	if err != nil {
 		return "", err
 	}

--- a/cli/azd/pkg/prompt/prompter.go
+++ b/cli/azd/pkg/prompt/prompter.go
@@ -136,7 +136,7 @@ func (p *DefaultPrompter) PromptResourceGroup(ctx context.Context) (string, erro
 
 	name, err := p.console.Prompt(ctx, input.ConsoleOptions{
 		Message:      "Enter a name for the new resource group:",
-		DefaultValue: fmt.Sprintf("rg-%s", p.env.GetEnvName()),
+		DefaultValue: fmt.Sprintf("rg-%s", p.env.Name()),
 	})
 	if err != nil {
 		return "", fmt.Errorf("prompting for resource group name: %w", err)
@@ -144,7 +144,7 @@ func (p *DefaultPrompter) PromptResourceGroup(ctx context.Context) (string, erro
 
 	err = p.azCli.CreateOrUpdateResourceGroup(ctx, p.env.GetSubscriptionId(), name, p.env.GetLocation(),
 		map[string]*string{
-			azure.TagKeyAzdEnvName: to.Ptr(p.env.GetEnvName()),
+			azure.TagKeyAzdEnvName: to.Ptr(p.env.Name()),
 		},
 	)
 	if err != nil {

--- a/cli/azd/pkg/tools/dotnet/dotnet.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet.go
@@ -129,7 +129,9 @@ func (cli *dotNetCli) PublishAppHostManifest(
 		m, err := os.ReadFile(filepath.Join(filepath.Dir(hostProject), "apphost-manifest.json"))
 		if err != nil {
 			return fmt.Errorf(
-				"reading apphost-manifest.json (did you mean to have AZD_DEBUG_DOTNET_APPHOST_USE_FIXED_MANIFEST set?): %w", err)
+				"reading apphost-manifest.json (did you mean to have AZD_DEBUG_DOTNET_APPHOST_USE_FIXED_MANIFEST set?): %w",
+				err,
+			)
 		}
 
 		return os.WriteFile(manifestPath, m, osutil.PermissionFile)

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -172,7 +172,7 @@ func Test_CLI_InfraCreateAndDelete(t *testing.T) {
 
 	// Verify that resource groups are created with tag
 	resourceManager := infra.NewAzureResourceManager(azCli, deploymentOperations)
-	rgs, err := resourceManager.GetResourceGroupsForEnvironment(ctx, env.GetSubscriptionId(), env.GetEnvName())
+	rgs, err := resourceManager.GetResourceGroupsForEnvironment(ctx, env.GetSubscriptionId(), env.Name())
 	require.NoError(t, err)
 	require.NotNil(t, rgs)
 
@@ -371,7 +371,7 @@ func Test_CLI_InfraCreateAndDeleteUpperCase(t *testing.T) {
 
 	// Verify that resource groups are created with tag
 	resourceManager := infra.NewAzureResourceManager(azCli, deploymentOperations)
-	rgs, err := resourceManager.GetResourceGroupsForEnvironment(ctx, env.GetSubscriptionId(), env.GetEnvName())
+	rgs, err := resourceManager.GetResourceGroupsForEnvironment(ctx, env.GetSubscriptionId(), env.Name())
 	require.NoError(t, err)
 	require.NotNil(t, rgs)
 


### PR DESCRIPTION
Resolves #3040 

Fixes an issue where if `AZURE__ENV_NAME` does not exist within the .env file then downstream operations will fail when looking up resource group or service names.

Also renames `GetEnvName()` to `Name()`