### PR TITLE
Set `DOTNET_ENVIRONMENT` when running AppHost

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -23,6 +23,8 @@ armcognitiveservices
 armcosmos
 armresourcegraph
 armsql
+aspnet
+aspnetcore
 asyncmy
 asyncpg
 azapi
@@ -58,6 +60,7 @@ circleci
 cmdrecord
 cmdsubst
 cognitiveservices
+conditionalize
 consolesize
 containerapp
 containerapps
@@ -135,6 +138,7 @@ otlp
 otlpconfig
 otlptrace
 otlptracehttp
+overriden
 paketobuildpacks
 pflag
 posix

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -88,7 +88,7 @@ func (i *Initializer) InitFromApp(
 			continue
 		}
 
-		manifest, err := apphost.ManifestFromAppHost(ctx, prj.Path, i.dotnetCli)
+		manifest, err := apphost.ManifestFromAppHost(ctx, prj.Path, i.dotnetCli, "")
 		if err != nil {
 			return fmt.Errorf("failed to generate manifest from app host project: %w", err)
 		}

--- a/cli/azd/internal/vsrpc/aspire_service.go
+++ b/cli/azd/internal/vsrpc/aspire_service.go
@@ -73,7 +73,7 @@ func (s *aspireService) GetAspireHostAsync(
 			Path: appHost.Path(),
 		}
 
-		manifest, err := apphost.ManifestFromAppHost(ctx, appHost.Path(), c.dotnetCli)
+		manifest, err := apphost.ManifestFromAppHost(ctx, appHost.Path(), c.dotnetCli, aspireEnv)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load app host manifest: %w", err)
 		}
@@ -101,7 +101,7 @@ func (s *aspireService) GetAspireHostAsync(
 			Path: hosts[0].Path,
 		}
 
-		manifest, err := apphost.ManifestFromAppHost(ctx, hosts[0].Path, c.dotnetCli)
+		manifest, err := apphost.ManifestFromAppHost(ctx, hosts[0].Path, c.dotnetCli, aspireEnv)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load app host manifest: %w", err)
 		}

--- a/cli/azd/internal/vsrpc/environment_service_load.go
+++ b/cli/azd/internal/vsrpc/environment_service_load.go
@@ -87,9 +87,8 @@ func (s *environmentService) loadEnvironmentAsync(
 	ret := &Environment{
 		Name: name,
 		Properties: map[string]string{
-			"Subscription":       e.GetSubscriptionId(),
-			"Location":           e.GetLocation(),
-			"ASPIRE_ENVIRONMENT": e.Getenv("ASPIRE_ENVIRONMENT"),
+			"Subscription": e.GetSubscriptionId(),
+			"Location":     e.GetLocation(),
 		},
 		IsCurrent: name == currentEnv,
 		Values:    e.Dotenv(),

--- a/cli/azd/pkg/apphost/generate_test.go
+++ b/cli/azd/pkg/apphost/generate_test.go
@@ -68,7 +68,7 @@ func TestAspireEscaping(t *testing.T) {
 	mockPublishManifest(mockCtx, aspireEscapingManifest, nil)
 	mockCli := dotnet.NewDotNetCli(mockCtx.CommandRunner)
 
-	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli)
+	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli, "")
 	require.NoError(t, err)
 
 	for _, name := range []string{"api"} {
@@ -90,7 +90,7 @@ func TestAspireStorageGeneration(t *testing.T) {
 	mockPublishManifest(mockCtx, aspireStorageManifest, nil)
 	mockCli := dotnet.NewDotNetCli(mockCtx.CommandRunner)
 
-	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli)
+	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli, "")
 	require.NoError(t, err)
 
 	files, err := BicepTemplate(m)
@@ -128,7 +128,7 @@ func TestAspireBicepGeneration(t *testing.T) {
 	mockPublishManifest(mockCtx, aspireBicepManifest, filesFromManifest)
 	mockCli := dotnet.NewDotNetCli(mockCtx.CommandRunner)
 
-	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli)
+	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli, "")
 	require.NoError(t, err)
 
 	files, err := BicepTemplate(m)
