### PR TITLE
Adds flexibility when resolving container registry names

### DIFF
--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -39,15 +39,33 @@ func NewContainerHelper(
 	}
 }
 
-func (ch *ContainerHelper) RegistryName(ctx context.Context) (string, error) {
-	loginServer, has := ch.env.LookupEnv(environment.ContainerRegistryEndpointEnvVarName)
-	if !has {
+// RegistryName returns the name of the container registry to use for the current environment from the following:
+// 1. AZURE_CONTAINER_REGISTRY_ENDPOINT environment variable
+// 2. docker.registry from the service configuration
+func (ch *ContainerHelper) RegistryName(ctx context.Context, serviceConfig *ServiceConfig) (string, error) {
+	var loginServer string
+	envVarRegistryName, _ := ch.env.LookupEnv(environment.ContainerRegistryEndpointEnvVarName)
+	yamlRegistryName, _ := serviceConfig.Docker.Registry.Envsubst(ch.env.Getenv)
+
+	registryNameResolution := []string{
+		envVarRegistryName,
+		yamlRegistryName,
+	}
+
+	for _, registryName := range registryNameResolution {
+		if registryName != "" {
+			loginServer = registryName
+			break
+		}
+	}
+
+	if loginServer == "" {
 		return "", fmt.Errorf(
-			"could not determine container registry endpoint, ensure %s is set as an output of your infrastructure",
+			//nolint:lll
+			"could not determine container registry endpoint, ensure 'registry' has been set in the docker options or '%s' environment variable has been set",
 			environment.ContainerRegistryEndpointEnvVarName,
 		)
 	}
-
 	return loginServer, nil
 }
 
@@ -56,7 +74,7 @@ func (ch *ContainerHelper) RemoteImageTag(
 	serviceConfig *ServiceConfig,
 	localImageTag string,
 ) (string, error) {
-	loginServer, err := ch.RegistryName(ctx)
+	loginServer, err := ch.RegistryName(ctx, serviceConfig)
 	if err != nil {
 		return "", err
 	}
@@ -94,9 +112,10 @@ func (ch *ContainerHelper) RequiredExternalTools(context.Context) []tools.Extern
 // it returns the name of the container registry that was logged into.
 func (ch *ContainerHelper) Login(
 	ctx context.Context,
+	serviceConfig *ServiceConfig,
 	targetResource *environment.TargetResource,
 ) (string, error) {
-	loginServer, err := ch.RegistryName(ctx)
+	loginServer, err := ch.RegistryName(ctx, serviceConfig)
 	if err != nil {
 		return "", err
 	}
@@ -106,9 +125,10 @@ func (ch *ContainerHelper) Login(
 
 func (ch *ContainerHelper) Credentials(
 	ctx context.Context,
+	serviceConfig *ServiceConfig,
 	targetResource *environment.TargetResource,
 ) (*azcli.DockerCredentials, error) {
-	loginServer, err := ch.RegistryName(ctx)
+	loginServer, err := ch.RegistryName(ctx, serviceConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +148,7 @@ func (ch *ContainerHelper) Deploy(
 	return async.RunTaskWithProgress(
 		func(task *async.TaskContextWithProgress[*ServiceDeployResult, ServiceProgress]) {
 			// Get ACR Login Server
-			loginServer, err := ch.RegistryName(ctx)
+			loginServer, err := ch.RegistryName(ctx, serviceConfig)
 			if err != nil {
 				task.SetError(err)
 				return

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -37,6 +37,7 @@ type DockerProjectOptions struct {
 	Platform  string           `yaml:"platform,omitempty"  json:"platform,omitempty"`
 	Target    string           `yaml:"target,omitempty"    json:"target,omitempty"`
 	Tag       ExpandableString `yaml:"tag,omitempty"       json:"tag,omitempty"`
+	Registry  ExpandableString `yaml:"registry,omitempty"  json:"registry,omitempty"`
 	BuildArgs []string         `yaml:"buildArgs,omitempty" json:"buildArgs,omitempty"`
 }
 

--- a/cli/azd/pkg/project/service_target_dotnet_containerapp.go
+++ b/cli/azd/pkg/project/service_target_dotnet_containerapp.go
@@ -102,7 +102,7 @@ func (at *dotnetContainerAppTarget) Deploy(
 			task.SetProgress(NewServiceProgress("Logging in to registry"))
 
 			// Login, tag & push container image to ACR
-			dockerCreds, err := at.containerHelper.Credentials(ctx, targetResource)
+			dockerCreds, err := at.containerHelper.Credentials(ctx, serviceConfig, targetResource)
 			if err != nil {
 				task.SetError(fmt.Errorf("logging in to registry: %w", err))
 				return

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -546,6 +546,11 @@
                     "title": "The tag that will be applied to the built container image.",
                     "description": "If omitted, a unique tag will be generated based on the format: {appName}/{serviceName}-{environmentName}:azd-deploy-{unix time (seconds)}. Supports environment variable substitution. For example, to generate unique tags for a given release: myapp/myimage:${DOCKER_IMAGE_TAG}"
                 },
+                "registry": {
+                    "type": "string",
+                    "title": "The container registry to push the image to.",
+                    "description": "If omitted, will default to value of AZURE_CONTAINER_REGISTRY_ENDPOINT environment variable. Supports environment variable substitution."
+                },
                 "buildArgs": {
                     "type": "array",
                     "title": "Optional. Build arguments to pass to the docker build command",


### PR DESCRIPTION
Adds more flexibility when resolving container registry names

**Options:**
1. From `AZURE_CONTAINER_REGISTRY_ENDPOINT` env var
2. From `registry` property of the `docker` configuration section of a service (Supports expandable strings)