### PR TITLE
aspire: Add support for `dockerfile.v0`

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -70,6 +70,7 @@ devcentersdk
 devel
 discarder
 docf
+dockerfiles
 dockerproject
 doublestar
 dskip

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -497,6 +497,12 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		}
 	}
 
+	err := container.RegisterNamedSingleton(
+		string(project.ServiceLanguageDocker), project.NewDockerProjectAsFrameworkService)
+	if err != nil {
+		panic(fmt.Errorf("registering docker framework service: %w", err))
+	}
+
 	// Pipelines
 	container.RegisterSingleton(pipeline.NewPipelineManager)
 	container.RegisterSingleton(func(flags *pipelineConfigFlags) *pipeline.PipelineManagerArgs {

--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -59,6 +59,25 @@ func ProjectPaths(manifest *Manifest) map[string]string {
 	return res
 }
 
+// Dockerfiles returns information about all dockerfile.v0 resources from a manifest.
+func Dockerfiles(manifest *Manifest) map[string]genDockerfile {
+	res := make(map[string]genDockerfile)
+
+	for name, comp := range manifest.Resources {
+		switch comp.Type {
+		case "dockerfile.v0":
+			res[name] = genDockerfile{
+				Path:     *comp.Path,
+				Context:  *comp.Context,
+				Env:      comp.Env,
+				Bindings: comp.Bindings,
+			}
+		}
+	}
+
+	return res
+}
+
 // ContainerAppManifestTemplateForProject returns the container app manifest template for a given project.
 // It can be used (after evaluation) to deploy the service to a container app environment.
 func ContainerAppManifestTemplateForProject(manifest *Manifest, projectName string) (string, error) {
@@ -84,7 +103,7 @@ func ContainerAppManifestTemplateForProject(manifest *Manifest, projectName stri
 
 // BicepTemplate returns a filesystem containing the generated bicep files for the given manifest. These files represent
 // the shared infrastructure that would normally be under the `infra/` folder for the given manifest.
-func BicepTemplate(manifest *Manifest) (fs.FS, error) {
+func BicepTemplate(manifest *Manifest) (*memfs.FS, error) {
 	generator := newInfraGenerator()
 
 	if err := generator.LoadManifest(manifest); err != nil {
@@ -185,6 +204,7 @@ func GenerateProjectArtifacts(
 
 type infraGenerator struct {
 	containers        map[string]genContainer
+	dockerfiles       map[string]genDockerfile
 	projects          map[string]genProject
 	connectionStrings map[string]string
 	resourceTypes     map[string]string
@@ -204,6 +224,7 @@ func newInfraGenerator() *infraGenerator {
 			ContainerApps:                   make(map[string]genContainerApp),
 		},
 		containers:                   make(map[string]genContainer),
+		dockerfiles:                  make(map[string]genDockerfile),
 		projects:                     make(map[string]genProject),
 		connectionStrings:            make(map[string]string),
 		resourceTypes:                make(map[string]string),
@@ -225,6 +246,8 @@ func (b *infraGenerator) LoadManifest(m *Manifest) error {
 			b.addProject(name, *comp.Path, comp.Env, comp.Bindings)
 		case "container.v0":
 			b.addContainer(name, *comp.Image, comp.Env, comp.Bindings)
+		case "dockerfile.v0":
+			b.addDockerfile(name, *comp.Path, *comp.Context, comp.Env, comp.Bindings)
 		case "redis.v0":
 			b.addContainerAppService(name, "redis")
 		case "azure.keyvault.v0":
@@ -356,6 +379,20 @@ func (b *infraGenerator) addContainer(name string, image string, env map[string]
 	}
 }
 
+func (b *infraGenerator) addDockerfile(
+	name string, path string, context string, env map[string]string, bindings map[string]*Binding,
+) {
+	b.requireCluster()
+	b.requireContainerRegistry()
+
+	b.dockerfiles[name] = genDockerfile{
+		Path:     path,
+		Context:  context,
+		Env:      env,
+		Bindings: bindings,
+	}
+}
+
 func validateAndMergeBindings(bindings map[string]*Binding) (*Binding, error) {
 	if len(bindings) == 0 {
 		return nil, nil
@@ -410,46 +447,53 @@ func validateAndMergeBindings(bindings map[string]*Binding) (*Binding, error) {
 // infrastructure.
 func (b *infraGenerator) Compile() error {
 	for name, container := range b.containers {
-		binding, err := validateAndMergeBindings(container.Bindings)
-		if err != nil {
-			return fmt.Errorf("validating binding for %s resource: %w", name, err)
-		}
-
 		cs := genContainerApp{
 			Image: container.Image,
 		}
 
-		if binding != nil {
-			if binding.ContainerPort == nil {
-				return fmt.Errorf(
-					"binding for %s resource does not specify a container port, "+
-						"ensure WithServiceBinding for this resource specifies a hostPort value", name)
-			}
-
-			cs.Ingress = &genContainerServiceIngress{
-				External:      binding.External,
-				TargetPort:    *binding.ContainerPort,
-				Transport:     binding.Transport,
-				AllowInsecure: strings.ToLower(binding.Transport) == "http2" || !binding.External,
-			}
+		ingress, err := buildIngress(container.Bindings)
+		if err != nil {
+			return fmt.Errorf("configuring ingress for resource %s: %w", name, err)
 		}
+
+		cs.Ingress = ingress
 
 		b.bicepContext.ContainerApps[name] = cs
 	}
 
-	for projectName, project := range b.projects {
+	for resourceName, docker := range b.dockerfiles {
 		projectTemplateCtx := genContainerAppManifestTemplateContext{
-			Name: projectName,
+			Name: resourceName,
+			Env:  make(map[string]string),
+		}
+
+		ingress, err := buildIngress(docker.Bindings)
+		if err != nil {
+			return fmt.Errorf("configuring ingress for resource %s: %w", resourceName, err)
+		}
+
+		projectTemplateCtx.Ingress = ingress
+
+		if err := b.buildEnvBlock(docker.Env, &projectTemplateCtx); err != nil {
+			return fmt.Errorf("configuring environment for resource %s: %w", resourceName, err)
+		}
+
+		b.containerAppTemplateContexts[resourceName] = projectTemplateCtx
+	}
+
+	for resourceName, project := range b.projects {
+		projectTemplateCtx := genContainerAppManifestTemplateContext{
+			Name: resourceName,
 			Env:  make(map[string]string),
 		}
 
 		binding, err := validateAndMergeBindings(project.Bindings)
 		if err != nil {
-			return fmt.Errorf("configuring ingress for project %s: %w", projectName, err)
+			return fmt.Errorf("configuring ingress for project %s: %w", resourceName, err)
 		}
 
 		if binding != nil {
-			projectTemplateCtx.Ingress = &genContainerAppManifestTemplateContextIngress{
+			projectTemplateCtx.Ingress = &genContainerAppIngress{
 				External:  binding.External,
 				Transport: binding.Transport,
 
@@ -470,131 +514,179 @@ func (b *infraGenerator) Compile() error {
 			}
 		}
 
-		for k, v := range project.Env {
-			if !strings.HasPrefix(v, "{") || !strings.HasSuffix(v, "}") {
-				// We want to ensure that we render these values in the YAML as strings.  If `v` was the string "false"
-				// (without the quotes), we would naturally create a value directive in yaml that looks like this:
-				//
-				// - name: OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES
-				//   value: true
-				//
-				// And YAML rules would treat the above as the value being a boolean instead of a string, which the container
-				// app service expects.
-				//
-				// JSON marshalling the string value will give us something like `"true"` (with the quotes, and any escaping
-				// that needs to be done), which is what we want here.
-				jsonStr, err := json.Marshal(v)
-				if err != nil {
-					return fmt.Errorf("marshalling env value: %w", err)
+		if err := b.buildEnvBlock(project.Env, &projectTemplateCtx); err != nil {
+			return err
+		}
+
+		b.containerAppTemplateContexts[resourceName] = projectTemplateCtx
+	}
+
+	return nil
+}
+
+// buildIngress builds the ingress configuration for a given set of bindings. It returns nil, nil if no ingress should
+// be configured (i.e. the bindings are empty).
+func buildIngress(bindings map[string]*Binding) (*genContainerAppIngress, error) {
+	binding, err := validateAndMergeBindings(bindings)
+	if err != nil {
+		return nil, err
+	}
+
+	if binding != nil {
+		if binding.ContainerPort == nil {
+			return nil, fmt.Errorf(
+				"binding for does not specify a container port, " +
+					"ensure WithServiceBinding for this resource specifies a hostPort value")
+		}
+
+		return &genContainerAppIngress{
+			External:      binding.External,
+			Transport:     binding.Transport,
+			TargetPort:    *binding.ContainerPort,
+			AllowInsecure: strings.ToLower(binding.Transport) == "http2" || !binding.External,
+		}, nil
+	}
+
+	return nil, nil
+}
+
+// buildEnvBlock creates the environment map in the template context. It does this by copying the values from the given map,
+// evaluating any binding expressions that are present.
+func (b *infraGenerator) buildEnvBlock(env map[string]string, manifestCtx *genContainerAppManifestTemplateContext) error {
+	for k, v := range env {
+		if !strings.HasPrefix(v, "{") || !strings.HasSuffix(v, "}") {
+			// We want to ensure that we render these values in the YAML as strings.  If `v` was the string "true"
+			// (without the quotes), we would naturally create a value directive in yaml that looks like this:
+			//
+			// - name: OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES
+			//   value: true
+			//
+			// And YAML rules would treat the above as the value being a boolean instead of a string, which the container
+			// app service expects.
+			//
+			// JSON marshalling the string value will give us something like `"true"` (with the quotes, and any escaping
+			// that needs to be done), which is what we want here.
+			jsonStr, err := json.Marshal(v)
+			if err != nil {
+				return fmt.Errorf("marshalling env value: %w", err)
+			}
+
+			manifestCtx.Env[k] = string(jsonStr)
+			continue
+		}
+
+		parts := strings.SplitN(v[1:len(v)-1], ".", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("malformed binding expression, expected <resourceName>.<propertyPath> but was: %s", v)
+		}
+
+		resource, prop := parts[0], parts[1]
+		targetType, ok := b.resourceTypes[resource]
+		if !ok {
+			return fmt.Errorf("unknown resource referenced in binding expression: %s", resource)
+		}
+
+		switch {
+		case targetType == "project.v0" || targetType == "container.v0" || targetType == "dockerfile.v0":
+			if !strings.HasPrefix(prop, "bindings.") {
+				return fmt.Errorf("unsupported property referenced in binding expression: %s for %s", prop, targetType)
+			}
+
+			parts := strings.Split(prop[len("bindings."):], ".")
+
+			if len(parts) != 2 {
+				return fmt.Errorf("malformed binding expression, expected bindings.<binding-name>.<property> but was: %s", v)
+			}
+
+			var binding *Binding
+			var has bool
+
+			if targetType == "project.v0" {
+				binding, has = b.projects[resource].Bindings[parts[0]]
+			} else if targetType == "container.v0" {
+				binding, has = b.containers[resource].Bindings[parts[0]]
+			} else if targetType == "dockerfile.v0" {
+				binding, has = b.dockerfiles[resource].Bindings[parts[0]]
+			}
+
+			if !has {
+				return fmt.Errorf(
+					"unknown binding referenced in binding expression: %s for resource %s", parts[0], resource)
+			}
+
+			switch parts[1] {
+			case "port":
+				manifestCtx.Env[k] = fmt.Sprintf(`"%d"`, *binding.ContainerPort)
+			case "url":
+				var urlFormatString string
+
+				if binding.External {
+					urlFormatString = "%s://%s.{{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN }}"
+				} else {
+					urlFormatString = "%s://%s.internal.{{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN }}"
 				}
 
-				projectTemplateCtx.Env[k] = string(jsonStr)
+				manifestCtx.Env[k] = fmt.Sprintf(urlFormatString, binding.Scheme, resource)
+			default:
+				return fmt.Errorf("malformed binding expression, expected bindings.<binding-name>.[port|url] but was: %s", v)
+			}
+		case targetType == "postgres.database.v0" || targetType == "redis.v0":
+			switch prop {
+			case "connectionString":
+				manifestCtx.Env[k] = fmt.Sprintf(`{{ connectionString "%s" }}`, resource)
+			default:
+				return errUnsupportedProperty(targetType, prop)
+			}
+		case targetType == "azure.servicebus.v0":
+			switch prop {
+			case "connectionString":
+				manifestCtx.Env[k] = fmt.Sprintf(
+					"{{ urlHost .Env.SERVICE_BINDING_%s_ENDPOINT }}", scaffold.AlphaSnakeUpper(resource))
+			default:
+				return errUnsupportedProperty("azure.servicebus.v0", prop)
+			}
+		case targetType == "azure.appinsights.v0":
+			switch prop {
+			case "connectionString":
+				manifestCtx.Env[k] = fmt.Sprintf(
+					"{{ .Env.SERVICE_BINDING_%s_CONNECTION_STRING }}", scaffold.AlphaSnakeUpper(resource))
+			default:
+				return errUnsupportedProperty("azure.appinsights.v0", prop)
+			}
+		case targetType == "azure.cosmosdb.connection.v0" ||
+			targetType == "postgres.connection.v0" ||
+			targetType == "rabbitmq.connection.v0":
+
+			switch prop {
+			case "connectionString":
+				manifestCtx.Env[k] = b.connectionStrings[resource]
+			default:
+				return errUnsupportedProperty(targetType, prop)
+			}
+		case targetType == "azure.keyvault.v0" ||
+			targetType == "azure.storage.blob.v0" ||
+			targetType == "azure.storage.queue.v0" ||
+			targetType == "azure.storage.table.v0":
+			switch prop {
+			case "connectionString":
+				manifestCtx.Env[k] = fmt.Sprintf(
+					"{{ .Env.SERVICE_BINDING_%s_ENDPOINT }}", scaffold.AlphaSnakeUpper(resource))
+			default:
+				return errUnsupportedProperty(targetType, prop)
+			}
+		default:
+			ignore, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES"))
+			if err == nil && ignore {
+				log.Printf("ignoring binding reference to resource of type %s since "+
+					"AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES is set", targetType)
+
+				manifestCtx.Env[k] = fmt.Sprintf(
+					"!!! expression '%s' to type '%s' unsupported by azd !!!", v, targetType)
 				continue
 			}
 
-			parts := strings.SplitN(v[1:len(v)-1], ".", 2)
-			if len(parts) != 2 {
-				return fmt.Errorf("malformed binding expression, expected <resourceName>.<propertyPath> but was: %s", v)
-			}
-
-			resource, prop := parts[0], parts[1]
-			targetType, ok := b.resourceTypes[resource]
-			if !ok {
-				return fmt.Errorf("unknown resource referenced in binding expression: %s", resource)
-			}
-
-			switch {
-			case targetType == "project.v0" || targetType == "container.v0":
-				if !strings.HasPrefix(prop, "bindings.") {
-					return fmt.Errorf("unsupported property referenced in binding expression: %s for %s", prop, targetType)
-				}
-
-				parts := strings.Split(prop[len("bindings."):], ".")
-				if len(parts) != 2 || parts[1] != "url" {
-					return fmt.Errorf("malformed binding expression, expected bindings.<binding-name>.url but was: %s", v)
-				}
-
-				var binding *Binding
-				var has bool
-
-				if targetType == "project.v0" {
-					binding, has = b.projects[resource].Bindings[parts[0]]
-				} else if targetType == "container.v0" {
-					binding, has = b.containers[resource].Bindings[parts[0]]
-				}
-
-				if !has {
-					return fmt.Errorf(
-						"unknown binding referenced in binding expression: %s for resource %s", parts[0], resource)
-				}
-
-				if binding.External {
-					projectTemplateCtx.Env[k] = fmt.Sprintf(
-						"%s://%s.{{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN }}", binding.Scheme, resource)
-				} else {
-					projectTemplateCtx.Env[k] = fmt.Sprintf(
-						"%s://%s.internal.{{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN }}", binding.Scheme, resource)
-				}
-			case targetType == "postgres.database.v0" || targetType == "redis.v0":
-				switch prop {
-				case "connectionString":
-					projectTemplateCtx.Env[k] = fmt.Sprintf(`{{ connectionString "%s" }}`, resource)
-				default:
-					return errUnsupportedProperty(targetType, prop)
-				}
-			case targetType == "azure.servicebus.v0":
-				switch prop {
-				case "connectionString":
-					projectTemplateCtx.Env[k] = fmt.Sprintf(
-						"{{ urlHost .Env.SERVICE_BINDING_%s_ENDPOINT }}", scaffold.AlphaSnakeUpper(resource))
-				default:
-					return errUnsupportedProperty("azure.servicebus.v0", prop)
-				}
-			case targetType == "azure.appinsights.v0":
-				switch prop {
-				case "connectionString":
-					projectTemplateCtx.Env[k] = fmt.Sprintf(
-						"{{ .Env.SERVICE_BINDING_%s_CONNECTION_STRING }}", scaffold.AlphaSnakeUpper(resource))
-				default:
-					return errUnsupportedProperty("azure.appinsights.v0", prop)
-				}
-			case targetType == "azure.cosmosdb.connection.v0" ||
-				targetType == "postgres.connection.v0" ||
-				targetType == "rabbitmq.connection.v0":
-
-				switch prop {
-				case "connectionString":
-					projectTemplateCtx.Env[k] = b.connectionStrings[resource]
-				default:
-					return errUnsupportedProperty(targetType, prop)
-				}
-			case targetType == "azure.keyvault.v0" ||
-				targetType == "azure.storage.blob.v0" ||
-				targetType == "azure.storage.queue.v0" ||
-				targetType == "azure.storage.table.v0":
-				switch prop {
-				case "connectionString":
-					projectTemplateCtx.Env[k] = fmt.Sprintf(
-						"{{ .Env.SERVICE_BINDING_%s_ENDPOINT }}", scaffold.AlphaSnakeUpper(resource))
-				default:
-					return errUnsupportedProperty(targetType, prop)
-				}
-			default:
-				ignore, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES"))
-				if err == nil && ignore {
-					log.Printf("ignoring binding reference to resource of type %s since "+
-						"AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES is set", targetType)
-
-					projectTemplateCtx.Env[k] = fmt.Sprintf(
-						"!!! expression '%s' to type '%s' unsupported by azd !!!", v, targetType)
-					continue
-				}
-
-				return fmt.Errorf("unsupported resource type %s referenced in binding expression", targetType)
-			}
+			return fmt.Errorf("unsupported resource type %s referenced in binding expression", targetType)
 		}
-
-		b.containerAppTemplateContexts[projectName] = projectTemplateCtx
 	}
 
 	return nil

--- a/cli/azd/pkg/apphost/generate_test.go
+++ b/cli/azd/pkg/apphost/generate_test.go
@@ -1,0 +1,84 @@
+package apphost
+
+import (
+	"context"
+	_ "embed"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/azure/azure-dev/cli/azd/test/snapshot"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed testdata/aspire-docker.json
+var aspireDockerManifest []byte
+
+func TestAspireDockerGeneration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping due to EOL issues on Windows with the baselines")
+	}
+
+	ctx := context.Background()
+	mockCtx := mocks.NewMockContext(ctx)
+	mockCtx.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return args.Cmd == "dotnet" && args.Args[0] == "run" && args.Args[3] == "--publisher" && args.Args[4] == "manifest"
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		err := os.WriteFile(args.Args[6], aspireDockerManifest, osutil.PermissionFile)
+		if err != nil {
+			return exec.RunResult{
+				ExitCode: -1,
+				Stderr:   err.Error(),
+			}, err
+		}
+		return exec.RunResult{}, nil
+	})
+
+	mockCli := dotnet.NewDotNetCli(mockCtx.CommandRunner)
+
+	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli)
+	require.NoError(t, err)
+
+	// The App Host manifest does not set the external bit for project resources. Instead, `azd` or whatever tool consumes
+	// the manifest should prompt the user to select which services should be exposed. For this test, we manually set the
+	// external bit on the resources on the webfrontend resource to simulate the user selecting the webfrontend to be
+	// exposed.
+	for _, value := range m.Resources["nodeapp"].Bindings {
+		value.External = true
+	}
+
+	for _, name := range []string{"nodeapp"} {
+		t.Run(name, func(t *testing.T) {
+			tmpl, err := ContainerAppManifestTemplateForProject(m, name)
+			require.NoError(t, err)
+			snapshot.SnapshotT(t, tmpl)
+		})
+	}
+
+	files, err := BicepTemplate(m)
+	require.NoError(t, err)
+
+	err = fs.WalkDir(files, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		contents, err := fs.ReadFile(files, path)
+		if err != nil {
+			return err
+		}
+		t.Run(path, func(t *testing.T) {
+			snapshot.SnapshotT(t, string(contents))
+		})
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/cli/azd/pkg/apphost/generate_types.go
+++ b/cli/azd/pkg/apphost/generate_types.go
@@ -21,10 +21,10 @@ type genKeyVault struct{}
 
 type genContainerApp struct {
 	Image   string
-	Ingress *genContainerServiceIngress
+	Ingress *genContainerAppIngress
 }
 
-type genContainerServiceIngress struct {
+type genContainerAppIngress struct {
 	External      bool
 	TargetPort    int
 	Transport     string
@@ -33,6 +33,13 @@ type genContainerServiceIngress struct {
 
 type genContainer struct {
 	Image    string
+	Env      map[string]string
+	Bindings map[string]*Binding
+}
+
+type genDockerfile struct {
+	Path     string
+	Context  string
 	Env      map[string]string
 	Bindings map[string]*Binding
 }
@@ -57,18 +64,11 @@ type genBicepTemplateContext struct {
 
 type genContainerAppManifestTemplateContext struct {
 	Name    string
-	Ingress *genContainerAppManifestTemplateContextIngress
+	Ingress *genContainerAppIngress
 	Env     map[string]string
 }
 
 type genProjectFileContext struct {
 	Name     string
 	Services map[string]string
-}
-
-type genContainerAppManifestTemplateContextIngress struct {
-	External      bool
-	Transport     string
-	TargetPort    int
-	AllowInsecure bool
 }

--- a/cli/azd/pkg/apphost/manifest.go
+++ b/cli/azd/pkg/apphost/manifest.go
@@ -20,8 +20,12 @@ type Resource struct {
 	// Type is present on all resource types
 	Type string `json:"type"`
 
-	// Path is present on a project.v0 resource and is the full path to the project file.
+	// Path is present on a project.v0 resource and is the path to the project file, and on a dockerfile.v0
+	// resource and is the path to the Dockerfile (including the "Dockerfile" filename).
 	Path *string `json:"path,omitempty"`
+
+	// Context is present on a dockerfile.v0 resource and is the path to the context directory.
+	Context *string `json:"context,omitempty"`
 
 	// Parent is present on a resource which is a child of another. It is the name of the parent resource. For example, a
 	// postgres.database.v0 is a child of a postgres.server.v0, and so it would have a parent of which is the name of
@@ -31,13 +35,14 @@ type Resource struct {
 	// Image is present on a container.v0 resource and is the image to use for the container.
 	Image *string `json:"image,omitempty"`
 
-	// Bindings is present on container.v0 and project.v0 resources, and is a map of binding names to binding details.
+	// Bindings is present on container.v0, project.v0 and dockerfile.v0 resources, and is a map of binding names to
+	// binding details.
 	Bindings map[string]*Binding `json:"bindings,omitempty"`
 
-	// Env is present on a project.v0 and container.v0 resource, and is a map of environment variable names to value
-	// expressions. The value expressions are simple expressions like "{redis.connectionString}" or "{postgres.port}" to
-	// allow referencing properties of other resources. The set of properties supported in these expressions
-	// depends on the type of resource you are referencing.
+	// Env is present on project.v0, container.v0 and dockerfile.v0 resources, and is a map of environment variable
+	// names to value  expressions. The value expressions are simple expressions like "{redis.connectionString}" or
+	// "{postgres.port}" to allow referencing properties of other resources. The set of properties supported in these
+	// expressions depends on the type of resource you are referencing.
 	Env map[string]string `json:"env,omitempty"`
 
 	// Queues is optionally present on a azure.servicebus.v0 resource, and is a list of queue names to create.
@@ -100,6 +105,12 @@ func ManifestFromAppHost(ctx context.Context, appHostProject string, dotnetCli d
 		if res.Path != nil {
 			if !filepath.IsAbs(*res.Path) {
 				*res.Path = filepath.Join(manifestDir, *res.Path)
+			}
+		}
+
+		if res.Type == "dockerfile.v0" {
+			if !filepath.IsAbs(*res.Context) {
+				*res.Context = filepath.Join(manifestDir, *res.Context)
 			}
 		}
 	}

--- a/cli/azd/pkg/apphost/service_ingress_configurer.go
+++ b/cli/azd/pkg/apphost/service_ingress_configurer.go
@@ -22,7 +22,7 @@ func NewIngressSelector(manifest *Manifest, console input.Console) *IngressSelec
 func (adc *IngressSelector) SelectPublicServices(ctx context.Context) ([]string, error) {
 	var services []string
 	for name, res := range adc.manifest.Resources {
-		if (res.Type == "container.v0" || res.Type == "project.v0") && len(res.Bindings) > 0 {
+		if (res.Type == "container.v0" || res.Type == "project.v0" || res.Type == "dockerfile.v0") && len(res.Bindings) > 0 {
 			services = append(services, name)
 		}
 	}

--- a/cli/azd/pkg/apphost/testdata/.gitattributes
+++ b/cli/azd/pkg/apphost/testdata/.gitattributes
@@ -1,0 +1,1 @@
+*.snap text !eol

--- a/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-main.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-main.bicep.snap
@@ -1,0 +1,36 @@
+targetScope = 'subscription'
+
+@minLength(1)
+@maxLength(64)
+@description('Name of the environment that can be used as part of naming resource convention, the name of the resource group for your application will use this name, prefixed with rg-')
+param environmentName string
+
+@minLength(1)
+@description('The location used for all deployed resources')
+param location string
+
+var tags = {
+  'azd-env-name': environmentName
+}
+
+resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module resources 'resources.bicep' = {
+  scope: rg
+  name: 'resources'
+  params: {
+    location: location
+    tags: tags
+  }
+}
+
+output MANAGED_IDENTITY_CLIENT_ID string = resources.outputs.MANAGED_IDENTITY_CLIENT_ID
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = resources.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = resources.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = resources.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = resources.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN
+

--- a/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-main.parameters.json.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-main.parameters.json.snap
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "environmentName": {
+        "value": "${AZURE_ENV_NAME}"
+      },
+      "location": {
+        "value": "${AZURE_LOCATION}"
+      }
+    }
+  }
+  

--- a/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-nodeapp.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-nodeapp.snap
@@ -1,0 +1,35 @@
+location: {{ .Env.AZURE_LOCATION }}
+identity:
+  type: UserAssigned
+  userAssignedIdentities:
+    ? "{{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}"
+    : {}
+properties:
+  environmentId: {{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_ID }}
+  configuration:
+    activeRevisionsMode: single
+    ingress:
+      external: true
+      targetPort: 3000
+      transport: http
+      allowInsecure: false
+    registries:
+    - server: {{ .Env.AZURE_CONTAINER_REGISTRY_ENDPOINT }}
+      identity: {{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}
+  template:
+    containers:
+    - image: {{ .Image }}
+      name: nodeapp
+      env:
+      - name: AZURE_CLIENT_ID
+        value: {{ .Env.MANAGED_IDENTITY_CLIENT_ID }}
+      - name: NODE_ENV
+        value: "development"
+      - name: PORT
+        value: "3000"
+    scale:
+      minReplicas: 1
+tags:
+  azd-service-name: nodeapp
+  aspire-resource-name: nodeapp
+

--- a/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-resources.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-resources.bicep.snap
@@ -1,0 +1,69 @@
+@description('The location used for all deployed resources')
+param location string = resourceGroup().location
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+var resourceToken = uniqueString(resourceGroup().id)
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: 'mi-${resourceToken}'
+  location: location
+  tags: tags
+}
+
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+  name: replace('acr-${resourceToken}', '-', '')
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  properties: {
+    adminUserEnabled: true
+  }
+  tags: tags
+}
+
+resource caeMiRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(containerRegistry.id, managedIdentity.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+  scope: containerRegistry
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId:  subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+  }
+}
+
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: 'law-${resourceToken}'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+  }
+  tags: tags
+}
+
+resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' = {
+  name: 'cae-${resourceToken}'
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalyticsWorkspace.properties.customerId
+        sharedKey: logAnalyticsWorkspace.listKeys().primarySharedKey
+      }
+    }
+  }
+  tags: tags
+}
+
+
+output MANAGED_IDENTITY_CLIENT_ID string = managedIdentity.properties.clientId
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.properties.loginServer
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = managedIdentity.id
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = containerAppEnvironment.id
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = containerAppEnvironment.properties.defaultDomain
+

--- a/cli/azd/pkg/apphost/testdata/aspire-docker.json
+++ b/cli/azd/pkg/apphost/testdata/aspire-docker.json
@@ -1,0 +1,21 @@
+{
+  "resources": {
+    "nodeapp": {
+      "type": "dockerfile.v0",
+      "path": "../NodeApp/Dockerfile",
+      "context": "../NodeApp",
+      "env": {
+        "NODE_ENV": "development",
+        "PORT": "{nodeapp.bindings.http.port}"
+      },
+      "bindings": {
+        "http": {
+          "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http",
+          "containerPort": 3000
+        }
+      }
+    }
+  }
+}

--- a/cli/azd/pkg/project/dotnet_importer.go
+++ b/cli/azd/pkg/project/dotnet_importer.go
@@ -180,6 +180,42 @@ func (ai *DotNetImporter) Services(
 
 		services[svc.Name] = svc
 	}
+
+	dockerfiles := apphost.Dockerfiles(manifest)
+	for name, dockerfile := range dockerfiles {
+		relPath, err := filepath.Rel(p.Path, filepath.Dir(dockerfile.Path))
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO(ellismg): Some of this code is duplicated from project.Parse, we should centralize this logic long term.
+		svc := &ServiceConfig{
+			RelativePath: relPath,
+			Language:     ServiceLanguageDocker,
+			Host:         DotNetContainerAppTarget,
+			Docker: DockerProjectOptions{
+				Path:    dockerfile.Path,
+				Context: dockerfile.Context,
+			},
+		}
+
+		svc.Name = name
+		svc.Project = p
+		svc.EventDispatcher = ext.NewEventDispatcher[ServiceLifecycleEventArgs]()
+
+		svc.Infra.Provider, err = provisioning.ParseProvider(svc.Infra.Provider)
+		if err != nil {
+			return nil, fmt.Errorf("parsing service %s: %w", svc.Name, err)
+		}
+
+		svc.DotNetContainerApp = &DotNetContainerAppOptions{
+			Manifest:    manifest,
+			ProjectName: name,
+			ProjectPath: svcConfig.Path(),
+		}
+
+		services[svc.Name] = svc
+	}
 	return services, nil
 }
 
@@ -224,24 +260,37 @@ func (ai *DotNetImporter) SynthAllInfrastructure(
 		return nil, err
 	}
 
-	for name, path := range apphost.ProjectPaths(manifest) {
+	// writeManifestForResource writes the containerApp.tmpl.yaml for the given resource to the generated filesystem. The
+	// manifest is written to a file name "containerApp.tmpl.yaml" in the same directory as the project that produces the
+	// container we will deploy.
+	writeManifestForResource := func(name string, path string) error {
 		containerAppManifest, err := apphost.ContainerAppManifestTemplateForProject(manifest, name)
 		if err != nil {
-			return nil, fmt.Errorf("generating containerApp.tmpl.yaml for project %s: %w", name, err)
+			return fmt.Errorf("generating containerApp.tmpl.yaml for resource %s: %w", name, err)
 		}
 
 		projectRelPath, err := filepath.Rel(p.Path, path)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		manifestPath := filepath.Join(filepath.Dir(projectRelPath), "manifests", "containerApp.tmpl.yaml")
 
 		if err := generatedFS.MkdirAll(filepath.Dir(manifestPath), osutil.PermissionDirectoryOwnerOnly); err != nil {
-			return nil, err
+			return err
 		}
 
-		if err := generatedFS.WriteFile(manifestPath, []byte(containerAppManifest), osutil.PermissionFileOwnerOnly); err != nil {
+		return generatedFS.WriteFile(manifestPath, []byte(containerAppManifest), osutil.PermissionFileOwnerOnly)
+	}
+
+	for name, path := range apphost.ProjectPaths(manifest) {
+		if writeManifestForResource(name, path) != nil {
+			return nil, err
+		}
+	}
+
+	for name, docker := range apphost.Dockerfiles(manifest) {
+		if writeManifestForResource(name, docker.Path) != nil {
 			return nil, err
 		}
 	}
@@ -280,6 +329,13 @@ func (ai *DotNetImporter) readManifest(ctx context.Context, svcConfig *ServiceCo
 						log.Printf("services.%s.config.exposedServices[%d] is not a string, ignoring value.",
 							svcConfig.Name, idx)
 					} else {
+						// This can happen if the user has removed a service from their app host that they previously
+						// had and had exposed (or changed the service such that it no longer has any bindings).
+						if binding, has := manifest.Resources[strName]; !has || binding.Bindings == nil {
+							log.Printf("service %s does not exist or has no bindings, ignoring value.", strName)
+							continue
+						}
+
 						for _, binding := range manifest.Resources[strName].Bindings {
 							binding.External = true
 						}

--- a/cli/azd/pkg/project/framework_service_noop.go
+++ b/cli/azd/pkg/project/framework_service_noop.go
@@ -1,0 +1,69 @@
+package project
+
+import (
+	"context"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/async"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+)
+
+// NewNoOpProject creates a new instance of a no-op project, which implements the FrameworkService interface
+// but does not perform any actions.
+func NewNoOpProject(env *environment.Environment) FrameworkService {
+	return &noOpProject{}
+}
+
+func (n *noOpProject) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+	return []tools.ExternalTool{}
+}
+
+func (n *noOpProject) Requirements() FrameworkRequirements {
+	return FrameworkRequirements{
+		Package: FrameworkPackageRequirements{
+			RequireRestore: false,
+			RequireBuild:   false,
+		},
+	}
+}
+
+func (n *noOpProject) Initialize(ctx context.Context, serviceConfig *ServiceConfig) error {
+	return nil
+}
+
+func (n *noOpProject) Restore(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+) *async.TaskWithProgress[*ServiceRestoreResult, ServiceProgress] {
+	return async.RunTaskWithProgress(
+		func(task *async.TaskContextWithProgress[*ServiceRestoreResult, ServiceProgress]) {
+			task.SetResult(&ServiceRestoreResult{})
+		},
+	)
+}
+
+func (n *noOpProject) Build(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	restoreOutput *ServiceRestoreResult,
+) *async.TaskWithProgress[*ServiceBuildResult, ServiceProgress] {
+	return async.RunTaskWithProgress(
+		func(task *async.TaskContextWithProgress[*ServiceBuildResult, ServiceProgress]) {
+			task.SetResult(&ServiceBuildResult{})
+		},
+	)
+}
+
+func (n *noOpProject) Package(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	buildOutput *ServiceBuildResult,
+) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress] {
+	return async.RunTaskWithProgress(
+		func(task *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
+			task.SetResult(&ServicePackageResult{})
+		},
+	)
+}
+
+type noOpProject struct{}

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -554,8 +554,9 @@ func (sm *serviceManager) GetFrameworkService(ctx context.Context, serviceConfig
 		))
 	}
 
-	// For containerized applications we use a composite framework service
-	if serviceConfig.Host == ContainerAppTarget || serviceConfig.Host == AksTarget {
+	// For hosts which run in containers, if the source project is not already a container, we need to wrap it in a docker
+	// project that handles the containerization.
+	if serviceConfig.Host.RequiresContainer() && serviceConfig.Language != ServiceLanguageDocker {
 		var compositeFramework CompositeFrameworkService
 		if err := sm.serviceLocator.ResolveNamed(string(ServiceLanguageDocker), &compositeFramework); err != nil {
 			panic(fmt.Errorf(

--- a/cli/azd/pkg/project/service_target.go
+++ b/cli/azd/pkg/project/service_target.go
@@ -27,6 +27,17 @@ const (
 	DotNetContainerAppTarget ServiceTargetKind = "containerapp-dotnet"
 )
 
+// RequiresContainer returns true if the service target runs a container image.
+func (stk ServiceTargetKind) RequiresContainer() bool {
+	switch stk {
+	case ContainerAppTarget,
+		AksTarget:
+		return true
+	}
+
+	return false
+}
+
 func parseServiceHost(kind ServiceTargetKind) (ServiceTargetKind, error) {
 	switch kind {
 

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -156,7 +156,7 @@ func (t *aksTarget) Deploy(
 			}
 
 			// Login, tag & push container image to ACR
-			containerDeployTask := t.containerHelper.Deploy(ctx, serviceConfig, packageOutput, targetResource)
+			containerDeployTask := t.containerHelper.Deploy(ctx, serviceConfig, packageOutput, targetResource, true)
 			syncProgress(task, containerDeployTask.Progress())
 
 			// Sync environment

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -86,7 +86,7 @@ func (at *containerAppTarget) Deploy(
 			}
 
 			// Login, tag & push container image to ACR
-			containerDeployTask := at.containerHelper.Deploy(ctx, serviceConfig, packageOutput, targetResource)
+			containerDeployTask := at.containerHelper.Deploy(ctx, serviceConfig, packageOutput, targetResource, true)
 			syncProgress(task, containerDeployTask.Progress())
 
 			_, err := containerDeployTask.Await()


### PR DESCRIPTION
As part of Preview 2, Aspire is adding support for a new resource, `dockerfile.v0`. This represents an image that should be built (from a Dockerfile) and deployed.

Consider the following AppHost:

```csharp
var builder = DistributedApplication.CreateBuilder(args);

builder.AddNodeApp("nodeapp", "../NodeApp/index.js")
    .WithServiceBinding(3000, scheme: "http", env: "PORT")
    .AsDockerfileInManifest();

builder.Build().Run();
```

The resulting manifest looks like this:

```json
{
  "resources": {
    "nodeapp": {
      "type": "dockerfile.v0",
      "path": "../NodeApp/Dockerfile",
      "context": "../NodeApp",
      "env": {
        "NODE_ENV": "development",
        "PORT": "{nodeapp.bindings.http.port}"
      },
      "bindings": {
        "http": {
          "scheme": "http",
          "protocol": "tcp",
          "transport": "http",
          "containerPort": 3000
        }
      }
    }
  }
}
```

From a high level, these are very similar to `project.v0` resources. The image needs to be built and pushed (either via `dotnet publish` or `docker build` + `docker push`) and then we need to create an Azure Container Apps App from it.

When doing `azd infra synth` we write the manifests for these types of services in a `manifests` folder that is SxS with the `Dockerfile`. This mimics the strategy for projects in spirit (where we use the `.csproj` file as the "project" file)