@@ -163,7 +163,7 @@ func TestAspireDockerGeneration(t *testing.T) {
 	mockPublishManifest(mockCtx, aspireDockerManifest, nil)
 	mockCli := dotnet.NewDotNetCli(mockCtx.CommandRunner)
 
-	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli)
+	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli, "")
 	require.NoError(t, err)
 
 	// The App Host manifest does not set the external bit for project resources. Instead, `azd` or whatever tool consumes
@@ -214,7 +214,7 @@ func TestAspireContainerGeneration(t *testing.T) {
 	mockPublishManifest(mockCtx, aspireContainerManifest, nil)
 	mockCli := dotnet.NewDotNetCli(mockCtx.CommandRunner)
 
-	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli)
+	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli, "")
 	require.NoError(t, err)
 
 	files, err := BicepTemplate(m)

--- a/cli/azd/pkg/apphost/manifest.go
+++ b/cli/azd/pkg/apphost/manifest.go
@@ -119,7 +119,9 @@ type InputDefaultGenerate struct {
 }
 
 // ManifestFromAppHost returns the Manifest from the given app host.
-func ManifestFromAppHost(ctx context.Context, appHostProject string, dotnetCli dotnet.DotNetCli) (*Manifest, error) {
+func ManifestFromAppHost(
+	ctx context.Context, appHostProject string, dotnetCli dotnet.DotNetCli, dotnetEnv string,
+) (*Manifest, error) {
 	tempDir, err := os.MkdirTemp("", "azd-provision")
 	if err != nil {
 		return nil, fmt.Errorf("creating temp directory for apphost-manifest.json: %w", err)
@@ -128,7 +130,7 @@ func ManifestFromAppHost(ctx context.Context, appHostProject string, dotnetCli d
 
 	manifestPath := filepath.Join(tempDir, "apphost-manifest.json")
 
-	if err := dotnetCli.PublishAppHostManifest(ctx, appHostProject, manifestPath); err != nil {
+	if err := dotnetCli.PublishAppHostManifest(ctx, appHostProject, manifestPath, dotnetEnv); err != nil {
 		return nil, fmt.Errorf("generating app host manifest: %w", err)
 	}
 

--- a/cli/azd/pkg/project/dotnet_importer.go
+++ b/cli/azd/pkg/project/dotnet_importer.go
@@ -37,11 +37,18 @@ type DotNetImporter struct {
 	// operation and it is expensive to generate. We should consider if this is the correct location for the cache or if
 	// it should be in some higher level component. Right now the lifetime issues are not too large of a deal, since
 	// `azd` processes are short lived.
-	cache   map[string]*apphost.Manifest
+	cache   map[manifestCacheKey]*apphost.Manifest
 	cacheMu sync.Mutex
 
 	hostCheck   map[string]hostCheckResult
 	hostCheckMu sync.Mutex
+}
+
+// manifestCacheKey is the key we use when caching manifests. It is a combination of the project path and the
+// DOTNET_ENVIRONMENT value (which can influence manifest generation)
+type manifestCacheKey struct {
+	projectPath       string
+	dotnetEnvironment string
 }
 
 func NewDotNetImporter(
@@ -55,7 +62,7 @@ func NewDotNetImporter(
 		console:        console,
 		lazyEnv:        lazyEnv,
 		lazyEnvManager: lazyEnvManager,
-		cache:          make(map[string]*apphost.Manifest),
+		cache:          make(map[manifestCacheKey]*apphost.Manifest),
 		hostCheck:      make(map[string]hostCheckResult),
 	}
 }
@@ -321,18 +328,29 @@ func (ai *DotNetImporter) ReadManifest(ctx context.Context, svcConfig *ServiceCo
 	ai.cacheMu.Lock()
 	defer ai.cacheMu.Unlock()
 
-	if cached, has := ai.cache[svcConfig.Path()]; has {
+	var dotnetEnv string
+
+	if env, err := ai.lazyEnv.GetValue(); err == nil {
+		dotnetEnv = env.Getenv("DOTNET_ENVIRONMENT")
+	}
+
+	cacheKey := manifestCacheKey{
+		projectPath:       svcConfig.Path(),
+		dotnetEnvironment: dotnetEnv,
+	}
+
+	if cached, has := ai.cache[cacheKey]; has {
 		return cached, nil
 	}
 
 	ai.console.ShowSpinner(ctx, "Analyzing Aspire Application (this might take a moment...)", input.Step)
-	manifest, err := apphost.ManifestFromAppHost(ctx, svcConfig.Path(), ai.dotnetCli)
+	manifest, err := apphost.ManifestFromAppHost(ctx, svcConfig.Path(), ai.dotnetCli, dotnetEnv)
 	ai.console.StopSpinner(ctx, "", input.Step)
 	if err != nil {
 		return nil, err
 	}
 
-	ai.cache[svcConfig.Path()] = manifest
+	ai.cache[cacheKey] = manifest
 	return manifest, nil
 }
 

--- a/cli/azd/pkg/tools/dotnet/dotnet.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet.go
@@ -28,7 +28,10 @@ type DotNetCli interface {
 		ctx context.Context, project, configuration, imageName, server, username, password string,
 	) error
 	InitializeSecret(ctx context.Context, project string) error
-	PublishAppHostManifest(ctx context.Context, hostProject string, manifestPath string) error
+	// PublishAppHostManifest runs the app host program with the correct configuration to generate an manifest. If dotnetEnv
+	// is non-empty, it will be passed as environment variables (named `DOTNET_ENVIRONMENT`) when running the app host
+	// program.
+	PublishAppHostManifest(ctx context.Context, hostProject string, manifestPath string, dotnetEnv string) error
 	SetSecrets(ctx context.Context, secrets map[string]string, project string) error
 	GetMsBuildProperty(ctx context.Context, project string, propertyName string) (string, error)
 }
@@ -120,9 +123,8 @@ func (cli *dotNetCli) Publish(ctx context.Context, project string, configuration
 }
 
 func (cli *dotNetCli) PublishAppHostManifest(
-	ctx context.Context, hostProject string, manifestPath string,
+	ctx context.Context, hostProject string, manifestPath string, dotnetEnv string,
 ) error {
-
 	// TODO(ellismg): Before we GA manifest support, we should remove this debug tool, but being able to control what
 	// manifest is used is helpful, while the manifest/generator is still being built.  So if
 	// `AZD_DEBUG_DOTNET_APPHOST_USE_FIXED_MANIFEST` is set, then we will expect to find apphost-manifest.json SxS with the host
@@ -143,6 +145,18 @@ func (cli *dotNetCli) PublishAppHostManifest(
 		"dotnet", "run", "--project", filepath.Base(hostProject), "--publisher", "manifest", "--output-path", manifestPath)
 
 	runArgs = runArgs.WithCwd(filepath.Dir(hostProject))
+
+	// AppHosts may conditionalize their infrastructure based on the environment, so we need to pass the environment when we
+	// are `dotnet run`ing the app host project to produce its manifest.
+	var envArgs []string
+
+	if dotnetEnv != "" {
+		envArgs = append(envArgs, fmt.Sprintf("DOTNET_ENVIRONMENT=%s", dotnetEnv))
+	}
+
+	if envArgs != nil {
+		runArgs = runArgs.WithEnv(envArgs)
+	}
 
 	_, err := cli.commandRunner.Run(ctx, runArgs)
 	if err != nil {

--- a/cli/azd/test/functional/aspire_test.go
+++ b/cli/azd/test/functional/aspire_test.go
@@ -84,7 +84,7 @@ func Test_CLI_Aspire_DetectGen(t *testing.T) {
 		appHostProject := filepath.Join(dir, "AspireAzdTests.AppHost")
 		manifestPath := filepath.Join(appHostProject, "manifest.json")
 
-		err = dotnetCli.PublishAppHostManifest(ctx, appHostProject, manifestPath)
+		err = dotnetCli.PublishAppHostManifest(ctx, appHostProject, manifestPath, "")
 		require.NoError(t, err)
 
 		err = snapshotFile(sn, snRoot, dir, manifestPath)


### PR DESCRIPTION
- Flow `DOTNET_ENVIRONMENT` into the process environment from the  `.env` file when running the app host program to generate the manifest.

- Use `ASPIRE_ENVIRONMENT` (when set, VS will likely remove it soon as we have decided to not introduce yet another concept) to influence `DOTNET_ENVIRONMENT` during environment creation in the VS Server RPC.

- When caching manifests in the `DotNetImporter`, use the tuple of  `{app-host-path, DOTNET_ENVIRONMENT}` as the   cache key, instead of just the path to the manifest as the output of these manifest can depend on these values.

Fixes: https://github.com/Azure/azure-dev/issues/3233