### PR TITLE
association for .bicept as go-template and extension for syntax

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,8 @@
                 "golang.go",
                 "ms-azuretools.vscode-bicep",
                 "eamodio.gitlens",
-                "hashicorp.terraform"
+                "hashicorp.terraform",
+                "jinliming2.vscode-go-template"
             ]
         }
     }

--- a/cli/azd/.vscode/extensions.json
+++ b/cli/azd/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "recommendations": [
         "golang.go",
         "streetsidesoftware.code-spell-checker",
-        "redhat.vscode-yaml"
+        "redhat.vscode-yaml",
+        "jinliming2.vscode-go-template"
     ]
 }

--- a/cli/azd/.vscode/settings.json
+++ b/cli/azd/.vscode/settings.json
@@ -7,5 +7,8 @@
     "go.lintFlags": ["--fast"],
     "go.lintOnSave": "package",
     "go.lintTool": "golangci-lint",
-    "go.testTimeout": "10m"
+    "go.testTimeout": "10m",
+    "files.associations": {
+        "*.bicept": "go-template"
+      }
 }


### PR DESCRIPTION
A little syntax highlighting for go-templates is better than nothing:

![image](https://github.com/Azure/azure-dev/assets/24213737/8a2efdb8-3d40-4985-9c93-3b88b6f7aad8)

This PR:
- Adds the vscode extension as part of devcontainer
- Adds the vscode extension as part of project config
- Creates file association for go-template to `.bicept`
