### PR TITLE
Add RPC Server for VS Aspire Deploy

### DIFF
--- a/cli/azd/.gitignore
+++ b/cli/azd/.gitignore
@@ -5,3 +5,5 @@ azd-record.exe
 build
 resource.syso
 versioninfo.json
+azd.sln
+

--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -5,6 +5,7 @@ aiopg
 alphafeatures
 apimanagement
 apims
+apiservice
 appconfiguration
 appdetect
 apphost
@@ -183,11 +184,14 @@ Truef
 typeflag
 unhide
 unmarshaled
+upgrader
 unmarshalling
 unsetenvs
 unsets
 utsname
+vsrpc
 vuejs
+webfrontend
 westus2
 wireinject
 yacspin

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -341,7 +341,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	)
 
 	// Project Config
-	container.MustRegisterSingleton(
+	container.MustRegisterTransient(
 		func(ctx context.Context, azdContext *azdcontext.AzdContext) (*project.ProjectConfig, error) {
 			if azdContext == nil {
 				return nil, azdcontext.ErrNoProject

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -140,6 +140,14 @@ func NewRootCmd(
 		},
 	})
 
+	root.Add("vs-server", &actions.ActionDescriptorOptions{
+		Command:        newVsServerCmd(),
+		FlagsResolver:  newVsServerFlags,
+		ActionResolver: newVsServerAction,
+		OutputFormats:  []output.Format{output.NoneFormat},
+		DefaultFormat:  output.NoneFormat,
+	})
+
 	root.Add("show", &actions.ActionDescriptorOptions{
 		Command:        newShowCmd(),
 		FlagsResolver:  newShowFlags,

--- a/cli/azd/cmd/vs_server.go
+++ b/cli/azd/cmd/vs_server.go
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/azure/azure-dev/cli/azd/cmd/actions"
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/internal/vsrpc"
+	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type vsServerFlags struct {
+	global *internal.GlobalCommandOptions
+	port   int
+}
+
+func (s *vsServerFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
+	s.global = global
+	local.IntVar(&s.port, "port", 0, "Port to listen on (0 for random port)")
+}
+
+func newVsServerFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *vsServerFlags {
+	flags := &vsServerFlags{}
+	flags.Bind(cmd.Flags(), global)
+
+	return flags
+}
+
+func newVsServerCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "vs-server",
+		Short:  "Run Server",
+	}
+
+	return cmd
+}
+
+type vsServerAction struct {
+	rootContainer *ioc.NestedContainer
+	flags         *vsServerFlags
+}
+
+func newVsServerAction(rootContainer *ioc.NestedContainer, flags *vsServerFlags) actions.Action {
+	return &vsServerAction{
+		rootContainer: rootContainer,
+		flags:         flags,
+	}
+}
+
+func (s *vsServerAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", s.flags.port))
+	if err != nil {
+		panic(err)
+	}
+
+	res, err := json.Marshal(struct {
+		Port int `json:"port"`
+		Pid  int `json:"pid"`
+	}{
+		Port: listener.Addr().(*net.TCPAddr).Port,
+		Pid:  os.Getpid(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("%s\n", string(res))
+
+	return nil, vsrpc.NewServer(s.rootContainer).Serve(listener)
+}

--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -199,6 +199,17 @@ func DetectDirectory(ctx context.Context, directory string, options ...DetectDir
 	return detectAny(ctx, config.detectors, directory, entries)
 }
 
+func DetectAspireHosts(ctx context.Context, root string, dotnetCli dotnet.DotNetCli) ([]Project, error) {
+	config := newConfig()
+	config.detectors = []projectDetector{
+		&dotNetAppHostDetector{
+			dotnetCli: dotnetCli,
+		},
+	}
+
+	return detectUnder(ctx, root, config)
+}
+
 func detectUnder(ctx context.Context, root string, config detectConfig) ([]Project, error) {
 	projects := []Project{}
 

--- a/cli/azd/internal/cmd/deploy.go
+++ b/cli/azd/internal/cmd/deploy.go
@@ -83,6 +83,13 @@ func NewDeployFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *
 	return flags
 }
 
+func NewDeployFlagsFromEnvAndOptions(envFlag *internal.EnvFlag, global *internal.GlobalCommandOptions) *DeployFlags {
+	return &DeployFlags{
+		EnvFlag: envFlag,
+		global:  global,
+	}
+}
+
 func NewDeployCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy <service>",

--- a/cli/azd/internal/cmd/provision.go
+++ b/cli/azd/internal/cmd/provision.go
@@ -74,6 +74,15 @@ func NewProvisionFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions
 	return flags
 }
 
+func NewProvisionFlagsFromEnvAndOptions(envFlag *internal.EnvFlag, global *internal.GlobalCommandOptions) *ProvisionFlags {
+	flags := &ProvisionFlags{
+		EnvFlag: envFlag,
+		global:  global,
+	}
+
+	return flags
+}
+
 func NewProvisionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "provision",

--- a/cli/azd/internal/vsrpc/aspire_service.go
+++ b/cli/azd/internal/vsrpc/aspire_service.go
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package vsrpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/azure/azure-dev/cli/azd/internal/appdetect"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
+)
+
+// aspireService is the RPC server for the '/AspireService/v1.0' endpoint.
+type aspireService struct {
+	server *Server
+}
+
+func newAspireService(server *Server) *aspireService {
+	return &aspireService{
+		server: server,
+	}
+}
+
+// GetAspireHostAsync is the server implementation of:
+// ValueTask<AspireHost> GetAspireHostAsync(Session session, string aspireEnv, CancellationToken cancellationToken).
+func (s *aspireService) GetAspireHostAsync(
+	ctx context.Context, sessionId Session, aspireEnv string, observer IObserver[ProgressMessage],
+) (*AspireHost, error) {
+	session, err := s.server.validateSession(ctx, sessionId)
+	if err != nil {
+		return nil, err
+	}
+
+	session.sessionMu.Lock()
+	defer session.sessionMu.Unlock()
+
+	var c struct {
+		azdContext *azdcontext.AzdContext `container:"type"`
+		dotnetCli  dotnet.DotNetCli       `container:"type"`
+	}
+
+	if err := session.container.Fill(&c); err != nil {
+		return nil, err
+	}
+
+	// If there is an azure.yaml, load it and return the services.
+	if _, err := os.Stat(c.azdContext.ProjectPath()); err == nil {
+		var cc struct {
+			projectConfig *project.ProjectConfig `container:"type"`
+		}
+
+		if err := session.container.Fill(&cc); err != nil {
+			return nil, err
+		}
+
+		if session.appHostPath == "" {
+			appHost, err := appHostForProject(ctx, cc.projectConfig, c.dotnetCli)
+			if err != nil {
+				return nil, err
+			}
+
+			session.appHostPath = appHost.Path()
+		}
+
+		hostInfo := &AspireHost{
+			Name: filepath.Base(filepath.Dir(session.appHostPath)),
+			Path: session.appHostPath,
+		}
+
+		manifest, err := session.readManifest(ctx, session.appHostPath, c.dotnetCli)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load app host manifest: %w", err)
+		}
+
+		hostInfo.Services = servicesFromManifest(manifest)
+
+		return hostInfo, nil
+
+	} else if errors.Is(err, os.ErrNotExist) {
+		hosts, err := appdetect.DetectAspireHosts(ctx, c.azdContext.ProjectDirectory(), c.dotnetCli)
+		if err != nil {
+			return nil, fmt.Errorf("failed to discover app host project under %s: %w", c.azdContext.ProjectPath(), err)
+		}
+
+		if len(hosts) == 0 {
+			return nil, fmt.Errorf("no app host projects found under %s", c.azdContext.ProjectPath())
+		}
+
+		if len(hosts) > 1 {
+			return nil, fmt.Errorf("multiple app host projects found under %s", c.azdContext.ProjectPath())
+		}
+
+		hostInfo := &AspireHost{
+			Name: filepath.Base(filepath.Dir(session.appHostPath)),
+			Path: hosts[0].Path,
+		}
+
+		session.appHostPath = hostInfo.Path
+
+		manifest, err := session.readManifest(ctx, session.appHostPath, c.dotnetCli)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load app host manifest: %w", err)
+		}
+
+		hostInfo.Services = servicesFromManifest(manifest)
+
+		return hostInfo, nil
+
+	} else {
+		return nil, fmt.Errorf("failed to stat project path: %w", err)
+	}
+
+}
+
+// RenameAspireHostAsync is the server implementation of:
+// ValueTask RenameAspireHostAsync(Session session, string newPath, CancellationToken cancellationToken).
+func (s *aspireService) RenameAspireHostAsync(
+	ctx context.Context, sessionId Session, newPath string, observer IObserver[ProgressMessage],
+) error {
+	session, err := s.server.validateSession(ctx, sessionId)
+	if err != nil {
+		return err
+	}
+
+	session.sessionMu.Lock()
+	defer session.sessionMu.Unlock()
+
+	// TODO(azure/azure-dev#3283): What should this do?  Rewrite azure.yaml?  We'll end up losing comments...
+	return errors.New("not implemented")
+}
+
+// ServeHTTP implements http.Handler.
+func (s *aspireService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	serveRpc(w, r, map[string]Handler{
+		"GetAspireHostAsync":    HandlerFunc3(s.GetAspireHostAsync),
+		"RenameAspireHostAsync": HandlerAction3(s.RenameAspireHostAsync),
+	})
+}

--- a/cli/azd/internal/vsrpc/debug_service.go
+++ b/cli/azd/internal/vsrpc/debug_service.go
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package vsrpc
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// debugService is the RPC server for the '/TestDebugService/v1.0' endpoint. It is only exposed when
+// AZD_DEBUG_SERVER_DEBUG_ENDPOINTS is set to true as per [strconv.ParseBool].
+type debugService struct {
+	server *Server
+}
+
+func newDebugService(server *Server) *debugService {
+	return &debugService{
+		server: server,
+	}
+}
+
+// TestCancelAsync is the server implementation of:
+// ValueTask<bool> InitializeAsync(int, CancellationToken);
+//
+// It waits for the given timeoutMs, and then returns true. However, if the context is cancelled before the timeout,
+// it returns false and ctx.Err() which should cause the client to throw a TaskCanceledException.
+func (s *debugService) TestCancelAsync(ctx context.Context, timeoutMs int) (bool, error) {
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	case <-time.After(time.Duration(timeoutMs) * time.Millisecond):
+		return true, nil
+	}
+}
+
+// TestCancelAsync is the server implementation of:
+// ValueTask<bool> TestIObserver(int, CancellationToken);
+//
+// It emits a sequence of integers to the observer, from 0 to max, and then completes the observer, before returning.
+func (s *debugService) TestIObserverAsync(ctx context.Context, max int, observer IObserver[int]) error {
+	for i := 0; i < max; i++ {
+		_ = observer.OnNext(ctx, i)
+	}
+	_ = observer.OnCompleted(ctx)
+	return nil
+}
+
+// ServeHTTP implements http.Handler.
+func (s *debugService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	serveRpc(w, r, map[string]Handler{
+		"TestCancelAsync":    HandlerFunc1(s.TestCancelAsync),
+		"TestIObserverAsync": HandlerAction2(s.TestIObserverAsync),
+	})
+}

