### PR TITLE
Update ado pipeline definition to use service-connection

### DIFF
--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -5,7 +5,6 @@ package azdo
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -155,16 +154,11 @@ func getDefinitionVariables(
 	provisioningProvider provisioning.Options,
 	additionalSecrets map[string]string,
 	additionalVariables map[string]string) (*map[string]build.BuildDefinitionVariable, error) {
-	rawCredential, err := json.Marshal(credentials)
-	if err != nil {
-		return nil, err
-	}
 	variables := map[string]build.BuildDefinitionVariable{
 		"AZURE_LOCATION":           createBuildDefinitionVariable(env.GetLocation(), false, false),
 		"AZURE_ENV_NAME":           createBuildDefinitionVariable(env.GetEnvName(), false, false),
 		"AZURE_SERVICE_CONNECTION": createBuildDefinitionVariable(ServiceConnectionName, false, false),
 		"AZURE_SUBSCRIPTION_ID":    createBuildDefinitionVariable(credentials.SubscriptionId, false, false),
-		"AZURE_CREDENTIALS":        createBuildDefinitionVariable(string(rawCredential), true, false),
 	}
 
 	if provisioningProvider.Provider == provisioning.Bicep {

--- a/templates/common/.azdo/pipelines/bicep/azure-dev.yml
+++ b/templates/common/.azdo/pipelines/bicep/azure-dev.yml
@@ -5,8 +5,9 @@ trigger:
   - master
 
 # Azure Pipelines workflow to deploy to Azure using azd
-# To configure required secrets for connecting to Azure, simply run `azd pipeline config --provider azdo`
+# To configure required secrets and service connection for connecting to Azure, simply run `azd pipeline config --provider azdo`
 # Task "Install azd" needs to install setup-azd extension for azdo - https://marketplace.visualstudio.com/items?itemName=ms-azuretools.azd
+# See below for alternative task to install azd if you can't install above task in your organization
 
 pool:
   vmImage: ubuntu-latest
@@ -15,28 +16,40 @@ steps:
   - task: setup-azd@0 
     displayName: Install azd
 
-  - pwsh: |
-      $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;
-      
-      azd auth login `
-        --client-id "$($info.clientId)" `
-        --client-secret "$($info.clientSecret)" `
-        --tenant-id "$($info.tenantId)"
-    displayName: azd login
-    env:
-      AZURE_CREDENTIALS: $(AZURE_CREDENTIALS)
+  # If you can't install above task in your organization, you can comment it and uncomment below task to install azd
+  # - task: Bash@3
+  #   displayName: Install azd
+  #   inputs:
+  #     targetType: 'inline'
+  #     script: |
+  #       curl -fsSL https://aka.ms/install-azd.sh | bash
 
+  # azd delegate auth to az to use service connection with AzureCLI@2
   - pwsh: |
-      azd provision --no-prompt
+      azd config set auth.useAzCliAuth "true"
+    displayName: Configure AZD to Use AZ CLI Authentication.
+
+  - task: AzureCLI@2
     displayName: Provision Infrastructure
+    inputs:
+      azureSubscription: azconnection
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        azd provision --no-prompt
     env:
       AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
       AZURE_ENV_NAME: $(AZURE_ENV_NAME)
       AZURE_LOCATION: $(AZURE_LOCATION)
 
-  - pwsh: |
-      azd deploy --no-prompt
+  - task: AzureCLI@2
     displayName: Deploy Application
+    inputs:
+      azureSubscription: azconnection
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        azd deploy --no-prompt
     env:
       AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
       AZURE_ENV_NAME: $(AZURE_ENV_NAME)

--- a/templates/common/.azdo/pipelines/java/azure-dev.yml
+++ b/templates/common/.azdo/pipelines/java/azure-dev.yml
@@ -5,8 +5,9 @@ trigger:
   - master
 
 # Azure Pipelines workflow to deploy to Azure using azd
-# To configure required secrets for connecting to Azure, simply run `azd pipeline config --provider azdo`
+# To configure required secrets and service connection for connecting to Azure, simply run `azd pipeline config --provider azdo`
 # Task "Install azd" needs to install setup-azd extension for azdo - https://marketplace.visualstudio.com/items?itemName=ms-azuretools.azd
+# See below for alternative task to install azd if you can't install above task in your organization
 
 pool:
   vmImage: ubuntu-latest
@@ -15,34 +16,46 @@ steps:
   - task: setup-azd@0
     displayName: Install azd
   
+  # If you can't install above task in your organization, you can comment it and uncomment below task to install azd
+  # - task: Bash@3
+  #   displayName: Install azd
+  #   inputs:
+  #     targetType: 'inline'
+  #     script: |
+  #       curl -fsSL https://aka.ms/install-azd.sh | bash
+
+  # azd delegate auth to az to use service connection with AzureCLI@2
+  - pwsh: |
+      azd config set auth.useAzCliAuth "true"
+    displayName: Configure AZD to Use AZ CLI Authentication.
+
   - task: JavaToolInstaller@0
     inputs:
       versionSpec: '17'
       jdkArchitectureOption: 'x64'
       jdkSourceOption: 'PreInstalled'
 
-  - pwsh: |
-      $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;
-      
-      azd auth login `
-        --client-id "$($info.clientId)" `
-        --client-secret "$($info.clientSecret)" `
-        --tenant-id "$($info.tenantId)"
-    displayName: azd login
-    env:
-      AZURE_CREDENTIALS: $(AZURE_CREDENTIALS)
-
-  - pwsh: |
-      azd provision --no-prompt
+  - task: AzureCLI@2
     displayName: Provision Infrastructure
+    inputs:
+      azureSubscription: azconnection
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        azd provision --no-prompt
     env:
       AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
       AZURE_ENV_NAME: $(AZURE_ENV_NAME)
       AZURE_LOCATION: $(AZURE_LOCATION)
 
-  - pwsh: |
-      azd deploy --no-prompt
+  - task: AzureCLI@2
     displayName: Deploy Application
+    inputs:
+      azureSubscription: azconnection
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        azd deploy --no-prompt
     env:
       AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
       AZURE_ENV_NAME: $(AZURE_ENV_NAME)

--- a/templates/common/.azdo/pipelines/terraform/azure-dev.yml
+++ b/templates/common/.azdo/pipelines/terraform/azure-dev.yml
@@ -5,8 +5,9 @@ trigger:
   - master
 
 # Azure Pipelines workflow to deploy to Azure using azd
-# To configure required secrets for connecting to Azure, simply run `azd pipeline config --provider azdo`
+# To configure required secrets and service connection for connecting to Azure, simply run `azd pipeline config --provider azdo`
 # Task "Install azd" needs to install setup-azd extension for azdo - https://marketplace.visualstudio.com/items?itemName=ms-azuretools.azd
+# See below for alternative task to install azd if you can't install above task in your organization
 
 pool:
   vmImage: ubuntu-latest
@@ -15,16 +16,18 @@ steps:
   - task: setup-azd@0
     displayName: Install azd
 
+  # If you can't install above task in your organization, you can comment it and uncomment below task to install azd
+  # - task: Bash@3
+  #   displayName: Install azd
+  #   inputs:
+  #     targetType: 'inline'
+  #     script: |
+  #       curl -fsSL https://aka.ms/install-azd.sh | bash
+
+  # azd delegate auth to az to use service connection with AzureCLI@2
   - pwsh: |
-      $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;
-      
-      azd auth login `
-        --client-id "$($info.clientId)" `
-        --client-secret "$($info.clientSecret)" `
-        --tenant-id "$($info.tenantId)"
-    displayName: azd login
-    env:
-      AZURE_CREDENTIALS: $(AZURE_CREDENTIALS)
+      azd config set auth.useAzCliAuth "true"
+    displayName: Configure AZD to Use AZ CLI Authentication.
 
   - task: AzureCLI@2
     displayName: Provision Infrastructure
@@ -45,11 +48,15 @@ steps:
       RS_STORAGE_ACCOUNT: $(RS_STORAGE_ACCOUNT)
       RS_CONTAINER_NAME: $(RS_CONTAINER_NAME)
 
-  - pwsh: |
-      azd deploy --no-prompt
+  - task: AzureCLI@2
     displayName: Deploy Application
+    inputs:
+      azureSubscription: azconnection
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        azd deploy --no-prompt
     env:
       AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
       AZURE_ENV_NAME: $(AZURE_ENV_NAME)
       AZURE_LOCATION: $(AZURE_LOCATION)
-

--- a/templates/common/.azdo/pipelines/terraform/java/azure-dev.yml
+++ b/templates/common/.azdo/pipelines/terraform/java/azure-dev.yml
@@ -5,8 +5,9 @@ trigger:
   - master
 
 # Azure Pipelines workflow to deploy to Azure using azd
-# To configure required secrets for connecting to Azure, simply run `azd pipeline config --provider azdo`
+# To configure required secrets and service connection for connecting to Azure, simply run `azd pipeline config --provider azdo`
 # Task "Install azd" needs to install setup-azd extension for azdo - https://marketplace.visualstudio.com/items?itemName=ms-azuretools.azd
+# See below for alternative task to install azd if you can't install above task in your organization
 
 pool:
   vmImage: ubuntu-latest
@@ -15,16 +16,18 @@ steps:
   - task: setup-azd@0
     displayName: Install azd
 
+  # If you can't install above task in your organization, you can comment it and uncomment below task to install azd
+  # - task: Bash@3
+  #   displayName: Install azd
+  #   inputs:
+  #     targetType: 'inline'
+  #     script: |
+  #       curl -fsSL https://aka.ms/install-azd.sh | bash
+
+  # azd delegate auth to az to use service connection with AzureCLI@2
   - pwsh: |
-      $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;
-      
-      azd auth login `
-        --client-id "$($info.clientId)" `
-        --client-secret "$($info.clientSecret)" `
-        --tenant-id "$($info.tenantId)"
-    displayName: azd login
-    env:
-      AZURE_CREDENTIALS: $(AZURE_CREDENTIALS)
+      azd config set auth.useAzCliAuth "true"
+    displayName: Configure AZD to Use AZ CLI Authentication.
 
   - task: JavaToolInstaller@0
     inputs:
@@ -51,11 +54,15 @@ steps:
       RS_STORAGE_ACCOUNT: $(RS_STORAGE_ACCOUNT)
       RS_CONTAINER_NAME: $(RS_CONTAINER_NAME)
 
-  - pwsh: |
-      azd deploy --no-prompt
+  - task: AzureCLI@2
     displayName: Deploy Application
+    inputs:
+      azureSubscription: azconnection
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        azd deploy --no-prompt
     env:
       AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
       AZURE_ENV_NAME: $(AZURE_ENV_NAME)
       AZURE_LOCATION: $(AZURE_LOCATION)
-


### PR DESCRIPTION
fix: https://github.com/Azure/azure-dev/issues/3088

The changes here are to restore the old behavior on azdo pipelines using a service-connection and delegating auth to az.

The reason is to be idiomatic to azdo, where a service connection is used instead of setting a secret with a credential (like in gh-action).

In the future, if this https://github.com/Azure/azure-dev/issues/3093 gets implemented, we could remove the az auth delegation.