### PR TITLE
ADE bug fixes

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -179,10 +179,10 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	})
 
 	// Azd Context
-	container.MustRegisterSingleton(azdcontext.NewAzdContext)
+	container.MustRegisterTransient(azdcontext.NewAzdContext)
 
 	// Lazy loads the Azd context after the azure.yaml file becomes available
-	container.MustRegisterSingleton(func() *lazy.Lazy[*azdcontext.AzdContext] {
+	container.MustRegisterTransient(func() *lazy.Lazy[*azdcontext.AzdContext] {
 		return lazy.NewLazy(func() (*azdcontext.AzdContext, error) {
 			return azdcontext.NewAzdContext()
 		})

--- a/cli/azd/pkg/devcenter/platform.go
+++ b/cli/azd/pkg/devcenter/platform.go
@@ -45,7 +45,7 @@ func (p *Platform) IsEnabled() bool {
 // ConfigureContainer configures the IoC container for the devcenter platform components
 func (p *Platform) ConfigureContainer(container *ioc.NestedContainer) error {
 	// DevCenter Config
-	container.MustRegisterSingleton(func(
+	container.MustRegisterTransient(func(
 		ctx context.Context,
 		lazyAzdCtx *lazy.Lazy[*azdcontext.AzdContext],
 		userConfigManager config.UserConfigManager,
@@ -75,7 +75,7 @@ func (p *Platform) ConfigureContainer(container *ioc.NestedContainer) error {
 		var environmentConfig *Config
 		if azdCtx != nil && localEnvStore != nil {
 			defaultEnvName, err := azdCtx.GetDefaultEnvironmentName()
-			if err != nil {
+			if err != nil || defaultEnvName == "" {
 				environmentConfig = &Config{}
 			} else {
 				// Attempt to load any devcenter configuration from local environment

--- a/cli/azd/pkg/devcenter/template_source.go
+++ b/cli/azd/pkg/devcenter/template_source.go
@@ -94,7 +94,7 @@ func (s *TemplateSource) ListTemplates(ctx context.Context) ([]*templates.Templa
 				// a repo url parameter as valid templates for azd
 				var repoUrls []string
 				containsRepoUrl := slices.ContainsFunc(envDefinition.Parameters, func(p devcentersdk.Parameter) bool {
-					if strings.EqualFold(p.Name, "repourl") {
+					if strings.EqualFold(p.Id, "repourl") {
 						// Repo url parameter can support multiple values
 						// Values can either have a default or multiple allowed values but not both
 						if p.Allowed != nil && len(p.Allowed) > 0 {


### PR DESCRIPTION
This fixes a few ADE issues during `azd init` flow for deployment environments:

## Incorrectly targeting ADE environment definition parameter `name` instead of `id`

This causes `azd` compatible templates from being discovered during template selection.

## Resolves additional prompts to supply devcenter configuration

During `azd init` flow and a template has already been selected `azd` should not need to ask from environment definition since it was already part of the template selection. 

To resolve this the lifetime of a devcenter configuration has been updated to be transient so that it is always constructed from realtime configuration of project, environment, etc.

During the `azd init` flow the `azdContext` is also constructed.  This has also been updated to a transient lifetime so that it can be constructed as needed during inital implementation.