--- a/cli/azd/internal/vsrpc/doc.go
+++ b/cli/azd/internal/vsrpc/doc.go
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Package vsrpc provides the RPC server that Visual Studio uses to interact with azd programmatically.
+//
+// The RPC server is implemented using JSON-RPC 2.0 over WebSockets.
+package vsrpc

--- a/cli/azd/internal/vsrpc/environment_service.go
+++ b/cli/azd/internal/vsrpc/environment_service.go
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package vsrpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+)
+
+// environmentService is the RPC server for the '/EnvironmentService/v1.0' endpoint.
+type environmentService struct {
+	server *Server
+}
+
+func newEnvironmentService(server *Server) *environmentService {
+	return &environmentService{
+		server: server,
+	}
+}
+
+// GetEnvironmentsAsync is the server implementation of:
+// ValueTask<IEnumerable<EnvironmentInfo>> GetEnvironmentsAsync(Session, IObserver<ProgressMessage>, CancellationToken);
+func (s *environmentService) GetEnvironmentsAsync(
+	ctx context.Context, sessionId Session, observer IObserver[ProgressMessage],
+) ([]*EnvironmentInfo, error) {
+	session, err := s.server.validateSession(ctx, sessionId)
+	if err != nil {
+		return nil, err
+	}
+
+	session.sessionMu.Lock()
+	defer session.sessionMu.Unlock()
+
+	var c struct {
+		envManager environment.Manager `container:"type"`
+	}
+
+	if err := session.container.Fill(&c); err != nil {
+		return nil, err
+	}
+
+	envs, err := c.envManager.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing environments: %w", err)
+	}
+
+	infos := make([]*EnvironmentInfo, len(envs))
+	for i, env := range envs {
+		infos[i] = &EnvironmentInfo{
+			Name:      env.Name,
+			IsCurrent: env.IsDefault,
+		}
+	}
+
+	return infos, nil
+}
+
+// SetCurrentEnvironmentAsync is the server implementation of:
+// ValueTask<bool> SetCurrentEnvironmentAsync(Session, string, IObserver<ProgressMessage>, CancellationToken);
+func (s *environmentService) SetCurrentEnvironmentAsync(
+	ctx context.Context, sessionId Session, name string, observer IObserver[ProgressMessage],
+) (bool, error) {
+	session, err := s.server.validateSession(ctx, sessionId)
+	if err != nil {
+		return false, err
+	}
+
+	session.sessionMu.Lock()
+	defer session.sessionMu.Unlock()
+
+	var c struct {
+		azdCtx *azdcontext.AzdContext `container:"type"`
+	}
+
+	if err := session.container.Fill(&c); err != nil {
+		return false, err
+	}
+
+	if err := c.azdCtx.SetDefaultEnvironmentName(name); err != nil {
+		return false, fmt.Errorf("saving default environment: %w", err)
+	}
+
+	return true, nil
+}
+
+// DeleteEnvironmentAsync is the server implementation of:
+// ValueTask<bool> DeleteEnvironmentAsync(Session, string, IObserver<ProgressMessage>, CancellationToken);
+func (s *environmentService) DeleteEnvironmentAsync(
+	ctx context.Context, sessionId Session, name string, observer IObserver[ProgressMessage],
+) (bool, error) {
+	session, err := s.server.validateSession(ctx, sessionId)
+	if err != nil {
+		return false, err
+	}
+
+	session.sessionMu.Lock()
+	defer session.sessionMu.Unlock()
+
+	// TODO(azure/azure-dev#3285): Implement this.
+	return false, errors.New("not implemented")
+}
+
+// ServeHTTP implements http.Handler.
+func (s *environmentService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	serveRpc(w, r, map[string]Handler{
+		"CreateEnvironmentAsync":     HandlerFunc3(s.CreateEnvironmentAsync),
+		"GetEnvironmentsAsync":       HandlerFunc2(s.GetEnvironmentsAsync),
+		"LoadEnvironmentAsync":       HandlerFunc3(s.LoadEnvironmentAsync),
+		"OpenEnvironmentAsync":       HandlerFunc3(s.OpenEnvironmentAsync),
+		"SetCurrentEnvironmentAsync": HandlerFunc3(s.SetCurrentEnvironmentAsync),
+		"DeleteEnvironmentAsync":     HandlerFunc3(s.DeleteEnvironmentAsync),
+		"RefreshEnvironmentAsync":    HandlerFunc3(s.RefreshEnvironmentAsync),
+		"DeployAsync":                HandlerFunc3(s.DeployAsync),
+	})
+}

--- a/cli/azd/internal/vsrpc/environment_service_create.go
+++ b/cli/azd/internal/vsrpc/environment_service_create.go
@@ -1,0 +1,121 @@
+package vsrpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/azure/azure-dev/cli/azd/internal/appdetect"
+	"github.com/azure/azure-dev/cli/azd/pkg/apphost"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
+)
+
+// CreateEnvironmentAsync is the server implementation of:
+// ValueTask<bool> CreateEnvironmentAsync(Session, Environment, IObserver<ProgressMessage>, CancellationToken);
+func (s *environmentService) CreateEnvironmentAsync(
+	ctx context.Context, sessionId Session, newEnv Environment, observer IObserver[ProgressMessage],
+) (bool, error) {
+	session, err := s.server.validateSession(ctx, sessionId)
+	if err != nil {
+		return false, err
+	}
+
+	session.sessionMu.Lock()
+	defer session.sessionMu.Unlock()
+
+	envSpec := environment.Spec{
+		Name:         newEnv.Name,
+		Subscription: newEnv.Properties["Subscription"],
+		Location:     newEnv.Properties["Location"],
+	}
+
+	var c struct {
+		azdContext *azdcontext.AzdContext `container:"type"`
+		dotnetCli  dotnet.DotNetCli       `container:"type"`
+		envManager environment.Manager    `container:"type"`
+	}
+
+	if err := session.container.Fill(&c); err != nil {
+		return false, err
+	}
+
+	// If an azure.yaml doesn't already exist, we need to create one. Creating an environment implies initializing the
+	// azd project if it does not already exist.
+	if _, err := os.Stat(c.azdContext.ProjectPath()); errors.Is(err, fs.ErrNotExist) {
+		// Write an azure.yaml file to the project.
+		if session.appHostPath == "" {
+			hosts, err := appdetect.DetectAspireHosts(ctx, c.azdContext.ProjectDirectory(), c.dotnetCli)
+			if err != nil {
+				return false, fmt.Errorf("failed to discover app host project under %s: %w", c.azdContext.ProjectPath(), err)
+			}
+
+			if len(hosts) == 0 {
+				return false, fmt.Errorf("no app host projects found under %s", c.azdContext.ProjectPath())
+			}
+
+			if len(hosts) > 1 {
+				return false, fmt.Errorf("multiple app host projects found under %s", c.azdContext.ProjectPath())
+			}
+
+			session.appHostPath = hosts[0].Path
+		}
+
+		manifest, err := session.readManifest(ctx, session.appHostPath, c.dotnetCli)
+		if err != nil {
+			return false, fmt.Errorf("reading app host manifest: %w", err)
+		}
+
+		files, err := apphost.GenerateProjectArtifacts(
+			ctx,
+			c.azdContext.ProjectDirectory(),
+			filepath.Base(c.azdContext.ProjectDirectory()),
+			manifest,
+			session.appHostPath)
+		if err != nil {
+			return false, fmt.Errorf("generating project artifacts: %w", err)
+		}
+
+		file := files["azure.yaml"]
+		projectFilePath := filepath.Join(c.azdContext.ProjectDirectory(), "azure.yaml")
+
+		if err := os.WriteFile(projectFilePath, []byte(file.Contents), file.Mode); err != nil {
+			return false, fmt.Errorf("writing azure.yaml: %w", err)
+		}
+	} else if err != nil {
+		return false, fmt.Errorf("checking for project: %w", err)
+	}
+
+	azdEnv, err := c.envManager.Create(ctx, envSpec)
+	if err != nil {
+		return false, fmt.Errorf("creating new environment: %w", err)
+	}
+
+	azdEnv.DotenvSet("ASPIRE_ENVIRONMENT", newEnv.Properties["ASPIRE_ENVIRONMENT"])
+
+	var servicesToExpose = make([]string, 0)
+
+	for _, svc := range newEnv.Services {
+		if svc.IsExternal {
+			servicesToExpose = append(servicesToExpose, svc.Name)
+		}
+	}
+
+	if err := azdEnv.Config.Set("services.app.config.exposedServices", servicesToExpose); err != nil {
+		return false, fmt.Errorf("setting exposed services: %w", err)
+	}
+
+	if err := c.envManager.Save(ctx, azdEnv); err != nil {
+		return false, fmt.Errorf("saving new environment: %w", err)
+	}
+
+	if err := c.azdContext.SetDefaultEnvironmentName(newEnv.Name); err != nil {
+		return false, fmt.Errorf("saving default environment: %w", err)
+	}
+
+	return true, nil
+}

--- a/cli/azd/internal/vsrpc/environment_service_deploy.go
+++ b/cli/azd/internal/vsrpc/environment_service_deploy.go
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package vsrpc
+
+import (
+	"context"
+
+	"github.com/azure/azure-dev/cli/azd/cmd/actions"
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/internal/cmd"
+	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
+)
+
+// DeployAsync is the server implementation of:
+// ValueTask<Environment> DeployAsync(Session, string, IObserver<ProgressMessage>, CancellationToken)
+//
+// While it is named simply `DeployAsync`, it behaves as if the user had run `azd provision` and `azd deploy`.
+func (s *environmentService) DeployAsync(
+	ctx context.Context, sessionId Session, name string, observer IObserver[ProgressMessage],
+) (*Environment, error) {
+	session, err := s.server.validateSession(ctx, sessionId)
+	if err != nil {
+		return nil, err
+	}
+
+	session.sessionMu.Lock()
+	defer session.sessionMu.Unlock()
+
+	outputWriter := &lineWriter{
+		next: &messageWriter{
+			ctx:      ctx,
+			observer: observer,
+		},
+	}
+
+	session.outWriter.AddWriter(outputWriter)
+	defer session.outWriter.RemoveWriter(outputWriter)
+
+	provisionFlags := cmd.NewProvisionFlagsFromEnvAndOptions(
+		&internal.EnvFlag{
+			EnvironmentName: name,
+		},
+		&internal.GlobalCommandOptions{
+			Cwd:      session.rootPath,
+			NoPrompt: true,
+		},
+	)
+
+	deployFlags := cmd.NewDeployFlagsFromEnvAndOptions(
+		&internal.EnvFlag{
+			EnvironmentName: name,
+		},
+		&internal.GlobalCommandOptions{
+			Cwd:      session.rootPath,
+			NoPrompt: true,
+		},
+	)
+
+	session.container.MustRegisterScoped(func() internal.EnvFlag {
+		return internal.EnvFlag{
+			EnvironmentName: name,
+		}
+	})
+
+	ioc.RegisterInstance[*cmd.ProvisionFlags](session.container, provisionFlags)
+	ioc.RegisterInstance[*cmd.DeployFlags](session.container, deployFlags)
+	ioc.RegisterInstance[[]string](session.container, []string{})
+
+	session.container.MustRegisterNamedTransient("provisionAction", cmd.NewProvisionAction)
+	session.container.MustRegisterNamedTransient("deployAction", cmd.NewDeployAction)
+
+	var c struct {
+		deployAction    actions.Action `container:"name"`
+		provisionAction actions.Action `container:"name"`
+	}
+
+	if err := session.container.Fill(&c); err != nil {
+		return nil, err
+	}
+
+	if _, err := c.provisionAction.Run(ctx); err != nil {
+		return nil, err
+	}
+
+	if _, err := c.deployAction.Run(ctx); err != nil {
+		return nil, err
+	}
+
+	if err := outputWriter.Flush(ctx); err != nil {
+		return nil, err
+	}
+
+	return s.refreshEnvironmentAsyncWithSession(ctx, session, name, observer)
+}

