### PR TITLE
Fix duplicated output for spinner updates in non-tty scenarios

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -53,7 +53,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/swa"
 	"github.com/azure/azure-dev/cli/azd/pkg/workflow"
 	"github.com/mattn/go-colorable"
-	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 )
@@ -111,8 +110,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		}
 
 		isTerminal := cmd.OutOrStdout() == os.Stdout &&
-			cmd.InOrStdin() == os.Stdin && isatty.IsTerminal(os.Stdin.Fd()) &&
-			isatty.IsTerminal(os.Stdout.Fd())
+			cmd.InOrStdin() == os.Stdin && input.IsTerminal(os.Stdout.Fd(), os.Stdin.Fd())
 
 		return input.NewConsole(rootOptions.NoPrompt, isTerminal, writer, input.ConsoleHandles{
 			Stdin:  cmd.InOrStdin(),

--- a/cli/azd/pkg/input/asker.go
+++ b/cli/azd/pkg/input/asker.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"slices"
 	"strings"
 
@@ -105,7 +104,7 @@ func askOnePrompt(p survey.Prompt, response interface{}, isTerminal bool, stdout
 		}
 	}
 
-	if isTerminal && os.Getenv("AZD_DEBUG_FORCE_NO_TTY") != "1" {
+	if isTerminal {
 		opts := []survey.AskOpt{}
 
 		// When asking a question which requires a text response, show the cursor, it helps

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -704,7 +704,7 @@ func NewConsole(noPrompt bool, isTerminal bool, w io.Writer, handles ConsoleHand
 // taking into account of environment variables that force TTY behavior.
 func IsTerminal(stdoutFd uintptr, stdinFd uintptr) bool {
 	// User override to force non-TTY behavior
-	if os.Getenv("AZD_DEBUG_FORCE_NO_TTY") == "1" {
+	if ok, _ := strconv.ParseBool(os.Getenv("AZD_DEBUG_FORCE_NO_TTY")); ok {
 		return false
 	}
 

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -360,7 +360,6 @@ func (c *AskerConsole) ShowSpinner(ctx context.Context, title string, format Spi
 	_ = c.spinner.Unpause()
 
 	if c.spinner.Status() == yacspin.SpinnerStopped {
-		// Start the spinner if it is not running.
 		// While it is indeed safe to call Start regardless of whether the spinner is running,
 		// calling Start may result in an additional line of output being written in non-tty scenarios
 		_ = c.spinner.Start()

--- a/cli/azd/pkg/input/console_test.go
+++ b/cli/azd/pkg/input/console_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package input
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type lineCapturer struct {
+	captured []string
+}
+
+func (l *lineCapturer) Write(bytes []byte) (n int, err error) {
+	var sb strings.Builder
+	for i, b := range bytes {
+		if b == '\n' {
+			l.captured = append(l.captured, sb.String())
+			sb.Reset()
+			continue
+		}
+
+		err = sb.WriteByte(b)
+		if err != nil {
+			return i, err
+		}
+
+	}
+	return len(bytes), nil
+}
+
+// Verifies no extra output is printed in non-tty scenarios.
+func TestAskerConsole_Spinner_NonTty(t *testing.T) {
+	// The underlying spinner relies on non-blocking channels for paint updates.
+	// We need to give it some time to paint.
+	const cSleep = 50 * time.Millisecond
+
+	lines := &lineCapturer{}
+	c := NewConsole(
+		false,
+		false,
+		lines,
+		ConsoleHandles{
+			Stderr: os.Stderr,
+			Stdin:  os.Stdin,
+			Stdout: lines,
+		},
+		nil)
+
+	ctx := context.Background()
+	require.Len(t, lines.captured, 0)
+	c.ShowSpinner(ctx, "Some title.", Step)
+	time.Sleep(cSleep)
+	require.Len(t, lines.captured, 1)
+	require.Equal(t, lines.captured[0], "Some title.")
+
+	c.ShowSpinner(ctx, "Some title 2.", Step)
+	time.Sleep(cSleep)
+	require.Len(t, lines.captured, 2)
+	require.Equal(t, lines.captured[1], "Some title 2.")
+
+	c.StopSpinner(ctx, "", StepDone)
+	time.Sleep(cSleep)
+	require.Len(t, lines.captured, 2)
+	require.Equal(t, lines.captured[1], "Some title 2.")
+
+	c.ShowSpinner(ctx, "Some title 3.", Step)
+	time.Sleep(cSleep)
+	require.Len(t, lines.captured, 3)
+	require.Equal(t, lines.captured[2], "Some title 3.")
+
+	c.Message(ctx, "Some message.")
+	time.Sleep(cSleep)
+	require.Len(t, lines.captured, 4)
+	require.Equal(t, lines.captured[3], "Some message.")
+
+	c.StopSpinner(ctx, "Done.", StepDone)
+	time.Sleep(cSleep)
+	require.Len(t, lines.captured, 5)
+}

--- a/cli/azd/pkg/input/console_test.go
+++ b/cli/azd/pkg/input/console_test.go
@@ -35,7 +35,7 @@ func (l *lineCapturer) Write(bytes []byte) (n int, err error) {
 	return len(bytes), nil
 }
 
-// Verifies no extra output is printed in non-tty scenarios.
+// Verifies no extra output is printed in non-tty scenarios for the spinner.
 func TestAskerConsole_Spinner_NonTty(t *testing.T) {
 	// The underlying spinner relies on non-blocking channels for paint updates.
 	// We need to give it some time to paint.


### PR DESCRIPTION
The spinner library we're using triggers a paint update when any data update occurs in non-tty scenarios. This unfortunately results in a lot of unexpected extra output in non-tty scenarios.

With this change, we sidestep the issues here by being more careful on how we use the spinner and add tests to verify the desired behavior. Perhaps down the line we could consider addressing this cleanly with our own spinner implementation.
 
Fixes #3254

Post-change output:
![image](https://github.com/Azure/azure-dev/assets/2322434/b1bab8c9-2980-4742-807a-808d78111120)
![image](https://github.com/Azure/azure-dev/assets/2322434/edda68c3-900c-496c-9c41-c209155eb2a9)
