### PR TITLE
Move deploy and provision actions to `internal/cmd`

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -14,6 +14,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/cmd/middleware"
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/internal/cmd"
 	"github.com/azure/azure-dev/cli/azd/internal/repository"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
@@ -606,7 +607,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.MustRegisterSingleton(workflow.NewRunner)
 
 	// Required for nested actions called from composite actions like 'up'
-	registerAction[*provisionAction](container, "azd-provision-action")
+	registerAction[*cmd.ProvisionAction](container, "azd-provision-action")
 	registerAction[*downAction](container, "azd-down-action")
 	registerAction[*configShowAction](container, "azd-config-show-action")
 }

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/internal/cmd"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/spf13/cobra"
 )
 
 type infraCreateFlags struct {
-	provisionFlags
+	cmd.ProvisionFlags
 }
 
 func newInfraCreateFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *infraCreateFlags {
@@ -31,17 +32,17 @@ func newInfraCreateCmd() *cobra.Command {
 }
 
 type infraCreateAction struct {
-	infraCreate *provisionAction
+	infraCreate *cmd.ProvisionAction
 	console     input.Console
 }
 
 func newInfraCreateAction(
 	createFlags *infraCreateFlags,
-	provision *provisionAction,
+	provision *cmd.ProvisionAction,
 	console input.Console,
 ) actions.Action {
 	// Required to ensure the sub action flags are bound correctly to the actions
-	provision.flags = &createFlags.provisionFlags
+	provision.SetFlags(&createFlags.ProvisionFlags)
 
 	return &infraCreateAction{
 		infraCreate: provision,

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/platform"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/internal/cmd"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/spf13/cobra"
@@ -211,13 +212,13 @@ func NewRootCmd(
 
 	root.
 		Add("provision", &actions.ActionDescriptorOptions{
-			Command:        newProvisionCmd(),
-			FlagsResolver:  newProvisionFlags,
-			ActionResolver: newProvisionAction,
+			Command:        cmd.NewProvisionCmd(),
+			FlagsResolver:  cmd.NewProvisionFlags,
+			ActionResolver: cmd.NewProvisionAction,
 			OutputFormats:  []output.Format{output.JsonFormat, output.NoneFormat},
 			DefaultFormat:  output.NoneFormat,
 			HelpOptions: actions.ActionHelpOptions{
-				Description: getCmdProvisionHelpDescription,
+				Description: cmd.GetCmdProvisionHelpDescription,
 				Footer:      getCmdHelpDefaultFooter,
 			},
 			GroupingOptions: actions.CommandGroupOptions{
@@ -251,14 +252,14 @@ func NewRootCmd(
 
 	root.
 		Add("deploy", &actions.ActionDescriptorOptions{
-			Command:        newDeployCmd(),
-			FlagsResolver:  newDeployFlags,
-			ActionResolver: newDeployAction,
+			Command:        cmd.NewDeployCmd(),
+			FlagsResolver:  cmd.NewDeployFlags,
+			ActionResolver: cmd.NewDeployAction,
 			OutputFormats:  []output.Format{output.JsonFormat, output.NoneFormat},
 			DefaultFormat:  output.NoneFormat,
 			HelpOptions: actions.ActionHelpOptions{
-				Description: getCmdDeployHelpDescription,
-				Footer:      getCmdDeployHelpFooter,
+				Description: cmd.GetCmdDeployHelpDescription,
+				Footer:      cmd.GetCmdDeployHelpFooter,
 			},
 			GroupingOptions: actions.CommandGroupOptions{
 				RootLevelHelp: actions.CmdGroupManage,

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -8,6 +8,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/internal/cmd"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
@@ -21,8 +22,8 @@ import (
 )
 
 type upFlags struct {
-	provisionFlags
-	deployFlags
+	cmd.ProvisionFlags
+	cmd.DeployFlags
 	global *internal.GlobalCommandOptions
 	internal.EnvFlag
 }
@@ -31,10 +32,10 @@ func (u *upFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptio
 	u.EnvFlag.Bind(local, global)
 	u.global = global
 
-	u.provisionFlags.bindNonCommon(local, global)
-	u.provisionFlags.setCommon(&u.EnvFlag)
-	u.deployFlags.bindNonCommon(local, global)
-	u.deployFlags.setCommon(&u.EnvFlag)
+	u.ProvisionFlags.BindNonCommon(local, global)
+	u.ProvisionFlags.SetCommon(&u.EnvFlag)
+	u.DeployFlags.BindNonCommon(local, global)
+	u.DeployFlags.SetCommon(&u.EnvFlag)
 }
 
 func newUpFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *upFlags {

--- a/cli/azd/internal/cmd/cmd_help.go
+++ b/cli/azd/internal/cmd/cmd_help.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+)
+
+// formatHelpNote provides the expected format in description notes using `•`.
+func formatHelpNote(note string) string {
+	return fmt.Sprintf("  • %s", note)
+}
+
+// generateCmdHelpDescription construct a help text block from a title and description notes.
+func generateCmdHelpDescription(title string, notes []string) string {
+	var note string
+	if len(notes) > 0 {
+		note = fmt.Sprintf("%s\n\n", strings.Join(notes, "\n"))
+	}
+	return fmt.Sprintf("%s\n\n%s", title, note)
+}
+
+// generateCmdHelpSamplesBlock converts the samples within the input `samples` to a help text block describing each sample
+// title and the command to run it.
+func generateCmdHelpSamplesBlock(samples map[string]string) string {
+	SamplesCount := len(samples)
+	if SamplesCount == 0 {
+		return ""
+	}
+	var lines []string
+	for title, command := range samples {
+		lines = append(lines, fmt.Sprintf("  %s\n    %s", title, command))
+	}
+	// sorting lines to keep a deterministic output, as map[string]string is not ordered
+	slices.Sort(lines)
+	return fmt.Sprintf("%s\n%s\n",
+		output.WithBold(output.WithUnderline("Examples")),
+		strings.Join(lines, "\n\n"),
+	)
+}

--- a/cli/azd/internal/cmd/deploy.go
+++ b/cli/azd/internal/cmd/deploy.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-type deployFlags struct {
+type DeployFlags struct {
 	serviceName string
 	all         bool
 	fromPackage string
@@ -34,12 +34,12 @@ type deployFlags struct {
 	*internal.EnvFlag
 }
 
-func (d *deployFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
-	d.bindNonCommon(local, global)
+func (d *DeployFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
+	d.BindNonCommon(local, global)
 	d.bindCommon(local, global)
 }
 
-func (d *deployFlags) bindNonCommon(
+func (d *DeployFlags) BindNonCommon(
 	local *pflag.FlagSet,
 	global *internal.GlobalCommandOptions) {
 	local.StringVar(
@@ -54,7 +54,7 @@ func (d *deployFlags) bindNonCommon(
 	d.global = global
 }
 
-func (d *deployFlags) bindCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
+func (d *DeployFlags) bindCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	d.EnvFlag = &internal.EnvFlag{}
 	d.EnvFlag.Bind(local, global)
 
@@ -72,18 +72,18 @@ func (d *deployFlags) bindCommon(local *pflag.FlagSet, global *internal.GlobalCo
 	)
 }
 
-func (d *deployFlags) setCommon(envFlag *internal.EnvFlag) {
+func (d *DeployFlags) SetCommon(envFlag *internal.EnvFlag) {
 	d.EnvFlag = envFlag
 }
 
-func newDeployFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *deployFlags {
-	flags := &deployFlags{}
+func NewDeployFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *DeployFlags {
+	flags := &DeployFlags{}
 	flags.Bind(cmd.Flags(), global)
 
 	return flags
 }
 
-func newDeployCmd() *cobra.Command {
+func NewDeployCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy <service>",
 		Short: "Deploy the application's code to Azure.",
@@ -93,8 +93,8 @@ func newDeployCmd() *cobra.Command {
 	return cmd
 }
 
-type deployAction struct {
-	flags               *deployFlags
+type DeployAction struct {
+	flags               *DeployFlags
 	args                []string
 	projectConfig       *project.ProjectConfig
 	azdCtx              *azdcontext.AzdContext
@@ -112,8 +112,8 @@ type deployAction struct {
 	importManager       *project.ImportManager
 }
 
-func newDeployAction(
-	flags *deployFlags,
+func NewDeployAction(
+	flags *DeployFlags,
 	args []string,
 	projectConfig *project.ProjectConfig,
 	projectManager project.ProjectManager,
@@ -130,7 +130,7 @@ func newDeployAction(
 	alphaFeatureManager *alpha.FeatureManager,
 	importManager *project.ImportManager,
 ) actions.Action {
-	return &deployAction{
+	return &DeployAction{
 		flags:               flags,
 		args:                args,
 		projectConfig:       projectConfig,
@@ -155,7 +155,7 @@ type DeploymentResult struct {
 	Services  map[string]*project.ServiceDeployResult `json:"services"`
 }
 
-func (da *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+func (da *DeployAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	targetServiceName := da.flags.serviceName
 	if len(da.args) == 1 {
 		targetServiceName = da.args[0]
@@ -306,7 +306,7 @@ func (da *deployAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 	}, nil
 }
 
-func getCmdDeployHelpDescription(*cobra.Command) string {
+func GetCmdDeployHelpDescription(*cobra.Command) string {
 	return generateCmdHelpDescription("Deploy application to Azure.", []string{
 		formatHelpNote(
 			"By default, deploys all services listed in 'azure.yaml' in the current directory," +
@@ -318,7 +318,7 @@ func getCmdDeployHelpDescription(*cobra.Command) string {
 	})
 }
 
-func getCmdDeployHelpFooter(*cobra.Command) string {
+func GetCmdDeployHelpFooter(*cobra.Command) string {
 	return generateCmdHelpSamplesBlock(map[string]string{
 		"Deploy all services in the current project to Azure.": output.WithHighLightFormat(
 			"azd deploy --all",

--- a/cli/azd/internal/cmd/provision.go
+++ b/cli/azd/internal/cmd/provision.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/multierr"
 )
 
-type provisionFlags struct {
+type ProvisionFlags struct {
 	noProgress            bool
 	preview               bool
 	ignoreDeploymentState bool
@@ -39,19 +39,19 @@ const (
 	azurePortalURL              = "https://ms.portal.azure.com/"
 )
 
-func (i *provisionFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
-	i.bindNonCommon(local, global)
+func (i *ProvisionFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
+	i.BindNonCommon(local, global)
 	i.bindCommon(local, global)
 }
 
-func (i *provisionFlags) bindNonCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
+func (i *ProvisionFlags) BindNonCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	local.BoolVar(&i.noProgress, "no-progress", false, "Suppresses progress information.")
 	//deprecate:Flag hide --no-progress
 	_ = local.MarkHidden("no-progress")
 	i.global = global
 }
 
-func (i *provisionFlags) bindCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
+func (i *ProvisionFlags) bindCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	local.BoolVar(&i.preview, "preview", false, "Preview changes to Azure resources.")
 	local.BoolVar(
 		&i.ignoreDeploymentState,
@@ -63,26 +63,26 @@ func (i *provisionFlags) bindCommon(local *pflag.FlagSet, global *internal.Globa
 	i.EnvFlag.Bind(local, global)
 }
 
-func (i *provisionFlags) setCommon(envFlag *internal.EnvFlag) {
+func (i *ProvisionFlags) SetCommon(envFlag *internal.EnvFlag) {
 	i.EnvFlag = envFlag
 }
 
-func newProvisionFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *provisionFlags {
-	flags := &provisionFlags{}
+func NewProvisionFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *ProvisionFlags {
+	flags := &ProvisionFlags{}
 	flags.Bind(cmd.Flags(), global)
 
 	return flags
 }
 
-func newProvisionCmd() *cobra.Command {
+func NewProvisionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "provision",
 		Short: "Provision the Azure resources for an application.",
 	}
 }
 
-type provisionAction struct {
-	flags            *provisionFlags
+type ProvisionAction struct {
+	flags            *ProvisionFlags
 	provisionManager *provisioning.Manager
 	projectManager   project.ProjectManager
 	resourceManager  project.ResourceManager
@@ -96,8 +96,8 @@ type provisionAction struct {
 	importManager    *project.ImportManager
 }
 
-func newProvisionAction(
-	flags *provisionFlags,
+func NewProvisionAction(
+	flags *ProvisionFlags,
 	provisionManager *provisioning.Manager,
 	projectManager project.ProjectManager,
 	importManager *project.ImportManager,
@@ -110,7 +110,7 @@ func newProvisionAction(
 	writer io.Writer,
 	subManager *account.SubscriptionsManager,
 ) actions.Action {
-	return &provisionAction{
+	return &ProvisionAction{
 		flags:            flags,
 		provisionManager: provisionManager,
 		projectManager:   projectManager,
@@ -126,7 +126,16 @@ func newProvisionAction(
 	}
 }
 
-func (p *provisionAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+// SetFlags sets the flags for the provision action. Panics if `flags` is nil
+func (p *ProvisionAction) SetFlags(flags *ProvisionFlags) {
+	if flags == nil {
+		panic("flags is nil")
+	}
+
+	p.flags = flags
+}
+
+func (p *ProvisionAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	if p.flags.noProgress {
 		fmt.Fprintln(
 			p.console.Handles().Stderr,
@@ -370,7 +379,7 @@ func deployResultToUx(previewResult *provisioning.DeployPreviewResult) ux.UxItem
 	}
 }
 
-func getCmdProvisionHelpDescription(c *cobra.Command) string {
+func GetCmdProvisionHelpDescription(c *cobra.Command) string {
 	return generateCmdHelpDescription(fmt.Sprintf(
 		"Provision the Azure resources for an application."+
 			" This step may take a while depending on the resources provisioned."+

--- a/cli/azd/internal/cmd/util.go
+++ b/cli/azd/internal/cmd/util.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/azure/azure-dev/cli/azd/internal/tracing"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
+)
+
+func getResourceGroupFollowUp(
+	ctx context.Context,
+	formatter output.Formatter,
+	projectConfig *project.ProjectConfig,
+	resourceManager project.ResourceManager,
+	env *environment.Environment,
+	whatIf bool,
+) (followUp string) {
+	if formatter.Kind() == output.JsonFormat {
+		return followUp
+	}
+
+	subscriptionId := env.GetSubscriptionId()
+	if resourceGroupName, err := resourceManager.GetResourceGroupName(ctx, subscriptionId, projectConfig); err == nil {
+		defaultFollowUpText := fmt.Sprintf(
+			"You can view the resources created under the resource group %s in Azure Portal:", resourceGroupName)
+		if whatIf {
+			defaultFollowUpText = fmt.Sprintf(
+				"You can view the current resources under the resource group %s in Azure Portal:", resourceGroupName)
+		}
+		followUp = fmt.Sprintf("%s\n%s",
+			defaultFollowUpText,
+			azurePortalLink(subscriptionId, resourceGroupName))
+	}
+
+	return followUp
+}
+
+func azurePortalLink(subscriptionId, resourceGroupName string) string {
+	if subscriptionId == "" || resourceGroupName == "" {
+		return ""
+	}
+	return output.WithLinkFormat(fmt.Sprintf(
+		"https://portal.azure.com/#@/resource/subscriptions/%s/resourceGroups/%s/overview",
+		subscriptionId,
+		resourceGroupName))
+}
+
+func serviceNameWarningCheck(console input.Console, serviceNameFlag string, commandName string) {
+	if serviceNameFlag == "" {
+		return
+	}
+
+	fmt.Fprintln(
+		console.Handles().Stderr,
+		output.WithWarningFormat("WARNING: The `--service` flag is deprecated and will be removed in a future release."),
+	)
+	fmt.Fprintf(console.Handles().Stderr, "Next time use `azd %s <service>`.\n\n", commandName)
+}
+
+func getTargetServiceName(
+	ctx context.Context,
+	projectManager project.ProjectManager,
+	importManager *project.ImportManager,
+	projectConfig *project.ProjectConfig,
+	commandName string,
+	targetServiceName string,
+	allFlagValue bool,
+) (string, error) {
+	if allFlagValue && targetServiceName != "" {
+		return "", fmt.Errorf("cannot specify both --all and <service>")
+	}
+
+	if !allFlagValue && targetServiceName == "" {
+		targetService, err := projectManager.DefaultServiceFromWd(ctx, projectConfig)
+		if errors.Is(err, project.ErrNoDefaultService) {
+			return "", fmt.Errorf(
+				"current working directory is not a project or service directory. Specify a service name to %s a service, "+
+					"or specify --all to %s all services",
+				commandName,
+				commandName,
+			)
+		} else if err != nil {
+			return "", err
+		}
+
+		if targetService != nil {
+			targetServiceName = targetService.Name
+		}
+	}
+
+	if targetServiceName != "" {
+		if has, err := importManager.HasService(ctx, projectConfig, targetServiceName); err != nil {
+			return "", err
+		} else if !has {
+			return "", fmt.Errorf("service name '%s' doesn't exist", targetServiceName)
+		}
+	}
+
+	return targetServiceName, nil
+}
+
+// Calculate the total time since t, excluding user interaction time.
+func since(t time.Time) time.Duration {
+	userInteractTime := tracing.InteractTimeMs.Load()
+	return time.Since(t) - time.Duration(userInteractTime)*time.Millisecond
+}


### PR DESCRIPTION
The VS Server will want to consume these types, so remove them from the root command packge to prevent import cycles and then export them so that both `cmd` and `internal/vsrpc` can reference them.