### PR TITLE
Simplify `ioc.NestedContainer` implementation

### DIFF
--- a/cli/azd/pkg/ioc/binding.go
+++ b/cli/azd/pkg/ioc/binding.go
@@ -1,22 +1,7 @@
 package ioc
 
-type lifetime string
-
-const (
-	// Singleton lifetime indicates that the IoC container should only
-	// create a single instance of the registered type.
-	Singleton lifetime = "Singleton"
-	// Scoped lifetime indicates that the IoC container should create a
-	// single instance of the registered type per scope
-	Scoped lifetime = "Scoped"
-	// Transient lifetime indicates that the IoC container should create a
-	// new instance of the registered type each time it is requested.
-	Transient lifetime = "Transient"
-)
-
-// binding represents the metadata used for an IoC registration consisting of a optional name, lifetime and resolver.
+// binding represents the metadata used for an IoC registration consisting of a optional name and resolver.
 type binding struct {
 	name     string
 	resolver any
-	lifetime lifetime
 }

--- a/cli/azd/pkg/ioc/container.go
+++ b/cli/azd/pkg/ioc/container.go
@@ -24,7 +24,6 @@ var (
 // Used for more complex registration scenarios such as scop based registration/resolution.
 type NestedContainer struct {
 	inner          container.Container
-	parent         *NestedContainer
 	scopedBindings []*binding
 }
 
@@ -40,8 +39,7 @@ func NewNestedContainer(parent *NestedContainer) *NestedContainer {
 	}
 
 	instance := &NestedContainer{
-		inner:  current,
-		parent: parent,
+		inner: current,
 	}
 
 	RegisterInstance[ServiceLocator](instance, instance)
@@ -114,7 +112,6 @@ func (c *NestedContainer) RegisterScoped(resolveFn any) error {
 	}
 
 	c.scopedBindings = append(c.scopedBindings, &binding{
-		lifetime: Scoped,
 		resolver: resolveFn,
 	})
 
@@ -141,7 +138,6 @@ func (c *NestedContainer) RegisterNamedScoped(name string, resolveFn any) error 
 
 	c.scopedBindings = append(c.scopedBindings, &binding{
 		name:     name,
-		lifetime: Scoped,
 		resolver: resolveFn,
 	})
 


### PR DESCRIPTION
- Remove `lifetime`, it was only ever set to Scoped and only in the `scopedBindings` slice. We don't need to track it, since by construction all bindings in that slice are scoped.

- Remove `parent` from `NestedContainer`. It was never read, so there is no need to track it.