### PR TITLE
net aspire support cosmos

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,8 @@
                 "golang.go",
                 "ms-azuretools.vscode-bicep",
                 "eamodio.gitlens",
-                "hashicorp.terraform"
+                "hashicorp.terraform",
+                "jinliming2.vscode-go-template"
             ]
         }
     }

--- a/cli/azd/.vscode/extensions.json
+++ b/cli/azd/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "recommendations": [
         "golang.go",
         "streetsidesoftware.code-spell-checker",
-        "redhat.vscode-yaml"
+        "redhat.vscode-yaml",
+        "jinliming2.vscode-go-template"
     ]
 }

--- a/cli/azd/.vscode/settings.json
+++ b/cli/azd/.vscode/settings.json
@@ -7,5 +7,8 @@
     "go.lintFlags": ["--fast"],
     "go.lintOnSave": "package",
     "go.lintTool": "golangci-lint",
-    "go.testTimeout": "10m"
+    "go.testTimeout": "10m",
+    "files.associations": {
+        "*.bicept": "go-template"
+      }
 }

--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -257,6 +257,7 @@ func newInfraGenerator() *infraGenerator {
 			KeyVaults:                       make(map[string]genKeyVault),
 			ContainerApps:                   make(map[string]genContainerApp),
 			DaprComponents:                  make(map[string]genDaprComponent),
+			CosmosDbAccounts:                make(map[string]genCosmosAccount),
 		},
 		containers:                   make(map[string]genContainer),
 		dapr:                         make(map[string]genDapr),
