### PR TITLE
Adds Devcenter (ADE) e2e functional test

### DIFF
--- a/cli/azd/cmd/container_test.go
+++ b/cli/azd/cmd/container_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
@@ -75,6 +76,73 @@ func Test_Lazy_Project_Config_Resolution(t *testing.T) {
 
 	// Finally we validate that the return project config across all resolutions point to the same project config pointer
 	require.Same(t, lazyProjectConfig, lazyComponent.lazy)
+	require.Same(t, lazyValue, directValue)
+	require.Same(t, directValue, staticComponent.concrete)
+}
+
+func Test_Lazy_AzdContext_Resolution(t *testing.T) {
+	ctx := context.Background()
+	container := ioc.NewNestedContainer(nil)
+	ioc.RegisterInstance(container, ctx)
+
+	registerCommonDependencies(container)
+
+	// Register the testing lazy component
+	container.MustRegisterTransient(
+		func(lazyAzdContext *lazy.Lazy[*azdcontext.AzdContext]) *testLazyComponent[*azdcontext.AzdContext] {
+			return &testLazyComponent[*azdcontext.AzdContext]{
+				lazy: lazyAzdContext,
+			}
+		},
+	)
+
+	// Register the testing concrete component
+	container.MustRegisterTransient(
+		func(azdContext *azdcontext.AzdContext) *testConcreteComponent[*azdcontext.AzdContext] {
+			return &testConcreteComponent[*azdcontext.AzdContext]{
+				concrete: azdContext,
+			}
+		},
+	)
+
+	// The lazy components depends on the lazy project config.
+	// The lazy instance itself should never be nil
+	var lazyComponent *testLazyComponent[*azdcontext.AzdContext]
+	err := container.Resolve(&lazyComponent)
+	require.NoError(t, err)
+	require.NotNil(t, lazyComponent.lazy)
+
+	// Get the lazy project config instance itself to use for comparison
+	var lazyInstance *lazy.Lazy[*azdcontext.AzdContext]
+	err = container.Resolve(&lazyInstance)
+	require.NoError(t, err)
+	require.NotNil(t, lazyInstance)
+
+	// At this point a project config is not available, so we should get an error
+	azdContext, err := lazyInstance.GetValue()
+	require.Nil(t, azdContext)
+	require.Error(t, err)
+
+	// Set a project config on the lazy instance
+	azdContext = azdcontext.NewAzdContextWithDirectory(t.TempDir())
+
+	lazyInstance.SetValue(azdContext)
+
+	// Now lets resolve a type that depends on a concrete project config
+	// The project config should be be available not that the lazy has been set above
+	var staticComponent *testConcreteComponent[*azdcontext.AzdContext]
+	err = container.Resolve(&staticComponent)
+	require.NoError(t, err)
+	require.NotNil(t, staticComponent.concrete)
+
+	// Now we validate that the instance returned by the lazy instance is the same as the one resolved directly
+	lazyValue, err := lazyComponent.lazy.GetValue()
+	require.NoError(t, err)
+	directValue, err := lazyInstance.GetValue()
+	require.NoError(t, err)
+
+	// Finally we validate that the return project config across all resolutions point to the same project config pointer
+	require.Same(t, lazyInstance, lazyComponent.lazy)
 	require.Same(t, lazyValue, directValue)
 	require.Same(t, directValue, staticComponent.concrete)
 }

