### PR TITLE
Remove unused `context.Context` parameter from `cmd.NewRootCmd`

### DIFF
--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -29,7 +28,7 @@ import (
 // Creates the root Cobra command for AZD.
 // staticHelp - False, except for running for doc generation
 // middlewareChain - nil, except for running unit tests
-func NewRootCmd(ctx context.Context, staticHelp bool, middlewareChain []*actions.MiddlewareRegistration) *cobra.Command {
+func NewRootCmd(staticHelp bool, middlewareChain []*actions.MiddlewareRegistration) *cobra.Command {
 	prevDir := ""
 	opts := &internal.GlobalCommandOptions{GenerateStaticHelp: staticHelp}
 	opts.EnableTelemetry = telemetry.IsTelemetryEnabled()

--- a/cli/azd/cmd/usage_test.go
+++ b/cli/azd/cmd/usage_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"html/template"
 	"strings"
 	"testing"
@@ -22,7 +21,7 @@ import (
 func TestUsage(t *testing.T) {
 	// disable rich formatting output
 	t.Setenv("TERM", "dumb")
-	root := NewRootCmd(context.Background(), false, nil)
+	root := NewRootCmd(false, nil)
 
 	usageSnapshot(t, root)
 }

--- a/cli/azd/docs/docgen.go
+++ b/cli/azd/docs/docgen.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -54,7 +53,7 @@ func main() {
 
 	// staticHelp is true to inform commands to use generate help text instead
 	// of generating help text that includes execution-specific state.
-	cmd := azd.NewRootCmd(context.Background(), true, nil)
+	cmd := azd.NewRootCmd(true, nil)
 
 	basename := strings.Replace(cmd.CommandPath(), " ", "_", -1) + ".md"
 	filename := filepath.Join("./md", basename)

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -58,7 +58,7 @@ func main() {
 	latest := make(chan semver.Version)
 	go fetchLatestVersion(latest)
 
-	cmdErr := cmd.NewRootCmd(ctx, false, nil).ExecuteContext(ctx)
+	cmdErr := cmd.NewRootCmd(false, nil).ExecuteContext(ctx)
 
 	if !isJsonOutput() {
 		if firstNotice := telemetry.FirstNotice(); firstNotice != "" {

--- a/cli/azd/test/functional/initialize_test.go
+++ b/cli/azd/test/functional/initialize_test.go
@@ -63,7 +63,7 @@ func Test_CommandsAndActions_Initialize(t *testing.T) {
 
 	// Creates the azd root command with a "Skip" middleware that will skip the invocation
 	// of the underlying command / actions
-	rootCmd := cmd.NewRootCmd(ctx, true, chain)
+	rootCmd := cmd.NewRootCmd(true, chain)
 	testCommand(t, rootCmd, ctx, chain, tempDir)
 }
 
@@ -85,7 +85,7 @@ func testCommand(
 			fullCmd := fmt.Sprintf("%s %s", testCmd.Parent().CommandPath(), use)
 			args := strings.Split(fullCmd, " ")[1:]
 			args = append(args, "--cwd", cwd)
-			childCmd := cmd.NewRootCmd(ctx, true, chain)
+			childCmd := cmd.NewRootCmd(true, chain)
 			childCmd.SetArgs(args)
 			err := childCmd.ExecuteContext(ctx)
 			require.NoError(t, err)


### PR DESCRIPTION
Does what it says on the tin.