### PR TITLE
Improve test coverage in `internal/vsrpc`

### DIFF
--- a/cli/azd/internal/vsrpc/handler_test.go
+++ b/cli/azd/internal/vsrpc/handler_test.go
@@ -1,0 +1,223 @@
+package vsrpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/jsonrpc2"
+)
+
+// newHandlerForCaseFunc is a function that constructs a new Handler for a given test case.
+type newHandlerForCaseFunc func(t *testing.T, tc handlerTestCase) Handler
+
+type handlerTestCase struct {
+	// name is the name of the test, as passed to (*testing.T).Run().
+	name string
+	// expected is the result the handler should return on success.
+	expected any
+	// err is the error returned by the handler when non nil.
+	err error
+	// cancel is true when the handler should be cancelled.
+	cancel bool
+	// params are the params that are passed to the call, this should be an slice of values.
+	params []any
+}
+
+// runHandlerSuite runs through a suite of tests for a handler. It exercises cases where the handler
+// returns a value, returns and error not notices it has been cancelled and returns a special error to
+// the caller.
+func runHandlerSuite(t *testing.T, newHandler newHandlerForCaseFunc, params []any, expected any) {
+	cases := []handlerTestCase{
+		{
+			name:     "Success",
+			expected: expected,
+			params:   params,
+		},
+		{
+			name:   "Error",
+			err:    errors.New("expected error"),
+			params: params,
+		},
+		{
+			name:   "Canceled",
+			cancel: true,
+			params: params,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newHandler(t, tc)
+
+			call, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), "Test", tc.params)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			if tc.err != nil {
+				_ = h(ctx, nil, validateError(t, tc.err), call)
+			} else if tc.cancel {
+				ctx, cancel := context.WithCancel(ctx)
+				cancel()
+				_ = h(ctx, nil, validateCancel(t), call)
+			} else {
+				_ = h(ctx, nil, validateResult(t, tc.expected), call)
+			}
+		})
+	}
+}
+
+func TestHandler(t *testing.T) {
+	t.Parallel()
+	t.Run("HandlerAction0", func(t *testing.T) { runHandlerSuite(t, newHandlerAction0, nil, nil) })
+	t.Run("HandlerAction1", func(t *testing.T) { runHandlerSuite(t, newHandlerAction1, []any{"arg0"}, nil) })
+	t.Run("HandlerAction2", func(t *testing.T) { runHandlerSuite(t, newHandlerAction2, []any{"arg0", "arg1"}, nil) })
+	t.Run("HandlerAction3", func(t *testing.T) { runHandlerSuite(t, newHandlerAction3, []any{"arg0", "arg1", "arg2"}, nil) })
+	t.Run("HandlerFunc0", func(t *testing.T) { runHandlerSuite(t, newHandlerFunc0, nil, "ok") })
+	t.Run("HandlerFunc1", func(t *testing.T) { runHandlerSuite(t, newHandlerFunc1, []any{"arg0"}, "ok") })
+	t.Run("HandlerFunc2", func(t *testing.T) { runHandlerSuite(t, newHandlerFunc2, []any{"arg0", "arg1"}, "ok") })
+	t.Run("HandlerFunc3", func(t *testing.T) { runHandlerSuite(t, newHandlerFunc3, []any{"arg0", "arg1", "arg2"}, "ok") })
+}
+
+func newHandlerAction0(t *testing.T, tc handlerTestCase) Handler {
+	return HandlerAction0(func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return tc.err
+		}
+	})
+}
+
+func newHandlerAction1(t *testing.T, tc handlerTestCase) Handler {
+	return HandlerAction1(func(ctx context.Context, arg0 string) error {
+		validateParam(t, tc.params, 0, arg0)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return tc.err
+		}
+	})
+}
+
+func newHandlerAction2(t *testing.T, tc handlerTestCase) Handler {
+	return HandlerAction2(func(ctx context.Context, arg0, arg1 string) error {
+		validateParam(t, tc.params, 0, arg0)
+		validateParam(t, tc.params, 1, arg1)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return tc.err
+		}
+	})
+}
+
+func newHandlerAction3(t *testing.T, tc handlerTestCase) Handler {
+	return HandlerAction3(func(ctx context.Context, arg0, arg1, arg2 string) error {
+		validateParam(t, tc.params, 0, arg0)
+		validateParam(t, tc.params, 1, arg1)
+		validateParam(t, tc.params, 2, arg2)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return tc.err
+		}
+	})
+}
+
+func newHandlerFunc0(t *testing.T, tc handlerTestCase) Handler {
+	return HandlerFunc0(func(ctx context.Context) (any, error) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			return tc.expected, tc.err
+		}
+	})
+}
+
+func newHandlerFunc1(t *testing.T, tc handlerTestCase) Handler {
+	return HandlerFunc1(func(ctx context.Context, arg0 string) (any, error) {
+		validateParam(t, tc.params, 0, arg0)
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			return tc.expected, tc.err
+		}
+	})
+}
+
+func newHandlerFunc2(t *testing.T, tc handlerTestCase) Handler {
+	return HandlerFunc2(func(ctx context.Context, arg0, arg1 string) (any, error) {
+		validateParam(t, tc.params, 0, arg0)
+		validateParam(t, tc.params, 1, arg1)
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			return tc.expected, tc.err
+		}
+	})
+}
+
+func newHandlerFunc3(t *testing.T, tc handlerTestCase) Handler {
+	return HandlerFunc3(func(ctx context.Context, arg0, arg1, arg2 string) (any, error) {
+		validateParam(t, tc.params, 0, arg0)
+		validateParam(t, tc.params, 1, arg1)
+		validateParam(t, tc.params, 2, arg2)
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			return tc.expected, tc.err
+		}
+	})
+}
+
+func validateParam(t *testing.T, params any, n int, expected any) {
+	require.IsType(t, []any(nil), params)
+	args := params.([]any)
+	require.GreaterOrEqual(t, len(args), n)
+	require.Equal(t, expected, args[n])
+}
+
+func validateError(t *testing.T, expected error) jsonrpc2.Replier {
+	return func(ctx context.Context, result any, err error) error {
+		require.Nil(t, result)
+		require.Equal(t, expected, err)
+		return nil
+	}
+}
+
+func validateCancel(t *testing.T) jsonrpc2.Replier {
+	return func(ctx context.Context, result any, err error) error {
+		require.Nil(t, result)
+		var rpcErr *jsonrpc2.Error
+		require.True(t, errors.As(err, &rpcErr))
+		require.Equal(t, requestCanceledErrorCode, rpcErr.Code)
+		return nil
+	}
+}
+
+func validateResult(t *testing.T, expected any) jsonrpc2.Replier {
+	return func(ctx context.Context, result any, err error) error {
+		require.Nil(t, err)
+		require.Equal(t, expected, result)
+		return nil
+	}
+}

