### PR TITLE
Prevent `azure.yaml` being placed under project directories

### DIFF
--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
@@ -93,8 +94,30 @@ func (i *Initializer) InitFromApp(
 		}
 		appHostManifests[prj.Path] = manifest
 
+		// Load projects referenced by the App Host,
+		// ensuring that projects are located under the azd project directory.
+		const parentDir = ".." + string(os.PathSeparator)
+		relParentCount := 0
+		relParentProject := ""
 		for _, path := range apphost.ProjectPaths(manifest) {
+			rel, err := filepath.Rel(wd, path)
+			if err != nil {
+				return err
+			}
+
+			if parentCount := countPrefix(rel, parentDir); parentCount > relParentCount {
+				relParentCount = parentCount
+				relParentProject = rel
+			}
+
 			appHostForProject[filepath.Dir(path)] = prj.Path
+		}
+
+		if relParentCount > 0 {
+			return fmt.Errorf(
+				"found project %s located above the current directory. To fix, rerun `azd init` in directory %s",
+				relParentProject,
+				filepath.Clean(filepath.Join(wd, strings.Repeat(parentDir, relParentCount))))
 		}
 	}
 
@@ -431,4 +454,15 @@ func prjConfigFromDetect(
 	}
 
 	return config, nil
+}
+
+func countPrefix(s string, prefix string) int {
+	count := 0
+	for strings.HasPrefix(s, prefix) {
+		count++
+		// len(s) >= len(prefix) guaranteed by HasPrefix
+		s = s[len(prefix):]
+	}
+
+	return count
 }

--- a/cli/azd/pkg/project/dotnet_importer.go
+++ b/cli/azd/pkg/project/dotnet_importer.go
@@ -290,13 +290,13 @@ func (ai *DotNetImporter) SynthAllInfrastructure(
 	}
 
 	for name, path := range apphost.ProjectPaths(manifest) {
-		if writeManifestForResource(name, path) != nil {
+		if err := writeManifestForResource(name, path); err != nil {
 			return nil, err
 		}
 	}
 
 	for name, docker := range apphost.Dockerfiles(manifest) {
-		if writeManifestForResource(name, docker.Path) != nil {
+		if err := writeManifestForResource(name, docker.Path); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Prevent `azure.yaml` being placed in a directory that is below .NET projects, which results in missing manifests during `azd infra synth`.

This is consistent with the rest of `azd`'s design that service projects referenced are always below/"rooted" by the `azure.yaml` root directory. 

Also, fixed an err return spotted while looking into infra generation code.

![image](https://github.com/Azure/azure-dev/assets/2322434/d718262d-bf37-4437-8e55-a537a64b35d8)

Fixes #3179