--- a/cli/azd/internal/vsrpc/environment_service_load.go
+++ b/cli/azd/internal/vsrpc/environment_service_load.go
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package vsrpc
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
+)
+
+// OpenEnvironmentAsync is the server implementation of:
+// ValueTask<Environment> OpenEnvironmentAsync(Session, string, IObserver<ProgressMessage>, CancellationToken);
+//
+// OpenEnvironmentAsync loads the specified environment, without connecting to Azure or fetching a manifest (unless it is
+// already cached) and is faster than `LoadEnvironmentAsync` in cases where we have not cached the manifest. This means
+// the Services array of the returned environment may be empty.
+func (s *environmentService) OpenEnvironmentAsync(
+	ctx context.Context, sessionId Session, name string, observer IObserver[ProgressMessage],
+) (*Environment, error) {
+	session, err := s.server.validateSession(ctx, sessionId)
+	if err != nil {
+		return nil, err
+	}
+
+	session.sessionMu.Lock()
+	defer session.sessionMu.Unlock()
+
+	return s.loadEnvironmentAsyncWithSession(ctx, session, name, false)
+}
+
+// LoadEnvironmentAsync is the server implementation of:
+// ValueTask<Environment> LoadEnvironmentAsync(Session, string, IObserver<ProgressMessage>, CancellationToken);
+//
+// LoadEnvironmentAsync loads the specified environment, without connecting to Azure. Because of this, certain properties of
+// the environment (like service endpoints) may not be available. Use `RefreshEnvironmentAsync` to load the environment and
+// fetch information from Azure.
+func (s *environmentService) LoadEnvironmentAsync(
+	ctx context.Context, sessionId Session, name string, observer IObserver[ProgressMessage],
+) (*Environment, error) {
+	session, err := s.server.validateSession(ctx, sessionId)
+	if err != nil {
+		return nil, err
+	}
+
+	session.sessionMu.Lock()
+	defer session.sessionMu.Unlock()
+
+	return s.loadEnvironmentAsyncWithSession(ctx, session, name, true)
+}
+
+// loadEnvironmentAsyncWithSession is not safe to be called concurrently, ensure that the session is locked before calling.
+func (s *environmentService) loadEnvironmentAsyncWithSession(
+	ctx context.Context, session *serverSession, name string, mustLoadServices bool,
+) (*Environment, error) {
+	var c struct {
+		azdCtx        *azdcontext.AzdContext `container:"type"`
+		envManager    environment.Manager    `container:"type"`
+		projectConfig *project.ProjectConfig `container:"type"`
+		dotnetCli     dotnet.DotNetCli       `container:"type"`
+	}
+
+	if err := session.container.Fill(&c); err != nil {
+		return nil, err
+	}
+
+	e, err := c.envManager.Get(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("getting environment: %w", err)
+	}
+
+	currentEnv, err := c.azdCtx.GetDefaultEnvironmentName()
+	if err != nil {
+		return nil, fmt.Errorf("getting default environment: %w", err)
+	}
+
+	ret := &Environment{
+		Name: name,
+		Properties: map[string]string{
+			"Subscription":       e.GetSubscriptionId(),
+			"Location":           e.GetLocation(),
+			"ASPIRE_ENVIRONMENT": e.Getenv("ASPIRE_ENVIRONMENT"),
+		},
+		IsCurrent: name == currentEnv,
+	}
+
+	// NOTE(ellismg): The IaC for Aspire Apps exposes these properties - we use them instead of trying to discover the
+	// deployed resources (perhaps by considering the resources in the resource group associated with the environment or
+	// by looking at the deployment).  This was the quickest path to get the information that VS needed for the spike,
+	// but we might want to revisit this strategy. A nice thing about this strategy is it means we can return the data
+	// promptly, which is nice for VS.
+	if v := e.Getenv("AZURE_CONTAINER_APPS_ENVIRONMENT_ID"); v != "" {
+		parts := strings.Split(v, "/")
+		ret.Properties["ContainerAppsEnvironment"] = parts[len(parts)-1]
+	}
+
+	if v := e.Getenv("AZURE_CONTAINER_REGISTRY_ENDPOINT"); v != "" {
+		ret.Properties["ContainerRegistry"] = strings.TrimSuffix(v, ".azurecr.io")
+	}
+
+	if v := e.Getenv("AZURE_LOG_ANALYTICS_WORKSPACE_NAME"); v != "" {
+		ret.Properties["LogAnalyticsWorkspace"] = v
+	}
+
+	// If we would have to discover the app host or load the manifest from disk and the caller did not request it
+	// skip this somewhat expensive operation, at the expense of not building out the services array.
+	if (session.appHostPath == "" || session.manifestCache[session.appHostPath] == nil) && !mustLoadServices {
+		return ret, nil
+	}
+
+	if session.appHostPath == "" {
+		appHost, err := appHostForProject(ctx, c.projectConfig, c.dotnetCli)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find Aspire app host: %w", err)
+		}
+
+		session.appHostPath = appHost.Path()
+	}
+
+	manifest, err := session.readManifest(ctx, session.appHostPath, c.dotnetCli)
+	if err != nil {
+		return nil, fmt.Errorf("reading app host manifest: %w", err)
+	}
+
+	ret.Services = servicesFromManifest(manifest)
+
+	var exposedServices []string
+
+	// TODO(azure/azure-dev#3284): We need to use the service name of the apphost from azure.yaml instead of assuming
+	// it will always be "app". "app" is just the default we use when creating an azure.yaml for the user.
+	val, has := e.Config.Get("services.app.config.exposedServices")
+	if has {
+		if v, ok := val.([]any); ok {
+			for _, svc := range v {
+				if s, ok := svc.(string); ok {
+					exposedServices = append(exposedServices, s)
+				}
+			}
+		}
+	}
+
+	for _, svc := range ret.Services {
+		if slices.Contains(exposedServices, svc.Name) {
+			svc.IsExternal = true
+		}
+	}
+
+	return ret, nil
+}

--- a/cli/azd/internal/vsrpc/environment_service_refresh.go
+++ b/cli/azd/internal/vsrpc/environment_service_refresh.go
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package vsrpc
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/bicep"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
+)
+
+// RefreshEnvironmentAsync is the server implementation of:
+// ValueTask<Environment> RefreshEnvironmentAsync(Session, string, IObserver<ProgressMessage>, CancellationToken);
+//
+// RefreshEnvironmentAsync loads the specified environment, and fetches information about it from Azure. If you are willing
+// to accept some loss of information in favor of a faster load time, use `LoadEnvironmentAsync` instead, which does not
+// contact azure to compute service endpoints or last deployment information.
+func (s *environmentService) RefreshEnvironmentAsync(
+	ctx context.Context, sessionId Session, name string, observer IObserver[ProgressMessage],
+) (*Environment, error) {
+	session, err := s.server.validateSession(ctx, sessionId)
+	if err != nil {
+		return nil, err
+	}
+
+	session.sessionMu.Lock()
+	defer session.sessionMu.Unlock()
+
+	return s.refreshEnvironmentAsyncWithSession(ctx, session, name, observer)
+}
+
+// refreshEnvironmentAsyncWithSession is not safe to be called concurrently, ensure that the session is locked before
+// calling.
+func (s *environmentService) refreshEnvironmentAsyncWithSession(
+	ctx context.Context, session *serverSession, name string, observer IObserver[ProgressMessage],
+) (*Environment, error) {
+
+	env, err := s.loadEnvironmentAsyncWithSession(ctx, session, name, true)
+	if err != nil {
+		return nil, err
+	}
+
+	var c struct {
+		projectManager       project.ProjectManager      `container:"type"`
+		projectConfig        *project.ProjectConfig      `container:"type"`
+		importManager        *project.ImportManager      `container:"type"`
+		bicep                provisioning.Provider       `container:"name"`
+		azureResourceManager *infra.AzureResourceManager `container:"type"`
+		resourceManager      project.ResourceManager     `container:"type"`
+		serviceManager       project.ServiceManager      `container:"type"`
+		envManager           environment.Manager         `container:"type"`
+	}
+
+	session.container.MustRegisterScoped(func() internal.EnvFlag {
+		return internal.EnvFlag{
+			EnvironmentName: name,
+		}
+	})
+
+	if err := session.container.Fill(&c); err != nil {
+		return nil, err
+	}
+
+	bicepProvider := c.bicep.(*bicep.BicepProvider)
+
+	if err := c.projectManager.Initialize(ctx, c.projectConfig); err != nil {
+		return nil, err
+	}
+
+	infra, err := c.importManager.ProjectInfrastructure(ctx, c.projectConfig)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = infra.Cleanup() }()
+
+	if err := bicepProvider.Initialize(ctx, c.projectConfig.Path, infra.Options); err != nil {
+		return nil, fmt.Errorf("initializing provisioning manager: %w", err)
+	}
+
+	_ = observer.OnNext(ctx, newInfoProgressMessage("Loading latest deployment information"))
+
+	deployment, err := bicepProvider.LastDeployment(ctx)
+	if err != nil {
+		log.Printf("failed to get latest deployment result: %v", err)
+	} else {
+		env.LastDeployment = &DeploymentResult{
+			DeploymentId: *deployment.ID,
+			Success:      *deployment.Properties.ProvisioningState == armresources.ProvisioningStateSucceeded,
+			Time:         *deployment.Properties.Timestamp,
+		}
+	}
+
+	stableServices, err := c.importManager.ServiceStable(ctx, c.projectConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	subId := env.Properties["Subscription"]
+	envName := env.Name
+
+	nameIdx := make(map[string]int, len(env.Services)) // maps service name to index in env.Services slice
+	for idx, svc := range env.Services {
+		nameIdx[svc.Name] = idx
+	}
+
+	_ = observer.OnNext(ctx, newInfoProgressMessage("Loading server resources"))
+
+	rgName, err := c.azureResourceManager.FindResourceGroupForEnvironment(ctx, subId, envName)
+	if err == nil {
+		env.Properties["ResourceGroup"] = rgName
+
+		for _, serviceConfig := range stableServices {
+			svcName := serviceConfig.Name
+
+			_ = observer.OnNext(ctx, newInfoProgressMessage("Loading server resources for service "+svcName))
+
+			resources, err := c.resourceManager.GetServiceResources(ctx, subId, rgName, serviceConfig)
+			if err == nil {
+				resourceIds := make([]string, len(resources))
+				for idx, res := range resources {
+					resourceIds[idx] = res.Id
+				}
+
+				if svcIdx, has := nameIdx[svcName]; has {
+					resSvc := env.Services[svcIdx]
+
+					if len(resourceIds) > 0 {
+						resSvc.ResourceId = convert.RefOf(resourceIds[0])
+					}
+
+					resSvc.Endpoint = convert.RefOf(s.serviceEndpoint(
+						ctx, subId, serviceConfig, c.resourceManager, c.serviceManager,
+					))
+				}
+			} else {
+				log.Printf("ignoring error determining resource id for service %s: %v", svcName, err)
+			}
+		}
+	} else {
+		log.Printf(
+			"ignoring error determining resource group for environment %s, resource ids will not be available: %v",
+			env.Name,
+			err)
+	}
+
+	return env, nil
+}
+
+func (s *environmentService) serviceEndpoint(
+	ctx context.Context,
+	subId string,
+	serviceConfig *project.ServiceConfig,
+	resourceManager project.ResourceManager,
+	serviceManager project.ServiceManager,
+) string {
+	targetResource, err := resourceManager.GetTargetResource(ctx, subId, serviceConfig)
+	if err != nil {
+		log.Printf("error: getting target-resource. Endpoints will be empty: %v", err)
+		return ""
+	}
+
+	st, err := serviceManager.GetServiceTarget(ctx, serviceConfig)
+	if err != nil {
+		log.Printf("error: getting service target. Endpoints will be empty: %v", err)
+		return ""
+	}
+
+	endpoints, err := st.Endpoints(ctx, serviceConfig, targetResource)
+	if err != nil {
+		log.Printf("error: getting service endpoints. Endpoints might be empty: %v", err)
+	}
+
+	if len(endpoints) == 0 {
+		return ""
+	}
+
+	return endpoints[0]
+}

