### PR TITLE
[NetAspire] Fix storage overriding after reading manifest

### DIFF
--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -428,7 +428,12 @@ func (b *infraGenerator) addContainerAppService(name string, serviceType string)
 }
 
 func (b *infraGenerator) addStorageAccount(name string) {
-	b.bicepContext.StorageAccounts[name] = genStorageAccount{}
+	// storage account can be added from addStorageTable, addStorageQueue or addStorageBlob
+	// We only need to add it if it wasn't added before to cover cases of manifest with only one storage account and no
+	// blobs, queues or tables
+	if _, exists := b.bicepContext.StorageAccounts[name]; !exists {
+		b.bicepContext.StorageAccounts[name] = genStorageAccount{}
+	}
 }
 
 func (b *infraGenerator) addKeyVault(name string) {
@@ -436,10 +441,6 @@ func (b *infraGenerator) addKeyVault(name string) {
 }
 
 func (b *infraGenerator) addStorageBlob(storageAccount, blobName string) {
-	// TODO(ellismg): We have to handle the case where we may visit the blob resource before the storage account resource.
-	// But this implementation means that if the parent storage account is not in the manifest, we will not detect that
-	// as an error.  We probably should.
-
 	account := b.bicepContext.StorageAccounts[storageAccount]
 	account.Blobs = append(account.Blobs, blobName)
 	b.bicepContext.StorageAccounts[storageAccount] = account

--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -430,7 +430,7 @@ func (b *infraGenerator) addContainerAppService(name string, serviceType string)
 func (b *infraGenerator) addStorageAccount(name string) {
 	// storage account can be added from addStorageTable, addStorageQueue or addStorageBlob
 	// We only need to add it if it wasn't added before to cover cases of manifest with only one storage account and no
-	// blobs, queues or tables
+	// blobs, queues or tables.
 	if _, exists := b.bicepContext.StorageAccounts[name]; !exists {
 		b.bicepContext.StorageAccounts[name] = genStorageAccount{}
 	}

--- a/cli/azd/pkg/apphost/generate_test.go
+++ b/cli/azd/pkg/apphost/generate_test.go
@@ -20,6 +20,9 @@ import (
 //go:embed testdata/aspire-docker.json
 var aspireDockerManifest []byte
 
+//go:embed testdata/aspire-storage.json
+var aspireStorageManifest []byte
+
 //go:embed testdata/aspire-escaping.json
 var aspireEscapingManifest []byte
 
@@ -59,6 +62,41 @@ func TestAspireEscaping(t *testing.T) {
 			snapshot.SnapshotT(t, tmpl)
 		})
 	}
+}
+
+func TestAspireStorageGeneration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping due to EOL issues on Windows with the baselines")
+	}
+
+	ctx := context.Background()
+	mockCtx := mocks.NewMockContext(ctx)
+	mockPublishManifest(mockCtx, aspireStorageManifest)
+	mockCli := dotnet.NewDotNetCli(mockCtx.CommandRunner)
+
+	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli)
+	require.NoError(t, err)
+
+	files, err := BicepTemplate(m)
+	require.NoError(t, err)
+
+	err = fs.WalkDir(files, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		contents, err := fs.ReadFile(files, path)
+		if err != nil {
+			return err
+		}
+		t.Run(path, func(t *testing.T) {
+			snapshot.SnapshotT(t, string(contents))
+		})
+		return nil
+	})
+	require.NoError(t, err)
 }
 
 func TestAspireDockerGeneration(t *testing.T) {

--- a/cli/azd/pkg/apphost/generate_test.go
+++ b/cli/azd/pkg/apphost/generate_test.go
@@ -142,3 +142,23 @@ func TestBuildEnvResolveServiceToConnectionString(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, manifestCtx.Env)
 }
+
+func TestAddContainerAppService(t *testing.T) {
+	// Create a mock infraGenerator instance
+	mockGenerator := &infraGenerator{
+		bicepContext: genBicepTemplateContext{
+			StorageAccounts: make(map[string]genStorageAccount),
+		},
+	}
+
+	// Call the method being tested
+	mockGenerator.addStorageBlob("storage", "blob")
+	mockGenerator.addStorageAccount("storage")
+	mockGenerator.addStorageQueue("storage", "quue")
+	mockGenerator.addStorageAccount("storage")
+	mockGenerator.addStorageTable("storage", "table")
+
+	require.Equal(t, 1, len(mockGenerator.bicepContext.StorageAccounts["storage"].Blobs))
+	require.Equal(t, 1, len(mockGenerator.bicepContext.StorageAccounts["storage"].Queues))
+	require.Equal(t, 1, len(mockGenerator.bicepContext.StorageAccounts["storage"].Tables))
+}

