### PR TITLE
console: handle interrupt to unhide cursor

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -178,6 +178,7 @@ tracetest
 trafficmanager
 Truef
 typeflag
+unhide
 unmarshaled
 unmarshalling
 unsetenvs


### PR DESCRIPTION
Handle interrupt to unhide terminal cursor from a potentially active spinner

#2194