### PR TITLE
Adding template to configure Authentication for Container Apps via EasyAuth

### DIFF
--- a/templates/common/infra/bicep/core/host/container-apps-auth.bicep
+++ b/templates/common/infra/bicep/core/host/container-apps-auth.bicep
@@ -1,0 +1,42 @@
+metadata description = 'Creates an Azure Container Apps Auth Config using Microsoft Entra as Identity Provider.'
+
+@description('The name of the container apps resource within the current resource group scope')
+param name string
+
+@description('The client ID of the Microsoft Entra application.')
+param clientId string
+
+@description('The name of the Container Apps secret that contains the client secret of the Microsoft Entra application.')
+param clientSecretName string
+
+@description('The OpenID issuer of the Microsoft Entra application.')
+param openIdIssuer string
+
+
+resource app 'Microsoft.App/containerApps@2023-05-01' existing = {
+  name: name
+}
+
+resource auth 'Microsoft.App/containerApps/authConfigs@2023-05-01' = {
+  parent: app
+  name: 'current'
+  properties: {
+    platform: {
+      enabled: true
+    }
+    globalValidation: {
+      redirectToProvider: 'azureactivedirectory'
+      unauthenticatedClientAction: 'RedirectToLoginPage'
+    }
+    identityProviders: {
+      azureActiveDirectory: {
+        registration: {
+          clientId: clientId
+          clientSecretSettingName: clientSecretName
+          openIdIssuer: openIdIssuer
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Adds AuthConfig (EasyAuth) support for Azure Container Apps.

Initially this only supports the Microsoft Entra (f/k/a Azure Active Directory) provider.