### PR TITLE
Update fpm to use Ubuntu 22.04 and use optional prefix

### DIFF
--- a/cli/installer/fpm/fpm.Dockerfile
+++ b/cli/installer/fpm/fpm.Dockerfile
@@ -1,5 +1,5 @@
 ARG prefix=''
-ARG base='ubuntu:20.04'
+ARG base='ubuntu:22.04'
 FROM ${prefix}${base}
 
 RUN apt update && \ 

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -1074,6 +1074,7 @@ stages:
               pwsh: true
               workingDirectory: cli/installer/fpm
               filePath: eng/scripts/Test-LinuxPackages.ps1
+              arguments: -DockerImagePrefix "$(docker-mirror-tag-prefix)/"
 
   - ${{ if eq(variables['Build.Repository.Name'], 'Azure/azure-dev') }}:
     - stage: PublishCLI

--- a/eng/pipelines/templates/steps/build-linux-packages.yml
+++ b/eng/pipelines/templates/steps/build-linux-packages.yml
@@ -8,7 +8,7 @@ steps:
     condition: ${{ parameters.Condition }}
     displayName: Copy binary to fpm working directory
 
-  - pwsh: docker build . -f fpm.Dockerfile -t fpm
+  - pwsh: docker build . -f fpm.Dockerfile -t fpm --build-arg prefix="$(docker-mirror-tag-prefix)/"
     condition: ${{ parameters.Condition }}
     workingDirectory: cli/installer/fpm
     displayName: Build fpm container

--- a/eng/scripts/Test-LinuxPackages.ps1
+++ b/eng/scripts/Test-LinuxPackages.ps1
@@ -1,5 +1,6 @@
 param(
-    $PackageTypes = @('deb', 'rpm')
+    $PackageTypes = @('deb', 'rpm'),
+    $DockerImagePrefix = ''
 )
 
 $originalLocation = Get-Location 
@@ -8,7 +9,7 @@ try {
     $currentPath = (Get-Location).Path
 
     foreach ($type in $PackageTypes) { 
-        docker build . -f "test-$type.Dockerfile" -t test-linux-package
+        docker build . -f "test-$type.Dockerfile" -t test-linux-package --build-arg prefix="$DockerImagePrefix"
         if ($LASTEXITCODE) { 
             Write-Host "Error building test container for type: $type"
             exit 1


### PR DESCRIPTION
Example build/test showing Linux packages built using Ubuntu 22.04. 

Moving up to Ubuntu 22.04 alleviates the version concerns that were causing errors in other builds. There is no hard requirement that packages be built on Ubuntu 20.04. 