--- a/cli/azd/internal/vsrpc/observer.go
+++ b/cli/azd/internal/vsrpc/observer.go
@@ -47,7 +47,7 @@ func (o *IObserver[T]) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if v, has := wire["__jsonrpc_marshaled"]; !has && v != 1 {
+	if v, has := wire["__jsonrpc_marshaled"]; !has || v != 1 {
 		return errors.New("expected __jsonrpc_marshaled=1")
 	}
 

--- a/cli/azd/internal/vsrpc/observer_test.go
+++ b/cli/azd/internal/vsrpc/observer_test.go
@@ -1,0 +1,76 @@
+package vsrpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/jsonrpc2"
+)
+
+func TestUnmarshalIObserver(t *testing.T) {
+	t.Parallel()
+	t.Run("Ok", func(t *testing.T) {
+		req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), "Test", []any{
+			map[string]any{
+				"__jsonrpc_marshaled": 1,
+				"handle":              1,
+			},
+		})
+		require.NoError(t, err)
+
+		// As part of unmarshaling, we expect the IObserver to have it's connection parameter set to be set so it can send
+		// messages back later. Create a new dummy jsonrpc2.Conn so we can validate this.
+		con := jsonrpc2.NewConn(nil)
+
+		o, err := unmarshalArg[IObserver[int]](con, req, 0)
+		require.NoError(t, err)
+		require.Equal(t, con, o.c, "rpc connection was not attached during unmarshaling!")
+	})
+
+	t.Run("No Tag", func(t *testing.T) {
+		req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), "Test", []any{
+			map[string]any{
+				"handle": 1,
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = unmarshalArg[IObserver[int]](nil, req, 0)
+		require.Error(t, err)
+	})
+
+	t.Run("Bad Tag", func(t *testing.T) {
+		req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), "Test", []any{
+			map[string]any{
+				"__jsonrpc_marshaled": 0,
+				"handle":              1,
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = unmarshalArg[IObserver[int]](nil, req, 0)
+		require.Error(t, err)
+	})
+
+	t.Run("No Handle", func(t *testing.T) {
+		req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), "Test", []any{
+			map[string]any{
+				"__jsonrpc_marshaled": 1,
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = unmarshalArg[IObserver[int]](nil, req, 0)
+		require.Error(t, err)
+	})
+
+	t.Run("Bad Format", func(t *testing.T) {
+		req, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), "Test", []any{
+			"not-an-observer",
+		})
+		require.NoError(t, err)
+
+		_, err = unmarshalArg[IObserver[int]](nil, req, 0)
+		require.Error(t, err)
+	})
+}

