### PR TITLE
Reverts ProjectConfig to have a singleton lifetime to fix hook registrations

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -344,7 +344,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	)
 
 	// Project Config
-	container.MustRegisterTransient(
+	container.MustRegisterSingleton(
 		func(ctx context.Context, azdContext *azdcontext.AzdContext) (*project.ProjectConfig, error) {
 			if azdContext == nil {
 				return nil, azdcontext.ErrNoProject

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -344,6 +344,8 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	)
 
 	// Project Config
+	// Required to be singleton (shared) because the project/service holds important event handlers
+	// from both hooks and internal that are used during azd lifecycle calls.
 	container.MustRegisterSingleton(
 		func(ctx context.Context, azdContext *azdcontext.AzdContext) (*project.ProjectConfig, error) {
 			if azdContext == nil {
@@ -360,6 +362,8 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	)
 
 	// Lazy loads the project config from the Azd Context when it becomes available
+	// Required to be singleton (shared) because the project/service holds important event handlers
+	// from both hooks and internal that are used during azd lifecycle calls.
 	container.MustRegisterSingleton(
 		func(
 			serviceLocator ioc.ServiceLocator,

--- a/cli/azd/cmd/vs_server.go
+++ b/cli/azd/cmd/vs_server.go
@@ -14,7 +14,9 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/vsrpc"
 	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -63,6 +65,22 @@ func (s *vsServerAction) Run(ctx context.Context) (*actions.ActionResult, error)
 	if err != nil {
 		panic(err)
 	}
+
+	// TODO(azure/azure-dev#3347): Rationalize lifetime issues with project config.
+	s.rootContainer.MustRegisterTransient(
+		func(ctx context.Context, azdContext *azdcontext.AzdContext) (*project.ProjectConfig, error) {
+			if azdContext == nil {
+				return nil, azdcontext.ErrNoProject
+			}
+
+			projectConfig, err := project.Load(ctx, azdContext.ProjectPath())
+			if err != nil {
+				return nil, err
+			}
+
+			return projectConfig, nil
+		},
+	)
 
 	var versionRes contracts.VersionResult
 	versionSpec := internal.VersionInfo()


### PR DESCRIPTION
Reverts changes to the `ProjectConfig` lifetime from `transient` back to `singleton` to persist project/service level event handlers across the component.