### PR TITLE
Update search-services.bicep to support free tier

### DIFF
--- a/templates/common/infra/bicep/core/search/search-services.bicep
+++ b/templates/common/infra/bicep/core/search/search-services.bicep
@@ -40,7 +40,8 @@ resource search 'Microsoft.Search/searchServices@2021-04-01-preview' = {
   name: name
   location: location
   tags: tags
-  identity: {
+  // The free tier does not support managed identity
+  identity: (sku.name == 'free') ? null : {
     type: 'SystemAssigned'
   }
   properties: {


### PR DESCRIPTION
The free tier of search service doesn't support managed identity, so you get an error if you try to provision with current Bicep. This PR sets identity to null for free tier.