### PR TITLE
Move `envFlag` out of `cmd`

### DIFF
--- a/cli/azd/cmd/build.go
+++ b/cli/azd/cmd/build.go
@@ -19,7 +19,7 @@ import (
 )
 
 type buildFlags struct {
-	*envFlag
+	*internal.EnvFlag
 	all    bool
 	global *internal.GlobalCommandOptions
 	only   bool
@@ -27,7 +27,7 @@ type buildFlags struct {
 
 func newBuildFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *buildFlags {
 	flags := &buildFlags{
-		envFlag: &envFlag{},
+		EnvFlag: &internal.EnvFlag{},
 	}
 
 	flags.Bind(cmd.Flags(), global)
@@ -36,7 +36,7 @@ func newBuildFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *b
 }
 
 func (bf *buildFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
-	bf.envFlag.Bind(local, global)
+	bf.EnvFlag.Bind(local, global)
 	bf.global = global
 
 	local.BoolVar(

--- a/cli/azd/cmd/deploy.go
+++ b/cli/azd/cmd/deploy.go
@@ -31,7 +31,7 @@ type deployFlags struct {
 	all         bool
 	fromPackage string
 	global      *internal.GlobalCommandOptions
-	*envFlag
+	*internal.EnvFlag
 }
 
 func (d *deployFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
@@ -55,8 +55,8 @@ func (d *deployFlags) bindNonCommon(
 }
 
 func (d *deployFlags) bindCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
-	d.envFlag = &envFlag{}
-	d.envFlag.Bind(local, global)
+	d.EnvFlag = &internal.EnvFlag{}
+	d.EnvFlag.Bind(local, global)
 
 	local.BoolVar(
 		&d.all,
@@ -72,8 +72,8 @@ func (d *deployFlags) bindCommon(local *pflag.FlagSet, global *internal.GlobalCo
 	)
 }
 
-func (d *deployFlags) setCommon(envFlag *envFlag) {
-	d.envFlag = envFlag
+func (d *deployFlags) setCommon(envFlag *internal.EnvFlag) {
+	d.EnvFlag = envFlag
 }
 
 func newDeployFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *deployFlags {

--- a/cli/azd/cmd/down.go
+++ b/cli/azd/cmd/down.go
@@ -22,7 +22,7 @@ type downFlags struct {
 	forceDelete bool
 	purgeDelete bool
 	global      *internal.GlobalCommandOptions
-	envFlag
+	internal.EnvFlag
 }
 
 func (i *downFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
@@ -34,7 +34,7 @@ func (i *downFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOpt
 		//nolint:lll
 		"Does not require confirmation before it permanently deletes resources that are soft-deleted by default (for example, key vaults).",
 	)
-	i.envFlag.Bind(local, global)
+	i.EnvFlag.Bind(local, global)
 	i.global = global
 }
 

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -95,12 +95,12 @@ func newEnvSetCmd() *cobra.Command {
 }
 
 type envSetFlags struct {
-	envFlag
+	internal.EnvFlag
 	global *internal.GlobalCommandOptions
 }
 
 func (f *envSetFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
-	f.envFlag.Bind(local, global)
+	f.EnvFlag.Bind(local, global)
 	f.global = global
 }
 
@@ -337,13 +337,13 @@ func (en *envNewAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 type envRefreshFlags struct {
 	hint   string
 	global *internal.GlobalCommandOptions
-	envFlag
+	internal.EnvFlag
 }
 
 func (er *envRefreshFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	local.StringVarP(&er.hint, "hint", "", "", "Hint to help identify the environment to refresh")
 
-	er.envFlag.Bind(local, global)
+	er.EnvFlag.Bind(local, global)
 	er.global = global
 }
 
@@ -371,14 +371,14 @@ func newEnvRefreshCmd() *cobra.Command {
 				return nil
 			}
 
-			if flagValue, err := cmd.Flags().GetString(environmentNameFlag); err == nil {
+			if flagValue, err := cmd.Flags().GetString(internal.EnvironmentNameFlagName); err == nil {
 				if flagValue != "" && args[0] != flagValue {
 					return errors.New(
 						"the --environment flag and an explicit environment name as an argument may not be used together")
 				}
 			}
 
-			return cmd.Flags().Set(environmentNameFlag, args[0])
+			return cmd.Flags().Set(internal.EnvironmentNameFlagName, args[0])
 		},
 		Annotations: map[string]string{},
 	}
@@ -518,12 +518,12 @@ func newEnvGetValuesCmd() *cobra.Command {
 }
 
 type envGetValuesFlags struct {
-	envFlag
+	internal.EnvFlag
 	global *internal.GlobalCommandOptions
 }
 
 func (eg *envGetValuesFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
-	eg.envFlag.Bind(local, global)
+	eg.EnvFlag.Bind(local, global)
 	eg.global = global
 }
 
@@ -563,8 +563,8 @@ func (eg *envGetValuesAction) Run(ctx context.Context) (*actions.ActionResult, e
 	// and later, when envManager.Get() is called with the empty string, azd returns an error.
 	// But if there is already an environment (default to be selected), azd must honor the --environment flag
 	// over the default environment.
-	if eg.flags.environmentName != "" {
-		name = eg.flags.environmentName
+	if eg.flags.EnvironmentName != "" {
+		name = eg.flags.EnvironmentName
 	}
 	env, err := eg.envManager.Get(ctx, name)
 	if errors.Is(err, environment.ErrNotFound) {

--- a/cli/azd/cmd/hooks.go
+++ b/cli/azd/cmd/hooks.go
@@ -54,14 +54,14 @@ func newHooksRunCmd() *cobra.Command {
 }
 
 type hooksRunFlags struct {
-	envFlag
+	internal.EnvFlag
 	global   *internal.GlobalCommandOptions
 	platform string
 	service  string
 }
 
 func (f *hooksRunFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
-	f.envFlag.Bind(local, global)
+	f.EnvFlag.Bind(local, global)
 	f.global = global
 
 	local.StringVar(&f.platform, "platform", "", "Forces hooks to run for the specified platform.")

--- a/cli/azd/cmd/infra_synth.go
+++ b/cli/azd/cmd/infra_synth.go
@@ -24,13 +24,13 @@ import (
 
 type infraSynthFlags struct {
 	global *internal.GlobalCommandOptions
-	*envFlag
+	*internal.EnvFlag
 	force bool
 }
 
 func newInfraSynthFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *infraSynthFlags {
 	flags := &infraSynthFlags{
-		envFlag: &envFlag{},
+		EnvFlag: &internal.EnvFlag{},
 	}
 	flags.Bind(cmd.Flags(), global)
 
@@ -39,7 +39,7 @@ func newInfraSynthFlags(cmd *cobra.Command, global *internal.GlobalCommandOption
 
 func (f *infraSynthFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	f.global = global
-	f.envFlag.Bind(local, global)
+	f.EnvFlag.Bind(local, global)
 	local.BoolVar(&f.force, "force", false, "Overwrite any existing files without prompting")
 }
 

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -53,7 +53,7 @@ type initFlags struct {
 	subscription   string
 	location       string
 	global         *internal.GlobalCommandOptions
-	envFlag
+	internal.EnvFlag
 }
 
 func (i *initFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
@@ -79,7 +79,7 @@ func (i *initFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOpt
 		"Name or ID of an Azure subscription to use for the new environment",
 	)
 	local.StringVarP(&i.location, "location", "l", "", "Azure location for the new environment")
-	i.envFlag.Bind(local, global)
+	i.EnvFlag.Bind(local, global)
 
 	i.global = global
 }
@@ -345,7 +345,7 @@ func (i *initAction) initializeEnv(
 	}
 
 	envSpec := environment.Spec{
-		Name:         i.flags.environmentName,
+		Name:         i.flags.EnvironmentName,
 		Subscription: i.flags.subscription,
 		Location:     i.flags.location,
 		Examples:     examples,

--- a/cli/azd/cmd/monitor.go
+++ b/cli/azd/cmd/monitor.go
@@ -28,7 +28,7 @@ type monitorFlags struct {
 	monitorLogs     bool
 	monitorOverview bool
 	global          *internal.GlobalCommandOptions
-	envFlag
+	internal.EnvFlag
 }
 
 func (m *monitorFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
@@ -40,7 +40,7 @@ func (m *monitorFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommand
 	)
 	local.BoolVar(&m.monitorLogs, "logs", false, "Open a browser to Application Insights Logs.")
 	local.BoolVar(&m.monitorOverview, "overview", false, "Open a browser to Application Insights Overview Dashboard.")
-	m.envFlag.Bind(local, global)
+	m.EnvFlag.Bind(local, global)
 	m.global = global
 }
 

--- a/cli/azd/cmd/package.go
+++ b/cli/azd/cmd/package.go
@@ -20,13 +20,13 @@ import (
 type packageFlags struct {
 	all    bool
 	global *internal.GlobalCommandOptions
-	*envFlag
+	*internal.EnvFlag
 	outputPath string
 }
 
 func newPackageFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *packageFlags {
 	flags := &packageFlags{
-		envFlag: &envFlag{},
+		EnvFlag: &internal.EnvFlag{},
 	}
 
 	flags.Bind(cmd.Flags(), global)
@@ -35,7 +35,7 @@ func newPackageFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) 
 }
 
 func (pf *packageFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
-	pf.envFlag.Bind(local, global)
+	pf.EnvFlag.Bind(local, global)
 	pf.global = global
 
 	local.BoolVar(

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -26,7 +26,7 @@ import (
 type pipelineConfigFlags struct {
 	pipeline.PipelineManagerArgs
 	global *internal.GlobalCommandOptions
-	envFlag
+	internal.EnvFlag
 }
 
 func (pc *pipelineConfigFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
@@ -66,7 +66,7 @@ func (pc *pipelineConfigFlags) Bind(local *pflag.FlagSet, global *internal.Globa
 	// there no customer input using --provider
 	local.StringVar(&pc.PipelineProvider, "provider", "",
 		"The pipeline provider to use (github for Github Actions and azdo for Azure Pipelines).")
-	pc.envFlag.Bind(local, global)
+	pc.EnvFlag.Bind(local, global)
 	pc.global = global
 }
 

--- a/cli/azd/cmd/provision.go
+++ b/cli/azd/cmd/provision.go
@@ -29,7 +29,7 @@ type provisionFlags struct {
 	preview               bool
 	ignoreDeploymentState bool
 	global                *internal.GlobalCommandOptions
-	*envFlag
+	*internal.EnvFlag
 }
 
 const (
@@ -59,12 +59,12 @@ func (i *provisionFlags) bindCommon(local *pflag.FlagSet, global *internal.Globa
 		false,
 		"Do not use latest Deployment State (bicep only).")
 
-	i.envFlag = &envFlag{}
-	i.envFlag.Bind(local, global)
+	i.EnvFlag = &internal.EnvFlag{}
+	i.EnvFlag.Bind(local, global)
 }
 
-func (i *provisionFlags) setCommon(envFlag *envFlag) {
-	i.envFlag = envFlag
+func (i *provisionFlags) setCommon(envFlag *internal.EnvFlag) {
+	i.EnvFlag = envFlag
 }
 
 func newProvisionFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *provisionFlags {

--- a/cli/azd/cmd/restore.go
+++ b/cli/azd/cmd/restore.go
@@ -26,7 +26,7 @@ type restoreFlags struct {
 	all         bool
 	global      *internal.GlobalCommandOptions
 	serviceName string
-	envFlag
+	internal.EnvFlag
 }
 
 func (r *restoreFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
@@ -50,7 +50,7 @@ func (r *restoreFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommand
 func newRestoreFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *restoreFlags {
 	flags := &restoreFlags{}
 	flags.Bind(cmd.Flags(), global)
-	flags.envFlag.Bind(cmd.Flags(), global)
+	flags.EnvFlag.Bind(cmd.Flags(), global)
 	flags.global = global
 
 	return flags

--- a/cli/azd/cmd/show.go
+++ b/cli/azd/cmd/show.go
@@ -29,11 +29,11 @@ import (
 
 type showFlags struct {
 	global *internal.GlobalCommandOptions
-	envFlag
+	internal.EnvFlag
 }
 
 func (s *showFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
-	s.envFlag.Bind(local, global)
+	s.EnvFlag.Bind(local, global)
 	s.global = global
 }
 
@@ -135,7 +135,7 @@ func (s *showAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	// having an environment injected into us so we can handle cases where the current environment doesn't exist (if we
 	// injected an environment, we'd prompt the user to see if they want to created one and we'd prefer not to have show
 	// interact with the user).
-	environmentName := s.flags.environmentName
+	environmentName := s.flags.EnvironmentName
 
 	if environmentName == "" {
 		var err error
@@ -147,7 +147,7 @@ func (s *showAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	}
 	var subId, rgName string
 	if env, err := s.envManager.Get(ctx, environmentName); err != nil {
-		if errors.Is(err, environment.ErrNotFound) && s.flags.environmentName != "" {
+		if errors.Is(err, environment.ErrNotFound) && s.flags.EnvironmentName != "" {
 			return nil, fmt.Errorf(
 				`"environment '%s' does not exist. You can create it with "azd env new"`, environmentName,
 			)

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -24,17 +24,17 @@ type upFlags struct {
 	provisionFlags
 	deployFlags
 	global *internal.GlobalCommandOptions
-	envFlag
+	internal.EnvFlag
 }
 
 func (u *upFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
-	u.envFlag.Bind(local, global)
+	u.EnvFlag.Bind(local, global)
 	u.global = global
 
 	u.provisionFlags.bindNonCommon(local, global)
-	u.provisionFlags.setCommon(&u.envFlag)
+	u.provisionFlags.setCommon(&u.EnvFlag)
 	u.deployFlags.bindNonCommon(local, global)
-	u.deployFlags.setCommon(&u.envFlag)
+	u.deployFlags.setCommon(&u.EnvFlag)
 }
 
 func newUpFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *upFlags {

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	azdExec "github.com/azure/azure-dev/cli/azd/pkg/exec"
@@ -21,29 +20,12 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/cli/browser"
-	"github.com/spf13/pflag"
 )
 
 // CmdAnnotations on a command
 type CmdAnnotations map[string]string
 
 type Asker func(p survey.Prompt, response interface{}) error
-
-const environmentNameFlag string = "environment"
-
-type envFlag struct {
-	environmentName string
-}
-
-func (e *envFlag) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
-	local.StringVarP(
-		&e.environmentName,
-		environmentNameFlag,
-		"e",
-		// Set the default value to AZURE_ENV_NAME value if available
-		os.Getenv(environment.EnvNameEnvVarName),
-		"The name of the environment to use.")
-}
 
 func getResourceGroupFollowUp(
 	ctx context.Context,

--- a/cli/azd/internal/env_flag.go
+++ b/cli/azd/internal/env_flag.go
@@ -1,0 +1,29 @@
+package internal
+
+import (
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+// EnvFlag is a flag that represents the environment name. Actions which inject an environment should also use this flag
+// so the user can control what environment is loaded in a uniform way across all our commands.
+type EnvFlag struct {
+	EnvironmentName string
+}
+
+// EnvironmentNameFlagName is the full name of the flag as it appears on the command line.
+const EnvironmentNameFlagName string = "environment"
+
+// envNameEnvVarName is the same as environment.EnvNameEnvVarName, but duplicated here to prevent an import cycle.
+const envNameEnvVarName = "AZURE_ENV_NAME"
+
+func (e *EnvFlag) Bind(local *pflag.FlagSet, global *GlobalCommandOptions) {
+	local.StringVarP(
+		&e.EnvironmentName,
+		EnvironmentNameFlagName,
+		"e",
+		// Set the default value to AZURE_ENV_NAME value if available
+		os.Getenv(envNameEnvVarName),
+		"The name of the environment to use.")
+}


### PR DESCRIPTION
The VS Server work is going to want to reference this type (it needs to register a provider for it in the IoC container because our actions pull it when loading an Environment) which means it can't live in the `cmd` package.

The `internal` package is not a great long term home for this, but it is where `GlobalCommandOptions` lives today and these two types are deeply related. Long term I'd like to move these both somewhere else since bare `internal.Xyz` imports read very poorly to me, but now at least these two types live in the same package and can move to a their final home together.