### PR TITLE
aspire: Set `allowInsecure` to true for internal services

### DIFF
--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -424,7 +424,7 @@ func (b *infraGenerator) Compile() error {
 				External:      binding.External,
 				TargetPort:    *binding.ContainerPort,
 				Transport:     binding.Transport,
-				AllowInsecure: strings.ToLower(binding.Transport) == "http2",
+				AllowInsecure: strings.ToLower(binding.Transport) == "http2" || !binding.External,
 			}
 		}
 
@@ -460,7 +460,7 @@ func (b *infraGenerator) Compile() error {
 				//
 				// Note that the protocol type is apparently optional.
 				TargetPort:    8080,
-				AllowInsecure: strings.ToLower(binding.Transport) == "http2",
+				AllowInsecure: strings.ToLower(binding.Transport) == "http2" || !binding.External,
 			}
 		}
 


### PR DESCRIPTION
In addition to setting `allowInscure` for HTTP2 (i.e. gRPC) services, we now also set this to true by default for any service that is not publicly exposed.

This allows inscure traffic to internal nodes, to allow requests to things like `http://backend` from one internal service to another.

Fixes #3201