### PR TITLE
show project how to detect ADE config

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -554,7 +554,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		if err != nil {
 			return false, fmt.Errorf("loading project config: %w", err)
 		}
-		return projectConfig.Platform.Type == devcenter.PlatformKindDevCenter, nil
+		return project.IsProjectADE(devcenter.IsDevCenterEnabled(projectConfig.Platform)), nil
 	})
 
 	container.MustRegisterSingleton(func(

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -554,7 +554,8 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		if err != nil {
 			return false, fmt.Errorf("loading project config: %w", err)
 		}
-		return project.IsProjectADE(devcenter.IsDevCenterEnabled(projectConfig.Platform)), nil
+		ade := devcenter.IsDevCenterEnabled(projectConfig)
+		return project.IsProjectADE(ade), nil
 	})
 
 	container.MustRegisterSingleton(func(

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -549,6 +549,14 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		})
 	})
 
+	container.MustRegisterSingleton(func(lazyConfig *lazy.Lazy[*project.ProjectConfig]) (project.IsProjectADE, error) {
+		projectConfig, err := lazyConfig.GetValue()
+		if err != nil {
+			return false, fmt.Errorf("loading project config: %w", err)
+		}
+		return projectConfig.Platform.Type == devcenter.PlatformKindDevCenter, nil
+	})
+
 	container.MustRegisterSingleton(func(
 		lazyProjectConfig *lazy.Lazy[*project.ProjectConfig],
 		userConfigManager config.UserConfigManager,

--- a/cli/azd/cmd/middleware/hooks_test.go
+++ b/cli/azd/cmd/middleware/hooks_test.go
@@ -344,7 +344,7 @@ func runMiddleware(
 		lazyEnvManager,
 		lazyEnv,
 		lazyProjectConfig,
-		project.NewImportManager(nil),
+		project.NewImportManager(nil, false),
 		mockContext.CommandRunner,
 		mockContext.Console,
 		runOptions,

--- a/cli/azd/pkg/devcenter/platform.go
+++ b/cli/azd/pkg/devcenter/platform.go
@@ -43,8 +43,11 @@ func (p *Platform) IsEnabled() bool {
 }
 
 // IsDevCenterEnabled returns true if the devcenter platform is enabled
-func IsDevCenterEnabled(config *platform.Config) bool {
-	return config.Type == PlatformKindDevCenter
+func IsDevCenterEnabled(config *project.ProjectConfig) bool {
+	if config.Platform == nil {
+		return false
+	}
+	return config.Platform.Type == PlatformKindDevCenter
 }
 
 // ConfigureContainer configures the IoC container for the devcenter platform components

--- a/cli/azd/pkg/devcenter/platform.go
+++ b/cli/azd/pkg/devcenter/platform.go
@@ -42,6 +42,11 @@ func (p *Platform) IsEnabled() bool {
 	return p.config.Type == PlatformKindDevCenter
 }
 
+// IsDevCenterEnabled returns true if the devcenter platform is enabled
+func IsDevCenterEnabled(config *platform.Config) bool {
+	return config.Type == PlatformKindDevCenter
+}
+
 // ConfigureContainer configures the IoC container for the devcenter platform components
 func (p *Platform) ConfigureContainer(container *ioc.NestedContainer) error {
 	// DevCenter Config

--- a/cli/azd/pkg/pipeline/pipeline_manager_test.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager_test.go
@@ -449,6 +449,6 @@ func createPipelineManager(
 		mockContext.Console,
 		args,
 		mockContext.Container,
-		project.NewImportManager(nil),
+		project.NewImportManager(nil, false),
 	)
 }

--- a/cli/azd/pkg/project/importer.go
+++ b/cli/azd/pkg/project/importer.go
@@ -149,7 +149,10 @@ func (im *ImportManager) ProjectInfrastructure(ctx context.Context, projectConfi
 		}
 	}
 
-	return &Infra{}, nil
+	return nil, fmt.Errorf(
+		"this project does not contain expected infrastructure, folder: '%s' and module: '%s'",
+		infraRoot,
+		projectConfig.Infra.Module)
 }
 
 // pathHasModule returns true if there is a file named "<module>" or "<module.bicep>" in path.

--- a/cli/azd/pkg/project/importer.go
+++ b/cli/azd/pkg/project/importer.go
@@ -17,13 +17,17 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 )
 
+type IsProjectADE bool
+
 type ImportManager struct {
 	dotNetImporter *DotNetImporter
+	isADE          IsProjectADE
 }
 
-func NewImportManager(dotNetImporter *DotNetImporter) *ImportManager {
+func NewImportManager(dotNetImporter *DotNetImporter, isADE IsProjectADE) *ImportManager {
 	return &ImportManager{
 		dotNetImporter: dotNetImporter,
+		isADE:          isADE,
 	}
 }
 
@@ -110,6 +114,12 @@ const (
 // The configuration can be explicitly defined on azure.yaml using path and module, or in case these values
 // are not explicitly defined, the project importer uses default values to find the infrastructure.
 func (im *ImportManager) ProjectInfrastructure(ctx context.Context, projectConfig *ProjectConfig) (*Infra, error) {
+	if im.isADE {
+		// im.isADE is resolved within the ioc container by looking at the resolution of the platform.Config
+		// It is safe to assume that whenever ProjectInfrastructure is called, the platform.Config has been resolved.
+		return &Infra{}, nil
+	}
+
 	// Use default project values for Infra when not specified in azure.yaml
 	if projectConfig.Infra.Module == "" {
 		projectConfig.Infra.Module = DefaultModule

--- a/cli/azd/pkg/project/importer_test.go
+++ b/cli/azd/pkg/project/importer_test.go
@@ -184,9 +184,8 @@ func TestImportManagerProjectInfrastructureDefaults(t *testing.T) {
 
 	// Get defaults and error b/c no infra found and no Aspire project
 	r, e := manager.ProjectInfrastructure(*mockContext.Context, &ProjectConfig{})
-	require.NoError(t, e, "this project does not contain expected infrastructure")
-	require.NotNil(t, r)
-	require.Equal(t, r, &Infra{})
+	require.Nil(t, r)
+	require.Error(t, e, "this project does not contain expected infrastructure")
 
 	// adding infra folder to test defaults
 	expectedDefaultFolder := DefaultPath
@@ -196,9 +195,8 @@ func TestImportManagerProjectInfrastructureDefaults(t *testing.T) {
 
 	// error should keep happening b/c infra folder exists but module is not found
 	r, e = manager.ProjectInfrastructure(*mockContext.Context, &ProjectConfig{})
-	require.NoError(t, e)
-	require.NotNil(t, r)
-	require.Equal(t, r, &Infra{})
+	require.Nil(t, r)
+	require.Error(t, e, "this project does not contain expected infrastructure")
 
 	// Create the file
 	expectedDefaultModule := DefaultModule

--- a/cli/azd/pkg/project/importer_test.go
+++ b/cli/azd/pkg/project/importer_test.go
@@ -39,7 +39,7 @@ func TestImportManagerHasService(t *testing.T) {
 		lazyEnvManager: lazy.NewLazy(func() (environment.Manager, error) {
 			return mockEnv, nil
 		}),
-	})
+	}, false)
 
 	// has service
 	r, e := manager.HasService(*mockContext.Context, &ProjectConfig{
@@ -81,7 +81,7 @@ func TestImportManagerHasServiceErrorNoMultipleServicesWithAppHost(t *testing.T)
 			return mockEnv, nil
 		}),
 		hostCheck: make(map[string]hostCheckResult),
-	})
+	}, false)
 
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 		return strings.Contains(command, "dotnet") &&
@@ -134,7 +134,7 @@ func TestImportManagerHasServiceErrorAppHostMustTargetContainerApp(t *testing.T)
 			return mockEnv, nil
 		}),
 		hostCheck: make(map[string]hostCheckResult),