@@ -335,6 +336,8 @@ func (b *infraGenerator) LoadManifest(m *Manifest) error {
 			b.addStorageQueue(*comp.Parent, name)
 		case "azure.storage.table.v0":
 			b.addStorageTable(*comp.Parent, name)
+		case "azure.cosmosdb.account.v0":
+			b.addCosmosDbAccount(name)
 		case "postgres.server.v0":
 			// We currently use a ACA Postgres Service per database. Because of this, we don't need to retain any
 			// information from the server resource.
@@ -405,6 +408,10 @@ func (b *infraGenerator) addServiceBus(name string, queues, topics *[]string) {
 func (b *infraGenerator) addAppInsights(name string) {
 	b.requireLogAnalyticsWorkspace()
 	b.bicepContext.AppInsights[name] = genAppInsight{}
+}
+
+func (b *infraGenerator) addCosmosDbAccount(name string) {
+	b.bicepContext.CosmosDbAccounts[name] = genCosmosAccount{}
 }
 
 func (b *infraGenerator) addProject(
@@ -895,7 +902,8 @@ func (b infraGenerator) evalBindingRef(v string, emitType inputEmitType) (string
 	case targetType == "azure.keyvault.v0" ||
 		targetType == "azure.storage.blob.v0" ||
 		targetType == "azure.storage.queue.v0" ||
-		targetType == "azure.storage.table.v0":
+		targetType == "azure.storage.table.v0" ||
+		targetType == "azure.cosmosdb.account.v0":
 		switch prop {
 		case "connectionString":
 			return fmt.Sprintf("{{ .Env.SERVICE_BINDING_%s_ENDPOINT }}", scaffold.AlphaSnakeUpper(resource)), nil

--- a/cli/azd/pkg/apphost/generate_types.go
+++ b/cli/azd/pkg/apphost/generate_types.go
@@ -8,6 +8,9 @@ type genStorageAccount struct {
 	Queues []string
 }
 
+type genCosmosAccount struct {
+}
+
 type genServiceBus struct {
 	Queues []string
 	Topics []string
@@ -96,6 +99,7 @@ type genBicepTemplateContext struct {
 	ContainerAppEnvironmentServices map[string]genContainerAppEnvironmentServices
 	ContainerApps                   map[string]genContainerApp
 	DaprComponents                  map[string]genDaprComponent
+	CosmosDbAccounts                map[string]genCosmosAccount
 }
 
 type genContainerAppManifestTemplateContext struct {

--- a/cli/azd/resources/apphost/templates/main.bicept
+++ b/cli/azd/resources/apphost/templates/main.bicept
@@ -61,6 +61,9 @@ output SERVICE_BINDING_{{alphaSnakeUpper $cname}}_ENDPOINT string = resources.ou
 {{end -}}
 {{end -}}
 {{range $name, $value := .KeyVaults -}}
-output SERVICE_BINDING_{{alphaSnakeUpper $name}}_ENDPOINT string =resources.outputs.SERVICE_BINDING_{{alphaSnakeUpper $name}}_ENDPOINT
+output SERVICE_BINDING_{{alphaSnakeUpper $name}}_ENDPOINT string = resources.outputs.SERVICE_BINDING_{{alphaSnakeUpper $name}}_ENDPOINT
+{{end -}}
+{{range $name, $value := .CosmosDbAccounts -}}
+output SERVICE_BINDING_{{alphaSnakeUpper $name}}_ENDPOINT string = resources.outputs.SERVICE_BINDING_{{alphaSnakeUpper $name}}_ENDPOINT
 {{end -}}
 {{ end}}

--- a/cli/azd/resources/apphost/templates/resources.bicept
+++ b/cli/azd/resources/apphost/templates/resources.bicept
@@ -346,7 +346,6 @@ resource {{bicepName $name}}OperatorRoleAssignment 'Microsoft.Authorization/role
   }
 }
 {{- end}}
-
 output MANAGED_IDENTITY_CLIENT_ID string = managedIdentity.properties.clientId
 {{if .HasContainerRegistry -}}
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.properties.loginServer

--- a/cli/azd/resources/apphost/templates/resources.bicept
+++ b/cli/azd/resources/apphost/templates/resources.bicept
@@ -309,6 +309,43 @@ resource {{bicepName $name}}RoleAssignment 'Microsoft.Authorization/roleAssignme
   }
 }
 {{- end}}
+{{range $name, $value := .CosmosDbAccounts}}
+resource {{bicepName $name}} 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' = {
+  name: replace('{{$name}}-${resourceToken}', '-', '')
+  location: location
+  tags: union(tags, {'aspire-resource-name': '{{$name}}'})
+  properties: {
+    consistencyPolicy: { defaultConsistencyLevel: 'Session' }
+    locations: [
+      {
+        locationName: location
+        failoverPriority: 0
+      }
+    ]
+    databaseAccountOfferType: 'Standard'
+  }
+}
+// Cosmos DB Account Reader Role
+resource {{bicepName $name}}ReaderRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid({{bicepName $name}}.id, managedIdentity.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'fbdf93bf-df7d-467e-a4d2-9458aa1360c8'))
+  scope: {{bicepName $name}}
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId:  subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'fbdf93bf-df7d-467e-a4d2-9458aa1360c8')
+  }
+}
+// Cosmos DB Operator
+resource {{bicepName $name}}OperatorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid({{bicepName $name}}.id, managedIdentity.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '230815da-be43-4aae-9cb4-875f7bd000aa'))
+  scope: {{bicepName $name}}
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId:  subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '230815da-be43-4aae-9cb4-875f7bd000aa')
+  }
+}
+{{- end}}
 
 output MANAGED_IDENTITY_CLIENT_ID string = managedIdentity.properties.clientId
 {{if .HasContainerRegistry -}}
@@ -338,5 +375,8 @@ output SERVICE_BINDING_{{alphaSnakeUpper $cname}}_ENDPOINT string = {{bicepName 
 {{end -}}
 {{range $name, $value := .KeyVaults -}}
 output SERVICE_BINDING_{{alphaSnakeUpper $name}}_ENDPOINT string = {{bicepName $name}}.properties.vaultUri
+{{end -}}
+{{range $name, $value := .CosmosDbAccounts -}}
+output SERVICE_BINDING_{{alphaSnakeUpper $name}}_ENDPOINT string = {{bicepName $name}}.properties.documentEndpoint
 {{end -}}
 {{ end}}


### PR DESCRIPTION
- association for .bicept as go-template and extension for syntax (https://github.com/Azure/azure-dev/pull/3163)
- net aspire - support cosmos db
fix: https://github.com/Azure/azure-dev/issues/3066

Strategy:
- Assigning `Cosmos DB Account Reader Role` and `Cosmos DB Operator` for the Cosmos DB Account. 
- Setting Documents Endpoint to the ENV for application to connect using managed identity (similar to Storage account)
