### PR TITLE
use stdin for gh variable and secret values

### DIFF
--- a/cli/azd/pkg/tools/github/github.go
+++ b/cli/azd/pkg/tools/github/github.go
@@ -224,7 +224,7 @@ func (cli *ghCli) ListSecrets(ctx context.Context, repoSlug string) error {
 }
 
 func (cli *ghCli) SetSecret(ctx context.Context, repoSlug string, name string, value string) error {
-	runArgs := cli.newRunArgs("-R", repoSlug, "secret", "set", name, "--body", value)
+	runArgs := cli.newRunArgs("-R", repoSlug, "secret", "set", name).WithStdIn(strings.NewReader(value))
 	_, err := cli.run(ctx, runArgs)
 	if err != nil {
 		return fmt.Errorf("failed running gh secret set: %w", err)
@@ -233,7 +233,7 @@ func (cli *ghCli) SetSecret(ctx context.Context, repoSlug string, name string, v
 }
 
 func (cli *ghCli) SetVariable(ctx context.Context, repoSlug string, name string, value string) error {
-	runArgs := cli.newRunArgs("-R", repoSlug, "variable", "set", name, "--body", value)
+	runArgs := cli.newRunArgs("-R", repoSlug, "variable", "set", name).WithStdIn(strings.NewReader(value))
 	_, err := cli.run(ctx, runArgs)
 	if err != nil {
 		return fmt.Errorf("failed running gh variable set: %w", err)


### PR DESCRIPTION
Updating the implementation for `gh secret` and `gh variable` to read the value from stdin.

The previous implementation, using `--body value`, does not work on Windows if the `value` contains special characters like double-quotes (used to serialize a json value).  The issue is for how parameters are parsed by either powershell or cmd and passed to `gh cli`.

Using `stdin`, the `value` is not parsed by a shell and `gh cli` reads the value directly from stdin stream. 

fix: https://github.com/Azure/azure-dev/issues/3199