### PR TITLE
Adds support to reference external or prebuilt image references

### DIFF
--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -145,7 +145,9 @@ func (ch *ContainerHelper) RemoteImageTag(
 		return "", err
 	}
 
-	containerImage.Registry = registryName
+	if registryName != "" {
+		containerImage.Registry = registryName
+	}
 
 	return containerImage.Remote(), nil
 }

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -162,6 +162,18 @@ func (ch *ContainerHelper) Deploy(
 				localImageTag = packageDetails.ImageTag
 			}
 
+			// If we don't have a registry specified and the service does not reference a project path
+			// then we are referencing a public/pre-existing image and don't have anything to tag or push
+			if loginServer == "" && serviceConfig.RelativePath != "" {
+				task.SetResult(&ServiceDeployResult{
+					Package: packageOutput,
+					Details: &dockerDeployResult{
+						RemoteImageTag: localImageTag,
+					},
+				})
+				return
+			}
+
 			if localImageTag == "" {
 				task.SetError(errors.New("failed retrieving package result details"))
 				return

--- a/cli/azd/pkg/project/container_helper_test.go
+++ b/cli/azd/pkg/project/container_helper_test.go
@@ -3,13 +3,19 @@ package project
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockenv"
 	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -88,7 +94,7 @@ func Test_ContainerHelper_RemoteImageTag_NoContainer_Registry(t *testing.T) {
 	require.Empty(t, imageTag)
 }
 
-func Test_Resolve_RegistryName(t *testing.T) {
+func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {
 	t.Run("Default EnvVar", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		env := environment.NewWithValues("dev", map[string]string{
@@ -141,4 +147,239 @@ func Test_Resolve_RegistryName(t *testing.T) {
 		require.Error(t, err)
 		require.Empty(t, registryName)
 	})
+}
+
+func Test_ContainerHelper_Deploy(t *testing.T) {
+	t.Run("Registry and private image", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		mockResults := setupDockerMocks(mockContext)
+		env := environment.NewWithValues("dev", map[string]string{
+			environment.ContainerRegistryEndpointEnvVarName: "contoso.azurecr.io",
+		})
+		dockerCli := docker.NewDocker(mockContext.CommandRunner)
+		envManager := &mockenv.MockEnvManager{}
+		envManager.On("Save", *mockContext.Context, env).Return(nil)
+
+		mockContainerRegistryService := &mockContainerRegistryService{}
+		setupContainerRegistryMocks(mockContext, &mockContainerRegistryService.Mock)
+
+		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), mockContainerRegistryService, dockerCli)
+		serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
+
+		packageOutput := &ServicePackageResult{
+			Details: &dockerPackageResult{
+				ImageHash: "1234567890",
+				ImageTag:  "my-app:azd-deploy-1234567890",
+			},
+		}
+
+		targetResource := environment.NewTargetResource(
+			"SUBSCRIPTION_ID",
+			"RESOURCE_GROUP",
+			"CONTAINER_APP",
+			"Microsoft.App/containerApps",
+		)
+
+		deployTask := containerHelper.Deploy(*mockContext.Context, serviceConfig, packageOutput, targetResource, true)
+		logProgress(deployTask)
+		deployResult, err := deployTask.Await()
+
+		require.NoError(t, err)
+		require.NotNil(t, deployResult)
+
+		dockerDeployDetails, _ := deployResult.Details.(*dockerDeployResult)
+		require.Equal(t, "contoso.azurecr.io/my-app:azd-deploy-1234567890", dockerDeployDetails.RemoteImageTag)
+
+		_, dockerTagCalled := mockResults["docker-tag"]
+		_, dockerPushCalled := mockResults["docker-push"]
+
+		require.True(t, dockerTagCalled)
+		require.True(t, dockerPushCalled)
+		mockContainerRegistryService.AssertCalled(t, "Login", *mockContext.Context, "SUBSCRIPTION_ID", "contoso.azurecr.io")
+	})
+
+	t.Run("Registry and public image", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		mockResults := setupDockerMocks(mockContext)
+		env := environment.NewWithValues("dev", map[string]string{
+			environment.ContainerRegistryEndpointEnvVarName: "contoso.azurecr.io",
+		})
+		dockerCli := docker.NewDocker(mockContext.CommandRunner)
+		envManager := &mockenv.MockEnvManager{}
+		envManager.On("Save", *mockContext.Context, env).Return(nil)
+
+		mockContainerRegistryService := &mockContainerRegistryService{}
+		setupContainerRegistryMocks(mockContext, &mockContainerRegistryService.Mock)
+
+		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), mockContainerRegistryService, dockerCli)
+		serviceConfig := createTestServiceConfig("", ContainerAppTarget, ServiceLanguageDocker)
+
+		packageOutput := &ServicePackageResult{
+			Details: &dockerPackageResult{
+				ImageHash: "",
+				ImageTag:  "nginx",
+			},
+		}
+
+		targetResource := environment.NewTargetResource(
+			"SUBSCRIPTION_ID",
+			"RESOURCE_GROUP",
+			"CONTAINER_APP",
+			"Microsoft.App/containerApps",
+		)
+
+		deployTask := containerHelper.Deploy(*mockContext.Context, serviceConfig, packageOutput, targetResource, true)
+		logProgress(deployTask)
+		deployResult, err := deployTask.Await()
+
+		require.NoError(t, err)
+		require.NotNil(t, deployResult)
+
+		dockerDeployDetails, _ := deployResult.Details.(*dockerDeployResult)
+		require.Equal(t, "contoso.azurecr.io/nginx", dockerDeployDetails.RemoteImageTag)
+
+		_, dockerTagCalled := mockResults["docker-tag"]
+		_, dockerPushCalled := mockResults["docker-push"]
+
+		require.True(t, dockerTagCalled)
+		require.True(t, dockerPushCalled)
+		mockContainerRegistryService.AssertCalled(t, "Login", *mockContext.Context, "SUBSCRIPTION_ID", "contoso.azurecr.io")
+	})
+
+	t.Run("No registry and public image", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		mockResults := setupDockerMocks(mockContext)
+		env := environment.NewWithValues("dev", map[string]string{})
+		dockerCli := docker.NewDocker(mockContext.CommandRunner)
+		envManager := &mockenv.MockEnvManager{}
+		envManager.On("Save", *mockContext.Context, env).Return(nil)
+
+		mockContainerRegistryService := &mockContainerRegistryService{}
+		setupContainerRegistryMocks(mockContext, &mockContainerRegistryService.Mock)
+
+		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), mockContainerRegistryService, dockerCli)
+		serviceConfig := createTestServiceConfig("", ContainerAppTarget, ServiceLanguageDocker)
+
+		packageOutput := &ServicePackageResult{
+			Details: &dockerPackageResult{
+				ImageHash: "",
+				ImageTag:  "nginx",
+			},
+		}
+
+		targetResource := environment.NewTargetResource(
+			"SUBSCRIPTION_ID",
+			"RESOURCE_GROUP",
+			"CONTAINER_APP",
+			"Microsoft.App/containerApps",
+		)
+
+		deployTask := containerHelper.Deploy(*mockContext.Context, serviceConfig, packageOutput, targetResource, true)
+		logProgress(deployTask)
+		deployResult, err := deployTask.Await()
+
+		require.NoError(t, err)
+		require.NotNil(t, deployResult)
+
+		dockerDeployDetails, _ := deployResult.Details.(*dockerDeployResult)
+		require.Equal(t, "nginx", dockerDeployDetails.RemoteImageTag)
+
+		_, dockerTagCalled := mockResults["docker-tag"]
+		_, dockerPushCalled := mockResults["docker-push"]
+
+		require.False(t, dockerTagCalled)
+		require.False(t, dockerPushCalled)
+		mockContainerRegistryService.AssertNotCalled(t, "Login")
+	})
+
+	t.Run("Code without registry", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		env := environment.NewWithValues("dev", map[string]string{})
+		dockerCli := docker.NewDocker(mockContext.CommandRunner)
+		envManager := &mockenv.MockEnvManager{}
+		envManager.On("Save", *mockContext.Context, env).Return(nil)
+
+		mockContainerRegistryService := &mockContainerRegistryService{}
+		setupContainerRegistryMocks(mockContext, &mockContainerRegistryService.Mock)
+
+		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), mockContainerRegistryService, dockerCli)
+		serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
+
+		targetResource := environment.NewTargetResource(
+			"SUBSCRIPTION_ID",
+			"RESOURCE_GROUP",
+			"CONTAINER_APP",
+			"Microsoft.App/containerApps",
+		)
+
+		deployTask := containerHelper.Deploy(*mockContext.Context, serviceConfig, nil, targetResource, true)
+		logProgress(deployTask)
+		deployResult, err := deployTask.Await()
+
+		// Expected to fail when no registry is specified
+		require.Error(t, err)
+		require.Nil(t, deployResult)
+	})
+}
+
+func setupContainerRegistryMocks(mockContext *mocks.MockContext, mockContainerRegistryService *mock.Mock) {
+	mockContainerRegistryService.On(
+		"Login",
+		*mockContext.Context,
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("string")).
+		Return(nil)
+}
+
+func setupDockerMocks(mockContext *mocks.MockContext) map[string]exec.RunArgs {
+	mockResults := map[string]exec.RunArgs{}
+
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "docker tag")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		mockResults["docker-tag"] = args
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "docker push")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		mockResults["docker-push"] = args
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "docker login")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		mockResults["docker-login"] = args
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	return mockResults
+}
+
+type mockContainerRegistryService struct {
+	mock.Mock
+}
+
+func (m *mockContainerRegistryService) Login(ctx context.Context, subscriptionId string, loginServer string) error {
+	args := m.Called(ctx, subscriptionId, loginServer)
+	return args.Error(0)
+}
+
+func (m *mockContainerRegistryService) Credentials(
+	ctx context.Context,
+	subscriptionId string,
+	loginServer string,
+) (*azcli.DockerCredentials, error) {
+	args := m.Called(ctx, subscriptionId, loginServer)
+	return args.Get(0).(*azcli.DockerCredentials), args.Error(1)
+}
+
+func (m *mockContainerRegistryService) GetContainerRegistries(
+	ctx context.Context,
+	subscriptionId string,
+) ([]*armcontainerregistry.Registry, error) {
+	args := m.Called(ctx, subscriptionId)
+	return args.Get(0).([]*armcontainerregistry.Registry), args.Error(1)
 }

