### PR TITLE
aspire: Enable Admin User on Container Registry

### DIFF
--- a/cli/azd/resources/apphost/templates/resources.bicept
+++ b/cli/azd/resources/apphost/templates/resources.bicept
@@ -19,6 +19,9 @@ resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-07-01' =
   sku: {
     name: 'Basic'
   }
+  properties: {
+    adminUserEnabled: true
+  }
   tags: tags
 }
 


### PR DESCRIPTION
Our intention is to use Azure RBAC to secure access to the container registry, and the exchange our AAD token for a time limited access token that we use to log into the registry. That has worked for some users, but others have run into issues like what we see in #2980

While we're still trying to root cause the actual issue, we have discovered that if the admin account is enabled, the end to end seems to work.

This change enables the admin account to allow `azd` to fall back to that when the token exchange doesn't work.

Contributes To: #2980