### PR TITLE
aspire: Support inputs and improve container.v0 support

### DIFF
--- a/cli/azd/cmd/provision.go
+++ b/cli/azd/cmd/provision.go
@@ -16,6 +16,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
+	"github.com/azure/azure-dev/cli/azd/pkg/password"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/spf13/cobra"
@@ -86,6 +87,7 @@ type provisionAction struct {
 	projectManager   project.ProjectManager
 	resourceManager  project.ResourceManager
 	env              *environment.Environment
+	envManager       environment.Manager
 	formatter        output.Formatter
 	projectConfig    *project.ProjectConfig
 	writer           io.Writer
@@ -102,6 +104,7 @@ func newProvisionAction(
 	resourceManager project.ResourceManager,
 	projectConfig *project.ProjectConfig,
 	env *environment.Environment,
+	envManager environment.Manager,
 	console input.Console,
 	formatter output.Formatter,
 	writer io.Writer,
@@ -113,6 +116,7 @@ func newProvisionAction(
 		projectManager:   projectManager,
 		resourceManager:  resourceManager,
 		env:              env,
+		envManager:       envManager,
 		formatter:        formatter,
 		projectConfig:    projectConfig,
 		writer:           writer,
@@ -158,6 +162,37 @@ func (p *provisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 		return nil, err
 	}
 	defer func() { _ = infra.Cleanup() }()
+
+	wroteNewInput := false
+
+	for inputName, inputInfo := range infra.Inputs {
+		inputConfigKey := fmt.Sprintf("inputs.%s", inputName)
+
+		if _, has := p.env.Config.GetString(inputConfigKey); !has {
+			// No value found, so we need to generate one, and store it in the config bag.
+			//
+			// TODO(ellismg): Today this dereference is safe because when loading a manifest we validate that every
+			// input has a generate block with a min length property.  We would like to relax this in Preview 3 to
+			// to support cases where this is not the case (and we'd prompt for the value).  When we do that, we'll need
+			// to audit these dereferences to check for nil.
+			val, err := password.FromAlphabet(password.LettersAndDigits, *inputInfo.Default.Generate.MinLength)
+			if err != nil {
+				return nil, fmt.Errorf("generating value for input %s: %w", inputName, err)
+			}
+
+			if err := p.env.Config.Set(inputConfigKey, val); err != nil {
+				return nil, fmt.Errorf("saving value for input %s: %w", inputName, err)
+			}
+
+			wroteNewInput = true
+		}
+	}
+
+	if wroteNewInput {
+		if err := p.envManager.Save(ctx, p.env); err != nil {
+			return nil, fmt.Errorf("saving environment: %w", err)
+		}
+	}
 
 	infraOptions := infra.Options
 	infraOptions.IgnoreDeploymentState = p.flags.ignoreDeploymentState

--- a/cli/azd/pkg/apphost/generate_types.go
+++ b/cli/azd/pkg/apphost/generate_types.go
@@ -21,6 +21,8 @@ type genKeyVault struct{}
 
 type genContainerApp struct {
 	Image   string
+	Dapr    *genContainerAppManifestTemplateContextDapr
+	Env     map[string]string
 	Ingress *genContainerAppIngress
 }
 
@@ -75,6 +77,11 @@ type genDaprComponent struct {
 	Secrets  map[string]genDaprComponentSecret
 	Type     string
 	Version  string
+}
+
+type genInput struct {
+	Secret           bool
+	DefaultMinLength int
 }
 
 type genBicepTemplateContext struct {

--- a/cli/azd/pkg/apphost/manifest.go
+++ b/cli/azd/pkg/apphost/manifest.go
@@ -60,6 +60,10 @@ type Resource struct {
 
 	// DaprComponent is present on dapr.component.v0 resources.
 	DaprComponent *DaprComponentResourceMetadata `json:"daprComponent,omitempty"`
+
+	// Inputs is present on resources that need inputs from during the provisioning process (e.g asking for an API key, or
+	// a password for a database).
+	Inputs map[string]Input `json:"inputs,omitempty"`
 }
 
 type DaprResourceMetadata struct {
@@ -87,6 +91,20 @@ type Binding struct {
 	Protocol      string `json:"protocol"`
 	Transport     string `json:"transport"`
 	External      bool   `json:"external"`
+}
+
+type Input struct {
+	Type    string        `json:"type"`
+	Secret  bool          `json:"secret"`
+	Default *InputDefault `json:"default,omitempty"`
+}
+
+type InputDefault struct {
+	Generate *InputDefaultGenerate `json:"generate,omitempty"`
+}
+
+type InputDefaultGenerate struct {
+	MinLength *int `json:"minLength,omitempty"`
 }
 
 // ManifestFromAppHost returns the Manifest from the given app host.

--- a/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-main.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-main.bicep.snap
@@ -9,6 +9,10 @@ param environmentName string
 @description('The location used for all deployed resources')
 param location string
 
+@secure()
+@metadata({azd: {type: 'inputs' }})
+param inputs object
+
 var tags = {
   'azd-env-name': environmentName
 }
@@ -25,6 +29,7 @@ module resources 'resources.bicep' = {
   params: {
     location: location
     tags: tags
+    inputs: inputs
   }
 }
 

--- a/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-nodeapp.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-nodeapp.snap
@@ -23,6 +23,8 @@ properties:
       env:
       - name: AZURE_CLIENT_ID
         value: {{ .Env.MANAGED_IDENTITY_CLIENT_ID }}
+      - name: MY_SQL_CONNECTION_STRING
+        value: Server=mysqlabstract;Port=3306;User ID=root;Password={{ index .Inputs `mysqlabstract` `password` }}
       - name: NODE_ENV
         value: development
       - name: PORT

--- a/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-resources.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-resources.bicep.snap
@@ -4,6 +4,10 @@ param location string = resourceGroup().location
 @description('Tags that will be applied to all resources')
 param tags object = {}
 
+@secure()
+@metadata({azd: {type: 'inputs' }})
+param inputs object
+
 var resourceToken = uniqueString(resourceGroup().id)
 
 resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
@@ -58,6 +62,37 @@ resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' 
     }
   }
   tags: tags
+}
+
+resource mysqlabstract 'Microsoft.App/containerApps@2023-05-02-preview' = {
+  name: 'mysqlabstract'
+  location: location
+  properties: {
+    environmentId: containerAppEnvironment.id
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: false
+        targetPort: 3306
+        transport: 'tcp'
+      }
+    }
+    template: {
+      containers: [
+        {
+          image: 'mysql:latest'
+          name: 'mysqlabstract'
+          env: [
+            {
+              name: 'MYSQL_ROOT_PASSWORD'
+              value: '${inputs['mysqlabstract']['password']}'
+            }
+          ]
+        }
+      ]
+    }
+  }
+  tags: union(tags, {'aspire-resource-name': 'mysqlabstract'})
 }
 
 

