### PR TITLE
Add template url and env name arguments to init VS Code command

### DIFF
--- a/ext/vscode/src/commands/init.ts
+++ b/ext/vscode/src/commands/init.ts
@@ -9,19 +9,28 @@ import { executeAsTask } from '../utils/executeAsTask';
 import { getAzDevTerminalTitle, selectApplicationTemplate, showReadmeFile } from './cmdUtil';
 import { TelemetryId } from '../telemetry/telemetryId';
 
-export async function init(context: IActionContext, selectedFile?: vscode.Uri, allSelectedFiles?: vscode.Uri): Promise<void> {
+interface InitCommandOptions {
+    templateUrl?: string;
+    environmentName?: string;
+}
+
+export async function init(context: IActionContext, selectedFile?: vscode.Uri, allSelectedFiles?: vscode.Uri, options?: InitCommandOptions): Promise<void> {
     let folder: vscode.WorkspaceFolder | undefined = (selectedFile ? vscode.workspace.getWorkspaceFolder(selectedFile) : undefined);
     if (!folder) {
         folder = await quickPickWorkspaceFolder(context, vscode.l10n.t("To run '{0}' command you must first open a folder or workspace in VS Code", 'init'));
     }
 
-    const templateUrl = await selectApplicationTemplate(context);
+    const templateUrl = options?.templateUrl ?? await selectApplicationTemplate(context);
 
     const azureCli = await createAzureDevCli(context);
     const command = azureCli.commandBuilder
         .withArg('init')
         .withNamedArg('-t', {value: templateUrl, quoting: vscode.ShellQuoting.Strong});
     const workspacePath = folder?.uri;
+
+    if (options?.environmentName) {
+        command.withNamedArg('-e', {value: options.environmentName, quoting: vscode.ShellQuoting.Strong});
+    }
 
     // Don't wait
     void executeAsTask(command.build(), getAzDevTerminalTitle(), {


### PR DESCRIPTION
I'm adding options to the init command so that I can call it with a template url and environment name. We're leveraging it for vscode.dev/azure so that the selected azd template is immediately initialized when VS Code loads. 

We plan to call this command directly.