### PR TITLE
fix: Removes requirement that infra must always exist for ADE/devcenter projects

### DIFF
--- a/cli/azd/pkg/project/importer.go
+++ b/cli/azd/pkg/project/importer.go
@@ -149,10 +149,7 @@ func (im *ImportManager) ProjectInfrastructure(ctx context.Context, projectConfi
 		}
 	}
 
-	return nil, fmt.Errorf(
-		"this project does not contain expected infrastructure, folder: '%s' and module: '%s'",
-		infraRoot,
-		projectConfig.Infra.Module)
+	return &Infra{}, nil
 }
 
 // pathHasModule returns true if there is a file named "<module>" or "<module.bicep>" in path.

--- a/cli/azd/pkg/project/importer_test.go
+++ b/cli/azd/pkg/project/importer_test.go
@@ -184,8 +184,9 @@ func TestImportManagerProjectInfrastructureDefaults(t *testing.T) {
 
 	// Get defaults and error b/c no infra found and no Aspire project
 	r, e := manager.ProjectInfrastructure(*mockContext.Context, &ProjectConfig{})
-	require.Nil(t, r)
-	require.Error(t, e, "this project does not contain expected infrastructure")
+	require.NoError(t, e, "this project does not contain expected infrastructure")
+	require.NotNil(t, r)
+	require.Equal(t, r, &Infra{})
 
 	// adding infra folder to test defaults
 	expectedDefaultFolder := DefaultPath
@@ -195,8 +196,9 @@ func TestImportManagerProjectInfrastructureDefaults(t *testing.T) {
 
 	// error should keep happening b/c infra folder exists but module is not found
 	r, e = manager.ProjectInfrastructure(*mockContext.Context, &ProjectConfig{})
-	require.Nil(t, r)
-	require.Error(t, e, "this project does not contain expected infrastructure")
+	require.NoError(t, e)
+	require.NotNil(t, r)
+	require.Equal(t, r, &Infra{})
 
 	// Create the file
 	expectedDefaultModule := DefaultModule


### PR DESCRIPTION
Resolves #3365

When users are leveraging ADE and devcenter it is expected that a local `infra` folder will not exist.
In the `importer` package we are unable to take a dependency on platform configuration and the importer should not enforce infra provider constraints