### PR TITLE
py-func: upgrade packages and function-host runtime

### DIFF
--- a/templates/todo/api/python/requirements.txt
+++ b/templates/todo/api/python/requirements.txt
@@ -6,5 +6,5 @@ python-dotenv == 0.20.*
 # https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/identity/azure-identity/CHANGELOG.md#1130b4-2023-04-11
 azure-identity == 1.13.0
 azure-keyvault-secrets == 4.4.*
-opentelemetry-instrumentation-fastapi == 0.30b1
-azure-monitor-opentelemetry-exporter == 1.0.0b5
+opentelemetry-instrumentation-fastapi == 0.42b0
+azure-monitor-opentelemetry-exporter == 1.0.0b19

--- a/templates/todo/common/infra/bicep/app/api-functions-python.bicep
+++ b/templates/todo/common/infra/bicep/app/api-functions-python.bicep
@@ -24,7 +24,7 @@ module api '../../../../../common/infra/bicep/core/host/functions.bicep' = {
     appServicePlanId: appServicePlanId
     keyVaultName: keyVaultName
     runtimeName: 'python'
-    runtimeVersion: '3.8'
+    runtimeVersion: '3.10'
     storageAccountName: storageAccountName
   }
 }


### PR DESCRIPTION
Fixes python function app failing to start due to `opentelemetry-sdk` library incompatibility with the runtime environment. Also, bumping function host runtime (missing change from #1463).