--- a/cli/azd/internal/vsrpc/handler.go
+++ b/cli/azd/internal/vsrpc/handler.go
@@ -1,0 +1,222 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package vsrpc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"go.lsp.dev/jsonrpc2"
+)
+
+const (
+	// requestCanceledErrorCode is the error code that is used when a request is cancelled. StreamJsonRpc understands this
+	// error code and causes the Task to throw a TaskCanceledException instead of a normal RemoteInvocationException error.
+	requestCanceledErrorCode jsonrpc2.Code = -32800
+)
+
+// Handler is the type of function that handles incoming RPC requests.
+type Handler func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error
+
+// HandlerAction0 is a helper for creating a Handler from a function that takes no arguments and returns an error.
+func HandlerAction0(f func(context.Context) error) Handler {
+	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		err := f(ctx)
+		if err != nil && errors.Is(err, ctx.Err()) {
+			err = &jsonrpc2.Error{
+				Code:    requestCanceledErrorCode,
+				Message: err.Error(),
+			}
+		}
+		return reply(ctx, nil, err)
+	}
+}
+
+// HandlerAction1 is a helper for creating a Handler from a function that takes one argument and returns an error.
+func HandlerAction1[T1 any](f func(context.Context, T1) error) Handler {
+	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		t1, err := unmarshalArg[T1](conn, req, 0)
+		if err != nil {
+			return reply(ctx, nil, err)
+		}
+
+		err = f(ctx, t1)
+		if err != nil && errors.Is(err, ctx.Err()) {
+			err = &jsonrpc2.Error{
+				Code:    requestCanceledErrorCode,
+				Message: err.Error(),
+			}
+		}
+		return reply(ctx, nil, err)
+	}
+}
+
+// HandlerAction2 is a helper for creating a Handler from a function that takes two arguments and returns an error.
+func HandlerAction2[T1 any, T2 any](f func(context.Context, T1, T2) error) Handler {
+	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		t1, err := unmarshalArg[T1](conn, req, 0)
+		if err != nil {
+			return reply(ctx, nil, err)
+		}
+
+		t2, err := unmarshalArg[T2](conn, req, 1)
+		if err != nil {
+			return reply(ctx, nil, err)
+		}
+
+		err = f(ctx, t1, t2)
+		if err != nil && errors.Is(err, ctx.Err()) {
+			err = &jsonrpc2.Error{
+				Code:    requestCanceledErrorCode,
+				Message: err.Error(),
+			}
+		}
+		return reply(ctx, nil, err)
+	}
+}
+
+// HandlerAction3 is a helper for creating a Handler from a function that takes two arguments and returns an error.
+func HandlerAction3[T1 any, T2 any, T3 any](f func(context.Context, T1, T2, T3) error) Handler {
+	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		t1, err := unmarshalArg[T1](conn, req, 0)
+		if err != nil {
+			return reply(ctx, nil, err)
+		}
+
+		t2, err := unmarshalArg[T2](conn, req, 1)
+		if err != nil {
+			return reply(ctx, nil, err)
+		}
+
+		t3, err := unmarshalArg[T3](conn, req, 2)
+		if err != nil {
+			return reply(ctx, nil, err)
+		}
+
+		err = f(ctx, t1, t2, t3)
+		if err != nil && errors.Is(err, ctx.Err()) {
+			err = &jsonrpc2.Error{
+				Code:    requestCanceledErrorCode,
+				Message: err.Error(),
+			}
+		}
+		return reply(ctx, nil, err)
+	}
+}
+
+// HandlerFunc0 is a helper for creating a Handler from a function that takes no arguments and returns a value and an error.
+func HandlerFunc0[TRet any](f func(context.Context) (TRet, error)) Handler {
+	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		ret, err := f(ctx)
+		if err != nil && errors.Is(err, ctx.Err()) {
+			err = &jsonrpc2.Error{
+				Code:    requestCanceledErrorCode,
+				Message: err.Error(),
+			}
+		}
+		return reply(ctx, ret, err)
+	}
+}
+
+// HandlerFunc1 is a helper for creating a Handler from a function that takes one argument and returns a value and an error.
+func HandlerFunc1[T1 any, TRet any](f func(context.Context, T1) (TRet, error)) Handler {
+	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		t1, err := unmarshalArg[T1](conn, req, 0)
+		if err != nil {
+			return reply(ctx, nil, err)
+		}
+
+		ret, err := f(ctx, t1)
+		if err != nil && errors.Is(err, ctx.Err()) {
+			err = &jsonrpc2.Error{
+				Code:    requestCanceledErrorCode,
+				Message: err.Error(),
+			}
+		}
+		return reply(ctx, ret, err)
+	}
+}
+
+// HandlerFunc2 is a helper for creating a Handler from a function that takes two arguments and returns a value and an error.
+func HandlerFunc2[T1 any, T2 any, TRet any](f func(context.Context, T1, T2) (TRet, error)) Handler {
+	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		t1, err := unmarshalArg[T1](conn, req, 0)
+		if err != nil {
+			return reply(ctx, nil, err)
+		}
+
+		t2, err := unmarshalArg[T2](conn, req, 1)
+		if err != nil {
+			return reply(ctx, nil, err)
+		}
+
+		ret, err := f(ctx, t1, t2)
+		if err != nil && errors.Is(err, ctx.Err()) {
+			err = &jsonrpc2.Error{
+				Code:    requestCanceledErrorCode,
+				Message: err.Error(),
+			}
+		}
+		return reply(ctx, ret, err)
+	}
+}
+
+// HandlerFunc3 is a helper for creating a Handler from a function that takes three arguments and returns a value and an
+// error.
+func HandlerFunc3[T1 any, T2 any, T3 any, TRet any](f func(context.Context, T1, T2, T3) (TRet, error)) Handler {
+	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		t1, err := unmarshalArg[T1](conn, req, 0)
+		if err != nil {
+			return reply(ctx, nil, err)
+		}
+
+		t2, err := unmarshalArg[T2](conn, req, 1)
+		if err != nil {
+			return reply(ctx, nil, err)
+		}
+
+		t3, err := unmarshalArg[T3](conn, req, 2)
+		if err != nil {
+			return reply(ctx, nil, err)
+		}
+
+		ret, err := f(ctx, t1, t2, t3)
+		if err != nil && errors.Is(err, ctx.Err()) {
+			err = &jsonrpc2.Error{
+				Code:    requestCanceledErrorCode,
+				Message: err.Error(),
+			}
+		}
+		return reply(ctx, ret, err)
+	}
+}
+
+// unmarshalArg returns the i'th member of the Params property of a request, after JSON unmarshalling it as an instance of T.
+// If an error is returned, it is of type *jsonrpc.Error with a code of jsonrpc2.InvalidParams.
+func unmarshalArg[T any](conn jsonrpc2.Conn, req jsonrpc2.Request, index int) (T, error) {
+	var args []json.RawMessage
+	if err := json.Unmarshal(req.Params(), &args); err != nil {
+		return *new(T), jsonrpc2.NewError(
+			jsonrpc2.InvalidParams, fmt.Sprintf("unmarshalling params as array: %s", err.Error()))
+	}
+
+	if index >= len(args) {
+		return *new(T), jsonrpc2.NewError(
+			jsonrpc2.InvalidParams, fmt.Sprintf("param out of range, len: %d index: %d", len(args), index))
+	}
+
+	var arg T
+	if err := json.Unmarshal(args[index], &arg); err != nil {
+		return *new(T), jsonrpc2.NewError(
+			jsonrpc2.InvalidParams, fmt.Sprintf("unmarshalling param: %s", err.Error()))
+	}
+
+	if v, ok := (any(&arg)).(connectionObserver); ok {
+		v.attachConnection(conn)
+	}
+
+	return arg, nil
+}

--- a/cli/azd/internal/vsrpc/message_writer.go
+++ b/cli/azd/internal/vsrpc/message_writer.go
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package vsrpc
+
+import (
+	"context"
+	"io"
+	"sync"
+)
+
+// messageWriter is an io.Writer that writes to an IObserver[ProgressMessage], emitting a message for each write.
+type messageWriter struct {
+	ctx      context.Context
+	observer IObserver[ProgressMessage]
+}
+
+// lineWriter is an io.Writer that writes to another io.Writer, emitting a message for each line written.
+type lineWriter struct {
+	next io.Writer
+	buf  []byte
+	// bufMu protects access to buf.
+	bufMu sync.Mutex
+}
+
+func (lw *lineWriter) Write(p []byte) (int, error) {
+	lw.bufMu.Lock()
+	defer lw.bufMu.Unlock()
+
+	for i, b := range p {
+		lw.buf = append(lw.buf, b)
+
+		if b == '\n' {
+			_, err := lw.next.Write(lw.buf)
+			if err != nil {
+				return i + 1, err
+			}
+
+			lw.buf = nil
+		}
+	}
+
+	return len(p), nil
+}
+
+// Flush sends any remaining output to the observer.
+func (mw *lineWriter) Flush(ctx context.Context) error {
+	mw.bufMu.Lock()
+	defer mw.bufMu.Unlock()
+
+	if len(mw.buf) > 0 {
+		buf := mw.buf
+		mw.buf = nil
+
+		_, err := mw.next.Write(buf)
+		return err
+	}
+
+	return nil
+}
+
+// Write implements io.Writer.
+func (mw *messageWriter) Write(p []byte) (int, error) {
+	err := mw.observer.OnNext(mw.ctx, newInfoProgressMessage(string(p)))
+	if err != nil {
+		return 0, err
+	}
+
+	return len(p), nil
+}

