### PR TITLE
make loading locations ephemeral

### DIFF
--- a/cli/azd/pkg/account/subscriptions_manager.go
+++ b/cli/azd/pkg/account/subscriptions_manager.go
@@ -317,7 +317,7 @@ func (m *SubscriptionsManager) ListLocations(
 	var err error
 	msg := "Retrieving locations..."
 	m.console.ShowSpinner(ctx, msg, input.Step)
-	defer m.console.StopSpinner(ctx, msg, input.GetStepResultFormat(err))
+	defer m.console.StopSpinner(ctx, "", input.GetStepResultFormat(err))
 
 	return m.listLocations(ctx, subscriptionId)
 }


### PR DESCRIPTION
This spinner used to be ephemeral, an internal refactor had changed it to non-ephemeral. This change restores the old behavior which has been signed off by PM and designer.

Before:
![image](https://github.com/Azure/azure-dev/assets/2322434/75402445-6e4f-4561-a47c-0b4875842918)

After:
![image](https://github.com/Azure/azure-dev/assets/2322434/df992a3d-3c0c-4e17-8d54-ff1919ce753b)