--- a/cli/azd/pkg/project/framework_service.go
+++ b/cli/azd/pkg/project/framework_service.go
@@ -15,6 +15,7 @@ import (
 type ServiceLanguageKind string
 
 const (
+	ServiceLanguageNone       ServiceLanguageKind = ""
 	ServiceLanguageDotNet     ServiceLanguageKind = "dotnet"
 	ServiceLanguageCsharp     ServiceLanguageKind = "csharp"
 	ServiceLanguageFsharp     ServiceLanguageKind = "fsharp"
@@ -25,18 +26,24 @@ const (
 	ServiceLanguageDocker     ServiceLanguageKind = "docker"
 )
 
-func parseServiceLanguage(kind ServiceLanguageKind) (ServiceLanguageKind, error) {
-	if string(kind) == "" {
-		return ServiceLanguageKind(""), fmt.Errorf("language property must not be empty")
+var (
+	NoFrameworkRequirements = FrameworkRequirements{
+		Package: FrameworkPackageRequirements{
+			RequireRestore: false,
+			RequireBuild:   false,
+		},
 	}
+)
 
+func parseServiceLanguage(kind ServiceLanguageKind) (ServiceLanguageKind, error) {
 	// aliases
 	if string(kind) == "py" {
 		return ServiceLanguagePython, nil
 	}
 
 	switch kind {
-	case ServiceLanguageDotNet,
+	case ServiceLanguageNone,
+		ServiceLanguageDotNet,
 		ServiceLanguageCsharp,
 		ServiceLanguageFsharp,
 		ServiceLanguageJavaScript,

--- a/cli/azd/pkg/project/framework_service.go
+++ b/cli/azd/pkg/project/framework_service.go
@@ -26,15 +26,6 @@ const (
 	ServiceLanguageDocker     ServiceLanguageKind = "docker"
 )
 
-var (
-	NoFrameworkRequirements = FrameworkRequirements{
-		Package: FrameworkPackageRequirements{
-			RequireRestore: false,
-			RequireBuild:   false,
-		},
-	}
-)
-
 func parseServiceLanguage(kind ServiceLanguageKind) (ServiceLanguageKind, error) {
 	// aliases
 	if string(kind) == "py" {

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -38,8 +38,9 @@ type DockerProjectOptions struct {
 	Context   string           `yaml:"context,omitempty"   json:"context,omitempty"`
 	Platform  string           `yaml:"platform,omitempty"  json:"platform,omitempty"`
 	Target    string           `yaml:"target,omitempty"    json:"target,omitempty"`
-	Tag       ExpandableString `yaml:"tag,omitempty"       json:"tag,omitempty"`
 	Registry  ExpandableString `yaml:"registry,omitempty"  json:"registry,omitempty"`
+	Image     ExpandableString `yaml:"image,omitempty"     json:"image,omitempty"`
+	Tag       ExpandableString `yaml:"tag,omitempty"       json:"tag,omitempty"`
 	BuildArgs []string         `yaml:"buildArgs,omitempty" json:"buildArgs,omitempty"`
 }
 
@@ -67,8 +68,13 @@ type dockerPackageResult struct {
 }
 
 func (dpr *dockerPackageResult) ToString(currentIndentation string) string {
+	imageHash := dpr.ImageHash
+	if imageHash == "" {
+		imageHash = "N/A"
+	}
+
 	lines := []string{
-		fmt.Sprintf("%s- Image Hash: %s", currentIndentation, output.WithLinkFormat(dpr.ImageHash)),
+		fmt.Sprintf("%s- Image Hash: %s", currentIndentation, output.WithLinkFormat(imageHash)),
 		fmt.Sprintf("%s- Image Tag: %s", currentIndentation, output.WithLinkFormat(dpr.ImageTag)),
 	}
 

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -261,12 +261,16 @@ func Test_DockerProject_Build(t *testing.T) {
 	env := environment.New("test")
 	dockerCli := docker.NewDocker(mockContext.CommandRunner)
 	serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
+
 	temp := t.TempDir()
+
+	serviceConfig.Docker.Registry = NewExpandableString("contoso.azurecr.io")
 	serviceConfig.Project.Path = temp
 	serviceConfig.RelativePath = ""
 	err := os.WriteFile(filepath.Join(temp, "Dockerfile"), []byte("FROM node:14"), 0600)
 	require.NoError(t, err)
 
+	npmProject := NewNpmProject(npm.NewNpmCli(mockContext.CommandRunner), env)
 	dockerProject := NewDockerProject(
 		env,
 		dockerCli,
@@ -274,6 +278,8 @@ func Test_DockerProject_Build(t *testing.T) {
 		mockinput.NewMockConsole(),
 		mockContext.AlphaFeaturesManager,
 		mockContext.CommandRunner)
+	dockerProject.SetSource(npmProject)
+
 	buildTask := dockerProject.Build(*mockContext.Context, serviceConfig, nil)
 	logProgress(buildTask)
 
@@ -319,7 +325,9 @@ func Test_DockerProject_Package(t *testing.T) {
 	env := environment.NewWithValues("test", map[string]string{})
 	dockerCli := docker.NewDocker(mockContext.CommandRunner)
 	serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
+	serviceConfig.Docker.Registry = NewExpandableString("contoso.azurecr.io")
 
+	npmProject := NewNpmProject(npm.NewNpmCli(mockContext.CommandRunner), env)
 	dockerProject := NewDockerProject(
 		env,
 		dockerCli,
@@ -327,6 +335,8 @@ func Test_DockerProject_Package(t *testing.T) {
 		mockinput.NewMockConsole(),
 		mockContext.AlphaFeaturesManager,
 		mockContext.CommandRunner)
+	dockerProject.SetSource(npmProject)
+
 	packageTask := dockerProject.Package(
 		*mockContext.Context,
 		serviceConfig,

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -102,6 +102,13 @@ func Parse(ctx context.Context, yamlContent string) (*ProjectConfig, error) {
 		if err != nil {
 			return nil, fmt.Errorf("parsing service %s: %w", svc.Name, err)
 		}
+
+		// TODO: Move parsing/validation requirements for service targets into their respective components.
+		// When working within container based applications users may be using external/pre-built images instead of source
+		// In this case it is valid to have not specified a language but would be required to specify a source image
+		if svc.Host == ContainerAppTarget && svc.Language == ServiceLanguageNone && svc.Image == "" {
+			return nil, fmt.Errorf("parsing service %s: must specify language or image", svc.Name)
+		}
 	}
 
 	return &projectConfig, nil

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -23,7 +23,9 @@ type ServiceConfig struct {
 	Language ServiceLanguageKind `yaml:"language"`
 	// The output path for build artifacts
 	OutputPath string `yaml:"dist,omitempty"`
-	// The optional docker options
+	// The source image to use for container based applications
+	Image string `yaml:"image,omitempty"`
+	// The optional docker options for configuring the output image
 	Docker DockerProjectOptions `yaml:"docker,omitempty"`
 	// The optional K8S / AKS options
 	K8s AksOptions `yaml:"k8s,omitempty"`

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
@@ -550,6 +551,11 @@ func (sm *serviceManager) GetServiceTarget(ctx context.Context, serviceConfig *S
 // GetFrameworkService constructs a framework service from the underlying service configuration
 func (sm *serviceManager) GetFrameworkService(ctx context.Context, serviceConfig *ServiceConfig) (FrameworkService, error) {
 	var frameworkService FrameworkService
+
+	if serviceConfig.Language == ServiceLanguageNone &&
+		!reflect.DeepEqual(serviceConfig.Docker, DefaultDockerProjectOptions) {
+		serviceConfig.Language = ServiceLanguageDocker
+	}
 
 	if err := sm.serviceLocator.ResolveNamed(string(serviceConfig.Language), &frameworkService); err != nil {
 		panic(fmt.Errorf(

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
@@ -552,8 +551,7 @@ func (sm *serviceManager) GetServiceTarget(ctx context.Context, serviceConfig *S
 func (sm *serviceManager) GetFrameworkService(ctx context.Context, serviceConfig *ServiceConfig) (FrameworkService, error) {
 	var frameworkService FrameworkService
 
-	if serviceConfig.Language == ServiceLanguageNone &&
-		!reflect.DeepEqual(serviceConfig.Docker, DefaultDockerProjectOptions) {
+	if serviceConfig.Language == ServiceLanguageNone && serviceConfig.Image != "" {
 		serviceConfig.Language = ServiceLanguageDocker
 	}
 

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -551,6 +551,7 @@ func (sm *serviceManager) GetServiceTarget(ctx context.Context, serviceConfig *S
 func (sm *serviceManager) GetFrameworkService(ctx context.Context, serviceConfig *ServiceConfig) (FrameworkService, error) {
 	var frameworkService FrameworkService
 
+	// Publishing from an existing image currently follows the same lifecycle as a docker project
 	if serviceConfig.Language == ServiceLanguageNone && serviceConfig.Image != "" {
 		serviceConfig.Language = ServiceLanguageDocker
 	}

--- a/cli/azd/pkg/project/service_manager_test.go
+++ b/cli/azd/pkg/project/service_manager_test.go
@@ -220,16 +220,48 @@ func Test_ServiceManager_Deploy(t *testing.T) {
 }
 
 func Test_ServiceManager_GetFrameworkService(t *testing.T) {
-	mockContext := mocks.NewMockContext(context.Background())
-	setupMocksForServiceManager(mockContext)
-	env := environment.New("test")
-	sm := createServiceManager(mockContext, env, ServiceOperationCache{})
-	serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
+	t.Run("Standard", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		setupMocksForServiceManager(mockContext)
+		env := environment.New("test")
+		sm := createServiceManager(mockContext, env, ServiceOperationCache{})
+		serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
-	framework, err := sm.GetFrameworkService(*mockContext.Context, serviceConfig)
-	require.NoError(t, err)
-	require.NotNil(t, framework)
-	require.IsType(t, new(fakeFramework), framework)
+		framework, err := sm.GetFrameworkService(*mockContext.Context, serviceConfig)
+		require.NoError(t, err)
+		require.NotNil(t, framework)
+		require.IsType(t, new(fakeFramework), framework)
+	})
+
+	t.Run("No project path and has docker tag", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.Container.MustRegisterNamedTransient("docker", newFakeFramework)
+
+		setupMocksForServiceManager(mockContext)
+		env := environment.New("test")
+		sm := createServiceManager(mockContext, env, ServiceOperationCache{})
+		serviceConfig := createTestServiceConfig("", ServiceTargetFake, ServiceLanguageNone)
+		serviceConfig.Docker.Tag = NewExpandableString("nginx")
+
+		framework, err := sm.GetFrameworkService(*mockContext.Context, serviceConfig)
+		require.NoError(t, err)
+		require.NotNil(t, framework)
+		require.IsType(t, new(fakeFramework), framework)
+	})
+
+	t.Run("No project path or docker tag", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(context.Background())
+		mockContext.Container.MustRegisterNamedTransient("docker", newFakeFramework)
+
+		setupMocksForServiceManager(mockContext)
+		env := environment.New("test")
+		sm := createServiceManager(mockContext, env, ServiceOperationCache{})
+		serviceConfig := createTestServiceConfig("", ServiceTargetFake, ServiceLanguageNone)
+
+		require.Panics(t, func() {
+			_, _ = sm.GetFrameworkService(*mockContext.Context, serviceConfig)
+		})
+	})
 }
 
 func Test_ServiceManager_GetServiceTarget(t *testing.T) {

--- a/cli/azd/pkg/project/service_manager_test.go
+++ b/cli/azd/pkg/project/service_manager_test.go
@@ -241,7 +241,7 @@ func Test_ServiceManager_GetFrameworkService(t *testing.T) {
 		env := environment.New("test")
 		sm := createServiceManager(mockContext, env, ServiceOperationCache{})
 		serviceConfig := createTestServiceConfig("", ServiceTargetFake, ServiceLanguageNone)
-		serviceConfig.Docker.Tag = NewExpandableString("nginx")
+		serviceConfig.Image = "nginx"
 
 		framework, err := sm.GetFrameworkService(*mockContext.Context, serviceConfig)
 		require.NoError(t, err)

--- a/cli/azd/pkg/project/service_models_test.go
+++ b/cli/azd/pkg/project/service_models_test.go
@@ -27,7 +27,7 @@ func Test_ServiceResults_Json_Marshal(t *testing.T) {
 			PackagePath: "package/path/project.zip",
 			Details: &dockerPackageResult{
 				ImageHash:   "image-hash",
-				SourceImage: "image-tag",
+				TargetImage: "image-tag",
 			},
 		},
 	}

--- a/cli/azd/pkg/project/service_models_test.go
+++ b/cli/azd/pkg/project/service_models_test.go
@@ -26,8 +26,8 @@ func Test_ServiceResults_Json_Marshal(t *testing.T) {
 			},
 			PackagePath: "package/path/project.zip",
 			Details: &dockerPackageResult{
-				ImageHash: "image-hash",
-				ImageTag:  "image-tag",
+				ImageHash:   "image-hash",
+				SourceImage: "image-tag",
 			},
 		},
 	}

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -92,7 +92,7 @@ func Test_Package_Deploy_HappyPath(t *testing.T) {
 			PackagePath: "test-app/api-test:azd-deploy-0",
 			Details: &dockerPackageResult{
 				ImageHash:   "IMAGE_HASH",
-				SourceImage: "test-app/api-test:azd-deploy-0",
+				TargetImage: "test-app/api-test:azd-deploy-0",
 			},
 		},
 	)

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -91,8 +91,8 @@ func Test_Package_Deploy_HappyPath(t *testing.T) {
 		&ServicePackageResult{
 			PackagePath: "test-app/api-test:azd-deploy-0",
 			Details: &dockerPackageResult{
-				ImageHash: "IMAGE_HASH",
-				ImageTag:  "test-app/api-test:azd-deploy-0",
+				ImageHash:   "IMAGE_HASH",
+				SourceImage: "test-app/api-test:azd-deploy-0",
 			},
 		},
 	)

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -90,7 +90,7 @@ func Test_ContainerApp_Deploy(t *testing.T) {
 			PackagePath: "test-app/api-test:azd-deploy-0",
 			Details: &dockerPackageResult{
 				ImageHash:   "IMAGE_HASH",
-				SourceImage: "test-app/api-test:azd-deploy-0",
+				TargetImage: "test-app/api-test:azd-deploy-0",
 			},
 		},
 	)

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -89,8 +89,8 @@ func Test_ContainerApp_Deploy(t *testing.T) {
 		&ServicePackageResult{
 			PackagePath: "test-app/api-test:azd-deploy-0",
 			Details: &dockerPackageResult{
-				ImageHash: "IMAGE_HASH",
-				ImageTag:  "test-app/api-test:azd-deploy-0",
+				ImageHash:   "IMAGE_HASH",
+				SourceImage: "test-app/api-test:azd-deploy-0",
 			},
 		},
 	)

--- a/cli/azd/pkg/tools/docker/container_image.go
+++ b/cli/azd/pkg/tools/docker/container_image.go
@@ -1,0 +1,86 @@
+package docker
+
+import (
+	"errors"
+	"strings"
+)
+
+// ContainerImage represents a container image and its components
+type ContainerImage struct {
+	// The registry name
+	Registry string
+	// The repository name or path
+	Repository string
+	// The tag
+	Tag string
+}
+
+// Local returns the local image name without registry
+func (ci *ContainerImage) Local() string {
+	builder := strings.Builder{}
+
+	if ci.Repository != "" {
+		builder.WriteString(ci.Repository)
+	}
+
+	if ci.Tag != "" {
+		builder.WriteString(":")
+		builder.WriteString(ci.Tag)
+	}
+
+	return builder.String()
+}
+
+// Remote returns the remote image name with registry when specified
+func (ci *ContainerImage) Remote() string {
+	builder := strings.Builder{}
+	if ci.Registry != "" {
+		builder.WriteString(ci.Registry)
+		builder.WriteString("/")
+	}
+
+	if ci.Repository != "" {
+		builder.WriteString(ci.Repository)
+	}
+
+	if ci.Tag != "" {
+		builder.WriteString(":")
+		builder.WriteString(ci.Tag)
+	}
+
+	return builder.String()
+}
+
+func ParseContainerImage(image string) (*ContainerImage, error) {
+	// Check if the imageURL is empty
+	if image == "" {
+		return nil, errors.New("empty image URL provided")
+	}
+
+	containerImage := &ContainerImage{}
+
+	// Detect tags
+	tagParts := strings.Split(image, ":")
+	if len(tagParts) > 2 {
+		return containerImage, errors.New("invalid tag format")
+	}
+
+	if len(tagParts) == 2 {
+		containerImage.Tag = tagParts[1]
+		image = tagParts[0]
+	}
+
+	// Split the imageURL by "/"
+	parts := strings.Split(image, "/")
+
+	// Check if the parts contain a registry (parts[0] contains ".")
+	if strings.Contains(parts[0], ".") {
+		containerImage.Registry = parts[0]
+		parts = parts[1:]
+	}
+
+	// Set the repository as the remaining parts joined by "/"
+	containerImage.Repository = strings.Join(parts, "/")
+
+	return containerImage, nil
+}

--- a/cli/azd/pkg/tools/docker/container_image_test.go
+++ b/cli/azd/pkg/tools/docker/container_image_test.go
@@ -1,0 +1,139 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ParseContainerImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected ContainerImage
+	}{
+		{
+			name:  "image with registry and tag",
+			input: "registry.example.com/my-image:1.0",
+			expected: ContainerImage{
+				Registry:   "registry.example.com",
+				Repository: "my-image",
+				Tag:        "1.0",
+			},
+		},
+		{
+			name:  "image with registry, no tag",
+			input: "registry.example.com/my-image",
+			expected: ContainerImage{
+				Registry:   "registry.example.com",
+				Repository: "my-image",
+				Tag:        "",
+			},
+		},
+		{
+			name:  "image with tag and no registry",
+			input: "my-image:1.0",
+			expected: ContainerImage{
+				Registry:   "", // no registry
+				Repository: "my-image",
+				Tag:        "1.0",
+			},
+		},
+		{
+			name:  "image with no registry or tag",
+			input: "my-image",
+			expected: ContainerImage{
+				Registry:   "", // no registry
+				Repository: "my-image",
+				Tag:        "",
+			},
+		},
+		{
+			name:  "image with multi-part repository",
+			input: "registry.example.com/my-image/foo/bar:1.0",
+			expected: ContainerImage{
+				Registry:   "registry.example.com",
+				Repository: "my-image/foo/bar",
+				Tag:        "1.0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := ParseContainerImage(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, *actual)
+		})
+	}
+}
+
+func Test_ContainerImage_Local_And_Remote(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          ContainerImage
+		expectedLocal  string
+		expectedRemote string
+	}{
+		{
+			name: "image with registry and tag",
+			input: ContainerImage{
+				Registry:   "registry.example.com",
+				Repository: "my-image",
+				Tag:        "1.0",
+			},
+			expectedRemote: "registry.example.com/my-image:1.0",
+			expectedLocal:  "my-image:1.0",
+		},
+		{
+			name: "image with registry and no tag",
+			input: ContainerImage{
+				Registry:   "registry.example.com",
+				Repository: "my-image",
+				Tag:        "",
+			},
+			expectedRemote: "registry.example.com/my-image",
+			expectedLocal:  "my-image",
+		},
+		{
+			name: "image with tag and no registry",
+			input: ContainerImage{
+				Registry:   "", // no registry
+				Repository: "my-image",
+				Tag:        "1.0",
+			},
+			expectedRemote: "my-image:1.0",
+			expectedLocal:  "my-image:1.0",
+		},
+		{
+			name: "image with no registry or tag",
+			input: ContainerImage{
+				Registry:   "", // no registry
+				Repository: "my-image",
+				Tag:        "",
+			},
+			expectedRemote: "my-image",
+			expectedLocal:  "my-image",
+		},
+		{
+			name: "image with multi-part repository",
+			input: ContainerImage{
+				Registry:   "registry.example.com",
+				Repository: "my-image/foo/bar",
+				Tag:        "1.0",
+			},
+			expectedRemote: "registry.example.com/my-image/foo/bar:1.0",
+			expectedLocal:  "my-image/foo/bar:1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualRemote := tt.input.Remote()
+			require.Equal(t, tt.expectedRemote, actualRemote)
+
+			actualLocal := tt.input.Local()
+			require.Equal(t, tt.expectedLocal, actualLocal)
+		})
+	}
+}

--- a/cli/azd/pkg/tools/docker/container_image_test.go
+++ b/cli/azd/pkg/tools/docker/container_image_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_ParseContainerImage(t *testing.T) {
+func Test_ParseContainerImage_Success(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -22,7 +22,7 @@ func Test_ParseContainerImage(t *testing.T) {
 			},
 		},
 		{
-			name:  "image with registry, no tag",
+			name:  "image with registry and no tag",
 			input: "registry.example.com/my-image",
 			expected: ContainerImage{
 				Registry:   "registry.example.com",
@@ -57,6 +57,15 @@ func Test_ParseContainerImage(t *testing.T) {
 				Tag:        "1.0",
 			},
 		},
+		{
+			name:  "image with host and port",
+			input: "registry.example.com:5000/my-image:1.0",
+			expected: ContainerImage{
+				Registry:   "registry.example.com:5000",
+				Repository: "my-image",
+				Tag:        "1.0",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -66,6 +75,43 @@ func Test_ParseContainerImage(t *testing.T) {
 			require.Equal(t, tt.expected, *actual)
 		})
 	}
+}
+
+func Test_ParseContainerImage_Invalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "empty image",
+			input: "",
+		},
+		{
+			name:  "image with only tag",
+			input: ":1.0",
+		},
+		{
+			name:  "image with multiple tags",
+			input: "my-image:1.0:latest",
+		},
+		{
+			name:  "image with only registry",
+			input: "registry.example.com",
+		},
+		{
+			name:  "image with only registry and tag",
+			input: "registry.example.com:1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := ParseContainerImage(tt.input)
+			require.Error(t, err)
+			require.Nil(t, actual)
+		})
+	}
+
 }
 
 func Test_ContainerImage_Local_And_Remote(t *testing.T) {

--- a/cli/azd/pkg/tools/docker/docker.go
+++ b/cli/azd/pkg/tools/docker/docker.go
@@ -34,6 +34,7 @@ type Docker interface {
 	) (string, error)
 	Tag(ctx context.Context, cwd string, imageName string, tag string) error
 	Push(ctx context.Context, cwd string, tag string) error
+	Pull(ctx context.Context, imageName string) error
 	Inspect(ctx context.Context, imageName string, format string) (string, error)
 }
 
@@ -149,6 +150,15 @@ func (d *docker) Push(ctx context.Context, cwd string, tag string) error {
 	_, err := d.executeCommand(ctx, cwd, "push", tag)
 	if err != nil {
 		return fmt.Errorf("pushing image: %w", err)
+	}
+
+	return nil
+}
+
+func (d *docker) Pull(ctx context.Context, imageName string) error {
+	_, err := d.executeCommand(ctx, "", "pull", imageName)
+	if err != nil {
+		return fmt.Errorf("pulling image: %w", err)
 	}
 
 	return nil

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -66,8 +66,7 @@
                 "type": "object",
                 "additionalProperties": false,
                 "required": [
-                    "project",
-                    "language"
+                    "host"
                 ],
                 "properties": {
                     "resourceName": {
@@ -81,10 +80,9 @@
                     },
                     "host": {
                         "type": "string",
-                        "title": "Type of Azure resource used for service implementation",
-                        "description": "If omitted, App Service will be assumed.",
+                        "title": "Required. The type of Azure resource used for service implementation",
+                        "description": "The Azure service that will be used as the target for deployment operations for the service.",
                         "enum": [
-                            "",
                             "appservice",
                             "containerapp",
                             "function",
@@ -176,6 +174,10 @@
                             }
                         },
                         "then": {
+                            "required": [
+                                "project",
+                                "language"
+                            ],
                             "properties": {
                                 "docker": false
                             }
@@ -541,15 +543,20 @@
                     "title": "The platform target",
                     "default": "amd64"
                 },
+                "registry": {
+                    "type": "string",
+                    "title": "Optional. The container registry to push the image to.",
+                    "description": "If omitted, will default to value of AZURE_CONTAINER_REGISTRY_ENDPOINT environment variable. Supports environment variable substitution."
+                },
+                "image": {
+                    "type": "string",
+                    "title": "Optional. The name of the container image to use for the service.",
+                    "description": "If omitted, will default to the '{appName}/{serviceName}-{environmentName}'. Supports environment variable substitution."
+                },
                 "tag": {
                     "type": "string",
                     "title": "The tag that will be applied to the built container image.",
-                    "description": "If omitted, a unique tag will be generated based on the format: {appName}/{serviceName}-{environmentName}:azd-deploy-{unix time (seconds)}. Supports environment variable substitution. For example, to generate unique tags for a given release: myapp/myimage:${DOCKER_IMAGE_TAG}"
-                },
-                "registry": {
-                    "type": "string",
-                    "title": "The container registry to push the image to.",
-                    "description": "If omitted, will default to value of AZURE_CONTAINER_REGISTRY_ENDPOINT environment variable. Supports environment variable substitution."
+                    "description": "If omitted, will default to 'azd-deploy-{unix time (seconds)}'. Supports environment variable substitution. For example, to generate unique tags for a given release: myapp/myimage:${DOCKER_IMAGE_TAG}"
                 },
                 "buildArgs": {
                     "type": "array",

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -78,6 +78,11 @@
                         "type": "string",
                         "title": "Path to the service source code directory"
                     },
+                    "image": {
+                        "type": "string",
+                        "title": "Optional. The source image to be used for the container image instead of building from source.",
+                        "description": "If omitted, container image will be built from source specified in the 'project' property. Setting both 'project' and 'image' is invalid."
+                    },
                     "host": {
                         "type": "string",
                         "title": "Required. The type of Azure resource used for service implementation",
@@ -160,6 +165,58 @@
                     }
                 },
                 "allOf": [
+                    {
+                        "if": {
+                            "properties": {
+                                "host": {
+                                    "const": "containerapp"
+                                }
+                            }
+                        },
+                        "then": {
+                            "anyOf": [
+                                {
+                                    "required": [
+                                        "image"
+                                    ],
+                                    "properties": {
+                                        "language": false
+                                    },
+                                    "not": {
+                                        "required": [
+                                            "project"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "required": [
+                                        "project"
+                                    ],
+                                    "not": {
+                                        "required": [
+                                            "image"
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "if": {
+                            "not": {
+                                "properties": {
+                                    "host": {
+                                        "const": "containerapp"
+                                    }
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "image": false
+                            }
+                        }
+                    },
                     {
                         "if": {
                             "not": {
@@ -550,7 +607,7 @@
                 },
                 "image": {
                     "type": "string",
-                    "title": "Optional. The name of the container image to use for the service.",
+                    "title": "Optional. The name that will be applied to the built container image.",
                     "description": "If omitted, will default to the '{appName}/{serviceName}-{environmentName}'. Supports environment variable substitution."
                 },
                 "tag": {


### PR DESCRIPTION
Adds the ability to reference public or prebuilt image references.

## Features
- Adds new `image` property at the root of service configuration only valid for `containerapp`
  - Allows specifying a source image that will be used for the container app service 
- Adds new `image` property within docker configuration options to set image name generation
  - Works in tandem with `tag` property for generating final docker image path & tags

## Notes:
- When a service configuration does not contain a path to a source code project (no `project` defined) the docker configuration options allow developer to reference existing container images.
- When the `image` setting does not contain a registry endpoint then docker hub is assumed. 
- `project` and `image` are mutually exclusive and cannot be set at the same time
- Fully qualified image paths, ex) `contoso.azurecr.io/myapp:latest` can be referenced as well.

## Examples
### Reference a public image from docker hub

In this example the project is referencing the prebuilt image `nginx` for a `containerapp` service.  No application code or building is required.  The container app revision will directly reference the public image on docker hub.

```yaml
# azure.yaml

name: my-project
services:
  nginx:
    host: containerapp
    image: nginx
```

### Reference a public image and copy it to private azure container registry

In this example the image reference `nginx` will be tagged and pushed to the `contoso.azurecr.io` azure container registry during `azd deploy`.  The container app revision will reference the copied nginx image on the specified registry.

```yaml
# azure.yaml

name: my-project
services:
  nginx:
    host: containerapp
    image: nginx
    docker:
      registry: contoso.azurecr.io
```

### Reference a public image and rename while copying to azure container registry

In this example the image reference `nginx` will be tagged with the specified image/tag and pushed to the `contoso.azurecr.io` azure container registry during `azd deploy`.  The container app revision will reference the copied nginx image on the specified registry.

Generates the following fully qualified image tag: `contoso.azurecr.io/my-custom-nginx:latest` tagged from the public `nginx` image.

```yaml
# azure.yaml

name: my-project
services:
  nginx:
    host: containerapp
    image: nginx
    docker:
      registry: contoso.azurecr.io
      image: my-custom-nginx
      tag: latest
```