### PR TITLE
Conditional around search identity

### DIFF
--- a/templates/common/infra/bicep/core/search/search-services.bicep
+++ b/templates/common/infra/bicep/core/search/search-services.bicep
@@ -36,14 +36,16 @@ param replicaCount int = 1
 ])
 param semanticSearch string = 'disabled'
 
+var searchIdentityProvider = (sku.name == 'free') ? null : {
+  type: 'SystemAssigned'
+}
+
 resource search 'Microsoft.Search/searchServices@2021-04-01-preview' = {
   name: name
   location: location
   tags: tags
   // The free tier does not support managed identity
-  identity: (sku.name == 'free') ? null : {
-    type: 'SystemAssigned'
-  }
+  identity: searchIdentityProvider
   properties: {
     authOptions: authOptions
     disableLocalAuth: disableLocalAuth
@@ -62,4 +64,5 @@ resource search 'Microsoft.Search/searchServices@2021-04-01-preview' = {
 output id string = search.id
 output endpoint string = 'https://${name}.search.windows.net/'
 output name string = search.name
-output principalId string = search.identity.principalId
+output principalId string = !empty(searchIdentityProvider) ? search.identity.principalId : ''
+


### PR DESCRIPTION
We realized we needed a conditional when outputting the principal ID since we don't have it in the case of free SKU. 