--- a/cli/azd/internal/vsrpc/models.go
+++ b/cli/azd/internal/vsrpc/models.go
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package vsrpc
+
+import (
+	"time"
+)
+
+type AspireHost struct {
+	Name     string
+	Path     string
+	Services []*Service
+}
+
+type Environment struct {
+	Name           string
+	IsCurrent      bool
+	Properties     map[string]string
+	Services       []*Service
+	LastDeployment *DeploymentResult `json:",omitempty"`
+}
+
+type EnvironmentInfo struct {
+	Name      string
+	IsCurrent bool
+}
+
+type Service struct {
+	Name       string
+	IsExternal bool
+	Kind       *string `json:",omitempty"`
+	Endpoint   *string `json:",omitempty"`
+	ResourceId *string `json:",omitempty"`
+}
+
+type DeploymentResult struct {
+	Success      bool
+	Time         time.Time
+	Message      string
+	DeploymentId string
+}
+
+type ProgressMessage struct {
+	Message            string
+	Severity           MessageSeverity
+	Time               time.Time
+	Kind               MessageKind
+	Code               string
+	AdditionalInfoLink string
+}
+
+func newInfoProgressMessage(message string) ProgressMessage {
+	return ProgressMessage{
+		Message:  message,
+		Severity: Info,
+		Time:     time.Now(),
+		Kind:     Logging,
+	}
+}
+
+type MessageSeverity int
+
+const (
+	Info MessageSeverity = iota
+	Warning
+	Error
+)
+
+type MessageKind int
+
+const (
+	Logging MessageKind = iota
+	Important
+)
+
+// Session represents an active connection to the server.  It is returned by InitializeAsync and holds an opaque
+// connection id that the server can use to identify the client across multiple RPC calls (since our service is exposed
+// over multiple endpoints a single client may have multiple connections to the server, and we want a way to correlate them
+// so we can cache state across connections).
+type Session struct {
+	Id string
+}

--- a/cli/azd/internal/vsrpc/observer.go
+++ b/cli/azd/internal/vsrpc/observer.go
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package vsrpc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"go.lsp.dev/jsonrpc2"
+)
+
+// connectionObserver is an interface that can be implemented by types that want to be notified when they are deserialized
+// during a JSON RPC call.
+type connectionObserver interface {
+	attachConnection(c jsonrpc2.Conn)
+}
+
+// IObserver is treated special by our JSON-RPC implementation and plays nicely with StreamJsonRpc's ideas on how to
+// marshal an IObserver<T> in .NET.
+//
+// The way this works is that that we can send a notification back to to the server with the method
+// `$/invokeProxy/{handle}/{onCompleted|onNext}`. When marshalled as an argument, the wire format of IObserver<T> is:
+//
+//	{
+//	  "__jsonrpc_marshaled": 1,
+//	  "handle": <some-integer>
+//	}
+type IObserver[T any] struct {
+	handle int
+	c      jsonrpc2.Conn
+}
+
+func (o *IObserver[T]) OnNext(ctx context.Context, value T) error {
+	return o.c.Notify(ctx, fmt.Sprintf("$/invokeProxy/%d/onNext", o.handle), []any{value})
+}
+
+func (o *IObserver[T]) OnCompleted(ctx context.Context) error {
+	return o.c.Notify(ctx, fmt.Sprintf("$/invokeProxy/%d/onCompleted", o.handle), nil)
+}
+
+func (o *IObserver[T]) UnmarshalJSON(data []byte) error {
+	var wire map[string]int
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+
+	if v, has := wire["__jsonrpc_marshaled"]; !has && v != 1 {
+		return errors.New("expected __jsonrpc_marshaled=1")
+	}
+
+	if v, has := wire["handle"]; !has {
+		return errors.New("expected handle")
+	} else {
+		o.handle = v
+	}
+
+	return nil
+}
+
+func (o *IObserver[T]) attachConnection(c jsonrpc2.Conn) {
+	o.c = c
+}

--- a/cli/azd/internal/vsrpc/server.go
+++ b/cli/azd/internal/vsrpc/server.go
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package vsrpc
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
+	"github.com/gorilla/websocket"
+	"go.lsp.dev/jsonrpc2"
+)
+
+type Server struct {
+	// sessions is a map of session IDs to server sessions.
+	sessions map[string]*serverSession
+	// sessionsMu protects access to sessions.
+	sessionsMu sync.Mutex
+	// rootContainer contains all the core registrations for the azd components. Each session creates a new scope from
+	// this root container.
+	rootContainer *ioc.NestedContainer
+}
+
+func NewServer(rootContainer *ioc.NestedContainer) *Server {
+	return &Server{
+		sessions:      make(map[string]*serverSession),
+		rootContainer: rootContainer,
+	}
+}
+
+// upgrader is the websocket.Upgrader used by the server to upgrade each request to a websocket connection.
+var upgrader = websocket.Upgrader{}
+
+// Serve calls http.Serve with the given listener and a handler that serves the VS RPC protocol.
+func (s *Server) Serve(l net.Listener) error {
+	mux := http.NewServeMux()
+
+	mux.Handle("/AspireService/v1.0", newAspireService(s))
+	mux.Handle("/ServerService/v1.0", newServerService(s))
+	mux.Handle("/EnvironmentService/v1.0", newEnvironmentService(s))
+
+	// Expose a few special test endpoints that can be used to debug our special RPC behavior around cancellation and
+	// IObservers. This is useful for both developers unit testing in VS Code (where they can set this value in launch.json
+	// as well as tests where we can set this value with t.SetEnv()).
+	if on, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_SERVER_DEBUG_ENDPOINTS")); err == nil && on {
+		mux.Handle("/TestDebugService/v1.0", newDebugService(s))
+	}
+
+	server := http.Server{
+		ReadHeaderTimeout: 1 * time.Second,
+		Handler:           mux,
+	}
+	return server.Serve(l)
+}
+
+// serveRpc upgrades the HTTP connection to a WebSocket connection and then serves a set of named method using JSON-RPC 2.0.
+func serveRpc(w http.ResponseWriter, r *http.Request, handlers map[string]Handler) {
+	c, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Print("upgrade:", err)
+		return
+	}
+	defer c.Close()
+
+	rpcServer := jsonrpc2.NewConn(NewWebSocketStream(c))
+	cancelers := make(map[jsonrpc2.ID]context.CancelFunc)
+	cancelersMu := sync.Mutex{}
+
+	rpcServer.Go(r.Context(), func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		log.Printf("handling rpc for %s", req.Method())
+
+		// Observe cancellation messages from the client to us. The protocol is a message sent to the `$/cancelRequest`
+		// method with an `id` parameter that is the ID of the request to cancel.  For each inflight RPC we track the
+		// corresponding cancel function in `cancelers` and use it to cancel the request when we observe it. When an RPC
+		// completes, we remove the cancel function from the map and invoke it, as the context package recommends.
+		//
+		// Inside the handler itself, we observe the error returned by the actual RPC function and if it matches the
+		// value of ctx.Err() we know that the function observed an responded to cancellation. We then return an RPC error
+		// with a special code that StreamJsonRpc understands as a cancellation error.
+		if req.Method() == "$/cancelRequest" {
+			var cancelArgs struct {
+				Id *int32 `json:"id"`
+			}
+			if err := json.Unmarshal(req.Params(), &cancelArgs); err != nil {
+				return reply(ctx, nil, jsonrpc2.ErrInvalidParams)
+			}
+			if cancelArgs.Id == nil {
+				return reply(ctx, nil, jsonrpc2.ErrInvalidParams)
+			}
+
+			id := jsonrpc2.NewNumberID(*cancelArgs.Id)
+
+			cancelersMu.Lock()
+			cancel, has := cancelers[id]
+			cancelersMu.Unlock()
+			if has {
+				cancel()
+				// We'll remove the cancel function from the map once the function observes cancellation and the handler
+				// returns, no need to remove it eagerly here.
+			}
+			return reply(ctx, nil, nil)
+		}
+
+		handler, ok := handlers[req.Method()]
+		if !ok {
+			return reply(ctx, nil, jsonrpc2.ErrMethodNotFound)
+		}
+
+		go func() {
+			var childCtx context.Context = ctx
+
+			// If this is a call, create a new context and cancel function to track the request and allow it to be
+			// canceled.
+			call, isCall := req.(*jsonrpc2.Call)
+			if isCall {
+				ctx, cancel := context.WithCancel(ctx)
+				childCtx = ctx
+				cancelersMu.Lock()
+				cancelers[call.ID()] = cancel
+				cancelersMu.Unlock()
+			}
+
+			err := handler(childCtx, rpcServer, reply, req)
+
+			if isCall {
+				cancelersMu.Lock()
+				cancel, has := cancelers[call.ID()]
+				cancelersMu.Unlock()
+				if has {
+					cancel()
+					cancelersMu.Lock()
+					delete(cancelers, call.ID())
+					cancelersMu.Unlock()
+				}
+			}
+
+			if err != nil {
+				log.Printf("handler for rpc %s returned error: %v", req.Method(), err)
+			}
+		}()
+
+		return nil
+	})
+
+	<-rpcServer.Done()
+}

