### PR TITLE
Adds support for Helm and Kustomize for AKS service target

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -88,6 +88,10 @@ overrides:
   - filename: pkg/azsdk/storage/storage_blob_client.go
     words:
       - azblob
+  - filename: pkg/project/service_target_aks.go
+    words:
+      - kustomization
+      - templating
 ignorePaths:
   - "**/*_test.go"
   - "**/mock*.go"

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -28,12 +28,14 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/helm"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/azure/azure-dev/cli/azd/pkg/kubelogin"
+	"github.com/azure/azure-dev/cli/azd/pkg/kustomize"
 	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/pipeline"
@@ -466,6 +468,8 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.MustRegisterSingleton(kubectl.NewKubectl)
 	container.MustRegisterSingleton(maven.NewMavenCli)
 	container.MustRegisterSingleton(kubelogin.NewCli)
+	container.MustRegisterSingleton(helm.NewCli)
+	container.MustRegisterSingleton(kustomize.NewCli)
 	container.MustRegisterSingleton(npm.NewNpmCli)
 	container.MustRegisterSingleton(python.NewPythonCli)
 	container.MustRegisterSingleton(swa.NewSwaCli)
@@ -481,7 +485,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 
 	// Service Targets
 	serviceTargetMap := map[project.ServiceTargetKind]any{
-		"":                               project.NewAppServiceTarget,
+		project.NonSpecifiedTarget:       project.NewAppServiceTarget,
 		project.AppServiceTarget:         project.NewAppServiceTarget,
 		project.AzureFunctionTarget:      project.NewFunctionAppTarget,
 		project.ContainerAppTarget:       project.NewContainerAppTarget,
@@ -497,7 +501,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 
 	// Languages
 	frameworkServiceMap := map[project.ServiceLanguageKind]any{
-		"":                                project.NewDotNetProject,
+		project.ServiceLanguageNone:       project.NewNoOpProject,
 		project.ServiceLanguageDotNet:     project.NewDotNetProject,
 		project.ServiceLanguageCsharp:     project.NewDotNetProject,
 		project.ServiceLanguageFsharp:     project.NewDotNetProject,

--- a/cli/azd/pkg/helm/cli.go
+++ b/cli/azd/pkg/helm/cli.go
@@ -1,0 +1,167 @@
+package helm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+)
+
+type Cli struct {
+	commandRunner exec.CommandRunner
+}
+
+func NewCli(commandRunner exec.CommandRunner) *Cli {
+	return &Cli{
+		commandRunner: commandRunner,
+	}
+}
+
+// Gets the name of the Tool
+func (cli *Cli) Name() string {
+	return "helm"
+}
+
+// Returns the installation URL to install the Helm CLI
+func (cli *Cli) InstallUrl() string {
+	return "https://aka.ms/azure-dev/helm-install"
+}
+
+// Checks whether or not the Helm CLI is installed and available within the PATH
+func (cli *Cli) CheckInstalled(ctx context.Context) error {
+	if err := tools.ToolInPath("helm"); err != nil {
+		return err
+	}
+
+	// We don't have a minimum required version of helm today, but
+	// for diagnostics purposes, let's fetch and log the version of helm
+	// we're using.
+	if ver, err := cli.getClientVersion(ctx); err != nil {
+		log.Printf("error fetching helm version: %s", err)
+	} else {
+		log.Printf("helm version: %s", ver)
+	}
+
+	return nil
+}
+
+// AddRepo adds a helm repo with the specified name and url
+func (c *Cli) AddRepo(ctx context.Context, repo *Repository) error {
+	runArgs := exec.NewRunArgs("helm", "repo", "add", repo.Name, repo.Url)
+	_, err := c.commandRunner.Run(ctx, runArgs)
+	if err != nil {
+		return fmt.Errorf("failed to add repo %s: %w", repo.Name, err)
+	}
+
+	return nil
+}
+
+// UpdateRepo updates the helm repo with the specified name
+func (c *Cli) UpdateRepo(ctx context.Context, repoName string) error {
+	runArgs := exec.NewRunArgs("helm", "repo", "update", repoName)
+	_, err := c.commandRunner.Run(ctx, runArgs)
+	if err != nil {
+		return fmt.Errorf("failed to add repo %s: %w", repoName, err)
+	}
+
+	return nil
+}
+
+// Install installs a helm release
+func (c *Cli) Install(ctx context.Context, release *Release) error {
+	runArgs := exec.NewRunArgs("helm", "install", release.Name, release.Chart)
+	if release.Values != "" {
+		runArgs = runArgs.AppendParams("--values", release.Values)
+	}
+
+	_, err := c.commandRunner.Run(ctx, runArgs)
+	if err != nil {
+		return fmt.Errorf("failed to install helm chart %s: %w", release.Chart, err)
+	}
+
+	return nil
+}
+
+// Upgrade upgrades a helm release to the specified version
+// If the release did not previously exist, it will be installed
+func (c *Cli) Upgrade(ctx context.Context, release *Release) error {
+	runArgs := exec.NewRunArgs("helm", "upgrade", release.Name, release.Chart, "--install", "--wait")
+	if release.Version != "" {
+		runArgs = runArgs.AppendParams("--version", release.Version)
+	}
+
+	if release.Values != "" {
+		runArgs = runArgs.AppendParams("--values", release.Values)
+	}
+
+	if release.Namespace != "" {
+		runArgs = runArgs.AppendParams(
+			"--namespace", release.Namespace,
+			"--create-namespace",
+		)
+	}
+
+	_, err := c.commandRunner.Run(ctx, runArgs)
+	if err != nil {
+		return fmt.Errorf("failed to install helm chart %s: %w", release.Chart, err)
+	}
+
+	return nil
+}
+
+// Status returns the status of a helm release
+func (c *Cli) Status(ctx context.Context, release *Release) (*StatusResult, error) {
+	runArgs := exec.NewRunArgs("helm", "status", release.Name, "--output", "json")
+	if release.Namespace != "" {
+		runArgs = runArgs.AppendParams("--namespace", release.Namespace)
+	}
+
+	runResult, err := c.commandRunner.Run(ctx, runArgs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query status for helm chart %s: %w", release.Chart, err)
+	}
+
+	var result *StatusResult
+	if err := json.Unmarshal([]byte(runResult.Stdout), &result); err != nil {
+		return nil, fmt.Errorf("failed to parse status for helm chart %s: %w", release.Chart, err)
+	}
+
+	return result, nil
+}
+
+func (cli *Cli) getClientVersion(ctx context.Context) (string, error) {
+	runArgs := exec.NewRunArgs("helm", "version", "--template", "{{.Version}}")
+	versionResult, err := cli.commandRunner.Run(ctx, runArgs)
+	if err != nil {
+		return "", fmt.Errorf("fetching helm version: %w", err)
+	}
+
+	return versionResult.Stdout[1:], nil
+}
+
+// StatusResult is the result of a helm status command
+type StatusResult struct {
+	Name      string     `json:"name"`
+	Info      StatusInfo `json:"info"`
+	Version   float64    `json:"version"`
+	Namespace string     `json:"namespace"`
+}
+
+// StatusInfo is the status information of a helm release
+type StatusInfo struct {
+	FirstDeployed time.Time  `json:"first_deployed"`
+	LastDeployed  time.Time  `json:"last_deployed"`
+	Status        StatusKind `json:"status"`
+	Notes         string     `json:"notes"`
+}
+
+type StatusKind string
+
+const (
+	// StatusKindDeployed is the status of a helm release that has been deployed
+	StatusKindDeployed StatusKind = "deployed"
+)

--- a/cli/azd/pkg/helm/cli_test.go
+++ b/cli/azd/pkg/helm/cli_test.go
@@ -1,0 +1,474 @@
+package helm
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Cli_AddRepo(t *testing.T) {
+	repo := &Repository{
+		Name: "test",
+		Url:  "https://test.com",
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		ran := false
+		var runArgs exec.RunArgs
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "helm repo add")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				runArgs = args
+				return exec.NewRunResult(0, "", ""), nil
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		err := cli.AddRepo(*mockContext.Context, repo)
+		require.True(t, ran)
+		require.NoError(t, err)
+
+		require.Equal(t, "helm", runArgs.Cmd)
+		require.Equal(t, []string{
+			"repo",
+			"add",
+			"test",
+			"https://test.com",
+		}, runArgs.Args)
+	})
+
+	t.Run("Failure", func(t *testing.T) {
+		ran := false
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "helm repo add")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				return exec.NewRunResult(1, "", ""), errors.New("failed to add repo")
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		err := cli.AddRepo(*mockContext.Context, repo)
+
+		require.True(t, ran)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to add repo")
+	})
+}
+
+func Test_Cli_UpdateRepo(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		ran := false
+		var runArgs exec.RunArgs
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "helm repo update")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				runArgs = args
+				return exec.NewRunResult(0, "", ""), nil
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		err := cli.UpdateRepo(*mockContext.Context, "test")
+		require.True(t, ran)
+		require.NoError(t, err)
+
+		require.Equal(t, "helm", runArgs.Cmd)
+		require.Equal(t, []string{
+			"repo",
+			"update",
+			"test",
+		}, runArgs.Args)
+	})
+
+	t.Run("Failure", func(t *testing.T) {
+		ran := false
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "helm repo update")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				return exec.NewRunResult(1, "", ""), errors.New("failed to update repo")
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		err := cli.UpdateRepo(*mockContext.Context, "test")
+
+		require.True(t, ran)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to update repo")
+	})
+}
+
+func Test_Cli_Install(t *testing.T) {
+	release := &Release{
+		Name:    "test",
+		Chart:   "test/chart",
+		Version: "1.0.0",
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		ran := false
+		var runArgs exec.RunArgs
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "helm install")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				runArgs = args
+				return exec.NewRunResult(0, "", ""), nil
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		err := cli.Install(*mockContext.Context, release)
+		require.True(t, ran)
+		require.NoError(t, err)
+
+		require.Equal(t, "helm", runArgs.Cmd)
+		require.Equal(t, []string{
+			"install",
+			"test",
+			"test/chart",
+		}, runArgs.Args)
+	})
+
+	t.Run("WithValues", func(t *testing.T) {
+		ran := false
+		var runArgs exec.RunArgs
+
+		releaseWithValues := *release
+		releaseWithValues.Values = "values.yaml"
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "helm install")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				runArgs = args
+				return exec.NewRunResult(0, "", ""), nil
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		err := cli.Install(*mockContext.Context, &releaseWithValues)
+		require.True(t, ran)
+		require.NoError(t, err)
+
+		require.Equal(t, "helm", runArgs.Cmd)
+		require.Equal(t, []string{
+			"install",
+			"test",
+			"test/chart",
+			"--values",
+			"values.yaml",
+		}, runArgs.Args)
+	})
+
+	t.Run("Failure", func(t *testing.T) {
+		ran := false
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "helm install")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				return exec.NewRunResult(1, "", ""), errors.New("failed to install release")
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		err := cli.Install(*mockContext.Context, release)
+
+		require.True(t, ran)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to install release")
+	})
+}
+
+func Test_Cli_Upgrade(t *testing.T) {
+	release := &Release{
+		Name:  "test",
+		Chart: "test/chart",
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		ran := false
+		var runArgs exec.RunArgs
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "helm upgrade")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				runArgs = args
+				return exec.NewRunResult(0, "", ""), nil
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		err := cli.Upgrade(*mockContext.Context, release)
+		require.True(t, ran)
+		require.NoError(t, err)
+
+		require.Equal(t, "helm", runArgs.Cmd)
+		require.Equal(t, []string{
+			"upgrade",
+			"test",
+			"test/chart",
+			"--install",
+			"--wait",
+		}, runArgs.Args)
+	})
+
+	t.Run("WithValues", func(t *testing.T) {
+		ran := false
+		var runArgs exec.RunArgs
+
+		releaseWithValues := *release
+		releaseWithValues.Values = "values.yaml"
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "helm upgrade")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				runArgs = args
+				return exec.NewRunResult(0, "", ""), nil
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		err := cli.Upgrade(*mockContext.Context, &releaseWithValues)
+		require.True(t, ran)
+		require.NoError(t, err)
+
+		require.Equal(t, "helm", runArgs.Cmd)
+		require.Equal(t, []string{
+			"upgrade",
+			"test",
+			"test/chart",
+			"--install",
+			"--wait",
+			"--values",
+			"values.yaml",
+		}, runArgs.Args)
+	})
+
+	t.Run("WithVersion", func(t *testing.T) {
+		ran := false
+		var runArgs exec.RunArgs
+
+		releaseWithVersion := *release
+		releaseWithVersion.Version = "1.0.0"
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "helm upgrade")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				runArgs = args
+				return exec.NewRunResult(0, "", ""), nil
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		err := cli.Upgrade(*mockContext.Context, &releaseWithVersion)
+		require.True(t, ran)
+		require.NoError(t, err)
+
+		require.Equal(t, "helm", runArgs.Cmd)
+		require.Equal(t, []string{
+			"upgrade",
+			"test",
+			"test/chart",
+			"--install",
+			"--wait",
+			"--version",
+			"1.0.0",
+		}, runArgs.Args)
+	})
+
+	t.Run("WithNamespace", func(t *testing.T) {
+		ran := false
+		var runArgs exec.RunArgs
+
+		releaseWithNamespace := *release
+		releaseWithNamespace.Namespace = "test-namespace"
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "helm upgrade")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				runArgs = args
+				return exec.NewRunResult(0, "", ""), nil
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		err := cli.Upgrade(*mockContext.Context, &releaseWithNamespace)
+		require.True(t, ran)
+		require.NoError(t, err)
+
+		require.Equal(t, "helm", runArgs.Cmd)
+		require.Equal(t, []string{
+			"upgrade",
+			"test",
+			"test/chart",
+			"--install",
+			"--wait",
+			"--namespace",
+			"test-namespace",
+			"--create-namespace",
+		}, runArgs.Args)
+	})
+
+	t.Run("Failure", func(t *testing.T) {
+		ran := false
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "helm upgrade")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				return exec.NewRunResult(1, "", ""), errors.New("failed to upgrade release")
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		err := cli.Upgrade(*mockContext.Context, release)
+
+		require.True(t, ran)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to upgrade release")
+	})
+}
+
+func Test_Cli_Status(t *testing.T) {
+	release := &Release{
+		Name: "test",
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		ran := false
+		var runArgs exec.RunArgs
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "helm status")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				runArgs = args
+				return exec.NewRunResult(0, `{
+					"info": {
+						"status": "deployed"
+					}
+				}`, ""), nil
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		status, err := cli.Status(*mockContext.Context, release)
+		require.True(t, ran)
+		require.NoError(t, err)
+		require.Equal(t, StatusKindDeployed, status.Info.Status)
+
+		require.Equal(t, "helm", runArgs.Cmd)
+		require.Equal(t, []string{
+			"status",
+			"test",
+			"--output",
+			"json",
+		}, runArgs.Args)
+	})
+
+	t.Run("WithNamespace", func(t *testing.T) {
+		ran := false
+		var runArgs exec.RunArgs
+
+		releaseWithNamespace := *release
+		releaseWithNamespace.Namespace = "test-namespace"
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "helm status")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				runArgs = args
+				return exec.NewRunResult(0, `{
+					"info": {
+						"status": "deployed"
+					}
+				}`, ""), nil
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		status, err := cli.Status(*mockContext.Context, &releaseWithNamespace)
+		require.True(t, ran)
+		require.NoError(t, err)
+		require.Equal(t, StatusKindDeployed, status.Info.Status)
+
+		require.Equal(t, "helm", runArgs.Cmd)
+		require.Equal(t, []string{
+			"status",
+			"test",
+			"--output",
+			"json",
+			"--namespace",
+			"test-namespace",
+		}, runArgs.Args)
+	})
+
+	t.Run("Failure", func(t *testing.T) {
+		ran := false
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "helm status")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				return exec.NewRunResult(1, "", ""), errors.New("failed to get status")
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		_, err := cli.Status(*mockContext.Context, release)
+
+		require.True(t, ran)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to get status")
+	})
+}