--- a/cli/azd/pkg/apphost/testdata/aspire-docker.json
+++ b/cli/azd/pkg/apphost/testdata/aspire-docker.json
@@ -6,7 +6,8 @@
       "context": "../NodeApp",
       "env": {
         "NODE_ENV": "development",
-        "PORT": "{nodeapp.bindings.http.port}"
+        "PORT": "{nodeapp.bindings.http.port}",
+        "MY_SQL_CONNECTION_STRING": "{mysqlabstract.connectionString}"
       },
       "bindings": {
         "http": {
@@ -14,6 +15,33 @@
           "protocol": "tcp",
           "transport": "http",
           "containerPort": 3000
+        }
+      }
+    },
+    "mysqlabstract": {
+      "type": "container.v0",
+      "image": "mysql:latest",
+      "env": {
+        "MYSQL_ROOT_PASSWORD": "{mysqlabstract.inputs.password}"
+      },
+      "bindings": {
+        "tcp": {
+          "scheme": "tcp",
+          "protocol": "tcp",
+          "transport": "tcp",
+          "containerPort": 3306
+        }
+      },
+      "connectionString": "Server={mysqlabstract.bindings.tcp.host};Port={mysqlabstract.bindings.tcp.port};User ID=root;Password={mysqlabstract.inputs.password}",
+      "inputs": {
+        "password": {
+          "type": "string",
+          "secret": true,
+          "default": {
+            "generate": {
+              "minLength": 10
+            }
+          }
         }
       }
     }

