### PR TITLE
Allow selecting an existing environment when no default environment is set

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -205,7 +205,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 			environmentName := envFlags.EnvironmentName
 			var err error
 
-			env, err := envManager.LoadOrCreateInteractive(ctx, environmentName)
+			env, err := envManager.LoadOrInitInteractive(ctx, environmentName)
 			if err != nil {
 				return nil, fmt.Errorf("loading environment: %w", err)
 			}

--- a/cli/azd/pkg/environment/manager.go
+++ b/cli/azd/pkg/environment/manager.go
@@ -52,7 +52,11 @@ var (
 // Manager is the interface used for managing instances of environments
 type Manager interface {
 	Create(ctx context.Context, spec Spec) (*Environment, error)
-	LoadOrCreateInteractive(ctx context.Context, name string) (*Environment, error)
+
+	// Loads the environment with the given name.
+	// If the name is empty, the user is prompted to select or create an environment.
+	// If the environment does not exist, the user is prompted to create it.
+	LoadOrInitInteractive(ctx context.Context, name string) (*Environment, error)
 	List(ctx context.Context) ([]*Description, error)
 	Get(ctx context.Context, name string) (*Environment, error)
 	Save(ctx context.Context, env *Environment) error
@@ -142,65 +146,8 @@ func (m *manager) Create(ctx context.Context, spec Spec) (*Environment, error) {
 	return env, nil
 }
 
-func (m *manager) LoadOrCreateInteractive(ctx context.Context, environmentName string) (*Environment, error) {
-	loadOrCreateEnvironment := func() (*Environment, bool, error) {
-		// If there's a default environment, use that
-		if environmentName == "" {
-			var err error
-			environmentName, err = m.azdContext.GetDefaultEnvironmentName()
-			if err != nil {
-				return nil, false, fmt.Errorf("getting default environment: %w", err)
-			}
-		}
-
-		if environmentName != "" {
-			env, err := m.Get(ctx, environmentName)
-			switch {
-			case errors.Is(err, ErrNotFound):
-				msg := fmt.Sprintf("Environment '%s' does not exist, would you like to create it?", environmentName)
-				shouldCreate, promptErr := m.console.Confirm(ctx, input.ConsoleOptions{
-					Message:      msg,
-					DefaultValue: true,
-				})
-				if promptErr != nil {
-					return nil, false, fmt.Errorf("prompting to create environment '%s': %w", environmentName, promptErr)
-				}
-				if !shouldCreate {
-					return nil, false, fmt.Errorf("environment '%s' not found: %w", environmentName, err)
-				}
-			case err != nil:
-				return nil, false, fmt.Errorf("loading environment '%s': %w", environmentName, err)
-			case err == nil:
-				return env, false, nil
-			}
-		}
-
-		// Two cases if we get to here:
-		// - The user has not specified an environment name (and there was no default environment set)
-		// - The user has specified an environment name, but the named environment didn't exist and they told us they would
-		//   like us to create it.
-		if environmentName != "" && !IsValidEnvironmentName(environmentName) {
-			fmt.Fprintf(
-				m.console.Handles().Stdout,
-				"environment name '%s' is invalid (it should contain only alphanumeric characters and hyphens)\n",
-				environmentName)
-			return nil, false, fmt.Errorf(
-				"environment name '%s' is invalid (it should contain only alphanumeric characters and hyphens)",
-				environmentName)
-		}
-
-		spec := &Spec{
-			Name: environmentName,
-		}
-
-		if err := m.ensureValidEnvironmentName(ctx, spec); err != nil {
-			return nil, false, err
-		}
-
-		return New(spec.Name), true, nil
-	}
-
-	env, isNew, err := loadOrCreateEnvironment()
+func (m *manager) LoadOrInitInteractive(ctx context.Context, environmentName string) (*Environment, error) {
+	env, isNew, err := m.loadOrInitEnvironment(ctx, environmentName)
 	switch {
 	case errors.Is(err, ErrNotFound):
 		return nil, fmt.Errorf("environment %s does not exist", environmentName)
@@ -219,6 +166,111 @@ func (m *manager) LoadOrCreateInteractive(ctx context.Context, environmentName s
 	}
 
 	return env, nil
+}
+
+func (m *manager) loadOrInitEnvironment(ctx context.Context, environmentName string) (*Environment, bool, error) {
+	// If there's a default environment, use that
+	if environmentName == "" {
+		var err error
+		environmentName, err = m.azdContext.GetDefaultEnvironmentName()
+		if err != nil {
+			return nil, false, fmt.Errorf("getting default environment: %w", err)
+		}
+	}
+
+	if environmentName != "" {
+		env, err := m.Get(ctx, environmentName)
+		switch {
+		case errors.Is(err, ErrNotFound):
+			msg := fmt.Sprintf("Environment '%s' does not exist, would you like to create it?", environmentName)
+			shouldCreate, promptErr := m.console.Confirm(ctx, input.ConsoleOptions{
+				Message:      msg,
+				DefaultValue: true,
+			})
+			if promptErr != nil {
+				return nil, false, fmt.Errorf("prompting to create environment '%s': %w", environmentName, promptErr)
+			}
+			if !shouldCreate {
+				return nil, false, fmt.Errorf("environment '%s' not found: %w", environmentName, err)
+			}
+		case err != nil:
+			return nil, false, fmt.Errorf("loading environment '%s': %w", environmentName, err)
+		case err == nil:
+			return env, false, nil
+		}
+	}
+
+	// Two cases if we get to here:
+	// - The user has not specified an environment name, and there was no default environment set
+	// - The user has specified an environment name, but the named environment didn't exist and they told us they would
+	//   like us to create it.
+	if environmentName != "" && !IsValidEnvironmentName(environmentName) {
+		fmt.Fprintf(
+			m.console.Handles().Stdout,
+			"environment name '%s' is invalid (it should contain only alphanumeric characters and hyphens)\n",
+			environmentName)
+		return nil, false, fmt.Errorf(
+			"environment name '%s' is invalid (it should contain only alphanumeric characters and hyphens)",
+			environmentName)
+	}
+
+	// No environment name, no default environment set.
+	// Ask the user if they want to create a new environment or select an existing one
+	if environmentName == "" {
+		envs, err := m.List(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+
+		choices := make([]string, 0, len(envs)+1)
+		choices = append(choices, "Create a new environment")
+		for _, env := range envs {
+			choices = append(choices, env.Name)
+		}
+
+		sel, err := m.console.Select(ctx, input.ConsoleOptions{
+			Message: "Select an environment to use:",
+			Options: choices,
+		})
+		if err != nil {
+			return nil, false, err
+		}
+
+		if sel > 0 {
+			// Return an existing environment
+			env, err := m.Get(ctx, choices[sel])
+			if err != nil {
+				return nil, false, err
+			}
+
+			setDefault, err := m.console.Confirm(ctx, input.ConsoleOptions{
+				Message:      fmt.Sprintf("Set '%s' as the default environment?", env.Name()),
+				DefaultValue: true,
+			})
+			if err != nil {
+				return nil, false, err
+			}
+
+			if setDefault {
+				if err := m.azdContext.SetDefaultEnvironmentName(env.Name()); err != nil {
+					return nil, false, fmt.Errorf("saving default environment: %w", err)
+				}
+			}
+
+			return env, false, nil
+		}
+	}
+
+	// Create the environment
+	spec := &Spec{
+		Name: environmentName,
+	}
+
+	if err := m.ensureValidEnvironmentName(ctx, spec); err != nil {
+		return nil, false, err
+	}
+
+	return New(spec.Name), true, nil
 }
 
 // ConfigPath returns the path to the environment config file

--- a/cli/azd/pkg/environment/manager.go
+++ b/cli/azd/pkg/environment/manager.go
@@ -222,39 +222,32 @@ func (m *manager) loadOrInitEnvironment(ctx context.Context, environmentName str
 			return nil, false, err
 		}
 
+		// Selection, 0 is the option to create a new environment
+		selection := 0
 		choices := make([]string, 0, len(envs)+1)
 		choices = append(choices, "Create a new environment")
-		for _, env := range envs {
-			choices = append(choices, env.Name)
-		}
-
-		sel, err := m.console.Select(ctx, input.ConsoleOptions{
-			Message: "Select an environment to use:",
-			Options: choices,
-		})
-		if err != nil {
-			return nil, false, err
-		}
-
-		if sel > 0 {
-			// Return an existing environment
-			env, err := m.Get(ctx, choices[sel])
-			if err != nil {
-				return nil, false, err
+		if len(envs) > 0 {
+			for _, env := range envs {
+				choices = append(choices, env.Name)
 			}
 
-			setDefault, err := m.console.Confirm(ctx, input.ConsoleOptions{
-				Message:      fmt.Sprintf("Set '%s' as the default environment?", env.Name()),
-				DefaultValue: true,
+			selection, err = m.console.Select(ctx, input.ConsoleOptions{
+				Message: "Select an environment to use:",
+				Options: choices,
 			})
 			if err != nil {
 				return nil, false, err
 			}
+		}
 
-			if setDefault {
-				if err := m.azdContext.SetDefaultEnvironmentName(env.Name()); err != nil {
-					return nil, false, fmt.Errorf("saving default environment: %w", err)
-				}
+		if selection > 0 {
+			// Return an existing environment
+			env, err := m.Get(ctx, choices[selection])
+			if err != nil {
+				return nil, false, err
+			}
+			if err := m.azdContext.SetDefaultEnvironmentName(env.Name()); err != nil {
+				return nil, false, fmt.Errorf("saving default environment: %w", err)
 			}
 
 			return env, false, nil

--- a/cli/azd/pkg/environment/manager_test.go
+++ b/cli/azd/pkg/environment/manager_test.go
@@ -83,7 +83,7 @@ func Test_EnvManager_PromptEnvironmentName(t *testing.T) {
 
 		expected := "hello"
 		envManager := createEnvManagerForManagerTest(t, mockContext)
-		env, err := envManager.LoadOrCreateInteractive(*mockContext.Context, expected)
+		env, err := envManager.LoadOrInitInteractive(*mockContext.Context, expected)
 		require.NoError(t, err)
 		require.NotNil(t, env)
 		require.Equal(t, expected, env.Name())
@@ -93,16 +93,18 @@ func Test_EnvManager_PromptEnvironmentName(t *testing.T) {
 		expected := "someEnv"
 
 		mockContext := mocks.NewMockContext(context.Background())
-		mockContext.Console.WhenConfirm(func(options input.ConsoleOptions) bool {
-			return strings.Contains(options.Message, "would you like to create it?")
-		}).Respond(true)
+		mockContext.Console.WhenSelect(func(options input.ConsoleOptions) bool {
+			return strings.Contains(options.Message, "Select an environment to use")
+		}).RespondFn(func(options input.ConsoleOptions) (any, error) {
+			return 0, nil // Create an environment
+		})
 
 		mockContext.Console.WhenPrompt(func(options input.ConsoleOptions) bool {
 			return true
 		}).Respond(expected)
 
 		envManager := createEnvManagerForManagerTest(t, mockContext)
-		env, err := envManager.LoadOrCreateInteractive(*mockContext.Context, "")
+		env, err := envManager.LoadOrInitInteractive(*mockContext.Context, "")
 
 		require.NoError(t, err)
 		require.NotNil(t, env)
@@ -127,7 +129,7 @@ func Test_EnvManager_CreateAndInitEnvironment(t *testing.T) {
 		}).Respond(true)
 
 		envManager := createEnvManagerForManagerTest(t, mockContext)
-		env, err := envManager.LoadOrCreateInteractive(*mockContext.Context, invalidEnvName)
+		env, err := envManager.LoadOrInitInteractive(*mockContext.Context, invalidEnvName)
 		require.Error(t, err)
 		require.Nil(t, env)
 		require.ErrorContains(t, err, fmt.Sprintf("environment name '%s' is invalid", invalidEnvName))

--- a/cli/azd/test/functional/env_test.go
+++ b/cli/azd/test/functional/env_test.go
@@ -133,8 +133,7 @@ func Test_CLI_Env_Management(t *testing.T) {
 
 	_, _ = cli.RunCommandWithStdIn(
 		ctx,
-		envName2+"\n"+
-			"y\n", // Set as default
+		envName2+"\n",
 		cmdNeedingEnv...)
 
 	environmentList = envList(ctx, t, cli)

--- a/cli/azd/test/functional/env_test.go
+++ b/cli/azd/test/functional/env_test.go
@@ -277,7 +277,7 @@ func envNew(ctx context.Context, t *testing.T, cli *azdcli.CLI, envName string, 
 
 	if usePrompt {
 		runArgs := append(defaultArgs, args...)
-		_, err := cli.RunCommandWithStdIn(ctx, "envName\n", runArgs...)
+		_, err := cli.RunCommandWithStdIn(ctx, envName+"\n", runArgs...)
 		require.NoError(t, err)
 	} else {
 		runArgs := append(defaultArgs, envName, "--subscription", cfg.SubscriptionID, "-l", cfg.Location)

--- a/cli/azd/test/functional/env_test.go
+++ b/cli/azd/test/functional/env_test.go
@@ -110,12 +110,12 @@ func Test_CLI_Env_Management(t *testing.T) {
 	_, err = cli.RunCommand(context.Background(), "env", "refresh", "-e", "from-flag", "from-arg")
 	require.Error(t, err)
 
-	// Verify create when no default environment is set
+	// Verify creating an environment when no default environment is set
 	azdCtx := azdcontext.NewAzdContextWithDirectory(dir)
 	err = azdCtx.SetDefaultEnvironmentName("")
 	require.NoError(t, err)
 
-	// Here we should 'monitor' as the command that requires environment to operate on
+	// Here we choose 'monitor' as the command that requires an environment to target
 	cmdNeedingEnv := []string{"monitor"}
 
 	envName3 := randomEnvName()
@@ -127,7 +127,7 @@ func Test_CLI_Env_Management(t *testing.T) {
 	require.Len(t, environmentList, 3)
 	requireIsDefault(t, environmentList, envName3)
 
-	// Verify select environment when no default environment is set
+	// Verify selecting an environment when no default environment is set
 	err = azdCtx.SetDefaultEnvironmentName("")
 	require.NoError(t, err)
 

--- a/cli/azd/test/functional/env_test.go
+++ b/cli/azd/test/functional/env_test.go
@@ -277,7 +277,7 @@ func envNew(ctx context.Context, t *testing.T, cli *azdcli.CLI, envName string, 
 
 	if usePrompt {
 		runArgs := append(defaultArgs, args...)
-		_, err := cli.RunCommandWithStdIn(ctx, stdinForInit(envName), runArgs...)
+		_, err := cli.RunCommandWithStdIn(ctx, "envName\n", runArgs...)
 		require.NoError(t, err)
 	} else {
 		runArgs := append(defaultArgs, envName, "--subscription", cfg.SubscriptionID, "-l", cfg.Location)

--- a/cli/azd/test/functional/package_test.go
+++ b/cli/azd/test/functional/package_test.go
@@ -27,12 +27,15 @@ func Test_CLI_Package_Err_WorkingDirectory(t *testing.T) {
 	err := copySample(dir, "webapp")
 	require.NoError(t, err, "failed expanding sample")
 
+	_, err = cli.RunCommandWithStdIn(ctx, stdinForInit("testenv"), "init")
+	require.NoError(t, err)
+
 	// cd infra
 	err = os.MkdirAll(filepath.Join(dir, "infra"), osutil.PermissionDirectory)
 	require.NoError(t, err)
 	cli.WorkingDirectory = filepath.Join(dir, "infra")
 
-	result, err := cli.RunCommandWithStdIn(ctx, stdinForInit("testenv"), "package")
+	result, err := cli.RunCommand(ctx, "package")
 	require.Error(t, err, "package should fail in non-project and non-service directory")
 	require.Contains(t, result.Stdout, "current working directory")
 }
@@ -53,9 +56,12 @@ func Test_CLI_Package_FromServiceDirectory(t *testing.T) {
 	err := copySample(dir, "webapp")
 	require.NoError(t, err, "failed expanding sample")
 
+	_, err = cli.RunCommandWithStdIn(ctx, stdinForInit("testenv"), "init")
+	require.NoError(t, err)
+
 	cli.WorkingDirectory = filepath.Join(dir, "src", "dotnet")
 
-	result, err := cli.RunCommandWithStdIn(ctx, stdinForInit("testenv"), "package")
+	result, err := cli.RunCommand(ctx, "package")
 	require.NoError(t, err)
 	require.Contains(t, result.Stdout, "Packaging service web")
 }
@@ -78,9 +84,11 @@ func Test_CLI_Package_WithOutputPath(t *testing.T) {
 		err := copySample(dir, "webapp")
 		require.NoError(t, err, "failed expanding sample")
 
-		packageResult, err := cli.RunCommandWithStdIn(
+		_, err = cli.RunCommandWithStdIn(ctx, stdinForInit(envName), "init")
+		require.NoError(t, err)
+
+		packageResult, err := cli.RunCommand(
 			ctx,
-			stdinForInit(envName),
 			"package", "--output-path", "./dist",
 		)
 		require.NoError(t, err)
@@ -109,9 +117,11 @@ func Test_CLI_Package_WithOutputPath(t *testing.T) {
 		err := copySample(dir, "webapp")
 		require.NoError(t, err, "failed expanding sample")
 
-		packageResult, err := cli.RunCommandWithStdIn(
+		_, err = cli.RunCommandWithStdIn(ctx, stdinForInit(envName), "init")
+		require.NoError(t, err)
+
+		packageResult, err := cli.RunCommand(
 			ctx,
-			stdinForInit(envName),
 			"package", "web", "--output-path", "./dist/web.zip",
 		)
 		require.NoError(t, err)
@@ -143,7 +153,10 @@ func Test_CLI_Package(t *testing.T) {
 	err := copySample(dir, "webapp")
 	require.NoError(t, err, "failed expanding sample")
 
-	packageResult, err := cli.RunCommandWithStdIn(ctx, stdinForInit(envName), "package", "web")
+	_, err = cli.RunCommandWithStdIn(ctx, stdinForInit(envName), "init")
+	require.NoError(t, err)
+
+	packageResult, err := cli.RunCommand(ctx, "package", "web")
 	require.NoError(t, err)
 	require.Contains(t, packageResult.Stdout, fmt.Sprintf("Package Output: %s", os.TempDir()))
 }

--- a/cli/azd/test/functional/up_test.go
+++ b/cli/azd/test/functional/up_test.go
@@ -348,7 +348,7 @@ func Test_CLI_Up_ResourceGroupScope(t *testing.T) {
 	_, err = cli.RunCommandWithStdIn(ctx, stdinForInit(envName), "init")
 	require.NoError(t, err)
 
-	_, err = cli.RunCommandWithStdIn(ctx, stdinForInit(envName), "env", "set", "AZURE_RESOURCE_GROUP", resourceGroupName)
+	_, err = cli.RunCommand(ctx, "env", "set", "AZURE_RESOURCE_GROUP", resourceGroupName)
 	require.NoError(t, err)
 
 	_, err = cli.RunCommandWithStdIn(ctx, stdinForProvision(), "infra", "create")

--- a/cli/azd/test/mocks/mockenv/mock_manager.go
+++ b/cli/azd/test/mocks/mockenv/mock_manager.go
@@ -16,7 +16,7 @@ func (m *MockEnvManager) Create(ctx context.Context, spec environment.Spec) (*en
 	return args.Get(0).(*environment.Environment), args.Error(1)
 }
 
-func (m *MockEnvManager) LoadOrCreateInteractive(ctx context.Context, name string) (*environment.Environment, error) {
+func (m *MockEnvManager) LoadOrInitInteractive(ctx context.Context, name string) (*environment.Environment, error) {
 	args := m.Called(ctx, name)
 	return args.Get(0).(*environment.Environment), args.Error(1)
 }


### PR DESCRIPTION
When a command requires an environment, and no default environment is set, the user is prompted to "Enter a new environment name".

This change updates the prompt slightly to allow selecting an existing environment.

Before:
![image](https://github.com/Azure/azure-dev/assets/2322434/2c655ba0-9a91-4020-b97e-1018eb36778d)

After:
![image](https://github.com/Azure/azure-dev/assets/2322434/fac01d0e-ac5e-4e76-8e57-8d99e63e7b3b)

"Create a new environment"
![image](https://github.com/Azure/azure-dev/assets/2322434/30779047-0de1-4a39-b9f6-0c4c0131d1dd)

"Select 'prod'"
![image](https://github.com/Azure/azure-dev/assets/2322434/838abec7-78f5-459b-9c56-b16dd73dd425)

I suspect that this is a good change overall, and will work nicely with upcoming work to delete environments: #937
