### PR TITLE
Allow services to free from package cache

### DIFF
--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -40,6 +40,10 @@ type ServiceConfig struct {
 	*ext.EventDispatcher[ServiceLifecycleEventArgs] `yaml:"-"`
 
 	initialized bool
+
+	// When true, azd will not cache the package result in memory. It allows re-packaging option for static web apps
+	// and any other service which depends on provision for deploying.
+	NoMemoryCache bool `yaml:"noCache,omitempty"`
 }
 
 type DotNetContainerAppOptions struct {

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -614,6 +614,10 @@ func (sm *serviceManager) setOperationResult(
 	operationName string,
 	result any,
 ) {
+	if serviceConfig.NoMemoryCache {
+		log.Println("skipping caching of operation result as per service configuration.")
+		return
+	}
 	key := fmt.Sprintf("%s:%s", serviceConfig.Name, operationName)
 	sm.operationCache[key] = result
 }


### PR DESCRIPTION
This change allows folks to define a service on azure.yaml and ask azd to avoid holding the result of `packaging` for deployment  during `azd up`.

By allowing this, azd would re-package the service during `azd up` , before deploy, automatically.

This strategy will enable front-end applications to use the outputs from `provision` during deploy.

**schema-updates to be done apart...