### PR TITLE
vs-server: Include `path` to service instead of `kind`

### DIFF
--- a/cli/azd/internal/vsrpc/models.go
+++ b/cli/azd/internal/vsrpc/models.go
@@ -30,7 +30,7 @@ type EnvironmentInfo struct {
 type Service struct {
 	Name       string
 	IsExternal bool
-	Kind       *string `json:",omitempty"`
+	Path       string
 	Endpoint   *string `json:",omitempty"`
 	ResourceId *string `json:",omitempty"`
 }

--- a/cli/azd/internal/vsrpc/utils.go
+++ b/cli/azd/internal/vsrpc/utils.go
@@ -37,6 +37,7 @@ func servicesFromManifest(manifest *apphost.Manifest) []*Service {
 		if res.Type == "project.v0" {
 			services = append(services, &Service{
 				Name: name,
+				Path: *res.Path,
 			})
 		}
 	}

--- a/cli/azd/test/functional/testdata/vs-server/tests/AcceptanceTests.cs
+++ b/cli/azd/test/functional/testdata/vs-server/tests/AcceptanceTests.cs
@@ -15,7 +15,11 @@ public class AcceptanceTests : TestBase
     {
         IObserver<ProgressMessage> observer = new WriterObserver<ProgressMessage>();
         var session = await svrSvc.InitializeAsync(_rootDir, CancellationToken.None);
-        var result = await asSvc.GetAspireHostAsync(session, "Production", observer, CancellationToken.None);
+        var result = await asSvc.GetAspireHostAsync(session, "Production", observer, CancellationToken.None);       
+        result.Services.Count.ShouldEqual(2);
+        result.Services[0].Path.ShouldNotBeEmpty();
+        result.Services[1].Path.ShouldNotBeEmpty();
+
         var environments = (await esSvc.GetEnvironmentsAsync(session, observer, CancellationToken.None)).ToList();
         environments.ShouldBeEmpty();
 
@@ -64,10 +68,16 @@ public class AcceptanceTests : TestBase
         var openEnv = await esSvc.OpenEnvironmentAsync(session, e.Name, observer, CancellationToken.None);
         openEnv.Name.ShouldEqual(e.Name);
         openEnv.IsCurrent.ShouldBeFalse();
+        openEnv.Services.Count.ShouldEqual(2);
+        openEnv.Services[0].Path.ShouldNotBeEmpty();
+        openEnv.Services[1].Path.ShouldNotBeEmpty();
 
         openEnv = await esSvc.OpenEnvironmentAsync(session, e2.Name, observer, CancellationToken.None);
         openEnv.Name.ShouldEqual(e2.Name);
         openEnv.IsCurrent.ShouldBeTrue();
+        openEnv.Services.Count.ShouldEqual(2);
+        openEnv.Services[0].Path.ShouldNotBeEmpty();
+        openEnv.Services[1].Path.ShouldNotBeEmpty();
 
         await esSvc.SetCurrentEnvironmentAsync(session, e.Name, observer, CancellationToken.None);
         openEnv = await esSvc.OpenEnvironmentAsync(session, e.Name, observer, CancellationToken.None);

--- a/cli/azd/test/functional/testdata/vs-server/tests/AzdServices.cs
+++ b/cli/azd/test/functional/testdata/vs-server/tests/AzdServices.cs
@@ -35,17 +35,13 @@ public class AspireHost {
     public string Path { get; set; } = "";
 
     public Service[] Services { get; set; } = [];
-
-    public string? Kind { get; set; }
-    public string? Endpoint { get; set; }
-    public string? ResourceId { get; set; }
 }
 
 public class Service {
     public string Name { get; set; }  = "";
 	public bool IsExternal { get; set; }
 
-    public string? Kind { get; set;}
+    public string Path { get; set;}
     public string? Endpoint { get; set;}
     public string? ResourceId { get; set;}
 }


### PR DESCRIPTION
Neither Aspire nor `azd` proper have the concept for a "kind" for a service. Instead of forcing us to come up with some meaning, simply return the full path to the project, as we would in other cases like `azd show`. Consumers can use the path to determine the "kind" of service it is, using whatever huristics they like.

Fixes #3374