### PR TITLE
aspire: Do not error when other projects present

### DIFF
--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -175,7 +175,9 @@ var allDetectors = []projectDetector{
 		// TODO(ellismg): Remove ambient authority.
 		dotnetCli: dotnet.NewDotNetCli(exec.NewCommandRunner(nil)),
 	},
-	&dotNetDetector{},
+	&dotNetDetector{
+		dotnetCli: dotnet.NewDotNetCli(exec.NewCommandRunner(nil)),
+	},
 	&pythonDetector{},
 	&javaScriptDetector{},
 }

--- a/cli/azd/internal/appdetect/appdetect_test.go
+++ b/cli/azd/internal/appdetect/appdetect_test.go
@@ -33,7 +33,7 @@ func TestDetect(t *testing.T) {
 			[]Project{
 				{
 					Language:      DotNet,
-					Path:          "dotnet",
+					Path:          filepath.Join("dotnet", "dotnettestapp.csproj"),
 					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
 				},
 				{
@@ -103,7 +103,7 @@ func TestDetect(t *testing.T) {
 			[]Project{
 				{
 					Language:      DotNet,
-					Path:          "dotnet",
+					Path:          filepath.Join("dotnet", "dotnettestapp.csproj"),
 					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
 				},
 				{
@@ -122,7 +122,7 @@ func TestDetect(t *testing.T) {
 			[]Project{
 				{
 					Language:      DotNet,
-					Path:          "dotnet",
+					Path:          filepath.Join("dotnet", "dotnettestapp.csproj"),
 					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
 				},
 				{
@@ -144,7 +144,7 @@ func TestDetect(t *testing.T) {
 			[]Project{
 				{
 					Language:      DotNet,
-					Path:          "dotnet",
+					Path:          filepath.Join("dotnet", "dotnettestapp.csproj"),
 					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
 				},
 				{
@@ -190,7 +190,7 @@ func TestDetectDocker(t *testing.T) {
 	require.Len(t, projects, 1)
 	require.Equal(t, projects[0], Project{
 		Language:      DotNet,
-		Path:          filepath.Join(dir, "dotnet"),
+		Path:          filepath.Join(dir, "dotnet", "dotnettestapp.csproj"),
 		DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
 		Docker: &Docker{
 			Path: filepath.Join(dir, "dotnet", "Dockerfile"),
@@ -217,7 +217,7 @@ func TestDetectNested(t *testing.T) {
 	require.Len(t, projects, 1)
 	require.Equal(t, projects[0], Project{
 		Language:      DotNet,
-		Path:          filepath.Join(src, "dotnet"),
+		Path:          filepath.Join(src, "dotnet", "dotnettestapp.csproj"),
 		DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
 	})
 }

--- a/cli/azd/internal/appdetect/appdetect_test.go
+++ b/cli/azd/internal/appdetect/appdetect_test.go
@@ -33,7 +33,7 @@ func TestDetect(t *testing.T) {
 			[]Project{
 				{
 					Language:      DotNet,
-					Path:          filepath.Join("dotnet", "dotnettestapp.csproj"),
+					Path:          "dotnet",
 					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
 				},
 				{
@@ -103,7 +103,7 @@ func TestDetect(t *testing.T) {
 			[]Project{
 				{
 					Language:      DotNet,
-					Path:          filepath.Join("dotnet", "dotnettestapp.csproj"),
+					Path:          "dotnet",
 					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
 				},
 				{
@@ -122,7 +122,7 @@ func TestDetect(t *testing.T) {
 			[]Project{
 				{
 					Language:      DotNet,
-					Path:          filepath.Join("dotnet", "dotnettestapp.csproj"),
+					Path:          "dotnet",
 					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
 				},
 				{
@@ -144,7 +144,7 @@ func TestDetect(t *testing.T) {
 			[]Project{
 				{
 					Language:      DotNet,
-					Path:          filepath.Join("dotnet", "dotnettestapp.csproj"),
+					Path:          "dotnet",
 					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
 				},
 				{
@@ -190,7 +190,7 @@ func TestDetectDocker(t *testing.T) {
 	require.Len(t, projects, 1)
 	require.Equal(t, projects[0], Project{
 		Language:      DotNet,
-		Path:          filepath.Join(dir, "dotnet", "dotnettestapp.csproj"),
+		Path:          filepath.Join(dir, "dotnet"),
 		DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
 		Docker: &Docker{
 			Path: filepath.Join(dir, "dotnet", "Dockerfile"),
@@ -217,7 +217,7 @@ func TestDetectNested(t *testing.T) {
 	require.Len(t, projects, 1)
 	require.Equal(t, projects[0], Project{
 		Language:      DotNet,
-		Path:          filepath.Join(src, "dotnet", "dotnettestapp.csproj"),
+		Path:          filepath.Join(src, "dotnet"),
 		DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
 	})
 }

--- a/cli/azd/internal/appdetect/appdetect_test.go
+++ b/cli/azd/internal/appdetect/appdetect_test.go
@@ -34,7 +34,7 @@ func TestDetect(t *testing.T) {
 				{
 					Language:      DotNet,
 					Path:          "dotnet",
-					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
+					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, Program.cs",
 				},
 				{
 					Language:      Java,
@@ -104,7 +104,7 @@ func TestDetect(t *testing.T) {
 				{
 					Language:      DotNet,
 					Path:          "dotnet",
-					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
+					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, Program.cs",
 				},
 				{
 					Language:      Java,
@@ -123,7 +123,7 @@ func TestDetect(t *testing.T) {
 				{
 					Language:      DotNet,
 					Path:          "dotnet",
-					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
+					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, Program.cs",
 				},
 				{
 					Language:      Java,
@@ -145,7 +145,7 @@ func TestDetect(t *testing.T) {
 				{
 					Language:      DotNet,
 					Path:          "dotnet",
-					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
+					DetectionRule: "Inferred by presence of: dotnettestapp.csproj, Program.cs",
 				},
 				{
 					Language:      Java,
@@ -191,7 +191,7 @@ func TestDetectDocker(t *testing.T) {
 	require.Equal(t, projects[0], Project{
 		Language:      DotNet,
 		Path:          filepath.Join(dir, "dotnet"),
-		DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
+		DetectionRule: "Inferred by presence of: dotnettestapp.csproj, Program.cs",
 		Docker: &Docker{
 			Path: filepath.Join(dir, "dotnet", "Dockerfile"),
 		},
@@ -218,7 +218,7 @@ func TestDetectNested(t *testing.T) {
 	require.Equal(t, projects[0], Project{
 		Language:      DotNet,
 		Path:          filepath.Join(src, "dotnet"),
-		DetectionRule: "Inferred by presence of: dotnettestapp.csproj, program.cs",
+		DetectionRule: "Inferred by presence of: dotnettestapp.csproj, Program.cs",
 	})
 }
 

--- a/cli/azd/internal/appdetect/dotnet.go
+++ b/cli/azd/internal/appdetect/dotnet.go
@@ -56,7 +56,7 @@ func (dd *dotNetDetector) DetectProject(ctx context.Context, path string, entrie
 
 		return &Project{
 			Language:      DotNet,
-			Path:          path,
+			Path:          projectPath,
 			DetectionRule: "Inferred by presence of: " + fmt.Sprintf("%s, %s", projFileName, startUpFileName),
 		}, nil
 	}

--- a/cli/azd/internal/appdetect/dotnet.go
+++ b/cli/azd/internal/appdetect/dotnet.go
@@ -49,7 +49,7 @@ func (dd *dotNetDetector) DetectProject(ctx context.Context, path string, entrie
 		projectPath := filepath.Join(path, projFileName)
 		if isWasm, err := dd.isWasmProject(ctx, projectPath); err != nil {
 			log.Printf("error checking if %s is a browser-wasm project: %v", projectPath, err)
-		} else if isWasm { // Web assembly projects currently not supported as hostable application project
+		} else if isWasm { // Web assembly projects currently not supported as a hosted application project
 			return nil, filepath.SkipDir
 		}
 

--- a/cli/azd/internal/appdetect/dotnet.go
+++ b/cli/azd/internal/appdetect/dotnet.go
@@ -51,7 +51,7 @@ func (dd *dotNetDetector) DetectProject(ctx context.Context, path string, entrie
 		if isWasm, err := dd.isWasmProject(ctx, projectPath); err != nil {
 			log.Printf("error checking if %s is a browser-wasm project: %v", projectPath, err)
 		} else if isWasm { // Web assembly projects currently not supported as hostable application project
-			return nil, nil
+			return nil, filepath.SkipDir
 		}
 
 		return &Project{

--- a/cli/azd/internal/appdetect/dotnet.go
+++ b/cli/azd/internal/appdetect/dotnet.go
@@ -55,7 +55,7 @@ func (dd *dotNetDetector) DetectProject(ctx context.Context, path string, entrie
 
 		return &Project{
 			Language:      DotNet,
-			Path:          projectPath,
+			Path:          path,
 			DetectionRule: "Inferred by presence of: " + fmt.Sprintf("%s, %s", projFileName, startUpFileName),
 		}, nil
 	}

--- a/cli/azd/internal/appdetect/dotnet.go
+++ b/cli/azd/internal/appdetect/dotnet.go
@@ -32,8 +32,7 @@ func (dd *dotNetDetector) DetectProject(ctx context.Context, path string, entrie
 		// This detection logic doesn't work if Program.cs has been renamed, or moved into a different directory.
 		// A true detection of an "Application" is much harder since ASP .NET applications are just libraries
 		// that are ran with "dotnet run".
-		name = strings.ToLower(name)
-		switch name {
+		switch strings.ToLower(name) {
 		case "program.cs", "program.fs", "program.vb":
 			hasStartupFile = true
 			startUpFileName = name

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -94,7 +94,7 @@ func (i *Initializer) InitFromApp(
 		appHostManifests[prj.Path] = manifest
 
 		for _, path := range apphost.ProjectPaths(manifest) {
-			appHostForProject[path] = prj.Path
+			appHostForProject[filepath.Dir(path)] = prj.Path
 		}
 	}
 

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -94,7 +94,7 @@ func (i *Initializer) InitFromApp(
 		appHostManifests[prj.Path] = manifest
 
 		for _, path := range apphost.ProjectPaths(manifest) {
-			appHostForProject[filepath.Dir(path)] = prj.Path
+			appHostForProject[path] = prj.Path
 		}
 	}
 

--- a/cli/azd/pkg/tools/dotnet/dotnet.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet.go
@@ -204,6 +204,10 @@ func (cli *dotNetCli) SetSecrets(ctx context.Context, secrets map[string]string,
 	return nil
 }
 
+// GetMsBuildProperty uses -getProperty to fetch a property after evaluation, without executing the build.
+//
+// This only works for versions dotnet >= 8, MSBuild >= 17.8.
+// On older tool versions, this will return an error.
 func (cli *dotNetCli) GetMsBuildProperty(ctx context.Context, project string, propertyName string) (string, error) {
 	runArgs := exec.NewRunArgs("dotnet", "msbuild", project, fmt.Sprintf("--getProperty:%s", propertyName))
 	res, err := cli.commandRunner.Run(ctx, runArgs)


### PR DESCRIPTION
This change relaxes the project detection logic during `azd init` to warn for projects unreferenced by the app host.

With this change, for dotnet app detection, we also exclude wasm based projects such as BlazorAssembly as hostable. These projects can be referenced by a Blazor server and act as a library.

Fixes #3024