### PR TITLE
Pass tenant ID from environment to credential options

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -424,7 +424,11 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	})
 
 	container.RegisterSingleton(func(ctx context.Context, authManager *auth.Manager) (azcore.TokenCredential, error) {
-		return authManager.CredentialForCurrentUser(ctx, nil)
+		var options = &auth.CredentialForCurrentUserOptions{
+			TenantID: os.Getenv(environment.TenantIdEnvVarName),
+		}
+
+		return authManager.CredentialForCurrentUser(ctx, options)
 	})
 
 	// Tools

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -44,6 +44,7 @@ func envActions(root *actions.ActionDescriptor) *actions.ActionDescriptor {
 
 	group.Add("select", &actions.ActionDescriptorOptions{
 		Command:        newEnvSelectCmd(),
+		FlagsResolver:  newEnvSelectFlags,
 		ActionResolver: newEnvSelectAction,
 	})
 
@@ -55,6 +56,7 @@ func envActions(root *actions.ActionDescriptor) *actions.ActionDescriptor {
 
 	group.Add("list", &actions.ActionDescriptorOptions{
 		Command:        newEnvListCmd(),
+		FlagsResolver:  newEnvListFlags,
 		ActionResolver: newEnvListAction,
 		OutputFormats:  []output.Format{output.JsonFormat, output.TableFormat},
 		DefaultFormat:  output.TableFormat,
@@ -96,11 +98,13 @@ func newEnvSetCmd() *cobra.Command {
 
 type envSetFlags struct {
 	envFlag
+	tenantIdFlag
 	global *internal.GlobalCommandOptions
 }
 
 func (f *envSetFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	f.envFlag.Bind(local, global)
+	f.tenantIdFlag.Bind(local, global)
 	f.global = global
 }
 
@@ -139,6 +143,23 @@ func (e *envSetAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	}
 
 	return nil, nil
+}
+
+type envSelectFlags struct {
+	envFlag
+	tenantIdFlag
+}
+
+func (f *envSelectFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
+	f.envFlag.Bind(local, global)
+	f.tenantIdFlag.Bind(local, global)
+}
+
+func newEnvSelectFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *envSelectFlags {
+	flags := &envSelectFlags{}
+	flags.Bind(cmd.Flags(), global)
+
+	return flags
 }
 
 func newEnvSelectCmd() *cobra.Command {
@@ -180,6 +201,23 @@ func (e *envSelectAction) Run(ctx context.Context) (*actions.ActionResult, error
 	}
 
 	return nil, nil
+}
+
+type envListFlags struct {
+	envFlag
+	tenantIdFlag
+}
+
+func (f *envListFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
+	f.envFlag.Bind(local, global)
+	f.tenantIdFlag.Bind(local, global)
+}
+
+func newEnvListFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *envListFlags {
+	flags := &envListFlags{}
+	flags.Bind(cmd.Flags(), global)
+
+	return flags
 }
 
 func newEnvListCmd() *cobra.Command {
@@ -255,6 +293,8 @@ type envNewFlags struct {
 	subscription string
 	location     string
 	global       *internal.GlobalCommandOptions
+	envFlag
+	tenantIdFlag
 }
 
 func (f *envNewFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
@@ -265,6 +305,9 @@ func (f *envNewFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandO
 		"Name or ID of an Azure subscription to use for the new environment",
 	)
 	local.StringVarP(&f.location, "location", "l", "", "Azure location for the new environment")
+
+	f.envFlag.Bind(local, global)
+	f.tenantIdFlag.Bind(local, global)
 
 	f.global = global
 }
@@ -338,12 +381,14 @@ type envRefreshFlags struct {
 	hint   string
 	global *internal.GlobalCommandOptions
 	envFlag
+	tenantIdFlag
 }
 
 func (er *envRefreshFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	local.StringVarP(&er.hint, "hint", "", "", "Hint to help identify the environment to refresh")
 
 	er.envFlag.Bind(local, global)
+	er.tenantIdFlag.Bind(local, global)
 	er.global = global
 }
 
@@ -519,11 +564,13 @@ func newEnvGetValuesCmd() *cobra.Command {
 
 type envGetValuesFlags struct {
 	envFlag
+	tenantIdFlag
 	global *internal.GlobalCommandOptions
 }
 
 func (eg *envGetValuesFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	eg.envFlag.Bind(local, global)
+	eg.tenantIdFlag.Bind(local, global)
 	eg.global = global
 }
 

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -146,12 +146,10 @@ func (e *envSetAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 }
 
 type envSelectFlags struct {
-	envFlag
 	tenantIdFlag
 }
 
 func (f *envSelectFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
-	f.envFlag.Bind(local, global)
 	f.tenantIdFlag.Bind(local, global)
 }
 
@@ -204,12 +202,10 @@ func (e *envSelectAction) Run(ctx context.Context) (*actions.ActionResult, error
 }
 
 type envListFlags struct {
-	envFlag
 	tenantIdFlag
 }
 
 func (f *envListFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
-	f.envFlag.Bind(local, global)
 	f.tenantIdFlag.Bind(local, global)
 }
 

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -30,6 +30,7 @@ type CmdAnnotations map[string]string
 type Asker func(p survey.Prompt, response interface{}) error
 
 const environmentNameFlag string = "environment"
+const tenantIdFlagName string = "tenant-id"
 
 type envFlag struct {
 	environmentName string
@@ -43,6 +44,14 @@ func (e *envFlag) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptio
 		// Set the default value to AZURE_ENV_NAME value if available
 		os.Getenv(environment.EnvNameEnvVarName),
 		"The name of the environment to use.")
+}
+
+type tenantIdFlag struct {
+	tenantID string
+}
+
+func (e *tenantIdFlag) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
+	local.StringVar(&e.tenantID, tenantIdFlagName, "", "Optional Tenant ID for the remote storage of the new environment")
 }
 
 func getResourceGroupFollowUp(

--- a/cli/azd/pkg/environment/manager.go
+++ b/cli/azd/pkg/environment/manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"


### PR DESCRIPTION
Background: I'm setting up a build/deploy workflow for a client, using their Azure subscription where my Entra account is a guest in their tenant.

I've been trying to figure out why I can't seem to make remote environments work. I tried setting `AZURE_TENANT_ID` in the environment, using `azd auth login --tenant-id` and various other tricks using Azure CLI to log in. I kept getting this error:

```
ERROR: initializing provisioning manager: saving remote environment, uploading config: failed getting next page of containers: GET https://<redacted>.blob.core.windows.net
--------------------------------------------------------------------------------
RESPONSE 401: 401 Server failed to authenticate the request. Please refer to the information in the www-authenticate header.
ERROR CODE: InvalidAuthenticationInfo
--------------------------------------------------------------------------------
﻿<?xml version="1.0" encoding="utf-8"?><Error><Code>InvalidAuthenticationInfo</Code><Message>Server failed to authenticate the request. Please refer to the information in the www-authenticate header.
RequestId:1c8750f0-401e-0048-4a29-338001000000
Time:2023-12-20T09:47:46.7572768Z</Message><AuthenticationErrorDetail>Issuer validation failed. Issuer did not match.</AuthenticationErrorDetail></Error>
--------------------------------------------------------------------------------

TraceID: <redacted>
```

Using Fiddler to trace the outgoing requests, I was able to confirm that the CLI is getting a token for my home tenant instead of the tenant connected to the subscription where the storage account is located. After getting frustrated enough, I cloned the repo and debugged for a bit, and it seems to me like the AZURE_TENANT_ID environment variable was being ignored.

I figured this would be the easiest way to get pass the correct tenant ID to the token credential provider, but I'll note that these are the first lines of golang I've ever written and I have no idea what is considered best practice. However, with this change, `azd env` commands now work for me.