--- a/cli/azd/pkg/password/generator.go
+++ b/cli/azd/pkg/password/generator.go
@@ -14,10 +14,27 @@ const (
 	UppercaseLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	Digits           = "0123456789"
 	Symbols          = "~!@#$%^&*()_+`-={}|[]\\:\"<>?,./"
+	LettersAndDigits = LowercaseLetters + UppercaseLetters + Digits
 )
 
 type PasswordComposition struct {
 	NumLowercase, NumUppercase, NumDigits, NumSymbols uint
+}
+
+// FromAlphabet generates a password of a given length, using only characters from the given alphabet (which should
+// be a string with no duplicates)
+func FromAlphabet(alphabet string, length int) (string, error) {
+	if length <= 0 {
+		return "", fmt.Errorf("Empty passwords are insecure")
+	}
+
+	chars := make([]byte, length)
+	var pos uint = 0
+	if err := addRandomChars(chars, &pos, uint(length), alphabet); err != nil {
+		return "", err
+	}
+
+	return string(chars), nil
 }
 
 // Generate password consisting of given number of lowercase letters, uppercase letters, digits, and "symbol" characters.

--- a/cli/azd/pkg/project/dotnet_importer.go
+++ b/cli/azd/pkg/project/dotnet_importer.go
@@ -99,6 +99,11 @@ func (ai *DotNetImporter) ProjectInfrastructure(ctx context.Context, svcConfig *
 		return nil, fmt.Errorf("generating bicep from manifest: %w", err)
 	}
 
+	inputs, err := apphost.Inputs(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("getting inputs from manifest: %w", err)
+	}
+
 	tmpDir, err := os.MkdirTemp("", "azd-infra")
 	if err != nil {
 		return nil, fmt.Errorf("creating temporary directory: %w", err)
@@ -135,6 +140,7 @@ func (ai *DotNetImporter) ProjectInfrastructure(ctx context.Context, svcConfig *
 			Path:     tmpDir,
 			Module:   "main",
 		},
+		Inputs:     inputs,
 		cleanupDir: tmpDir,
 	}, nil
 }

--- a/cli/azd/pkg/project/importer.go
+++ b/cli/azd/pkg/project/importer.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/apphost"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 )
 
@@ -151,6 +152,7 @@ func (im *ImportManager) SynthAllInfrastructure(ctx context.Context, projectConf
 // which will cause any temporarily generated files to be removed.
 type Infra struct {
 	Options    provisioning.Options
+	Inputs     map[string]apphost.Input
 	cleanupDir string
 }
 

--- a/cli/azd/pkg/project/service_target_dotnet_containerapp.go
+++ b/cli/azd/pkg/project/service_target_dotnet_containerapp.go
@@ -21,6 +21,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/containerapps"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/azure/azure-dev/cli/azd/pkg/password"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
 )
@@ -192,13 +193,64 @@ func (at *dotnetContainerAppTarget) Deploy(
 				return
 			}
 