--- a/cli/azd/pkg/helm/config.go
+++ b/cli/azd/pkg/helm/config.go
@@ -1,0 +1,19 @@
+package helm
+
+type Config struct {
+	Repositories []*Repository `yaml:"repositories"`
+	Releases     []*Release    `yaml:"releases"`
+}
+
+type Repository struct {
+	Name string `yaml:"name"`
+	Url  string `yaml:"url"`
+}
+
+type Release struct {
+	Name      string `yaml:"name"`
+	Chart     string `yaml:"chart"`
+	Version   string `yaml:"version"`
+	Namespace string `yaml:"namespace"`
+	Values    string `yaml:"values"`
+}

--- a/cli/azd/pkg/kustomize/cli.go
+++ b/cli/azd/pkg/kustomize/cli.go
@@ -1,0 +1,84 @@
+package kustomize
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+)
+
+// Cli is a wrapper around the kustomize cli
+type Cli struct {
+	commandRunner exec.CommandRunner
+	cwd           string
+}
+
+// NewCli creates a new instance of the kustomize cli
+func NewCli(commandRunner exec.CommandRunner) *Cli {
+	return &Cli{
+		commandRunner: commandRunner,
+	}
+}
+
+func (cli *Cli) Name() string {
+	return "kustomize"
+}
+
+// Returns the installation URL to install the Kustomize CLI
+func (cli *Cli) InstallUrl() string {
+	return "https://aka.ms/azure-dev/kustomize-install"
+}
+
+// Checks whether or not the Kustomize CLI is installed and available within the PATH
+func (cli *Cli) CheckInstalled(ctx context.Context) error {
+	if err := tools.ToolInPath("kustomize"); err != nil {
+		return err
+	}
+
+	// We don't have a minimum required version of kustomize today, but
+	// for diagnostics purposes, let's fetch and log the version of kustomize
+	// we're using.
+	if ver, err := cli.getClientVersion(ctx); err != nil {
+		log.Printf("error fetching kustomize version: %s", err)
+	} else {
+		log.Printf("kustomize version: %s", ver)
+	}
+
+	return nil
+}
+
+// WithCwd sets the working directory for the kustomize command
+func (cli *Cli) WithCwd(cwd string) *Cli {
+	cli.cwd = cwd
+	return cli
+}
+
+// Edit runs the kustomize edit command with the specified args
+func (cli *Cli) Edit(ctx context.Context, args ...string) error {
+	runArgs := exec.NewRunArgs("kustomize", "edit").
+		AppendParams(args...)
+
+	if cli.cwd != "" {
+		runArgs = runArgs.WithCwd(cli.cwd)
+	}
+
+	_, err := cli.commandRunner.Run(ctx, runArgs)
+
+	if err != nil {
+		return fmt.Errorf("failed running kustomize edit: %w", err)
+	}
+
+	return nil
+}
+
+func (cli *Cli) getClientVersion(ctx context.Context) (string, error) {
+	runArgs := exec.NewRunArgs("kustomize", "version")
+	versionResult, err := cli.commandRunner.Run(ctx, runArgs)
+	if err != nil {
+		return "", fmt.Errorf("fetching kustomize version: %w", err)
+	}
+
+	return versionResult.Stdout[1:], nil
+}