--- a/cli/azd/internal/vsrpc/server_service.go
+++ b/cli/azd/internal/vsrpc/server_service.go
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package vsrpc
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/mattn/go-colorable"
+)
+
+// serverService is the RPC server for the '/ServerService/v1.0' endpoint.
+type serverService struct {
+	server *Server
+}
+
+func newServerService(server *Server) *serverService {
+	return &serverService{
+		server: server,
+	}
+}
+
+// InitializeAsync is the server implementation of:
+// ValueTask<Session> InitializeAsync(string rootPath, CancellationToken cancellationToken);
+func (s *serverService) InitializeAsync(ctx context.Context, rootPath string) (*Session, error) {
+	// TODO(azure/azure-dev#3288): Ideally the Chdir would be be something we injected into components instead of it being
+	// ambient authority. We'll get there, but for now let's also just Chdir into the root folder so places where we use
+	// a relative path will work.
+	//
+	// In practice we do not expect multiple clients with different root paths to be calling into the same server. If you
+	// need that today, launch a new server for each root path...
+	if err := os.Chdir(rootPath); err != nil {
+		return nil, err
+	}
+
+	id, session, err := s.server.newSession()
+	if err != nil {
+		return nil, err
+	}
+
+	container, err := s.server.rootContainer.NewScope()
+	if err != nil {
+		return nil, err
+	}
+
+	azdCtx := azdcontext.NewAzdContextWithDirectory(rootPath)
+
+	outWriter := newWriter(fmt.Sprintf("[%s stdout] ", id))
+	errWriter := newWriter(fmt.Sprintf("[%s stderr] ", id))
+
+	// Useful for debugging, direct all the output to the console, so you can see it in VS Code.
+	outWriter.AddWriter(&lineWriter{
+		next: writerFunc(func(p []byte) (n int, err error) {
+			os.Stdout.Write([]byte(fmt.Sprintf("[%s stdout] %s", id, string(p))))
+			return n, nil
+		}),
+	})
+
+	errWriter.AddWriter(&lineWriter{
+		next: writerFunc(func(p []byte) (n int, err error) {
+			os.Stdout.Write([]byte(fmt.Sprintf("[%s stderr] %s", id, string(p))))
+			return n, nil
+		}),
+	})
+
+	container.MustRegisterScoped(func() input.Console {
+		stdout := outWriter
+		stderr := errWriter
+		stdin := strings.NewReader("")
+		writer := colorable.NewNonColorable(stdout)
+
+		return input.NewConsole(true, false, writer, input.ConsoleHandles{
+			Stdin:  stdin,
+			Stdout: stdout,
+			Stderr: stderr,
+		}, &output.NoneFormatter{})
+	})
+
+	container.MustRegisterScoped(func(console input.Console) io.Writer {
+		return colorable.NewNonColorable(console.Handles().Stdout)
+	})
+
+	container.MustRegisterScoped(func() *internal.GlobalCommandOptions {
+		return &internal.GlobalCommandOptions{
+			NoPrompt: true,
+			Cwd:      rootPath,
+		}
+	})
+
+	container.MustRegisterScoped(func() *azdcontext.AzdContext {
+		return azdCtx
+	})
+
+	container.MustRegisterScoped(func() *lazy.Lazy[*azdcontext.AzdContext] {
+		return lazy.From(azdCtx)
+	})
+
+	session.rootPath = rootPath
+	session.container = container
+	session.outWriter = outWriter
+	session.errWriter = errWriter
+
+	return &Session{
+		Id: id,
+	}, nil
+}
+
+// StopAsync is the server implementation of:
+// ValueTask StopAsync(CancellationToken cancellationToken);
+func (s *serverService) StopAsync(ctx context.Context) error {
+	// TODO(azure/azure-dev#3286): Need to think about how shutdown works. For now it is probably best to just have the
+	// client terminate `azd` once they know all outstanding RPCs have completed instead of trying to do a graceful
+	// shutdown on our end.
+	return nil
+}
+
+// ServeHTTP implements http.Handler.
+func (s *serverService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	serveRpc(w, r, map[string]Handler{
+		"InitializeAsync": HandlerFunc1(s.InitializeAsync),
+		"StopAsync":       HandlerAction0(s.StopAsync),
+	})
+}
+
+// newWriter returns a *writerMultiplexer that has a default writer that writes to log.Printf with the given prefix.
+func newWriter(prefix string) *writerMultiplexer {
+	wm := &writerMultiplexer{}
+	wm.AddWriter(writerFunc(func(p []byte) (n int, err error) {
+		log.Printf("%s%s", prefix, string(p))
+		return n, nil
+	}))
+
+	return wm
+}

--- a/cli/azd/internal/vsrpc/server_session.go
+++ b/cli/azd/internal/vsrpc/server_session.go
@@ -1,0 +1,107 @@
+package vsrpc
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"sync"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/apphost"
+	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
+	"go.lsp.dev/jsonrpc2"
+)
+
+// serverSession represents a logical connection from a single client. Since our RPCs are split over multiple HTTP endpoints,
+// we need a way to correlate these multiple connections together. This is the purpose of the session. Sessions are assigned
+// a unique ID when they are created and are stored in the sessions map. The serverSession object holds a container (created
+// via NewScope from the root container the server uses) as well as a few other bits of state. Since our RPCs run
+// asynchronously, multiple RPCs can be running concurrently on the same session. This means that the serverSession object
+// needs to be safe to access from multiple goroutines. sessionMu is used to protect access to the session itself.
+//
+// TODO(azure/azure-dev#3287): Today we lock the session at the start of each RPC and hold it for the entire lifetime of the
+// RPC. In practice this can be problematic because DeployAsync and RefreshEnvironmentAsync can take a long time to run.
+// Ideally we would do finer grained locking the session itself and know that the rest of the system is safe to run
+// concurrently. To do this we need to get better disciplined about what state we store and how we access it, so for now
+// we just do very coarse grained locking.
+type serverSession struct {
+	// container is the IoC container for the session. It is created during the InitializeAsync by scoping the
+	// root container from the server.
+	container *ioc.NestedContainer
+	// rootPath is the path to the root of the solution.
+	rootPath string
+	// sessionMu protects access to the session.
+	sessionMu sync.Mutex
+	// outWriter is the writer connected to stdout for all azd components in this session.
+	outWriter *writerMultiplexer
+	// errWriter is the writer connected to stderr for all azd components in this session.
+	errWriter *writerMultiplexer
+	// manifestCache is a cache of manifests for the session. The key is the full path to to the app host csproj file.
+	manifestCache map[string]*apphost.Manifest
+	// the path to the app host for this session.
+	appHostPath string
+}
+
+// readManifest reads the manifest for the given app host. It caches the result for future calls.
+func (s *serverSession) readManifest(
+	ctx context.Context, appHostPath string, dotnetCli dotnet.DotNetCli,
+) (*apphost.Manifest, error) {
+	manifest, has := s.manifestCache[appHostPath]
+	if has {
+		return manifest, nil
+	}
+
+	manifest, err := apphost.ManifestFromAppHost(ctx, appHostPath, dotnetCli)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load app host manifest: %w", err)
+	}
+	s.manifestCache[appHostPath] = manifest
+
+	return manifest, nil
+}
+
+// newSession creates a new session and returns the session ID and session. newSession is safe to call by multiple
+// goroutines. A Session can be recovered from an id with [sessionFromId].
+func (s *Server) newSession() (string, *serverSession, error) {
+	b := make([]byte, 8)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", nil, err
+	}
+
+	id := base64.StdEncoding.EncodeToString(b)
+	session := &serverSession{
+		manifestCache: make(map[string]*apphost.Manifest),
+	}
+
+	s.sessionsMu.Lock()
+	defer s.sessionsMu.Unlock()
+	s.sessions[id] = session
+
+	return id, session, nil
+}
+
+// sessionFromId fetches the session with the given ID, if it exists. sessionFromId is safe to call by multiple goroutines.
+func (s *Server) sessionFromId(id string) (*serverSession, bool) {
+	s.sessionsMu.Lock()
+	defer s.sessionsMu.Unlock()
+
+	session, ok := s.sessions[id]
+	return session, ok
+}
+
+// validateSession ensures the session id is valid and returns the corresponding and serverSession object. If there
+// is an error it will be of type *jsonrpc2.Error.
+func (s *Server) validateSession(ctx context.Context, session Session) (*serverSession, error) {
+	if session.Id == "" {
+		return nil, jsonrpc2.NewError(jsonrpc2.InvalidParams, "session.Id is required")
+	}
+
+	serverSession, has := s.sessionFromId(session.Id)
+	if !has {
+		return nil, jsonrpc2.NewError(jsonrpc2.InvalidParams, "session.Id is invalid")
+	}
+
+	return serverSession, nil
+}

--- a/cli/azd/internal/vsrpc/stream.go
+++ b/cli/azd/internal/vsrpc/stream.go
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package vsrpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gorilla/websocket"
+	"go.lsp.dev/jsonrpc2"
+)
+
+// wsStream adapts the websocket.Conn to jsonrpc2.Stream interface
+type wsStream struct {
+	c *websocket.Conn
+}
+
+// Close implements jsonrpc2.Stream.
+func (*wsStream) Close() error {
+	// TODO(azure/azure-dev#3286): Need to think about what to do here.  Close the conn?
+	return nil
+}
+
+// Read implements jsonrpc2.Stream.
+func (s *wsStream) Read(ctx context.Context) (jsonrpc2.Message, int64, error) {
+	mt, data, err := s.c.ReadMessage()
+	if err != nil {
+		return nil, 0, err
+	}
+	if mt != websocket.TextMessage {
+		return nil, 0, fmt.Errorf("unexpected message type: %v", mt)
+	}
+	msg, err := jsonrpc2.DecodeMessage(data)
+	if err != nil {
+		return nil, 0, err
+	}
+	return msg, int64(len(data)), nil
+}
+
+// Write implements jsonrpc2.Stream.
+func (s *wsStream) Write(ctx context.Context, msg jsonrpc2.Message) (int64, error) {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return 0, fmt.Errorf("marshaling message: %w", err)
+	}
+
+	if err := s.c.WriteMessage(websocket.TextMessage, data); err != nil {
+		return 0, err
+	}
+
+	return int64(len(data)), nil
+}
+
+func NewWebSocketStream(c *websocket.Conn) *wsStream {
+	return &wsStream{c: c}
+}

--- a/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/.gitignore
+++ b/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/.gitignore
@@ -1,0 +1,5 @@
+[B|b]in/
+[O|o]bj/
+# This was added after the template was checked in, you can modify
+# so you can modify the file without git pending the edits.
+Settings.cs

--- a/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/.vscode/launch.json
+++ b/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/bin/Debug/net8.0/dotnet-azd-client.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/.vscode/tasks.json
+++ b/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/dotnet-azd-client.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/dotnet-azd-client.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/dotnet-azd-client.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/AzdServices.cs
+++ b/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/AzdServices.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+public class EnvironmentInfo
+{
+    public EnvironmentInfo(string name, bool isCurrent = false)
+    {
+        Name = name;
+        IsCurrent = isCurrent;
+    }
+
+    public string Name { get; }
+
+    public bool IsCurrent { get; }
+}
+
+public class Environment {
+    public string Name { get; set; } = "";
+    public bool IsCurrent { get; set; } = false;
+
+    public Dictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
+
+    public Service[] Services { get; set; } = [];
+
+    public Environment(string name) {
+        Name = name;
+    }
+}
+
+public class AspireHost {
+    public string Name { get; set; } = "";
+    public string Path { get; set; } = "";
+
+    public Service[] Services { get; set; } = [];
+
+    public string? Kind { get; set; }
+    public string? Endpoint { get; set; }
+    public string? ResourceId { get; set; }
+}
+
+public class Service {
+    public string Name { get; set; }  = "";
+	public bool IsExternal { get; set; }
+
+    public string? Kind { get; set;}
+    public string? Endpoint { get; set;}
+    public string? ResourceId { get; set;}
+}
+
+public class Session {
+    public string Id { get; set; } = "";
+}
+
+public class ProgressMessage
+{
+    public ProgressMessage(
+        string message, MessageSeverity severity, DateTime time, MessageKind kind, string code, string additionalInfoLink)
+    {
+        Message = message;
+        Severity = severity;
+        Time = time;
+        Kind = kind;
+        Code = code;
+        AdditionalInfoLink = additionalInfoLink;
+    }
+
+    public string Message;
+    public MessageSeverity Severity;
+    public DateTime Time;
+    public MessageKind Kind;
+    public string Code;
+    public string AdditionalInfoLink;
+
+    public override string ToString() => $"{Time}: {Severity} {Message}";
+}
+
+public enum MessageSeverity
+{
+    Info = 0,
+    Warning = 1,
+    Error = 2,
+}
+
+public enum MessageKind
+{
+    Logging = 0,
+    Important = 1
+}
+
+// To expose this, ensure that AZD_DEBUG_SERVER_DEBUG_ENDPOINTS is set to true when running `azd vs-server`.
+public interface IDebugService {
+    ValueTask<bool> TestCancelAsync(int timeoutMs, CancellationToken cancellationToken);
+    ValueTask TestIObserverAsync(int max, IObserver<int> observer, CancellationToken cancellationToken);
+}
+
+public interface IServerService {
+    ValueTask<Session> InitializeAsync(string rootPath, CancellationToken cancellationToken);
+}
+
+public interface IEnvironmentService {
+    ValueTask<IEnumerable<EnvironmentInfo>> GetEnvironmentsAsync(Session s, IObserver<ProgressMessage> outputObserver, CancellationToken cancellationToken);
+    ValueTask<Environment> OpenEnvironmentAsync(Session s, string envName, IObserver<ProgressMessage> outputObserver, CancellationToken cancellationToken);
+    ValueTask<Environment> LoadEnvironmentAsync(Session s, string envName, IObserver<ProgressMessage> outputObserver, CancellationToken cancellationToken);
+    ValueTask<Environment> RefreshEnvironmentAsync(Session s, string envName, IObserver<ProgressMessage> outputObserver, CancellationToken cancellationToken);
+    ValueTask<bool> CreateEnvironmentAsync(Session s, Environment newEnv,IObserver<ProgressMessage> outputObserver,  CancellationToken cancellationToken);
+    ValueTask<bool> SetCurrentEnvironmentAsync(Session s, string envName, IObserver<ProgressMessage> outputObserver, CancellationToken cancellationToken);
+    ValueTask<Environment> DeployAsync(Session s, string envName, IObserver<ProgressMessage> outputObserver, CancellationToken cancellationToken);
+}
+
+public interface IAspireService {
+    ValueTask<AspireHost> GetAspireHostAsync(Session s, string aspireEnvironment, IObserver<ProgressMessage> outputObserver, CancellationToken cancellationToken);
+}

