### PR TITLE
Allow caller to control root container in `NewRootCmd`

### DIFF
--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -28,7 +28,13 @@ import (
 // Creates the root Cobra command for AZD.
 // staticHelp - False, except for running for doc generation
 // middlewareChain - nil, except for running unit tests
-func NewRootCmd(staticHelp bool, middlewareChain []*actions.MiddlewareRegistration) *cobra.Command {
+// rootContainer - The IoC container to use for registering and resolving dependencies. If nil is provided, a new
+// container empty will be created.
+func NewRootCmd(
+	staticHelp bool,
+	middlewareChain []*actions.MiddlewareRegistration,
+	rootContainer *ioc.NestedContainer,
+) *cobra.Command {
 	prevDir := ""
 	opts := &internal.GlobalCommandOptions{GenerateStaticHelp: staticHelp}
 	opts.EnableTelemetry = telemetry.IsTelemetryEnabled()
@@ -322,7 +328,9 @@ func NewRootCmd(staticHelp bool, middlewareChain []*actions.MiddlewareRegistrati
 		})
 
 	// Register common dependencies for the IoC rootContainer
-	rootContainer := ioc.NewNestedContainer(nil)
+	if rootContainer == nil {
+		rootContainer = ioc.NewNestedContainer(nil)
+	}
 	ioc.RegisterNamedInstance(rootContainer, "root-cmd", rootCmd)
 	registerCommonDependencies(rootContainer)
 

--- a/cli/azd/cmd/usage_test.go
+++ b/cli/azd/cmd/usage_test.go
@@ -21,7 +21,7 @@ import (
 func TestUsage(t *testing.T) {
 	// disable rich formatting output
 	t.Setenv("TERM", "dumb")
-	root := NewRootCmd(false, nil)
+	root := NewRootCmd(false, nil, nil)
 
 	usageSnapshot(t, root)
 }

--- a/cli/azd/docs/docgen.go
+++ b/cli/azd/docs/docgen.go
@@ -53,7 +53,7 @@ func main() {
 
 	// staticHelp is true to inform commands to use generate help text instead
 	// of generating help text that includes execution-specific state.
-	cmd := azd.NewRootCmd(true, nil)
+	cmd := azd.NewRootCmd(true, nil, nil)
 
 	basename := strings.Replace(cmd.CommandPath(), " ", "_", -1) + ".md"
 	filename := filepath.Join("./md", basename)

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -58,7 +58,7 @@ func main() {
 	latest := make(chan semver.Version)
 	go fetchLatestVersion(latest)
 
-	cmdErr := cmd.NewRootCmd(false, nil).ExecuteContext(ctx)
+	cmdErr := cmd.NewRootCmd(false, nil, nil).ExecuteContext(ctx)
 
 	if !isJsonOutput() {
 		if firstNotice := telemetry.FirstNotice(); firstNotice != "" {

--- a/cli/azd/test/functional/initialize_test.go
+++ b/cli/azd/test/functional/initialize_test.go
@@ -63,7 +63,7 @@ func Test_CommandsAndActions_Initialize(t *testing.T) {
 
 	// Creates the azd root command with a "Skip" middleware that will skip the invocation
 	// of the underlying command / actions
-	rootCmd := cmd.NewRootCmd(true, chain)
+	rootCmd := cmd.NewRootCmd(true, chain, nil)
 	testCommand(t, rootCmd, ctx, chain, tempDir)
 }
 
@@ -85,7 +85,7 @@ func testCommand(
 			fullCmd := fmt.Sprintf("%s %s", testCmd.Parent().CommandPath(), use)
 			args := strings.Split(fullCmd, " ")[1:]
 			args = append(args, "--cwd", cwd)
-			childCmd := cmd.NewRootCmd(true, chain)
+			childCmd := cmd.NewRootCmd(true, chain, nil)
 			childCmd.SetArgs(args)
 			err := childCmd.ExecuteContext(ctx)
 			require.NoError(t, err)


### PR DESCRIPTION
This change adds a parameter to `NewRootCmd` to allow a caller to pass the IoC container that is used during construction of the root cobra command. Doing so allows a caller to change the result of registrations (as our vs-server needs to do).

Because `NewRootCmd` registers dependencies itself, a caller needs to take care to override whatever they want after calling `NewRootCmd` but before trying to actually run any methods on the returned `*cobra.Command`.

In an ideal world, `NewRootCommand` would not do any registrations and the caller would be required to do all the registrations.  We'll get there next. Right now this change provides the surgical hook needed by the VS sever work without being overly distruptive to the codebase.