--- a/cli/azd/pkg/kustomize/cli_test.go
+++ b/cli/azd/pkg/kustomize/cli_test.go
@@ -1,0 +1,96 @@
+package kustomize
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Edit(t *testing.T) {
+	args := []string{"set", "image", "nginx=nginx:1.7.9"}
+
+	t.Run("Success", func(t *testing.T) {
+		ran := false
+		var runArgs exec.RunArgs
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "kustomize edit")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				runArgs = args
+				return exec.NewRunResult(0, "", ""), nil
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		err := cli.Edit(*mockContext.Context, args...)
+		require.True(t, ran)
+		require.NoError(t, err)
+
+		expected := []string{"edit"}
+		expected = append(expected, args...)
+
+		require.Equal(t, "kustomize", runArgs.Cmd)
+		require.Equal(t, "", runArgs.Cwd)
+		require.Equal(t, expected, runArgs.Args)
+	})
+
+	t.Run("WithCwd", func(t *testing.T) {
+		ran := false
+		var runArgs exec.RunArgs
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "kustomize edit")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				runArgs = args
+				return exec.NewRunResult(0, "", ""), nil
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		err := cli.
+			WithCwd("/tmp").
+			Edit(*mockContext.Context, args...)
+
+		require.True(t, ran)
+		require.NoError(t, err)
+
+		expected := []string{"edit"}
+		expected = append(expected, args...)
+
+		require.Equal(t, "kustomize", runArgs.Cmd)
+		require.Equal(t, "/tmp", runArgs.Cwd)
+		require.Equal(t, expected, runArgs.Args)
+	})
+
+	t.Run("Failure", func(t *testing.T) {
+		ran := false
+
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.CommandRunner.
+			When(func(args exec.RunArgs, command string) bool {
+				return strings.Contains(command, "kustomize edit")
+			}).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				ran = true
+				return exec.NewRunResult(1, "", ""), errors.New("failed to edit kustomize config")
+			})
+
+		cli := NewCli(mockContext.CommandRunner)
+		err := cli.Edit(*mockContext.Context, args...)
+
+		require.True(t, ran)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to edit kustomize config")
+	})
+}

--- a/cli/azd/pkg/kustomize/config.go
+++ b/cli/azd/pkg/kustomize/config.go
@@ -1,0 +1,9 @@
+package kustomize
+
+import "github.com/azure/azure-dev/cli/azd/pkg/osutil"
+
+type Config struct {
+	Directory osutil.ExpandableString            `yaml:"dir"`
+	Edits     []osutil.ExpandableString          `yaml:"edits"`
+	Env       map[string]osutil.ExpandableString `yaml:"env"`
+}