--- a/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/Program.cs
+++ b/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/Program.cs
@@ -1,0 +1,211 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net.WebSockets;
+using StreamJsonRpc;
+
+ClientWebSocket wsClientES = new ClientWebSocket();
+await wsClientES.ConnectAsync(new Uri("ws://127.0.0.1:8080/EnvironmentService/v1.0"), CancellationToken.None);
+
+ClientWebSocket wsClientAS = new ClientWebSocket();
+await wsClientAS.ConnectAsync(new Uri("ws://127.0.0.1:8080/AspireService/v1.0"), CancellationToken.None);
+
+ClientWebSocket wsClientSS = new ClientWebSocket();
+await wsClientSS.ConnectAsync(new Uri("ws://127.0.0.1:8080/ServerService/v1.0"), CancellationToken.None);
+
+ClientWebSocket wsClientDS = new ClientWebSocket();
+await wsClientDS.ConnectAsync(new Uri("ws://127.0.0.1:8080/TestDebugService/v1.0"), CancellationToken.None);
+
+IEnvironmentService esSvc = JsonRpc.Attach<IEnvironmentService>(new WebSocketMessageHandler(wsClientES));
+IAspireService asSvc = JsonRpc.Attach<IAspireService>(new WebSocketMessageHandler(wsClientAS));
+IServerService ssSvc = JsonRpc.Attach<IServerService>(new WebSocketMessageHandler(wsClientSS));
+IDebugService dsSvc = JsonRpc.Attach<IDebugService>(new WebSocketMessageHandler(wsClientDS));
+
+{
+    Console.WriteLine("== Testing Cancel ==");
+    var cts = new CancellationTokenSource();
+    var t = dsSvc.TestCancelAsync(1000 * 10, cts.Token);
+    await Task.Delay(1000);
+    Console.WriteLine("Cancelling");
+    cts.Cancel();
+    Console.WriteLine("Observing Task");
+    try {
+        var result = await t;
+        Console.WriteLine($"TestCancelAsync completed with result: {result}");
+    } catch (TaskCanceledException) {
+        Console.WriteLine($"TestCancelAsync was cancelled");
+    } catch (Exception e) {
+        Console.WriteLine($"TestCancelAsync threw unexpected exception: {e}");
+    }
+}
+
+{
+    Console.WriteLine("== Testing IObservable ==");
+    var intObserver = new WriterObserver<int>();
+    var t = dsSvc.TestIObserverAsync(10, intObserver, CancellationToken.None);
+    await Task.Delay(2000);
+    await t;
+    Console.WriteLine("== Done Testing IObservable ==");
+}
+
+await RunLifecycle();
+
+/*
+ * Run an end to end life cycle test for AZD, we do the following steps:
+ * 1. Initialize a new session.
+ * 2. Call GetAspireHostAsync to fetch information about the host and print it.
+ * 3. Call GetEnvironmentsAsync to fetch information about each environment and print it.
+ * 4. If the Environment set in the EnvironmentName variable does not exist, create it.
+ * 5. Call GetEnvironmentsAsync to fetch information about each environment and print it.
+ * 6. Call OpenEnvironmentAsync to fetch brief information about the specific environment and print it.
+ * 7. Call LoadEnvironmentAsync to fetch more detailed information about the specific environment and print it.
+ * 8. Call RefreshEnvironmentAsync to fetch even more detailed information about the specific environment and print it.
+ * 9. Call DeployAsync to deploy the specific environment, writing the output to stdout and then printing the result.
+ * 10. Call SetCurrentEnvironmentAsync to set the specific environment as the current environment.
+ */
+#pragma warning disable CS8321 // The local function 'RunLifecycle' is declared but never used
+async Task RunLifecycle() {
+#pragma warning restore CS8321 // The local function 'RunLifecycle' is declared but never used
+    if (string.IsNullOrEmpty(Settings.RootPath)) {
+        throw new ArgumentException("RootPath must be set");
+    }
+
+    if (string.IsNullOrEmpty(Settings.EnvironmentName)) {
+        throw new ArgumentException("EnvironmentName must be set");
+    }
+
+    if (string.IsNullOrEmpty(Settings.SubscriptionId)) {
+        throw new ArgumentException("SubscriptionId must be set");
+    }
+
+    if (string.IsNullOrEmpty(Settings.Location)) {
+        throw new ArgumentException("Location must be set");
+    }
+
+    bool hasEnvironment = false;
+
+    IObserver<ProgressMessage> observer = new WriterObserver<ProgressMessage>();
+
+    Console.WriteLine($"== Initializing ==");
+    var session = await ssSvc.InitializeAsync(Settings.RootPath, CancellationToken.None);
+    Console.WriteLine($"== Done Initializing ==");
+
+    {
+        Console.WriteLine("== Getting Host Info: Production ==");
+        var result = await asSvc.GetAspireHostAsync(session, "Production", observer, CancellationToken.None);   
+        Console.WriteLine($"Aspire Host: {result.Name} ({result.Path})");
+        foreach (Service s in result.Services) {
+            Console.WriteLine($"  Service: {s.Name} ({s.IsExternal})");
+        }
+        Console.WriteLine("== Got Host Info ==");
+    }
+
+    { 
+        Console.WriteLine("== Getting Environments ==");
+        foreach (var e in await esSvc.GetEnvironmentsAsync(session, observer, CancellationToken.None)) {
+            Console.WriteLine($"Environment: {e.Name} IsCurrent: {e.IsCurrent}");           
+            hasEnvironment = hasEnvironment || e.Name == Settings.EnvironmentName;
+        }
+        Console.WriteLine("== Got Environments ==");
+    }
+
+    if (!hasEnvironment)
+    {
+        Console.WriteLine($"== Creating Environment: {Settings.EnvironmentName} ==");
+        Environment e = new Environment(Settings.EnvironmentName) {
+            Properties = new Dictionary<string, string>() {
+                { "ASPIRE_ENVIRONMENT", "Production" },
+                { "Subscription", Settings.SubscriptionId },
+                { "Location", Settings.Location}
+            },
+            Services = [
+                new Service() {
+                    Name = "apiservice",
+                    IsExternal = false,
+                },
+                new Service() {
+                    Name = "webfrontend",
+                    IsExternal = true,
+                }
+            ],
+        };
+
+        var result = await esSvc.CreateEnvironmentAsync(session, e, observer, CancellationToken.None);
+        Console.WriteLine($"Created environment: {result}");
+        Console.WriteLine("== Done Creating Environment ==");
+    }
+
+    { 
+        Console.WriteLine("== Getting Environments ==");
+        foreach (var e in await esSvc.GetEnvironmentsAsync(session, observer, CancellationToken.None)) {
+            Console.WriteLine($"Environment: {e.Name} IsCurrent: {e.IsCurrent}");
+        }
+        Console.WriteLine("== Done Getting Environments ==");
+    }
+
+    { 
+        Console.WriteLine($"== Opening Environment: {Settings.EnvironmentName} ==");
+        var result = await esSvc.OpenEnvironmentAsync(session, Settings.EnvironmentName, observer, CancellationToken.None);
+        WriteEnvironment(result);
+        Console.WriteLine($"== Done Environment: {Settings.EnvironmentName} ==");
+    }
+
+
+    { 
+        Console.WriteLine($"== Loading Environment: {Settings.EnvironmentName} ==");
+        var result = await esSvc.LoadEnvironmentAsync(session, Settings.EnvironmentName, observer, CancellationToken.None);
+        WriteEnvironment(result);
+        Console.WriteLine($"== Done Loading Environment: {Settings.EnvironmentName} ==");
+    }
+
+    { 
+        Console.WriteLine($"== Refreshing Environment: {Settings.EnvironmentName} ==");
+        var result = await esSvc.RefreshEnvironmentAsync(session, Settings.EnvironmentName, observer, CancellationToken.None);
+        WriteEnvironment(result);
+        Console.WriteLine($"== Done Refreshing Environment: {Settings.EnvironmentName} ==");
+    }
+
+    {
+        Console.WriteLine($"== Deploying Environment: {Settings.EnvironmentName} ==");
+        var result = await esSvc.DeployAsync(session, Settings.EnvironmentName, observer, CancellationToken.None);
+        WriteEnvironment(result);
+        Console.WriteLine("== Done Deploying Environment ==");
+    }
+
+    {
+        Console.WriteLine($"== Setting Current Environment: {Settings.EnvironmentName} ==");
+        var result = await esSvc.SetCurrentEnvironmentAsync(session, Settings.EnvironmentName, observer, CancellationToken.None);
+        Console.WriteLine($"Result: {result}");
+        Console.WriteLine("== Done Setting Current Environment ==");
+    }
+}
+
+
+#pragma warning disable CS8321 // The local function 'WriteEnvironment' is declared but never used
+void WriteEnvironment(Environment e) {
+#pragma warning restore CS8321 // The local function 'WriteEnvironment' is declared but never used
+    Console.WriteLine($"Environment: {e.Name} {e.IsCurrent}");
+    foreach (Service s in e.Services) {
+         Console.WriteLine($"  Service: {s.Name}");
+         Console.WriteLine($"    External: {s.IsExternal}");
+         Console.WriteLine($"    Endpoint: {s.Endpoint}");
+         Console.WriteLine($"    Resource: {s.ResourceId}");
+    }
+    foreach (KeyValuePair<string, string> kvp in e.Properties) {
+         Console.WriteLine($"  Property: {kvp.Key} = {kvp.Value}");
+    }
+}
+
+class WriterObserver<ProgressMessage> : IObserver<ProgressMessage>
+{
+    public void OnCompleted() => Console.WriteLine("Completed");
+    public void OnError(Exception error) => Console.WriteLine($"Error: {error}");
+    public void OnNext(ProgressMessage value) {
+        var msg = value!.ToString()!;
+        if (msg[msg.Length-1] == '\n') {
+            Console.Write(msg);
+        } else {
+            Console.WriteLine(msg);
+        }
+    }
+}