--- a/cli/azd/internal/vsrpc/server.go
+++ b/cli/azd/internal/vsrpc/server.go
@@ -51,7 +51,7 @@ func (s *Server) Serve(l net.Listener) error {
 	// IObservers. This is useful for both developers unit testing in VS Code (where they can set this value in launch.json
 	// as well as tests where we can set this value with t.SetEnv()).
 	if on, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_SERVER_DEBUG_ENDPOINTS")); err == nil && on {
-		mux.Handle("/TestDebugService/v1.0", newDebugService(s))
+		mux.Handle("/TestDebugService/v1.0", newDebugService())
 	}
 
 	server := http.Server{
@@ -70,7 +70,7 @@ func serveRpc(w http.ResponseWriter, r *http.Request, handlers map[string]Handle
 	}
 	defer c.Close()
 
-	rpcServer := jsonrpc2.NewConn(NewWebSocketStream(c))
+	rpcServer := jsonrpc2.NewConn(newWebSocketStream(c))
 	cancelers := make(map[jsonrpc2.ID]context.CancelFunc)
 	cancelersMu := sync.Mutex{}
 

--- a/cli/azd/internal/vsrpc/server_test.go
+++ b/cli/azd/internal/vsrpc/server_test.go
@@ -1,0 +1,134 @@
+package vsrpc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/jsonrpc2"
+)
+
+func TestCancellation(t *testing.T) {
+	// wg controls when cancellation is sent by the client. We wait until the server RPC has started
+	// to run before requesting cancellation so we ensure we are testing our logic.
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	debugService := newDebugService()
+	debugService.wg = &wg
+	debugServer := httptest.NewServer(debugService)
+	defer debugServer.Close()
+
+	// Connect to the server and start running a JSON-RPC 2.0 connection so we can send and recieve messages.
+	serverUrl, err := url.Parse(debugServer.URL)
+	require.NoError(t, err)
+	serverUrl.Scheme = "ws"
+
+	wsConn, _, err := websocket.DefaultDialer.Dial(serverUrl.String(), nil)
+	require.NoError(t, err)
+
+	rpcConn := jsonrpc2.NewConn(newWebSocketStream(wsConn))
+	rpcConn.Go(context.Background(), nil)
+
+	// Call blocks until the response is returned from the server, so spin off a goroutine that will make
+	// the call and the shuttle the response back to us.
+	result := make(chan struct {
+		res bool
+		err error
+	})
+
+	go func() {
+		var res bool
+		_, err := rpcConn.Call(context.Background(), "TestCancelAsync", []any{10000}, &res)
+		result <- struct {
+			res bool
+			err error
+		}{res, err}
+		close(result)
+	}()
+
+	// Wait until the server starts processing the RPC, then request it be cancelled. We know the
+	// id of the inflight call is 1 because the jsonrpc2 package assigns ids starting at 1.
+	wg.Wait()
+	err = rpcConn.Notify(context.Background(), "$/cancelRequest", struct {
+		Id int `json:"id"`
+	}{Id: 1})
+	require.NoError(t, err)
+
+	// Now, wait for the RPC to either complete (if we have a bug) or to observe cancellation and have
+	// the results sent back here.
+	res := <-result
+	var rpcErr *jsonrpc2.Error
+
+	require.False(t, res.res, "call should have been aborted, and returned false")
+	require.True(t, errors.As(res.err, &rpcErr))
+	require.Equal(t, requestCanceledErrorCode, rpcErr.Code)
+}
+
+func TestObserverable(t *testing.T) {
+	debugServer := httptest.NewServer(newDebugService())
+	defer debugServer.Close()
+
+	// Connect to the server and start running a JSON-RPC 2.0 connection so we can send and recieve messages.
+	serverUrl, err := url.Parse(debugServer.URL)
+	require.NoError(t, err)
+	serverUrl.Scheme = "ws"
+
+	wsConn, _, err := websocket.DefaultDialer.Dial(serverUrl.String(), nil)
+	require.NoError(t, err)
+
+	// The IObserver machinary ends up sending RPCs back to the client, capture them so we can validate they are
+	// correct later.
+	var onNextParams []json.RawMessage
+	var onCompletedParams []json.RawMessage
+
+	rpcConn := jsonrpc2.NewConn(newWebSocketStream(wsConn))
+	rpcConn.Go(context.Background(), func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		switch req.Method() {
+		case "$/invokeProxy/1/onNext":
+			onNextParams = append(onNextParams, req.Params())
+		case "$/invokeProxy/1/onCompleted":
+			onCompletedParams = append(onCompletedParams, req.Params())
+		default:
+			require.Fail(t, "unexpected rpc %s delivered", req.Method())
+		}
+
+		return nil
+	})
+
+	// The second argument is the wire form of an IObserver as marshalled by StreamJsonRpc. We use the handle when sending
+	// messages back to the client.
+	args := []any{
+		10,
+		map[string]any{
+			"__jsonrpc_marshaled": 1,
+			"handle":              1,
+		},
+	}
+
+	require.NoError(t, err)
+
+	_, err = rpcConn.Call(context.Background(), "TestIObserverAsync", args, nil)
+	require.NoError(t, err)
+
+	require.Len(t, onNextParams, 10)
+	require.Len(t, onCompletedParams, 1)
+
+	// Ensure the correct integers were sent back in the correct order, this should match
+	// the order the were emited by the server.
+	for idx, params := range onNextParams {
+		var args []int
+		require.NoError(t, json.Unmarshal(params, &args))
+		require.Len(t, args, 1)
+		require.Equal(t, idx, args[0])
+	}
+
+	// The onCompleted message takes no parameters and the args value is empty.
+	require.Len(t, onCompletedParams[0], 0)
+}