--- a/cli/azd/cmd/deps_record.go
+++ b/cli/azd/cmd/deps_record.go
@@ -20,6 +20,8 @@ func createHttpClient() *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	// Allow for self-signed certificates, which is what the recording proxy uses.
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	// AZD_TEST_HTTPS_PROXY is the proxy setting that only affects azd in record mode.
+	// This is useful since the recording proxy server isn't trusted by other processes currently.
 	if val, ok := os.LookupEnv("AZD_TEST_HTTPS_PROXY"); ok {
 		proxyUrl, err := url.Parse(val)
 		if err != nil {

--- a/cli/azd/cmd/deps_record.go
+++ b/cli/azd/cmd/deps_record.go
@@ -20,8 +20,6 @@ func createHttpClient() *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	// Allow for self-signed certificates, which is what the recording proxy uses.
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	// AZD_TEST_HTTPS_PROXY is the proxy setting that only affects azd in record mode.
-	// This is useful since the recording proxy server isn't trusted by other processes currently.
 	if val, ok := os.LookupEnv("AZD_TEST_HTTPS_PROXY"); ok {
 		proxyUrl, err := url.Parse(val)
 		if err != nil {
@@ -29,6 +27,7 @@ func createHttpClient() *http.Client {
 		}
 
 		transport.Proxy = http.ProxyURL(proxyUrl)
+		http.DefaultTransport = transport
 	}
 
 	client := &http.Client{

--- a/cli/azd/pkg/devcenter/manager.go
+++ b/cli/azd/pkg/devcenter/manager.go
@@ -24,6 +24,9 @@ type ProjectFilterPredicate func(p *devcentersdk.Project) bool
 // DevCenterFilterPredicate is a predicate function for filtering dev centers
 type DevCenterFilterPredicate func(dc *devcentersdk.DevCenter) bool
 
+// EnvironmentDefinitionFilterPredicate is a predicate function for filtering environment definitions
+type EnvironmentDefinitionFilterPredicate func(ed *devcentersdk.EnvironmentDefinition) bool
+
 // EnvironmentFilterPredicate is a predicate function for filtering environments
 type EnvironmentFilterPredicate func(e *devcentersdk.Environment) bool
 

--- a/cli/azd/pkg/devcenter/platform.go
+++ b/cli/azd/pkg/devcenter/platform.go
@@ -60,7 +60,7 @@ func (p *Platform) ConfigureContainer(container *ioc.NestedContainer) error {
 
 		// Shell environment variables
 		envVarConfig := &Config{
-			Name:                  os.Getenv(DevCenterCatalogEnvName),
+			Name:                  os.Getenv(DevCenterNameEnvName),
 			Project:               os.Getenv(DevCenterProjectEnvName),
 			Catalog:               os.Getenv(DevCenterCatalogEnvName),
 			EnvironmentType:       os.Getenv(DevCenterEnvTypeEnvName),

--- a/cli/azd/pkg/devcenter/prompter.go
+++ b/cli/azd/pkg/devcenter/prompter.go
@@ -232,76 +232,79 @@ func (p *Prompter) PromptParameters(
 		paramPath := fmt.Sprintf("%s.%s", ProvisionParametersConfigPath, param.Id)
 		paramValue, exists := env.Config.Get(paramPath)
 
+		if exists {
+			paramValues[param.Id] = paramValue
+			continue
+		}
+
 		// Only prompt for parameter values when it has not already been set in the environment configuration
-		if !exists {
-			if param.Name == "environmentName" {
-				paramValues[param.Id] = env.Name()
+		if param.Id == "environmentName" {
+			paramValues[param.Id] = env.Name()
+			continue
+		}
+
+		// Process repoUrl parameter from defaults and allowed values
+		if param.Id == "repoUrl" {
+			var repoUrlValue string
+			if len(param.Allowed) > 0 {
+				repoUrlValue = param.Allowed[0]
+			} else {
+				value, ok := param.Default.(string)
+				if ok {
+					repoUrlValue = value
+				}
+			}
+
+			if repoUrlValue != "" {
+				paramValues[param.Id] = repoUrlValue
 				continue
 			}
+		}
 
-			// Process repoUrl parameter from defaults and allowed values
-			if param.Name == "repoUrl" {
-				var repoUrlValue string
-				if len(param.Allowed) > 0 {
-					repoUrlValue = param.Allowed[0]
-				} else {
-					value, ok := param.Default.(string)
-					if ok {
-						repoUrlValue = value
-					}
-				}
+		promptOptions := input.ConsoleOptions{
+			DefaultValue: param.Default,
+			Options:      param.Allowed,
+			Message:      fmt.Sprintf("Enter a value for %s", param.Name),
+			Help:         param.Description,
+		}
 
-				if repoUrlValue != "" {
-					paramValues[param.Id] = repoUrlValue
-					continue
-				}
+		switch param.Type {
+		case devcentersdk.ParameterTypeBool:
+			confirmValue, err := p.console.Confirm(ctx, promptOptions)
+			if err != nil {
+				return nil, fmt.Errorf("failed to prompt for %s: %w", param.Name, err)
 			}
-
-			promptOptions := input.ConsoleOptions{
-				DefaultValue: param.Default,
-				Options:      param.Allowed,
-				Message:      fmt.Sprintf("Enter a value for %s", param.Name),
-				Help:         param.Description,
-			}
-
-			switch param.Type {
-			case devcentersdk.ParameterTypeBool:
-				confirmValue, err := p.console.Confirm(ctx, promptOptions)
+			paramValue = confirmValue
+		case devcentersdk.ParameterTypeString:
+			if param.Allowed != nil && len(param.Allowed) > 0 {
+				selectedIndex, err := p.console.Select(ctx, promptOptions)
 				if err != nil {
 					return nil, fmt.Errorf("failed to prompt for %s: %w", param.Name, err)
 				}
-				paramValue = confirmValue
-			case devcentersdk.ParameterTypeString:
-				if param.Allowed != nil && len(param.Allowed) > 0 {
-					selectedIndex, err := p.console.Select(ctx, promptOptions)
-					if err != nil {
-						return nil, fmt.Errorf("failed to prompt for %s: %w", param.Name, err)
-					}
 
-					paramValue = param.Allowed[selectedIndex]
-				} else {
-					promptValue, err := p.console.Prompt(ctx, promptOptions)
-					if err != nil {
-						return nil, err
-					}
-
-					paramValue = promptValue
-				}
-
-			case devcentersdk.ParameterTypeInt:
+				paramValue = param.Allowed[selectedIndex]
+			} else {
 				promptValue, err := p.console.Prompt(ctx, promptOptions)
 				if err != nil {
-					return nil, fmt.Errorf("failed to prompt for %s: %w", param.Name, err)
+					return nil, err
 				}
 
-				numValue, err := strconv.Atoi(promptValue)
-				if err != nil {
-					return nil, fmt.Errorf("failed to convert %s to int: %w", param.Name, err)
-				}
-				paramValue = numValue
-			default:
-				return nil, fmt.Errorf("failed to prompt for %s, unsupported parameter type: %s", param.Name, param.Type)
+				paramValue = promptValue
 			}
+
+		case devcentersdk.ParameterTypeInt:
+			promptValue, err := p.console.Prompt(ctx, promptOptions)
+			if err != nil {
+				return nil, fmt.Errorf("failed to prompt for %s: %w", param.Name, err)
+			}
+
+			numValue, err := strconv.Atoi(promptValue)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert %s to int: %w", param.Name, err)
+			}
+			paramValue = numValue
+		default:
+			return nil, fmt.Errorf("failed to prompt for %s, unsupported parameter type: %s", param.Name, param.Type)
 		}
 
 		paramValues[param.Id] = paramValue

--- a/cli/azd/pkg/devcenter/provision_provider.go
+++ b/cli/azd/pkg/devcenter/provision_provider.go
@@ -399,6 +399,10 @@ func (p *ProvisionProvider) EnsureEnv(ctx context.Context) error {
 		}
 	}
 
+	if err := p.envManager.Save(ctx, p.env); err != nil {
+		return fmt.Errorf("failed saving environment: %w", err)
+	}
+
 	p.config = updatedConfig
 
 	return nil
@@ -406,6 +410,12 @@ func (p *ProvisionProvider) EnsureEnv(ctx context.Context) error {
 
 // Polls for the ADE environment and ARM deployment to be created
 func (p *ProvisionProvider) pollForEnvironment(ctx context.Context, envName string) {
+	// Disable reporting progress if needed
+	if use, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_PROVISION_PROGRESS_DISABLE")); err == nil && use {
+		log.Println("Disabling progress reporting since AZD_DEBUG_PROVISION_PROGRESS_DISABLE was set")
+		return
+	}
+
 	initialDelay := 3 * time.Second
 	regularDelay := 5 * time.Second
 	timer := time.NewTimer(initialDelay)

--- a/cli/azd/pkg/devcenter/template_source.go
+++ b/cli/azd/pkg/devcenter/template_source.go
@@ -43,10 +43,17 @@ func (s *TemplateSource) Name() string {
 func (s *TemplateSource) ListTemplates(ctx context.Context) ([]*templates.Template, error) {
 	var devCenterFilter DevCenterFilterPredicate
 	var projectFilter ProjectFilterPredicate
+	var catalogFilter EnvironmentDefinitionFilterPredicate
 
 	if s.config.Name != "" {
 		devCenterFilter = func(dc *devcentersdk.DevCenter) bool {
 			return strings.EqualFold(dc.Name, s.config.Name)
+		}
+	}
+
+	if s.config.Catalog != "" {
+		catalogFilter = func(ed *devcentersdk.EnvironmentDefinition) bool {
+			return strings.EqualFold(ed.CatalogName, s.config.Catalog)
 		}
 	}
 
@@ -90,6 +97,11 @@ func (s *TemplateSource) ListTemplates(ctx context.Context) ([]*templates.Templa
 			}
 
 			for _, envDefinition := range envDefinitions.Value {
+				// Filter out environment definitions that do not match the specified catalog
+				if catalogFilter != nil && !catalogFilter(envDefinition) {
+					continue
+				}
+
 				// We only want to consider environment definitions that have
 				// a repo url parameter as valid templates for azd
 				var repoUrls []string

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -43,6 +43,9 @@ const AksClusterEnvVarName = "AZURE_AKS_CLUSTER_NAME"
 // ResourceGroupEnvVarName is the name of the azure resource group that should be used for deployments
 const ResourceGroupEnvVarName = "AZURE_RESOURCE_GROUP"
 
+// PlatformTypeEnvVarName is the name of the key used to store the current azd platform type
+const PlatformTypeEnvVarName = "AZD_PLATFORM_TYPE"
+
 // The zero value of an Environment is not valid. Use [New] to create one. When writing tests,
 // [Ephemeral] and [EphemeralWithValues] are useful to create environments which are not persisted to disk.
 type Environment struct {

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -31,11 +31,13 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/azure/azure-dev/cli/azd/pkg/devcenter"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/test/azdcli"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockaccount"
@@ -114,6 +116,75 @@ func TestMain(m *testing.M) {
 
 	exitVal := m.Run()
 	os.Exit(exitVal)
+}
+
+func Test_CLI_DevCenter_Init_Up_Down(t *testing.T) {
+	// running this test in parallel is ok as it uses a t.TempDir()
+	t.Parallel()
+	ctx, cancel := newTestContext(t)
+	defer cancel()
+
+	dir := tempDirWithDiagnostics(t)
+	t.Logf("DIR: %s", dir)
+
+	session := recording.Start(t)
+	envName := randomOrStoredEnvName(session)
+
+	t.Logf("AZURE_ENV_NAME: %s", envName)
+
+	cli := azdcli.NewCLI(t, azdcli.WithSession(session))
+	cli.WorkingDirectory = dir
+	cli.Env = append(cli.Env, os.Environ()...)
+	cli.Env = append(cli.Env, fmt.Sprintf("%s=devcenter", environment.PlatformTypeEnvVarName))
+	cli.Env = append(cli.Env, fmt.Sprintf("%s=wbreza", devcenter.DevCenterCatalogEnvName))
+
+	initStdIn := strings.Join(
+		[]string{
+			"Select a template",
+			"HelloWorld",
+			envName,
+			"Project-1",
+		},
+		"\n",
+	)
+
+	// azd init
+	_, err := cli.RunCommandWithStdIn(ctx, initStdIn, "init")
+	require.NoError(t, err)
+
+	// evaluate the project and environment configuration
+	azdCtx := azdcontext.NewAzdContextWithDirectory(dir)
+	projectConfig, err := project.Load(ctx, azdCtx.ProjectPath())
+	require.NoError(t, err)
+
+	require.Equal(t, "dc-wabrez-od3kzvk4mwe72", projectConfig.Platform.Config["name"])
+	require.Equal(t, "wbreza", projectConfig.Platform.Config["catalog"])
+	require.Equal(t, "HelloWorld", projectConfig.Platform.Config["environmentDefinition"])
+
+	env, err := envFromAzdRoot(ctx, dir, envName)
+	require.NoError(t, err)
+
+	require.Equal(t, envName, env.Name())
+	projectName, _ := env.Config.Get(devcenter.DevCenterProjectPath)
+	repoUrl, _ := env.Config.Get("provision.parameters.repoUrl")
+	require.Equal(t, "Project-1", projectName)
+	require.Equal(t, "https://github.com/wbreza/azd-hello-world", repoUrl)
+
+	// azd up
+	upStdIn := strings.Join([]string{"Dev"}, "\n")
+	_, err = cli.RunCommandWithStdIn(ctx, upStdIn, "up")
+	require.NoError(t, err)
+
+	// re-evaluate the environment configuration
+	env, err = envFromAzdRoot(ctx, dir, envName)
+	require.NoError(t, err)
+
+	envTypeName, _ := env.Config.Get(devcenter.DevCenterEnvTypePath)
+	require.Equal(t, "Dev", envTypeName)
+
+	// azd down
+	_, err = cli.RunCommand(ctx, "down", "--force", "--purge")
+	require.NoError(t, err)
 }
 
 func Test_CLI_InfraCreateAndDelete(t *testing.T) {

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_DevCenter_Init_Up_Down.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_DevCenter_Init_Up_Down.yaml
@@ -1,0 +1,4177 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 238
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"options":{"allowPartialScopes":true},"query":"\n\tResources\n\t| where type in~ (''microsoft.devcenter/projects'')\n\t| where properties[''provisioningState''] =~ ''Succeeded''\n\t| project id, location, tenantId, name, properties, type\n\t"}'
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Length:
+                - "238"
+            Content-Type:
+                - application/json
+            User-Agent:
+                - azsdk-go-armresourcegraph.Client/v0.7.1 (go1.21.6; Windows_NT),azd
+        url: https://management.azure.com:443/providers/Microsoft.ResourceGraph/resources?api-version=2021-06-01-preview
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 8615
+        uncompressed: false
+        body: '{"totalRecords":14,"count":14,"data":[{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioClient","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSVendors","properties":{"provisioningState":"Succeeded","description":"Project for vendors","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/basic","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"basic","properties":{"provisioningState":"Succeeded","description":"project with basic image","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"MicroBuild","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourceGroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DevDivAzureService","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourceGroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"LanguageAndFrameworkServices","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourceGroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSCode","properties":{"provisioningState":"Succeeded","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourceGroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ServerlessPaaS","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourceGroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"PMUXDesign","properties":{"provisioningState":"Succeeded","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourceGroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"NuGet","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourceGroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DataAndAI","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Contoso-Demo","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Contoso-Demo","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-1","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-2","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"}],"facets":[],"resultTruncated":"false"}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "8615"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 68f9d8e4-1f28-4996-8969-cc584a2d5d00
+            X-Ms-Ratelimit-Remaining-Tenant-Reads:
+                - "11999"
+            X-Ms-Ratelimit-Remaining-Tenant-Resource-Requests:
+                - "14"
+            X-Ms-Request-Id:
+                - 68f9d8e4-1f28-4996-8969-cc584a2d5d00
+            X-Ms-Resource-Graph-Request-Duration:
+                - "0:00:00:00.6858326"
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193732Z:68f9d8e4-1f28-4996-8969-cc584a2d5d00
+            X-Ms-User-Quota-Remaining:
+                - "14"
+            X-Ms-User-Quota-Resets-After:
+                - "00:00:05"
+            X-Msedge-Ref:
+                - 'Ref A: 32D30B6B267047B2AA11ACD1D9B6059E Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:31Z'
+        status: 200 OK
+        code: 200
+        duration: 840.0147ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourcegroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - e6741d43-dea1-4bb6-8b5b-c0cfbce7ecfd
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193732Z:bef010cd-d19d-4dc4-b583-fb78f17e2375
+            X-Msedge-Ref:
+                - 'Ref A: 4EE2666E2E6A46608180D9A8C1A252F8 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+        status: 200 OK
+        code: 200
+        duration: 379.5165ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourcegroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 140cf611-1489-4da7-912d-17ef16d24ffa
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193732Z:6c978ba3-9329-4e8c-85a5-1241a449f540
+            X-Msedge-Ref:
+                - 'Ref A: 91689A8BF0254E75BE98DFDCC7EFA532 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+        status: 200 OK
+        code: 200
+        duration: 384.9654ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 0c2ac6a0-7770-4562-9a5e-4d6a0ec44e32
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193732Z:a4206ee5-285e-4f16-9b5b-e547ac967b82
+            X-Msedge-Ref:
+                - 'Ref A: D8569A2A3651473C95F34964C2462A1D Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+        status: 200 OK
+        code: 200
+        duration: 433.3025ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourcegroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - f66be0e1-8ff6-4772-baf2-7bf4eaf405f8
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193732Z:8682a156-5f10-4ce3-ba3a-98c2ec2ec1bc
+            X-Msedge-Ref:
+                - 'Ref A: B22465D9B34F46D3BDB4D93BB88835CD Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+        status: 200 OK
+        code: 200
+        duration: 431.5628ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - ef986f39-2ada-43b3-bd85-d2c51f95e739
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193732Z:0d2db4bf-8b91-43d0-8d11-ef6f986a92e8
+            X-Msedge-Ref:
+                - 'Ref A: 9CA5D2818EE54B679D3122F143A4CBCB Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+        status: 200 OK
+        code: 200
+        duration: 432.139ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Contoso-Demo/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2328
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2328"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 782b9277-5753-4092-b7aa-7266c39896d1
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193732Z:5e46c64d-ef9b-43ab-ac02-3e1fe5fb16bd
+            X-Msedge-Ref:
+                - 'Ref A: 60EE775FBD87489C8C4E4DACF394FADC Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+        status: 200 OK
+        code: 200
+        duration: 454.6ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourcegroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 9fd9c3e7-f907-49a4-9cb1-66bdda2bc921
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193732Z:a789c9f2-1d15-42aa-bc0e-976421a061cb
+            X-Msedge-Ref:
+                - 'Ref A: E7DAB5C37DCE4BF89A0C981017767C48 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+        status: 200 OK
+        code: 200
+        duration: 456.5003ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-1/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2328
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2328"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 1e5d57c8-f4d1-4034-849c-e68ec8549f1e
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193732Z:208c395e-684c-46ce-9008-a9d09c47cd6b
+            X-Msedge-Ref:
+                - 'Ref A: AE78C6AA23EB4C5D8BB72D67D3D17ACF Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+        status: 200 OK
+        code: 200
+        duration: 476.6393ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/basic/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - 8118d2de-056f-429d-89f1-3e6f84950426
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193732Z:1f9699ac-b08d-4c67-a2ea-b35dea2d2b27
+            X-Msedge-Ref:
+                - 'Ref A: 4B2EA5574AFC4FA5AF64898BEB5509FC Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+        status: 200 OK
+        code: 200
+        duration: 482.4223ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourcegroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 16bc85a7-9fe2-4cdb-8231-957f8d9a1a23
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193732Z:a1edf255-6e9f-4b75-b9c6-36fb02e11447
+            X-Msedge-Ref:
+                - 'Ref A: 4976B23BEC6B4034925C275853E16666 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+        status: 200 OK
+        code: 200
+        duration: 491.9096ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - f2e30063-ce36-4a65-98dd-4065b5a27ac5
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193732Z:137fa10d-4989-4262-963e-082f676110b1
+            X-Msedge-Ref:
+                - 'Ref A: 3AC193C57F354FE38E89A2E6BA1FF536 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+        status: 200 OK
+        code: 200
+        duration: 497.9907ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-2/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2328
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2328"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - bef25fd4-ea8b-47db-9938-18ccff5ef6c7
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193732Z:af91e355-5ff0-42c4-9e3a-a95bde92ff0b
+            X-Msedge-Ref:
+                - 'Ref A: B35A8FBA104E49ED8717611794CEDA40 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+        status: 200 OK
+        code: 200
+        duration: 517.084ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourcegroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 8e0b2002-8c12-47be-bf10-5b502995d36e
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193732Z:c7714685-cd7d-49eb-88f6-64eff0842300
+            X-Msedge-Ref:
+                - 'Ref A: 961F8D7ABD554452BF3C4589D8390B13 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+        status: 200 OK
+        code: 200
+        duration: 529.1689ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourcegroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - f1436512-09a3-4f67-852d-c22cffdd0d82
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193732Z:a5e9b19b-55fb-4298-bc5f-b79e7d23ec39
+            X-Msedge-Ref:
+                - 'Ref A: 1A1FD2A7964F4A11826517B0898F86B9 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+        status: 200 OK
+        code: 200
+        duration: 604.5548ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/environmentDefinitions?api-version=2023-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |-
+            {
+              "value": [
+                {
+                  "id": "/projects/Project-1/catalogs/example/environmentDefinitions/function-app-with-cosmos_azd-template",
+                  "name": "Function-App-with-Cosmos_AZD-template",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure Function App with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the Function App runtime,eg python or nodejs",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-nodejs-mongo-swa-func",
+                        "https://github.com/azure-samples/todo-python-mongo-swa-func"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the Function App runtime,eg python or nodejs\",\"enum\":[\"python\",\"nodejs\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-nodejs-mongo-swa-func\",\"https://github.com/azure-samples/todo-python-mongo-swa-func\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Function-App-with-Cosmos_AZD-template/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Project-1/catalogs/example/environmentDefinitions/webapp",
+                  "name": "WebApp",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure Web App without a data store",
+                  "parameters": [],
+                  "parametersSchema": "{\"type\":\"object\"}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/WebApp/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Project-1/catalogs/example/environmentDefinitions/sandbox",
+                  "name": "Sandbox",
+                  "catalogName": "Example",
+                  "description": "Deploys a sandbox environment",
+                  "parameters": [],
+                  "parametersSchema": "{\"type\":\"object\"}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Sandbox/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Project-1/catalogs/example/environmentDefinitions/container-app-with-cosmos_azd-template",
+                  "name": "Container-App-with-Cosmos_AZD-template",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure Container App with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the container App runtime,eg python, nodejs or java.",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs",
+                        "java"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-java-mongo-aca",
+                        "https://github.com/azure-samples/todo-nodejs-mongo-aca",
+                        "https://github.com/azure-samples/todo-python-mongo-aca"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the container App runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo-aca\",\"https://github.com/azure-samples/todo-nodejs-mongo-aca\",\"https://github.com/azure-samples/todo-python-mongo-aca\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Container-App-with-Cosmos_AZD-template/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Project-1/catalogs/wbreza/environmentDefinitions/helloworld",
+                  "name": "HelloWorld",
+                  "catalogName": "wbreza",
+                  "description": "Deploys an Azure App Service within App Service Plan",
+                  "parameters": [
+                    {
+                      "id": "environmentName",
+                      "name": "Environment Name",
+                      "description": "Name of the environment",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/wbreza/azd-hello-world"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"environmentName\":{\"title\":\"Environment Name\",\"description\":\"Name of the environment\"},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/wbreza/azd-hello-world\"]}}}",
+                  "templatePath": "EnvironmentDefinitions/HelloWorld/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Project-1/catalogs/example/environmentDefinitions/app-service-with-cosmos_azd-template",
+                  "name": "App-Service-with-Cosmos_AZD-template",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure App Service with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the App Service runtime,eg python, nodejs or java.",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs",
+                        "java"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-java-mongo",
+                        "https://github.com/azure-samples/todo-nodejs-mongo",
+                        "https://github.com/azure-samples/todo-python-mongo"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the App Service runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo\",\"https://github.com/azure-samples/todo-nodejs-mongo\",\"https://github.com/azure-samples/todo-python-mongo\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/App-Service-with-Cosmos_AZD-template/azuredeploy.json"
+                }
+              ]
+            }
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:34 GMT
+            Strict-Transport-Security:
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - 7359bd73-e812-48bc-bca8-c35b834f095d
+            X-Ms-Correlation-Request-Id:
+                - 84d38064-993c-4e60-af24-acf8428f6ff6
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "298"
+            X-Rate-Limit-Reset:
+                - "2024-02-26T19:38:33.7359520Z"
+        status: 200 OK
+        code: 200
+        duration: 1.3284849s
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Contoso-Demo/environmentDefinitions?api-version=2023-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |-
+            {
+              "value": [
+                {
+                  "id": "/projects/Contoso-Demo/catalogs/example/environmentDefinitions/function-app-with-cosmos_azd-template",
+                  "name": "Function-App-with-Cosmos_AZD-template",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure Function App with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the Function App runtime,eg python or nodejs",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-nodejs-mongo-swa-func",
+                        "https://github.com/azure-samples/todo-python-mongo-swa-func"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the Function App runtime,eg python or nodejs\",\"enum\":[\"python\",\"nodejs\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-nodejs-mongo-swa-func\",\"https://github.com/azure-samples/todo-python-mongo-swa-func\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Function-App-with-Cosmos_AZD-template/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Contoso-Demo/catalogs/example/environmentDefinitions/webapp",
+                  "name": "WebApp",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure Web App without a data store",
+                  "parameters": [],
+                  "parametersSchema": "{\"type\":\"object\"}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/WebApp/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Contoso-Demo/catalogs/example/environmentDefinitions/sandbox",
+                  "name": "Sandbox",
+                  "catalogName": "Example",
+                  "description": "Deploys a sandbox environment",
+                  "parameters": [],
+                  "parametersSchema": "{\"type\":\"object\"}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Sandbox/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Contoso-Demo/catalogs/example/environmentDefinitions/container-app-with-cosmos_azd-template",
+                  "name": "Container-App-with-Cosmos_AZD-template",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure Container App with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the container App runtime,eg python, nodejs or java.",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs",
+                        "java"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-java-mongo-aca",
+                        "https://github.com/azure-samples/todo-nodejs-mongo-aca",
+                        "https://github.com/azure-samples/todo-python-mongo-aca"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the container App runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo-aca\",\"https://github.com/azure-samples/todo-nodejs-mongo-aca\",\"https://github.com/azure-samples/todo-python-mongo-aca\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Container-App-with-Cosmos_AZD-template/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Contoso-Demo/catalogs/wbreza/environmentDefinitions/helloworld",
+                  "name": "HelloWorld",
+                  "catalogName": "wbreza",
+                  "description": "Deploys an Azure App Service within App Service Plan",
+                  "parameters": [
+                    {
+                      "id": "environmentName",
+                      "name": "Environment Name",
+                      "description": "Name of the environment",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/wbreza/azd-hello-world"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"environmentName\":{\"title\":\"Environment Name\",\"description\":\"Name of the environment\"},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/wbreza/azd-hello-world\"]}}}",
+                  "templatePath": "EnvironmentDefinitions/HelloWorld/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Contoso-Demo/catalogs/example/environmentDefinitions/app-service-with-cosmos_azd-template",
+                  "name": "App-Service-with-Cosmos_AZD-template",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure App Service with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the App Service runtime,eg python, nodejs or java.",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs",
+                        "java"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-java-mongo",
+                        "https://github.com/azure-samples/todo-nodejs-mongo",
+                        "https://github.com/azure-samples/todo-python-mongo"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the App Service runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo\",\"https://github.com/azure-samples/todo-nodejs-mongo\",\"https://github.com/azure-samples/todo-python-mongo\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/App-Service-with-Cosmos_AZD-template/azuredeploy.json"
+                }
+              ]
+            }
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:34 GMT
+            Strict-Transport-Security:
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - 1439a90b-7884-43a1-9732-1b4c3786cf0e
+            X-Ms-Correlation-Request-Id:
+                - 18ddb8b9-eb14-4e63-9521-03a2fbce9408
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "299"
+            X-Rate-Limit-Reset:
+                - "2024-02-26T19:38:33.7359520Z"
+        status: 200 OK
+        code: 200
+        duration: 1.3332792s
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-2/environmentDefinitions?api-version=2023-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |-
+            {
+              "value": [
+                {
+                  "id": "/projects/Project-2/catalogs/example/environmentDefinitions/function-app-with-cosmos_azd-template",
+                  "name": "Function-App-with-Cosmos_AZD-template",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure Function App with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the Function App runtime,eg python or nodejs",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-nodejs-mongo-swa-func",
+                        "https://github.com/azure-samples/todo-python-mongo-swa-func"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the Function App runtime,eg python or nodejs\",\"enum\":[\"python\",\"nodejs\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-nodejs-mongo-swa-func\",\"https://github.com/azure-samples/todo-python-mongo-swa-func\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Function-App-with-Cosmos_AZD-template/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Project-2/catalogs/example/environmentDefinitions/webapp",
+                  "name": "WebApp",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure Web App without a data store",
+                  "parameters": [],
+                  "parametersSchema": "{\"type\":\"object\"}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/WebApp/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Project-2/catalogs/example/environmentDefinitions/sandbox",
+                  "name": "Sandbox",
+                  "catalogName": "Example",
+                  "description": "Deploys a sandbox environment",
+                  "parameters": [],
+                  "parametersSchema": "{\"type\":\"object\"}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Sandbox/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Project-2/catalogs/example/environmentDefinitions/container-app-with-cosmos_azd-template",
+                  "name": "Container-App-with-Cosmos_AZD-template",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure Container App with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the container App runtime,eg python, nodejs or java.",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs",
+                        "java"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-java-mongo-aca",
+                        "https://github.com/azure-samples/todo-nodejs-mongo-aca",
+                        "https://github.com/azure-samples/todo-python-mongo-aca"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the container App runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo-aca\",\"https://github.com/azure-samples/todo-nodejs-mongo-aca\",\"https://github.com/azure-samples/todo-python-mongo-aca\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Container-App-with-Cosmos_AZD-template/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Project-2/catalogs/wbreza/environmentDefinitions/helloworld",
+                  "name": "HelloWorld",
+                  "catalogName": "wbreza",
+                  "description": "Deploys an Azure App Service within App Service Plan",
+                  "parameters": [
+                    {
+                      "id": "environmentName",
+                      "name": "Environment Name",
+                      "description": "Name of the environment",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/wbreza/azd-hello-world"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"environmentName\":{\"title\":\"Environment Name\",\"description\":\"Name of the environment\"},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/wbreza/azd-hello-world\"]}}}",
+                  "templatePath": "EnvironmentDefinitions/HelloWorld/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Project-2/catalogs/example/environmentDefinitions/app-service-with-cosmos_azd-template",
+                  "name": "App-Service-with-Cosmos_AZD-template",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure App Service with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the App Service runtime,eg python, nodejs or java.",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs",
+                        "java"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-java-mongo",
+                        "https://github.com/azure-samples/todo-nodejs-mongo",
+                        "https://github.com/azure-samples/todo-python-mongo"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the App Service runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo\",\"https://github.com/azure-samples/todo-nodejs-mongo\",\"https://github.com/azure-samples/todo-python-mongo\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/App-Service-with-Cosmos_AZD-template/azuredeploy.json"
+                }
+              ]
+            }
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:34 GMT
+            Strict-Transport-Security:
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - 4be6b13b-39db-431e-8b62-53cf87e6c0b3
+            X-Ms-Correlation-Request-Id:
+                - 4b7ccd57-d54b-47de-9ba0-b0dfbd99e23c
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "299"
+            X-Rate-Limit-Reset:
+                - "2024-02-26T19:38:33.7198478Z"
+        status: 200 OK
+        code: 200
+        duration: 1.6123605s
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourcegroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:35 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 1e2f16fb-fd74-489c-ace5-0d1a080cdfd4
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193735Z:12d7a70d-ea15-4937-bd55-04fdbb4900ff
+            X-Msedge-Ref:
+                - 'Ref A: B9F1DD41B85F4C4787B86CE91896DA8E Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+        status: 200 OK
+        code: 200
+        duration: 123.7636ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:35 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - b9028c47-2782-4e57-b643-6930c056ed39
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193735Z:49e15898-f92e-4dc3-bebc-4892cd12d13f
+            X-Msedge-Ref:
+                - 'Ref A: 08E33DA1791A4D298E6947D516C2B652 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+        status: 200 OK
+        code: 200
+        duration: 124.8661ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourcegroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:35 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - bf0f28d6-12aa-4689-9d58-25bb4b895f48
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193736Z:9438bab5-1846-4b85-b4a8-179af6a408fa
+            X-Msedge-Ref:
+                - 'Ref A: 094FC8A8875949AB873A6435BD6BDCA1 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+        status: 200 OK
+        code: 200
+        duration: 132.4907ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourcegroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:35 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 798a9b8c-0ac0-4cc2-886d-0b62be1b458e
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193736Z:9ffba7bc-a79f-413d-8bc0-acf5add23292
+            X-Msedge-Ref:
+                - 'Ref A: C81D923721C0467487044C43D16C87F2 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+        status: 200 OK
+        code: 200
+        duration: 131.5596ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/basic/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:35 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 294d3076-4cb2-465c-8e4e-25c21ed0cfc5
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193736Z:d2ef4716-4d30-4aa1-92a6-cc92ea8aaa49
+            X-Msedge-Ref:
+                - 'Ref A: 075F50BD69AD45FC8C8343F34FE1377F Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+        status: 200 OK
+        code: 200
+        duration: 141.5191ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:35 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - c5c6097f-161c-4f38-b054-62ceed393ab8
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193736Z:f32d16ba-214a-42f8-8b0f-c53cba5f062f
+            X-Msedge-Ref:
+                - 'Ref A: AD2FCE5C7B304E65B10D34101220713D Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+        status: 200 OK
+        code: 200
+        duration: 140.6441ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-2/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2328
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2328"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:35 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11997"
+            X-Ms-Request-Id:
+                - fbccb4eb-e000-4842-81dc-74b7ade4cbf0
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193736Z:125935fb-e482-45a6-874a-17071b0f1174
+            X-Msedge-Ref:
+                - 'Ref A: 248733D0BE3449C38D0572275B43D402 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+        status: 200 OK
+        code: 200
+        duration: 149.5436ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Contoso-Demo/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2328
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2328"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:35 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 0536ce13-cb25-4594-bb35-05cfa7366267
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193736Z:b16dd151-afb6-45e2-9111-5b3d7a456c8c
+            X-Msedge-Ref:
+                - 'Ref A: C977743089E44E069240259B388C0187 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+        status: 200 OK
+        code: 200
+        duration: 150.9427ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-1/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2328
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2328"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:35 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - c25bf3e0-1f4c-43d5-970f-2eb48dd4ea5d
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193736Z:7f162909-089e-48f5-a0ef-d8185ddd85a3
+            X-Msedge-Ref:
+                - 'Ref A: 272B165A1D8149F6AB9158C8A29944B3 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+        status: 200 OK
+        code: 200
+        duration: 148.6605ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourcegroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:35 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - e4a5f705-755b-484a-873a-d3675bf0834a
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193736Z:a9601eb2-54f0-4601-849c-ac1897c669d5
+            X-Msedge-Ref:
+                - 'Ref A: F41E729BE3C74B92987CA08C09F5A975 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+        status: 200 OK
+        code: 200
+        duration: 152.891ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourcegroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:35 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - ab129ec1-2125-45ac-831e-e28495b6e9fa
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193736Z:3514626d-984c-4a18-8bc2-3de5c03131e9
+            X-Msedge-Ref:
+                - 'Ref A: 2EB60F97DA284BA8BF80310BD6438363 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+        status: 200 OK
+        code: 200
+        duration: 170.2127ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourcegroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:35 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 1340761c-e0c7-4247-bb95-5a416cfd8816
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193736Z:582fd482-606b-45f1-92b2-f1f409a5914e
+            X-Msedge-Ref:
+                - 'Ref A: 908C5A94144D4F68ABAF5EB7D952B7E5 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+        status: 200 OK
+        code: 200
+        duration: 170.1154ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:35 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - cde29130-44b4-45c2-8f4f-95b2b6687e3b
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193736Z:5011b49c-1ba8-4932-8de3-9671862794fd
+            X-Msedge-Ref:
+                - 'Ref A: 87F166304C714076BE47FCDF1CC03D8F Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+        status: 200 OK
+        code: 200
+        duration: 175.0971ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+        url: https://management.azure.com:443/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourcegroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:35 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3acbc1075ef07304f1a9328bd4faa9c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 711727c2-f476-422a-9a30-e33931304d8d
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193736Z:d49498af-da96-4adc-a5fb-cb0f0ffabd96
+            X-Msedge-Ref:
+                - 'Ref A: F793800369D54CB09B7B2189DA36FB3C Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+        status: 200 OK
+        code: 200
+        duration: 190.6537ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/environments?api-version=2023-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |-
+            {
+              "value": [
+                {
+                  "name": "azdtest-w19ee8a",
+                  "environmentType": "Dev",
+                  "user": "19a2053b-445a-4023-95d3-c339051e0f32",
+                  "provisioningState": "Succeeded",
+                  "resourceGroupId": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w19ee8a",
+                  "catalogName": "wbreza",
+                  "environmentDefinitionName": "HelloWorld",
+                  "parameters": {
+                    "environmentName": "azdtest-w19ee8a",
+                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
+                  }
+                }
+              ]
+            }
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:36 GMT
+            Strict-Transport-Security:
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - b4954822-e4a0-4e8c-9289-195fea05279a
+            X-Ms-Correlation-Request-Id:
+                - f87b6c86-7409-47dd-a349-163ca91472a2
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "297"
+            X-Rate-Limit-Reset:
+                - "2024-02-26T19:38:33.7359520Z"
+        status: 200 OK
+        code: 200
+        duration: 791.4647ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 238
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"options":{"allowPartialScopes":true},"query":"\n\tResources\n\t| where type in~ (''microsoft.devcenter/projects'')\n\t| where properties[''provisioningState''] =~ ''Succeeded''\n\t| project id, location, tenantId, name, properties, type\n\t"}'
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Length:
+                - "238"
+            Content-Type:
+                - application/json
+            User-Agent:
+                - azsdk-go-armresourcegraph.Client/v0.7.1 (go1.21.6; Windows_NT),azd
+        url: https://management.azure.com:443/providers/Microsoft.ResourceGraph/resources?api-version=2021-06-01-preview
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 8615
+        uncompressed: false
+        body: '{"totalRecords":14,"count":14,"data":[{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioClient","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSVendors","properties":{"provisioningState":"Succeeded","description":"Project for vendors","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/basic","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"basic","properties":{"provisioningState":"Succeeded","description":"project with basic image","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"MicroBuild","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourceGroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DevDivAzureService","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourceGroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"LanguageAndFrameworkServices","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourceGroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSCode","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourceGroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ServerlessPaaS","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourceGroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"PMUXDesign","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourceGroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"NuGet","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourceGroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DataAndAI","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Contoso-Demo","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Contoso-Demo","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-1","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-2","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"}],"facets":[],"resultTruncated":"false"}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "8615"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:37 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - f7975e48-dd3d-4599-9f55-889ea9fac528
+            X-Ms-Ratelimit-Remaining-Tenant-Reads:
+                - "11999"
+            X-Ms-Ratelimit-Remaining-Tenant-Resource-Requests:
+                - "14"
+            X-Ms-Request-Id:
+                - f7975e48-dd3d-4599-9f55-889ea9fac528
+            X-Ms-Resource-Graph-Request-Duration:
+                - "0:00:00:00.4395981"
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T193737Z:f7975e48-dd3d-4599-9f55-889ea9fac528
+            X-Ms-User-Quota-Remaining:
+                - "14"
+            X-Ms-User-Quota-Resets-After:
+                - "00:00:05"
+            X-Msedge-Ref:
+                - 'Ref A: 5AFD1B39EE2F4A099AC7546303EEB2EF Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:37Z'
+        status: 200 OK
+        code: 200
+        duration: 477.5477ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/environmentTypes?api-version=2023-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |-
+            {
+              "value": [
+                {
+                  "name": "Test",
+                  "deploymentTargetId": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57",
+                  "status": "Enabled"
+                },
+                {
+                  "name": "Prod",
+                  "deploymentTargetId": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57",
+                  "status": "Enabled"
+                },
+                {
+                  "name": "Dev",
+                  "deploymentTargetId": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57",
+                  "status": "Enabled"
+                }
+              ]
+            }
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:38 GMT
+            Strict-Transport-Security:
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - 43290825-4af1-45ce-9bee-0d0ad5e3bec2
+            X-Ms-Correlation-Request-Id:
+                - e725a046-13c3-4534-aab5-73bbdaecd50a
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "299"
+            X-Rate-Limit-Reset:
+                - "2024-02-26T19:38:38.3647570Z"
+        status: 200 OK
+        code: 200
+        duration: 781.8033ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/catalogs/wbreza/environmentDefinitions/HelloWorld?api-version=2023-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |-
+            {
+              "id": "/projects/Project-1/catalogs/wbreza/environmentDefinitions/helloworld",
+              "name": "HelloWorld",
+              "catalogName": "wbreza",
+              "description": "Deploys an Azure App Service within App Service Plan",
+              "parameters": [
+                {
+                  "id": "environmentName",
+                  "name": "Environment Name",
+                  "description": "Name of the environment",
+                  "type": "string",
+                  "readOnly": false,
+                  "required": false
+                },
+                {
+                  "id": "repoUrl",
+                  "name": "Repository URL",
+                  "description": "Path the the application source code",
+                  "type": "string",
+                  "readOnly": false,
+                  "required": false,
+                  "allowed": [
+                    "https://github.com/wbreza/azd-hello-world"
+                  ]
+                }
+              ],
+              "parametersSchema": "{\"type\":\"object\",\"properties\":{\"environmentName\":{\"title\":\"Environment Name\",\"description\":\"Name of the environment\"},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/wbreza/azd-hello-world\"]}}}",
+              "templatePath": "EnvironmentDefinitions/HelloWorld/azuredeploy.json"
+            }
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:41 GMT
+            Strict-Transport-Security:
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - c661085c-79d5-49f1-bcc5-07e2dbece5e5
+            X-Ms-Correlation-Request-Id:
+                - 8e4c578c-b0f3-4873-ac4c-a0944ce4e3df
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "298"
+            X-Rate-Limit-Reset:
+                - "2024-02-26T19:38:33.7198478Z"
+        status: 200 OK
+        code: 200
+        duration: 1.0721088s
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w4789fc?api-version=2023-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 188
+        uncompressed: false
+        body: |-
+            {
+              "status": "Failed",
+              "error": {
+                "code": "EnvironmentNotFound",
+                "message": "The environment azdtest-w4789fc cannot be found.",
+                "details": [],
+                "additionalInfo": []
+              }
+            }
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
+            Content-Length:
+                - "188"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:41 GMT
+            Strict-Transport-Security:
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - 8918a95e-9f4f-4919-b52d-81d0f6f4301b
+            X-Ms-Correlation-Request-Id:
+                - 1cce2430-a5b7-45d1-95e2-b15c849c2353
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "296"
+            X-Rate-Limit-Reset:
+                - "2024-02-26T19:38:33.7359520Z"
+        status: 404 Not Found
+        code: 404
+        duration: 108.3127ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        transfer_encoding:
+            - chunked
+        trailer: {}
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"catalogName":"wbreza","environmentDefinitionName":"HelloWorld","environmentType":"Dev","parameters":{"environmentName":"azdtest-w4789fc","repoUrl":"https://github.com/wbreza/azd-hello-world"}}'
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Type:
+                - application/json
+            User-Agent:
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w4789fc?api-version=2023-04-01
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 340
+        uncompressed: false
+        body: |-
+            {
+              "name": "azdtest-w4789fc",
+              "environmentType": "Dev",
+              "user": "19a2053b-445a-4023-95d3-c339051e0f32",
+              "provisioningState": "Creating",
+              "catalogName": "wbreza",
+              "environmentDefinitionName": "HelloWorld",
+              "parameters": {
+                "environmentName": "azdtest-w4789fc",
+                "repoUrl": "https://github.com/wbreza/azd-hello-world"
+              }
+            }
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
+            Content-Length:
+                - "340"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:37:44 GMT
+            Location:
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/66faedc4-b93b-4b50-97eb-64a53c861b98?api-version=2023-04-01&monitor=true
+            Operation-Location:
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/66faedc4-b93b-4b50-97eb-64a53c861b98?api-version=2023-04-01
+            Strict-Transport-Security:
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - 55b50c3e-ea78-4a09-8b15-08b27a367424
+            X-Ms-Correlation-Request-Id:
+                - a792229e-e8e3-48f6-b63c-5ccd14d46f3f
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "298"
+            X-Rate-Limit-Reset:
+                - "2024-02-26T19:38:38.3647570Z"
+        status: 201 Created
+        code: 201
+        duration: 2.9544595s
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/project-1/operationstatuses/66faedc4-b93b-4b50-97eb-64a53c861b98?api-version=2023-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |-
+            {
+              "id": "/projects/project-1/operationStatuses/66faedc4-b93b-4b50-97eb-64a53c861b98",
+              "name": "66faedc4-b93b-4b50-97eb-64a53c861b98",
+              "status": "Succeeded",
+              "startTime": "2024-02-26T19:37:43.0095229+00:00",
+              "endTime": "2024-02-26T19:41:19.7367454+00:00"
+            }
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:41:47 GMT
+            Location:
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/66faedc4-b93b-4b50-97eb-64a53c861b98?api-version=2023-04-01&monitor=true
+            Operation-Location:
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/66faedc4-b93b-4b50-97eb-64a53c861b98?api-version=2023-04-01
+            Retry-After:
+                - "30"
+            Strict-Transport-Security:
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - 14a1e451-b2f2-4b5b-8d79-1c56540e79cb
+            X-Ms-Correlation-Request-Id:
+                - 8e488f1a-5814-4d7c-88a8-ffd700e10b88
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "299"
+            X-Rate-Limit-Reset:
+                - "2024-02-26T19:42:47.2817354Z"
+        status: 200 OK
+        code: 200
+        duration: 147.4086ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w4789fc?api-version=2023-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |-
+            {
+              "name": "azdtest-w4789fc",
+              "environmentType": "Dev",
+              "user": "19a2053b-445a-4023-95d3-c339051e0f32",
+              "provisioningState": "Succeeded",
+              "resourceGroupId": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc",
+              "catalogName": "wbreza",
+              "environmentDefinitionName": "HelloWorld",
+              "parameters": {
+                "environmentName": "azdtest-w4789fc",
+                "repoUrl": "https://github.com/wbreza/azd-hello-world"
+              }
+            }
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:41:48 GMT
+            Strict-Transport-Security:
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - 47b8e77c-e9bf-46c3-a38a-a8052d27de27
+            X-Ms-Correlation-Request-Id:
+                - e1518b35-6ae3-4385-8f3f-917d5e20dacb
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "299"
+            X-Rate-Limit-Reset:
+                - "2024-02-26T19:42:48.1726074Z"
+        status: 200 OK
+        code: 200
+        duration: 877.4358ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w4789fc?api-version=2023-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |-
+            {
+              "name": "azdtest-w4789fc",
+              "environmentType": "Dev",
+              "user": "19a2053b-445a-4023-95d3-c339051e0f32",
+              "provisioningState": "Succeeded",
+              "resourceGroupId": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc",
+              "catalogName": "wbreza",
+              "environmentDefinitionName": "HelloWorld",
+              "parameters": {
+                "environmentName": "azdtest-w4789fc",
+                "repoUrl": "https://github.com/wbreza/azd-hello-world"
+              }
+            }
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:41:48 GMT
+            Strict-Transport-Security:
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - 3a60cbe0-96d2-4e7a-862d-796417207b96
+            X-Ms-Correlation-Request-Id:
+                - 81ed031b-2e45-4177-9a41-b5e67ce81b13
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "298"
+            X-Rate-Limit-Reset:
+                - "2024-02-26T19:42:17.1172344Z"
+        status: 200 OK
+        code: 200
+        duration: 129.2514ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
+            X-Ms-Correlation-Request-Id:
+                - baa93f9791f77e8989aa1ed042639dbb
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 13713
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/app-helloworld-4y6ae2hdnphbq-appSettings","name":"app-helloworld-4y6ae2hdnphbq-appSettings","type":"Microsoft.Resources/deployments","properties":{"templateHash":"1502109241172037927","parameters":{"name":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"appSettings":{"type":"Object","value":{"SCM_DO_BUILD_DURING_DEPLOYMENT":"True","ENABLE_ORYX_BUILD":"True"}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:40:01.4134974Z","duration":"PT13.6022714S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"sites/config","locations":[null]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/appsettings"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/app-helloworld-4y6ae2hdnphbq-app-module","name":"app-helloworld-4y6ae2hdnphbq-app-module","type":"Microsoft.Resources/deployments","properties":{"templateHash":"3548910797978781823","parameters":{"name":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w4789fc","azd-service-name":"helloworld"}},"applicationInsightsName":{"type":"String","value":""},"appServicePlanId":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"},"keyVaultName":{"type":"String","value":""},"managedIdentity":{"type":"Bool","value":false},"runtimeName":{"type":"String","value":"node"},"runtimeNameAndVersion":{"type":"String","value":"node|18-lts"},"runtimeVersion":{"type":"String","value":"18-lts"},"kind":{"type":"String","value":"app,linux"},"allowedOrigins":{"type":"Array","value":[]},"alwaysOn":{"type":"Bool","value":true},"appCommandLine":{"type":"String","value":""},"clientAffinityEnabled":{"type":"Bool","value":false},"enableOryxBuild":{"type":"Bool","value":true},"functionAppScaleLimit":{"type":"Int","value":-1},"linuxFxVersion":{"type":"String","value":"node|18-lts"},"minimumElasticInstanceCount":{"type":"Int","value":-1},"numberOfWorkers":{"type":"Int","value":-1},"scmDoBuildDuringDeployment":{"type":"Bool","value":true},"use32BitWorkerProcess":{"type":"Bool","value":false},"ftpsState":{"type":"String","value":"FtpsOnly"},"healthCheckPath":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:40:05.3286583Z","duration":"PT37.9814816S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"sites/config","locations":[null]},{"resourceType":"sites/basicPublishingCredentialsPolicies","locations":[null]},{"resourceType":"sites","locations":["eastus2"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-4y6ae2hdnphbq"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/logs","resourceType":"Microsoft.Web/sites/config","resourceName":"app-helloworld-4y6ae2hdnphbq/logs"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-4y6ae2hdnphbq"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/ftp","resourceType":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","resourceName":"app-helloworld-4y6ae2hdnphbq/ftp"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-4y6ae2hdnphbq"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/scm","resourceType":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","resourceName":"app-helloworld-4y6ae2hdnphbq/scm"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-4y6ae2hdnphbq"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/app-helloworld-4y6ae2hdnphbq-appSettings","resourceType":"Microsoft.Resources/deployments","resourceName":"app-helloworld-4y6ae2hdnphbq-appSettings"}],"outputs":{"identityPrincipalId":{"type":"String","value":""},"name":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"uri":{"type":"String","value":"https://app-helloworld-4y6ae2hdnphbq.azurewebsites.net"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/logs"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/helloworld","name":"helloworld","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12313645452229774503","parameters":{"name":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w4789fc"}},"appCommandLine":{"type":"String","value":""},"appServicePlanId":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"},"serviceName":{"type":"String","value":"helloworld"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:40:16.4892974Z","duration":"PT52.443231S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"servicE_HELLOWORLD_IDENTITY_PRINCIPAL_ID":{"type":"String","value":""},"servicE_HELLOWORLD_NAME":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"servicE_HELLOWORLD_URI":{"type":"String","value":"https://app-helloworld-4y6ae2hdnphbq.azurewebsites.net"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/logs"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/appserviceplan","name":"appserviceplan","type":"Microsoft.Resources/deployments","properties":{"templateHash":"7476659406584400671","parameters":{"name":{"type":"String","value":"plan-4y6ae2hdnphbq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w4789fc"}},"kind":{"type":"String","value":""},"reserved":{"type":"Bool","value":true},"sku":{"type":"Object","value":{"name":"B1"}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:39:14.509538Z","duration":"PT6.5263397S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"serverfarms","locations":["eastus2"]}]}],"dependencies":[],"outputs":{"id":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"},"name":{"type":"String","value":"plan-4y6ae2hdnphbq"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/project-1.azdtest-w4789fc.133534499416341033","name":"project-1.azdtest-w4789fc.133534499416341033","type":"Microsoft.Resources/deployments","tags":{"AdeEnvironmentName":"azdtest-w4789fc","AdeProjectName":"project-1","AdeDevCenterName":"dc-wabrez-od3kzvk4mwe72","AdeEnvironmentTypeName":"Dev"},"properties":{"templateLink":{"uri":"https://d55vj9m1o8u4cm4o.blob.core.windows.net/templates/project-1.azdtest-w4789fc.133534499416341033/EnvironmentDefinitions/HelloWorld/azuredeploy.json","contentVersion":"1.0.0.0"},"templateHash":"17645299908346333518","parameters":{"repoUrl":{"type":"String","value":"https://github.com/wbreza/azd-hello-world"},"environmentName":{"type":"String","value":"azdtest-w4789fc"},"location":{"type":"String","value":"eastus2"},"serviceName":{"type":"String","value":""},"appServicePlanName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:40:27.6950264Z","duration":"PT1M20.8125551S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/appserviceplan","resourceType":"Microsoft.Resources/deployments","resourceName":"appserviceplan"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/appserviceplan","resourceType":"Microsoft.Resources/deployments","resourceName":"appserviceplan","apiVersion":"2022-09-01"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/helloworld","resourceType":"Microsoft.Resources/deployments","resourceName":"helloworld"}],"outputs":{"azurE_LOCATION":{"type":"String","value":"eastus2"},"azurE_TENANT_ID":{"type":"String","value":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"servicE_API_ENDPOINTS":{"type":"Array","value":["https://app-helloworld-4y6ae2hdnphbq.azurewebsites.net"]}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/logs"}]}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "13713"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:41:49 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - baa93f9791f77e8989aa1ed042639dbb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 42ec1337-6d92-4096-98e2-1897e154f257
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T194149Z:42ec1337-6d92-4096-98e2-1897e154f257
+            X-Msedge-Ref:
+                - 'Ref A: 40A2B5F02FA04E3F93F075622A5FB1C8 Ref B: CO6AA3150217053 Ref C: 2024-02-26T19:41:49Z'
+        status: 200 OK
+        code: 200
+        duration: 987.2808ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.Client/v1.1.1 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
+            X-Ms-Correlation-Request-Id:
+                - baa93f9791f77e8989aa1ed042639dbb
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27helloworld%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 403
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","name":"app-helloworld-4y6ae2hdnphbq","type":"Microsoft.Web/sites","kind":"app,linux","managedBy":"","location":"eastus2","tags":{"project":"Project-1","env":"dev","azd-env-name":"wabrez-devcenter","azd-service-name":"helloworld"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "403"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:41:49 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - baa93f9791f77e8989aa1ed042639dbb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 4c719731-8eca-4695-b986-80ef1e4efe63
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T194150Z:4c719731-8eca-4695-b986-80ef1e4efe63
+            X-Msedge-Ref:
+                - 'Ref A: 9750A5DEC90A4089B67FB01AD03AC067 Ref B: CO6AA3150217053 Ref C: 2024-02-26T19:41:49Z'
+        status: 200 OK
+        code: 200
+        duration: 263.4773ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        transfer_encoding:
+            - chunked
+        trailer: {}
+        host: app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net
+        remote_addr: ""
+        request_uri: ""
+        body: !!binary |
+            UEsDBBQACAAIALRcWlgAAAAAAAAAAAAAAAAKAAkALmdpdGlnbm9yZVVUBQABhOjcZXRVTW
+            /cNhC981cMsIfUC0hqektvddwEDdy0sHspimJBkbMy19SQ4AzXq/z6gtRH7Li5rPVmHkcz
+            j2/kHdyGgZUvP/vWh0FRHBuLfR4K2qtJJ3qFMaWQZuwxkX5OUDu4cXqgwOIMJIwhCcMPDy
+            KRf+46ChZP3IY0dDq6bs63DzL6K7WAf35s3v27//8/Jw5UXnGXSdyIYLVoFZ0t3Udn1b5l
+            RDuD1gfzOPeT0EhIExxDAkcsKY9Igha86xkGJEy6wH6CE5twxqQH7D7dvy+Pyru+MeFcSr
+            1fcmC3mpnngxKCZ/DuEcGxaOqzV2upou1SgSYDgiyw5VqazCFkiVkK4WPKJOBIMI1onRYE
+            llBfuqk4FM6JWxPGziTU4mhoos+DI94VdsGi+bE5Oo98pdp6opS/Dk+YwGJEskhmejbJVr
+            4vnNaF7krVx4MJYwyEJFxHCBabJ30EE+johpy0uECq6t08sUkuyizWGJ0v6jjSaQJtbaDv
+            e2FOL17os/O2u0OPmrFe4uuOHbIqNQ5jsNkjd+rEcTxEbR71UKDawV9TxPvaEZzfgkXj9d
+            wuVGWUTNHR8IprtHkotyZcG3F0DIXxRyxHtQeK48z5Kp9qKY4vSMje0VqrndEM1A5+dyaF
+            PpP1uDJSlJ8O9blTbRJewMGc+GUAv8F5tN2LN9/9+uctPDhe+ioaJYz+sIYKtxoOwhHelG
+            GKaG/KwMOXkv1bJ4LfSHBITqaqlWrr7rs1WGg2CNIZkM4uBSo7BWednO498nII6Vx/2mL6
+            cibqZNA38+hpUXHzxJxdXHGl2k2vz3iR9sRQ7wOWdWkJL7Xo5/w8220r/ZWYL6Ksm1v4qI
+            X7aXFAuyhe/VpHcATygBBz750B7whLyB1hCjlBTOGERsre81pJk4U9BdmvbaodbC7Hiyzz
+            9D4MFTfvmre7uX6zGajhHMsHsGhUU6XVc8aYkL+dew1360j3mM6YfGE+X4+Wt3h1yIfMeB
+            0uq+OOmbEPl5q6mUiP4eYaboPRfhXH1qjt5wXBRJ/uoTS53K5goqY2rXbwy5ecED5kMsWG
+            DDqJO2oj5f+L0b5llPKh4voV/y8AAP//UEsHCBcl+6EvAwAAegYAAFBLAwQUAAgACAC0XF
+            pYAAAAAAAAAAAAAAAACQAJAFJFQURNRS5tZFVUBQABhOjcZXyTQW/iOhSF9/yKIyG9Rxel
+            RW/xOqwmTaNOJAiIpBppNsQkF2LJ2B77Gsr8+pEDnbaqOjsn997v3OOcDFGYlnCU3KE6Wf
+            KNk5aRPVtH3mOVlRWSZT4YDIcoiYONpyGWjhz9DNJLJj8YXJ8po8ndePL/eHIVXyznGH0Z
+            38WnfmRmGqGQ6YN0Ru9J82CQOhJMEKjHpA/1eQvuCFujlDlKvUNj9FbughMsjZ5GpTr58b
+            TK1uminC/Kdbooiiyt8kWxLqtVXjzWuEZq/N54PNzHcU1NnIVnF4GjudE7E2tCeQMfrDWO
+            qb36gH5IquQ+KbN1kcyz99hWsNgIT9BiTxh9l0pBBDZ7wbIRSp2wITS9uxZyC8loDXn9L4
+            OepecrjFraiqB4isq05iy+XM7yNIle8qLMH79Vn9hLfgVHSKxVsunvBbn2ctex/+j3M/Bq
+            MXs19hfgyqgXl382Tpb55Zvm2rNQCg9kSbekGxnTsAoatbZ7NLIGG8hLl+oT0L7rjZT7IF
+            WLf5CavZWK3gBc0NjEas/ZXPqac1+flDeZbWIEpWbTF+rxTSs91zFLLbmzUgSLV5tvlDwL
+            x71Kf+oRL/seSBkbEwtP7hBZMxF002HjzNGTw1fUHbOd3tz0I53xPP1vcntbj1F1hMvFwY
+            odIRZ9j19Y0vEu8ZTj2JEjnExAIzTYnWDCeYn48/0OAAD//1BLBwihoHHtDQIAAKUDAABQ
+            SwMEFAAIAAgAtFxaWAAAAAAAAAAAAAAAAAgACQBpbmRleC5qc1VUBQABhOjcZUyQUWsiMR
+            SF3/MrzsLCRBhmhH0U92VX2kKhRS19NThXDcTceG9GCup/L5lR6FO4J/ec8yVti5djYsk+
+            7iF06r1QhyN3fSA1frgCfSUhVeyEj6juUzUzpm3xT8gNZhexuO+5lILfuuw5mi1HzUXB/J
+            FjJ6P1P+18JDgI95mQGQcXu0B4WqwHFtKsRc4HgjBnfCxfjUup2VO2VVvVsEKnGkI6wfwv
+            LgZAmRql2NnqmULgGp8softVTWbmVppHouFhcyThLak2FM/N+9tyjesVf6bT6Ui4ym78mU
+            KgJGcScBy9ZWuACV4zRVvEGvYHSCniQE3gvd2sRrdXSB9jyXwE/b6U47a5830HAAD//1BL
+            BwjQN+xoCwEAAJIBAABQSwMEFAAIAAgAtFxaWAAAAAAAAAAAAAAAABEACQBwYWNrYWdlLW
+            xvY2suanNvblVUBQABhOjcZcR8aZOiXtLv+/kUHf3Wa7HJ4sT9TwSiKCiLggjeuHODTUD2
+            fbnPzGd/Qq2u0uqyirK7n3lRURwO/JBf5sk8JzMP//9v3759j/TQ/v73b9+L2IqHUWzZwy
+            If2k2S2Xk+DOPIib//r9N1lZ3lXhydLgWfoCfwcjaITf/gBbby0oucz2d2WnqZnX//+7ci
+            K+3zuUQ3fd05nzs9+du37y9H/X/H+dp3f8u5J/BMO8rPQBwjv5637MSOLDsyvavnn3ueH3
+            G645+jJ4h4gr4/d/7r6u5q+gbgX3+7uuT76ff+vzC2ysDOAd007aS4fsz1D4aekCfi9Ydl
+            dh4HlW2dutyiSPK/A0BmO15eZO1TlITH/CnOnB+YwPDH0fCM81Q43SuWFxW2k3lFewLLXR
+            2F4KGokYUr63AIK8umrKQpMhUpYN4OtoNcIKEVWcpE6IebsqoHPElJuq3O1gN+YSo0ngl8
+            gKWm3ijItrTDWq/9AT6Q2FX91199qA290B4WbXI+//3f8BP0hIxebjzRZjtx4elFnF1EiT
+            0hP5NvR44XvYU+EX665x9/fQOfsJebPhBKlunt8BDoRWFHd0UDPUFfF8018klA1+3hGbOH
+            mCiFXOf1zg5LbGs1+ZSmVWDgKLaWLsnYQqbIVgnH0HFRt5FTCjVZaaLbEBEfcIMBn27MJU
+            Y1TbLVD8fQZaylt/CM1Pnrr+/3GTFiqx0mepbb2V0+YPABQq6AgeF1a3gB/JyN487DdUM2
+            tFo/Cm2xo9YmgitlEO68jW6jm1ZOdKqdmhIKBJxV1FKHBkIynWF4ntXAQrMR9AB1yGG6rg
+            dI0Ti4wxe7nkprtMVFX5En6Am+1lYzjgo7Ks4afVZo6Al8utFnyzZK59QFP2FP49uexLp0
+            gFfm6tyRF1ncPtN923fieGhnWZzl797rmXFUDQOvsC/DZ/QE3/ycOBoevMjLXfv52aMraX
+            779j09w2JPEHSLm+n18CS2y03o7U2ntx96+TMB2BNEXPeWUeJd2IHOv/aB0XyDFyXhD2oI
+            EAS//dd/ffvHX9+g05v0GfU/hPmedt/Kt7dynxBPan36PzxjfK7PAH/A5baTG0xC2g0rGA
+            Kp4GMUywgzgwfCkSAp1CqIWhKRyZqMbRUl+HjRUltCJLq5z6tScZQlDzt0AkaDycQyNWPm
+            XOtzH1o/p8vUg2BoeJF11yCAT/iXKXtBBYavx8Mz1ufUzReyxEsaQ63x3Fzg+X7AwRkdJ5
+            t45RIFbKykHTYxnKxY5borMBPUa0mFPYznx90SMTV5qnPHkWpNEg4ySSxhJHBZwT1NgZ0P
+            LfvgRfYwyeLEzi4/7J/Q23Fo51ej9J8nx3zTfSgjs/Di6Aezp0vemBbHLoZeVGRelHvm8y
+            XwrW3J7WL4ghTYkVO4Lxe+M2X5XCFGP990KCPLi5zbm8osuBaw4xVuaTyZcQjkSRzlcZYD
+            wdHVM6OPgj2bUMvLkzj3iotevadq4BN69f69Ve1n/JPS/Xx2eMb/XP3oyt7LfDmvwZHZBK
+            S3MzoP62RyBQSu7eo7Qy6coGTdETAbo9OUq+XQ1ZHlnod0ckcSJs24i47bb6uVXfk1ukn9
+            QSGt+6lfrh/soVEeDmcH/R19VNB9DOUb33Zv8KMPS+QEfCWKsxc5I34ug0g+pgdzQs+8ZG
+            mpVDXSpusddQjN1X4ZElBg0WBCxolctRk9Vwxzg4mAQpIWOsf5AVjIGbFOvS1Y0Lo1xejl
+            iC/YWiC/Zj37cRj73j32Tm8KPsDeCfLM2+ngrLXg54xpe2S+bSMgJpzDkg2iQMUdvElHTi
+            tgglS6c3Gp6/M8n0/g1JluJdARnUKu4na/kosxaWAWNXIP5thSUD3zKxMQqDCr/xRjw9xz
+            Ir0os480D3uQu1fwVxZfTp01EPuczzU57QJ9YRKeqRAMXhk6q7J1bI0XOy0hSio9QI0+Eg
+            58Cck4qzRrJts6wq5YWPy0EL22DmnDkyBYOcYFo66yJYfE2frD2fmPqeR7fNzOLvvycUYE
+            hpf/wzPG529uUPgsyCxWZyPRIMUBNIsLrUr3uYHYZoDWHjY5eNiElbcmH9cJZlZ54oBHtY
+            s28nJ6DIEZTloOPVFsUlQ43lzO8wVH9rN/4dWs93NdevbUll7o1+763jrv677lvQec6fz5
+            9HnV18O7ZBOuYrogIYkKmw0kdh/Hg8GC1NJ8lfkOzkkHxos4kXZDP85qXB1Ygqqw63ywlr
+            FxN/c7rj1MI4bj4Z1nQQPeWCHyoCe7v2ly48SJ9XLjQ+7pPzEPeV6OvT+4wAcM9QnwrAyJ
+            NTwjfC58B48WmIhZ7dSL2dghyXmSzROqUJiQdRPRB7KY6iwDOTAuBgE5EIn5YYPFUcvVPk
+            VuACGgkHZCgcFMqrbxekbmOfNVI91nUfC6Qr0TI3iIrjPmmbHz0fCM8zlpcM7OWVlXGUbf
+            QPXIYyU+5kE34jR8nphARExHqUSxNbFO6Z16wM2SdKLZopkkta0rpmhXFBwgy+SoUQ3Ct8
+            l67ejsl1dSV/r/iwtU2x4evCwvfmtE6gcoMHw57BuH2nF1OF65m2082G31DT+oNuVMTufE
+            mHH2iatIvG/Rjm1guQTMRkI2ZXi8GBEUadfSQjUxigjsw5RYLg8ZWmkYZGTrIK4/9HR2ZM
+            aWfRnd97z/19fpL6gnEn4cn/19j/W6LLJqSrAprStaCFO7UKwiEWbaeLSXOBxYL00pLLnV
+            VDAOyQI9ePhmOw8tIJOnh0FWFkCue1NvPbMVmXfIkJ1ZpNCAf2BovmvD73H49VH6M/yJzJ
+            9OnlntMXaPjd6ulpKbzdK0Y0G7DNeG4sramoNx6iBDMoIOHMqZ0vGKgNlVrqYyi2NdhZGg
+            thKcWbTactWqy6f5nMkCgqcTGXZ6rqXuLbB/cPwFwYz6CebFab4vD+QxeVxQL2K4HJ8TAT
+            3Y3x/QBbxsCrg5ypXBViK8361mDNWQ2HHgkiHXMUGbtKPGnDhQtVSihhjvWnBuSAP/gJo1
+            pdB0Z1G0C6sSRfPblYSZ+Rd1uh91pp7YQ7cIPzIIyAPkveCe6XtpndUX+ZxA3pPKZD8S7H
+            JeZxgRzBm7DQE/Z/YcG1vbuSBRe4CWIrkxM9s3qjRzrG0TsAKXeEd9uVeOJJvtsnkOYGxL
+            CFzZHsefmcZCv7cGgJ6IRzxDoZ+WAKd/wzPC56+tMyuUbvBQrxUdAUE9gCfRbDby+CqG0p
+            ncrDKRAWIQXeEd5sT4gaohFputQ2M5okMWJiXcdxQaWM72u/IwOVhUwJniFz1uL0/6ksd7
+            j65zZu8BL3IBPVH2nIm8AH1OGwqI+Qrz5qJ1WAPBkoO2pWcHmlMhk23MHjpI39bbcbXYD1
+            jcaavaWqv0bMLMGL2x5wdwzpiZTcp8O5k1hR54+dQoubSnsXtNQH7/92268dT5JhH2Zo7x
+            7dv328TQ2yzQVSLkNor3JmTXK2HyEjJ5Ex956bqJDbwJBDyWcLmeblx+0U0k9tb8XC5Abi
+            64jMlTD3FLy8GL9MDVIyt4Ie5NIDizc/fHy9489bNMT2hnjj207NzMvKR4vuqy4rq5qnBj
+            64fc34SYP0sGnQX+Sgty+9aJXrjDIh5mtmM3yffnxDt+c0kWN+1Qt6zzy/8bvskVfJhtih
+            z7St/+fYloX13xbiD0ut++xNXB09gEb3uyyh7mhV5cvD70BKFvryiSLC7ik47Gh3fFdrq9
+            zO0XyXwlHVZ4QT48S+9diVV61l6J67njK7MRqF905I1u/r6V3DUwMLxp9l3ToaVqbpVDEa
+            w5OtpR47QE8srfVchctmDxsHWXACKufI0nbZw2UpYrEBRCF3ozw+zNCh/NrTzzvLo8enpt
+            6RNokswYyelnKu8bkF+1E7823j7Uudck679/IcvaQ2nirNYzy74XKgEf05gfqCd1+XE8BP
+            vpilFu5uAhmRSbhSRTAinZmDuFUaKYlQYdb1bGaM+TGN9wyoKvYUcw60U8rlvdCDquE0i0
+            GzfkeAUt+aMP8AXGyWNdi784i+0zG/lh6u+lAr4+FTkjnig7/T8nAnrMQjoWDtcaBxHZjB
+            ZKy1ZGc8mV58wa3xgdicedsR0zgDpJQtxPHa6tnbANuFpdNHs29JVY8yN9bMGJoiqqaGmy
+            OLaPxPoP0PUmRXovFvIAbdfIJ/qu2+eoSA8acXXBNws8VcfNHA2ZuvHdMpTjBuCYDW8Kzj
+            RrdjlXwAmZwchukWBctgl4nJ5IdEIl2SBWBJDGRyNv62wIOGK5wxyWbuK0fzzi+XYBfM8D
+            fD0ufoMMDG/bZx/QIxKOlpqbswtCYSdyhcd54IwmXcRq7jTeMFita1TDhZQVyZlJZQsSOF
+            D0MpbpDmaXyxm4sKb0lsaBeF26XRmq7BJP9Mmm53T519P3rp4Pz7OI76+R8DfdeRsacZC/
+            XIC8uSCuzyL4J/yoQf9PhNGfg//3FulfX5+eAE8qFCeXApEe61MLQw0+YHSrqRIDIGHdUK
+            wgXaYKiiHHchPtoV3hYzmUMxui5HN1g4NNynRK2igHyJbTaRnVMsz5ZjezdbujlvLerXvm
+            UN6LKkHv1TD+cUk8a+AlHne7Tvh9MdV7DwGGd7v6RlxRlOWXJbMbVOloaUOToyAfOVgziz
+            VTUTI+p7tFHR724jxG6yhzfM8CtXURkYFNS2kZ7sOR3iERPJEGdma0qJewlpP1nAN+mAn7
+            j4nybEx+X/jrBfVVWEXcN/QlsZAe7kl26+2lgejmyuqAFvPWCnRlQswsOtElYeSE3na5FR
+            qfSLsIJZl2tLfZbejCcBcxlg+UHLmV4SRA6KZTtovBF6cR/wn7dmu4f68wnnGfxfHc6iuQ
+            AFlRJY1xzpSv5enSt7T5zHO1Y4EmG9GYOSMsK4IwksRgazjhhFgJTLZkDU2jJ5IRiTprN9
+            yy8ESBcEN7c9x0sGwNvlgS8x8SyMVRvicL+CGXc4G8iCGuo3P2tofbgYDCHXGLY1RHZq3m
+            zA5bc11QaauxP0dtgEqUarXZ2yNV1AlZ2PIGNVulYeVOw8jnc/JY6/PRgCEcll2B7KSS5Z
+            UwTnu6nXszkp/k8RUhfkD6TXDqHvNfXwhe4Z7of231zaDTRZ3NAbucdPrsqNmbVHCCFp+D
+            aeV5aszuomq2gPdQEkws1THaY4WMkoUsGeMuthdcO20RZDDdteiuGO/igbzdFILWtzjvbn
+            zRi1w784qXlfvbIs5fizbFnmVHhXfwfoQYHyy66LP8vykvf38he1Nx3lfur7jA8KoxvMB9
+            LvYK4dRoT5pV1Na+vJ3t45AhzSKw8Y2q2rYlbBCorgNcCdpYFUZrb6xnlWRH/HoX2ZBsbm
+            qXWkGLesXAkDFLreRIAFnPoZfrBzu7ikX+469v8Gnsffvf376+daV39O5Kp+4NvwfE8Ax6
+            EsLz4Xng9ZCAD1RzXR0BWqAju67lqEpeC6pmM4sqFZZFlE6sspMXSZes9x2Z+0vO3cPLwS
+            yaeBI37uZSzNA2l6jLRh9Zmr1n1qldf1wP5yW6ZWVPx/uOePyA8X9BPZHw43h4xvqcBXDJ
+            ABiIN3EjyfECnx95iD5IxireggOjkD3zmK+l3TpwAXff+jyxTELugJdaLe6QzUD399gGqC
+            FiH6jSYqKpnrYVBeSLmTGoj/qEtuXp5yzMvdgv+FA++goXGF63hmC/nLSVDlI7WI91f5GY
+            QgA4W2UjNwoj+CQL1RtkTVbGaJMrR4mIlZg+TueyieHjmtXCbehHWxpd1NxKcAxUGOjIsj
+            ns9ET84ryyT3jqvfTL71v0/oR+JvPNub7LYZPyMAcB9hnkpWsPayUjtzlIreJYHxM8WCPQ
+            sdtqmSqqcJMKRkjPFyxYrNESHy2QUHHxehWXcm7vW41JkbFDmHwCfZylfk07vc/JI2G7Z8
+            wzE+ejvqE6zwzIhc2nfIgRHV1Ee9AeQCu43TJW1fGxXi63o92ERJRqAVQi7dk0nh42Qb3d
+            bwdTciyODVFlpDFYBk28jakFjOQK/AcCxKEX3i93xh4ZjF548qfnPZdnhM+5akAlIvKEGd
+            QlCwmYhDuRoa8dQmzcEc8vDHwpMXw42y09cTbaLIUkqLxjNOD9UAvDjSNiRGji4BGeGbZM
+            b/Isr/W1fWPADC+65en5tb+bgXey5T946ktun+nqmQHLuEsu+kjS4hn0B8GWMbwAfU5yLm
+            5HpYJbWlAVO7ap62YxBcXScxXem+FySxprVNo1U2oyDrdaJThZvBZqbb0WliJLUIwxG0Az
+            WQmEeAltKTjaIo5WfdFL9FXIl826788yoCfk6xtAXnF/kHduDC9wn/O3n2oDQwzRTpbpgZ
+            ZQGbkdR0tw6zCUJsrgupAhfr+jq1E+GMi8bzqKLoMONhht4JIZccf1sWvzxQTqmnK3QkG3
+            023V67kB7FWVfujNVxW2L/m/d2UVnrnuvY6SkwQDRYzZslO5FFIA3ROmlfsdWx4PdXoQZD
+            +rmfqIMxtGSiKfjWRMatmRSInRnIvpIzW2LFcP0KXCaAVZjHGvAVHyQ59xs/P7/RkJ9kBg
+            5RUWGF41hme0z4kYzLZ5OhdXOTc4Ap1FuftjHqko5IzUbEELjFofIkoR58HaB3zU8XTfXO
+            ZlQwnGZFNiUykcx0kNCFge7AzWctw1NzImf2CsxsbRNouhF+WJbX5QO4w8MBu5xQaGb04M
+            L7Cfc4mm8RHabL2lwOUUxa8UiJp4ojaDwLzz5DwK+cYnGSDbu94UQygaZ1KLnlOA2h13x0
+            RyVgdw1agqYkxpxgVnEHHAtu76fzRndpvCf394jh6h+BX3xO9ra3jG+5zbWAk630FmPOlS
+            PtxZFc6wtQWst9NRB2+aTZ345lwjkpxSTErb8+mo1iJlR64W3MDIipI92uLO02iACsJymh
+            GUiw78vtHy14r159KxB2xin/DDVYHE++qNPGAgfoACw5fDcwFtD+NAea0tNLQMsPuWR0Ow
+            G4sHtR5J1ITFpNbpoGkSgHV6DNzpbD6fiNA8yrfKbAUmGOLGc+hgHpHDoo1Ub8xrwijaCa
+            tB+sXFSj/e3pRqvW9eoQd2ct9Cnzm8PjE8o37OJDql/TJOgwoqtfWyaYk4pCc2K65NK56B
+            +LKC84OdTamMTKHYFbYDTprm9ZQxogbRSA4DU0aINB1F6omr7sCZwcXRJ9vpborT7jnaBw
+            h5gT2R8dI4O94eRATBOudW0na6FeXR6GhlW0BA8DSIvINXTMXBvs7CcG/G0rJdLati3ySt
+            AkYwYEwBflRMSHIPOOzM2m/xJZfp8RIaqBrZcxxfF/e8qeQ5/dqrcMtzbOWBYd4rOpHem/
+            u8KRXsK5P0NPlJ8+Hl9s+FwFXHmKPYeqZnkrHVfFQYRGEsdVJZSLlc0wTamQtxPRaygI73
+            gsYc9XRCskzKqMekaKdoJbvNPEVhtQQ4ne02PuOPekaRc8+yh6arR5F9dlv/vFTIfpXq61
+            nD/5x7fFO4+b6Rhh/wj9fAwPCmea4n6eEhF5mTN4M4S+PWiUKXNpb6YoaZ8BhjBwuZXKtx
+            M6Mxhy+TjRCGc3YTt91hjpgmWdkpNcnqDIDbZo1OFAuYywGqO0It/YGZ3NWnVt63SuhD/F
+            1Az9xdDodnpM95S1N2UsxaxZHAfSjOLYoWdyxCZ3acVvMRp6yDCPAph8aFIB2jjCEkIDDZ
+            tVxtWEU0UuTK5wgN911qDauODxRmRqleT4t0/8s77i9+COe3fJXmc2He1im/J0/0ofFwhQ
+            sMr1tDtN9oyBJEikF8aVphuDTmlaPzzVpiM9yYK5Lio9J4lkL0IEmMTYyDA83Wp41fo1OL
+            4EV+MJ9ixjHSQlgpxZJSw6TUqpBS78zF/88Lga9UPtdJn37RxeJcCaefUTrYWZy/xIuuRH
+            fnMYleZHYcfficuq6fnq87P+yrzzDjKC+D4vTaHz3mAnsRZJkkcVZcPeL56P9+rFTZx1oF
+            PxRivQZ+VqsfzXNwpkewVdvHyJKApSm+8VoPnEGztRgfVx3uJ3YSSWtmzLSisVg4kKqqdm
+            WgFsvgRdLyMDlt5ubaWMzxymw3Cx80jTo115m3LT7+atlzrf+dOS3xwHzhhHh6fzuyhheI
+            z188TXddKRwlWihT8UjbI17IuZV+kOP1up5IwiyRBnQ9KxASVpBqWRpyWspIFa7kdUI7nJ
+            oQZEDv6FKE0qXO7oVCTBS1p5l8YM/LRx8Z+9U69w/2wzy+3eU5SnwbCb/6JAT0tVr7HltM
+            fsq6P/d9yUf0Suae9a1v9A96YI37Gv2D+qxrMTroSkNe7ecIC+sAr1BkYM/cY5eiceMsWp
+            3ajltNrcxVXsWKvmBTIEcblcEAVRWxosM344YUikUkCUChFjSy28jBx9G/N9ty7kSvHvlg
+            zjXyeVC/NocXyM8JUeflZsof1a13zLcrsAqwSJriZr3dlN3McQJD0Olyz40dxK+nqrBTZN
+            MHj6vuKHbz6UDWu51hxHutRGFgDKiitXUie9xzcP/qaPxkV8ntRqk/qOLvfavs9y0Q3sE/
+            C/uns32XC8dRgZmmOVDyZa0t8njgzwITjex9cizS8SzaMBS9L3btJF/FRze0aWA/sQA7SE
+            MY3rEuMOm8qQ1IE0+wyQIM4fCwmoI9RX7nwzXvlJn/eqH6+9vgb3TkzQddrq32/Rrj3/L5
+            lw/16bZs6p4qPWIwrqEvWnR1ou8ethm6mqr4LksIdOkFqOHuqxF2JI6CbcTLFGW5UOMQR5
+            lb8wXR0Im4U7dczmeBMKUyP264mc17gLpn6nJTaSOVrzWOTT5Ou7+JHbxPySOfbLsGPhFy
+            1ez7yba16XjMThntFDzdzRqDR4OgwA7ZegIEk8qOxkkaeCv1MBcng+V4r6nNNO4SsF75Cw
+            ke+TsqHGCaugAO4MKNBGMf7YVJ1DOmcv0Ry4teYl8YRD2+xPhT9uU80JBfVf+Xm/544OZq
+            snMvFPqATX4GPWnM82HfWtpNzZPjPYCL2RLEMm3FdDQX6PQgwBGvTro83TC0Y3ArQzZXU8
+            wU9JiAZX1nH0R1XU3gg0CNyGOpSbPIknAeCGXK8K0/EFl/U315b8R9nbtrYGB40+xb9xOj
+            uSQuZ74DTJk1Hy5GiAICpZ2tsqRTbMvfukQx5yvdVpNDUtbHpR0FUtwAsABM5GC/LWb2gJ
+            3jOaq5sw4DCTEgF5uvVIT3i3e9bpd+n72bDdS96buAnpi7HA0vQJ+zJvubZTbOt3IzWxCc
+            dSgpScQVr2PbbsNzxyPMwlYMsxmybEN0TLCKNfPzshPXVBTQ4m7kt+P1wCMHoT6ezEMQU9
+            eTlujp92+r8t6U4L3/9XT466HhnnHIlwjZPaX+ume9QALD54O+XwlKji1saK6Ul4d6Fyxr
+            0RwEiMnjg7pkgyVWdqBmsTMhWE+NADvGgBaI3ig0CN3Z+gpFTGhcIfiys1uRTzd+TiJuVy
+            z/gDG43dr/+2zBFe6Ju9dWX0uQcHu5YnwZsgYyPa+mQhpbghk04Hrn+46HyVasEw5FHA5z
+            kky7cdKJ8n5HtoaRLxbxbAp0BVf4FaDEmqy1kruNCMj9iiU4ebVey4Tnrx/cWf49ENI6AQ
+            LD87++9YITfm7sVgcLtLeibri+ulVC8EiUZbWZtbKLxtVGB6w2roFJShp7tqUG6GE7YLq1
+            0IXkstNSbUMyUrxxrXWG2MweENX0i4mCt+r2t9Pfv/723wEAAP//UEsHCHbot40uHAAAn2
+            MAAFBLAwQUAAgACAC0XFpYAAAAAAAAAAAAAAAADAAJAHBhY2thZ2UuanNvblVUBQABhOjc
+            ZVyPTUsDQQyG7/srwpzdsQsepDfBHnoQRPcsLJugI91kmKSlIvvfJTP1A69vnvcjnx1A4G
+            mhsIVggtKzIPWmPZ1zIdV+EX6VcOXciYomYUc3cYibpiLpXFK2y2XXfDAKCjztnke4e9w3
+            0j5y7VkEjwdq2jKlasOkdp0Y6RzftZ1arIYt+EoXbCrmsG+EH7gDWKthOtqbFAdawCHNxF
+            orH/bj99pMjMRzoj/Jl2edfLmJw20cflORTvf/TGu3fgUAAP//UEsHCNa/M9vCAAAAOQEA
+            AFBLAQIUABQACAAIALRcWlgXJfuhLwMAAHoGAAAKAAkAAAAAAAAAAAAAAAAAAAAuZ2l0aW
+            dub3JlVVQFAAGE6NxlUEsBAhQAFAAIAAgAtFxaWKGgce0NAgAApQMAAAkACQAAAAAAAAAA
+            AAAAcAMAAFJFQURNRS5tZFVUBQABhOjcZVBLAQIUABQACAAIALRcWljQN+xoCwEAAJIBAA
+            AIAAkAAAAAAAAAAAAAAL0FAABpbmRleC5qc1VUBQABhOjcZVBLAQIUABQACAAIALRcWlh2
+            6LeNLhwAAJ9jAAARAAkAAAAAAAAAAAAAAAcHAABwYWNrYWdlLWxvY2suanNvblVUBQABhO
+            jcZVBLAQIUABQACAAIALRcWljWvzPbwgAAADkBAAAMAAkAAAAAAAAAAAAAAH0jAABwYWNr
+            YWdlLmpzb25VVAUAAYTo3GVQSwUGAAAAAAUABQBLAQAAgiQAAAAA
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Type:
+                - application/octet-stream
+            User-Agent:
+                - azsdk-go-zip-deploy/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
+            X-Ms-Correlation-Request-Id:
+                - baa93f9791f77e8989aa1ed042639dbb
+        url: https://app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net:443/api/zipdeploy?isAsync=true
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 26 Feb 2024 19:42:20 GMT
+            Location:
+                - https://app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net:443/api/deployments/latest?deployer=Push-Deployer&time=2024-02-26_19-42-20Z
+            Retryafter:
+                - "30"
+            Scm-Deployment-Id:
+                - cefdc91c-a6b4-442e-a683-ea05ce33cd8f
+            Server:
+                - Kestrel
+            Set-Cookie:
+                - ARRAffinity=58203501dbaee15c4cd518c7b7697694be4cbec1031fdad6f0532854f9ed447a;Path=/;HttpOnly;Secure;Domain=app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net
+                - ARRAffinitySameSite=58203501dbaee15c4cd518c7b7697694be4cbec1031fdad6f0532854f9ed447a;Path=/;HttpOnly;SameSite=None;Secure;Domain=app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net
+        status: 202 Accepted
+        code: 202
+        duration: 30.9969845s
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net:443
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-zip-deploy/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
+            X-Ms-Correlation-Request-Id:
+                - baa93f9791f77e8989aa1ed042639dbb
+        url: https://app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net:443/api/deployments/latest?deployer=Push-Deployer&time=2024-02-26_19-42-20Z
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding:
+            - chunked
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cefdc91c-a6b4-442e-a683-ea05ce33cd8f","status":4,"status_text":"","author_email":"N/A","author":"N/A","deployer":"Push-Deployer","message":"Created via a push deployment","progress":"","received_time":"2024-02-26T19:42:31.5437278Z","start_time":"2024-02-26T19:42:33.2397Z","end_time":"2024-02-26T19:42:40.8062946Z","last_success_end_time":"2024-02-26T19:42:40.8062946Z","complete":true,"active":true,"is_temp":false,"is_readonly":true,"url":"https://app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net/api/deployments/cefdc91c-a6b4-442e-a683-ea05ce33cd8f","log_url":"https://app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net/api/deployments/cefdc91c-a6b4-442e-a683-ea05ce33cd8f/log","site_name":"app-helloworld-4y6ae2hdnphbq","build_summary":{"errors":[],"warnings":[]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:42:47 GMT
+            Server:
+                - Kestrel
+            Set-Cookie:
+                - ARRAffinity=58203501dbaee15c4cd518c7b7697694be4cbec1031fdad6f0532854f9ed447a;Path=/;HttpOnly;Secure;Domain=app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net
+                - ARRAffinitySameSite=58203501dbaee15c4cd518c7b7697694be4cbec1031fdad6f0532854f9ed447a;Path=/;HttpOnly;SameSite=None;Secure;Domain=app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net
+            Vary:
+                - Accept-Encoding
+        status: 200 OK
+        code: 200
+        duration: 1.3659085s
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armappservice/v1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
+            X-Ms-Correlation-Request-Id:
+                - baa93f9791f77e8989aa1ed042639dbb
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq?api-version=2021-03-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 7266
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","name":"app-helloworld-4y6ae2hdnphbq","type":"Microsoft.Web/sites","kind":"app,linux","location":"East US 2","tags":{"azd-env-name":"wabrez-devcenter","azd-service-name":"helloworld","env":"dev","project":"Project-1"},"properties":{"name":"app-helloworld-4y6ae2hdnphbq","state":"Running","hostNames":["app-helloworld-4y6ae2hdnphbq.azurewebsites.net"],"webSpace":"project-1-azdtest-w4789fc-EastUS2webspace-Linux","selfLink":"https://waws-prod-bn1-067.api.azurewebsites.windows.net:454/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/webspaces/project-1-azdtest-w4789fc-EastUS2webspace-Linux/sites/app-helloworld-4y6ae2hdnphbq","repositorySiteName":"app-helloworld-4y6ae2hdnphbq","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"afdEnabled":false,"enabledHostNames":["app-helloworld-4y6ae2hdnphbq.azurewebsites.net","app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"node|18-lts"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"app-helloworld-4y6ae2hdnphbq.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq","reserved":true,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2024-02-26T19:39:50.7233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"node|18-lts","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null},"daprConfig":null,"deploymentId":"app-helloworld-4y6ae2hdnphbq","slotName":null,"trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","kind":"app,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"40.70.147.13","possibleInboundIpAddresses":"40.70.147.13","ftpUsername":"app-helloworld-4y6ae2hdnphbq\\$app-helloworld-4y6ae2hdnphbq","ftpsHostName":"ftps://waws-prod-bn1-067.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"104.208.138.157,104.46.127.127,52.251.126.49,104.209.194.156,40.70.147.13","possibleOutboundIpAddresses":"104.208.138.157,104.46.127.127,52.251.126.49,104.209.194.156,52.251.115.213,104.209.219.240,52.251.114.9,13.77.69.217,40.123.55.50,20.7.100.98,20.7.100.108,20.7.100.134,20.7.100.139,20.7.100.160,20.7.100.206,20.22.16.191,20.22.17.198,20.22.17.229,20.22.18.73,20.22.18.236,20.22.19.80,40.70.147.13","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bn1-067","cloningInfo":null,"hostingEnvironmentId":null,"tags":{"azd-env-name":"wabrez-devcenter","azd-service-name":"helloworld","env":"dev","project":"Project-1"},"resourceGroup":"project-1-azdtest-w4789fc","defaultHostName":"app-helloworld-4y6ae2hdnphbq.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs","inFlightFeatures":["SiteContainers"],"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null}}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "7266"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 26 Feb 2024 19:42:48 GMT
+            Etag:
+                - '"1DA68EB903AE635"'
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Aspnet-Version:
+                - 4.0.30319
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - baa93f9791f77e8989aa1ed042639dbb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - c6490f23-163a-427e-a3ea-26157513af9d
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T194248Z:6fb54ea1-c656-482c-a1df-eec88284be66
+            X-Msedge-Ref:
+                - 'Ref A: E827ABF943974621AEAB5F30766F5603 Ref B: CO6AA3150217053 Ref C: 2024-02-26T19:42:48Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 584.6043ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 238
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"options":{"allowPartialScopes":true},"query":"\n\tResources\n\t| where type in~ (''microsoft.devcenter/projects'')\n\t| where properties[''provisioningState''] =~ ''Succeeded''\n\t| project id, location, tenantId, name, properties, type\n\t"}'
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Length:
+                - "238"
+            Content-Type:
+                - application/json
+            User-Agent:
+                - azsdk-go-armresourcegraph.Client/v0.7.1 (go1.21.6; Windows_NT),azd
+        url: https://management.azure.com:443/providers/Microsoft.ResourceGraph/resources?api-version=2021-06-01-preview
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 8615
+        uncompressed: false
+        body: '{"totalRecords":14,"count":14,"data":[{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioClient","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSVendors","properties":{"provisioningState":"Succeeded","description":"Project for vendors","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/basic","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"basic","properties":{"provisioningState":"Succeeded","description":"project with basic image","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"MicroBuild","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourceGroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DevDivAzureService","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourceGroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"LanguageAndFrameworkServices","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourceGroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSCode","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourceGroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ServerlessPaaS","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourceGroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"PMUXDesign","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourceGroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"NuGet","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourceGroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DataAndAI","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Contoso-Demo","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Contoso-Demo","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-1","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-2","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"}],"facets":[],"resultTruncated":"false"}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "8615"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:42:50 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3925c80f-5248-4874-aede-ca510b484267
+            X-Ms-Ratelimit-Remaining-Tenant-Reads:
+                - "11998"
+            X-Ms-Ratelimit-Remaining-Tenant-Resource-Requests:
+                - "14"
+            X-Ms-Request-Id:
+                - 3925c80f-5248-4874-aede-ca510b484267
+            X-Ms-Resource-Graph-Request-Duration:
+                - "0:00:00:00.3140579"
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T194250Z:3925c80f-5248-4874-aede-ca510b484267
+            X-Ms-User-Quota-Remaining:
+                - "14"
+            X-Ms-User-Quota-Resets-After:
+                - "00:00:05"
+            X-Msedge-Ref:
+                - 'Ref A: 01C49FDD14354A8BB130CEA7B1EE25E6 Ref B: CO6AA3150217053 Ref C: 2024-02-26T19:42:50Z'
+        status: 200 OK
+        code: 200
+        duration: 562.9374ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w4789fc?api-version=2023-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |-
+            {
+              "name": "azdtest-w4789fc",
+              "environmentType": "Dev",
+              "user": "19a2053b-445a-4023-95d3-c339051e0f32",
+              "provisioningState": "Succeeded",
+              "resourceGroupId": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc",
+              "catalogName": "wbreza",
+              "environmentDefinitionName": "HelloWorld",
+              "parameters": {
+                "environmentName": "azdtest-w4789fc",
+                "repoUrl": "https://github.com/wbreza/azd-hello-world"
+              }
+            }
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:42:51 GMT
+            Strict-Transport-Security:
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - c472e3e6-ab7a-47c1-905b-cf92f89a9a31
+            X-Ms-Correlation-Request-Id:
+                - 73b2e1e4-c56b-4e0f-83a8-40a70cbcf363
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "299"
+            X-Rate-Limit-Reset:
+                - "2024-02-26T19:43:51.4958571Z"
+        status: 200 OK
+        code: 200
+        duration: 707.215ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
+            X-Ms-Correlation-Request-Id:
+                - 89a6dd550f0c0aac637bbf734451b612
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 13713
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/app-helloworld-4y6ae2hdnphbq-appSettings","name":"app-helloworld-4y6ae2hdnphbq-appSettings","type":"Microsoft.Resources/deployments","properties":{"templateHash":"1502109241172037927","parameters":{"name":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"appSettings":{"type":"Object","value":{"SCM_DO_BUILD_DURING_DEPLOYMENT":"True","ENABLE_ORYX_BUILD":"True"}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:40:01.4134974Z","duration":"PT13.6022714S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"sites/config","locations":[null]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/appsettings"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/app-helloworld-4y6ae2hdnphbq-app-module","name":"app-helloworld-4y6ae2hdnphbq-app-module","type":"Microsoft.Resources/deployments","properties":{"templateHash":"3548910797978781823","parameters":{"name":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w4789fc","azd-service-name":"helloworld"}},"applicationInsightsName":{"type":"String","value":""},"appServicePlanId":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"},"keyVaultName":{"type":"String","value":""},"managedIdentity":{"type":"Bool","value":false},"runtimeName":{"type":"String","value":"node"},"runtimeNameAndVersion":{"type":"String","value":"node|18-lts"},"runtimeVersion":{"type":"String","value":"18-lts"},"kind":{"type":"String","value":"app,linux"},"allowedOrigins":{"type":"Array","value":[]},"alwaysOn":{"type":"Bool","value":true},"appCommandLine":{"type":"String","value":""},"clientAffinityEnabled":{"type":"Bool","value":false},"enableOryxBuild":{"type":"Bool","value":true},"functionAppScaleLimit":{"type":"Int","value":-1},"linuxFxVersion":{"type":"String","value":"node|18-lts"},"minimumElasticInstanceCount":{"type":"Int","value":-1},"numberOfWorkers":{"type":"Int","value":-1},"scmDoBuildDuringDeployment":{"type":"Bool","value":true},"use32BitWorkerProcess":{"type":"Bool","value":false},"ftpsState":{"type":"String","value":"FtpsOnly"},"healthCheckPath":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:40:05.3286583Z","duration":"PT37.9814816S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"sites/config","locations":[null]},{"resourceType":"sites/basicPublishingCredentialsPolicies","locations":[null]},{"resourceType":"sites","locations":["eastus2"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-4y6ae2hdnphbq"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/logs","resourceType":"Microsoft.Web/sites/config","resourceName":"app-helloworld-4y6ae2hdnphbq/logs"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-4y6ae2hdnphbq"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/ftp","resourceType":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","resourceName":"app-helloworld-4y6ae2hdnphbq/ftp"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-4y6ae2hdnphbq"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/scm","resourceType":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","resourceName":"app-helloworld-4y6ae2hdnphbq/scm"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-4y6ae2hdnphbq"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/app-helloworld-4y6ae2hdnphbq-appSettings","resourceType":"Microsoft.Resources/deployments","resourceName":"app-helloworld-4y6ae2hdnphbq-appSettings"}],"outputs":{"identityPrincipalId":{"type":"String","value":""},"name":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"uri":{"type":"String","value":"https://app-helloworld-4y6ae2hdnphbq.azurewebsites.net"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/logs"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/helloworld","name":"helloworld","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12313645452229774503","parameters":{"name":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w4789fc"}},"appCommandLine":{"type":"String","value":""},"appServicePlanId":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"},"serviceName":{"type":"String","value":"helloworld"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:40:16.4892974Z","duration":"PT52.443231S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"servicE_HELLOWORLD_IDENTITY_PRINCIPAL_ID":{"type":"String","value":""},"servicE_HELLOWORLD_NAME":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"servicE_HELLOWORLD_URI":{"type":"String","value":"https://app-helloworld-4y6ae2hdnphbq.azurewebsites.net"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/logs"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/appserviceplan","name":"appserviceplan","type":"Microsoft.Resources/deployments","properties":{"templateHash":"7476659406584400671","parameters":{"name":{"type":"String","value":"plan-4y6ae2hdnphbq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w4789fc"}},"kind":{"type":"String","value":""},"reserved":{"type":"Bool","value":true},"sku":{"type":"Object","value":{"name":"B1"}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:39:14.509538Z","duration":"PT6.5263397S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"serverfarms","locations":["eastus2"]}]}],"dependencies":[],"outputs":{"id":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"},"name":{"type":"String","value":"plan-4y6ae2hdnphbq"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/project-1.azdtest-w4789fc.133534499416341033","name":"project-1.azdtest-w4789fc.133534499416341033","type":"Microsoft.Resources/deployments","tags":{"AdeEnvironmentName":"azdtest-w4789fc","AdeProjectName":"project-1","AdeDevCenterName":"dc-wabrez-od3kzvk4mwe72","AdeEnvironmentTypeName":"Dev"},"properties":{"templateLink":{"uri":"https://d55vj9m1o8u4cm4o.blob.core.windows.net/templates/project-1.azdtest-w4789fc.133534499416341033/EnvironmentDefinitions/HelloWorld/azuredeploy.json","contentVersion":"1.0.0.0"},"templateHash":"17645299908346333518","parameters":{"repoUrl":{"type":"String","value":"https://github.com/wbreza/azd-hello-world"},"environmentName":{"type":"String","value":"azdtest-w4789fc"},"location":{"type":"String","value":"eastus2"},"serviceName":{"type":"String","value":""},"appServicePlanName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:40:27.6950264Z","duration":"PT1M20.8125551S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/appserviceplan","resourceType":"Microsoft.Resources/deployments","resourceName":"appserviceplan"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/appserviceplan","resourceType":"Microsoft.Resources/deployments","resourceName":"appserviceplan","apiVersion":"2022-09-01"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/helloworld","resourceType":"Microsoft.Resources/deployments","resourceName":"helloworld"}],"outputs":{"azurE_LOCATION":{"type":"String","value":"eastus2"},"azurE_TENANT_ID":{"type":"String","value":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"servicE_API_ENDPOINTS":{"type":"Array","value":["https://app-helloworld-4y6ae2hdnphbq.azurewebsites.net"]}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/logs"}]}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "13713"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:42:52 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 89a6dd550f0c0aac637bbf734451b612
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11996"
+            X-Ms-Request-Id:
+                - c9ba5318-0aae-48cb-af31-c1e80965b008
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T194252Z:c9ba5318-0aae-48cb-af31-c1e80965b008
+            X-Msedge-Ref:
+                - 'Ref A: 3A6507CBBF3B40A0BA512C2D2B171EEC Ref B: CO6AA3150217053 Ref C: 2024-02-26T19:42:52Z'
+        status: 200 OK
+        code: 200
+        duration: 550.9765ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w4789fc?api-version=2023-04-01
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 275
+        uncompressed: false
+        body: |-
+            {
+              "id": "/projects/project-1/operationStatuses/82a5d0b5-6b7a-4fff-863b-bc1297aeb486",
+              "name": "82a5d0b5-6b7a-4fff-863b-bc1297aeb486",
+              "status": "NotStarted",
+              "resourceId": "/projects/project-1/users/19a2053b-445a-4023-95d3-c339051e0f32/environments/azdtest-w4789fc"
+            }
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
+            Content-Length:
+                - "275"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:42:55 GMT
+            Location:
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/82a5d0b5-6b7a-4fff-863b-bc1297aeb486?api-version=2023-04-01&monitor=true
+            Operation-Location:
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/82a5d0b5-6b7a-4fff-863b-bc1297aeb486?api-version=2023-04-01
+            Strict-Transport-Security:
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - cf755848-eb18-43b7-b657-bb9e18c7dcbf
+            X-Ms-Correlation-Request-Id:
+                - bbd4869f-2ad8-4143-a5d6-688ec25c6936
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "299"
+            X-Rate-Limit-Reset:
+                - "2024-02-26T19:43:53.4750476Z"
+        status: 202 Accepted
+        code: 202
+        duration: 2.3481616s
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/project-1/operationstatuses/82a5d0b5-6b7a-4fff-863b-bc1297aeb486?api-version=2023-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |-
+            {
+              "id": "/projects/project-1/operationStatuses/82a5d0b5-6b7a-4fff-863b-bc1297aeb486",
+              "name": "82a5d0b5-6b7a-4fff-863b-bc1297aeb486",
+              "status": "Succeeded",
+              "startTime": "2024-02-26T19:42:53.8066979+00:00",
+              "endTime": "2024-02-26T19:43:44.1206993+00:00"
+            }
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 19:43:55 GMT
+            Location:
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/82a5d0b5-6b7a-4fff-863b-bc1297aeb486?api-version=2023-04-01&monitor=true
+            Operation-Location:
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/82a5d0b5-6b7a-4fff-863b-bc1297aeb486?api-version=2023-04-01
+            Retry-After:
+                - "30"
+            Strict-Transport-Security:
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - 544c4ed9-347e-4662-bc36-2c735fe8db72
+            X-Ms-Correlation-Request-Id:
+                - 4df969f3-08f4-4170-8604-de075d6acc61
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "299"
+            X-Rate-Limit-Reset:
+                - "2024-02-26T19:44:55.5410830Z"
+        status: 200 OK
+        code: 200
+        duration: 137.8488ms
+---
+env_name: azdtest-w4789fc
+time: "1708976237"


### PR DESCRIPTION
Adds e2e tests for ADE deventer integration and performs a complete `azd init` + `azd up` + `azd down` flow.

**Adds the following to support better testability:**
- Ability to set platform type via environment variable `AZD_PLATFORM_TYPE`
- Adds ability to filter dev center templates by catalog name
- Removes unnecessary custom poller implementation (works better with recorder as well)

**Fixes some minor ADE bugs found in testing**
- Fixes bug with incorrect environment variable reference for devcenter name 
- Ensures devcenter configuration parameters are stored back into environment configuration