### PR TITLE
Enable admin user for registry in ACA sample

### DIFF
--- a/templates/common/infra/bicep/core/host/container-apps.bicep
+++ b/templates/common/infra/bicep/core/host/container-apps.bicep
@@ -6,6 +6,7 @@ param tags object = {}
 param containerAppsEnvironmentName string
 param containerRegistryName string
 param containerRegistryResourceGroupName string = ''
+param containerRegistryAdminUserEnabled bool = false
 param logAnalyticsWorkspaceName string
 param applicationInsightsName string = ''
 
@@ -26,6 +27,7 @@ module containerRegistry 'container-registry.bicep' = {
   params: {
     name: containerRegistryName
     location: location
+    adminUserEnabled: containerRegistryAdminUserEnabled
     tags: tags
   }
 }

--- a/templates/todo/projects/java-mongo-aca/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/java-mongo-aca/.repo/bicep/infra/main.bicep
@@ -60,6 +60,13 @@ module containerApps '../../../../../../common/infra/bicep/core/host/container-a
     tags: tags
     containerAppsEnvironmentName: !empty(containerAppsEnvironmentName) ? containerAppsEnvironmentName : '${abbrs.appManagedEnvironments}${resourceToken}'
     containerRegistryName: !empty(containerRegistryName) ? containerRegistryName : '${abbrs.containerRegistryRegistries}${resourceToken}'
+    // Work around Azure/azure-dev#3157 (the root cause of which is Azure/acr#723) by explicitly enabling the admin user to allow users which
+    // don't have the `Owner` role granted (and instead are classic administrators) to access the registry to push even if AAD authentication fails.
+    //
+    // This addresses the following error during deploy:
+    //
+    // failed getting ACR token: POST https://<some-random-name>.azurecr.io/oauth2/exchange 401 Unauthorized
+    containerRegistryAdminUserEnabled: true
     logAnalyticsWorkspaceName: monitoring.outputs.logAnalyticsWorkspaceName
     applicationInsightsName: monitoring.outputs.applicationInsightsName
   }

--- a/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/infra/main.bicep
@@ -60,6 +60,13 @@ module containerApps '../../../../../../common/infra/bicep/core/host/container-a
     tags: tags
     containerAppsEnvironmentName: !empty(containerAppsEnvironmentName) ? containerAppsEnvironmentName : '${abbrs.appManagedEnvironments}${resourceToken}'
     containerRegistryName: !empty(containerRegistryName) ? containerRegistryName : '${abbrs.containerRegistryRegistries}${resourceToken}'
+    // Work around Azure/azure-dev#3157 (the root cause of which is Azure/acr#723) by explicitly enabling the admin user to allow users which 
+    // don't have the `Owner` role granted (and instead are classic administrators) to access the registry to push even if AAD authentication fails.
+    //
+    // This addresses the following error during deploy:
+    //
+    // failed getting ACR token: POST https://<some-random-name>.azurecr.io/oauth2/exchange 401 Unauthorized
+    containerRegistryAdminUserEnabled: true
     logAnalyticsWorkspaceName: monitoring.outputs.logAnalyticsWorkspaceName
     applicationInsightsName: monitoring.outputs.applicationInsightsName
   }

--- a/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/infra/main.bicep
@@ -60,7 +60,7 @@ module containerApps '../../../../../../common/infra/bicep/core/host/container-a
     tags: tags
     containerAppsEnvironmentName: !empty(containerAppsEnvironmentName) ? containerAppsEnvironmentName : '${abbrs.appManagedEnvironments}${resourceToken}'
     containerRegistryName: !empty(containerRegistryName) ? containerRegistryName : '${abbrs.containerRegistryRegistries}${resourceToken}'
-    // Work around Azure/azure-dev#3157 (the root cause of which is Azure/acr#723) by explicitly enabling the admin user to allow users which 
+    // Work around Azure/azure-dev#3157 (the root cause of which is Azure/acr#723) by explicitly enabling the admin user to allow users which
     // don't have the `Owner` role granted (and instead are classic administrators) to access the registry to push even if AAD authentication fails.
     //
     // This addresses the following error during deploy:

--- a/templates/todo/projects/python-mongo-aca/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/python-mongo-aca/.repo/bicep/infra/main.bicep
@@ -60,6 +60,13 @@ module containerApps '../../../../../../common/infra/bicep/core/host/container-a
     tags: tags
     containerAppsEnvironmentName: !empty(containerAppsEnvironmentName) ? containerAppsEnvironmentName : '${abbrs.appManagedEnvironments}${resourceToken}'
     containerRegistryName: !empty(containerRegistryName) ? containerRegistryName : '${abbrs.containerRegistryRegistries}${resourceToken}'
+    // Work around Azure/azure-dev#3157 (the root cause of which is Azure/acr#723) by explicitly enabling the admin user to allow users which
+    // don't have the `Owner` role granted (and instead are classic administrators) to access the registry to push even if AAD authentication fails.
+    //
+    // This addresses the following error during deploy:
+    //
+    // failed getting ACR token: POST https://<some-random-name>.azurecr.io/oauth2/exchange 401 Unauthorized
+    containerRegistryAdminUserEnabled: true
     logAnalyticsWorkspaceName: monitoring.outputs.logAnalyticsWorkspaceName
     applicationInsightsName: monitoring.outputs.applicationInsightsName
   }


### PR DESCRIPTION
This enables the admin user on the provisioned container registry so that `azd` can connect to it to push even if RBAC is not working because the user is not anowner of the resource.  We've seen cases where users who's accounts where created a long while back are set as [classic adminisrators](https://learn.microsoft.com/en-us/azure/role-based-access-control/classic-administrators) and not Owners on their accounts and ther is presently a service issue that prevents these users from exchanging their AAD creds for an access token.

Fixes #3157