### PR TITLE
buildpacks: Update dotnet base image to bullseye

### DIFF
--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -289,7 +289,7 @@ func (p *dockerProject) Package(
 }
 
 // Default builder image to produce container images from source
-const DefaultBuilderImage = "mcr.microsoft.com/oryx/builder:debian-bullseye-20231004.1"
+const DefaultBuilderImage = "mcr.microsoft.com/oryx/builder:debian-bullseye-20231107.2"
 
 func (p *dockerProject) packBuild(
 	ctx context.Context,

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -290,7 +290,6 @@ func (p *dockerProject) Package(
 
 // Default builder image to produce container images from source
 const DefaultBuilderImage = "mcr.microsoft.com/oryx/builder:debian-bullseye-20231004.1"
-const DefaultDotNetBuilderImage = "mcr.microsoft.com/oryx/builder:debian-buster-20231004.1"
 
 func (p *dockerProject) packBuild(
 	ctx context.Context,
@@ -302,9 +301,6 @@ func (p *dockerProject) packBuild(
 		return nil, err
 	}
 	builder := DefaultBuilderImage
-	if svc.Language == ServiceLanguageDotNet {
-		builder = DefaultDotNetBuilderImage
-	}
 
 	environ := []string{}
 	userDefinedImage := false


### PR DESCRIPTION
Upgrade dotnet base images to be based on bullseye-20131107.2 which is the current stable version and supports .NET 8.

Fixes https://github.com/Azure/azure-dev/issues/3108