--- a/cli/azd/pkg/apphost/generate_test.go
+++ b/cli/azd/pkg/apphost/generate_test.go
@@ -195,8 +195,25 @@ func TestAddContainerAppService(t *testing.T) {
 	mockGenerator.addStorageQueue("storage", "quue")
 	mockGenerator.addStorageAccount("storage")
 	mockGenerator.addStorageTable("storage", "table")
+	mockGenerator.addStorageAccount("storage2")
+	mockGenerator.addStorageAccount("storage3")
+	mockGenerator.addStorageTable("storage4", "table")
+	mockGenerator.addStorageTable("storage2", "table")
+	mockGenerator.addStorageQueue("storage", "quue2")
 
 	require.Equal(t, 1, len(mockGenerator.bicepContext.StorageAccounts["storage"].Blobs))
-	require.Equal(t, 1, len(mockGenerator.bicepContext.StorageAccounts["storage"].Queues))
+	require.Equal(t, 2, len(mockGenerator.bicepContext.StorageAccounts["storage"].Queues))
 	require.Equal(t, 1, len(mockGenerator.bicepContext.StorageAccounts["storage"].Tables))
+
+	require.Equal(t, 0, len(mockGenerator.bicepContext.StorageAccounts["storage2"].Blobs))
+	require.Equal(t, 0, len(mockGenerator.bicepContext.StorageAccounts["storage2"].Queues))
+	require.Equal(t, 1, len(mockGenerator.bicepContext.StorageAccounts["storage2"].Tables))
+
+	require.Equal(t, 0, len(mockGenerator.bicepContext.StorageAccounts["storage3"].Blobs))
+	require.Equal(t, 0, len(mockGenerator.bicepContext.StorageAccounts["storage3"].Queues))
+	require.Equal(t, 0, len(mockGenerator.bicepContext.StorageAccounts["storage3"].Tables))
+
+	require.Equal(t, 0, len(mockGenerator.bicepContext.StorageAccounts["storage4"].Blobs))
+	require.Equal(t, 0, len(mockGenerator.bicepContext.StorageAccounts["storage4"].Queues))
+	require.Equal(t, 1, len(mockGenerator.bicepContext.StorageAccounts["storage4"].Tables))
 }

--- a/cli/azd/pkg/apphost/testdata/TestAspireStorageGeneration-main.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireStorageGeneration-main.bicep.snap
@@ -1,0 +1,45 @@
+targetScope = 'subscription'
+
+@minLength(1)
+@maxLength(64)
+@description('Name of the environment that can be used as part of naming resource convention, the name of the resource group for your application will use this name, prefixed with rg-')
+param environmentName string
+
+@minLength(1)
+@description('The location used for all deployed resources')
+param location string
+
+@secure()
+@metadata({azd: {type: 'inputs' }})
+param inputs object
+
+var tags = {
+  'azd-env-name': environmentName
+}
+
+resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module resources 'resources.bicep' = {
+  scope: rg
+  name: 'resources'
+  params: {
+    location: location
+    tags: tags
+    inputs: inputs
+  }
+}
+
+output MANAGED_IDENTITY_CLIENT_ID string = resources.outputs.MANAGED_IDENTITY_CLIENT_ID
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = resources.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = resources.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = resources.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = resources.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN
+output SERVICE_BINDING_BLOBS_ENDPOINT string = resources.outputs.SERVICE_BINDING_BLOBS_ENDPOINT
+output SERVICE_BINDING_QUEUES_ENDPOINT string = resources.outputs.SERVICE_BINDING_QUEUES_ENDPOINT
+output SERVICE_BINDING_PHOTOBLOBS_ENDPOINT string = resources.outputs.SERVICE_BINDING_PHOTOBLOBS_ENDPOINT
+output SERVICE_BINDING_PHOTOQUEUES_ENDPOINT string = resources.outputs.SERVICE_BINDING_PHOTOQUEUES_ENDPOINT
+

--- a/cli/azd/pkg/apphost/testdata/TestAspireStorageGeneration-main.parameters.json.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireStorageGeneration-main.parameters.json.snap
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "environmentName": {
+        "value": "${AZURE_ENV_NAME}"
+      },
+      "location": {
+        "value": "${AZURE_LOCATION}"
+      }
+    }
+  }
+  

