### PR TITLE
remove index unique attribute to fix cosmos terraform module - fixes terraform template tests

### DIFF
--- a/templates/common/infra/terraform/core/database/cosmos/cosmos.tf
+++ b/templates/common/infra/terraform/core/database/cosmos/cosmos.tf
@@ -68,7 +68,6 @@ resource "azurerm_cosmosdb_mongo_collection" "list" {
 
   index {
     keys   = ["_id"]
-    unique = true
   }
 }
 
@@ -81,6 +80,5 @@ resource "azurerm_cosmosdb_mongo_collection" "item" {
 
   index {
     keys   = ["_id"]
-    unique = true
   }
 }

--- a/templates/todo/common/tests/playwright.config.ts
+++ b/templates/todo/common/tests/playwright.config.ts
@@ -9,14 +9,14 @@ import dotenv from "dotenv";
  */
 const config: PlaywrightTestConfig = {
   testDir: ".",
-  /* Maximum time one test can run for. Using 10 min per test */
-  timeout: 10 * 60 * 1000,
+  /* Maximum time one test can run for. Using 2 hours per test */
+  timeout: 2 * 60 * 60 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 5000,
+    timeout: 60 * 60 * 1000,
   },
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,

--- a/templates/todo/common/tests/todo.spec.ts
+++ b/templates/todo/common/tests/todo.spec.ts
@@ -4,9 +4,7 @@ import { v4 as uuidv4 } from "uuid";
 test("Create and delete item test", async ({ page }) => {
   await page.goto("/", { waitUntil: 'networkidle' });
 
-  await expect(page.locator("text=My List").first()).toBeVisible({
-    timeout: 360 * 1000,
-  });
+  await expect(page.locator("text=My List").first()).toBeVisible();
 
   await expect(page.locator("text=This list is empty.").first()).toBeVisible()
 

--- a/templates/todo/common/tests/todo.spec.ts
+++ b/templates/todo/common/tests/todo.spec.ts
@@ -11,7 +11,7 @@ test("Create and delete item test", async ({ page }) => {
   const guid = uuidv4();
   console.log(`Creating item with text: ${guid}`);
 
-  await page.locator('[placeholder="Add an item"]').focus();;
+  await page.locator('[placeholder="Add an item"]').focus();
   await page.locator('[placeholder="Add an item"]').type(guid);
   await page.locator('[placeholder="Add an item"]').press("Enter");
 

--- a/templates/todo/common/tests/todo.spec.ts
+++ b/templates/todo/common/tests/todo.spec.ts
@@ -11,7 +11,7 @@ test("Create and delete item test", async ({ page }) => {
   const guid = uuidv4();
   console.log(`Creating item with text: ${guid}`);
 
-  await page.locator('[placeholder="Add an item"]').focus();
+  await page.locator('[placeholder="Add an item"]').focus();;
   await page.locator('[placeholder="Add an item"]').type(guid);
   await page.locator('[placeholder="Add an item"]').press("Enter");
 


### PR DESCRIPTION
Background:
MongoDB allows you to create indexes on fields to optimize query performance.
The _id field is automatically indexed with a unique constraint, ensuring each document has a unique identifier.
You can also create custom indexes on other fields to improve query efficiency.

The Error:
When you attempt to create an index on the _id field with the unique: true option, MongoDB throws an error.

> This behavior changed in MongoDB version 3.4.2.

Why?:
The _id field already has an automatically created index (usually ascending order).
MongoDB prevents you from creating a second index with the same fields as the existing _id index.
The unique and background attributes are not allowed for the _id index.

Workaround:
omit unique field.