### PR TITLE
Defense in depth changes for potential $PSNativeCommandArgumentPassing problems

### DIFF
--- a/eng/pipelines/templates/steps/publish-cli-choco.yml
+++ b/eng/pipelines/templates/steps/publish-cli-choco.yml
@@ -53,6 +53,9 @@ steps:
     displayName: Publish Choco Package Artifact
 
   - pwsh: |
+      # Defense in depth: Legacy argument passing may be needed here
+      $PSNativeCommandArgumentPassing = 'Legacy'
+
       Write-Host 'Pushing Choco Package...'
       choco push azd.$(MSI_VERSION).nupkg `
         --source https://push.chocolatey.org/ `

--- a/eng/scripts/Set-GitHubReleaseTag.ps1
+++ b/eng/scripts/Set-GitHubReleaseTag.ps1
@@ -25,6 +25,8 @@ param(
     [switch] $DevOpsOutputFormat
 )
 
+$PSNativeCommandArgumentPassing = 'Legacy'
+
 git fetch --tags
 $existingTag = git tag -l $Tag
 

--- a/eng/scripts/Update-WinGetManifest.ps1
+++ b/eng/scripts/Update-WinGetManifest.ps1
@@ -6,6 +6,7 @@ param(
     [string] $OutLocation = "winget",
     [switch] $Submit
 )
+$PSNativeCommandArgumentPassing = 'Legacy'
 
 Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
 

--- a/eng/scripts/Wait-ChocoPackage.ps1
+++ b/eng/scripts/Wait-ChocoPackage.ps1
@@ -3,6 +3,7 @@ param(
     $PackageVersion,
     $TimeoutInSeconds = 300
 )
+$PSNativeCommandArgumentPassing = 'Legacy'
 
 $startTime = Get-Date
 

--- a/eng/scripts/Wait-WinGetPackage.ps1
+++ b/eng/scripts/Wait-WinGetPackage.ps1
@@ -3,6 +3,7 @@ param(
     $PackageVersion,
     $TimeoutInSeconds = 300
 )
+$PSNativeCommandArgumentPassing = 'Legacy'
 
 if (!(Test-Path wingetcreate.exe)) {
     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe


### PR DESCRIPTION
These tasks did not run in the last release as a PowerShell problem prevented them from executing. After some investigation it's possible that these tasks/scripts might be affected by the recent PowerShell upgrade and so this change increases the chances that these commands will work. 