### PR TITLE
handle name of container to be valid

### DIFF
--- a/cli/azd/resources/apphost/templates/resources.bicept
+++ b/cli/azd/resources/apphost/templates/resources.bicept
@@ -168,7 +168,7 @@ resource {{bicepName $name}} 'Microsoft.App/containerApps@2023-05-02-preview' = 
       containers: [
         {
           image: '{{$value.Image}}'
-          name: '{{$name}}'
+          name: '{{containerAppName $name}}-${resourceToken}'
 {{- if $value.Env }}
           env: [
 {{- range $name, $value := $value.Env}}


### PR DESCRIPTION
In aspire, for a container resource like:

```
var rabbitMq = builder.AddRabbitMQContainer("EventBus");
```

azd will fail trying to use `EvenBus` as the name of the container when creating the ACA.

The change in this PR converts the name into a valid container name.