--- a/cli/azd/pkg/osutil/expandable_string.go
+++ b/cli/azd/pkg/osutil/expandable_string.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package project
+package osutil
 
 import (
 	"fmt"

--- a/cli/azd/pkg/osutil/expandable_string_test.go
+++ b/cli/azd/pkg/osutil/expandable_string_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package project
+package osutil
 
 import (
 	"testing"

--- a/cli/azd/pkg/project/container_helper_test.go
+++ b/cli/azd/pkg/project/container_helper_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
-	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -47,7 +47,7 @@ func Test_ContainerHelper_LocalImageTag(t *testing.T) {
 		{
 			"ImageTagSpecified",
 			DockerProjectOptions{
-				Image: NewExpandableString("contoso/contoso-image:latest"),
+				Image: osutil.NewExpandableString("contoso/contoso-image:latest"),
 			},
 			"contoso/contoso-image:latest",
 		},
@@ -146,7 +146,7 @@ func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {
 		envManager := &mockenv.MockEnvManager{}
 		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil)
 		serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
-		serviceConfig.Docker.Registry = NewExpandableString("contoso.azurecr.io")
+		serviceConfig.Docker.Registry = osutil.NewExpandableString("contoso.azurecr.io")
 		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig)
 
 		require.NoError(t, err)
@@ -160,7 +160,7 @@ func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {
 		envManager := &mockenv.MockEnvManager{}
 		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil)
 		serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
-		serviceConfig.Docker.Registry = NewExpandableString("${MY_CUSTOM_REGISTRY}")
+		serviceConfig.Docker.Registry = osutil.NewExpandableString("${MY_CUSTOM_REGISTRY}")
 		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig)
 
 		require.NoError(t, err)

--- a/cli/azd/pkg/project/container_helper_test.go
+++ b/cli/azd/pkg/project/container_helper_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
@@ -71,14 +72,14 @@ func Test_ContainerHelper_RemoteImageTag(t *testing.T) {
 		name              string
 		project           string
 		localImageTag     string
-		registry          ExpandableString
+		registry          osutil.ExpandableString
 		expectedRemoteTag string
 		expectError       bool
 	}{
 		{
 			name:              "with registry",
 			project:           "./src/api",
-			registry:          NewExpandableString("contoso.azurecr.io"),
+			registry:          osutil.NewExpandableString("contoso.azurecr.io"),
 			localImageTag:     "test-app/api-dev:azd-deploy-0",
 			expectedRemoteTag: "contoso.azurecr.io/test-app/api-dev:azd-deploy-0",
 		},
@@ -91,7 +92,7 @@ func Test_ContainerHelper_RemoteImageTag(t *testing.T) {
 		{
 			name:              "registry with fully qualified custom image",
 			project:           "",
-			registry:          NewExpandableString("contoso.azurecr.io"),
+			registry:          osutil.NewExpandableString("contoso.azurecr.io"),
 			localImageTag:     "docker.io/org/my-custom-image:latest",
 			expectedRemoteTag: "contoso.azurecr.io/org/my-custom-image:latest",
 		},
@@ -183,7 +184,7 @@ func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {
 func Test_ContainerHelper_Deploy(t *testing.T) {
 	tests := []struct {
 		name                   string
-		registry               ExpandableString
+		registry               osutil.ExpandableString
 		image                  string
 		project                string
 		packagePath            string
@@ -197,7 +198,7 @@ func Test_ContainerHelper_Deploy(t *testing.T) {
 		{
 			name:     "Source code and registry",
 			project:  "./src/api",
-			registry: NewExpandableString("contoso.azurecr.io"),
+			registry: osutil.NewExpandableString("contoso.azurecr.io"),
 			dockerDetails: &dockerPackageResult{
 				ImageHash:   "IMAGE_ID",
 				SourceImage: "",
@@ -225,7 +226,7 @@ func Test_ContainerHelper_Deploy(t *testing.T) {
 		{
 			name:                   "Source code with existing package path",
 			project:                "./src/api",
-			registry:               NewExpandableString("contoso.azurecr.io"),
+			registry:               osutil.NewExpandableString("contoso.azurecr.io"),
 			packagePath:            "my-project/my-service:azd-deploy-0",
 			expectedRemoteImage:    "contoso.azurecr.io/my-project/my-service:azd-deploy-0",
 			expectDockerPullCalled: false,
@@ -236,7 +237,7 @@ func Test_ContainerHelper_Deploy(t *testing.T) {
 		{
 			name:     "Source image and registry",
 			image:    "nginx",
-			registry: NewExpandableString("contoso.azurecr.io"),
+			registry: osutil.NewExpandableString("contoso.azurecr.io"),
 			dockerDetails: &dockerPackageResult{
 				ImageHash:   "",
 				SourceImage: "nginx",
@@ -264,7 +265,7 @@ func Test_ContainerHelper_Deploy(t *testing.T) {
 		},
 		{
 			name:                   "Source image with existing package path and registry",
-			registry:               NewExpandableString("contoso.azurecr.io"),
+			registry:               osutil.NewExpandableString("contoso.azurecr.io"),
 			packagePath:            "my-project/my-service:azd-deploy-0",
 			expectedRemoteImage:    "contoso.azurecr.io/my-project/my-service:azd-deploy-0",
 			expectDockerPullCalled: false,
@@ -350,9 +351,9 @@ func Test_ContainerHelper_ConfiguredImage(t *testing.T) {
 		serviceName          string
 		sourceImage          string
 		env                  map[string]string
-		registry             ExpandableString
-		image                ExpandableString
-		tag                  ExpandableString
+		registry             osutil.ExpandableString
+		image                osutil.ExpandableString
+		tag                  osutil.ExpandableString
 		expectedImage        docker.ContainerImage
 		expectError          bool
 		expectedErrorMessage string
@@ -367,7 +368,7 @@ func Test_ContainerHelper_ConfiguredImage(t *testing.T) {
 		},
 		{
 			name: "with custom tag",
-			tag:  NewExpandableString("custom-tag"),
+			tag:  osutil.NewExpandableString("custom-tag"),
 			expectedImage: docker.ContainerImage{
 				Registry:   "",
 				Repository: "test-app/api-dev",
@@ -376,7 +377,7 @@ func Test_ContainerHelper_ConfiguredImage(t *testing.T) {
 		},
 		{
 			name:  "with custom iamge",
-			image: NewExpandableString("custom-image"),
+			image: osutil.NewExpandableString("custom-image"),
 			expectedImage: docker.ContainerImage{
 				Registry:   "",
 				Repository: "custom-image",
@@ -385,8 +386,8 @@ func Test_ContainerHelper_ConfiguredImage(t *testing.T) {
 		},
 		{
 			name:  "with custom iamge and tag",
-			image: NewExpandableString("custom-image"),
-			tag:   NewExpandableString("custom-tag"),
+			image: osutil.NewExpandableString("custom-image"),
+			tag:   osutil.NewExpandableString("custom-tag"),
 			expectedImage: docker.ContainerImage{
 				Registry:   "",
 				Repository: "custom-image",
@@ -395,7 +396,7 @@ func Test_ContainerHelper_ConfiguredImage(t *testing.T) {
 		},
 		{
 			name:     "with registry",
-			registry: NewExpandableString("contoso.azurecr.io"),
+			registry: osutil.NewExpandableString("contoso.azurecr.io"),
 			expectedImage: docker.ContainerImage{
 				Registry:   "contoso.azurecr.io",
 				Repository: "test-app/api-dev",
@@ -404,9 +405,9 @@ func Test_ContainerHelper_ConfiguredImage(t *testing.T) {
 		},
 		{
 			name:     "with registry, custom image and tag",
-			registry: NewExpandableString("contoso.azurecr.io"),
-			image:    NewExpandableString("custom-image"),
-			tag:      NewExpandableString("custom-tag"),
+			registry: osutil.NewExpandableString("contoso.azurecr.io"),
+			image:    osutil.NewExpandableString("custom-image"),
+			tag:      osutil.NewExpandableString("custom-tag"),
 			expectedImage: docker.ContainerImage{
 				Registry:   "contoso.azurecr.io",
 				Repository: "custom-image",
@@ -420,9 +421,9 @@ func Test_ContainerHelper_ConfiguredImage(t *testing.T) {
 				"MY_CUSTOM_IMAGE":    "custom-image",
 				"MY_CUSTOM_TAG":      "custom-tag",
 			},
-			registry: NewExpandableString("${MY_CUSTOM_REGISTRY}"),
-			image:    NewExpandableString("${MY_CUSTOM_IMAGE}"),
-			tag:      NewExpandableString("${MY_CUSTOM_TAG}"),
+			registry: osutil.NewExpandableString("${MY_CUSTOM_REGISTRY}"),
+			image:    osutil.NewExpandableString("${MY_CUSTOM_IMAGE}"),
+			tag:      osutil.NewExpandableString("${MY_CUSTOM_TAG}"),
 			expectedImage: docker.ContainerImage{
 				Registry:   "custom.azurecr.io",
 				Repository: "custom-image",
@@ -431,13 +432,13 @@ func Test_ContainerHelper_ConfiguredImage(t *testing.T) {
 		},
 		{
 			name:                 "invalid image name",
-			image:                NewExpandableString("${MISSING_CLOSING_BRACE"),
+			image:                osutil.NewExpandableString("${MISSING_CLOSING_BRACE"),
 			expectError:          true,
 			expectedErrorMessage: "missing closing brace",
 		},
 		{
 			name:                 "invalid tag",
-			image:                NewExpandableString("repo/::latest"),
+			image:                osutil.NewExpandableString("repo/::latest"),
 			expectError:          true,
 			expectedErrorMessage: "invalid tag",
 		},

--- a/cli/azd/pkg/project/framework_service.go
+++ b/cli/azd/pkg/project/framework_service.go
@@ -45,7 +45,7 @@ func parseServiceLanguage(kind ServiceLanguageKind) (ServiceLanguageKind, error)
 		return kind, nil
 	}
 
-	return ServiceLanguageKind(""), fmt.Errorf("unsupported language '%s'", kind)
+	return ServiceLanguageKind("Unsupported"), fmt.Errorf("unsupported language '%s'", kind)
 }
 
 type FrameworkRequirements struct {

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -38,8 +38,8 @@ type DockerProjectOptions struct {
 	Platform  string                  `yaml:"platform,omitempty"  json:"platform,omitempty"`
 	Target    string                  `yaml:"target,omitempty"    json:"target,omitempty"`
 	Registry  osutil.ExpandableString `yaml:"registry,omitempty"  json:"registry,omitempty"`
-	Image     ExpandableString        `yaml:"image,omitempty"     json:"image,omitempty"`
-	Tag       ExpandableString        `yaml:"tag,omitempty"       json:"tag,omitempty"`
+	Image     osutil.ExpandableString `yaml:"image,omitempty"     json:"image,omitempty"`
+	Tag       osutil.ExpandableString `yaml:"tag,omitempty"       json:"tag,omitempty"`
 	BuildArgs []string                `yaml:"buildArgs,omitempty" json:"buildArgs,omitempty"`
 }
 

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
@@ -32,14 +33,14 @@ import (
 )
 
 type DockerProjectOptions struct {
-	Path      string           `yaml:"path,omitempty"      json:"path,omitempty"`
-	Context   string           `yaml:"context,omitempty"   json:"context,omitempty"`
-	Platform  string           `yaml:"platform,omitempty"  json:"platform,omitempty"`
-	Target    string           `yaml:"target,omitempty"    json:"target,omitempty"`
-	Registry  ExpandableString `yaml:"registry,omitempty"  json:"registry,omitempty"`
-	Image     ExpandableString `yaml:"image,omitempty"     json:"image,omitempty"`
-	Tag       ExpandableString `yaml:"tag,omitempty"       json:"tag,omitempty"`
-	BuildArgs []string         `yaml:"buildArgs,omitempty" json:"buildArgs,omitempty"`
+	Path      string                  `yaml:"path,omitempty"      json:"path,omitempty"`
+	Context   string                  `yaml:"context,omitempty"   json:"context,omitempty"`
+	Platform  string                  `yaml:"platform,omitempty"  json:"platform,omitempty"`
+	Target    string                  `yaml:"target,omitempty"    json:"target,omitempty"`
+	Registry  osutil.ExpandableString `yaml:"registry,omitempty"  json:"registry,omitempty"`
+	Image     ExpandableString        `yaml:"image,omitempty"     json:"image,omitempty"`
+	Tag       ExpandableString        `yaml:"tag,omitempty"       json:"tag,omitempty"`
+	BuildArgs []string                `yaml:"buildArgs,omitempty" json:"buildArgs,omitempty"`
 }
 
 type dockerBuildResult struct {

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/npm"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -264,7 +265,7 @@ func Test_DockerProject_Build(t *testing.T) {
 
 	temp := t.TempDir()
 
-	serviceConfig.Docker.Registry = NewExpandableString("contoso.azurecr.io")
+	serviceConfig.Docker.Registry = osutil.NewExpandableString("contoso.azurecr.io")
 	serviceConfig.Project.Path = temp
 	serviceConfig.RelativePath = ""
 	err := os.WriteFile(filepath.Join(temp, "Dockerfile"), []byte("FROM node:14"), 0600)
@@ -332,8 +333,8 @@ func Test_DockerProject_Package(t *testing.T) {
 			name:    "source with custom docker options",
 			project: "./src/api",
 			docker: DockerProjectOptions{
-				Image: NewExpandableString("foo/bar"),
-				Tag:   NewExpandableString("latest"),
+				Image: osutil.NewExpandableString("foo/bar"),
+				Tag:   osutil.NewExpandableString("latest"),
 			},
 			expectedPackageResult: dockerPackageResult{
 				ImageHash:   "IMAGE_ID",
@@ -358,8 +359,8 @@ func Test_DockerProject_Package(t *testing.T) {
 			name:  "image with custom docker options",
 			image: "nginx:latest",
 			docker: DockerProjectOptions{
-				Image: NewExpandableString("foo/bar"),
-				Tag:   NewExpandableString("latest"),
+				Image: osutil.NewExpandableString("foo/bar"),
+				Tag:   osutil.NewExpandableString("latest"),
 			},
 			expectedPackageResult: dockerPackageResult{
 				ImageHash:   "",
@@ -373,8 +374,8 @@ func Test_DockerProject_Package(t *testing.T) {
 			name:  "fully qualified image with custom docker options",
 			image: "docker.io/repository/iamge:latest",
 			docker: DockerProjectOptions{
-				Image: NewExpandableString("myapp-service"),
-				Tag:   NewExpandableString("latest"),
+				Image: osutil.NewExpandableString("myapp-service"),
+				Tag:   osutil.NewExpandableString("latest"),
 			},
 			expectedPackageResult: dockerPackageResult{
 				ImageHash:   "",

--- a/cli/azd/pkg/project/project_config.go
+++ b/cli/azd/pkg/project/project_config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/platform"
 	"github.com/azure/azure-dev/cli/azd/pkg/state"
 	"github.com/azure/azure-dev/cli/azd/pkg/workflow"
@@ -16,7 +17,7 @@ import (
 type ProjectConfig struct {
 	RequiredVersions  *RequiredVersions          `yaml:"requiredVersions,omitempty"`
 	Name              string                     `yaml:"name"`
-	ResourceGroupName ExpandableString           `yaml:"resourceGroup,omitempty"`
+	ResourceGroupName osutil.ExpandableString    `yaml:"resourceGroup,omitempty"`
 	Path              string                     `yaml:"-"`
 	Metadata          *ProjectMetadata           `yaml:"metadata,omitempty"`
 	Services          map[string]*ServiceConfig  `yaml:"services,omitempty"`

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/apphost"
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 )
 
 type ServiceConfig struct {
@@ -14,7 +15,7 @@ type ServiceConfig struct {
 	// The friendly name/key of the project from the azure.yaml file
 	Name string `yaml:"-"`
 	// The name used to override the default azure resource name
-	ResourceName ExpandableString `yaml:"resourceName,omitempty"`
+	ResourceName osutil.ExpandableString `yaml:"resourceName,omitempty"`
 	// The relative path to the project folder from the project root
 	RelativePath string `yaml:"project"`
 	// The azure hosting model to use, ex) appservice, function, containerapp

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -567,7 +567,8 @@ func (sm *serviceManager) GetFrameworkService(ctx context.Context, serviceConfig
 
 	// For hosts which run in containers, if the source project is not already a container, we need to wrap it in a docker
 	// project that handles the containerization.
-	if serviceConfig.Host.RequiresContainer() && serviceConfig.Language != ServiceLanguageDocker {
+	requiresLanguage := serviceConfig.Language != ServiceLanguageDocker && serviceConfig.Language != ServiceLanguageNone
+	if serviceConfig.Host.RequiresContainer() && requiresLanguage {
 		var compositeFramework CompositeFrameworkService
 		if err := sm.serviceLocator.ResolveNamed(string(ServiceLanguageDocker), &compositeFramework); err != nil {
 			panic(fmt.Errorf(
@@ -579,7 +580,6 @@ func (sm *serviceManager) GetFrameworkService(ctx context.Context, serviceConfig
 		}
 
 		compositeFramework.SetSource(frameworkService)
-
 		frameworkService = compositeFramework
 	}
 

--- a/cli/azd/pkg/project/service_target.go
+++ b/cli/azd/pkg/project/service_target.go
@@ -18,6 +18,7 @@ import (
 type ServiceTargetKind string
 
 const (
+	NonSpecifiedTarget       ServiceTargetKind = ""
 	AppServiceTarget         ServiceTargetKind = "appservice"
 	ContainerAppTarget       ServiceTargetKind = "containerapp"
 	AzureFunctionTarget      ServiceTargetKind = "function"

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -285,8 +285,8 @@ func Test_Deploy_Helm(t *testing.T) {
 	packageResult := &ServicePackageResult{
 		PackagePath: "test-app/api-test:azd-deploy-0",
 		Details: &dockerPackageResult{
-			ImageHash: "IMAGE_HASH",
-			ImageTag:  "test-app/api-test:azd-deploy-0",
+			ImageHash:   "IMAGE_HASH",
+			TargetImage: "test-app/api-test:azd-deploy-0",
 		},
 	}
 
@@ -351,8 +351,8 @@ func Test_Deploy_Kustomize(t *testing.T) {
 	packageResult := &ServicePackageResult{
 		PackagePath: "test-app/api-test:azd-deploy-0",
 		Details: &dockerPackageResult{
-			ImageHash: "IMAGE_HASH",
-			ImageTag:  "test-app/api-test:azd-deploy-0",
+			ImageHash:   "IMAGE_HASH",
+			TargetImage: "test-app/api-test:azd-deploy-0",
 		},
 	}
 
@@ -748,6 +748,13 @@ func setupMocksForDocker(mockContext *mocks.MockContext) {
 	// Docker login
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 		return strings.Contains(command, "docker login")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	// Docker Pull
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "docker pull")
 	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
 		return exec.NewRunResult(0, "", ""), nil
 	})

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -14,12 +14,16 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2"
+	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/helm"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/kubelogin"
+	"github.com/azure/azure-dev/cli/azd/pkg/kustomize"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
@@ -43,7 +47,7 @@ func Test_NewAksTarget(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api", AksTarget, ServiceLanguageTypeScript)
 	env := createEnv()
 
-	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env)
+	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env, nil)
 
 	require.NotNil(t, serviceTarget)
 	require.NotNil(t, serviceConfig)
@@ -60,12 +64,37 @@ func Test_Required_Tools(t *testing.T) {
 	serviceConfig := createTestServiceConfig(tempDir, AksTarget, ServiceLanguageTypeScript)
 	env := createEnv()
 
-	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env)
+	userConfig := config.NewConfig(nil)
+	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env, userConfig)
 
 	requiredTools := serviceTarget.RequiredExternalTools(*mockContext.Context)
 	require.Len(t, requiredTools, 2)
 	require.Implements(t, new(docker.Docker), requiredTools[0])
 	require.Implements(t, new(kubectl.KubectlCli), requiredTools[1])
+}
+
+func Test_Required_Tools_WithAlpha(t *testing.T) {
+	tempDir := t.TempDir()
+	ostest.Chdir(t, tempDir)
+
+	mockContext := mocks.NewMockContext(context.Background())
+	err := setupMocksForAksTarget(mockContext)
+	require.NoError(t, err)
+
+	serviceConfig := createTestServiceConfig(tempDir, AksTarget, ServiceLanguageTypeScript)
+	env := createEnv()
+
+	userConfig := config.NewConfig(nil)
+	_ = userConfig.Set("alpha.aks.helm", "on")
+	_ = userConfig.Set("alpha.aks.kustomize", "on")
+	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env, userConfig)
+
+	requiredTools := serviceTarget.RequiredExternalTools(*mockContext.Context)
+	require.Len(t, requiredTools, 4)
+	require.Implements(t, new(docker.Docker), requiredTools[0])
+	require.Implements(t, new(kubectl.KubectlCli), requiredTools[1])
+	require.IsType(t, &helm.Cli{}, requiredTools[2])
+	require.IsType(t, &kustomize.Cli{}, requiredTools[3])
 }
 
 func Test_Package_Deploy_HappyPath(t *testing.T) {
@@ -79,7 +108,7 @@ func Test_Package_Deploy_HappyPath(t *testing.T) {
 	serviceConfig := createTestServiceConfig(tempDir, AksTarget, ServiceLanguageTypeScript)
 	env := createEnv()
 
-	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env)
+	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env, nil)
 	err = simulateInitliaze(*mockContext.Context, serviceTarget, serviceConfig)
 	require.NoError(t, err)
 
@@ -133,7 +162,7 @@ func Test_Resolve_Cluster_Name(t *testing.T) {
 		serviceConfig := createTestServiceConfig(tempDir, AksTarget, ServiceLanguageTypeScript)
 		env := createEnv()
 
-		serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env)
+		serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env, nil)
 		err = simulateInitliaze(*mockContext.Context, serviceTarget, serviceConfig)
 		require.NoError(t, err)
 	})
@@ -144,13 +173,13 @@ func Test_Resolve_Cluster_Name(t *testing.T) {
 		require.NoError(t, err)
 
 		serviceConfig := createTestServiceConfig(tempDir, AksTarget, ServiceLanguageTypeScript)
-		serviceConfig.ResourceName = NewExpandableString("AKS_CLUSTER")
+		serviceConfig.ResourceName = osutil.NewExpandableString("AKS_CLUSTER")
 		env := createEnv()
 
 		// Remove default AKS cluster name from env file
 		env.DotenvDelete(environment.AksClusterEnvVarName)
 
-		serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env)
+		serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env, nil)
 		err = simulateInitliaze(*mockContext.Context, serviceTarget, serviceConfig)
 		require.NoError(t, err)
 	})
@@ -161,14 +190,14 @@ func Test_Resolve_Cluster_Name(t *testing.T) {
 		require.NoError(t, err)
 
 		serviceConfig := createTestServiceConfig(tempDir, AksTarget, ServiceLanguageTypeScript)
-		serviceConfig.ResourceName = NewExpandableString("${MY_CUSTOM_ENV_VAR}")
+		serviceConfig.ResourceName = osutil.NewExpandableString("${MY_CUSTOM_ENV_VAR}")
 		env := createEnv()
 		env.DotenvSet("MY_CUSTOM_ENV_VAR", "AKS_CLUSTER")
 
 		// Remove default AKS cluster name from env file
 		env.DotenvDelete(environment.AksClusterEnvVarName)
 
-		serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env)
+		serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env, nil)
 		err = simulateInitliaze(*mockContext.Context, serviceTarget, serviceConfig)
 		require.NoError(t, err)
 	})
@@ -187,7 +216,7 @@ func Test_Resolve_Cluster_Name(t *testing.T) {
 		// Simulate AKS cluster name not found in env file
 		env.DotenvDelete(environment.AksClusterEnvVarName)
 
-		serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env)
+		serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env, nil)
 		err = simulateInitliaze(*mockContext.Context, serviceTarget, serviceConfig)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "could not determine AKS cluster")
@@ -210,10 +239,143 @@ func Test_Deploy_No_Credentials(t *testing.T) {
 	serviceConfig := createTestServiceConfig(tempDir, AksTarget, ServiceLanguageTypeScript)
 	env := createEnv()
 
-	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env)
+	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env, nil)
 	err = simulateInitliaze(*mockContext.Context, serviceTarget, serviceConfig)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "failed retrieving cluster user credentials")
+}
+
+func Test_Deploy_Helm(t *testing.T) {
+	tempDir := t.TempDir()
+	ostest.Chdir(t, tempDir)
+
+	mockContext := mocks.NewMockContext(context.Background())
+	err := setupMocksForAksTarget(mockContext)
+	require.NoError(t, err)
+
+	mockResults, err := setupMocksForHelm(mockContext)
+	require.NoError(t, err)
+
+	serviceConfig := *createTestServiceConfig(tempDir, AksTarget, ServiceLanguageTypeScript)
+	serviceConfig.RelativePath = ""
+	serviceConfig.K8s.Helm = &helm.Config{
+		Repositories: []*helm.Repository{
+			{
+				Name: "argo",
+				Url:  "https://argoproj.github.io/argo-helm",
+			},
+		},
+		Releases: []*helm.Release{
+			{
+				Name:    "argocd",
+				Chart:   "argo/argo-cd",
+				Version: "5.51.4",
+			},
+		},
+	}
+
+	env := createEnv()
+	userConfig := config.NewConfig(nil)
+	_ = userConfig.Set("alpha.aks.helm", "on")
+
+	serviceTarget := createAksServiceTarget(mockContext, &serviceConfig, env, userConfig)
+	err = simulateInitliaze(*mockContext.Context, serviceTarget, &serviceConfig)
+	require.NoError(t, err)
+
+	packageResult := &ServicePackageResult{
+		PackagePath: "test-app/api-test:azd-deploy-0",
+		Details: &dockerPackageResult{
+			ImageHash: "IMAGE_HASH",
+			ImageTag:  "test-app/api-test:azd-deploy-0",
+		},
+	}
+
+	scope := environment.NewTargetResource("SUB_ID", "RG_ID", "", string(infra.AzureResourceTypeManagedCluster))
+	deployTask := serviceTarget.Deploy(*mockContext.Context, &serviceConfig, packageResult, scope)
+	logProgress(deployTask)
+	deployResult, err := deployTask.Await()
+
+	require.NoError(t, err)
+	require.NotNil(t, deployResult)
+
+	repoAdd, repoAddCalled := mockResults["helm-repo-add"]
+	require.True(t, repoAddCalled)
+	require.Equal(t, []string{"repo", "add", "argo", "https://argoproj.github.io/argo-helm"}, repoAdd.Args)
+
+	repoUpdate, repoUpdateCalled := mockResults["helm-repo-update"]
+	require.True(t, repoUpdateCalled)
+	require.Equal(t, []string{"repo", "update", "argo"}, repoUpdate.Args)
+
+	helmUpgrade, helmUpgradeCalled := mockResults["helm-upgrade"]
+	require.True(t, helmUpgradeCalled)
+	require.Contains(t, strings.Join(helmUpgrade.Args, " "), "upgrade argocd argo/argo-cd")
+
+	helmStatus, helmStatusCalled := mockResults["helm-status"]
+	require.True(t, helmStatusCalled)
+	require.Contains(t, strings.Join(helmStatus.Args, " "), "status argocd")
+}
+
+func Test_Deploy_Kustomize(t *testing.T) {
+	tempDir := t.TempDir()
+	ostest.Chdir(t, tempDir)
+
+	mockContext := mocks.NewMockContext(context.Background())
+	err := setupMocksForAksTarget(mockContext)
+	require.NoError(t, err)
+
+	mockResults, err := setupMocksForKustomize(mockContext)
+	require.NoError(t, err)
+
+	serviceConfig := *createTestServiceConfig(tempDir, AksTarget, ServiceLanguageTypeScript)
+	serviceConfig.RelativePath = ""
+	serviceConfig.K8s.Kustomize = &kustomize.Config{
+		Directory: osutil.NewExpandableString("./kustomize/overlays/dev"),
+		Edits: []osutil.ExpandableString{
+			osutil.NewExpandableString("set image todo-api=${SERVICE_API_IMAGE_NAME}"),
+		},
+	}
+
+	err = os.MkdirAll(filepath.Join(tempDir, "./kustomize/overlays/dev"), osutil.PermissionDirectory)
+	require.NoError(t, err)
+
+	env := createEnv()
+	env.DotenvSet("SERVICE_API_IMAGE_NAME", "REGISTRY.azurecr.io/test-app/api-test:azd-deploy-0")
+
+	userConfig := config.NewConfig(nil)
+	_ = userConfig.Set("alpha.aks.kustomize", "on")
+
+	serviceTarget := createAksServiceTarget(mockContext, &serviceConfig, env, userConfig)
+	err = simulateInitliaze(*mockContext.Context, serviceTarget, &serviceConfig)
+	require.NoError(t, err)
+
+	packageResult := &ServicePackageResult{
+		PackagePath: "test-app/api-test:azd-deploy-0",
+		Details: &dockerPackageResult{
+			ImageHash: "IMAGE_HASH",
+			ImageTag:  "test-app/api-test:azd-deploy-0",
+		},
+	}
+
+	scope := environment.NewTargetResource("SUB_ID", "RG_ID", "", string(infra.AzureResourceTypeManagedCluster))
+	deployTask := serviceTarget.Deploy(*mockContext.Context, &serviceConfig, packageResult, scope)
+	logProgress(deployTask)
+	deployResult, err := deployTask.Await()
+
+	require.NoError(t, err)
+	require.NotNil(t, deployResult)
+
+	kustomizeEdit, kustomizeEditCalled := mockResults["kustomize-edit"]
+	require.True(t, kustomizeEditCalled)
+	require.Equal(t, []string{
+		"edit",
+		"set",
+		"image",
+		"todo-api=REGISTRY.azurecr.io/test-app/api-test:azd-deploy-0",
+	}, kustomizeEdit.Args)
+
+	kubectlApplyKustomize, kubectlApplyKustomizeCalled := mockResults["kubectl-apply-kustomize"]
+	require.True(t, kubectlApplyKustomizeCalled)
+	require.Equal(t, []string{"apply", "-k", filepath.FromSlash("kustomize/overlays/dev")}, kubectlApplyKustomize.Args)
 }
 
 func setupK8sManifests(t *testing.T, serviceConfig *ServiceConfig) error {
@@ -229,6 +391,65 @@ func setupK8sManifests(t *testing.T, serviceConfig *ServiceConfig) error {
 	}
 
 	return nil
+}
+
+func setupMocksForHelm(mockContext *mocks.MockContext) (map[string]exec.RunArgs, error) {
+	result := map[string]exec.RunArgs{}
+
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "helm repo add")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		result["helm-repo-add"] = args
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "helm repo update")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		result["helm-repo-update"] = args
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "helm upgrade")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		result["helm-upgrade"] = args
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "helm status")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		result["helm-status"] = args
+		statusResult := `{
+			"info": {
+				"status": "deployed"
+			}
+		}`
+		return exec.NewRunResult(0, statusResult, ""), nil
+	})
+
+	return result, nil
+}
+
+func setupMocksForKustomize(mockContext *mocks.MockContext) (map[string]exec.RunArgs, error) {
+	result := map[string]exec.RunArgs{}
+
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "kustomize edit")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		result["kustomize-edit"] = args
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "kubectl apply -k")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		result["kubectl-apply-kustomize"] = args
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	return result, nil
 }
 
 func setupMocksForAksTarget(mockContext *mocks.MockContext) error {
@@ -577,8 +798,11 @@ func createAksServiceTarget(
 	mockContext *mocks.MockContext,
 	serviceConfig *ServiceConfig,
 	env *environment.Environment,
+	userConfig config.Config,
 ) ServiceTarget {
 	kubeCtl := kubectl.NewKubectl(mockContext.CommandRunner)
+	helmCli := helm.NewCli(mockContext.CommandRunner)
+	kustomizeCli := kustomize.NewCli(mockContext.CommandRunner)
 	dockerCli := docker.NewDocker(mockContext.CommandRunner)
 	kubeLoginCli := kubelogin.NewCli(mockContext.CommandRunner)
 	credentialProvider := mockaccount.SubscriptionCredentialProviderFunc(
@@ -604,6 +828,13 @@ func createAksServiceTarget(
 	containerRegistryService := azcli.NewContainerRegistryService(credentialProvider, mockContext.HttpClient, dockerCli)
 	containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), containerRegistryService, dockerCli)
 
+	if userConfig == nil {
+		userConfig = config.NewConfig(nil)
+	}
+
+	configManager := &mockUserConfigManager{}
+	configManager.On("Load").Return(userConfig, nil)
+
 	return NewAksTarget(
 		env,
 		envManager,
@@ -612,7 +843,10 @@ func createAksServiceTarget(
 		resourceManager,
 		kubeCtl,
 		kubeLoginCli,
+		helmCli,
+		kustomizeCli,
 		containerHelper,
+		alpha.NewFeaturesManagerWithConfig(userConfig),
 	)
 }
 
@@ -713,4 +947,18 @@ func (m *MockResourceManager) GetTargetResource(
 ) (*environment.TargetResource, error) {
 	args := m.Called(ctx, subscriptionId, serviceConfig)
 	return args.Get(0).(*environment.TargetResource), args.Error(1)
+}
+
+type mockUserConfigManager struct {
+	mock.Mock
+}
+
+func (m *mockUserConfigManager) Load() (config.Config, error) {
+	args := m.Called()
+	return args.Get(0).(config.Config), args.Error(1)
+}
+
+func (m *mockUserConfigManager) Save(config config.Config) error {
+	args := m.Called(config)
+	return args.Error(0)
 }

--- a/cli/azd/pkg/tools/kubectl/kubectl.go
+++ b/cli/azd/pkg/tools/kubectl/kubectl.go
@@ -39,6 +39,8 @@ type KubectlCli interface {
 	Exec(ctx context.Context, flags *KubeCliFlags, args ...string) (exec.RunResult, error)
 	// Gets the deployment rollout status
 	RolloutStatus(ctx context.Context, deploymentName string, flags *KubeCliFlags) (*exec.RunResult, error)
+	// Applies the manifests at the specified path using kustomize
+	ApplyWithKustomize(ctx context.Context, path string, flags *KubeCliFlags) error
 }
 
 type OutputType string
@@ -223,6 +225,18 @@ func (cli *kubectlCli) ApplyWithFile(ctx context.Context, filePath string, flags
 func (cli *kubectlCli) Apply(ctx context.Context, path string, flags *KubeCliFlags) error {
 	if err := cli.applyTemplates(ctx, path, flags); err != nil {
 		return fmt.Errorf("failed process templates, %w", err)
+	}
+
+	return nil
+}
+
+// Applies the manifests at the specified path using kustomize
+func (cli *kubectlCli) ApplyWithKustomize(ctx context.Context, path string, flags *KubeCliFlags) error {
+	runArgs := exec.NewRunArgs("kubectl", "apply", "-k", path)
+
+	_, err := cli.executeCommandWithArgs(ctx, runArgs, flags)
+	if err != nil {
+		return fmt.Errorf("failing running kubectl apply -k: %w", err)
 	}
 
 	return nil

--- a/cli/azd/resources/alpha_features.yaml
+++ b/cli/azd/resources/alpha_features.yaml
@@ -2,3 +2,7 @@
   description: "Support infrastructure deployments at resource group scope."
 - id: infraSynth
   description: "Enable the `infra synth` command to write generated infrastructure to disk."
+- id: aks.helm
+  description: "Enable Helm support for AKS deployments."
+- id: aks.kustomize
+  description: "Enable Kustomize support for AKS deployments."

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -681,6 +681,107 @@
                             "description": "When set will be appended to the root of your ingress resource path."
                         }
                     }
+                },
+                "helm": {
+                    "type": "object",
+                    "title": "Optional. The helm configuration",
+                    "additionalProperties": false,
+                    "properties": {
+                        "repositories": {
+                            "type": "array",
+                            "title": "Optional. The helm repositories to add",
+                            "description": "When set will add the helm repositories to the helm client.",
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                    "name",
+                                    "url"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "title": "The name of the helm repository",
+                                        "description": "The name of the helm repository to add."
+                                    },
+                                    "url": {
+                                        "type": "string",
+                                        "title": "The url of the helm repository",
+                                        "description": "The url of the helm repository to add."
+                                    }
+                                }
+                            }
+                        },
+                        "releases": {
+                            "type": "array",
+                            "title": "Optional. The helm releases to install",
+                            "description": "When set will install the helm releases to the k8s cluster.",
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                    "name",
+                                    "chart"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "title": "The name of the helm release",
+                                        "description": "The name of the helm release to install."
+                                    },
+                                    "chart": {
+                                        "type": "string",
+                                        "title": "The name of the helm chart",
+                                        "description": "The name of the helm chart to install."
+                                    },
+                                    "version": {
+                                        "type": "string",
+                                        "title": "The version of the helm chart",
+                                        "description": "The version of the helm chart to install."
+                                    },
+                                    "values": {
+                                        "type": "string",
+                                        "title": "Optional. Relative path from service to a values.yaml to pass to the helm chart",
+                                        "description": "When set will pass the values to the helm chart."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "kustomize": {
+                    "type": "object",
+                    "title": "Optional. The kustomize configuration",
+                    "additionalProperties": false,
+                    "properties": {
+                        "dir": {
+                            "type": "string",
+                            "title": "Optional. The relative path to the kustomize directory.",
+                            "description": "When set will use the kustomize directory to deploy to the k8s cluster. Supports environment variable substitution."
+                        },
+                        "edits": {
+                            "type": "array",
+                            "title": "Optional. The kustomize edits to apply before deployment.",
+                            "description": "When set will apply the edits to the kustomize directory before deployment. Supports environment variable substitution.",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "env": {
+                            "type": "object",
+                            "title": "Optional. The environment key/value pairs used to generate a .env file.",
+                            "description": "When set will generate a .env file in the kustomize directory. Values support environment variable substitution.",
+                            "additionalProperties": {
+                                "type": [
+                                    "string",
+                                    "boolean",
+                                    "number"
+                                ]
+                            }
+                        }
+                    }
                 }
             }
         },


### PR DESCRIPTION
# Helm

This PR adds [Helm](https://helm.sh/) support for using `azd` with AKS.
Resolves: #1618 

> [!IMPORTANT]
> To enable Helm support ensure you have the Helm CLI installed
> Enable the helm feature flag by running `azd config set alpha.aks.helm on`

### What Included so far
- [x] Ability to define a list of helm charts to be installed for each `azd` service
- [x] `azd` service does not require any code/docker files

## `azure.yaml` configuration for `azd` 

- [x] Adds new `helm` configuration section under the `k8s` section
- [x] Ability to define a list of helm repositories / releases to install 

```yaml
name: todo-nodejs-mongo-aks
metadata:
  template: todo-nodejs-mongo-aks@0.0.1-beta
services:
  argocd:
    host: aks
    k8s:
      namespace: argo
      service:
        name: argocd-server
      helm:
        repositories:
          - name: argo
            url: https://argoproj.github.io/argo-helm
        releases:
          - name: argocd
            chart: argo/argo-cd
            verson: 5.51.4
  jupyterhub:
    host: aks
    k8s:
      namespace: jupyterhub
      service:
        name: proxy-public
      helm:
        repositories:
          - name: jupyterhub
            url: https://hub.jupyter.org/helm-chart/
        releases:
          - name: jupyterhub
            chart: jupyterhub/jupyterhub
            version: 3.1.0
```

## `azd deploy` Output

- [x] Adds any referenced helm repositories and/or updates them
- [x] Installs the referenced helm charts
- [x] Waits for helm release to transition to a `deployed` state
- [x] Lists relevant services/ingresses defined within the deployed resources 

<img width="833" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/923fe466-9e14-411a-bfd7-1b80f1a046d5">

# Kustomize

> [!IMPORTANT]
> To enable Helm support ensure you have the Kustomize CLI installed
> Enable the helm feature flag by running `azd config set alpha.aks.kustomize on`

Adds support to leverage [kustomize](https://kustomize.io/) as part of k8s deployments.

Includes the following:
- Supports `base` and `variant` configurations
- `edits` that can be run before deployments
- `configMapGenerator` with azd environments

# Configuration

The following new configurations are available within the `azure.yaml` file.

## service.k8s.kustomize

- `dir`: Relative path from the service to your kustomize directory that contains a `kustomization.yaml` file
  - Supports environment variable substitution
- `edits`: Array of edit expression that are applied before deployment
  - Supports environment variable substitution
- `env`: Map of key/value pairs generated before deployment
-   - Map values support environment variable substitution

# Use Cases

The following use cases are supported by this change

## Use Case: Dev want to deploy k8s manifests with basic kustomization

The following configuration will perform a `kubectl apply -k <dir>` command that points to your manifests folder that contains a `kustomization.yaml`.

```yaml
# azure.yaml

name: todo-nodejs-mongo-aks
metadata:
  template: todo-nodejs-mongo-aks@0.0.1-beta
services:
  api:
    project: ./src/api
    language: js
    host: aks
    k8s:
      kustomize:
        dir: ./kustomize/base
```

## Use Case: Dev wants to use overlays to deploy to with different variants

This use case is typically used to have custom configurations for deploying to different stages or environments. 
Examples of this would be `dev`, `test` and `prod`

In this example the user can specify the `${AZURE_ENV_NAME}` environment variable within the kustomize directory to automatically leverage the azd environments as your default overlay convention.

```yaml
# azure.yaml

name: todo-nodejs-mongo-aks
metadata:
  template: todo-nodejs-mongo-aks@0.0.1-beta
services:
  api:
    project: ./src/api
    language: js
    host: aks
    k8s:
      kustomize:
        dir: ./kustomize/overlays/${AZURE_ENV_NAME}
```

## Use Case: Dev wants to modify kustomization.yaml before deployment

A common use case for modifying the kustomization.yaml would be for modifying container [image names/versions](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/images/) used as part of your deployment

In the following example, specify an `edits` configuration and set any valid `kustomize edit ...` command. Environment variables referenced within the edit command are automatically interpolated from your azd environment variables.

```yaml
# azure.yaml

name: todo-nodejs-mongo-aks
metadata:
  template: todo-nodejs-mongo-aks@0.0.1-beta
services:
  api:
    project: ./src/api
    language: js
    host: aks
    k8s:
      kustomize:
        dir: ./kustomize/overlays/${AZURE_ENV_NAME}
        edits:
          - set image todo-api=${SERVICE_API_IMAGE_NAME}
```

## Use Case: Dev want to use `azd` environment variables within config maps

Config maps or secrets are critical in configuring your k8s clusters.  Since [kustomize does not support any direct environment variable substitution](https://kubectl.docs.kubernetes.io/faq/kustomize/eschewedfeatures/#build-time-side-effects-from-cli-args-or-env-variables) we can leverage the kustomize `configMapGenerator` with a `.env` file.

The `kustomize` configuration section supports a `env` section where one or many key/value pairs can be defined.  This configuration will automatically generate a temporary `.env` file within your kustomization directory that can be used by a `configMapGenerator`

The following configuration will create a `.env` with the specified key/value pairs.

```yaml
# azure.yaml

name: todo-nodejs-mongo-aks
metadata:
  template: todo-nodejs-mongo-aks@0.0.1-beta
services:
  api:
    project: ./src/api
    language: js
    host: aks
    k8s:
      kustomize:
        dir: ./kustomize/overlays/${AZURE_ENV_NAME}
        edits:
          - set image todo-api=${SERVICE_API_IMAGE_NAME}
        env:
          AZURE_AKS_IDENTITY_CLIENT_ID: ${AZURE_AKS_IDENTITY_CLIENT_ID}
          AZURE_KEY_VAULT_ENDPOINT: ${AZURE_KEY_VAULT_ENDPOINT}
          APPLICATIONINSIGHTS_CONNECTION_STRING: ${APPLICATIONINSIGHTS_CONNECTION_STRING}
```

The `configMapGenerator` will now generated a k8s config map with the specified name and contain all the key/value pairs referenced within the `.env` file.

```yaml
# kustomization.yaml

apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

resources:
  - deployment.yaml
  - service.yaml
  - ingress.yaml

configMapGenerator:
  - name: todo-web-config
    envs:
      - .env
```


