### PR TITLE
Skip unnecessary packaging for containerized dotnet apps

### DIFF
--- a/.vscode/cspell-github-user-aliases.txt
+++ b/.vscode/cspell-github-user-aliases.txt
@@ -27,3 +27,4 @@ stretchr
 theckman
 bmatcuk
 tonybaloney
+weilim

--- a/cli/azd/pkg/project/framework_service_dotnet.go
+++ b/cli/azd/pkg/project/framework_service_dotnet.go
@@ -156,6 +156,19 @@ func (dp *dotnetProject) Package(
 ) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress] {
 	return async.RunTaskWithProgress(
 		func(task *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
+			if serviceConfig.Host == DotNetContainerAppTarget {
+				// TODO(weilim): For containerized projects, we publish the produced container image in a single call
+				// via `dotnet publish /p:PublishProfile=DefaultContainer`, thus the default `dotnet publish` command
+				// executed here is not useful.
+				//
+				// It's probably right for us to think about "package" for a containerized application as meaning
+				// "produce the tgz" of the image, as would be done by `docker save`, but this is currently not supported.
+				//
+				// See related comment in cmd/package.go.
+				task.SetResult(&ServicePackageResult{})
+				return
+			}
+
 			packageDest, err := os.MkdirTemp("", "azd")
 			if err != nil {
 				task.SetError(fmt.Errorf("creating package directory for %s: %w", serviceConfig.Name, err))


### PR DESCRIPTION
For containerized projects, we publish the produced container image in a single call `dotnet publish /p:PublishProfile=DefaultContainer`. Thus, running the default `dotnet publish` command is not required. Similar to `package.go`'s treatment of `DotNetContainerAppTarget `, we skip packaging for these projects.

Fixes #3300