### PR TITLE
Fix incorrect log analytics dependency

### DIFF
--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -363,11 +363,11 @@ func (b *infraGenerator) LoadManifest(m *Manifest) error {
 }
 
 func (b *infraGenerator) requireCluster() {
+	b.requireLogAnalyticsWorkspace()
 	b.bicepContext.HasContainerEnvironment = true
 }
 
 func (b *infraGenerator) requireContainerRegistry() {
-	b.requireLogAnalyticsWorkspace()
 	b.bicepContext.HasContainerRegistry = true
 }
 

--- a/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-main.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-main.bicep.snap
@@ -1,0 +1,39 @@
+targetScope = 'subscription'
+
+@minLength(1)
+@maxLength(64)
+@description('Name of the environment that can be used as part of naming resource convention, the name of the resource group for your application will use this name, prefixed with rg-')
+param environmentName string
+
+@minLength(1)
+@description('The location used for all deployed resources')
+param location string
+
+@secure()
+@metadata({azd: {type: 'inputs' }})
+param inputs object
+
+var tags = {
+  'azd-env-name': environmentName
+}
+
+resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module resources 'resources.bicep' = {
+  scope: rg
+  name: 'resources'
+  params: {
+    location: location
+    tags: tags
+    inputs: inputs
+  }
+}
+
+output MANAGED_IDENTITY_CLIENT_ID string = resources.outputs.MANAGED_IDENTITY_CLIENT_ID
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = resources.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = resources.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN
+

--- a/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-main.parameters.json.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-main.parameters.json.snap
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "environmentName": {
+        "value": "${AZURE_ENV_NAME}"
+      },
+      "location": {
+        "value": "${AZURE_LOCATION}"
+      }
+    }
+  }
+  

--- a/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-resources.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-resources.bicep.snap
@@ -16,6 +16,17 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-
   tags: tags
 }
 
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: 'law-${resourceToken}'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+  }
+  tags: tags
+}
+
 resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' = {
   name: 'cae-${resourceToken}'
   location: location

--- a/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-resources.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-resources.bicep.snap
@@ -1,0 +1,69 @@
+@description('The location used for all deployed resources')
+param location string = resourceGroup().location
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+@secure()
+@metadata({azd: {type: 'inputs' }})
+param inputs object
+
+var resourceToken = uniqueString(resourceGroup().id)
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: 'mi-${resourceToken}'
+  location: location
+  tags: tags
+}
+
+resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' = {
+  name: 'cae-${resourceToken}'
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalyticsWorkspace.properties.customerId
+        sharedKey: logAnalyticsWorkspace.listKeys().primarySharedKey
+      }
+    }
+  }
+  tags: tags
+}
+
+resource mysqlabstract 'Microsoft.App/containerApps@2023-05-02-preview' = {
+  name: 'mysqlabstract'
+  location: location
+  properties: {
+    environmentId: containerAppEnvironment.id
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: false
+        targetPort: 3306
+        transport: 'tcp'
+      }
+    }
+    template: {
+      containers: [
+        {
+          image: 'mysql:latest'
+          name: 'mysqlabstract'
+          env: [
+            {
+              name: 'MYSQL_ROOT_PASSWORD'
+              value: '${inputs['mysqlabstract']['password']}'
+            }
+          ]
+        }
+      ]
+    }
+  }
+  tags: union(tags, {'aspire-resource-name': 'mysqlabstract'})
+}
+
+
+output MANAGED_IDENTITY_CLIENT_ID string = managedIdentity.properties.clientId
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = containerAppEnvironment.id
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = containerAppEnvironment.properties.defaultDomain
+

--- a/cli/azd/pkg/apphost/testdata/aspire-container.json
+++ b/cli/azd/pkg/apphost/testdata/aspire-container.json
@@ -1,0 +1,31 @@
+{
+  "resources": {
+    "mysqlabstract": {
+      "type": "container.v0",
+      "image": "mysql:latest",
+      "env": {
+        "MYSQL_ROOT_PASSWORD": "{mysqlabstract.inputs.password}"
+      },
+      "bindings": {
+        "tcp": {
+          "scheme": "tcp",
+          "protocol": "tcp",
+          "transport": "tcp",
+          "containerPort": 3306
+        }
+      },
+      "connectionString": "Server={mysqlabstract.bindings.tcp.host};Port={mysqlabstract.bindings.tcp.port};User ID=root;Password={mysqlabstract.inputs.password}",
+      "inputs": {
+        "password": {
+          "type": "string",
+          "secret": true,
+          "default": {
+            "generate": {
+              "minLength": 10
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix the generation logic: emit a log analytics workspace when a container apps environment is required.

Remove the dependency of container registry on log analytics workspace since that is actually extraneous based on the [bicep template](https://github.com/Azure/azure-dev/blob/fbbcfbe30f2175d980267329f0c0916c2270d4ed/cli/azd/resources/apphost/templates/resources.bicept#L19-L41)/

Fixes #3141