### PR TITLE
Add version to vs-server

### DIFF
--- a/cli/azd/pkg/contracts/vs_server.go
+++ b/cli/azd/pkg/contracts/vs_server.go
@@ -1,0 +1,7 @@
+package contracts
+
+type VsServerResult struct {
+	Port int `json:"port"`
+	Pid  int `json:"pid"`
+	VersionResult
+}


### PR DESCRIPTION
To simplify consumption for diagnostics purposes, we also include version information in `azd vs-server` invocation.

```
./azd vs-server                  
{"port":40899,"pid":74476,"azd":{"version":"1.2.3-dev.0","commit":"8a49ae5ae9ab13beeade35f91ad4b4611c2f5574"}}
```

Fixes #3314