+			requiredInputs, err := apphost.Inputs(serviceConfig.DotNetContainerApp.Manifest)
+			if err != nil {
+				task.SetError(fmt.Errorf("failed to get required inputs: %w", err))
+			}
+
+			wroteNewInput := false
+
+			for inputName, inputInfo := range requiredInputs {
+				inputConfigKey := fmt.Sprintf("inputs.%s", inputName)
+
+				if _, has := at.env.Config.GetString(inputConfigKey); !has {
+					// No value found, so we need to generate one, and store it in the config bag.
+					//
+					// TODO(ellismg): Today this dereference is safe because when loading a manifest we validate that every
+					// input has a generate block with a min length property.  We would like to relax this in Preview 3 to
+					// to support cases where this is not the case (and we'd prompt for the value).  When we do that, we'll
+					// need to audit these dereferences to check for nil.
+					val, err := password.FromAlphabet(password.LettersAndDigits, *inputInfo.Default.Generate.MinLength)
+					if err != nil {
+						task.SetError(fmt.Errorf("generating value for input %s: %w", inputName, err))
+						return
+
+					}
+
+					if err := at.env.Config.Set(inputConfigKey, val); err != nil {
+						task.SetError(fmt.Errorf("saving value for input %s: %w", inputName, err))
+						return
+					}
+
+					wroteNewInput = true
+				}
+			}
+
+			if wroteNewInput {
+				if err := at.containerHelper.envManager.Save(ctx, at.env); err != nil {
+					task.SetError(fmt.Errorf("saving environment: %w", err))
+					return
+				}
+			}
+
+			var inputs map[string]any
+
+			if has, err := at.env.Config.GetSection("inputs", &inputs); err != nil {
+				task.SetError(fmt.Errorf("failed to get inputs section: %w", err))
+				return
+			} else if !has {
+				inputs = make(map[string]any)
+			}
+
 			builder := strings.Builder{}
 			err = tmpl.Execute(&builder, struct {
-				Env   map[string]string
-				Image string
+				Env    map[string]string
+				Image  string
+				Inputs map[string]any
 			}{
-				Env:   at.env.Dotenv(),
-				Image: remoteImageName,
+				Env:    at.env.Dotenv(),
+				Image:  remoteImageName,
+				Inputs: inputs,
 			})
 			if err != nil {
 				task.SetError(fmt.Errorf("failed executing template file: %w", err))

--- a/cli/azd/resources/apphost/templates/main.bicept
+++ b/cli/azd/resources/apphost/templates/main.bicept
@@ -10,6 +10,10 @@ param environmentName string
 @description('The location used for all deployed resources')
 param location string
 
+@secure()
+@metadata({azd: {type: 'inputs' }})
+param inputs object
+
 var tags = {
   'azd-env-name': environmentName
 }
@@ -26,6 +30,7 @@ module resources 'resources.bicep' = {
   params: {
     location: location
     tags: tags
+    inputs: inputs
   }
 }
 

--- a/cli/azd/resources/apphost/templates/resources.bicept
+++ b/cli/azd/resources/apphost/templates/resources.bicept
@@ -5,6 +5,10 @@ param location string = resourceGroup().location
 @description('Tags that will be applied to all resources')
 param tags object = {}
 
+@secure()
+@metadata({azd: {type: 'inputs' }})
+param inputs object
+
 var resourceToken = uniqueString(resourceGroup().id)
 
 resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
@@ -125,44 +129,56 @@ resource {{bicepName $name}} 'Microsoft.App/containerApps@2023-05-02-preview' = 
     environmentId: containerAppEnvironment.id
     configuration: {
       activeRevisionsMode: 'Single'
-{{if $value.Dapr}}
+{{- if $value.Dapr}}
       dapr: {
         appId: {{$value.Dapr.AppId}}
-{{if $value.Dapr.AppPort}}
+{{- if $value.Dapr.AppPort}}
         appPort: {{$value.Dapr.AppPort}}
-{{end}}
-{{if $value.Dapr.AppProtocol}}
+{{- end}}
+{{- if $value.Dapr.AppProtocol}}
         appProtocol: {{$value.Dapr.AppProtocol}}
-{{end}}
-{{if $value.Dapr.EnableApiLogging}}
+{{- end}}
+{{- if $value.Dapr.EnableApiLogging}}
         enableApiLogging: {{$value.Dapr.EnableApiLogging}}
-{{end}}
+{{- end}}
         enabled: true
-{{if $value.Dapr.HttpMaxRequestSize}}
+{{- if $value.Dapr.HttpMaxRequestSize}}
         httpMaxRequestSize: {{$value.Dapr.HttpMaxRequestSize}}
-{{end}}
-{{if $value.Dapr.HttpReadBufferSize}}
+{{- end}}
+{{- if $value.Dapr.HttpReadBufferSize}}
         httpReadBufferSize: {{$value.Dapr.HttpReadBufferSize}}
-{{end}}
-{{if $value.Dapr.LogLevel}}
+{{- end}}
+{{- if $value.Dapr.LogLevel}}
         logLevel: {{$value.Dapr.LogLevel}}
-{{end}}
+{{- end}}
       }
-{{end}}
-{{if $value.Ingress}}      
+{{- end}}
+{{- if $value.Ingress}}
       ingress: {
         external: {{$value.Ingress.External}}
         targetPort: {{$value.Ingress.TargetPort}}
         transport: '{{$value.Ingress.Transport}}'
+{{- if ne $value.Ingress.Transport "tcp" }}
         allowInsecure: {{$value.Ingress.AllowInsecure}}
+{{- end}}
       }
-{{end}}      
+{{- end}}
     }
     template: {
       containers: [
         {
           image: '{{$value.Image}}'
           name: '{{$name}}'
+{{- if $value.Env }}
+          env: [
+{{- range $name, $value := $value.Env}}
+            {
+              name: '{{$name}}'
+              value: '{{$value}}'
+            }
+{{- end}}
+          ]
+{{- end}}
         }
       ]
     }


### PR DESCRIPTION
This change adds supports for `inputs` which is a new (optional) property on resources in the Aspire manifest. These inputs represent values that deployment tools like `azd` need to provide "somehow".

For our initial support, we support string inputs which contain metadata on how to generate a default value, based on a minumum random length. Aspire uses this today to model passwords for cases like `AddMySqlContainer()` where a deployment tool needs to provide a password for the root user.

Consider the following AppHost manifest:

```json
{
  "resources": {
    "demoapp": {
      "type": "project.v0",
      "path": "../AspireContainers.DemoApp/AspireContainers.DemoApp.csproj",
      "env": {
        "ConnectionStrings__MySql": "{mysqlabstract.connectionString}"
      },
      "bindings": {
        "http": {
          "scheme": "http",
          "protocol": "tcp",
          "transport": "http",
        }
      }
    },
    "mysqlabstract": {
      "type": "container.v0",
      "image": "mysql:latest",
      "env": {
        "MYSQL_ROOT_PASSWORD": "{mysqlabstract.inputs.password}"
      },
      "bindings": {
        "tcp": {
          "scheme": "tcp",
          "protocol": "tcp",
          "transport": "tcp",
          "containerPort": 3306
        }
      },
      "connectionString": "Server={mysqlabstract.bindings.tcp.host};Port={mysqlabstract.bindings.tcp.port};User ID=root;Password={mysqlabstract.inputs.password}",
      "inputs": {
        "password": {
          "type": "string",
          "secret": true,
          "default": {
            "generate": {
              "minLength": 10
            }
          }
        }
      }
    }
  }
}
```

In this example, we spin up a MySql Container (with a randomly generated password at least 10 characters long). The container resource now has an expression with binding references in for its `connectionString` property, and other resources (like `demoapp`) can refer to this property to create connections to it.

To support this, we need to teach `azd` how to handle these inputs and where to store them as well as decide how to the flow into both the infrastructure and service deployments.

The strategy here for now is to model a new `Inputs` object, which holds all the values for the given inputs. The object contains a top level key for every resource with an input and the value is an object that maps inputs from that resource to their values, eg:

```json
{
  "mysqlabstract": {
     "password": "<value-from-deployment-tool>"
  }
}
```

For bicep deployments, you can mark an object or secure object parameter with `@metdata(azd: { type: 'inputs' } )` the value will be passed as this object.

For container app deployments, the new `Inputs` field is present on the root context object and you can read values from this map.

These are stored in the environment config (so they can vary per environment) under the "inputs" section.

Values which are marked as `secure` today are not encrypted at rest, but this is something we will improve before GA, by storing these values in KeyVault and then reference from there.

We do, however, mark the parameter that gets the value in the bicep deployment as an `@secure()` parameter, so the values like passwords are not retained in the deployment log.

As part of this change, some small improvements where made to the binding expression evaluator, to allow using `.host` in references to container apps (we know the value will be the same as the container app name, due to how networking works in ACA).