--- a/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/Settings.Template.cs
+++ b/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/Settings.Template.cs
@@ -1,0 +1,15 @@
+// Copy this file's contents to Settings.cs and fill in the values. Settings.cs is in the .gitignore file so it won't be
+// Checked in.
+/*
+public static class Settings {
+    // The name of the environment to create and use as part of the RunLifecycle function.
+    public const string EnvironmentName = "";
+    // The Root Path to the Aspire solution to use as part of the RunLifecycle function. The test expects this to be
+    // a folder with the output of `dotnet new aspire-starter` in it.
+    public const string RootPath = ""; 
+    // The SubscriptionId to use as part of the RunLifecycle function when creating a new environment.
+    public const string SubscriptionId = "";
+    // The Location to use as part of the RunLifecycle function when creating a new environment.
+    public const string Location = "";
+}
+*/

--- a/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/dotnet-azd-client.csproj
+++ b/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/dotnet-azd-client.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>dotnet_azd_client</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StreamJsonRpc" Version="2.17.8" />
+  </ItemGroup>
+
+</Project>

--- a/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/dotnet-azd-client.sln
+++ b/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/dotnet-azd-client.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-azd-client", "dotnet-azd-client.csproj", "{52FFE814-829C-42EA-A6FB-4EF1AAFE3EB4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{52FFE814-829C-42EA-A6FB-4EF1AAFE3EB4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52FFE814-829C-42EA-A6FB-4EF1AAFE3EB4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52FFE814-829C-42EA-A6FB-4EF1AAFE3EB4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52FFE814-829C-42EA-A6FB-4EF1AAFE3EB4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F9693DD1-6A70-4356-99B2-9A29497E7D12}
+	EndGlobalSection
+EndGlobal

--- a/cli/azd/internal/vsrpc/utils.go
+++ b/cli/azd/internal/vsrpc/utils.go
@@ -1,0 +1,45 @@
+package vsrpc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/apphost"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
+)
+
+// appHostServiceForProject returns the ServiceConfig of the service for the AppHost project for the given azd project.
+func appHostForProject(
+	ctx context.Context, pc *project.ProjectConfig, dotnetCli dotnet.DotNetCli,
+) (*project.ServiceConfig, error) {
+	for _, service := range pc.Services {
+		if service.Language == project.ServiceLanguageDotNet {
+			isAppHost, err := dotnetCli.GetMsBuildProperty(ctx, service.Path(), "IsAspireHost")
+			if err != nil {
+				log.Printf("error checking if %s is an app host project: %v", service.Path(), err)
+			}
+			if strings.TrimSpace(isAppHost) == "true" {
+				return service, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no app host project found for project: %s", pc.Name)
+}
+
+func servicesFromManifest(manifest *apphost.Manifest) []*Service {
+	var services []*Service
+
+	for name, res := range manifest.Resources {
+		if res.Type == "project.v0" {
+			services = append(services, &Service{
+				Name: name,
+			})
+		}
+	}
+
+	return services
+}

--- a/cli/azd/internal/vsrpc/writer_multiplexer.go
+++ b/cli/azd/internal/vsrpc/writer_multiplexer.go
@@ -1,0 +1,56 @@
+package vsrpc
+
+import (
+	"io"
+	"sync"
+)
+
+// writerMultiplexer is an io.Writer that writes to multiple io.Writers and allows these writers to be added and removed
+// dynamically.
+type writerMultiplexer struct {
+	writers []io.Writer
+	mu      sync.Mutex
+}
+
+// Write writes the given bytes to all the writers in the multiplexer.
+func (m *writerMultiplexer) Write(p []byte) (n int, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, w := range m.writers {
+		n, err = w.Write(p)
+		if err != nil {
+			return n, err
+		}
+	}
+	return n, nil
+}
+
+// AddWriter adds a writer to the multiplexer.
+func (m *writerMultiplexer) AddWriter(w io.Writer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.writers = append(m.writers, w)
+}
+
+// RemoveWriter removes a writer from the multiplexer.
+func (m *writerMultiplexer) RemoveWriter(w io.Writer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for i, writer := range m.writers {
+		if writer == w {
+			m.writers = append(m.writers[:i], m.writers[i+1:]...)
+			return
+		}
+	}
+}
+
+// writerFunc is an io.Writer implemented by a function.
+type writerFunc func(p []byte) (n int, err error)
+
+// Write implements the io.Writer interface.
+func (f writerFunc) Write(p []byte) (n int, err error) {
+	return f(p)
+}

--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -165,7 +165,7 @@ func Inputs(manifest *Manifest) (map[string]Input, error) {
 	return res, nil
 }
 
-// GenerateProjectArtifacts generates all the artifacts to manage a project with `azd`. Te azure.yaml file as well as
+// GenerateProjectArtifacts generates all the artifacts to manage a project with `azd`. The azure.yaml file as well as
 // a helpful next-steps.md file.
 func GenerateProjectArtifacts(
 	ctx context.Context, projectDir string, projectName string, manifest *Manifest, appHostProject string,

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -181,6 +181,21 @@ func (p *BicepProvider) EnsureEnv(ctx context.Context) error {
 	return nil
 }
 
+func (p *BicepProvider) LastDeployment(ctx context.Context) (*armresources.DeploymentExtended, error) {
+	modulePath := p.modulePath()
+	compileResult, err := p.compileBicep(ctx, modulePath)
+	if err != nil {
+		return nil, fmt.Errorf("compiling bicep template: %w", err)
+	}
+
+	scope, err := p.scopeForTemplate(ctx, compileResult.Template)
+	if err != nil {
+		return nil, fmt.Errorf("computing deployment scope: %w", err)
+	}
+
+	return p.latestDeploymentResult(ctx, scope)
+}
+
 func (p *BicepProvider) State(ctx context.Context, options *StateOptions) (*StateResult, error) {
 	if options == nil {
 		options = &StateOptions{}
@@ -453,7 +468,7 @@ func (p *BicepProvider) deploymentState(
 	return prevDeploymentResult, nil
 }
 
-// prevDeploymentResult looks and finds a previous deployment for the current azd project.
+// latestDeploymentResult looks and finds a previous deployment for the current azd project.
 func (p *BicepProvider) latestDeploymentResult(
 	ctx context.Context,
 	scope infra.Scope,

--- a/cli/azd/pkg/ioc/container.go
+++ b/cli/azd/pkg/ioc/container.go
@@ -47,6 +47,11 @@ func NewNestedContainer(parent *NestedContainer) *NestedContainer {
 	return instance
 }
 
+// Fill takes a structure and resolves fields with the tag `container:"type" or `container:"name"`.
+func (c *NestedContainer) Fill(structure any) error {
+	return c.inner.Fill(structure)
+}
+
 // Registers a resolver with a singleton lifetime
 // Returns an error if the resolver is not valid
 func (c *NestedContainer) RegisterSingleton(resolveFn any) error {

--- a/cli/azd/test/functional/initialize_test.go
+++ b/cli/azd/test/functional/initialize_test.go
@@ -73,6 +73,7 @@ func testCommand(
 	ctx context.Context,
 	chain []*actions.MiddlewareRegistration,
 	cwd string) {
+
 	// Run the command when we find a leaf command
 	if testCmd.Runnable() {
 		t.Run(testCmd.CommandPath(), func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/gofrs/flock v0.8.1
 	github.com/golobby/container/v3 v3.3.1
 	github.com/google/uuid v1.3.1
+	github.com/gorilla/websocket v1.5.1
 	github.com/joho/godotenv v1.4.0
 	github.com/magefile/mage v1.12.1
 	github.com/mattn/go-colorable v0.1.12
@@ -50,6 +51,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
 	github.com/theckman/yacspin v0.13.12
+	go.lsp.dev/jsonrpc2 v0.10.0
 	go.opentelemetry.io/otel v1.8.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.8.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.8.0
@@ -88,6 +90,8 @@ require (
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.3.4 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.8.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -300,6 +300,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
+github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
+github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 h1:BZHcxBETFHIdVyhyEfOvn/RdU/QGdLI4y34qQGjGWO0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
@@ -460,6 +462,10 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.3.4 h1:WM4IBnxH8B9TakiM2QD5LyNl9JSndh88QbHqVC+Pauc=
+github.com/segmentio/encoding v0.3.4/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
 github.com/sethvargo/go-retry v0.2.3 h1:oYlgvIvsju3jNbottWABtbnoLC+GDtLdBHxKWxQm/iU=
 github.com/sethvargo/go-retry v0.2.3/go.mod h1:1afjQuvh7s4gflMObvjLPaWgluLLyhA1wmVZ6KLpICw=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -503,6 +509,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 go.etcd.io/etcd/api/v3 v3.5.1/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
+go.lsp.dev/jsonrpc2 v0.10.0 h1:Pr/YcXJoEOTMc/b6OTmcR1DPJ3mSWl/SWiU1Cct6VmI=
+go.lsp.dev/jsonrpc2 v0.10.0/go.mod h1:fmEzIdXPi/rf6d4uFcayi8HpFP1nBF99ERP1htC72Ac=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -725,6 +733,7 @@ golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
This change adds a new command to `azd`, `azd vs-server`.  When run,
`azd` starts a listener on `127.0.0.1` and prints a JSON object
containing the port it is listing on and its PID followed by a newline
to standard out.

Clients may connect via WebSockets to one of three services:

- `ws://127.0.0.1:XYZ/EnvironmentService/v1.0`
- `ws://127.0.0.1:XYZ/ServerService/v1.0`
- `ws://127.0.0.1:XYZ/AspireService/v1.0`

Each of these corresponds to a set of services VS Expects (their names
map to the I<Foo>Service.cs interfaces in their source tree)

The general interaction model is that a client connects and calls the
`InitializeAsync` method on the `ServerService` service which gives it
back an opqaue session ID. The client can then call any methods on the
`EnvironmentService` or `AspireService`. Internally the server tracks
these ids to allow caching of data between a single logical
connection. Each session also contains a scoped IoC container which is
used for resolving dependencies, allowing us to leverage much of the
existing `azd` implementation.  We do need to think long term about
lifetime in this new model, but things seem to hang together okay
right now.

Most methods have an `IObserver<ProgressMessage>` parameter that
allows `azd` to write messages during operations back to VS.  This
uses some special features of the `StreamJsonRpc` package, from .NET,
we implement their strategy to allow it to marshal a proxy for the
IObserver to us, which we can then call `onNext` on.

You can use `StreamJsonRpc` (as VS Does) to interact with these
endpoints. A small test program is included in
`vsrpc/testdata/dotnet-azd-client` which exercises these RPCs and
writes log output which can be helpful when debugging the server. It
expects to connect to the server on port 8080, so use the `--port
8080` flag when launching the server.

Fixes #276