### PR TITLE
aspire: Better error msg for missing containerPort in binding

### DIFF
--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -421,7 +421,9 @@ func (b *infraGenerator) Compile() error {
 
 		if binding != nil {
 			if binding.ContainerPort == nil {
-				return fmt.Errorf("binding for %s resource does not have containerPort specified", name)
+				return fmt.Errorf(
+					"binding for %s resource does not specify a container port, "+
+						"ensure WithServiceBinding for this resource specifies a hostPort value", name)
 			}
 
 			cs.Ingress = &genContainerServiceIngress{

--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -420,6 +420,10 @@ func (b *infraGenerator) Compile() error {
 		}
 
 		if binding != nil {
+			if binding.ContainerPort == nil {
+				return fmt.Errorf("binding for %s resource does not have containerPort specified", name)
+			}
+
 			cs.Ingress = &genContainerServiceIngress{
 				External:      binding.External,
 				TargetPort:    *binding.ContainerPort,


### PR DESCRIPTION
Based on https://github.com/dotnet/aspire/issues/693, this should be a required property. However, we should still avoid a panic and provide a better error message.

Related to: #3070 