### PR TITLE
patch resource with parent as container

### DIFF
--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -297,12 +297,17 @@ func pullParentSettings(resourceName string, resource *Resource, manifest *Manif
 
 	reNameParentToChild := func(source, parent, child string) string {
 		return strings.ReplaceAll(
-			source, fmt.Sprintf("%s.inputs.", parent), fmt.Sprintf("%s.inputs.", child))
+			source, fmt.Sprintf("%s.", parent), fmt.Sprintf("%s.", child))
 	}
 
 	reMapEnv := make(map[string]string, len(parentResource.Env))
 	for k, v := range parentResource.Env {
 		reMapEnv[k] = reNameParentToChild(v, *resource.Parent, resourceName)
+	}
+
+	connectionString := reNameParentToChild(*parentResource.ConnectionString, *resource.Parent, resourceName)
+	if resource.Type == "postgres.database.v0" {
+		connectionString = fmt.Sprintf("%sDatabase=%s;", connectionString, resourceName)
 	}
 
 	return &Resource{
@@ -311,7 +316,7 @@ func pullParentSettings(resourceName string, resource *Resource, manifest *Manif
 		Env:              reMapEnv,
 		Inputs:           parentResource.Inputs,
 		Bindings:         parentResource.Bindings,
-		ConnectionString: to.Ptr(reNameParentToChild(*parentResource.ConnectionString, *resource.Parent, resourceName)),
+		ConnectionString: to.Ptr(connectionString),
 	}
 }
 

--- a/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-resources.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-resources.bicep.snap
@@ -75,6 +75,9 @@ resource mysqlabstract 'Microsoft.App/containerApps@2023-05-02-preview' = {
         }
       ]
     }
+    scale: {
+      minReplicas: 1
+    }
   }
   tags: union(tags, {'aspire-resource-name': 'mysqlabstract'})
 }

--- a/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-resources.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-resources.bicep.snap
@@ -97,6 +97,9 @@ resource mysqlabstract 'Microsoft.App/containerApps@2023-05-02-preview' = {
         }
       ]
     }
+    scale: {
+      minReplicas: 1
+    }
   }
   tags: union(tags, {'aspire-resource-name': 'mysqlabstract'})
 }

--- a/cli/azd/resources/apphost/templates/resources.bicept
+++ b/cli/azd/resources/apphost/templates/resources.bicept
@@ -117,6 +117,9 @@ resource {{bicepName $name}} 'Microsoft.App/containerApps@2023-05-02-preview' = 
         }
       ]
     }
+    scale: {
+      minReplicas: 1
+    }
   }
   tags: union(tags, {'aspire-resource-name': '{{$name}}'})
 }
@@ -197,6 +200,9 @@ resource {{bicepName $name}} 'Microsoft.App/containerApps@2023-05-02-preview' = 
 {{- end}}
         }
       ]
+    }
+    scale: {
+      minReplicas: 1
     }
   }
   tags: union(tags, {'aspire-resource-name': '{{$name}}'})

--- a/cli/azd/resources/apphost/templates/resources.bicept
+++ b/cli/azd/resources/apphost/templates/resources.bicept
@@ -116,9 +116,9 @@ resource {{bicepName $name}} 'Microsoft.App/containerApps@2023-05-02-preview' = 
           name: '{{$value.Type}}'
         }
       ]
-    }
-    scale: {
-      minReplicas: 1
+      scale: {
+        minReplicas: 1
+      }
     }
   }
   tags: union(tags, {'aspire-resource-name': '{{$name}}'})
@@ -200,9 +200,9 @@ resource {{bicepName $name}} 'Microsoft.App/containerApps@2023-05-02-preview' = 
 {{- end}}
         }
       ]
-    }
-    scale: {
-      minReplicas: 1
+      scale: {
+        minReplicas: 1
+      }
     }
   }
   tags: union(tags, {'aspire-resource-name': '{{$name}}'})


### PR DESCRIPTION
Adding special case for a container.v0 with children resources, for example, Postgres server running in containerApp and multiple dbs defined with such server as parent.

With this change, azd uses the parent configuration for define a containerApp for each resource, using the parent settings.
In the Postgres example, each db becomes a containerApp, using the same image, ports, input and connection string as the parent (but adapter to work for the db instance). 