### PR TITLE
Fixes issues where deploying to AKS fails when service does not build any container

### DIFF
--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -222,8 +222,8 @@ func (ch *ContainerHelper) Deploy(
 			var sourceImage string
 			targetImage := packageOutput.PackagePath
 
-			packageDetails := packageOutput.Details.(*dockerPackageResult)
-			if packageDetails != nil {
+			packageDetails, ok := packageOutput.Details.(*dockerPackageResult)
+			if ok && packageDetails != nil {
 				sourceImage = packageDetails.SourceImage
 				targetImage = packageDetails.TargetImage
 			}

--- a/cli/azd/pkg/project/container_helper_test.go
+++ b/cli/azd/pkg/project/container_helper_test.go
@@ -189,7 +189,6 @@ func Test_ContainerHelper_Deploy(t *testing.T) {
 		project                string
 		packagePath            string
 		dockerDetails          *dockerPackageResult
-		k8s                    *AksOptions
 		expectedRemoteImage    string
 		expectDockerPullCalled bool
 		expectDockerTagCalled  bool

--- a/cli/azd/pkg/project/container_helper_test.go
+++ b/cli/azd/pkg/project/container_helper_test.go
@@ -318,10 +318,6 @@ func Test_ContainerHelper_Deploy(t *testing.T) {
 			serviceConfig.RelativePath = tt.project
 			serviceConfig.Docker.Registry = tt.registry
 
-			if tt.k8s != nil {
-				serviceConfig.K8s = *tt.k8s
-			}
-
 			packageOutput := &ServicePackageResult{
 				Details:     tt.dockerDetails,
 				PackagePath: tt.packagePath,

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -192,14 +192,19 @@ func (t *aksTarget) Deploy(
 				return
 			}
 
-			// Login, tag & push container image to ACR
-			containerDeployTask := t.containerHelper.Deploy(ctx, serviceConfig, packageOutput, targetResource, true)
-			syncProgress(task, containerDeployTask.Progress())
+			// Only deploy the container image if a package output has been defined
+			// Empty package details is a valid scenario for any AKS deployment that does not build any containers
+			// Ex) Helm charts, or other manifests that reference external images
+			if packageOutput.Details != nil || packageOutput.PackagePath != "" {
+				// Login, tag & push container image to ACR
+				containerDeployTask := t.containerHelper.Deploy(ctx, serviceConfig, packageOutput, targetResource, true)
+				syncProgress(task, containerDeployTask.Progress())
 
-			_, err := containerDeployTask.Await()
-			if err != nil {
-				task.SetError(err)
-				return
+				_, err := containerDeployTask.Await()
+				if err != nil {
+					task.SetError(err)
+					return
+				}
 			}
 
 			// Sync environment

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -283,11 +283,7 @@ func Test_Deploy_Helm(t *testing.T) {
 	require.NoError(t, err)
 
 	packageResult := &ServicePackageResult{
-		PackagePath: "test-app/api-test:azd-deploy-0",
-		Details: &dockerPackageResult{
-			ImageHash:   "IMAGE_HASH",
-			TargetImage: "test-app/api-test:azd-deploy-0",
-		},
+		PackagePath: "",
 	}
 
 	scope := environment.NewTargetResource("SUB_ID", "RG_ID", "", string(infra.AzureResourceTypeManagedCluster))
@@ -349,11 +345,8 @@ func Test_Deploy_Kustomize(t *testing.T) {
 	require.NoError(t, err)
 
 	packageResult := &ServicePackageResult{
-		PackagePath: "test-app/api-test:azd-deploy-0",
-		Details: &dockerPackageResult{
-			ImageHash:   "IMAGE_HASH",
-			TargetImage: "test-app/api-test:azd-deploy-0",
-		},
+		PackagePath: "",
+		Details:     nil,
 	}
 
 	scope := environment.NewTargetResource("SUB_ID", "RG_ID", "", string(infra.AzureResourceTypeManagedCluster))

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -346,7 +346,6 @@ func Test_Deploy_Kustomize(t *testing.T) {
 
 	packageResult := &ServicePackageResult{
 		PackagePath: "",
-		Details:     nil,
 	}
 
 	scope := environment.NewTargetResource("SUB_ID", "RG_ID", "", string(infra.AzureResourceTypeManagedCluster))


### PR DESCRIPTION
Fixes issues where deploying to AKS fails when service does not build any container

**Valid use cases:**
- Helm charts that reference external images
- Kustomize or vanilla manifests that reference external images