--- a/cli/azd/pkg/apphost/testdata/TestAspireStorageGeneration-resources.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireStorageGeneration-resources.bicep.snap
@@ -1,0 +1,143 @@
+@description('The location used for all deployed resources')
+param location string = resourceGroup().location
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+@secure()
+@metadata({azd: {type: 'inputs' }})
+param inputs object
+
+var resourceToken = uniqueString(resourceGroup().id)
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: 'mi-${resourceToken}'
+  location: location
+  tags: tags
+}
+
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+  name: replace('acr-${resourceToken}', '-', '')
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  properties: {
+    adminUserEnabled: true
+  }
+  tags: tags
+}
+
+resource caeMiRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(containerRegistry.id, managedIdentity.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+  scope: containerRegistry
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId:  subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+  }
+}
+
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: 'law-${resourceToken}'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+  }
+  tags: tags
+}
+
+resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' = {
+  name: 'cae-${resourceToken}'
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalyticsWorkspace.properties.customerId
+        sharedKey: logAnalyticsWorkspace.listKeys().primarySharedKey
+      }
+    }
+  }
+  tags: tags
+}
+
+resource mydata 'Microsoft.Storage/storageAccounts@2022-05-01' = {
+  name: replace('mydata-${resourceToken}', '-', '')
+  location: location
+  kind: 'Storage'
+  sku: {
+    name: 'Standard_GRS'
+  }
+  tags: union(tags, {'aspire-resource-name': 'mydata'})
+
+  resource blobs 'blobServices@2022-05-01' = {
+    name: 'default'
+  }
+}
+
+resource mydataBlobsRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(mydata.id, managedIdentity.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'))
+  scope: mydata
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId:  subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
+  }
+}
+resource mydataQueuesRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(mydata.id, managedIdentity.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88'))
+  scope: mydata
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId:  subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88')
+  }
+}
+
+resource photos 'Microsoft.Storage/storageAccounts@2022-05-01' = {
+  name: replace('photos-${resourceToken}', '-', '')
+  location: location
+  kind: 'Storage'
+  sku: {
+    name: 'Standard_GRS'
+  }
+  tags: union(tags, {'aspire-resource-name': 'photos'})
+
+  resource blobs 'blobServices@2022-05-01' = {
+    name: 'default'
+  }
+}
+
+resource photosBlobsRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(photos.id, managedIdentity.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'))
+  scope: photos
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId:  subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
+  }
+}
+resource photosQueuesRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(photos.id, managedIdentity.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88'))
+  scope: photos
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId:  subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88')
+  }
+}
+
+
+output MANAGED_IDENTITY_CLIENT_ID string = managedIdentity.properties.clientId
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.properties.loginServer
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = managedIdentity.id
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = containerAppEnvironment.id
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = containerAppEnvironment.properties.defaultDomain
+output SERVICE_BINDING_BLOBS_ENDPOINT string = mydata.properties.primaryEndpoints.blob
+output SERVICE_BINDING_QUEUES_ENDPOINT string = mydata.properties.primaryEndpoints.queue
+output SERVICE_BINDING_PHOTOBLOBS_ENDPOINT string = photos.properties.primaryEndpoints.blob
+output SERVICE_BINDING_PHOTOQUEUES_ENDPOINT string = photos.properties.primaryEndpoints.queue
+

--- a/cli/azd/pkg/apphost/testdata/aspire-storage.json
+++ b/cli/azd/pkg/apphost/testdata/aspire-storage.json
@@ -1,0 +1,37 @@
+{
+    "resources": {
+      "mydata": {
+        "type": "azure.storage.v0"
+      },
+      "blobs": {
+        "type": "azure.storage.blob.v0",
+        "parent": "mydata"
+      },
+      "queues": {
+        "type": "azure.storage.queue.v0",
+        "parent": "mydata"
+      },
+      "frontend": {
+        "type": "project.v0",
+        "path": "../Test1.Web/Test1.Web.csproj",
+        "env": {
+          "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+          "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
+          "ConnectionStrings__blobs": "{blobs.connectionString}",
+          "ConnectionStrings__queues": "{queues.connectionString}"
+        },
+        "bindings": {
+          "http": {
+            "scheme": "http",
+            "protocol": "tcp",
+            "transport": "http"
+          },
+          "https": {
+            "scheme": "https",
+            "protocol": "tcp",
+            "transport": "http"
+          }
+        }
+      }
+    }
+  }

--- a/cli/azd/pkg/apphost/testdata/aspire-storage.json
+++ b/cli/azd/pkg/apphost/testdata/aspire-storage.json
@@ -11,6 +11,17 @@
         "type": "azure.storage.queue.v0",
         "parent": "mydata"
       },
+      "photos": {
+        "type": "azure.storage.v0"
+      },
+      "photoblobs": {
+        "type": "azure.storage.blob.v0",
+        "parent": "photos"
+      },
+      "photoqueues": {
+        "type": "azure.storage.queue.v0",
+        "parent": "photos"
+      },
       "frontend": {
         "type": "project.v0",
         "path": "../Test1.Web/Test1.Web.csproj",
@@ -18,7 +29,9 @@
           "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
           "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
           "ConnectionStrings__blobs": "{blobs.connectionString}",
-          "ConnectionStrings__queues": "{queues.connectionString}"
+          "ConnectionStrings__queues": "{queues.connectionString}",
+          "ConnectionStrings__photoblobs": "{photoblobs.connectionString}",
+          "ConnectionStrings__photoqueues": "{photoqueues.connectionString}"
         },
         "bindings": {
           "http": {


### PR DESCRIPTION
azd was parsing manifest into unordered map, and the manifest->azure resource translation had a bug that would present itself with the ordering:
 
If the ordering was:
StorageAccount
Blob
Queue
This would work fine.
 
But if the ordering was:
Queue
StorageAccount (resets whatever was added by Queue)
Blob
Would lead to missing queue output

fix: https://github.com/Azure/azure-dev/issues/3137