### PR TITLE
templates: Increase resiliency of devcontainer install for function tools 

### DIFF
--- a/templates/common/.devcontainer/devcontainer.json/csharp/func/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/csharp/func/devcontainer.json
@@ -28,7 +28,7 @@
         3000,
         3100
     ],
-    "postCreateCommand": "echo 'Installing functions-core-tools:' && cd && mkdir functions-core-tools-install && cd functions-core-tools-install && wget -q \"https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.5455/Azure.Functions.Cli.linux-x64.4.0.5455.zip\" && echo ' - extracting files.' && unzip -q -d azure-functions-cli Azure.Functions.Cli.linux-x64.4.0.5455.zip && rm Azure.Functions.Cli.linux-x64.4.0.5455.zip && cd azure-functions-cli && chmod +x func && chmod +x gozip && echo ' - export func.' && sudo rsync -av ~/functions-core-tools-install/azure-functions-cli/ /usr/bin/",
+    "postCreateCommand": "echo 'Installing functions-core-tools:' && tmp_folder=$(mktemp -d) && install_folder=/opt/microsoft/azure-functions-core-tools && cd $tmp_folder && wget -q \"https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.5455/Azure.Functions.Cli.linux-x64.4.0.5455.zip\" && echo ' - extracting files.' && unzip -q Azure.Functions.Cli.linux-x64.4.0.5455.zip && rm Azure.Functions.Cli.linux-x64.4.0.5455.zip && chmod +x func && chmod +x gozip && sudo mkdir -p $install_folder && sudo rsync -av $tmp_folder/ $install_folder && rm -rf $tmp_folder && echo ' - export func.'  && sudo ln -fs $install_folder/func /usr/local/bin/func",
     "remoteUser": "vscode",
     "hostRequirements": {
         "memory": "8gb"

--- a/templates/common/.devcontainer/devcontainer.json/nodejs/func/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/nodejs/func/devcontainer.json
@@ -25,7 +25,7 @@
         3000,
         3100
     ],
-    "postCreateCommand": "echo 'Installing functions-core-tools:' && cd && mkdir functions-core-tools-install && cd functions-core-tools-install && wget -q \"https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.5455/Azure.Functions.Cli.linux-x64.4.0.5455.zip\" && echo ' - extracting files.' && unzip -q -d azure-functions-cli Azure.Functions.Cli.linux-x64.4.0.5455.zip && rm Azure.Functions.Cli.linux-x64.4.0.5455.zip && cd azure-functions-cli && chmod +x func && chmod +x gozip && echo ' - export func.' && sudo rsync -av ~/functions-core-tools-install/azure-functions-cli/ /usr/bin/",
+    "postCreateCommand": "echo 'Installing functions-core-tools:' && tmp_folder=$(mktemp -d) && install_folder=/opt/microsoft/azure-functions-core-tools && cd $tmp_folder && wget -q \"https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.5455/Azure.Functions.Cli.linux-x64.4.0.5455.zip\" && echo ' - extracting files.' && unzip -q Azure.Functions.Cli.linux-x64.4.0.5455.zip && rm Azure.Functions.Cli.linux-x64.4.0.5455.zip && chmod +x func && chmod +x gozip && sudo mkdir -p $install_folder && sudo rsync -av $tmp_folder/ $install_folder && rm -rf $tmp_folder && echo ' - export func.'  && sudo ln -fs $install_folder/func /usr/local/bin/func",
     "remoteUser": "node",
     "hostRequirements": {
         "memory": "8gb"

--- a/templates/common/.devcontainer/devcontainer.json/python/func/devcontainer.json
+++ b/templates/common/.devcontainer/devcontainer.json/python/func/devcontainer.json
@@ -27,7 +27,7 @@
         3000,
         3100
     ],
-    "postCreateCommand": "echo 'Installing functions-core-tools:' && cd && mkdir functions-core-tools-install && cd functions-core-tools-install && wget -q \"https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.5455/Azure.Functions.Cli.linux-x64.4.0.5455.zip\" && echo ' - extracting files.' && unzip -q -d azure-functions-cli Azure.Functions.Cli.linux-x64.4.0.5455.zip && rm Azure.Functions.Cli.linux-x64.4.0.5455.zip && cd azure-functions-cli && chmod +x func && chmod +x gozip && echo ' - export func.' && sudo cp -r ~/functions-core-tools-install/azure-functions-cli/* /usr/bin/",
+    "postCreateCommand": "echo 'Installing functions-core-tools:' && tmp_folder=$(mktemp -d) && install_folder=/opt/microsoft/azure-functions-core-tools && cd $tmp_folder && wget -q \"https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.5455/Azure.Functions.Cli.linux-x64.4.0.5455.zip\" && echo ' - extracting files.' && unzip -q Azure.Functions.Cli.linux-x64.4.0.5455.zip && rm Azure.Functions.Cli.linux-x64.4.0.5455.zip && chmod +x func && chmod +x gozip && sudo mkdir -p $install_folder && sudo rsync -av $tmp_folder/ $install_folder && rm -rf $tmp_folder && echo ' - export func.'  && sudo ln -fs $install_folder/func /usr/local/bin/func",
     "remoteUser": "vscode",
     "hostRequirements": {
         "memory": "8gb"


### PR DESCRIPTION
Increase resiliency of devcontainer install scripts for function tools:

- Install under `/opt/microsoft/azure-function-core-tools`
- Symbolic link just `func` instead of installing binaries into `/usr/bin`

Tested `func` in devcontainer install:

![image](https://github.com/Azure/azure-dev/assets/2322434/3dfd1779-822e-4247-b8ed-4a39534df54b)