--- a/cli/azd/internal/vsrpc/stream.go
+++ b/cli/azd/internal/vsrpc/stream.go
@@ -53,6 +53,6 @@ func (s *wsStream) Write(ctx context.Context, msg jsonrpc2.Message) (int64, erro
 	return int64(len(data)), nil
 }
 
-func NewWebSocketStream(c *websocket.Conn) *wsStream {
+func newWebSocketStream(c *websocket.Conn) *wsStream {
 	return &wsStream{c: c}
 }

--- a/cli/azd/internal/vsrpc/writer_multiplexer_test.go
+++ b/cli/azd/internal/vsrpc/writer_multiplexer_test.go
@@ -1,0 +1,32 @@
+package vsrpc
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriterMutiplexer(t *testing.T) {
+	w := &writerMultiplexer{}
+
+	var buf1 bytes.Buffer
+	var buf2 bytes.Buffer
+	var buf3 bytes.Buffer
+
+	w.AddWriter(&buf1)
+	w.AddWriter(&buf2)
+
+	_, err := w.Write([]byte("hello\n"))
+	require.NoError(t, err)
+
+	w.AddWriter(&buf3)
+	w.RemoveWriter(&buf2)
+
+	_, err = w.Write([]byte("world\n"))
+	require.NoError(t, err)
+
+	require.Equal(t, "hello\nworld\n", buf1.String())
+	require.Equal(t, "hello\n", buf2.String())
+	require.Equal(t, "world\n", buf3.String())
+}


### PR DESCRIPTION
This change adds some tests around the infrastructure for serving our RPC endpoints.

We now have coverage of our logic for cancellation and our support for `IObserver` as well as coverage of all our `Handler[Action|Func][0-3]` functions which validate the core marshalling logic of our server.

While writing these tests, I discovered a small functional bug in our logic for unmarshalling `IObserver`. We intended to validate that the tag when present was 1, but due to a logic error this was not happening.