### PR TITLE
AKS Service Target: Adds support for Azure RBAC when local user accounts are disabled

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -103,6 +103,7 @@ javac
 jmes
 jquery
 keychain
+kubelogin
 LASTEXITCODE
 ldflags
 lechnerc77

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -33,6 +33,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
+	"github.com/azure/azure-dev/cli/azd/pkg/kubelogin"
 	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/pipeline"
@@ -464,6 +465,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.MustRegisterSingleton(javac.NewCli)
 	container.MustRegisterSingleton(kubectl.NewKubectl)
 	container.MustRegisterSingleton(maven.NewMavenCli)
+	container.MustRegisterSingleton(kubelogin.NewCli)
 	container.MustRegisterSingleton(npm.NewNpmCli)
 	container.MustRegisterSingleton(python.NewPythonCli)
 	container.MustRegisterSingleton(swa.NewSwaCli)

--- a/cli/azd/pkg/kubelogin/cli.go
+++ b/cli/azd/pkg/kubelogin/cli.go
@@ -1,0 +1,82 @@
+package kubelogin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+)
+
+// Cli is a wrapper around the kubelogin CLI
+type Cli struct {
+	commandRunner exec.CommandRunner
+}
+
+// NewCli creates a new instance of the kubelogin CLI wrapper
+func NewCli(commandRunner exec.CommandRunner) *Cli {
+	return &Cli{
+		commandRunner: commandRunner,
+	}
+}
+
+// Gets the name of the Tool
+func (cli *Cli) Name() string {
+	return "kubelogin"
+}
+
+// Returns the installation URL to install the kubelogin CLI
+func (cli *Cli) InstallUrl() string {
+	return "https://aka.ms/azure-dev/kubelogin-install"
+}
+
+// Checks whether or not the kubelogin CLI is installed and available within the PATH
+func (cli *Cli) CheckInstalled(ctx context.Context) error {
+	if err := tools.ToolInPath("kubelogin"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ConvertKubeConfig converts a kubeconfig file to use the exec auth module
+func (c *Cli) ConvertKubeConfig(ctx context.Context, options *ConvertOptions) error {
+	if options == nil {
+		options = &ConvertOptions{}
+	}
+
+	if options.Login == "" {
+		options.Login = "azd"
+	}
+
+	runArgs := exec.NewRunArgs("kubelogin", "convert-kubeconfig", "--login", options.Login)
+	if options.KubeConfig != "" {
+		runArgs = runArgs.AppendParams("--kubeconfig", options.KubeConfig)
+	}
+
+	if options.TenantId != "" {
+		runArgs = runArgs.AppendParams("--tenant-id", options.TenantId)
+	}
+
+	if options.Context != "" {
+		runArgs = runArgs.AppendParams("--context", options.Context)
+	}
+
+	if _, err := c.commandRunner.Run(ctx, runArgs); err != nil {
+		return fmt.Errorf("converting kubeconfig: %w", err)
+	}
+
+	return nil
+}
+
+// ConvertOptions are the options for converting a kubeconfig file
+type ConvertOptions struct {
+	// Login method to use (defaults to azd)
+	Login string
+	// AAD tenant ID
+	TenantId string
+	// The name of the kubeconfig context to use
+	Context string
+	// KubeConfig is the path to the kube config file
+	KubeConfig string
+}

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -32,7 +32,6 @@ import (
 )
 
 type DockerProjectOptions struct {
-	Registry  string                  `yaml:"registry,omitempty"  json:"registry,omitempty"`
 	Path      string           `yaml:"path,omitempty"      json:"path,omitempty"`
 	Context   string           `yaml:"context,omitempty"   json:"context,omitempty"`
 	Platform  string           `yaml:"platform,omitempty"  json:"platform,omitempty"`

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -32,6 +32,7 @@ import (
 )
 
 type DockerProjectOptions struct {
+	Registry  string                  `yaml:"registry,omitempty"  json:"registry,omitempty"`
 	Path      string           `yaml:"path,omitempty"      json:"path,omitempty"`
 	Context   string           `yaml:"context,omitempty"   json:"context,omitempty"`
 	Platform  string           `yaml:"platform,omitempty"  json:"platform,omitempty"`

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -291,12 +291,14 @@ func (t *aksTarget) ensureClusterContext(
 		return kubeConfigPath, nil
 	}
 
-	// Login to AKS cluster
+	// Resolve cluster name
 	clusterName, err := t.resolveClusterName(serviceConfig, targetResource)
 	if err != nil {
 		return "", err
+
 	}
 
+	// Login to AKS cluster
 	log.Printf("getting AKS credentials for cluster '%s'\n", clusterName)
 	clusterCreds, err := t.managedClustersService.GetUserCredentials(
 		ctx,

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -302,14 +302,15 @@ func (t *aksTarget) ensureClusterContext(
 	)
 	if err != nil {
 		return "", fmt.Errorf(
-			"failed retrieving cluster admin credentials. Ensure your cluster has been configured to support admin credentials, %w",
+			//nolint:lll
+			"failed retrieving cluster user credentials. Ensure the current principal has been granted rights to the AKS cluster, %w",
 			err,
 		)
 	}
 
 	if len(clusterCreds.Kubeconfigs) == 0 {
 		return "", fmt.Errorf(
-			"cluster credentials is empty. Ensure your cluster has been configured to support admin credentials. , %w",
+			"cluster credentials is empty. Ensure the current principal has been granted rights to the AKS cluster. , %w",
 			err,
 		)
 	}

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -355,12 +355,13 @@ func (t *aksTarget) ensureClusterContext(
 		return "", fmt.Errorf("failed retrieving managed cluster, %w", err)
 	}
 
-	rbacEnabled := convert.ToValueWithDefault(managedCluster.Properties.EnableRBAC, false)
+	azureRbacEnabled := managedCluster.Properties.AADProfile != nil &&
+		convert.ToValueWithDefault(managedCluster.Properties.AADProfile.EnableAzureRBAC, false)
 	localAccountsDisabled := convert.ToValueWithDefault(managedCluster.Properties.DisableLocalAccounts, false)
 
 	// If we're connecting to a cluster with RBAC enabled and local accounts disabled
 	// then we need to convert the kube config to use the exec auth module with azd auth
-	if rbacEnabled && localAccountsDisabled {
+	if azureRbacEnabled || localAccountsDisabled {
 		convertOptions := &kubelogin.ConvertOptions{
 			Login:      "azd",
 			KubeConfig: kubeConfigPath,

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -229,10 +229,6 @@ func (t *aksTarget) Deploy(
 		})
 }
 
-	deploymentPath = filepath.Join(serviceConfig.Path(), deploymentPath)
-
-	err := t.kubectl.Apply(ctx, deploymentPath, nil)
-	kustomizeDir := filepath.Join(serviceConfig.Project.Path, serviceConfig.RelativePath, overlayPath)
 // Gets the service endpoints for the AKS service target
 func (t *aksTarget) Endpoints(
 	ctx context.Context,
@@ -291,14 +287,12 @@ func (t *aksTarget) ensureClusterContext(
 		return kubeConfigPath, nil
 	}
 
-	// Resolve cluster name
+	// Login to AKS cluster
 	clusterName, err := t.resolveClusterName(serviceConfig, targetResource)
 	if err != nil {
 		return "", err
-
 	}
 
-	// Login to AKS cluster
 	log.Printf("getting AKS credentials for cluster '%s'\n", clusterName)
 	clusterCreds, err := t.managedClustersService.GetUserCredentials(
 		ctx,

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -232,7 +232,7 @@ func (t *aksTarget) Deploy(
 	deploymentPath = filepath.Join(serviceConfig.Path(), deploymentPath)
 
 	err := t.kubectl.Apply(ctx, deploymentPath, nil)
-	kustomizeDir := filepath.Join(serviceConfig.Path(), overlayPath)
+	kustomizeDir := filepath.Join(serviceConfig.Project.Path, serviceConfig.RelativePath, overlayPath)
 // Gets the service endpoints for the AKS service target
 func (t *aksTarget) Endpoints(
 	ctx context.Context,

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -359,8 +359,6 @@ func (t *aksTarget) ensureClusterContext(
 	// If we're connecting to a cluster with RBAC enabled and local accounts disabled
 	// then we need to convert the kube config to use the exec auth module with azd auth
 	if rbacEnabled && localAccountsDisabled {
-		// Verify we have proper cluster connection using call to `kubectl cluster-info`
-		// If not, attempt to convert kube config to use the exec auth module with azd auth
 		convertOptions := &kubelogin.ConvertOptions{
 			Login:      "azd",
 			KubeConfig: kubeConfigPath,

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -9,12 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/kubelogin"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
@@ -62,6 +62,7 @@ type aksTarget struct {
 	managedClustersService azcli.ManagedClustersService
 	resourceManager        ResourceManager
 	kubectl                kubectl.KubectlCli
+	kubeLoginCli           *kubelogin.Cli
 	containerHelper        *ContainerHelper
 }
 
@@ -73,6 +74,7 @@ func NewAksTarget(
 	managedClustersService azcli.ManagedClustersService,
 	resourceManager ResourceManager,
 	kubectlCli kubectl.KubectlCli,
+	kubeLoginCli *kubelogin.Cli,
 	containerHelper *ContainerHelper,
 ) ServiceTarget {
 	return &aksTarget{
@@ -82,6 +84,7 @@ func NewAksTarget(
 		managedClustersService: managedClustersService,
 		resourceManager:        resourceManager,
 		kubectl:                kubectlCli,
+		kubeLoginCli:           kubeLoginCli,
 		containerHelper:        containerHelper,
 	}
 }
@@ -312,9 +315,52 @@ func (t *aksTarget) ensureClusterContext(
 
 	// The kubeConfig that we care about will also be at position 0
 	// I don't know if there is a valid use case where this credential results would container multiple configs
-	kubeConfigPath, err = t.configureK8sContext(ctx, clusterName, defaultNamespace, clusterCreds.Kubeconfigs[0])
+	kubeConfig, err := kubectl.ParseKubeConfig(ctx, clusterCreds.Kubeconfigs[0].Value)
+	if err != nil {
+		return "", fmt.Errorf(
+			"failed parsing kube config. Ensure your configuration is valid yaml. %w",
+			err,
+		)
+	}
+
+	// Set default namespace for the context
+	// This avoids having to specify the namespace for every kubectl command
+	kubeConfig.Contexts[0].Context.Namespace = defaultNamespace
+	kubeConfigManager, err := kubectl.NewKubeConfigManager(t.kubectl)
 	if err != nil {
 		return "", err
+	}
+
+	// Create or update the kube config/context for the AKS cluster
+	kubeConfigPath, err = kubeConfigManager.AddOrUpdateContext(ctx, clusterName, kubeConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed adding/updating kube context, %w", err)
+	}
+
+	// Verify we have proper cluster connection using call to `kubectl cluster-info`
+	// If not, attempt to convert kube config to use the exec auth module with azd auth
+	convertOptions := &kubelogin.ConvertOptions{
+		Login:      "azd",
+		KubeConfig: kubeConfigPath,
+	}
+	if err := t.kubeLoginCli.ConvertKubeConfig(ctx, convertOptions); err != nil {
+		return "", err
+	}
+
+	// Merge the cluster config/context into the default kube config
+	kubeConfigPath, err = kubeConfigManager.MergeConfigs(ctx, "config", clusterName)
+	if err != nil {
+		return "", err
+	}
+
+	t.kubectl.SetKubeConfig(kubeConfigPath)
+
+	// Setup the default kube context to use the AKS cluster context
+	if _, err := t.kubectl.ConfigUseContext(ctx, clusterName, nil); err != nil {
+		return "", fmt.Errorf(
+			"failed setting kube context '%s'. Ensure the specified context exists. %w", clusterName,
+			err,
+		)
 	}
 
 	return kubeConfigPath, nil
@@ -340,43 +386,6 @@ func (t *aksTarget) ensureNamespace(ctx context.Context, namespace string) error
 	}
 
 	return nil
-}
-
-func (t *aksTarget) configureK8sContext(
-	ctx context.Context,
-	clusterName string,
-	namespace string,
-	credentialResult *armcontainerservice.CredentialResult,
-) (string, error) {
-	kubeConfigManager, err := kubectl.NewKubeConfigManager(t.kubectl)
-	if err != nil {
-		return "", err
-	}
-
-	kubeConfig, err := kubectl.ParseKubeConfig(ctx, credentialResult.Value)
-	if err != nil {
-		return "", fmt.Errorf(
-			"failed parsing kube config. Ensure your configuration is valid yaml. %w",
-			err,
-		)
-	}
-
-	// Set default namespace for the context
-	// This avoids having to specify the namespace for every kubectl command
-	kubeConfig.Contexts[0].Context.Namespace = namespace
-	kubeConfigPath, err := kubeConfigManager.AddOrUpdateContext(ctx, clusterName, kubeConfig)
-	if err != nil {
-		return "", fmt.Errorf("failed adding/updating kube context, %w", err)
-	}
-
-	if _, err := t.kubectl.ConfigUseContext(ctx, clusterName, nil); err != nil {
-		return "", fmt.Errorf(
-			"failed setting kube context '%s'. Ensure the specified context exists. %w", clusterName,
-			err,
-		)
-	}
-
-	return kubeConfigPath, nil
 }
 
 // Finds a deployment using the specified deploymentNameFilter string

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/azure/azure-dev/cli/azd/pkg/kubelogin"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
@@ -550,6 +551,7 @@ func createAksServiceTarget(
 ) ServiceTarget {
 	kubeCtl := kubectl.NewKubectl(mockContext.CommandRunner)
 	dockerCli := docker.NewDocker(mockContext.CommandRunner)
+	kubeLoginCli := kubelogin.NewCli(mockContext.CommandRunner)
 	credentialProvider := mockaccount.SubscriptionCredentialProviderFunc(
 		func(_ context.Context, _ string) (azcore.TokenCredential, error) {
 			return mockContext.Credentials, nil
@@ -580,6 +582,7 @@ func createAksServiceTarget(
 		managedClustersService,
 		resourceManager,
 		kubeCtl,
+		kubeLoginCli,
 		containerHelper,
 	)
 }

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -213,7 +213,7 @@ func Test_Deploy_No_Credentials(t *testing.T) {
 	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env)
 	err = simulateInitliaze(*mockContext.Context, serviceTarget, serviceConfig)
 	require.Error(t, err)
-	require.ErrorContains(t, err, "failed retrieving cluster admin credentials")
+	require.ErrorContains(t, err, "failed retrieving cluster user credentials")
 }
 
 func setupK8sManifests(t *testing.T, serviceConfig *ServiceConfig) error {

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -144,7 +144,7 @@ func Test_Resolve_Cluster_Name(t *testing.T) {
 		require.NoError(t, err)
 
 		serviceConfig := createTestServiceConfig(tempDir, AksTarget, ServiceLanguageTypeScript)
-		serviceConfig.ResourceName = NewExpandableString("MY_AKS_CLUSTER")
+		serviceConfig.ResourceName = NewExpandableString("AKS_CLUSTER")
 		env := createEnv()
 
 		// Remove default AKS cluster name from env file
@@ -161,9 +161,9 @@ func Test_Resolve_Cluster_Name(t *testing.T) {
 		require.NoError(t, err)
 
 		serviceConfig := createTestServiceConfig(tempDir, AksTarget, ServiceLanguageTypeScript)
-		serviceConfig.ResourceName = NewExpandableString("$MY_CUSTOM_ENV_VAR")
+		serviceConfig.ResourceName = NewExpandableString("${MY_CUSTOM_ENV_VAR}")
 		env := createEnv()
-		env.DotenvSet("MY_CUSTOM_ENV_VAR", "MY_AKS_CLUSTER")
+		env.DotenvSet("MY_CUSTOM_ENV_VAR", "AKS_CLUSTER")
 
 		// Remove default AKS cluster name from env file
 		env.DotenvDelete(environment.AksClusterEnvVarName)

--- a/cli/azd/pkg/tools/azcli/managed_clusters.go
+++ b/cli/azd/pkg/tools/azcli/managed_clusters.go
@@ -12,6 +12,13 @@ import (
 
 // ManagedClustersService provides actions on top of Azure Kubernetes Service (AKS) Managed Clusters
 type ManagedClustersService interface {
+	// Gets the managed cluster resource by name
+	Get(
+		ctx context.Context,
+		subscriptionId string,
+		resourceGroupName string,
+		resourceName string,
+	) (*armcontainerservice.ManagedCluster, error)
 	// Gets the admin credentials for the specified resource
 	GetAdminCredentials(
 		ctx context.Context,
@@ -44,6 +51,26 @@ func NewManagedClustersService(
 		httpClient:         httpClient,
 		userAgent:          azdinternal.UserAgent(),
 	}
+}
+
+// Gets the managed cluster resource by name
+func (cs *managedClustersService) Get(
+	ctx context.Context,
+	subscriptionId string,
+	resourceGroupName string,
+	resourceName string,
+) (*armcontainerservice.ManagedCluster, error) {
+	client, err := cs.createManagedClusterClient(ctx, subscriptionId)
+	if err != nil {
+		return nil, err
+	}
+
+	managedCluster, err := client.Get(ctx, resourceGroupName, resourceName, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &managedCluster.ManagedCluster, nil
 }
 
 // Gets the user credentials for the specified resource

--- a/cli/azd/pkg/tools/azcli/managed_clusters.go
+++ b/cli/azd/pkg/tools/azcli/managed_clusters.go
@@ -19,13 +19,6 @@ type ManagedClustersService interface {
 		resourceGroupName string,
 		resourceName string,
 	) (*armcontainerservice.ManagedCluster, error)
-	// Gets the admin credentials for the specified resource
-	GetAdminCredentials(
-		ctx context.Context,
-		subscriptionId string,
-		resourceGroupName string,
-		resourceName string,
-	) (*armcontainerservice.CredentialResults, error)
 	// Gets the user credentials for the specified resource
 	GetUserCredentials(
 		ctx context.Context,
@@ -86,26 +79,6 @@ func (cs *managedClustersService) GetUserCredentials(
 	}
 
 	credResult, err := client.ListClusterUserCredentials(ctx, resourceGroupName, resourceName, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return &credResult.CredentialResults, nil
-}
-
-// Gets the admin credentials for the specified resource
-func (cs *managedClustersService) GetAdminCredentials(
-	ctx context.Context,
-	subscriptionId string,
-	resourceGroupName string,
-	resourceName string,
-) (*armcontainerservice.CredentialResults, error) {
-	client, err := cs.createManagedClusterClient(ctx, subscriptionId)
-	if err != nil {
-		return nil, err
-	}
-
-	credResult, err := client.ListClusterAdminCredentials(ctx, resourceGroupName, resourceName, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/pkg/tools/kubectl/kube_config.go
+++ b/cli/azd/pkg/tools/kubectl/kube_config.go
@@ -105,14 +105,9 @@ func (kcm *KubeConfigManager) AddOrUpdateContext(
 	contextName string,
 	newKubeConfig *KubeConfig,
 ) (string, error) {
-	_, err := kcm.SaveKubeConfig(ctx, contextName, newKubeConfig)
+	configPath, err := kcm.SaveKubeConfig(ctx, contextName, newKubeConfig)
 	if err != nil {
 		return "", fmt.Errorf("failed write new kube context file: %w", err)
-	}
-
-	configPath, err := kcm.MergeConfigs(ctx, "config", contextName)
-	if err != nil {
-		return "", fmt.Errorf("failed merging KUBE configs: %w", err)
 	}
 
 	return configPath, nil


### PR DESCRIPTION
When a cluster is provisioned with Azure RBAC and local accounts are disabled `azd` will leverage `kubelogin` to use exec auth module with azd authentication.

Requires `azd` login method [feature](https://github.com/Azure/kubelogin/pull/398) for `kubelogin` 

>[!IMPORTANT]
> Requires that the principal logged into `azd` has been granted the required RBAC roles to the AKS cluster during provisioning.