### PR TITLE
Cache manifest reads in a single execution

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -407,7 +407,8 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		})
 	})
 	container.MustRegisterSingleton(project.NewProjectManager)
-	container.MustRegisterScoped(project.NewDotNetImporter)
+	// Currently caches manifest across command executions
+	container.MustRegisterSingleton(project.NewDotNetImporter)
 	container.MustRegisterScoped(project.NewImportManager)
 	container.MustRegisterScoped(project.NewServiceManager)
 

--- a/cli/azd/internal/vsrpc/environment_service_load.go
+++ b/cli/azd/internal/vsrpc/environment_service_load.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/azure/azure-dev/cli/azd/pkg/apphost"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
@@ -64,10 +63,11 @@ func (s *environmentService) loadEnvironmentAsync(
 	ctx context.Context, container *container, name string, mustLoadServices bool,
 ) (*Environment, error) {
 	var c struct {
-		azdCtx        *azdcontext.AzdContext `container:"type"`
-		envManager    environment.Manager    `container:"type"`
-		projectConfig *project.ProjectConfig `container:"type"`
-		dotnetCli     dotnet.DotNetCli       `container:"type"`
+		azdCtx         *azdcontext.AzdContext  `container:"type"`
+		envManager     environment.Manager     `container:"type"`
+		projectConfig  *project.ProjectConfig  `container:"type"`
+		dotnetCli      dotnet.DotNetCli        `container:"type"`
+		dotnetImporter *project.DotNetImporter `container:"type"`
 	}
 
 	if err := container.Fill(&c); err != nil {
@@ -123,7 +123,7 @@ func (s *environmentService) loadEnvironmentAsync(
 		return nil, fmt.Errorf("failed to find Aspire app host: %w", err)
 	}
 
-	manifest, err := apphost.ManifestFromAppHost(ctx, appHost.Path(), c.dotnetCli)
+	manifest, err := c.dotnetImporter.ReadManifest(ctx, appHost)
 	if err != nil {
 		return nil, fmt.Errorf("reading app host manifest: %w", err)
 	}


### PR DESCRIPTION
Restore dotnet importer as singleton to cache manifest reads in a single `up` execution. Reuse dotnet importer in vsrpc to cache per-request.

Fixes #3303, #3405