### PR TITLE
aspire: Publish projects as framework dependent

### DIFF
--- a/cli/azd/pkg/tools/dotnet/dotnet.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet.go
@@ -167,9 +167,6 @@ func (cli *dotNetCli) PublishContainer(
 		fmt.Sprintf("-p:ContainerRegistry=%s", server),
 	)
 
-	// TODO(ellismg): Remove this when the .NET 8 RTM base images have been pushed.
-	runArgs = runArgs.AppendParams("--self-contained")
-
 	_, err := cli.commandRunner.Run(ctx, runArgs)
 	if err != nil {
 		return fmt.Errorf("dotnet publish on project '%s' failed: %w", project, err)


### PR DESCRIPTION
When publishing an .NET Application, you have two choices as to how to reference the .NET Runtime.  You can either publish as a framework dependent project, where your app will use a pre-deployed copy the .NET Runtime, or self contained, where your app will care the .NET Framework for your target platform with it.

Framework dependent projects are the default, because they are smaller (you don't need to bring along an entire .NET runtime with your application).

In Aspire, we were publishing as self contained because we needed the latest and greatest version of the .NET Runtime, since there were some breaking changes that impacted Aspire and it depended on, and the public base container images on MCR had `rc2` bits.

Now that .NET 8 has shipped, this is no longer a problem, and we can publish as a framework dependent project once again. This results in smaller container images, because they can leverage the shared framework from the base container image instead of including yet another copy of the runtime in the application layer.