-	})
+	}, false)
 
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 		return strings.Contains(command, "dotnet") &&
@@ -180,7 +180,7 @@ func TestImportManagerProjectInfrastructureDefaults(t *testing.T) {
 			return mockEnv, nil
 		}),
 		hostCheck: make(map[string]hostCheckResult),
-	})
+	}, false)
 
 	// Get defaults and error b/c no infra found and no Aspire project
 	r, e := manager.ProjectInfrastructure(*mockContext.Context, &ProjectConfig{})
@@ -227,7 +227,7 @@ func TestImportManagerProjectInfrastructure(t *testing.T) {
 			return mockEnv, nil
 		}),
 		hostCheck: make(map[string]hostCheckResult),
-	})
+	}, false)
 
 	// Do not use defaults
 	expectedDefaultFolder := "customFolder"
@@ -304,7 +304,7 @@ func TestImportManagerProjectInfrastructureAspire(t *testing.T) {
 		}),
 		hostCheck: make(map[string]hostCheckResult),
 		cache:     make(map[string]*apphost.Manifest),
-	})
+	}, false)
 
 	// adding infra folder to test defaults
 	err := os.Mkdir(DefaultPath, os.ModePerm)


### PR DESCRIPTION
- revert patch
- Inject a hook to the project importer that checks the project config for ADE configuration
