### PR TITLE
Aspire fix for json arrays

### DIFF
--- a/cli/azd/pkg/apphost/generate_test.go
+++ b/cli/azd/pkg/apphost/generate_test.go
@@ -125,6 +125,7 @@ func TestAspireBicepGeneration(t *testing.T) {
 	filesFromManifest := make(map[string]string)
 	filesFromManifest["test.bicep"] = "bicep file contents"
 	filesFromManifest["aspire.hosting.azure.bicep.postgres.bicep"] = "bicep file contents"
+	filesFromManifest["aspire.hosting.azure.bicep.servicebus.bicep"] = "bicep file contents"
 	mockPublishManifest(mockCtx, aspireBicepManifest, filesFromManifest)
 	mockCli := dotnet.NewDotNetCli(mockCtx.CommandRunner)
 

--- a/cli/azd/pkg/apphost/generate_test.go
+++ b/cli/azd/pkg/apphost/generate_test.go
@@ -123,9 +123,10 @@ func TestAspireBicepGeneration(t *testing.T) {
 	ctx := context.Background()
 	mockCtx := mocks.NewMockContext(ctx)
 	filesFromManifest := make(map[string]string)
-	filesFromManifest["test.bicep"] = "bicep file contents"
-	filesFromManifest["aspire.hosting.azure.bicep.postgres.bicep"] = "bicep file contents"
-	filesFromManifest["aspire.hosting.azure.bicep.servicebus.bicep"] = "bicep file contents"
+	ignoredBicepContent := "bicep file contents"
+	filesFromManifest["test.bicep"] = ignoredBicepContent
+	filesFromManifest["aspire.hosting.azure.bicep.postgres.bicep"] = ignoredBicepContent
+	filesFromManifest["aspire.hosting.azure.bicep.servicebus.bicep"] = ignoredBicepContent
 	mockPublishManifest(mockCtx, aspireBicepManifest, filesFromManifest)
 	mockCli := dotnet.NewDotNetCli(mockCtx.CommandRunner)
 

--- a/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-main.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-main.bicep.snap
@@ -53,6 +53,18 @@ module postgres2 'postgres2/aspire.hosting.azure.bicep.postgres.bicep' = {
     serverName: 'postgres2'
   }
 }
+module sb 'sb/aspire.hosting.azure.bicep.servicebus.bicep' = {
+  name: 'sb'
+  scope: rg
+  params: {
+    location: location
+    principalId: resources.outputs.MANAGED_IDENTITY_PRINCIPAL_ID
+    principalType: 'ServicePrincipal'
+    queues: ['queue1']
+    serviceBusNamespaceName: 'sb'
+    topics: [{name:'topic1',subscriptions:['subscription1','subscription2']},{name:'topic2',subscriptions:['subscription1']}]
+  }
+}
 module test 'test/test.bicep' = {
   name: 'test'
   scope: rg
@@ -71,5 +83,6 @@ output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = resources.outputs.AZURE_CONT
 output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = resources.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN
 output SERVICE_BINDING_POSTGRES2KV_ENDPOINT string = resources.outputs.SERVICE_BINDING_POSTGRES2KV_ENDPOINT
 
+output SB_SERVICEBUSENDPOINT string = sb.outputs.serviceBusEndpoint
 output TEST_TEST string = test.outputs.test
 output TEST_VAL0 string = test.outputs.val0

--- a/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-sb-aspire.hosting.azure.bicep.servicebus.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-sb-aspire.hosting.azure.bicep.servicebus.bicep.snap
@@ -1,0 +1,1 @@
+bicep file contents

--- a/cli/azd/pkg/apphost/testdata/aspire-bicep.json
+++ b/cli/azd/pkg/apphost/testdata/aspire-bicep.json
@@ -58,6 +58,34 @@
         "parent": "postgres2",
         "connectionString": "{postgres2.connectionString};Database=db2;"
       },
+      "sb": {
+        "type": "azure.bicep.v0",
+        "connectionString": "{sb.outputs.serviceBusEndpoint}",
+        "path": "aspire.hosting.azure.bicep.servicebus.bicep",
+        "params": {
+          "serviceBusNamespaceName": "sb",
+          "principalId": "",
+          "principalType": "",
+          "queues": [
+            "queue1"
+          ],
+          "topics": [
+            {
+              "name": "topic1",
+              "subscriptions": [
+                "subscription1",
+                "subscription2"
+              ]
+            },
+            {
+              "name": "topic2",
+              "subscriptions": [
+                "subscription1"
+              ]
+            }
+          ]
+        }
+      },
       "frontend": {
         "type": "project.v0",
         "path": "../Test1.Web/Test1.Web.csproj",
@@ -66,7 +94,8 @@
           "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
           "ConnectionStrings__db2": "{db2.connectionString}",
           "bicepValue_test": "{test.outputs.test}",
-          "bicepValue0": "{test.outputs.val0}"
+          "bicepValue0": "{test.outputs.val0}",
+          "ConnectionStrings__sb": "{sb.connectionString}"
         },
         "bindings": {
           "http": {


### PR DESCRIPTION
Fix to support array of objects as input parameters for bicep.v0

A param like:
```json
"params": {
          "topics": [
            {
              "name": "topic1",
              "subscriptions": [
                "subscription1",
                "subscription2"
              ]
            }
}
```

should be modeled into bicep:

```bicep
  params: {
    topics: [{name:'topic1',subscriptions:['subscription1','subscription2']},{name:'topic2',subscriptions:['subscription1']}]
  }
```