### PR TITLE
Remove support for `.connection.v0` resource types.

### DIFF
--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -350,11 +350,6 @@ func (b *infraGenerator) LoadManifest(m *Manifest) error {
 			// resource type.
 		case "postgres.database.v0":
 			b.addContainerAppService(name, "postgres")
-		case "postgres.connection.v0", "rabbitmq.connection.v0", "azure.cosmosdb.connection.v0":
-			// Only interesting thing about the connection resource is the connection string, which we handle above.
-
-			// We have the case statement here to ensure we don't error out on the resource type by treating it as an unknown
-			// resource type.
 		default:
 			ignore, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES"))
 			if err == nil && ignore {
@@ -906,16 +901,6 @@ func (b infraGenerator) evalBindingRef(v string, emitType inputEmitType) (string
 			return fmt.Sprintf("{{ .Env.SERVICE_BINDING_%s_CONNECTION_STRING }}", scaffold.AlphaSnakeUpper(resource)), nil
 		default:
 			return "", errUnsupportedProperty("azure.appinsights.v0", prop)
-		}
-	case targetType == "azure.cosmosdb.connection.v0" ||
-		targetType == "postgres.connection.v0" ||
-		targetType == "rabbitmq.connection.v0":
-
-		switch prop {
-		case "connectionString":
-			return b.connectionStrings[resource], nil
-		default:
-			return "", errUnsupportedProperty(targetType, prop)
 		}
 	case targetType == "azure.keyvault.v0" ||
 		targetType == "azure.storage.blob.v0" ||


### PR DESCRIPTION
Aspire removed the `.connection.v0` resource types in Preview 2. We kept our support in because it was easy to do so and gave folks a chance to migrate from Preview 1 to Preview 2.

However, as we get ready for Aspire Preview 3, it's time for us to remove support from `azd`. We'll never see these in manifests anymore, so it is safe to remove the code.