### PR TITLE
fix: AKS deploy issues with containers & manifests

### DIFF
--- a/cli/azd/pkg/project/container_helper_test.go
+++ b/cli/azd/pkg/project/container_helper_test.go
@@ -336,6 +336,7 @@ func Test_ContainerHelper_Deploy(t *testing.T) {
 			require.Equal(t, tt.expectDockerPullCalled, dockerPullCalled)
 			require.Equal(t, tt.expectDockerTagCalled, dockerTagCalled)
 			require.Equal(t, tt.expectDockerPushCalled, dockerPushCalled)
+			require.Equal(t, tt.expectedRemoteImage, env.GetServiceProperty("api", "IMAGE_NAME"))
 		})
 	}
 }
@@ -376,7 +377,7 @@ func Test_ContainerHelper_ConfiguredImage(t *testing.T) {
 			},
 		},
 		{
-			name:  "with custom iamge",
+			name:  "with custom image",
 			image: osutil.NewExpandableString("custom-image"),
 			expectedImage: docker.ContainerImage{
 				Registry:   "",
@@ -385,7 +386,7 @@ func Test_ContainerHelper_ConfiguredImage(t *testing.T) {
 			},
 		},
 		{
-			name:  "with custom iamge and tag",
+			name:  "with custom image and tag",
 			image: osutil.NewExpandableString("custom-image"),
 			tag:   osutil.NewExpandableString("custom-tag"),
 			expectedImage: docker.ContainerImage{

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -372,14 +372,14 @@ func Test_DockerProject_Package(t *testing.T) {
 		},
 		{
 			name:  "fully qualified image with custom docker options",
-			image: "docker.io/repository/iamge:latest",
+			image: "docker.io/repository/image:latest",
 			docker: DockerProjectOptions{
 				Image: osutil.NewExpandableString("myapp-service"),
 				Tag:   osutil.NewExpandableString("latest"),
 			},
 			expectedPackageResult: dockerPackageResult{
 				ImageHash:   "",
-				SourceImage: "docker.io/repository/iamge:latest",
+				SourceImage: "docker.io/repository/image:latest",
 				TargetImage: "myapp-service:latest",
 			},
 			expectDockerPullCalled: true,

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -192,16 +192,14 @@ func (t *aksTarget) Deploy(
 				return
 			}
 
-			if packageOutput.PackagePath != "" {
-				// Login, tag & push container image to ACR
-				containerDeployTask := t.containerHelper.Deploy(ctx, serviceConfig, packageOutput, targetResource, true)
-				syncProgress(task, containerDeployTask.Progress())
+			// Login, tag & push container image to ACR
+			containerDeployTask := t.containerHelper.Deploy(ctx, serviceConfig, packageOutput, targetResource, true)
+			syncProgress(task, containerDeployTask.Progress())
 
-				_, err := containerDeployTask.Await()
-				if err != nil {
-					task.SetError(err)
-					return
-				}
+			_, err := containerDeployTask.Await()
+			if err != nil {
+				task.SetError(err)
+				return
 			}
 
 			// Sync environment
@@ -294,6 +292,8 @@ func (t *aksTarget) deployManifests(
 		deploymentPath = defaultDeploymentPath
 	}
 
+	deploymentPath = filepath.Join(serviceConfig.Path(), deploymentPath)
+
 	// Manifests are optional so we will continue if the directory does not exist
 	if _, err := os.Stat(deploymentPath); os.IsNotExist(err) {
 		return nil, err
@@ -302,7 +302,7 @@ func (t *aksTarget) deployManifests(
 	task.SetProgress(NewServiceProgress("Applying k8s manifests"))
 	err := t.kubectl.Apply(
 		ctx,
-		filepath.Join(serviceConfig.RelativePath, deploymentPath),
+		deploymentPath,
 		nil,
 	)
 	if err != nil {


### PR DESCRIPTION
Resolves #3376

Fixes a few issues for AKS service target when building containers with yaml manifests.

A couple merge issues resulted in some missed changes:
- [x] Built images were not getting deployed
- [x] Manifest deployment paths was not found
- [x] Services with external image urls not correctly setting IMAGE_NAME environment variables  