### PR TITLE
vsrpc: Expose provisioned resources

### DIFF
--- a/cli/azd/cmd/deps_record.go
+++ b/cli/azd/cmd/deps_record.go
@@ -8,6 +8,7 @@ package cmd
 import (
 	"crypto/tls"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"time"
@@ -19,6 +20,17 @@ func createHttpClient() *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	// Allow for self-signed certificates, which is what the recording proxy uses.
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	// AZD_TEST_HTTPS_PROXY is the proxy setting that only affects azd in record mode.
+	// This is useful since the recording proxy server isn't trusted by other processes currently.
+	if val, ok := os.LookupEnv("AZD_TEST_HTTPS_PROXY"); ok {
+		proxyUrl, err := url.Parse(val)
+		if err != nil {
+			panic(err)
+		}
+
+		transport.Proxy = http.ProxyURL(proxyUrl)
+	}
+
 	client := &http.Client{
 		Transport: transport,
 	}

--- a/cli/azd/internal/cmd/deploy.go
+++ b/cli/azd/internal/cmd/deploy.go
@@ -28,7 +28,7 @@ import (
 
 type DeployFlags struct {
 	serviceName string
-	all         bool
+	All         bool
 	fromPackage string
 	global      *internal.GlobalCommandOptions
 	*internal.EnvFlag
@@ -59,7 +59,7 @@ func (d *DeployFlags) bindCommon(local *pflag.FlagSet, global *internal.GlobalCo
 	d.EnvFlag.Bind(local, global)
 
 	local.BoolVar(
-		&d.all,
+		&d.All,
 		"all",
 		false,
 		"Deploys all services that are listed in "+azdcontext.ProjectFileName,
@@ -183,13 +183,13 @@ func (da *DeployAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 		da.projectConfig,
 		string(project.ServiceEventDeploy),
 		targetServiceName,
-		da.flags.all,
+		da.flags.All,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	if da.flags.all && da.flags.fromPackage != "" {
+	if da.flags.All && da.flags.fromPackage != "" {
 		return nil, errors.New(
 			"'--from-package' cannot be specified when '--all' is set. Specify a specific service by passing a <service>")
 	}

--- a/cli/azd/internal/vsrpc/environment_service_deploy.go
+++ b/cli/azd/internal/vsrpc/environment_service_deploy.go
@@ -57,6 +57,7 @@ func (s *environmentService) DeployAsync(
 			NoPrompt: true,
 		},
 	)
+	deployFlags.All = true
 
 	container.MustRegisterScoped(func() internal.EnvFlag {
 		return internal.EnvFlag{

--- a/cli/azd/internal/vsrpc/models.go
+++ b/cli/azd/internal/vsrpc/models.go
@@ -20,6 +20,13 @@ type Environment struct {
 	Services       []*Service
 	Values         map[string]string
 	LastDeployment *DeploymentResult `json:",omitempty"`
+	Resources      []*Resource
+}
+
+type Resource struct {
+	Name string
+	Type string
+	Id   string
 }
 
 type EnvironmentInfo struct {

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -623,6 +623,21 @@ func randomOrStoredEnvName(session *recording.Session) string {
 	return randName
 }
 
+func cfgOrStoredSubscription(session *recording.Session) string {
+	if session != nil && session.Playback {
+		if _, ok := session.Variables[recording.SubscriptionIdKey]; ok {
+			return session.Variables[recording.SubscriptionIdKey]
+		}
+	}
+
+	subID := cfg.SubscriptionID
+	if session != nil {
+		session.Variables[recording.SubscriptionIdKey] = subID
+	}
+
+	return subID
+}
+
 func randomEnvName() string {
 	bytes := make([]byte, 4)
 	_, err := rand.Read(bytes)

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_VsServer/LiveDeployRefresh.dotnet.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_VsServer/LiveDeployRefresh.dotnet.yaml
@@ -4,76 +4,76 @@ interactions:
     - id: 0
       args:
         - publish
-        - /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.ApiService/AspireAzdTests.ApiService.csproj
+        - /tmp/Test_CLI_VsServerLiveDeployRefresh3447454072/001/AspireAzdTests.ApiService/AspireAzdTests.ApiService.csproj
         - -r
         - linux-x64
         - -c
         - Debug
         - -p:PublishProfile=DefaultContainer
-        - -p:ContainerImageName=azd-deploy-apiservice-1708717459
-        - -p:ContainerRegistry=acrgnxzs2f5m4idm.azurecr.io
+        - -p:ContainerImageName=azd-deploy-apiservice-1708981409
+        - -p:ContainerRegistry=acrsoindfxt2muzw.azurecr.io
       exitCode: 0
       stdout: |
         MSBuild version 17.8.3+195e7f5a3 for .NET
           Determining projects to restore...
-          Restored /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.ServiceDefaults/AspireAzdTests.ServiceDefaults.csproj (in 501 ms).
-          Restored /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.ApiService/AspireAzdTests.ApiService.csproj (in 491 ms).
-          AspireAzdTests.ServiceDefaults -> /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.ServiceDefaults/bin/Debug/net8.0/AspireAzdTests.ServiceDefaults.dll
-          AspireAzdTests.ApiService -> /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.ApiService/bin/Debug/net8.0/linux-x64/AspireAzdTests.ApiService.dll
-          AspireAzdTests.ApiService -> /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.ApiService/bin/Debug/net8.0/linux-x64/publish/
-        /home/weilim/.dotnet/sdk/8.0.100/Containers/build/Microsoft.NET.Build.Containers.targets(73,5): warning CONTAINER003: The property 'ContainerImageName' was set but is obsolete - please use 'ContainerRepository' instead. [/tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.ApiService/AspireAzdTests.ApiService.csproj]
-          Building image 'azd-deploy-apiservice-1708717459' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime-deps:8.0'.
-          Uploading layer 'sha256:e1caac4eb9d2ec24aa3618e5992208321a92492aef5fef5eb9e470895f771c56' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Uploading layer 'sha256:bee002b9602903883406290e40d3b516d52d4c84a115ce16261a643f98f781ad' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Uploading layer 'sha256:e65deb0614ae8da7b6f6c2c049d03a47bfeb6a717d593de703d1c3471087eaaf' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Uploading layer 'sha256:0431bf7479963cb95650372df48718c37de7520d904f8b55c21697eca07f671e' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Finished uploading layer 'sha256:e65deb0614ae8da7b6f6c2c049d03a47bfeb6a717d593de703d1c3471087eaaf' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Finished uploading layer 'sha256:e1caac4eb9d2ec24aa3618e5992208321a92492aef5fef5eb9e470895f771c56' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Finished uploading layer 'sha256:0431bf7479963cb95650372df48718c37de7520d904f8b55c21697eca07f671e' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Finished uploading layer 'sha256:bee002b9602903883406290e40d3b516d52d4c84a115ce16261a643f98f781ad' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Uploading config to registry at blob 'sha256:6caa9f51ff3238e0a27a7d333381fb2465af5e428128ba67a6aded50dc8d6656',
+          Restored /tmp/Test_CLI_VsServerLiveDeployRefresh3447454072/001/AspireAzdTests.ServiceDefaults/AspireAzdTests.ServiceDefaults.csproj (in 526 ms).
+          Restored /tmp/Test_CLI_VsServerLiveDeployRefresh3447454072/001/AspireAzdTests.ApiService/AspireAzdTests.ApiService.csproj (in 512 ms).
+          AspireAzdTests.ServiceDefaults -> /tmp/Test_CLI_VsServerLiveDeployRefresh3447454072/001/AspireAzdTests.ServiceDefaults/bin/Debug/net8.0/AspireAzdTests.ServiceDefaults.dll
+          AspireAzdTests.ApiService -> /tmp/Test_CLI_VsServerLiveDeployRefresh3447454072/001/AspireAzdTests.ApiService/bin/Debug/net8.0/linux-x64/AspireAzdTests.ApiService.dll
+          AspireAzdTests.ApiService -> /tmp/Test_CLI_VsServerLiveDeployRefresh3447454072/001/AspireAzdTests.ApiService/bin/Debug/net8.0/linux-x64/publish/
+        /home/weilim/.dotnet/sdk/8.0.100/Containers/build/Microsoft.NET.Build.Containers.targets(73,5): warning CONTAINER003: The property 'ContainerImageName' was set but is obsolete - please use 'ContainerRepository' instead. [/tmp/Test_CLI_VsServerLiveDeployRefresh3447454072/001/AspireAzdTests.ApiService/AspireAzdTests.ApiService.csproj]
+          Building image 'azd-deploy-apiservice-1708981409' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime-deps:8.0'.
+          Uploading layer 'sha256:e1caac4eb9d2ec24aa3618e5992208321a92492aef5fef5eb9e470895f771c56' to 'acrsoindfxt2muzw.azurecr.io'.
+          Uploading layer 'sha256:bee002b9602903883406290e40d3b516d52d4c84a115ce16261a643f98f781ad' to 'acrsoindfxt2muzw.azurecr.io'.
+          Uploading layer 'sha256:e65deb0614ae8da7b6f6c2c049d03a47bfeb6a717d593de703d1c3471087eaaf' to 'acrsoindfxt2muzw.azurecr.io'.
+          Uploading layer 'sha256:e93a3b0c33ad6a063eb30b66b8db034a88c2d3bafb098768a057200dfe687c8d' to 'acrsoindfxt2muzw.azurecr.io'.
+          Finished uploading layer 'sha256:e65deb0614ae8da7b6f6c2c049d03a47bfeb6a717d593de703d1c3471087eaaf' to 'acrsoindfxt2muzw.azurecr.io'.
+          Finished uploading layer 'sha256:bee002b9602903883406290e40d3b516d52d4c84a115ce16261a643f98f781ad' to 'acrsoindfxt2muzw.azurecr.io'.
+          Finished uploading layer 'sha256:e93a3b0c33ad6a063eb30b66b8db034a88c2d3bafb098768a057200dfe687c8d' to 'acrsoindfxt2muzw.azurecr.io'.
+          Finished uploading layer 'sha256:e1caac4eb9d2ec24aa3618e5992208321a92492aef5fef5eb9e470895f771c56' to 'acrsoindfxt2muzw.azurecr.io'.
+          Uploading config to registry at blob 'sha256:8b008c7866af996e78c2bd1af6fea62a20f8bb2f59c0fd4ea5384993e76ccc60',
           Uploaded config to registry.
-          Uploading tag 'latest' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Uploaded tag 'latest' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Pushed image 'azd-deploy-apiservice-1708717459:latest' to registry 'acrgnxzs2f5m4idm.azurecr.io'.
+          Uploading tag 'latest' to 'acrsoindfxt2muzw.azurecr.io'.
+          Uploaded tag 'latest' to 'acrsoindfxt2muzw.azurecr.io'.
+          Pushed image 'azd-deploy-apiservice-1708981409:latest' to registry 'acrsoindfxt2muzw.azurecr.io'.
 
         Workload updates are available. Run `dotnet workload list` for more information.
       stderr: ""
     - id: 1
       args:
         - publish
-        - /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.Web/AspireAzdTests.Web.csproj
+        - /tmp/Test_CLI_VsServerLiveDeployRefresh3447454072/001/AspireAzdTests.Web/AspireAzdTests.Web.csproj
         - -r
         - linux-x64
         - -c
         - Debug
         - -p:PublishProfile=DefaultContainer
-        - -p:ContainerImageName=azd-deploy-webfrontend-1708717493
-        - -p:ContainerRegistry=acrgnxzs2f5m4idm.azurecr.io
+        - -p:ContainerImageName=azd-deploy-webfrontend-1708981443
+        - -p:ContainerRegistry=acrsoindfxt2muzw.azurecr.io
       exitCode: 0
       stdout: |
         MSBuild version 17.8.3+195e7f5a3 for .NET
           Determining projects to restore...
-          Restored /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.Web/AspireAzdTests.Web.csproj (in 568 ms).
+          Restored /tmp/Test_CLI_VsServerLiveDeployRefresh3447454072/001/AspireAzdTests.Web/AspireAzdTests.Web.csproj (in 449 ms).
           1 of 2 projects are up-to-date for restore.
-          AspireAzdTests.ServiceDefaults -> /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.ServiceDefaults/bin/Debug/net8.0/AspireAzdTests.ServiceDefaults.dll
-          AspireAzdTests.Web -> /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.Web/bin/Debug/net8.0/linux-x64/AspireAzdTests.Web.dll
-          AspireAzdTests.Web -> /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.Web/bin/Debug/net8.0/linux-x64/publish/
-        /home/weilim/.dotnet/sdk/8.0.100/Containers/build/Microsoft.NET.Build.Containers.targets(73,5): warning CONTAINER003: The property 'ContainerImageName' was set but is obsolete - please use 'ContainerRepository' instead. [/tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.Web/AspireAzdTests.Web.csproj]
-          Building image 'azd-deploy-webfrontend-1708717493' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime-deps:8.0'.
-          Uploading layer 'sha256:e1caac4eb9d2ec24aa3618e5992208321a92492aef5fef5eb9e470895f771c56' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Uploading layer 'sha256:bee002b9602903883406290e40d3b516d52d4c84a115ce16261a643f98f781ad' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Uploading layer 'sha256:e65deb0614ae8da7b6f6c2c049d03a47bfeb6a717d593de703d1c3471087eaaf' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Uploading layer 'sha256:9e2db8191805d750229efc3dafdf23f50b16af2c77eac1eb8e26481e114857a7' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Finished uploading layer 'sha256:e65deb0614ae8da7b6f6c2c049d03a47bfeb6a717d593de703d1c3471087eaaf' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Finished uploading layer 'sha256:bee002b9602903883406290e40d3b516d52d4c84a115ce16261a643f98f781ad' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Finished uploading layer 'sha256:e1caac4eb9d2ec24aa3618e5992208321a92492aef5fef5eb9e470895f771c56' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Finished uploading layer 'sha256:9e2db8191805d750229efc3dafdf23f50b16af2c77eac1eb8e26481e114857a7' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Uploading config to registry at blob 'sha256:11f2eea78317b2408766eb045b664a046eeb63088becf24d64baeaf879a0166f',
+          AspireAzdTests.ServiceDefaults -> /tmp/Test_CLI_VsServerLiveDeployRefresh3447454072/001/AspireAzdTests.ServiceDefaults/bin/Debug/net8.0/AspireAzdTests.ServiceDefaults.dll
+          AspireAzdTests.Web -> /tmp/Test_CLI_VsServerLiveDeployRefresh3447454072/001/AspireAzdTests.Web/bin/Debug/net8.0/linux-x64/AspireAzdTests.Web.dll
+          AspireAzdTests.Web -> /tmp/Test_CLI_VsServerLiveDeployRefresh3447454072/001/AspireAzdTests.Web/bin/Debug/net8.0/linux-x64/publish/
+        /home/weilim/.dotnet/sdk/8.0.100/Containers/build/Microsoft.NET.Build.Containers.targets(73,5): warning CONTAINER003: The property 'ContainerImageName' was set but is obsolete - please use 'ContainerRepository' instead. [/tmp/Test_CLI_VsServerLiveDeployRefresh3447454072/001/AspireAzdTests.Web/AspireAzdTests.Web.csproj]
+          Building image 'azd-deploy-webfrontend-1708981443' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime-deps:8.0'.
+          Uploading layer 'sha256:e1caac4eb9d2ec24aa3618e5992208321a92492aef5fef5eb9e470895f771c56' to 'acrsoindfxt2muzw.azurecr.io'.
+          Uploading layer 'sha256:bee002b9602903883406290e40d3b516d52d4c84a115ce16261a643f98f781ad' to 'acrsoindfxt2muzw.azurecr.io'.
+          Uploading layer 'sha256:e65deb0614ae8da7b6f6c2c049d03a47bfeb6a717d593de703d1c3471087eaaf' to 'acrsoindfxt2muzw.azurecr.io'.
+          Uploading layer 'sha256:ed680b65daddfea2488824a68c580c9df690ac62c7d3a65170dd1211d395439f' to 'acrsoindfxt2muzw.azurecr.io'.
+          Finished uploading layer 'sha256:e65deb0614ae8da7b6f6c2c049d03a47bfeb6a717d593de703d1c3471087eaaf' to 'acrsoindfxt2muzw.azurecr.io'.
+          Finished uploading layer 'sha256:bee002b9602903883406290e40d3b516d52d4c84a115ce16261a643f98f781ad' to 'acrsoindfxt2muzw.azurecr.io'.
+          Finished uploading layer 'sha256:e1caac4eb9d2ec24aa3618e5992208321a92492aef5fef5eb9e470895f771c56' to 'acrsoindfxt2muzw.azurecr.io'.
+          Finished uploading layer 'sha256:ed680b65daddfea2488824a68c580c9df690ac62c7d3a65170dd1211d395439f' to 'acrsoindfxt2muzw.azurecr.io'.
+          Uploading config to registry at blob 'sha256:afcc2d154cae10ee61a5c0d02ff6b48add3d70435580abcadf3c6c45df3c092c',
           Uploaded config to registry.
-          Uploading tag 'latest' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Uploaded tag 'latest' to 'acrgnxzs2f5m4idm.azurecr.io'.
-          Pushed image 'azd-deploy-webfrontend-1708717493:latest' to registry 'acrgnxzs2f5m4idm.azurecr.io'.
+          Uploading tag 'latest' to 'acrsoindfxt2muzw.azurecr.io'.
+          Uploaded tag 'latest' to 'acrsoindfxt2muzw.azurecr.io'.
+          Pushed image 'azd-deploy-webfrontend-1708981443:latest' to registry 'acrsoindfxt2muzw.azurecr.io'.
 
         Workload updates are available. Run `dotnet workload list` for more information.
       stderr: ""

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_VsServer/LiveDeployRefresh.dotnet.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_VsServer/LiveDeployRefresh.dotnet.yaml
@@ -1,0 +1,79 @@
+version: "1.0"
+tool: dotnet
+interactions:
+    - id: 0
+      args:
+        - publish
+        - /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.ApiService/AspireAzdTests.ApiService.csproj
+        - -r
+        - linux-x64
+        - -c
+        - Debug
+        - -p:PublishProfile=DefaultContainer
+        - -p:ContainerImageName=azd-deploy-apiservice-1708717459
+        - -p:ContainerRegistry=acrgnxzs2f5m4idm.azurecr.io
+      exitCode: 0
+      stdout: |
+        MSBuild version 17.8.3+195e7f5a3 for .NET
+          Determining projects to restore...
+          Restored /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.ServiceDefaults/AspireAzdTests.ServiceDefaults.csproj (in 501 ms).
+          Restored /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.ApiService/AspireAzdTests.ApiService.csproj (in 491 ms).
+          AspireAzdTests.ServiceDefaults -> /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.ServiceDefaults/bin/Debug/net8.0/AspireAzdTests.ServiceDefaults.dll
+          AspireAzdTests.ApiService -> /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.ApiService/bin/Debug/net8.0/linux-x64/AspireAzdTests.ApiService.dll
+          AspireAzdTests.ApiService -> /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.ApiService/bin/Debug/net8.0/linux-x64/publish/
+        /home/weilim/.dotnet/sdk/8.0.100/Containers/build/Microsoft.NET.Build.Containers.targets(73,5): warning CONTAINER003: The property 'ContainerImageName' was set but is obsolete - please use 'ContainerRepository' instead. [/tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.ApiService/AspireAzdTests.ApiService.csproj]
+          Building image 'azd-deploy-apiservice-1708717459' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime-deps:8.0'.
+          Uploading layer 'sha256:e1caac4eb9d2ec24aa3618e5992208321a92492aef5fef5eb9e470895f771c56' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Uploading layer 'sha256:bee002b9602903883406290e40d3b516d52d4c84a115ce16261a643f98f781ad' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Uploading layer 'sha256:e65deb0614ae8da7b6f6c2c049d03a47bfeb6a717d593de703d1c3471087eaaf' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Uploading layer 'sha256:0431bf7479963cb95650372df48718c37de7520d904f8b55c21697eca07f671e' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Finished uploading layer 'sha256:e65deb0614ae8da7b6f6c2c049d03a47bfeb6a717d593de703d1c3471087eaaf' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Finished uploading layer 'sha256:e1caac4eb9d2ec24aa3618e5992208321a92492aef5fef5eb9e470895f771c56' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Finished uploading layer 'sha256:0431bf7479963cb95650372df48718c37de7520d904f8b55c21697eca07f671e' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Finished uploading layer 'sha256:bee002b9602903883406290e40d3b516d52d4c84a115ce16261a643f98f781ad' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Uploading config to registry at blob 'sha256:6caa9f51ff3238e0a27a7d333381fb2465af5e428128ba67a6aded50dc8d6656',
+          Uploaded config to registry.
+          Uploading tag 'latest' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Uploaded tag 'latest' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Pushed image 'azd-deploy-apiservice-1708717459:latest' to registry 'acrgnxzs2f5m4idm.azurecr.io'.
+
+        Workload updates are available. Run `dotnet workload list` for more information.
+      stderr: ""
+    - id: 1
+      args:
+        - publish
+        - /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.Web/AspireAzdTests.Web.csproj
+        - -r
+        - linux-x64
+        - -c
+        - Debug
+        - -p:PublishProfile=DefaultContainer
+        - -p:ContainerImageName=azd-deploy-webfrontend-1708717493
+        - -p:ContainerRegistry=acrgnxzs2f5m4idm.azurecr.io
+      exitCode: 0
+      stdout: |
+        MSBuild version 17.8.3+195e7f5a3 for .NET
+          Determining projects to restore...
+          Restored /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.Web/AspireAzdTests.Web.csproj (in 568 ms).
+          1 of 2 projects are up-to-date for restore.
+          AspireAzdTests.ServiceDefaults -> /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.ServiceDefaults/bin/Debug/net8.0/AspireAzdTests.ServiceDefaults.dll
+          AspireAzdTests.Web -> /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.Web/bin/Debug/net8.0/linux-x64/AspireAzdTests.Web.dll
+          AspireAzdTests.Web -> /tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.Web/bin/Debug/net8.0/linux-x64/publish/
+        /home/weilim/.dotnet/sdk/8.0.100/Containers/build/Microsoft.NET.Build.Containers.targets(73,5): warning CONTAINER003: The property 'ContainerImageName' was set but is obsolete - please use 'ContainerRepository' instead. [/tmp/Test_CLI_VsServerLiveDeployRefresh2261280644/001/AspireAzdTests.Web/AspireAzdTests.Web.csproj]
+          Building image 'azd-deploy-webfrontend-1708717493' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime-deps:8.0'.
+          Uploading layer 'sha256:e1caac4eb9d2ec24aa3618e5992208321a92492aef5fef5eb9e470895f771c56' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Uploading layer 'sha256:bee002b9602903883406290e40d3b516d52d4c84a115ce16261a643f98f781ad' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Uploading layer 'sha256:e65deb0614ae8da7b6f6c2c049d03a47bfeb6a717d593de703d1c3471087eaaf' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Uploading layer 'sha256:9e2db8191805d750229efc3dafdf23f50b16af2c77eac1eb8e26481e114857a7' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Finished uploading layer 'sha256:e65deb0614ae8da7b6f6c2c049d03a47bfeb6a717d593de703d1c3471087eaaf' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Finished uploading layer 'sha256:bee002b9602903883406290e40d3b516d52d4c84a115ce16261a643f98f781ad' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Finished uploading layer 'sha256:e1caac4eb9d2ec24aa3618e5992208321a92492aef5fef5eb9e470895f771c56' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Finished uploading layer 'sha256:9e2db8191805d750229efc3dafdf23f50b16af2c77eac1eb8e26481e114857a7' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Uploading config to registry at blob 'sha256:11f2eea78317b2408766eb045b664a046eeb63088becf24d64baeaf879a0166f',
+          Uploaded config to registry.
+          Uploading tag 'latest' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Uploaded tag 'latest' to 'acrgnxzs2f5m4idm.azurecr.io'.
+          Pushed image 'azd-deploy-webfrontend-1708717493:latest' to registry 'acrgnxzs2f5m4idm.azurecr.io'.
+
+        Workload updates are available. Run `dotnet workload list` for more information.
+      stderr: ""

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_VsServer/LiveDeployRefresh.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_VsServer/LiveDeployRefresh.yaml
@@ -3829,4 +3829,5 @@ interactions:
         duration: 129.102812ms
 ---
 env_name: azdtest-l88c996
+subscription_id: faa080af-c1d8-40ad-9cce-e1a450ca5b57
 time: "1708717227"

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_VsServer/LiveDeployRefresh.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_VsServer/LiveDeployRefresh.yaml
@@ -42,7 +42,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:40:54 GMT
+                - Mon, 26 Feb 2024 21:00:34 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -54,18 +54,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 044ffa1f-01c3-4ade-82c9-f117a7bfbbbc
+                - 2fbf2163-7da8-4cd1-a941-0d1bea133355
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 044ffa1f-01c3-4ade-82c9-f117a7bfbbbc
+                - 2fbf2163-7da8-4cd1-a941-0d1bea133355
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194054Z:044ffa1f-01c3-4ade-82c9-f117a7bfbbbc
+                - WESTUS2:20240226T210035Z:2fbf2163-7da8-4cd1-a941-0d1bea133355
             X-Msedge-Ref:
-                - 'Ref A: E90621D38C2043C2892E7F5824371E8A Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:40:52Z'
+                - 'Ref A: CEACE3153327430EA7FF00065966F091 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:00:32Z'
         status: 200 OK
         code: 200
-        duration: 2.522425503s
+        duration: 2.547464881s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -96,18 +96,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 954766
+        content_length: 1168040
         uncompressed: false
-        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1Y7faoMwFMafxVw7MKUtw7voOWWwJjbJSUp7VzY3RImwWXQW3322ax9id9%2bf3wffhb21oavC%2bdRVbaC2LsM3Sy8MhSVnF1cZyqHbnb666kq8lj8sZTx6jhQdBjkenlh8I0zbPzrO15GpN5mEz167I0inlwqyzEADOvEb6TBRlIEmnyt6%2fzBcFVub9AW4matHSWJRgB4UyEHCvM05Gbc6ard68ejJg%2bgl4FrWMzOKpaKbT9gU33%2f%2fu9t7tITOFDtkaTg3TczsHgFVjoqM2D7Cu3X2L5imXw%3d%3d","value":[]}'
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1Y7faoMwFMafxVxbSDYHwzv1nMJYE5vkpKW7K50bTklgs1gtvvvs1j5E774%2fPz6%2bMzsE39X%2buO%2fq4Ck0lf9h6ZlhZsnZh4v01alb77%2b7%2bkK8VgNLmYieI0W7kxx3Cxb%2fESb0t07wJDLNMpfw2Wv3BtLpREGeG2hB881SOuSKctC0KRS9fxihypXlfQlu5ppRAj4pygb5pXkJOpGFUBZeBkVhMICP864o4TDO7IJN8fXrXVzdoiV0plwjS%2f2xbWNmtwioClRkstUtvFpn%2f4Np%2bgU%3d","value":[]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "954766"
+                - "1168040"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:40:58 GMT
+                - Mon, 26 Feb 2024 21:00:38 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -119,18 +119,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - a473f723-2498-4acd-a051-60c27bfbc4f9
+                - f0272048-1e6f-418f-aa05-6cb468943a70
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - a473f723-2498-4acd-a051-60c27bfbc4f9
+                - f0272048-1e6f-418f-aa05-6cb468943a70
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194058Z:a473f723-2498-4acd-a051-60c27bfbc4f9
+                - WESTUS2:20240226T210038Z:f0272048-1e6f-418f-aa05-6cb468943a70
             X-Msedge-Ref:
-                - 'Ref A: 40845632B80347E1A398AEB4E1327307 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:40:54Z'
+                - 'Ref A: C6E184F44D1C4BA8B8403D388607B0A0 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:00:35Z'
         status: 200 OK
         code: 200
-        duration: 4.028374863s
+        duration: 3.785809422s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -151,7 +151,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1Y7faoMwFMafxVw7MKUtw7voOWWwJjbJSUp7VzY3RImwWXQW3322ax9id9%2bf3wffhb21oavC%2bdRVbaC2LsM3Sy8MhSVnF1cZyqHbnb666kq8lj8sZTx6jhQdBjkenlh8I0zbPzrO15GpN5mEz167I0inlwqyzEADOvEb6TBRlIEmnyt6%2fzBcFVub9AW4matHSWJRgB4UyEHCvM05Gbc6ard68ejJg%2bgl4FrWMzOKpaKbT9gU33%2f%2fu9t7tITOFDtkaTg3TczsHgFVjoqM2D7Cu3X2L5imXw%3d%3d
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1Y7faoMwFMafxVxbSDYHwzv1nMJYE5vkpKW7K50bTklgs1gtvvvs1j5E774%2fPz6%2bMzsE39X%2buO%2fq4Ck0lf9h6ZlhZsnZh4v01alb77%2b7%2bkK8VgNLmYieI0W7kxx3Cxb%2fESb0t07wJDLNMpfw2Wv3BtLpREGeG2hB881SOuSKctC0KRS9fxihypXlfQlu5ppRAj4pygb5pXkJOpGFUBZeBkVhMICP864o4TDO7IJN8fXrXVzdoiV0plwjS%2f2xbWNmtwioClRkstUtvFpn%2f4Np%2bgU%3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -159,18 +159,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2487770
+        content_length: 1780521
         uncompressed: false
-        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1ZDRToMwFIafhV5jUgYxhjugXdSth7U93YJ3iyJhJcUoC7iFd9c5SPYK3p3%2f%2b7%2bLP%2bdMXlvX1e647%2brWYWtL90XiM%2bGJRqMXl9OVQ7fZf3b1xViV3yQmgffgARaDOBV3xP8zVNvPXUAjT9llKljVS%2fPChJERsDRVrGGSbpfCcAqYMonbDPDtXQWQrzXtc2Z%2bPUuBJREcqoXApxAORSiyADT%2feJbI74WVA5ySUKCNBFYDGf1p67%2bYalY6N%2fhIYndsGp%2fs%2bPTl2xjettyofMNnonecccg4oErWM5yi0Vcwjj8%3d","value":[]}'
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1ZDdaoNAEIWfxb02sNZQinfqbIgkO7p%2fBnsXWluMskJr0CT47jWtQl6hd3O%2bc4Y5zI28tbar7PnYVa3VbV3abxLcCAuVNurpPtpy6LLjV1fdE7vyQgLiOS8O6mLg12JF3N%2bEbPvF8%2bjakfUm4vDZC%2fMK3Ig1QhRJaEDQfMMNo6gjEDqPUb9%2fSA%2fTvaJ9CmbK1ZSfxAUh6ad9D0%2bJz2OvyHOZcUieeS0GvIb%2bdJki8J6M7tz1X1Q1O5UavSWBPTeNSw5s%2fvKj9B9dZmSasYWoAwOGMUMtw%2f0CZ2nUHxjHHw%3d%3d","value":[]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "2487770"
+                - "1780521"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:41:03 GMT
+                - Mon, 26 Feb 2024 21:00:42 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -182,18 +182,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 654bfd8b-dd96-4814-b538-8392ea28165b
+                - c17b0a8e-8d5c-4f77-816d-6ee08e37ba46
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 654bfd8b-dd96-4814-b538-8392ea28165b
+                - c17b0a8e-8d5c-4f77-816d-6ee08e37ba46
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194103Z:654bfd8b-dd96-4814-b538-8392ea28165b
+                - WESTUS2:20240226T210043Z:c17b0a8e-8d5c-4f77-816d-6ee08e37ba46
             X-Msedge-Ref:
-                - 'Ref A: 1D2143E7C0DB4881A91613F2F08FAB3C Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:40:58Z'
+                - 'Ref A: 1B0A08DB0A124C85BB2024982865392B Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:00:39Z'
         status: 200 OK
         code: 200
-        duration: 4.494903935s
+        duration: 4.283024675s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -214,7 +214,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1ZDRToMwFIafhV5jUgYxhjugXdSth7U93YJ3iyJhJcUoC7iFd9c5SPYK3p3%2f%2b7%2bLP%2bdMXlvX1e647%2brWYWtL90XiM%2bGJRqMXl9OVQ7fZf3b1xViV3yQmgffgARaDOBV3xP8zVNvPXUAjT9llKljVS%2fPChJERsDRVrGGSbpfCcAqYMonbDPDtXQWQrzXtc2Z%2bPUuBJREcqoXApxAORSiyADT%2feJbI74WVA5ySUKCNBFYDGf1p67%2bYalY6N%2fhIYndsGp%2fs%2bPTl2xjettyofMNnonecccg4oErWM5yi0Vcwjj8%3d
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1ZDdaoNAEIWfxb02sNZQinfqbIgkO7p%2fBnsXWluMskJr0CT47jWtQl6hd3O%2bc4Y5zI28tbar7PnYVa3VbV3abxLcCAuVNurpPtpy6LLjV1fdE7vyQgLiOS8O6mLg12JF3N%2bEbPvF8%2bjakfUm4vDZC%2fMK3Ig1QhRJaEDQfMMNo6gjEDqPUb9%2fSA%2fTvaJ9CmbK1ZSfxAUh6ad9D0%2bJz2OvyHOZcUieeS0GvIb%2bdJki8J6M7tz1X1Q1O5UavSWBPTeNSw5s%2fvKj9B9dZmSasYWoAwOGMUMtw%2f0CZ2nUHxjHHw%3d%3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -222,18 +222,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3021248
+        content_length: 3283326
         uncompressed: false
-        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1VJBbsIwEHwLPhcphoAqbk7WiApsE3udKNxQSylNlEhtUEIQf28MREL9QNXbznh2PR7vmbyWRXUojtvqUBZYZrvim8zOhDOD1oxcWeyaar39qg5OsdydyIzQwfNAYtqINh2Sp6tCl3V%2fRul0oLN5IGBfR3YDwka%2bhCDQkEPkxXNhuScxgAjjUOLbu6ZSrYxXK7CdLvNkm45lm1GFwleY1TKkiYk3QZLzqcj03HofawvlSQMfC0h90Xaaz%2f2QXJ7uvv%2bd7YS7uP%2fCdiuQjRREjQTRCOh%2bKqSo7WQT2cki5jHGwGoBLvlO0zJf4hV7Lm1mDWq2emEhl64gs%2bKY5w%2b8W6OetEujLC56eHtyt2G3lhscP0JutVrznjEJBy5%2fXXSHLjo35nL5AQ%3d%3d","value":[]}'
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=3VLLbsIwEPwWci5SQlJUuCWso%2fLwGr%2bC4IYorVKjpGqD8kD8e2MgEuqxvfXkndldW%2bOZk7PLsyLNjtsizTOVm3325YxPDgml0nJgy2xfFcvtZ5Haifm%2bdsaO13vqoVpXtFn3nYfLhMjLrucNg54wcUThreR6A1TzACGKBByAu0lMNXFRRcBVMkH18io8ZAvplgx0O2fanmlrUiHwAUJYYuox0eS1IJtEGdRSj5i%2b4I8oMbHi3mymYz6kRiiehPYERUaJgHYnRiL9Kubu2qcNCdBsIqZpiTD1nfPDTee%2fl7ki1s7fyXT%2f5GZDgTyiCmv6zl0GPKATDyVMa1StO0D8NiUeg13TOt%2b3joRaKhEupuGEoC2ccXY8HO54G82O1HPJtHru4FVmm9rryhX695BowZakY%2bSKAMEfD92g%2fS57zfn8DQ%3d%3d","value":[]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "3021248"
+                - "3283326"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:41:09 GMT
+                - Mon, 26 Feb 2024 21:00:48 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -245,18 +245,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 4da9e988-9ad4-45df-8cce-1db4fe32d670
+                - a1623a73-3b7d-46be-8331-966879066784
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11998"
             X-Ms-Request-Id:
-                - 4da9e988-9ad4-45df-8cce-1db4fe32d670
+                - a1623a73-3b7d-46be-8331-966879066784
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194109Z:4da9e988-9ad4-45df-8cce-1db4fe32d670
+                - WESTUS2:20240226T210049Z:a1623a73-3b7d-46be-8331-966879066784
             X-Msedge-Ref:
-                - 'Ref A: 8A68414D85394F7899A884B8C424EF98 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:41:03Z'
+                - 'Ref A: FB5288B9779E4DAAAFA8A71D606EC4F1 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:00:43Z'
         status: 200 OK
         code: 200
-        duration: 5.422608116s
+        duration: 5.468181514s
     - id: 4
       request:
         proto: HTTP/1.1
@@ -277,7 +277,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1VJBbsIwEHwLPhcphoAqbk7WiApsE3udKNxQSylNlEhtUEIQf28MREL9QNXbznh2PR7vmbyWRXUojtvqUBZYZrvim8zOhDOD1oxcWeyaar39qg5OsdydyIzQwfNAYtqINh2Sp6tCl3V%2fRul0oLN5IGBfR3YDwka%2bhCDQkEPkxXNhuScxgAjjUOLbu6ZSrYxXK7CdLvNkm45lm1GFwleY1TKkiYk3QZLzqcj03HofawvlSQMfC0h90Xaaz%2f2QXJ7uvv%2bd7YS7uP%2fCdiuQjRREjQTRCOh%2bKqSo7WQT2cki5jHGwGoBLvlO0zJf4hV7Lm1mDWq2emEhl64gs%2bKY5w%2b8W6OetEujLC56eHtyt2G3lhscP0JutVrznjEJBy5%2fXXSHLjo35nL5AQ%3d%3d
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=3VLLbsIwEPwWci5SQlJUuCWso%2fLwGr%2bC4IYorVKjpGqD8kD8e2MgEuqxvfXkndldW%2bOZk7PLsyLNjtsizTOVm3325YxPDgml0nJgy2xfFcvtZ5Haifm%2bdsaO13vqoVpXtFn3nYfLhMjLrucNg54wcUThreR6A1TzACGKBByAu0lMNXFRRcBVMkH18io8ZAvplgx0O2fanmlrUiHwAUJYYuox0eS1IJtEGdRSj5i%2b4I8oMbHi3mymYz6kRiiehPYERUaJgHYnRiL9Kubu2qcNCdBsIqZpiTD1nfPDTee%2fl7ki1s7fyXT%2f5GZDgTyiCmv6zl0GPKATDyVMa1StO0D8NiUeg13TOt%2b3joRaKhEupuGEoC2ccXY8HO54G82O1HPJtHru4FVmm9rryhX695BowZakY%2bSKAMEfD92g%2fS57zfn8DQ%3d%3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -285,18 +285,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 271460
+        content_length: 1021766
         uncompressed: false
-        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=XZBRT4MwFIV%2fC32eCQxiDG%2bFdnFuvaz0dgu%2bLYqEQYpRFnAL%2f13r1sX41u%2bcc9OccyYvnelrc9z3dWewa0rzSeIz4VShVnMSm2Pbzq7oaMetaWOmHPvN%2fqOv7fWq%2fCIxCbwHD7AYxam4I7PfRN4Nzgv8yMubRSJYNUj9zISWEbAkyVnLpL9dCM19wIRJ3KaAr295ANla%2bUPG9E%2bu8YHRCA7VXOAyhEMRijQAxd%2bfJPJ70cgRTjQU2EQCq5FMM0K1wpyulzTlYB%2buwk23RZ2oVyrT%2bOjwUvO2wQXDvy7XebbhTlE7zjj8%2b%2biKdi475TR9Aw%3d%3d","value":[]}'
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=XVBda4MwFP0t5tlBnGUM39SbMmkTzZfFvZXNDatE2CzaFv%2f7zNqUsbd7vricc0FvvRkac9wPTW9U39bmG0UXRGKptHxEkTl2nX%2bDDu2IFa3N1NNQ7L%2bGxqY39QlFKPCePaaqiZ6rB%2bT%2fOkQ%2fOi3AK0%2b064TC58j1K1DNVwySREAHHJdrqglmKgGuypSp9w8RsHwr8ZiDXnwtpgd%2bYpCNSz5ghyykaVCVpSgoZE%2b05RM7x%2bHyGTOgI5p9FGupRLzN4pQwe7gKd94WdaTeyFyrFwevNe8bXGH4VyVa5AVxjNwRIOzfoxu0c9kp5%2fkH","value":[]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "271460"
+                - "1021766"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:41:10 GMT
+                - Mon, 26 Feb 2024 21:00:50 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -308,18 +308,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 92376ea2-536e-4daf-a553-2a0b9dbe741e
+                - bdfd0241-e1ca-4efe-a18d-0097b17091e4
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11997"
             X-Ms-Request-Id:
-                - 92376ea2-536e-4daf-a553-2a0b9dbe741e
+                - bdfd0241-e1ca-4efe-a18d-0097b17091e4
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194110Z:92376ea2-536e-4daf-a553-2a0b9dbe741e
+                - WESTUS2:20240226T210051Z:bdfd0241-e1ca-4efe-a18d-0097b17091e4
             X-Msedge-Ref:
-                - 'Ref A: CB372AE4B5574DA899AFB829329FFC7E Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:41:09Z'
+                - 'Ref A: C7AE1E0F6C0E467985CD255FD95AD34B Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:00:49Z'
         status: 200 OK
         code: 200
-        duration: 1.039660579s
+        duration: 1.90750204s
     - id: 5
       request:
         proto: HTTP/1.1
@@ -340,7 +340,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=XZBRT4MwFIV%2fC32eCQxiDG%2bFdnFuvaz0dgu%2bLYqEQYpRFnAL%2f13r1sX41u%2bcc9OccyYvnelrc9z3dWewa0rzSeIz4VShVnMSm2Pbzq7oaMetaWOmHPvN%2fqOv7fWq%2fCIxCbwHD7AYxam4I7PfRN4Nzgv8yMubRSJYNUj9zISWEbAkyVnLpL9dCM19wIRJ3KaAr295ANla%2bUPG9E%2bu8YHRCA7VXOAyhEMRijQAxd%2bfJPJ70cgRTjQU2EQCq5FMM0K1wpyulzTlYB%2buwk23RZ2oVyrT%2bOjwUvO2wQXDvy7XebbhTlE7zjj8%2b%2biKdi475TR9Aw%3d%3d
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=XVBda4MwFP0t5tlBnGUM39SbMmkTzZfFvZXNDatE2CzaFv%2f7zNqUsbd7vricc0FvvRkac9wPTW9U39bmG0UXRGKptHxEkTl2nX%2bDDu2IFa3N1NNQ7L%2bGxqY39QlFKPCePaaqiZ6rB%2bT%2fOkQ%2fOi3AK0%2b064TC58j1K1DNVwySREAHHJdrqglmKgGuypSp9w8RsHwr8ZiDXnwtpgd%2bYpCNSz5ghyykaVCVpSgoZE%2b05RM7x%2bHyGTOgI5p9FGupRLzN4pQwe7gKd94WdaTeyFyrFwevNe8bXGH4VyVa5AVxjNwRIOzfoxu0c9kp5%2fkH
         method: GET
       response:
         proto: HTTP/2.0
@@ -348,18 +348,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20482
+        content_length: 20512
         uncompressed: false
-        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=ZZBda4MwFIZ%2fi7luwUwpwzs1kY42ieZDsXdldZ2LRNgsthb%2f%2b5p1GWO7O8%2f7vueDcwXPvRlac9oPbW9krxvzAaIrqLCQStjKNOch378PrQ1smguIAPQePSrrM5nqJVh8JXg%2fOg%2fClcd1lhB0HAu1Q0QVIUVJwlGHCr%2fMiMI%2blQkqZJlSeXjhkLKt8EeG1C2nfTrVAZ00ZJKETOqRprAS5S6pOrwimmfKf80V6i8c4YCgOiTTLfN2XIJ5AXBsz34AkTl1nUNHsRKSx9unOMXUFv902%2b1EtRFMybXD%2bz9%2bBt8x%2bO1ixVmOnSIqjDD9s%2bgb7V%2ftffP8CQ%3d%3d","value":[]}'
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=ZZHLbsIwEEW%2fBa%2bplBCECruEcVQeHuPHBMEOtbSKjJKqDUoA8e%2bNoamqduU5994Zvy7suSyqvDjuqrwsbOn2xSebXNiaG0vGV8W%2bqVa7jyr3gcX%2bxCYs7D320G4acd48sP4tocu688LRsKddmgh4qxVtQZAaIiSJhgOoIEsF8QBtAspmU7QvrzpEuTRBLYHanGs919a8QVADhLjGPJT6XJ4032bWIRkaS7rxe5K51KpwPqdUjYTTVmWxX8Hycaah7UmRm6hJVbCJxJkP0W0TSaJGmEXs2mc89tccsElxPBw67CgmY3W8nMVTjr74p%2fvuTqSFkWSfOry%2f38%2fgO0a%2fXU5arninmDUHjn82%2bkb%2fD%2f581%2bsX","value":[]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "20482"
+                - "20512"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:41:11 GMT
+                - Mon, 26 Feb 2024 21:00:51 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -371,18 +371,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 6969bb01-72d9-4a06-aa09-ccc89bed37c8
+                - b5448e86-53dd-4115-9281-d9a306e3c350
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11996"
             X-Ms-Request-Id:
-                - 6969bb01-72d9-4a06-aa09-ccc89bed37c8
+                - b5448e86-53dd-4115-9281-d9a306e3c350
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194111Z:6969bb01-72d9-4a06-aa09-ccc89bed37c8
+                - WESTUS2:20240226T210052Z:b5448e86-53dd-4115-9281-d9a306e3c350
             X-Msedge-Ref:
-                - 'Ref A: 314266C15A7641FEA59972350349825A Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:41:10Z'
+                - 'Ref A: 6FABF474C2DC47FEABD2CD2ED4C680F4 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:00:51Z'
         status: 200 OK
         code: 200
-        duration: 970.653731ms
+        duration: 686.652657ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -403,7 +403,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=ZZBda4MwFIZ%2fi7luwUwpwzs1kY42ieZDsXdldZ2LRNgsthb%2f%2b5p1GWO7O8%2f7vueDcwXPvRlac9oPbW9krxvzAaIrqLCQStjKNOch378PrQ1smguIAPQePSrrM5nqJVh8JXg%2fOg%2fClcd1lhB0HAu1Q0QVIUVJwlGHCr%2fMiMI%2blQkqZJlSeXjhkLKt8EeG1C2nfTrVAZ00ZJKETOqRprAS5S6pOrwimmfKf80V6i8c4YCgOiTTLfN2XIJ5AXBsz34AkTl1nUNHsRKSx9unOMXUFv902%2b1EtRFMybXD%2bz9%2bBt8x%2bO1ixVmOnSIqjDD9s%2bgb7V%2ftffP8CQ%3d%3d
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=ZZHLbsIwEEW%2fBa%2bplBCECruEcVQeHuPHBMEOtbSKjJKqDUoA8e%2bNoamqduU5994Zvy7suSyqvDjuqrwsbOn2xSebXNiaG0vGV8W%2bqVa7jyr3gcX%2bxCYs7D320G4acd48sP4tocu688LRsKddmgh4qxVtQZAaIiSJhgOoIEsF8QBtAspmU7QvrzpEuTRBLYHanGs919a8QVADhLjGPJT6XJ4032bWIRkaS7rxe5K51KpwPqdUjYTTVmWxX8Hycaah7UmRm6hJVbCJxJkP0W0TSaJGmEXs2mc89tccsElxPBw67CgmY3W8nMVTjr74p%2fvuTqSFkWSfOry%2f38%2fgO0a%2fXU5arninmDUHjn82%2bkb%2fD%2f581%2bsX
         method: GET
       response:
         proto: HTTP/2.0
@@ -422,7 +422,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:41:12 GMT
+                - Mon, 26 Feb 2024 21:00:52 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -434,18 +434,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - b9ede364-bbe8-48f5-895d-252e7aa74be6
+                - bd5b4a0a-7ec4-4df9-9fbd-57e1d41920e0
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - b9ede364-bbe8-48f5-895d-252e7aa74be6
+                - bd5b4a0a-7ec4-4df9-9fbd-57e1d41920e0
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194112Z:b9ede364-bbe8-48f5-895d-252e7aa74be6
+                - WESTUS2:20240226T210052Z:bd5b4a0a-7ec4-4df9-9fbd-57e1d41920e0
             X-Msedge-Ref:
-                - 'Ref A: D0A9F62389F8422F8206BB3A38604354 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:41:11Z'
+                - 'Ref A: 267A1B45F7EB4115AD1359FA5C3B4891 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:00:52Z'
         status: 200 OK
         code: 200
-        duration: 421.126749ms
+        duration: 466.805484ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -457,7 +457,7 @@ interactions:
         host: management.azure.com
         remote_addr: ""
         request_uri: ""
-        body: '{"location":"eastus2","properties":{"mode":"Incremental","parameters":{"environmentName":{"value":"azdtest-l88c996"},"inputs":{"value":{}},"location":{"value":"eastus2"}},"template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","metadata":{"_generator":{"name":"bicep","version":"0.25.3.34343","templateHash":"14419117427229910140"}},"parameters":{"environmentName":{"type":"string","minLength":1,"maxLength":64,"metadata":{"description":"Name of the environment that can be used as part of naming resource convention, the name of the resource group for your application will use this name, prefixed with rg-"}},"location":{"type":"string","minLength":1,"metadata":{"description":"The location used for all deployed resources"}},"inputs":{"type":"secureObject","metadata":{"azd":{"type":"inputs"}}}},"variables":{"tags":{"azd-env-name":"[parameters(''environmentName'')]"}},"resources":[{"type":"Microsoft.Resources/resourceGroups","apiVersion":"2022-09-01","name":"[format(''rg-{0}'', parameters(''environmentName''))]","location":"[parameters(''location'')]","tags":"[variables(''tags'')]"},{"type":"Microsoft.Resources/deployments","apiVersion":"2022-09-01","name":"resources","resourceGroup":"[format(''rg-{0}'', parameters(''environmentName''))]","properties":{"expressionEvaluationOptions":{"scope":"inner"},"mode":"Incremental","parameters":{"location":{"value":"[parameters(''location'')]"},"tags":{"value":"[variables(''tags'')]"},"inputs":{"value":"[parameters(''inputs'')]"}},"template":{"$schema":"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","metadata":{"_generator":{"name":"bicep","version":"0.25.3.34343","templateHash":"17406160295075632591"}},"parameters":{"location":{"type":"string","defaultValue":"[resourceGroup().location]","metadata":{"description":"The location used for all deployed resources"}},"tags":{"type":"object","defaultValue":{},"metadata":{"description":"Tags that will be applied to all resources"}},"inputs":{"type":"secureObject","metadata":{"azd":{"type":"inputs"}}}},"variables":{"resourceToken":"[uniqueString(resourceGroup().id)]"},"resources":[{"type":"Microsoft.Storage/storageAccounts/blobServices","apiVersion":"2022-05-01","name":"[format(''{0}/{1}'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''), ''default'')]","dependsOn":["[resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]"]},{"type":"Microsoft.ManagedIdentity/userAssignedIdentities","apiVersion":"2023-01-31","name":"[format(''mi-{0}'', variables(''resourceToken''))]","location":"[parameters(''location'')]","tags":"[parameters(''tags'')]"},{"type":"Microsoft.ContainerRegistry/registries","apiVersion":"2023-07-01","name":"[replace(format(''acr-{0}'', variables(''resourceToken'')), ''-'', '''')]","location":"[parameters(''location'')]","sku":{"name":"Basic"},"properties":{"adminUserEnabled":true},"tags":"[parameters(''tags'')]"},{"type":"Microsoft.Authorization/roleAssignments","apiVersion":"2022-04-01","scope":"[format(''Microsoft.ContainerRegistry/registries/{0}'', replace(format(''acr-{0}'', variables(''resourceToken'')), ''-'', ''''))]","name":"[guid(resourceId(''Microsoft.ContainerRegistry/registries'', replace(format(''acr-{0}'', variables(''resourceToken'')), ''-'', '''')), resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''7f951dda-4ed3-4680-a7ca-43fe172d538d''))]","properties":{"principalId":"[reference(resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), ''2023-01-31'').principalId]","principalType":"ServicePrincipal","roleDefinitionId":"[subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''7f951dda-4ed3-4680-a7ca-43fe172d538d'')]"},"dependsOn":["[resourceId(''Microsoft.ContainerRegistry/registries'', replace(format(''acr-{0}'', variables(''resourceToken'')), ''-'', ''''))]","[resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken'')))]"]},{"type":"Microsoft.OperationalInsights/workspaces","apiVersion":"2022-10-01","name":"[format(''law-{0}'', variables(''resourceToken''))]","location":"[parameters(''location'')]","properties":{"sku":{"name":"PerGB2018"}},"tags":"[parameters(''tags'')]"},{"type":"Microsoft.App/managedEnvironments","apiVersion":"2023-05-01","name":"[format(''cae-{0}'', variables(''resourceToken''))]","location":"[parameters(''location'')]","properties":{"appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"[reference(resourceId(''Microsoft.OperationalInsights/workspaces'', format(''law-{0}'', variables(''resourceToken''))), ''2022-10-01'').customerId]","sharedKey":"[listKeys(resourceId(''Microsoft.OperationalInsights/workspaces'', format(''law-{0}'', variables(''resourceToken''))), ''2022-10-01'').primarySharedKey]"}}},"tags":"[parameters(''tags'')]","dependsOn":["[resourceId(''Microsoft.OperationalInsights/workspaces'', format(''law-{0}'', variables(''resourceToken'')))]"]},{"type":"Microsoft.App/containerApps","apiVersion":"2023-05-02-preview","name":"cache","location":"[parameters(''location'')]","properties":{"environmentId":"[resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken'')))]","configuration":{"service":{"type":"redis"}},"template":{"containers":[{"image":"redis","name":"redis"}],"scale":{"minReplicas":1}}},"tags":"[union(parameters(''tags''), createObject(''aspire-resource-name'', ''cache''))]","dependsOn":["[resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken'')))]"]},{"type":"Microsoft.App/containerApps","apiVersion":"2023-05-02-preview","name":"pubsub","location":"[parameters(''location'')]","properties":{"environmentId":"[resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken'')))]","configuration":{"service":{"type":"redis"}},"template":{"containers":[{"image":"redis","name":"redis"}],"scale":{"minReplicas":1}}},"tags":"[union(parameters(''tags''), createObject(''aspire-resource-name'', ''pubsub''))]","dependsOn":["[resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken'')))]"]},{"type":"Microsoft.Storage/storageAccounts","apiVersion":"2022-05-01","name":"[replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')]","location":"[parameters(''location'')]","kind":"Storage","sku":{"name":"Standard_GRS"},"tags":"[union(parameters(''tags''), createObject(''aspire-resource-name'', ''storage''))]"},{"type":"Microsoft.Authorization/roleAssignments","apiVersion":"2022-04-01","scope":"[format(''Microsoft.Storage/storageAccounts/{0}'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]","name":"[guid(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''ba92f5b4-2d11-453d-a403-e96b0029c9fe''))]","properties":{"principalId":"[reference(resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), ''2023-01-31'').principalId]","principalType":"ServicePrincipal","roleDefinitionId":"[subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''ba92f5b4-2d11-453d-a403-e96b0029c9fe'')]"},"dependsOn":["[resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken'')))]","[resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]"]},{"type":"Microsoft.Authorization/roleAssignments","apiVersion":"2022-04-01","scope":"[format(''Microsoft.Storage/storageAccounts/{0}'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]","name":"[guid(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''974c5e8b-45b9-4653-ba55-5f855dd0fb88''))]","properties":{"principalId":"[reference(resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), ''2023-01-31'').principalId]","principalType":"ServicePrincipal","roleDefinitionId":"[subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''974c5e8b-45b9-4653-ba55-5f855dd0fb88'')]"},"dependsOn":["[resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken'')))]","[resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]"]},{"type":"Microsoft.Authorization/roleAssignments","apiVersion":"2022-04-01","scope":"[format(''Microsoft.Storage/storageAccounts/{0}'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]","name":"[guid(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3''))]","properties":{"principalId":"[reference(resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), ''2023-01-31'').principalId]","principalType":"ServicePrincipal","roleDefinitionId":"[subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'')]"},"dependsOn":["[resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken'')))]","[resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]"]}],"outputs":{"MANAGED_IDENTITY_CLIENT_ID":{"type":"string","value":"[reference(resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), ''2023-01-31'').clientId]"},"AZURE_LOG_ANALYTICS_WORKSPACE_NAME":{"type":"string","value":"[format(''law-{0}'', variables(''resourceToken''))]"},"AZURE_CONTAINER_REGISTRY_ENDPOINT":{"type":"string","value":"[reference(resourceId(''Microsoft.ContainerRegistry/registries'', replace(format(''acr-{0}'', variables(''resourceToken'')), ''-'', '''')), ''2023-07-01'').loginServer]"},"AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID":{"type":"string","value":"[resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken'')))]"},"AZURE_CONTAINER_APPS_ENVIRONMENT_ID":{"type":"string","value":"[resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken'')))]"},"AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN":{"type":"string","value":"[reference(resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken''))), ''2023-05-01'').defaultDomain]"},"SERVICE_BINDING_MARKDOWN_ENDPOINT":{"type":"string","value":"[reference(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), ''2022-05-01'').primaryEndpoints.blob]"},"SERVICE_BINDING_REQUESTLOG_ENDPOINT":{"type":"string","value":"[reference(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), ''2022-05-01'').primaryEndpoints.table]"},"SERVICE_BINDING_MESSAGES_ENDPOINT":{"type":"string","value":"[reference(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), ''2022-05-01'').primaryEndpoints.queue]"}}}},"dependsOn":["[subscriptionResourceId(''Microsoft.Resources/resourceGroups'', format(''rg-{0}'', parameters(''environmentName'')))]"]}],"outputs":{"MANAGED_IDENTITY_CLIENT_ID":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.MANAGED_IDENTITY_CLIENT_ID.value]"},"AZURE_LOG_ANALYTICS_WORKSPACE_NAME":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.AZURE_LOG_ANALYTICS_WORKSPACE_NAME.value]"},"AZURE_CONTAINER_REGISTRY_ENDPOINT":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT.value]"},"AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID.value]"},"AZURE_CONTAINER_APPS_ENVIRONMENT_ID":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID.value]"},"AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN.value]"},"SERVICE_BINDING_MARKDOWN_ENDPOINT":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.SERVICE_BINDING_MARKDOWN_ENDPOINT.value]"},"SERVICE_BINDING_REQUESTLOG_ENDPOINT":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.SERVICE_BINDING_REQUESTLOG_ENDPOINT.value]"},"SERVICE_BINDING_MESSAGES_ENDPOINT":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.SERVICE_BINDING_MESSAGES_ENDPOINT.value]"}}}},"tags":{"azd-env-name":"azdtest-l88c996","azd-provision-param-hash":"6354240e3b61edb702891d88e5c50b42b4af01f4c1dec5d56a7532a298f4fb48"}}'
+        body: '{"location":"eastus2","properties":{"mode":"Incremental","parameters":{"environmentName":{"value":"azdtest-l4c10c9"},"inputs":{"value":{}},"location":{"value":"eastus2"}},"template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","metadata":{"_generator":{"name":"bicep","version":"0.25.3.34343","templateHash":"14419117427229910140"}},"parameters":{"environmentName":{"type":"string","minLength":1,"maxLength":64,"metadata":{"description":"Name of the environment that can be used as part of naming resource convention, the name of the resource group for your application will use this name, prefixed with rg-"}},"location":{"type":"string","minLength":1,"metadata":{"description":"The location used for all deployed resources"}},"inputs":{"type":"secureObject","metadata":{"azd":{"type":"inputs"}}}},"variables":{"tags":{"azd-env-name":"[parameters(''environmentName'')]"}},"resources":[{"type":"Microsoft.Resources/resourceGroups","apiVersion":"2022-09-01","name":"[format(''rg-{0}'', parameters(''environmentName''))]","location":"[parameters(''location'')]","tags":"[variables(''tags'')]"},{"type":"Microsoft.Resources/deployments","apiVersion":"2022-09-01","name":"resources","resourceGroup":"[format(''rg-{0}'', parameters(''environmentName''))]","properties":{"expressionEvaluationOptions":{"scope":"inner"},"mode":"Incremental","parameters":{"location":{"value":"[parameters(''location'')]"},"tags":{"value":"[variables(''tags'')]"},"inputs":{"value":"[parameters(''inputs'')]"}},"template":{"$schema":"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","metadata":{"_generator":{"name":"bicep","version":"0.25.3.34343","templateHash":"17406160295075632591"}},"parameters":{"location":{"type":"string","defaultValue":"[resourceGroup().location]","metadata":{"description":"The location used for all deployed resources"}},"tags":{"type":"object","defaultValue":{},"metadata":{"description":"Tags that will be applied to all resources"}},"inputs":{"type":"secureObject","metadata":{"azd":{"type":"inputs"}}}},"variables":{"resourceToken":"[uniqueString(resourceGroup().id)]"},"resources":[{"type":"Microsoft.Storage/storageAccounts/blobServices","apiVersion":"2022-05-01","name":"[format(''{0}/{1}'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''), ''default'')]","dependsOn":["[resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]"]},{"type":"Microsoft.ManagedIdentity/userAssignedIdentities","apiVersion":"2023-01-31","name":"[format(''mi-{0}'', variables(''resourceToken''))]","location":"[parameters(''location'')]","tags":"[parameters(''tags'')]"},{"type":"Microsoft.ContainerRegistry/registries","apiVersion":"2023-07-01","name":"[replace(format(''acr-{0}'', variables(''resourceToken'')), ''-'', '''')]","location":"[parameters(''location'')]","sku":{"name":"Basic"},"properties":{"adminUserEnabled":true},"tags":"[parameters(''tags'')]"},{"type":"Microsoft.Authorization/roleAssignments","apiVersion":"2022-04-01","scope":"[format(''Microsoft.ContainerRegistry/registries/{0}'', replace(format(''acr-{0}'', variables(''resourceToken'')), ''-'', ''''))]","name":"[guid(resourceId(''Microsoft.ContainerRegistry/registries'', replace(format(''acr-{0}'', variables(''resourceToken'')), ''-'', '''')), resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''7f951dda-4ed3-4680-a7ca-43fe172d538d''))]","properties":{"principalId":"[reference(resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), ''2023-01-31'').principalId]","principalType":"ServicePrincipal","roleDefinitionId":"[subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''7f951dda-4ed3-4680-a7ca-43fe172d538d'')]"},"dependsOn":["[resourceId(''Microsoft.ContainerRegistry/registries'', replace(format(''acr-{0}'', variables(''resourceToken'')), ''-'', ''''))]","[resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken'')))]"]},{"type":"Microsoft.OperationalInsights/workspaces","apiVersion":"2022-10-01","name":"[format(''law-{0}'', variables(''resourceToken''))]","location":"[parameters(''location'')]","properties":{"sku":{"name":"PerGB2018"}},"tags":"[parameters(''tags'')]"},{"type":"Microsoft.App/managedEnvironments","apiVersion":"2023-05-01","name":"[format(''cae-{0}'', variables(''resourceToken''))]","location":"[parameters(''location'')]","properties":{"appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"[reference(resourceId(''Microsoft.OperationalInsights/workspaces'', format(''law-{0}'', variables(''resourceToken''))), ''2022-10-01'').customerId]","sharedKey":"[listKeys(resourceId(''Microsoft.OperationalInsights/workspaces'', format(''law-{0}'', variables(''resourceToken''))), ''2022-10-01'').primarySharedKey]"}}},"tags":"[parameters(''tags'')]","dependsOn":["[resourceId(''Microsoft.OperationalInsights/workspaces'', format(''law-{0}'', variables(''resourceToken'')))]"]},{"type":"Microsoft.App/containerApps","apiVersion":"2023-05-02-preview","name":"cache","location":"[parameters(''location'')]","properties":{"environmentId":"[resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken'')))]","configuration":{"service":{"type":"redis"}},"template":{"containers":[{"image":"redis","name":"redis"}],"scale":{"minReplicas":1}}},"tags":"[union(parameters(''tags''), createObject(''aspire-resource-name'', ''cache''))]","dependsOn":["[resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken'')))]"]},{"type":"Microsoft.App/containerApps","apiVersion":"2023-05-02-preview","name":"pubsub","location":"[parameters(''location'')]","properties":{"environmentId":"[resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken'')))]","configuration":{"service":{"type":"redis"}},"template":{"containers":[{"image":"redis","name":"redis"}],"scale":{"minReplicas":1}}},"tags":"[union(parameters(''tags''), createObject(''aspire-resource-name'', ''pubsub''))]","dependsOn":["[resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken'')))]"]},{"type":"Microsoft.Storage/storageAccounts","apiVersion":"2022-05-01","name":"[replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')]","location":"[parameters(''location'')]","kind":"Storage","sku":{"name":"Standard_GRS"},"tags":"[union(parameters(''tags''), createObject(''aspire-resource-name'', ''storage''))]"},{"type":"Microsoft.Authorization/roleAssignments","apiVersion":"2022-04-01","scope":"[format(''Microsoft.Storage/storageAccounts/{0}'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]","name":"[guid(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''ba92f5b4-2d11-453d-a403-e96b0029c9fe''))]","properties":{"principalId":"[reference(resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), ''2023-01-31'').principalId]","principalType":"ServicePrincipal","roleDefinitionId":"[subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''ba92f5b4-2d11-453d-a403-e96b0029c9fe'')]"},"dependsOn":["[resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken'')))]","[resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]"]},{"type":"Microsoft.Authorization/roleAssignments","apiVersion":"2022-04-01","scope":"[format(''Microsoft.Storage/storageAccounts/{0}'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]","name":"[guid(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''974c5e8b-45b9-4653-ba55-5f855dd0fb88''))]","properties":{"principalId":"[reference(resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), ''2023-01-31'').principalId]","principalType":"ServicePrincipal","roleDefinitionId":"[subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''974c5e8b-45b9-4653-ba55-5f855dd0fb88'')]"},"dependsOn":["[resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken'')))]","[resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]"]},{"type":"Microsoft.Authorization/roleAssignments","apiVersion":"2022-04-01","scope":"[format(''Microsoft.Storage/storageAccounts/{0}'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]","name":"[guid(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3''))]","properties":{"principalId":"[reference(resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), ''2023-01-31'').principalId]","principalType":"ServicePrincipal","roleDefinitionId":"[subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'')]"},"dependsOn":["[resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken'')))]","[resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]"]}],"outputs":{"MANAGED_IDENTITY_CLIENT_ID":{"type":"string","value":"[reference(resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), ''2023-01-31'').clientId]"},"AZURE_LOG_ANALYTICS_WORKSPACE_NAME":{"type":"string","value":"[format(''law-{0}'', variables(''resourceToken''))]"},"AZURE_CONTAINER_REGISTRY_ENDPOINT":{"type":"string","value":"[reference(resourceId(''Microsoft.ContainerRegistry/registries'', replace(format(''acr-{0}'', variables(''resourceToken'')), ''-'', '''')), ''2023-07-01'').loginServer]"},"AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID":{"type":"string","value":"[resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken'')))]"},"AZURE_CONTAINER_APPS_ENVIRONMENT_ID":{"type":"string","value":"[resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken'')))]"},"AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN":{"type":"string","value":"[reference(resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken''))), ''2023-05-01'').defaultDomain]"},"SERVICE_BINDING_MARKDOWN_ENDPOINT":{"type":"string","value":"[reference(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), ''2022-05-01'').primaryEndpoints.blob]"},"SERVICE_BINDING_REQUESTLOG_ENDPOINT":{"type":"string","value":"[reference(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), ''2022-05-01'').primaryEndpoints.table]"},"SERVICE_BINDING_MESSAGES_ENDPOINT":{"type":"string","value":"[reference(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), ''2022-05-01'').primaryEndpoints.queue]"}}}},"dependsOn":["[subscriptionResourceId(''Microsoft.Resources/resourceGroups'', format(''rg-{0}'', parameters(''environmentName'')))]"]}],"outputs":{"MANAGED_IDENTITY_CLIENT_ID":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.MANAGED_IDENTITY_CLIENT_ID.value]"},"AZURE_LOG_ANALYTICS_WORKSPACE_NAME":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.AZURE_LOG_ANALYTICS_WORKSPACE_NAME.value]"},"AZURE_CONTAINER_REGISTRY_ENDPOINT":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT.value]"},"AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID.value]"},"AZURE_CONTAINER_APPS_ENVIRONMENT_ID":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID.value]"},"AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN.value]"},"SERVICE_BINDING_MARKDOWN_ENDPOINT":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.SERVICE_BINDING_MARKDOWN_ENDPOINT.value]"},"SERVICE_BINDING_REQUESTLOG_ENDPOINT":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.SERVICE_BINDING_REQUESTLOG_ENDPOINT.value]"},"SERVICE_BINDING_MESSAGES_ENDPOINT":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.SERVICE_BINDING_MESSAGES_ENDPOINT.value]"}}}},"tags":{"azd-env-name":"azdtest-l4c10c9","azd-provision-param-hash":"c6534960363d73a71040bdc189ecb233003bc8a557aebd182ec26315f8f83cd3"}}'
         form: {}
         headers:
             Accept:
@@ -472,7 +472,7 @@ interactions:
                 - application/json
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l88c996-1708717227?api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l4c10c9-1708981207?api-version=2021-04-01
         method: PUT
       response:
         proto: HTTP/2.0
@@ -482,10 +482,10 @@ interactions:
         trailer: {}
         content_length: 1362
         uncompressed: false
-        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l88c996-1708717227","name":"azdtest-l88c996-1708717227","type":"Microsoft.Resources/deployments","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996","azd-provision-param-hash":"6354240e3b61edb702891d88e5c50b42b4af01f4c1dec5d56a7532a298f4fb48"},"properties":{"templateHash":"14419117427229910140","parameters":{"environmentName":{"type":"String","value":"azdtest-l88c996"},"location":{"type":"String","value":"eastus2"},"inputs":{"type":"SecureObject"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2024-02-23T19:41:14.4628533Z","duration":"PT0.0008563S","correlationId":"788803d5-d997-4a8f-bf79-f709132f8a66","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["eastus2"]},{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","resourceType":"Microsoft.Resources/resourceGroups","resourceName":"rg-azdtest-l88c996"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources"}]}}'
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l4c10c9-1708981207","name":"azdtest-l4c10c9-1708981207","type":"Microsoft.Resources/deployments","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9","azd-provision-param-hash":"c6534960363d73a71040bdc189ecb233003bc8a557aebd182ec26315f8f83cd3"},"properties":{"templateHash":"14419117427229910140","parameters":{"environmentName":{"type":"String","value":"azdtest-l4c10c9"},"location":{"type":"String","value":"eastus2"},"inputs":{"type":"SecureObject"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2024-02-26T21:00:54.4318935Z","duration":"PT0.0008641S","correlationId":"18b8d868-9ab3-44e5-91e6-04536c0cf51e","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["eastus2"]},{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9","resourceType":"Microsoft.Resources/resourceGroups","resourceName":"rg-azdtest-l4c10c9"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources"}]}}'
         headers:
             Azure-Asyncoperation:
-                - https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l88c996-1708717227/operationStatuses/08584928896130978657?api-version=2021-04-01
+                - https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l4c10c9-1708981207/operationStatuses/08584926256321632175?api-version=2021-04-01
             Cache-Control:
                 - no-cache
             Content-Length:
@@ -493,7 +493,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:41:15 GMT
+                - Mon, 26 Feb 2024 21:00:54 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -505,18 +505,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 788803d5-d997-4a8f-bf79-f709132f8a66
+                - 18b8d868-9ab3-44e5-91e6-04536c0cf51e
             X-Ms-Ratelimit-Remaining-Subscription-Writes:
                 - "1199"
             X-Ms-Request-Id:
-                - 788803d5-d997-4a8f-bf79-f709132f8a66
+                - 18b8d868-9ab3-44e5-91e6-04536c0cf51e
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194115Z:788803d5-d997-4a8f-bf79-f709132f8a66
+                - WESTUS2:20240226T210055Z:18b8d868-9ab3-44e5-91e6-04536c0cf51e
             X-Msedge-Ref:
-                - 'Ref A: 850BFD8D28EC459C8AEEDE8E9391041E Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:41:12Z'
+                - 'Ref A: C8F0C5885A044291BA8F4F0F8BCACDE3 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:00:52Z'
         status: 201 Created
         code: 201
-        duration: 2.99919948s
+        duration: 2.113301968s
     - id: 8
       request:
         proto: HTTP/1.1
@@ -537,7 +537,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l88c996-1708717227/operationStatuses/08584928896130978657?api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l4c10c9-1708981207/operationStatuses/08584926256321632175?api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -556,7 +556,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:44:17 GMT
+                - Mon, 26 Feb 2024 21:03:26 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -568,18 +568,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - f0df61ed-71e4-4532-8c27-729ffccf2142
+                - ba29587f-71ef-446c-9584-8b8dc6aeb959
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - f0df61ed-71e4-4532-8c27-729ffccf2142
+                - ba29587f-71ef-446c-9584-8b8dc6aeb959
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194417Z:f0df61ed-71e4-4532-8c27-729ffccf2142
+                - WESTUS2:20240226T210327Z:ba29587f-71ef-446c-9584-8b8dc6aeb959
             X-Msedge-Ref:
-                - 'Ref A: 4CFF84E433134F1882880D314AB20C58 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:17Z'
+                - 'Ref A: 7057E26F1D124C4D8CE36DB9D40793DB Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:03:27Z'
         status: 200 OK
         code: 200
-        duration: 190.157062ms
+        duration: 386.634091ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -600,7 +600,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l88c996-1708717227?api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l4c10c9-1708981207?api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -608,18 +608,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 4954
+        content_length: 4955
         uncompressed: false
-        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l88c996-1708717227","name":"azdtest-l88c996-1708717227","type":"Microsoft.Resources/deployments","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996","azd-provision-param-hash":"6354240e3b61edb702891d88e5c50b42b4af01f4c1dec5d56a7532a298f4fb48"},"properties":{"templateHash":"14419117427229910140","parameters":{"environmentName":{"type":"String","value":"azdtest-l88c996"},"location":{"type":"String","value":"eastus2"},"inputs":{"type":"SecureObject"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-23T19:43:53.0492909Z","duration":"PT2M38.5872939S","correlationId":"788803d5-d997-4a8f-bf79-f709132f8a66","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["eastus2"]},{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","resourceType":"Microsoft.Resources/resourceGroups","resourceName":"rg-azdtest-l88c996"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources"}],"outputs":{"manageD_IDENTITY_CLIENT_ID":{"type":"String","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},"azurE_LOG_ANALYTICS_WORKSPACE_NAME":{"type":"String","value":"law-gnxzs2f5m4idm"},"azurE_CONTAINER_REGISTRY_ENDPOINT":{"type":"String","value":"acrgnxzs2f5m4idm.azurecr.io"},"azurE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"},"azurE_CONTAINER_APPS_ENVIRONMENT_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm"},"azurE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN":{"type":"String","value":"happybush-752e10b4.eastus2.azurecontainerapps.io"},"servicE_BINDING_MARKDOWN_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.blob.core.windows.net/"},"servicE_BINDING_REQUESTLOG_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.table.core.windows.net/"},"servicE_BINDING_MESSAGES_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.queue.core.windows.net/"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/cache"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/pubsub"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ContainerRegistry/registries/acrgnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ContainerRegistry/registries/acrgnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/faee5324-3278-5609-995a-8e845396fbe9"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.OperationalInsights/workspaces/law-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/blobServices/default"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/7bc4c3d5-404b-5a27-b547-08f357bed58b"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/a9bde9d1-b484-5092-9aaa-77577f0c97dd"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/aa646b75-ef6f-5e88-adff-bd4e630fcb69"}]}}'
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l4c10c9-1708981207","name":"azdtest-l4c10c9-1708981207","type":"Microsoft.Resources/deployments","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9","azd-provision-param-hash":"c6534960363d73a71040bdc189ecb233003bc8a557aebd182ec26315f8f83cd3"},"properties":{"templateHash":"14419117427229910140","parameters":{"environmentName":{"type":"String","value":"azdtest-l4c10c9"},"location":{"type":"String","value":"eastus2"},"inputs":{"type":"SecureObject"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T21:03:24.5994655Z","duration":"PT2M30.1684361S","correlationId":"18b8d868-9ab3-44e5-91e6-04536c0cf51e","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["eastus2"]},{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9","resourceType":"Microsoft.Resources/resourceGroups","resourceName":"rg-azdtest-l4c10c9"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources"}],"outputs":{"manageD_IDENTITY_CLIENT_ID":{"type":"String","value":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"},"azurE_LOG_ANALYTICS_WORKSPACE_NAME":{"type":"String","value":"law-soindfxt2muzw"},"azurE_CONTAINER_REGISTRY_ENDPOINT":{"type":"String","value":"acrsoindfxt2muzw.azurecr.io"},"azurE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"},"azurE_CONTAINER_APPS_ENVIRONMENT_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw"},"azurE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN":{"type":"String","value":"mangoplant-0534793d.eastus2.azurecontainerapps.io"},"servicE_BINDING_MARKDOWN_ENDPOINT":{"type":"String","value":"https://storagesoindfxt2muzw.blob.core.windows.net/"},"servicE_BINDING_REQUESTLOG_ENDPOINT":{"type":"String","value":"https://storagesoindfxt2muzw.table.core.windows.net/"},"servicE_BINDING_MESSAGES_ENDPOINT":{"type":"String","value":"https://storagesoindfxt2muzw.queue.core.windows.net/"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/cache"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/pubsub"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ContainerRegistry/registries/acrsoindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ContainerRegistry/registries/acrsoindfxt2muzw/providers/Microsoft.Authorization/roleAssignments/f11e9f84-10b6-5a7a-823a-ff920999efab"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.OperationalInsights/workspaces/law-soindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw/blobServices/default"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw/providers/Microsoft.Authorization/roleAssignments/375d2d03-b2cb-5480-8c5f-1ed90a8964a2"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw/providers/Microsoft.Authorization/roleAssignments/b7bc2b96-e891-5847-a299-e1b73a980306"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw/providers/Microsoft.Authorization/roleAssignments/e303f4d9-03e1-5676-8709-5c1e78da21ae"}]}}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "4954"
+                - "4955"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:44:17 GMT
+                - Mon, 26 Feb 2024 21:03:26 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -631,18 +631,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 69f17048-3483-43e5-85d4-d373e40ca035
+                - f2092dcc-5ebe-45d6-bf55-c34781e81841
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11998"
+                - "11999"
             X-Ms-Request-Id:
-                - 69f17048-3483-43e5-85d4-d373e40ca035
+                - f2092dcc-5ebe-45d6-bf55-c34781e81841
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194417Z:69f17048-3483-43e5-85d4-d373e40ca035
+                - WESTUS2:20240226T210327Z:f2092dcc-5ebe-45d6-bf55-c34781e81841
             X-Msedge-Ref:
-                - 'Ref A: 6788482058404A76A1D021D36896BADC Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:17Z'
+                - 'Ref A: 00A7E45FB5CA4B2E94FC7ED6F3FB65AD Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:03:27Z'
         status: 200 OK
         code: 200
-        duration: 384.323129ms
+        duration: 222.275648ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -665,7 +665,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l4c10c9%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -675,7 +675,7 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9","name":"rg-azdtest-l4c10c9","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"},"properties":{"provisioningState":"Succeeded"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -684,7 +684,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:44:17 GMT
+                - Mon, 26 Feb 2024 21:03:26 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -696,18 +696,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 5f795794-7a37-48c8-9cd2-5b0fb27d1bac
+                - 60cb4c51-c0ed-44bf-8239-1efd8833b67c
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11998"
             X-Ms-Request-Id:
-                - 5f795794-7a37-48c8-9cd2-5b0fb27d1bac
+                - 60cb4c51-c0ed-44bf-8239-1efd8833b67c
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194417Z:5f795794-7a37-48c8-9cd2-5b0fb27d1bac
+                - WESTUS2:20240226T210327Z:60cb4c51-c0ed-44bf-8239-1efd8833b67c
             X-Msedge-Ref:
-                - 'Ref A: 74E485B13C1B4ACD884822E835726DA3 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:17Z'
+                - 'Ref A: 1F9D978515F34BB3948BCFD4250AC610 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:03:27Z'
         status: 200 OK
         code: 200
-        duration: 53.447345ms
+        duration: 44.173708ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -730,7 +730,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l4c10c9%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -740,7 +740,7 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9","name":"rg-azdtest-l4c10c9","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"},"properties":{"provisioningState":"Succeeded"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -749,7 +749,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:44:18 GMT
+                - Mon, 26 Feb 2024 21:03:27 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -761,18 +761,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - dfe37988-d443-4877-91bb-cf5f5e275bd6
+                - 56d1dfb1-cb66-43cf-b0ca-778e5bee3e47
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - dfe37988-d443-4877-91bb-cf5f5e275bd6
+                - 56d1dfb1-cb66-43cf-b0ca-778e5bee3e47
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194418Z:dfe37988-d443-4877-91bb-cf5f5e275bd6
+                - WESTUS2:20240226T210328Z:56d1dfb1-cb66-43cf-b0ca-778e5bee3e47
             X-Msedge-Ref:
-                - 'Ref A: 91625CF16D2F417D9ACCA6CAE4232BCB Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:18Z'
+                - 'Ref A: 77CEF4DD0B7F4694856E4182EFD48431 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:03:28Z'
         status: 200 OK
         code: 200
-        duration: 76.709511ms
+        duration: 56.989173ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -782,17 +782,17 @@ interactions:
         transfer_encoding:
             - chunked
         trailer: {}
-        host: acrgnxzs2f5m4idm.azurecr.io
+        host: acrsoindfxt2muzw.azurecr.io
         remote_addr: ""
         request_uri: ""
-        body: access_token=SANITIZED&grant_type=access_token&service=acrgnxzs2f5m4idm.azurecr.io
+        body: access_token=SANITIZED&grant_type=access_token&service=acrsoindfxt2muzw.azurecr.io
         form:
             access_token:
                 - SANITIZED
             grant_type:
                 - access_token
             service:
-                - acrgnxzs2f5m4idm.azurecr.io
+                - acrsoindfxt2muzw.azurecr.io
         headers:
             Accept-Encoding:
                 - gzip
@@ -802,7 +802,7 @@ interactions:
                 - application/x-www-form-urlencoded
             User-Agent:
                 - azsdk-go-azd-acr/0.0.0-dev.0 (commit 0000000000000000000000000000000000000000) (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://acrgnxzs2f5m4idm.azurecr.io:443/oauth2/exchange
+        url: https://acrsoindfxt2muzw.azurecr.io:443/oauth2/exchange
         method: POST
       response:
         proto: HTTP/1.1
@@ -820,18 +820,18 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:44:19 GMT
+                - Mon, 26 Feb 2024 21:03:28 GMT
             Server:
                 - openresty
             Strict-Transport-Security:
                 - max-age=31536000; includeSubDomains
             X-Ms-Correlation-Request-Id:
-                - 0d7ebf54-5e4d-4ac5-b868-cc3e20455df4
+                - c1502df5-7551-459e-be5b-faae52519401
             X-Ms-Ratelimit-Remaining-Calls-Per-Second:
                 - "166.65"
         status: 200 OK
         code: 200
-        duration: 492.855676ms
+        duration: 549.092112ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -843,7 +843,7 @@ interactions:
         host: management.azure.com
         remote_addr: ""
         request_uri: ""
-        body: '{"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{}}},"location":"eastus2","properties":{"configuration":{"activeRevisionsMode":"single","ingress":{"allowInsecure":true,"external":false,"targetPort":8080,"transport":"http"},"registries":[{"identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm","server":"acrgnxzs2f5m4idm.azurecr.io"}]},"environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","template":{"containers":[{"env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-apiservice-1708717459","name":"apiservice"}],"scale":{"minReplicas":1}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"}}'
+        body: '{"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{}}},"location":"eastus2","properties":{"configuration":{"activeRevisionsMode":"single","ingress":{"allowInsecure":true,"external":false,"targetPort":8080,"transport":"http"},"registries":[{"identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw","server":"acrsoindfxt2muzw.azurecr.io"}]},"environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","template":{"containers":[{"env":[{"name":"AZURE_CLIENT_ID","value":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"image":"acrsoindfxt2muzw.azurecr.io/azd-deploy-apiservice-1708981409","name":"apiservice"}],"scale":{"minReplicas":1}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"}}'
         form: {}
         headers:
             Accept:
@@ -858,7 +858,7 @@ interactions:
                 - application/json
             User-Agent:
                 - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice?api-version=2022-11-01-preview
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/apiservice?api-version=2022-11-01-preview
         method: PUT
       response:
         proto: HTTP/2.0
@@ -868,12 +868,12 @@ interactions:
         trailer: {}
         content_length: 2979
         uncompressed: false
-        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:44:34.9263707Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:44:34.9263707Z"},"properties":{"provisioningState":"InProgress","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"","latestReadyRevisionName":"","latestRevisionFqdn":"","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","external":false,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-apiservice-1708717459","name":"apiservice","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/apiservice/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerapps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:03:45.0704226Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:03:45.0704226Z"},"properties":{"provisioningState":"InProgress","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","workloadProfileName":null,"outboundIpAddresses":["172.175.21.8"],"latestRevisionName":"","latestReadyRevisionName":"","latestRevisionFqdn":"","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io","external":false,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrsoindfxt2muzw.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrsoindfxt2muzw.azurecr.io/azd-deploy-apiservice-1708981409","name":"apiservice","env":[{"name":"AZURE_CLIENT_ID","value":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/containerApps/apiservice/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}}}'
         headers:
             Api-Supported-Versions:
                 - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
             Azure-Asyncoperation:
-                - https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/a651f0a6-e38d-43c6-aa76-e446ed34f3fe?api-version=2022-11-01-preview&azureAsyncOperation=true&t=638443142770357565&c=MIIHADCCBeigAwIBAgITfARmPsJdo2ShuN-ImAAABGY-wjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUwHhcNMjQwMTMxMjIwNzA5WhcNMjUwMTI1MjIwNzA5WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOVFiSMi9Sg6cKnrBuPHbDk_Zwa1ZNYHwLVPJArEI9N2bLrgd1mU0ZdNVcdf6rtZCkUUuCe3vxnVTGwufpwH9GPWDgJOpJoL9wgKOzUDiHLUeiWPjrK1AoaQVprZgjnzXBIWiZC2tZjbUT9pOI_ixYJJPrsCfLt7HEccnhObROE1mo_hpiPDrtOQDaX-BboNceB8vI1wmSPApGpPRM9hBRQbXgqKFC8094UNsMVkWPCrsPvP5YlMBLARlGf2WTevGKRREjstkApf1Swi7uKnpyhhsidD1yREMU0mWY9wnZfAX0jpEp3p9jKVMPQ3L-m-nSZI4zrtbW0AnI0O3pAEwe0CAwEAAaOCA-0wggPpMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9DTzFQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA1LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MB0GA1UdDgQWBBT2vcy9ccvhGewsiHI1BQHsz3Wn8zAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBR61hmFKHlscXYeYPjzS--iBUIWHTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBADNBZjhX44bpBtC8kogZJGe4lYeHX95whfZ7X_CMSUuZRbQQ_b6raUpp8V8eF0YUa9b3Oa-DGrs5WfzogCuGcJPeoEVnDYzc1jlKubSIpGw73aGZzhbTjJeNf-Qe-5vTG-GcNzVtIcrwi93YSiK2LSbgrLpTL7T7znjePcGRRkCBjAslrV5SqufcsrpGmqvPAVKXRV-OIOzvXy6qmn9CHmdo0RGBXGIakbLMec_1SIS8NdPsB6i6XPjL2SDjqKTa5car7bVYlXEVsgL-000VF1t6x1II3VBNfsEJ81CdJyxaCJnwvWI6kHtCtJX9QYK3qZab9PfZRBvcetJoPdMFvBU&s=CxpCKXA74prS2HiBMdIUNg__c8TONOppiAVTMlQ95COvNm4svecEUcpCXpEVPUh07PABZg8zSKbJ0KdKJwxh9eKJsB4USvHy8-36mPLGAFWURj8yIR9dukUHrn0629oqzpTzRx7-NzvenRnej1LVURwtmKSeRyjsqdsppSmpiJ0BI7l_jXyi8a1tm29B1MZrhh8df8WVO0zuPgYwIn6BwPUdDDHMSkSolHpI6I-Oltib5wsYO0-C1k93EoN8XJ9DAgWESep3zodDqt9mSmjKMxsYSssTx1LZshdMg6GZbGm8Jj6_Ij_WNBs9fQBuh_E3GKQ170OtQLOS-WIdCHN-eg&h=uQAxmHN8_62WefIDJneIYWv18BVU00sqxDIDhIhyL2Q
+                - https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/aecdf612-6438-482c-8c58-7f6b19dbd1d6?api-version=2022-11-01-preview&azureAsyncOperation=true&t=638445782269763183&c=MIIHADCCBeigAwIBAgITfARmPsJdo2ShuN-ImAAABGY-wjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUwHhcNMjQwMTMxMjIwNzA5WhcNMjUwMTI1MjIwNzA5WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOVFiSMi9Sg6cKnrBuPHbDk_Zwa1ZNYHwLVPJArEI9N2bLrgd1mU0ZdNVcdf6rtZCkUUuCe3vxnVTGwufpwH9GPWDgJOpJoL9wgKOzUDiHLUeiWPjrK1AoaQVprZgjnzXBIWiZC2tZjbUT9pOI_ixYJJPrsCfLt7HEccnhObROE1mo_hpiPDrtOQDaX-BboNceB8vI1wmSPApGpPRM9hBRQbXgqKFC8094UNsMVkWPCrsPvP5YlMBLARlGf2WTevGKRREjstkApf1Swi7uKnpyhhsidD1yREMU0mWY9wnZfAX0jpEp3p9jKVMPQ3L-m-nSZI4zrtbW0AnI0O3pAEwe0CAwEAAaOCA-0wggPpMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9DTzFQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA1LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MB0GA1UdDgQWBBT2vcy9ccvhGewsiHI1BQHsz3Wn8zAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBR61hmFKHlscXYeYPjzS--iBUIWHTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBADNBZjhX44bpBtC8kogZJGe4lYeHX95whfZ7X_CMSUuZRbQQ_b6raUpp8V8eF0YUa9b3Oa-DGrs5WfzogCuGcJPeoEVnDYzc1jlKubSIpGw73aGZzhbTjJeNf-Qe-5vTG-GcNzVtIcrwi93YSiK2LSbgrLpTL7T7znjePcGRRkCBjAslrV5SqufcsrpGmqvPAVKXRV-OIOzvXy6qmn9CHmdo0RGBXGIakbLMec_1SIS8NdPsB6i6XPjL2SDjqKTa5car7bVYlXEVsgL-000VF1t6x1II3VBNfsEJ81CdJyxaCJnwvWI6kHtCtJX9QYK3qZab9PfZRBvcetJoPdMFvBU&s=4YDvyDcK1SGW9Ti6BzXwzAK0kJn_NawTjFAHeuWV7NBU1NyE8eN-nP49VHBg0nFLuHuiUCOE-idgvSq1VedOiWmExS6Xs58hDtIKEXuE1WyVp3jyx_dbbt97Xve0f1G04OHB6W2gA3YUfLZ1E1NIdYilHyOgfDnR_WpX9SnC8cinvK1KoPBDj-jRFyxirb6eBcAZde2A9Pur4sHfWHeJpzd7pk3XvndV-o2x3JhAg-MxpIJvLU7l2TS4piQ2ZTlX3ZpwhP988KKfkBetGpAimaIixsyiwunp4chuINwIB6hbk58PAFztgUf30bMGosCgdFN2chYvkHVgOcAow9LBcA&h=Q-9M9iPWQRvvgSjm_PMKWSgHX3nzk16QRdaAu5FfIjw
             Cache-Control:
                 - no-cache
             Content-Length:
@@ -881,7 +881,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:44:36 GMT
+                - Mon, 26 Feb 2024 21:03:46 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -897,20 +897,20 @@ interactions:
             X-Ms-Async-Operation-Timeout:
                 - PT15M
             X-Ms-Correlation-Request-Id:
-                - 7c1f7438-ffdd-466a-a856-5513f9386970
+                - 8a1116e9-c2ed-42d3-87e0-090d1039b399
             X-Ms-Ratelimit-Remaining-Subscription-Resource-Requests:
                 - "699"
             X-Ms-Request-Id:
-                - 7c1f7438-ffdd-466a-a856-5513f9386970
+                - 8a1116e9-c2ed-42d3-87e0-090d1039b399
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194437Z:7c1f7438-ffdd-466a-a856-5513f9386970
+                - WESTUS2:20240226T210346Z:8a1116e9-c2ed-42d3-87e0-090d1039b399
             X-Msedge-Ref:
-                - 'Ref A: C1249D776F3D48E888DF690E938FBAA3 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:34Z'
+                - 'Ref A: F8D5ABF8BEBB4D5793349BD4833BD6E4 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:03:44Z'
             X-Powered-By:
                 - ASP.NET
         status: 201 Created
         code: 201
-        duration: 2.814389168s
+        duration: 2.715769967s
     - id: 14
       request:
         proto: HTTP/1.1
@@ -931,7 +931,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/a651f0a6-e38d-43c6-aa76-e446ed34f3fe?api-version=2022-11-01-preview&azureAsyncOperation=true&t=638443142770357565&c=MIIHADCCBeigAwIBAgITfARmPsJdo2ShuN-ImAAABGY-wjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUwHhcNMjQwMTMxMjIwNzA5WhcNMjUwMTI1MjIwNzA5WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOVFiSMi9Sg6cKnrBuPHbDk_Zwa1ZNYHwLVPJArEI9N2bLrgd1mU0ZdNVcdf6rtZCkUUuCe3vxnVTGwufpwH9GPWDgJOpJoL9wgKOzUDiHLUeiWPjrK1AoaQVprZgjnzXBIWiZC2tZjbUT9pOI_ixYJJPrsCfLt7HEccnhObROE1mo_hpiPDrtOQDaX-BboNceB8vI1wmSPApGpPRM9hBRQbXgqKFC8094UNsMVkWPCrsPvP5YlMBLARlGf2WTevGKRREjstkApf1Swi7uKnpyhhsidD1yREMU0mWY9wnZfAX0jpEp3p9jKVMPQ3L-m-nSZI4zrtbW0AnI0O3pAEwe0CAwEAAaOCA-0wggPpMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9DTzFQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA1LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MB0GA1UdDgQWBBT2vcy9ccvhGewsiHI1BQHsz3Wn8zAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBR61hmFKHlscXYeYPjzS--iBUIWHTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBADNBZjhX44bpBtC8kogZJGe4lYeHX95whfZ7X_CMSUuZRbQQ_b6raUpp8V8eF0YUa9b3Oa-DGrs5WfzogCuGcJPeoEVnDYzc1jlKubSIpGw73aGZzhbTjJeNf-Qe-5vTG-GcNzVtIcrwi93YSiK2LSbgrLpTL7T7znjePcGRRkCBjAslrV5SqufcsrpGmqvPAVKXRV-OIOzvXy6qmn9CHmdo0RGBXGIakbLMec_1SIS8NdPsB6i6XPjL2SDjqKTa5car7bVYlXEVsgL-000VF1t6x1II3VBNfsEJ81CdJyxaCJnwvWI6kHtCtJX9QYK3qZab9PfZRBvcetJoPdMFvBU&s=CxpCKXA74prS2HiBMdIUNg__c8TONOppiAVTMlQ95COvNm4svecEUcpCXpEVPUh07PABZg8zSKbJ0KdKJwxh9eKJsB4USvHy8-36mPLGAFWURj8yIR9dukUHrn0629oqzpTzRx7-NzvenRnej1LVURwtmKSeRyjsqdsppSmpiJ0BI7l_jXyi8a1tm29B1MZrhh8df8WVO0zuPgYwIn6BwPUdDDHMSkSolHpI6I-Oltib5wsYO0-C1k93EoN8XJ9DAgWESep3zodDqt9mSmjKMxsYSssTx1LZshdMg6GZbGm8Jj6_Ij_WNBs9fQBuh_E3GKQ170OtQLOS-WIdCHN-eg&h=uQAxmHN8_62WefIDJneIYWv18BVU00sqxDIDhIhyL2Q
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/aecdf612-6438-482c-8c58-7f6b19dbd1d6?api-version=2022-11-01-preview&azureAsyncOperation=true&t=638445782269763183&c=MIIHADCCBeigAwIBAgITfARmPsJdo2ShuN-ImAAABGY-wjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUwHhcNMjQwMTMxMjIwNzA5WhcNMjUwMTI1MjIwNzA5WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOVFiSMi9Sg6cKnrBuPHbDk_Zwa1ZNYHwLVPJArEI9N2bLrgd1mU0ZdNVcdf6rtZCkUUuCe3vxnVTGwufpwH9GPWDgJOpJoL9wgKOzUDiHLUeiWPjrK1AoaQVprZgjnzXBIWiZC2tZjbUT9pOI_ixYJJPrsCfLt7HEccnhObROE1mo_hpiPDrtOQDaX-BboNceB8vI1wmSPApGpPRM9hBRQbXgqKFC8094UNsMVkWPCrsPvP5YlMBLARlGf2WTevGKRREjstkApf1Swi7uKnpyhhsidD1yREMU0mWY9wnZfAX0jpEp3p9jKVMPQ3L-m-nSZI4zrtbW0AnI0O3pAEwe0CAwEAAaOCA-0wggPpMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9DTzFQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA1LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MB0GA1UdDgQWBBT2vcy9ccvhGewsiHI1BQHsz3Wn8zAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBR61hmFKHlscXYeYPjzS--iBUIWHTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBADNBZjhX44bpBtC8kogZJGe4lYeHX95whfZ7X_CMSUuZRbQQ_b6raUpp8V8eF0YUa9b3Oa-DGrs5WfzogCuGcJPeoEVnDYzc1jlKubSIpGw73aGZzhbTjJeNf-Qe-5vTG-GcNzVtIcrwi93YSiK2LSbgrLpTL7T7znjePcGRRkCBjAslrV5SqufcsrpGmqvPAVKXRV-OIOzvXy6qmn9CHmdo0RGBXGIakbLMec_1SIS8NdPsB6i6XPjL2SDjqKTa5car7bVYlXEVsgL-000VF1t6x1II3VBNfsEJ81CdJyxaCJnwvWI6kHtCtJX9QYK3qZab9PfZRBvcetJoPdMFvBU&s=4YDvyDcK1SGW9Ti6BzXwzAK0kJn_NawTjFAHeuWV7NBU1NyE8eN-nP49VHBg0nFLuHuiUCOE-idgvSq1VedOiWmExS6Xs58hDtIKEXuE1WyVp3jyx_dbbt97Xve0f1G04OHB6W2gA3YUfLZ1E1NIdYilHyOgfDnR_WpX9SnC8cinvK1KoPBDj-jRFyxirb6eBcAZde2A9Pur4sHfWHeJpzd7pk3XvndV-o2x3JhAg-MxpIJvLU7l2TS4piQ2ZTlX3ZpwhP988KKfkBetGpAimaIixsyiwunp4chuINwIB6hbk58PAFztgUf30bMGosCgdFN2chYvkHVgOcAow9LBcA&h=Q-9M9iPWQRvvgSjm_PMKWSgHX3nzk16QRdaAu5FfIjw
         method: GET
       response:
         proto: HTTP/2.0
@@ -941,7 +941,7 @@ interactions:
         trailer: {}
         content_length: 278
         uncompressed: false
-        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/a651f0a6-e38d-43c6-aa76-e446ed34f3fe","name":"a651f0a6-e38d-43c6-aa76-e446ed34f3fe","status":"Succeeded","startTime":"2024-02-23T19:44:35.7922444"}'
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/aecdf612-6438-482c-8c58-7f6b19dbd1d6","name":"aecdf612-6438-482c-8c58-7f6b19dbd1d6","status":"Succeeded","startTime":"2024-02-26T21:03:45.8399496"}'
         headers:
             Api-Supported-Versions:
                 - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
@@ -952,7 +952,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:44:52 GMT
+                - Mon, 26 Feb 2024 21:04:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -966,20 +966,20 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 83d0b64e-9d9e-4f2f-b95e-08804c37b8e2
+                - 6128c118-7b8b-4afd-a9ce-f5cb570f5d5f
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11998"
             X-Ms-Request-Id:
-                - 83d0b64e-9d9e-4f2f-b95e-08804c37b8e2
+                - 6128c118-7b8b-4afd-a9ce-f5cb570f5d5f
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194452Z:83d0b64e-9d9e-4f2f-b95e-08804c37b8e2
+                - WESTUS2:20240226T210402Z:6128c118-7b8b-4afd-a9ce-f5cb570f5d5f
             X-Msedge-Ref:
-                - 'Ref A: 30B16D5B82914D7CB20A267FAC8F9938 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:52Z'
+                - 'Ref A: 93A0EA5C79F9414CA43305B8BB6F861B Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:04:02Z'
             X-Powered-By:
                 - ASP.NET
         status: 200 OK
         code: 200
-        duration: 275.370641ms
+        duration: 321.372862ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -1000,7 +1000,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice?api-version=2022-11-01-preview
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/apiservice?api-version=2022-11-01-preview
         method: GET
       response:
         proto: HTTP/2.0
@@ -1008,20 +1008,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3091
+        content_length: 3092
         uncompressed: false
-        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:44:34.9263707","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:44:34.9263707"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"apiservice--sjvfox3","latestReadyRevisionName":"apiservice--sjvfox3","latestRevisionFqdn":"apiservice--sjvfox3.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","external":false,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-apiservice-1708717459","name":"apiservice","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/apiservice/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerapps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:03:45.0704226","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:03:45.0704226"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","workloadProfileName":null,"outboundIpAddresses":["172.175.21.8"],"latestRevisionName":"apiservice--54vuttn","latestReadyRevisionName":"apiservice--54vuttn","latestRevisionFqdn":"apiservice--54vuttn.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io","external":false,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrsoindfxt2muzw.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrsoindfxt2muzw.azurecr.io/azd-deploy-apiservice-1708981409","name":"apiservice","env":[{"name":"AZURE_CLIENT_ID","value":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/containerApps/apiservice/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}}}'
         headers:
             Api-Supported-Versions:
                 - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "3091"
+                - "3092"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:44:52 GMT
+                - Mon, 26 Feb 2024 21:04:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1035,20 +1035,20 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 45a234ab-7f3b-4777-a40e-de34ee7aefcb
+                - 7de64baf-259f-4652-a9c5-d39b14307be0
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 45a234ab-7f3b-4777-a40e-de34ee7aefcb
+                - 7de64baf-259f-4652-a9c5-d39b14307be0
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194452Z:45a234ab-7f3b-4777-a40e-de34ee7aefcb
+                - WESTUS2:20240226T210402Z:7de64baf-259f-4652-a9c5-d39b14307be0
             X-Msedge-Ref:
-                - 'Ref A: 912355F0A55F4AAE9D22681E2C62156D Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:52Z'
+                - 'Ref A: CC84841886A54B8BB318038156E51C7F Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:04:02Z'
             X-Powered-By:
                 - ASP.NET
         status: 200 OK
         code: 200
-        duration: 425.163637ms
+        duration: 500.878595ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -1071,7 +1071,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice?api-version=2022-11-01-preview
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/apiservice?api-version=2022-11-01-preview
         method: GET
       response:
         proto: HTTP/2.0
@@ -1079,20 +1079,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3091
+        content_length: 3092
         uncompressed: false
-        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:44:34.9263707","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:44:34.9263707"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"apiservice--sjvfox3","latestReadyRevisionName":"apiservice--sjvfox3","latestRevisionFqdn":"apiservice--sjvfox3.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","external":false,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-apiservice-1708717459","name":"apiservice","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/apiservice/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerapps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:03:45.0704226","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:03:45.0704226"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","workloadProfileName":null,"outboundIpAddresses":["172.175.21.8"],"latestRevisionName":"apiservice--54vuttn","latestReadyRevisionName":"apiservice--54vuttn","latestRevisionFqdn":"apiservice--54vuttn.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io","external":false,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrsoindfxt2muzw.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrsoindfxt2muzw.azurecr.io/azd-deploy-apiservice-1708981409","name":"apiservice","env":[{"name":"AZURE_CLIENT_ID","value":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/containerApps/apiservice/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}}}'
         headers:
             Api-Supported-Versions:
                 - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "3091"
+                - "3092"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:44:53 GMT
+                - Mon, 26 Feb 2024 21:04:02 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1106,20 +1106,20 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 046b821c-3806-451f-a3b9-7fffef775a99
+                - b45e5b37-5e82-4b0c-9e75-62e1e5390fb0
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11998"
             X-Ms-Request-Id:
-                - 046b821c-3806-451f-a3b9-7fffef775a99
+                - b45e5b37-5e82-4b0c-9e75-62e1e5390fb0
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194453Z:046b821c-3806-451f-a3b9-7fffef775a99
+                - WESTUS2:20240226T210403Z:b45e5b37-5e82-4b0c-9e75-62e1e5390fb0
             X-Msedge-Ref:
-                - 'Ref A: FD1977043233452BBF5B13A8ECBF7420 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:52Z'
+                - 'Ref A: B81DD17EE6F04A398B5E7F5155F1348B Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:04:02Z'
             X-Powered-By:
                 - ASP.NET
         status: 200 OK
         code: 200
-        duration: 489.524672ms
+        duration: 430.273863ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -1142,7 +1142,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l4c10c9%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -1152,7 +1152,7 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9","name":"rg-azdtest-l4c10c9","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"},"properties":{"provisioningState":"Succeeded"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -1161,7 +1161,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:44:53 GMT
+                - Mon, 26 Feb 2024 21:04:02 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1173,18 +1173,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 03c07d4e-a317-493b-a477-aa8286da9df4
+                - 6558bc91-c35f-4bb0-bad7-418f1abb4fa3
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 03c07d4e-a317-493b-a477-aa8286da9df4
+                - 6558bc91-c35f-4bb0-bad7-418f1abb4fa3
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194453Z:03c07d4e-a317-493b-a477-aa8286da9df4
+                - WESTUS2:20240226T210403Z:6558bc91-c35f-4bb0-bad7-418f1abb4fa3
             X-Msedge-Ref:
-                - 'Ref A: 7421B36ECBC940BB88AC3EAAEAA185AA Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:53Z'
+                - 'Ref A: F1954BBEFC9A42D792F34329F3DB2691 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:04:03Z'
         status: 200 OK
         code: 200
-        duration: 46.589323ms
+        duration: 79.120921ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -1194,17 +1194,17 @@ interactions:
         transfer_encoding:
             - chunked
         trailer: {}
-        host: acrgnxzs2f5m4idm.azurecr.io
+        host: acrsoindfxt2muzw.azurecr.io
         remote_addr: ""
         request_uri: ""
-        body: access_token=SANITIZED&grant_type=access_token&service=acrgnxzs2f5m4idm.azurecr.io
+        body: access_token=SANITIZED&grant_type=access_token&service=acrsoindfxt2muzw.azurecr.io
         form:
             access_token:
                 - SANITIZED
             grant_type:
                 - access_token
             service:
-                - acrgnxzs2f5m4idm.azurecr.io
+                - acrsoindfxt2muzw.azurecr.io
         headers:
             Accept-Encoding:
                 - gzip
@@ -1214,7 +1214,7 @@ interactions:
                 - application/x-www-form-urlencoded
             User-Agent:
                 - azsdk-go-azd-acr/0.0.0-dev.0 (commit 0000000000000000000000000000000000000000) (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://acrgnxzs2f5m4idm.azurecr.io:443/oauth2/exchange
+        url: https://acrsoindfxt2muzw.azurecr.io:443/oauth2/exchange
         method: POST
       response:
         proto: HTTP/1.1
@@ -1232,18 +1232,18 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:44:53 GMT
+                - Mon, 26 Feb 2024 21:04:03 GMT
             Server:
                 - openresty
             Strict-Transport-Security:
                 - max-age=31536000; includeSubDomains
             X-Ms-Correlation-Request-Id:
-                - 29a93275-1c74-4cce-8ce2-a7f4c9ef71ba
+                - a577b748-b432-4e32-b239-8c65f35a71be
             X-Ms-Ratelimit-Remaining-Calls-Per-Second:
-                - "166.616667"
+                - "166.633333"
         status: 200 OK
         code: 200
-        duration: 81.529461ms
+        duration: 87.326693ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1268,7 +1268,7 @@ interactions:
                 - "0"
             User-Agent:
                 - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/cache/listSecrets?api-version=2022-11-01-preview
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/cache/listSecrets?api-version=2022-11-01-preview
         method: POST
       response:
         proto: HTTP/2.0
@@ -1289,7 +1289,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:09 GMT
+                - Mon, 26 Feb 2024 21:04:17 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1303,20 +1303,20 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 6713982f-74da-4601-912e-91ee1a93a828
+                - 7e82f8e9-01a3-4c89-b478-e6497a8da8bc
             X-Ms-Ratelimit-Remaining-Subscription-Writes:
                 - "1199"
             X-Ms-Request-Id:
-                - 6713982f-74da-4601-912e-91ee1a93a828
+                - 7e82f8e9-01a3-4c89-b478-e6497a8da8bc
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194509Z:6713982f-74da-4601-912e-91ee1a93a828
+                - WESTUS2:20240226T210418Z:7e82f8e9-01a3-4c89-b478-e6497a8da8bc
             X-Msedge-Ref:
-                - 'Ref A: D2AB97F0DF4D4522A4956C10662CA69C Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:08Z'
+                - 'Ref A: 7DD3B3C705834C978FB69922D043AF85 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:04:17Z'
             X-Powered-By:
                 - ASP.NET
         status: 200 OK
         code: 200
-        duration: 802.381148ms
+        duration: 963.098506ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1341,7 +1341,7 @@ interactions:
                 - "0"
             User-Agent:
                 - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/pubsub/listSecrets?api-version=2022-11-01-preview
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/pubsub/listSecrets?api-version=2022-11-01-preview
         method: POST
       response:
         proto: HTTP/2.0
@@ -1362,7 +1362,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:09 GMT
+                - Mon, 26 Feb 2024 21:04:17 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1376,32 +1376,32 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - c4796ab8-122a-475a-ae7d-15e7a348d7ba
+                - 371a386e-e76a-4e7a-ba40-e71f0e5d1b0e
             X-Ms-Ratelimit-Remaining-Subscription-Writes:
-                - "1199"
+                - "1198"
             X-Ms-Request-Id:
-                - c4796ab8-122a-475a-ae7d-15e7a348d7ba
+                - 371a386e-e76a-4e7a-ba40-e71f0e5d1b0e
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194509Z:c4796ab8-122a-475a-ae7d-15e7a348d7ba
+                - WESTUS2:20240226T210418Z:371a386e-e76a-4e7a-ba40-e71f0e5d1b0e
             X-Msedge-Ref:
-                - 'Ref A: FF6015962A0F4C32B270CF695A9B9256 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:09Z'
+                - 'Ref A: 70C14B2FF3434DEA9862F796419270DE Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:04:18Z'
             X-Powered-By:
                 - ASP.NET
         status: 200 OK
         code: 200
-        duration: 581.607369ms
+        duration: 687.32418ms
     - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 2630
+        content_length: 2632
         transfer_encoding: []
         trailer: {}
         host: management.azure.com
         remote_addr: ""
         request_uri: ""
-        body: '{"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{}}},"location":"eastus2","properties":{"configuration":{"activeRevisionsMode":"single","ingress":{"allowInsecure":false,"external":true,"targetPort":8080,"transport":"http"},"registries":[{"identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm","server":"acrgnxzs2f5m4idm.azurecr.io"}],"secrets":[{"name":"connectionstrings--cache","value":"cache:6379,password=0VqFkT9yYDKGBvb1I4HhfT88ISck5Zr2pwabko4vCoReFl3XvDHOAL0Bto8DSKjVOEHSvcPT3SkPy3zuIWTOpri81M66qs3zvKRCXb6qNSuX2ccClL38zHCrjrDUEFsZ"},{"name":"connectionstrings--markdown","value":"https://storagegnxzs2f5m4idm.blob.core.windows.net/"},{"name":"connectionstrings--messages","value":"https://storagegnxzs2f5m4idm.queue.core.windows.net/"},{"name":"connectionstrings--pubsub","value":"pubsub:6379,password=4HDzb2KindOAg2oGPXeiCWh1DXBFjrOS3i19ynWQJO5UFlsMSAHVdO5PHqkwURunqV3wlGgiR1OVo7xzzjtREGuNCAuijcBbrtSUpwOeWqudJ9FopETuxMyb3c3aVivf"},{"name":"connectionstrings--requestlog","value":"https://storagegnxzs2f5m4idm.table.core.windows.net/"}]},"environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","template":{"containers":[{"env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-webfrontend-1708717493","name":"webfrontend"}],"scale":{"minReplicas":1}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"}}'
+        body: '{"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{}}},"location":"eastus2","properties":{"configuration":{"activeRevisionsMode":"single","ingress":{"allowInsecure":false,"external":true,"targetPort":8080,"transport":"http"},"registries":[{"identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw","server":"acrsoindfxt2muzw.azurecr.io"}],"secrets":[{"name":"connectionstrings--cache","value":"cache:6379,password=9WYnYvvARK9lDuI9w2npyxWm3FH3v4HsTi9HTCIqNpGTCz2kigzqve4RMi1p5fN3XJWS77edocDZsJmOFDxeeoUP4s8jekIhuCv5rfl57IyLIpM2Hs18Le7RKiRwSoBW"},{"name":"connectionstrings--markdown","value":"https://storagesoindfxt2muzw.blob.core.windows.net/"},{"name":"connectionstrings--messages","value":"https://storagesoindfxt2muzw.queue.core.windows.net/"},{"name":"connectionstrings--pubsub","value":"pubsub:6379,password=bnEsap7SKYgINGTcPvqxee8NmBaiFxewMnwCZkJlncmGFuRlcF9GRFIt2mvzJ78MoKdkFT2hqO8d622d4lmrjvEuzf6MXrXF0GSlD8ymbr3WlVsIxlaLIZms9iea8PIJ"},{"name":"connectionstrings--requestlog","value":"https://storagesoindfxt2muzw.table.core.windows.net/"}]},"environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","template":{"containers":[{"env":[{"name":"AZURE_CLIENT_ID","value":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"image":"acrsoindfxt2muzw.azurecr.io/azd-deploy-webfrontend-1708981443","name":"webfrontend"}],"scale":{"minReplicas":1}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"}}'
         form: {}
         headers:
             Accept:
@@ -1411,12 +1411,12 @@ interactions:
             Authorization:
                 - SANITIZED
             Content-Length:
-                - "2630"
+                - "2632"
             Content-Type:
                 - application/json
             User-Agent:
                 - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend?api-version=2022-11-01-preview
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/webfrontend?api-version=2022-11-01-preview
         method: PUT
       response:
         proto: HTTP/2.0
@@ -1426,12 +1426,12 @@ interactions:
         trailer: {}
         content_length: 3809
         uncompressed: false
-        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:45:10.6566857Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:45:10.6566857Z"},"properties":{"provisioningState":"InProgress","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"","latestReadyRevisionName":"","latestRevisionFqdn":"","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"connectionstrings--cache"},{"name":"connectionstrings--markdown"},{"name":"connectionstrings--messages"},{"name":"connectionstrings--pubsub"},{"name":"connectionstrings--requestlog"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"webfrontend.happybush-752e10b4.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-webfrontend-1708717493","name":"webfrontend","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/webfrontend/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerapps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:04:19.562851Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:04:19.562851Z"},"properties":{"provisioningState":"InProgress","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","workloadProfileName":null,"outboundIpAddresses":["172.175.21.8"],"latestRevisionName":"","latestReadyRevisionName":"","latestRevisionFqdn":"","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"connectionstrings--cache"},{"name":"connectionstrings--markdown"},{"name":"connectionstrings--messages"},{"name":"connectionstrings--pubsub"},{"name":"connectionstrings--requestlog"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"webfrontend.mangoplant-0534793d.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrsoindfxt2muzw.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrsoindfxt2muzw.azurecr.io/azd-deploy-webfrontend-1708981443","name":"webfrontend","env":[{"name":"AZURE_CLIENT_ID","value":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/containerApps/webfrontend/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}}}'
         headers:
             Api-Supported-Versions:
                 - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
             Azure-Asyncoperation:
-                - https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/80129667-daf6-446e-a53e-013923dd46e7?api-version=2022-11-01-preview&azureAsyncOperation=true&t=638443143123441960&c=MIIHADCCBeigAwIBAgITfARmPsJdo2ShuN-ImAAABGY-wjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUwHhcNMjQwMTMxMjIwNzA5WhcNMjUwMTI1MjIwNzA5WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOVFiSMi9Sg6cKnrBuPHbDk_Zwa1ZNYHwLVPJArEI9N2bLrgd1mU0ZdNVcdf6rtZCkUUuCe3vxnVTGwufpwH9GPWDgJOpJoL9wgKOzUDiHLUeiWPjrK1AoaQVprZgjnzXBIWiZC2tZjbUT9pOI_ixYJJPrsCfLt7HEccnhObROE1mo_hpiPDrtOQDaX-BboNceB8vI1wmSPApGpPRM9hBRQbXgqKFC8094UNsMVkWPCrsPvP5YlMBLARlGf2WTevGKRREjstkApf1Swi7uKnpyhhsidD1yREMU0mWY9wnZfAX0jpEp3p9jKVMPQ3L-m-nSZI4zrtbW0AnI0O3pAEwe0CAwEAAaOCA-0wggPpMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9DTzFQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA1LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MB0GA1UdDgQWBBT2vcy9ccvhGewsiHI1BQHsz3Wn8zAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBR61hmFKHlscXYeYPjzS--iBUIWHTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBADNBZjhX44bpBtC8kogZJGe4lYeHX95whfZ7X_CMSUuZRbQQ_b6raUpp8V8eF0YUa9b3Oa-DGrs5WfzogCuGcJPeoEVnDYzc1jlKubSIpGw73aGZzhbTjJeNf-Qe-5vTG-GcNzVtIcrwi93YSiK2LSbgrLpTL7T7znjePcGRRkCBjAslrV5SqufcsrpGmqvPAVKXRV-OIOzvXy6qmn9CHmdo0RGBXGIakbLMec_1SIS8NdPsB6i6XPjL2SDjqKTa5car7bVYlXEVsgL-000VF1t6x1II3VBNfsEJ81CdJyxaCJnwvWI6kHtCtJX9QYK3qZab9PfZRBvcetJoPdMFvBU&s=FicIiMAUJPnQ7FyhoB5mKjFaVJpoX2FbQs5mlKBtNJjlLCe8AtY1MiRTAjK15FLEmE1BPUHhkRtIDzsbL_KcYEdpcywxnsTf_V9yM5_ScFzhkTi6tQx8Orp-fHnw2IMcz1Ba5rIMbw8Guy4PJRKG5u6_36iCTFLMm9k1SOB-CBamGMqkLUxtMXL2e-1goTkWOASqPq4Q3VoPolqRDhwaEd_ClFvERkEJzJbJpNuFkkHIY7bjq_MgeCe2yOgdHYyUwBVPl4YF5N_Nr6tVRBV-MKRsHQfokY2z_JouMPkCnM8WSMevm57UQPYDg-500Dr9fjDUi0eC7DckpGW5Sxkveg&h=HQ2T7fy5c-oxHVabFlVVvdDsqTm6VsBMjMJtCRMzMiI
+                - https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/6f73b1bc-7dd6-4c5a-b5c6-8073d7639159?api-version=2022-11-01-preview&azureAsyncOperation=true&t=638445782611566148&c=MIIHADCCBeigAwIBAgITfARmPsJdo2ShuN-ImAAABGY-wjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUwHhcNMjQwMTMxMjIwNzA5WhcNMjUwMTI1MjIwNzA5WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOVFiSMi9Sg6cKnrBuPHbDk_Zwa1ZNYHwLVPJArEI9N2bLrgd1mU0ZdNVcdf6rtZCkUUuCe3vxnVTGwufpwH9GPWDgJOpJoL9wgKOzUDiHLUeiWPjrK1AoaQVprZgjnzXBIWiZC2tZjbUT9pOI_ixYJJPrsCfLt7HEccnhObROE1mo_hpiPDrtOQDaX-BboNceB8vI1wmSPApGpPRM9hBRQbXgqKFC8094UNsMVkWPCrsPvP5YlMBLARlGf2WTevGKRREjstkApf1Swi7uKnpyhhsidD1yREMU0mWY9wnZfAX0jpEp3p9jKVMPQ3L-m-nSZI4zrtbW0AnI0O3pAEwe0CAwEAAaOCA-0wggPpMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9DTzFQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA1LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MB0GA1UdDgQWBBT2vcy9ccvhGewsiHI1BQHsz3Wn8zAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBR61hmFKHlscXYeYPjzS--iBUIWHTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBADNBZjhX44bpBtC8kogZJGe4lYeHX95whfZ7X_CMSUuZRbQQ_b6raUpp8V8eF0YUa9b3Oa-DGrs5WfzogCuGcJPeoEVnDYzc1jlKubSIpGw73aGZzhbTjJeNf-Qe-5vTG-GcNzVtIcrwi93YSiK2LSbgrLpTL7T7znjePcGRRkCBjAslrV5SqufcsrpGmqvPAVKXRV-OIOzvXy6qmn9CHmdo0RGBXGIakbLMec_1SIS8NdPsB6i6XPjL2SDjqKTa5car7bVYlXEVsgL-000VF1t6x1II3VBNfsEJ81CdJyxaCJnwvWI6kHtCtJX9QYK3qZab9PfZRBvcetJoPdMFvBU&s=ck_g4LZ3_pagDZ9jC8-iQUBCRXBTlzLztZ5WtsEH6h0onhmhk8W2WbnvqRYmJO9u3p_M14fFdZhWNnuZ_IYg4-HdDTxK7UFa1O-p5BctjscSvRz-R5VVB0t3UUTKotMTTm4SndpiyLzOXFOdoMS9bUgMfCU5PGuphJitdrsBR5KKyPmFV40_9QCh39t-FRhrCJ_pILhUwk4mDEsdN10m0wzrQht4OOpKY8tmWe0t1EyWrmqJ9rEoeA1AEO1rJA2y3kw95i2gpBkk4OA7VibPPeYb6lzUNlXPC4ucG-VLHYl6XqwcqPSbrm21zLaEEHKmjxs_U4U3P3cB2g6f_zUvsA&h=BiB1BzqV7Jp8QOv4hJ8dCQa_-UYrHkVo8bZGDnzt44M
             Cache-Control:
                 - no-cache
             Content-Length:
@@ -1439,7 +1439,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:12 GMT
+                - Mon, 26 Feb 2024 21:04:21 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1455,20 +1455,20 @@ interactions:
             X-Ms-Async-Operation-Timeout:
                 - PT15M
             X-Ms-Correlation-Request-Id:
-                - dad86f6d-9747-403f-8a8f-53280618c278
+                - 4dc27101-1fe7-4959-ac00-85298f53e95e
             X-Ms-Ratelimit-Remaining-Subscription-Resource-Requests:
                 - "699"
             X-Ms-Request-Id:
-                - dad86f6d-9747-403f-8a8f-53280618c278
+                - 4dc27101-1fe7-4959-ac00-85298f53e95e
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194512Z:dad86f6d-9747-403f-8a8f-53280618c278
+                - WESTUS2:20240226T210421Z:4dc27101-1fe7-4959-ac00-85298f53e95e
             X-Msedge-Ref:
-                - 'Ref A: 340B7DADA83240B18E2F18632B7903E0 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:10Z'
+                - 'Ref A: D6E4DBD443E347808AFE8AA0B719F686 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:04:18Z'
             X-Powered-By:
                 - ASP.NET
         status: 201 Created
         code: 201
-        duration: 2.321125667s
+        duration: 2.220675595s
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1489,7 +1489,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/80129667-daf6-446e-a53e-013923dd46e7?api-version=2022-11-01-preview&azureAsyncOperation=true&t=638443143123441960&c=MIIHADCCBeigAwIBAgITfARmPsJdo2ShuN-ImAAABGY-wjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUwHhcNMjQwMTMxMjIwNzA5WhcNMjUwMTI1MjIwNzA5WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOVFiSMi9Sg6cKnrBuPHbDk_Zwa1ZNYHwLVPJArEI9N2bLrgd1mU0ZdNVcdf6rtZCkUUuCe3vxnVTGwufpwH9GPWDgJOpJoL9wgKOzUDiHLUeiWPjrK1AoaQVprZgjnzXBIWiZC2tZjbUT9pOI_ixYJJPrsCfLt7HEccnhObROE1mo_hpiPDrtOQDaX-BboNceB8vI1wmSPApGpPRM9hBRQbXgqKFC8094UNsMVkWPCrsPvP5YlMBLARlGf2WTevGKRREjstkApf1Swi7uKnpyhhsidD1yREMU0mWY9wnZfAX0jpEp3p9jKVMPQ3L-m-nSZI4zrtbW0AnI0O3pAEwe0CAwEAAaOCA-0wggPpMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9DTzFQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA1LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MB0GA1UdDgQWBBT2vcy9ccvhGewsiHI1BQHsz3Wn8zAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBR61hmFKHlscXYeYPjzS--iBUIWHTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBADNBZjhX44bpBtC8kogZJGe4lYeHX95whfZ7X_CMSUuZRbQQ_b6raUpp8V8eF0YUa9b3Oa-DGrs5WfzogCuGcJPeoEVnDYzc1jlKubSIpGw73aGZzhbTjJeNf-Qe-5vTG-GcNzVtIcrwi93YSiK2LSbgrLpTL7T7znjePcGRRkCBjAslrV5SqufcsrpGmqvPAVKXRV-OIOzvXy6qmn9CHmdo0RGBXGIakbLMec_1SIS8NdPsB6i6XPjL2SDjqKTa5car7bVYlXEVsgL-000VF1t6x1II3VBNfsEJ81CdJyxaCJnwvWI6kHtCtJX9QYK3qZab9PfZRBvcetJoPdMFvBU&s=FicIiMAUJPnQ7FyhoB5mKjFaVJpoX2FbQs5mlKBtNJjlLCe8AtY1MiRTAjK15FLEmE1BPUHhkRtIDzsbL_KcYEdpcywxnsTf_V9yM5_ScFzhkTi6tQx8Orp-fHnw2IMcz1Ba5rIMbw8Guy4PJRKG5u6_36iCTFLMm9k1SOB-CBamGMqkLUxtMXL2e-1goTkWOASqPq4Q3VoPolqRDhwaEd_ClFvERkEJzJbJpNuFkkHIY7bjq_MgeCe2yOgdHYyUwBVPl4YF5N_Nr6tVRBV-MKRsHQfokY2z_JouMPkCnM8WSMevm57UQPYDg-500Dr9fjDUi0eC7DckpGW5Sxkveg&h=HQ2T7fy5c-oxHVabFlVVvdDsqTm6VsBMjMJtCRMzMiI
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/6f73b1bc-7dd6-4c5a-b5c6-8073d7639159?api-version=2022-11-01-preview&azureAsyncOperation=true&t=638445782611566148&c=MIIHADCCBeigAwIBAgITfARmPsJdo2ShuN-ImAAABGY-wjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUwHhcNMjQwMTMxMjIwNzA5WhcNMjUwMTI1MjIwNzA5WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOVFiSMi9Sg6cKnrBuPHbDk_Zwa1ZNYHwLVPJArEI9N2bLrgd1mU0ZdNVcdf6rtZCkUUuCe3vxnVTGwufpwH9GPWDgJOpJoL9wgKOzUDiHLUeiWPjrK1AoaQVprZgjnzXBIWiZC2tZjbUT9pOI_ixYJJPrsCfLt7HEccnhObROE1mo_hpiPDrtOQDaX-BboNceB8vI1wmSPApGpPRM9hBRQbXgqKFC8094UNsMVkWPCrsPvP5YlMBLARlGf2WTevGKRREjstkApf1Swi7uKnpyhhsidD1yREMU0mWY9wnZfAX0jpEp3p9jKVMPQ3L-m-nSZI4zrtbW0AnI0O3pAEwe0CAwEAAaOCA-0wggPpMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9DTzFQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA1LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MB0GA1UdDgQWBBT2vcy9ccvhGewsiHI1BQHsz3Wn8zAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBR61hmFKHlscXYeYPjzS--iBUIWHTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBADNBZjhX44bpBtC8kogZJGe4lYeHX95whfZ7X_CMSUuZRbQQ_b6raUpp8V8eF0YUa9b3Oa-DGrs5WfzogCuGcJPeoEVnDYzc1jlKubSIpGw73aGZzhbTjJeNf-Qe-5vTG-GcNzVtIcrwi93YSiK2LSbgrLpTL7T7znjePcGRRkCBjAslrV5SqufcsrpGmqvPAVKXRV-OIOzvXy6qmn9CHmdo0RGBXGIakbLMec_1SIS8NdPsB6i6XPjL2SDjqKTa5car7bVYlXEVsgL-000VF1t6x1II3VBNfsEJ81CdJyxaCJnwvWI6kHtCtJX9QYK3qZab9PfZRBvcetJoPdMFvBU&s=ck_g4LZ3_pagDZ9jC8-iQUBCRXBTlzLztZ5WtsEH6h0onhmhk8W2WbnvqRYmJO9u3p_M14fFdZhWNnuZ_IYg4-HdDTxK7UFa1O-p5BctjscSvRz-R5VVB0t3UUTKotMTTm4SndpiyLzOXFOdoMS9bUgMfCU5PGuphJitdrsBR5KKyPmFV40_9QCh39t-FRhrCJ_pILhUwk4mDEsdN10m0wzrQht4OOpKY8tmWe0t1EyWrmqJ9rEoeA1AEO1rJA2y3kw95i2gpBkk4OA7VibPPeYb6lzUNlXPC4ucG-VLHYl6XqwcqPSbrm21zLaEEHKmjxs_U4U3P3cB2g6f_zUvsA&h=BiB1BzqV7Jp8QOv4hJ8dCQa_-UYrHkVo8bZGDnzt44M
         method: GET
       response:
         proto: HTTP/2.0
@@ -1499,7 +1499,7 @@ interactions:
         trailer: {}
         content_length: 278
         uncompressed: false
-        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/80129667-daf6-446e-a53e-013923dd46e7","name":"80129667-daf6-446e-a53e-013923dd46e7","status":"Succeeded","startTime":"2024-02-23T19:45:11.3783127"}'
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/6f73b1bc-7dd6-4c5a-b5c6-8073d7639159","name":"6f73b1bc-7dd6-4c5a-b5c6-8073d7639159","status":"Succeeded","startTime":"2024-02-26T21:04:20.2434705"}'
         headers:
             Api-Supported-Versions:
                 - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
@@ -1510,7 +1510,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:27 GMT
+                - Mon, 26 Feb 2024 21:04:36 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1524,20 +1524,20 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3e75afe7-9834-4212-9dde-700180dcfb41
+                - e7d67d0b-6a03-463b-bf76-10541b00fd7d
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11998"
             X-Ms-Request-Id:
-                - 3e75afe7-9834-4212-9dde-700180dcfb41
+                - e7d67d0b-6a03-463b-bf76-10541b00fd7d
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194527Z:3e75afe7-9834-4212-9dde-700180dcfb41
+                - WESTUS2:20240226T210436Z:e7d67d0b-6a03-463b-bf76-10541b00fd7d
             X-Msedge-Ref:
-                - 'Ref A: 1427FA829C13459780D0FF8A2D74C08E Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:27Z'
+                - 'Ref A: 3FFC8F6B857045A09D7A15C5C499F376 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:04:36Z'
             X-Powered-By:
                 - ASP.NET
         status: 200 OK
         code: 200
-        duration: 267.864717ms
+        duration: 299.867023ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1558,7 +1558,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend?api-version=2022-11-01-preview
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/webfrontend?api-version=2022-11-01-preview
         method: GET
       response:
         proto: HTTP/2.0
@@ -1566,20 +1566,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3915
+        content_length: 3916
         uncompressed: false
-        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:45:10.6566857","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:45:10.6566857"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"webfrontend--v4b3j5p","latestReadyRevisionName":"webfrontend--v4b3j5p","latestRevisionFqdn":"webfrontend--v4b3j5p.happybush-752e10b4.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"connectionstrings--cache"},{"name":"connectionstrings--markdown"},{"name":"connectionstrings--messages"},{"name":"connectionstrings--pubsub"},{"name":"connectionstrings--requestlog"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"webfrontend.happybush-752e10b4.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-webfrontend-1708717493","name":"webfrontend","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/webfrontend/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerapps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:04:19.562851","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:04:19.562851"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","workloadProfileName":null,"outboundIpAddresses":["172.175.21.8"],"latestRevisionName":"webfrontend--8r6gfli","latestReadyRevisionName":"webfrontend--8r6gfli","latestRevisionFqdn":"webfrontend--8r6gfli.mangoplant-0534793d.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"connectionstrings--cache"},{"name":"connectionstrings--markdown"},{"name":"connectionstrings--messages"},{"name":"connectionstrings--pubsub"},{"name":"connectionstrings--requestlog"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"webfrontend.mangoplant-0534793d.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrsoindfxt2muzw.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrsoindfxt2muzw.azurecr.io/azd-deploy-webfrontend-1708981443","name":"webfrontend","env":[{"name":"AZURE_CLIENT_ID","value":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/containerApps/webfrontend/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}}}'
         headers:
             Api-Supported-Versions:
                 - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "3915"
+                - "3916"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:27 GMT
+                - Mon, 26 Feb 2024 21:04:36 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1593,20 +1593,20 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - e608cf54-f6d9-41e2-8cf9-76a9e23433c1
+                - a86b2267-02a1-43d2-b0d4-54774cbdd5f3
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - e608cf54-f6d9-41e2-8cf9-76a9e23433c1
+                - a86b2267-02a1-43d2-b0d4-54774cbdd5f3
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194528Z:e608cf54-f6d9-41e2-8cf9-76a9e23433c1
+                - WESTUS2:20240226T210436Z:a86b2267-02a1-43d2-b0d4-54774cbdd5f3
             X-Msedge-Ref:
-                - 'Ref A: 9570385D2E4D4FBA9CC799D111090FDD Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:27Z'
+                - 'Ref A: 92FADD46646F44DB973D7C30E3365BCB Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:04:36Z'
             X-Powered-By:
                 - ASP.NET
         status: 200 OK
         code: 200
-        duration: 358.806673ms
+        duration: 403.804693ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1629,7 +1629,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend?api-version=2022-11-01-preview
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/webfrontend?api-version=2022-11-01-preview
         method: GET
       response:
         proto: HTTP/2.0
@@ -1637,20 +1637,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3915
+        content_length: 3916
         uncompressed: false
-        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:45:10.6566857","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:45:10.6566857"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"webfrontend--v4b3j5p","latestReadyRevisionName":"webfrontend--v4b3j5p","latestRevisionFqdn":"webfrontend--v4b3j5p.happybush-752e10b4.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"connectionstrings--cache"},{"name":"connectionstrings--markdown"},{"name":"connectionstrings--messages"},{"name":"connectionstrings--pubsub"},{"name":"connectionstrings--requestlog"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"webfrontend.happybush-752e10b4.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-webfrontend-1708717493","name":"webfrontend","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/webfrontend/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerapps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:04:19.562851","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:04:19.562851"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","workloadProfileName":null,"outboundIpAddresses":["172.175.21.8"],"latestRevisionName":"webfrontend--8r6gfli","latestReadyRevisionName":"webfrontend--8r6gfli","latestRevisionFqdn":"webfrontend--8r6gfli.mangoplant-0534793d.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"connectionstrings--cache"},{"name":"connectionstrings--markdown"},{"name":"connectionstrings--messages"},{"name":"connectionstrings--pubsub"},{"name":"connectionstrings--requestlog"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"webfrontend.mangoplant-0534793d.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrsoindfxt2muzw.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrsoindfxt2muzw.azurecr.io/azd-deploy-webfrontend-1708981443","name":"webfrontend","env":[{"name":"AZURE_CLIENT_ID","value":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/containerApps/webfrontend/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}}}'
         headers:
             Api-Supported-Versions:
                 - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "3915"
+                - "3916"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:28 GMT
+                - Mon, 26 Feb 2024 21:04:37 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1664,20 +1664,20 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 0a386fc1-a966-4437-9cdd-3220d1482084
+                - 0c9b3c33-92fc-4d9e-a3ce-2306d64fa55e
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11998"
             X-Ms-Request-Id:
-                - 0a386fc1-a966-4437-9cdd-3220d1482084
+                - 0c9b3c33-92fc-4d9e-a3ce-2306d64fa55e
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194528Z:0a386fc1-a966-4437-9cdd-3220d1482084
+                - WESTUS2:20240226T210437Z:0c9b3c33-92fc-4d9e-a3ce-2306d64fa55e
             X-Msedge-Ref:
-                - 'Ref A: 00B650FD2D5E444A8831E9BB2FB0668E Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:28Z'
+                - 'Ref A: 2D0F17590F5142E1B8A289DBD4BAEE0A Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:04:36Z'
             X-Powered-By:
                 - ASP.NET
         status: 200 OK
         code: 200
-        duration: 369.513046ms
+        duration: 472.704687ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1700,7 +1700,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l4c10c9%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -1710,7 +1710,7 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9","name":"rg-azdtest-l4c10c9","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"},"properties":{"provisioningState":"Succeeded"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -1719,7 +1719,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:28 GMT
+                - Mon, 26 Feb 2024 21:04:37 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1731,18 +1731,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - f068ab56-690b-4f82-a15c-ecf68c52154e
+                - 71399749-bb22-429b-9669-b75ccc4b855e
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - f068ab56-690b-4f82-a15c-ecf68c52154e
+                - 71399749-bb22-429b-9669-b75ccc4b855e
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194528Z:f068ab56-690b-4f82-a15c-ecf68c52154e
+                - WESTUS2:20240226T210437Z:71399749-bb22-429b-9669-b75ccc4b855e
             X-Msedge-Ref:
-                - 'Ref A: E92E2CD635BA486EAB8854E628F9AA71 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:28Z'
+                - 'Ref A: 19B0446B90A940698882ED209DF4197F Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:04:37Z'
         status: 200 OK
         code: 200
-        duration: 45.710654ms
+        duration: 45.098584ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1773,18 +1773,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 959721
+        content_length: 1172996
         uncompressed: false
-        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1Y7faoMwFMafxVw7MKUtw7voOWWwJjbJSUp7VzY3RImwWXQW3322ax9id9%2bf3wffhb21oavC%2bdRVbaC2LsM3Sy8MhSVnF1cZyqHbnb666kq8lj8sZTx6jhQdBjkenlh8I0zbPzrO15GpN5mEz167I0inlwqyzEADOvEb6TBRlIEmnyt6%2fzBcFVub9AW4matHSWJRgB4UyEHCvM05Gbc6ard68ejJg%2bgl4FrWMzOKpaKbT9gU33%2f%2fu9t7tITOFDtkaTg3TczsHgFVjoqM2D7Cu3X2L5imXw%3d%3d","value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l88c996-1708717227","location":"eastus2","name":"azdtest-l88c996-1708717227","properties":{"correlationId":"788803d5-d997-4a8f-bf79-f709132f8a66","dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","resourceName":"rg-azdtest-l88c996","resourceType":"Microsoft.Resources/resourceGroups"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Resources/deployments/resources","resourceName":"resources","resourceType":"Microsoft.Resources/deployments"}],"duration":"PT2M38.5872939S","mode":"Incremental","outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/cache"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/pubsub"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ContainerRegistry/registries/acrgnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ContainerRegistry/registries/acrgnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/faee5324-3278-5609-995a-8e845396fbe9"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.OperationalInsights/workspaces/law-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/blobServices/default"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/7bc4c3d5-404b-5a27-b547-08f357bed58b"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/a9bde9d1-b484-5092-9aaa-77577f0c97dd"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/aa646b75-ef6f-5e88-adff-bd4e630fcb69"}],"outputs":{"azurE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN":{"type":"String","value":"happybush-752e10b4.eastus2.azurecontainerapps.io"},"azurE_CONTAINER_APPS_ENVIRONMENT_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm"},"azurE_CONTAINER_REGISTRY_ENDPOINT":{"type":"String","value":"acrgnxzs2f5m4idm.azurecr.io"},"azurE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"},"azurE_LOG_ANALYTICS_WORKSPACE_NAME":{"type":"String","value":"law-gnxzs2f5m4idm"},"manageD_IDENTITY_CLIENT_ID":{"type":"String","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},"servicE_BINDING_MARKDOWN_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.blob.core.windows.net/"},"servicE_BINDING_MESSAGES_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.queue.core.windows.net/"},"servicE_BINDING_REQUESTLOG_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.table.core.windows.net/"}},"parameters":{"environmentName":{"type":"String","value":"azdtest-l88c996"},"inputs":{"type":"SecureObject"},"location":{"type":"String","value":"eastus2"}},"providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"locations":["eastus2"],"resourceType":"resourceGroups"},{"locations":[null],"resourceType":"deployments"}]}],"provisioningState":"Succeeded","templateHash":"14419117427229910140","timestamp":"2024-02-23T19:43:53.0492909Z"},"tags":{"azd-env-name":"azdtest-l88c996","azd-provision-param-hash":"6354240e3b61edb702891d88e5c50b42b4af01f4c1dec5d56a7532a298f4fb48"},"type":"Microsoft.Resources/deployments"}]}'
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1Y7faoMwFMafxVxbSDYHwzv1nMJYE5vkpKW7K50bTklgs1gtvvvs1j5E774%2fPz6%2bMzsE39X%2buO%2fq4Ck0lf9h6ZlhZsnZh4v01alb77%2b7%2bkK8VgNLmYieI0W7kxx3Cxb%2fESb0t07wJDLNMpfw2Wv3BtLpREGeG2hB881SOuSKctC0KRS9fxihypXlfQlu5ppRAj4pygb5pXkJOpGFUBZeBkVhMICP864o4TDO7IJN8fXrXVzdoiV0plwjS%2f2xbWNmtwioClRkstUtvFpn%2f4Np%2bgU%3d","value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l4c10c9-1708981207","location":"eastus2","name":"azdtest-l4c10c9-1708981207","properties":{"correlationId":"18b8d868-9ab3-44e5-91e6-04536c0cf51e","dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9","resourceName":"rg-azdtest-l4c10c9","resourceType":"Microsoft.Resources/resourceGroups"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Resources/deployments/resources","resourceName":"resources","resourceType":"Microsoft.Resources/deployments"}],"duration":"PT2M30.1684361S","mode":"Incremental","outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/cache"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/pubsub"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ContainerRegistry/registries/acrsoindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ContainerRegistry/registries/acrsoindfxt2muzw/providers/Microsoft.Authorization/roleAssignments/f11e9f84-10b6-5a7a-823a-ff920999efab"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.OperationalInsights/workspaces/law-soindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw/blobServices/default"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw/providers/Microsoft.Authorization/roleAssignments/375d2d03-b2cb-5480-8c5f-1ed90a8964a2"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw/providers/Microsoft.Authorization/roleAssignments/b7bc2b96-e891-5847-a299-e1b73a980306"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw/providers/Microsoft.Authorization/roleAssignments/e303f4d9-03e1-5676-8709-5c1e78da21ae"}],"outputs":{"azurE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN":{"type":"String","value":"mangoplant-0534793d.eastus2.azurecontainerapps.io"},"azurE_CONTAINER_APPS_ENVIRONMENT_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw"},"azurE_CONTAINER_REGISTRY_ENDPOINT":{"type":"String","value":"acrsoindfxt2muzw.azurecr.io"},"azurE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"},"azurE_LOG_ANALYTICS_WORKSPACE_NAME":{"type":"String","value":"law-soindfxt2muzw"},"manageD_IDENTITY_CLIENT_ID":{"type":"String","value":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"},"servicE_BINDING_MARKDOWN_ENDPOINT":{"type":"String","value":"https://storagesoindfxt2muzw.blob.core.windows.net/"},"servicE_BINDING_MESSAGES_ENDPOINT":{"type":"String","value":"https://storagesoindfxt2muzw.queue.core.windows.net/"},"servicE_BINDING_REQUESTLOG_ENDPOINT":{"type":"String","value":"https://storagesoindfxt2muzw.table.core.windows.net/"}},"parameters":{"environmentName":{"type":"String","value":"azdtest-l4c10c9"},"inputs":{"type":"SecureObject"},"location":{"type":"String","value":"eastus2"}},"providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"locations":["eastus2"],"resourceType":"resourceGroups"},{"locations":[null],"resourceType":"deployments"}]}],"provisioningState":"Succeeded","templateHash":"14419117427229910140","timestamp":"2024-02-26T21:03:24.5994655Z"},"tags":{"azd-env-name":"azdtest-l4c10c9","azd-provision-param-hash":"c6534960363d73a71040bdc189ecb233003bc8a557aebd182ec26315f8f83cd3"},"type":"Microsoft.Resources/deployments"}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "959721"
+                - "1172996"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:42 GMT
+                - Mon, 26 Feb 2024 21:04:51 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1796,18 +1796,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 0d342dfe-c625-4efb-b86c-2dc37926e4d0
+                - f23fa5f6-aeb4-4cbf-8ff7-6da207ba841e
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11998"
+                - "11999"
             X-Ms-Request-Id:
-                - 0d342dfe-c625-4efb-b86c-2dc37926e4d0
+                - f23fa5f6-aeb4-4cbf-8ff7-6da207ba841e
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194542Z:0d342dfe-c625-4efb-b86c-2dc37926e4d0
+                - WESTUS2:20240226T210451Z:f23fa5f6-aeb4-4cbf-8ff7-6da207ba841e
             X-Msedge-Ref:
-                - 'Ref A: DDC119CCA3374D0FA288CE7D6CB2F569 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:38Z'
+                - 'Ref A: 5B7009A5144D4B38822C99AE99D29C2A Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:04:47Z'
         status: 200 OK
         code: 200
-        duration: 4.186568898s
+        duration: 4.15239241s
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1828,7 +1828,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1Y7faoMwFMafxVw7MKUtw7voOWWwJjbJSUp7VzY3RImwWXQW3322ax9id9%2bf3wffhb21oavC%2bdRVbaC2LsM3Sy8MhSVnF1cZyqHbnb666kq8lj8sZTx6jhQdBjkenlh8I0zbPzrO15GpN5mEz167I0inlwqyzEADOvEb6TBRlIEmnyt6%2fzBcFVub9AW4matHSWJRgB4UyEHCvM05Gbc6ard68ejJg%2bgl4FrWMzOKpaKbT9gU33%2f%2fu9t7tITOFDtkaTg3TczsHgFVjoqM2D7Cu3X2L5imXw%3d%3d
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1Y7faoMwFMafxVxbSDYHwzv1nMJYE5vkpKW7K50bTklgs1gtvvvs1j5E774%2fPz6%2bMzsE39X%2buO%2fq4Ck0lf9h6ZlhZsnZh4v01alb77%2b7%2bkK8VgNLmYieI0W7kxx3Cxb%2fESb0t07wJDLNMpfw2Wv3BtLpREGeG2hB881SOuSKctC0KRS9fxihypXlfQlu5ppRAj4pygb5pXkJOpGFUBZeBkVhMICP864o4TDO7IJN8fXrXVzdoiV0plwjS%2f2xbWNmtwioClRkstUtvFpn%2f4Np%2bgU%3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1836,18 +1836,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2487770
+        content_length: 1780521
         uncompressed: false
-        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1ZDRToMwFIafhV5jUgYxhjugXdSth7U93YJ3iyJhJcUoC7iFd9c5SPYK3p3%2f%2b7%2bLP%2bdMXlvX1e647%2brWYWtL90XiM%2bGJRqMXl9OVQ7fZf3b1xViV3yQmgffgARaDOBV3xP8zVNvPXUAjT9llKljVS%2fPChJERsDRVrGGSbpfCcAqYMonbDPDtXQWQrzXtc2Z%2bPUuBJREcqoXApxAORSiyADT%2feJbI74WVA5ySUKCNBFYDGf1p67%2bYalY6N%2fhIYndsGp%2fs%2bPTl2xjettyofMNnonecccg4oErWM5yi0Vcwjj8%3d","value":[]}'
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1ZDdaoNAEIWfxb02sNZQinfqbIgkO7p%2fBnsXWluMskJr0CT47jWtQl6hd3O%2bc4Y5zI28tbar7PnYVa3VbV3abxLcCAuVNurpPtpy6LLjV1fdE7vyQgLiOS8O6mLg12JF3N%2bEbPvF8%2bjakfUm4vDZC%2fMK3Ig1QhRJaEDQfMMNo6gjEDqPUb9%2fSA%2fTvaJ9CmbK1ZSfxAUh6ad9D0%2bJz2OvyHOZcUieeS0GvIb%2bdJki8J6M7tz1X1Q1O5UavSWBPTeNSw5s%2fvKj9B9dZmSasYWoAwOGMUMtw%2f0CZ2nUHxjHHw%3d%3d","value":[]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "2487770"
+                - "1780521"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:46 GMT
+                - Mon, 26 Feb 2024 21:04:59 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1859,18 +1859,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - ff9142a8-d7e1-468a-ad6d-b5ad84f25c94
+                - cf2a523b-a25d-4cf4-8cee-271755e5e19d
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - ff9142a8-d7e1-468a-ad6d-b5ad84f25c94
+                - cf2a523b-a25d-4cf4-8cee-271755e5e19d
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194547Z:ff9142a8-d7e1-468a-ad6d-b5ad84f25c94
+                - WESTUS2:20240226T210459Z:cf2a523b-a25d-4cf4-8cee-271755e5e19d
             X-Msedge-Ref:
-                - 'Ref A: 2D12D932F9144F95AD3BF54CEF782679 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:42Z'
+                - 'Ref A: 2BD72231387943F2BBDF9FD71608FEA2 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:04:51Z'
         status: 200 OK
         code: 200
-        duration: 4.505739314s
+        duration: 7.546518918s
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1891,7 +1891,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1ZDRToMwFIafhV5jUgYxhjugXdSth7U93YJ3iyJhJcUoC7iFd9c5SPYK3p3%2f%2b7%2bLP%2bdMXlvX1e647%2brWYWtL90XiM%2bGJRqMXl9OVQ7fZf3b1xViV3yQmgffgARaDOBV3xP8zVNvPXUAjT9llKljVS%2fPChJERsDRVrGGSbpfCcAqYMonbDPDtXQWQrzXtc2Z%2bPUuBJREcqoXApxAORSiyADT%2feJbI74WVA5ySUKCNBFYDGf1p67%2bYalY6N%2fhIYndsGp%2fs%2bPTl2xjettyofMNnonecccg4oErWM5yi0Vcwjj8%3d
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1ZDdaoNAEIWfxb02sNZQinfqbIgkO7p%2fBnsXWluMskJr0CT47jWtQl6hd3O%2bc4Y5zI28tbar7PnYVa3VbV3abxLcCAuVNurpPtpy6LLjV1fdE7vyQgLiOS8O6mLg12JF3N%2bEbPvF8%2bjakfUm4vDZC%2fMK3Ig1QhRJaEDQfMMNo6gjEDqPUb9%2fSA%2fTvaJ9CmbK1ZSfxAUh6ad9D0%2bJz2OvyHOZcUieeS0GvIb%2bdJki8J6M7tz1X1Q1O5UavSWBPTeNSw5s%2fvKj9B9dZmSasYWoAwOGMUMtw%2f0CZ2nUHxjHHw%3d%3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1899,18 +1899,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3021248
+        content_length: 3283326
         uncompressed: false
-        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1VJBbsIwEHwLPhcphoAqbk7WiApsE3udKNxQSylNlEhtUEIQf28MREL9QNXbznh2PR7vmbyWRXUojtvqUBZYZrvim8zOhDOD1oxcWeyaar39qg5OsdydyIzQwfNAYtqINh2Sp6tCl3V%2fRul0oLN5IGBfR3YDwka%2bhCDQkEPkxXNhuScxgAjjUOLbu6ZSrYxXK7CdLvNkm45lm1GFwleY1TKkiYk3QZLzqcj03HofawvlSQMfC0h90Xaaz%2f2QXJ7uvv%2bd7YS7uP%2fCdiuQjRREjQTRCOh%2bKqSo7WQT2cki5jHGwGoBLvlO0zJf4hV7Lm1mDWq2emEhl64gs%2bKY5w%2b8W6OetEujLC56eHtyt2G3lhscP0JutVrznjEJBy5%2fXXSHLjo35nL5AQ%3d%3d","value":[]}'
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=3VLLbsIwEPwWci5SQlJUuCWso%2fLwGr%2bC4IYorVKjpGqD8kD8e2MgEuqxvfXkndldW%2bOZk7PLsyLNjtsizTOVm3325YxPDgml0nJgy2xfFcvtZ5Haifm%2bdsaO13vqoVpXtFn3nYfLhMjLrucNg54wcUThreR6A1TzACGKBByAu0lMNXFRRcBVMkH18io8ZAvplgx0O2fanmlrUiHwAUJYYuox0eS1IJtEGdRSj5i%2b4I8oMbHi3mymYz6kRiiehPYERUaJgHYnRiL9Kubu2qcNCdBsIqZpiTD1nfPDTee%2fl7ki1s7fyXT%2f5GZDgTyiCmv6zl0GPKATDyVMa1StO0D8NiUeg13TOt%2b3joRaKhEupuGEoC2ccXY8HO54G82O1HPJtHru4FVmm9rryhX695BowZakY%2bSKAMEfD92g%2fS57zfn8DQ%3d%3d","value":[]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "3021248"
+                - "3283326"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:52 GMT
+                - Mon, 26 Feb 2024 21:05:04 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1922,18 +1922,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - ecad1e69-944b-4d96-8901-e508c2462a27
+                - b8e20147-1b86-4402-bea1-87ec1df9f3f8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11997"
             X-Ms-Request-Id:
-                - ecad1e69-944b-4d96-8901-e508c2462a27
+                - b8e20147-1b86-4402-bea1-87ec1df9f3f8
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194552Z:ecad1e69-944b-4d96-8901-e508c2462a27
+                - WESTUS2:20240226T210504Z:b8e20147-1b86-4402-bea1-87ec1df9f3f8
             X-Msedge-Ref:
-                - 'Ref A: 00BD0F39A7AE4DAC98645EF11ED57870 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:47Z'
+                - 'Ref A: 33ED14C198C345DDBBB9354364FED4FE Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:04:59Z'
         status: 200 OK
         code: 200
-        duration: 5.023060419s
+        duration: 5.115306602s
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1954,7 +1954,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1VJBbsIwEHwLPhcphoAqbk7WiApsE3udKNxQSylNlEhtUEIQf28MREL9QNXbznh2PR7vmbyWRXUojtvqUBZYZrvim8zOhDOD1oxcWeyaar39qg5OsdydyIzQwfNAYtqINh2Sp6tCl3V%2fRul0oLN5IGBfR3YDwka%2bhCDQkEPkxXNhuScxgAjjUOLbu6ZSrYxXK7CdLvNkm45lm1GFwleY1TKkiYk3QZLzqcj03HofawvlSQMfC0h90Xaaz%2f2QXJ7uvv%2bd7YS7uP%2fCdiuQjRREjQTRCOh%2bKqSo7WQT2cki5jHGwGoBLvlO0zJf4hV7Lm1mDWq2emEhl64gs%2bKY5w%2b8W6OetEujLC56eHtyt2G3lhscP0JutVrznjEJBy5%2fXXSHLjo35nL5AQ%3d%3d
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=3VLLbsIwEPwWci5SQlJUuCWso%2fLwGr%2bC4IYorVKjpGqD8kD8e2MgEuqxvfXkndldW%2bOZk7PLsyLNjtsizTOVm3325YxPDgml0nJgy2xfFcvtZ5Haifm%2bdsaO13vqoVpXtFn3nYfLhMjLrucNg54wcUThreR6A1TzACGKBByAu0lMNXFRRcBVMkH18io8ZAvplgx0O2fanmlrUiHwAUJYYuox0eS1IJtEGdRSj5i%2b4I8oMbHi3mymYz6kRiiehPYERUaJgHYnRiL9Kubu2qcNCdBsIqZpiTD1nfPDTee%2fl7ki1s7fyXT%2f5GZDgTyiCmv6zl0GPKATDyVMa1StO0D8NiUeg13TOt%2b3joRaKhEupuGEoC2ccXY8HO54G82O1HPJtHru4FVmm9rryhX695BowZakY%2bSKAMEfD92g%2fS57zfn8DQ%3d%3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -1962,18 +1962,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 271460
+        content_length: 1021766
         uncompressed: false
-        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=XZBRT4MwFIV%2fC32eCQxiDG%2bFdnFuvaz0dgu%2bLYqEQYpRFnAL%2f13r1sX41u%2bcc9OccyYvnelrc9z3dWewa0rzSeIz4VShVnMSm2Pbzq7oaMetaWOmHPvN%2fqOv7fWq%2fCIxCbwHD7AYxam4I7PfRN4Nzgv8yMubRSJYNUj9zISWEbAkyVnLpL9dCM19wIRJ3KaAr295ANla%2bUPG9E%2bu8YHRCA7VXOAyhEMRijQAxd%2bfJPJ70cgRTjQU2EQCq5FMM0K1wpyulzTlYB%2buwk23RZ2oVyrT%2bOjwUvO2wQXDvy7XebbhTlE7zjj8%2b%2biKdi475TR9Aw%3d%3d","value":[]}'
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=XVBda4MwFP0t5tlBnGUM39SbMmkTzZfFvZXNDatE2CzaFv%2f7zNqUsbd7vricc0FvvRkac9wPTW9U39bmG0UXRGKptHxEkTl2nX%2bDDu2IFa3N1NNQ7L%2bGxqY39QlFKPCePaaqiZ6rB%2bT%2fOkQ%2fOi3AK0%2b064TC58j1K1DNVwySREAHHJdrqglmKgGuypSp9w8RsHwr8ZiDXnwtpgd%2bYpCNSz5ghyykaVCVpSgoZE%2b05RM7x%2bHyGTOgI5p9FGupRLzN4pQwe7gKd94WdaTeyFyrFwevNe8bXGH4VyVa5AVxjNwRIOzfoxu0c9kp5%2fkH","value":[]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "271460"
+                - "1021766"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:53 GMT
+                - Mon, 26 Feb 2024 21:05:06 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1985,18 +1985,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - cb4c260c-287f-4d7c-bb2d-e63f40fc9b1d
+                - fe45612f-2225-4be7-b7a0-09931152a1e3
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11997"
             X-Ms-Request-Id:
-                - cb4c260c-287f-4d7c-bb2d-e63f40fc9b1d
+                - fe45612f-2225-4be7-b7a0-09931152a1e3
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194553Z:cb4c260c-287f-4d7c-bb2d-e63f40fc9b1d
+                - WESTUS2:20240226T210506Z:fe45612f-2225-4be7-b7a0-09931152a1e3
             X-Msedge-Ref:
-                - 'Ref A: 1BE2C8DD07F342E09B8814459F6C8BBE Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:52Z'
+                - 'Ref A: 94AC42CD4D724D58B1850BB324EC58E2 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:04Z'
         status: 200 OK
         code: 200
-        duration: 1.256039934s
+        duration: 2.101662821s
     - id: 30
       request:
         proto: HTTP/1.1
@@ -2017,7 +2017,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=XZBRT4MwFIV%2fC32eCQxiDG%2bFdnFuvaz0dgu%2bLYqEQYpRFnAL%2f13r1sX41u%2bcc9OccyYvnelrc9z3dWewa0rzSeIz4VShVnMSm2Pbzq7oaMetaWOmHPvN%2fqOv7fWq%2fCIxCbwHD7AYxam4I7PfRN4Nzgv8yMubRSJYNUj9zISWEbAkyVnLpL9dCM19wIRJ3KaAr295ANla%2bUPG9E%2bu8YHRCA7VXOAyhEMRijQAxd%2bfJPJ70cgRTjQU2EQCq5FMM0K1wpyulzTlYB%2buwk23RZ2oVyrT%2bOjwUvO2wQXDvy7XebbhTlE7zjj8%2b%2biKdi475TR9Aw%3d%3d
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=XVBda4MwFP0t5tlBnGUM39SbMmkTzZfFvZXNDatE2CzaFv%2f7zNqUsbd7vricc0FvvRkac9wPTW9U39bmG0UXRGKptHxEkTl2nX%2bDDu2IFa3N1NNQ7L%2bGxqY39QlFKPCePaaqiZ6rB%2bT%2fOkQ%2fOi3AK0%2b064TC58j1K1DNVwySREAHHJdrqglmKgGuypSp9w8RsHwr8ZiDXnwtpgd%2bYpCNSz5ghyykaVCVpSgoZE%2b05RM7x%2bHyGTOgI5p9FGupRLzN4pQwe7gKd94WdaTeyFyrFwevNe8bXGH4VyVa5AVxjNwRIOzfoxu0c9kp5%2fkH
         method: GET
       response:
         proto: HTTP/2.0
@@ -2025,18 +2025,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20482
+        content_length: 20512
         uncompressed: false
-        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=ZZBda4MwFIZ%2fi7luwUwpwzs1kY42ieZDsXdldZ2LRNgsthb%2f%2b5p1GWO7O8%2f7vueDcwXPvRlac9oPbW9krxvzAaIrqLCQStjKNOch378PrQ1smguIAPQePSrrM5nqJVh8JXg%2fOg%2fClcd1lhB0HAu1Q0QVIUVJwlGHCr%2fMiMI%2blQkqZJlSeXjhkLKt8EeG1C2nfTrVAZ00ZJKETOqRprAS5S6pOrwimmfKf80V6i8c4YCgOiTTLfN2XIJ5AXBsz34AkTl1nUNHsRKSx9unOMXUFv902%2b1EtRFMybXD%2bz9%2bBt8x%2bO1ixVmOnSIqjDD9s%2bgb7V%2ftffP8CQ%3d%3d","value":[]}'
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=ZZHLbsIwEEW%2fBa%2bplBCECruEcVQeHuPHBMEOtbSKjJKqDUoA8e%2bNoamqduU5994Zvy7suSyqvDjuqrwsbOn2xSebXNiaG0vGV8W%2bqVa7jyr3gcX%2bxCYs7D320G4acd48sP4tocu688LRsKddmgh4qxVtQZAaIiSJhgOoIEsF8QBtAspmU7QvrzpEuTRBLYHanGs919a8QVADhLjGPJT6XJ4032bWIRkaS7rxe5K51KpwPqdUjYTTVmWxX8Hycaah7UmRm6hJVbCJxJkP0W0TSaJGmEXs2mc89tccsElxPBw67CgmY3W8nMVTjr74p%2fvuTqSFkWSfOry%2f38%2fgO0a%2fXU5arninmDUHjn82%2bkb%2fD%2f581%2bsX","value":[]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "20482"
+                - "20512"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:54 GMT
+                - Mon, 26 Feb 2024 21:05:07 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2048,18 +2048,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 0f9ee5c7-febf-4572-b57d-3fd621e91800
+                - c801ae41-4a4f-48f1-99a7-88a704c0d4a3
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 0f9ee5c7-febf-4572-b57d-3fd621e91800
+                - c801ae41-4a4f-48f1-99a7-88a704c0d4a3
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194554Z:0f9ee5c7-febf-4572-b57d-3fd621e91800
+                - WESTUS2:20240226T210507Z:c801ae41-4a4f-48f1-99a7-88a704c0d4a3
             X-Msedge-Ref:
-                - 'Ref A: 284EBDCE567B41AE9FC3131EE7DE6771 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:53Z'
+                - 'Ref A: DEF649B2EEFD4E70AB10B4ACCBE5FCF0 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:07Z'
         status: 200 OK
         code: 200
-        duration: 726.824455ms
+        duration: 749.083972ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -2080,7 +2080,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=ZZBda4MwFIZ%2fi7luwUwpwzs1kY42ieZDsXdldZ2LRNgsthb%2f%2b5p1GWO7O8%2f7vueDcwXPvRlac9oPbW9krxvzAaIrqLCQStjKNOch378PrQ1smguIAPQePSrrM5nqJVh8JXg%2fOg%2fClcd1lhB0HAu1Q0QVIUVJwlGHCr%2fMiMI%2blQkqZJlSeXjhkLKt8EeG1C2nfTrVAZ00ZJKETOqRprAS5S6pOrwimmfKf80V6i8c4YCgOiTTLfN2XIJ5AXBsz34AkTl1nUNHsRKSx9unOMXUFv902%2b1EtRFMybXD%2bz9%2bBt8x%2bO1ixVmOnSIqjDD9s%2bgb7V%2ftffP8CQ%3d%3d
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=ZZHLbsIwEEW%2fBa%2bplBCECruEcVQeHuPHBMEOtbSKjJKqDUoA8e%2bNoamqduU5994Zvy7suSyqvDjuqrwsbOn2xSebXNiaG0vGV8W%2bqVa7jyr3gcX%2bxCYs7D320G4acd48sP4tocu688LRsKddmgh4qxVtQZAaIiSJhgOoIEsF8QBtAspmU7QvrzpEuTRBLYHanGs919a8QVADhLjGPJT6XJ4032bWIRkaS7rxe5K51KpwPqdUjYTTVmWxX8Hycaah7UmRm6hJVbCJxJkP0W0TSaJGmEXs2mc89tccsElxPBw67CgmY3W8nMVTjr74p%2fvuTqSFkWSfOry%2f38%2fgO0a%2fXU5arninmDUHjn82%2bkb%2fD%2f581%2bsX
         method: GET
       response:
         proto: HTTP/2.0
@@ -2099,7 +2099,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:54 GMT
+                - Mon, 26 Feb 2024 21:05:08 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2111,18 +2111,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 9dec5d4b-efb5-409d-877d-2e71f1be6bd4
+                - f176a42d-b466-4d0b-a0e3-885738a5b1c6
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11996"
             X-Ms-Request-Id:
-                - 9dec5d4b-efb5-409d-877d-2e71f1be6bd4
+                - f176a42d-b466-4d0b-a0e3-885738a5b1c6
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194555Z:9dec5d4b-efb5-409d-877d-2e71f1be6bd4
+                - WESTUS2:20240226T210508Z:f176a42d-b466-4d0b-a0e3-885738a5b1c6
             X-Msedge-Ref:
-                - 'Ref A: AF844BCDF84A4F6F891CD1792529AC2E Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:54Z'
+                - 'Ref A: 602D4851E35743559DF4730BADE97C53 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:07Z'
         status: 200 OK
         code: 200
-        duration: 403.973167ms
+        duration: 535.743198ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -2145,7 +2145,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l4c10c9%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2155,7 +2155,7 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9","name":"rg-azdtest-l4c10c9","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"},"properties":{"provisioningState":"Succeeded"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -2164,7 +2164,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:54 GMT
+                - Mon, 26 Feb 2024 21:05:08 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2176,18 +2176,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3f04f47f-4a79-4e1f-af5d-aa1d4cffca25
+                - d87513a7-e45a-4e30-a572-1ae2dbd435da
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 3f04f47f-4a79-4e1f-af5d-aa1d4cffca25
+                - d87513a7-e45a-4e30-a572-1ae2dbd435da
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194555Z:3f04f47f-4a79-4e1f-af5d-aa1d4cffca25
+                - WESTUS2:20240226T210508Z:d87513a7-e45a-4e30-a572-1ae2dbd435da
             X-Msedge-Ref:
-                - 'Ref A: 572B68A7E5054A1F8834208A2DDA76DA Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:55Z'
+                - 'Ref A: FE8DCE53A7EC474BAA3F8F0940B6664F Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:08Z'
         status: 200 OK
         code: 200
-        duration: 49.378307ms
+        duration: 49.448077ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -2210,7 +2210,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27apiservice%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27apiservice%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2220,7 +2220,7 @@ interactions:
         trailer: {}
         content_length: 666
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}},"tags":{"azd-service-name":"apiservice","aspire-resource-name":"apiservice"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -2229,7 +2229,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:55 GMT
+                - Mon, 26 Feb 2024 21:05:08 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2241,18 +2241,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - fea03cb7-c6d2-4464-a6d1-425a2a59181a
+                - a65c4c0a-6bc8-42b7-b695-422a406eb7e3
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11998"
+                - "11995"
             X-Ms-Request-Id:
-                - fea03cb7-c6d2-4464-a6d1-425a2a59181a
+                - a65c4c0a-6bc8-42b7-b695-422a406eb7e3
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194555Z:fea03cb7-c6d2-4464-a6d1-425a2a59181a
+                - WESTUS2:20240226T210508Z:a65c4c0a-6bc8-42b7-b695-422a406eb7e3
             X-Msedge-Ref:
-                - 'Ref A: 4A4B7285F02546548692C0E6AF0CE294 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:55Z'
+                - 'Ref A: 4F8F442CAA2242B1AECBD5CCDC9E1865 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:08Z'
         status: 200 OK
         code: 200
-        duration: 91.40507ms
+        duration: 287.669359ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -2275,7 +2275,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l4c10c9%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2285,7 +2285,7 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9","name":"rg-azdtest-l4c10c9","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"},"properties":{"provisioningState":"Succeeded"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -2294,7 +2294,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:55 GMT
+                - Mon, 26 Feb 2024 21:05:08 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2306,18 +2306,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 6b423896-6bfa-4412-9602-b2f2b45f0659
+                - 28b0a231-1e66-48a1-a67a-f1ce7e85f99d
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11997"
             X-Ms-Request-Id:
-                - 6b423896-6bfa-4412-9602-b2f2b45f0659
+                - 28b0a231-1e66-48a1-a67a-f1ce7e85f99d
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194555Z:6b423896-6bfa-4412-9602-b2f2b45f0659
+                - WESTUS2:20240226T210508Z:28b0a231-1e66-48a1-a67a-f1ce7e85f99d
             X-Msedge-Ref:
-                - 'Ref A: 51F5B52F1AB84519BA9CD5CF30170A6A Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:55Z'
+                - 'Ref A: 145A6DA4A1F540A5A8C4D920C423EA56 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:08Z'
         status: 200 OK
         code: 200
-        duration: 49.171447ms
+        duration: 44.460179ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -2340,7 +2340,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27apiservice%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27apiservice%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2350,7 +2350,7 @@ interactions:
         trailer: {}
         content_length: 666
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -2359,7 +2359,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:55 GMT
+                - Mon, 26 Feb 2024 21:05:09 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2371,18 +2371,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 53cafe6a-6cad-4cf1-ad20-2ae6931b2138
+                - e1900bfb-e267-4013-ad8e-bcf585355765
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 53cafe6a-6cad-4cf1-ad20-2ae6931b2138
+                - e1900bfb-e267-4013-ad8e-bcf585355765
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194555Z:53cafe6a-6cad-4cf1-ad20-2ae6931b2138
+                - WESTUS2:20240226T210509Z:e1900bfb-e267-4013-ad8e-bcf585355765
             X-Msedge-Ref:
-                - 'Ref A: CC8D454131C8410399E8B2BE5B93A11A Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:55Z'
+                - 'Ref A: C4E3B4836E744A24B8EC4A2938532E96 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:08Z'
         status: 200 OK
         code: 200
-        duration: 259.796828ms
+        duration: 303.168642ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -2405,7 +2405,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice?api-version=2022-11-01-preview
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/apiservice?api-version=2022-11-01-preview
         method: GET
       response:
         proto: HTTP/2.0
@@ -2413,20 +2413,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3091
+        content_length: 3092
         uncompressed: false
-        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:44:34.9263707","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:44:34.9263707"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"apiservice--sjvfox3","latestReadyRevisionName":"apiservice--sjvfox3","latestRevisionFqdn":"apiservice--sjvfox3.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","external":false,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-apiservice-1708717459","name":"apiservice","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/apiservice/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerapps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:03:45.0704226","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:03:45.0704226"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","workloadProfileName":null,"outboundIpAddresses":["172.175.21.8"],"latestRevisionName":"apiservice--54vuttn","latestReadyRevisionName":"apiservice--54vuttn","latestRevisionFqdn":"apiservice--54vuttn.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io","external":false,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrsoindfxt2muzw.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrsoindfxt2muzw.azurecr.io/azd-deploy-apiservice-1708981409","name":"apiservice","env":[{"name":"AZURE_CLIENT_ID","value":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/containerApps/apiservice/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}}}'
         headers:
             Api-Supported-Versions:
                 - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "3091"
+                - "3092"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:55 GMT
+                - Mon, 26 Feb 2024 21:05:09 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2440,20 +2440,20 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 29aebb12-8c38-4f12-ae80-f2c7dcfd213d
+                - 0328316b-4f63-4979-a83c-231753ff03a5
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 29aebb12-8c38-4f12-ae80-f2c7dcfd213d
+                - 0328316b-4f63-4979-a83c-231753ff03a5
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194556Z:29aebb12-8c38-4f12-ae80-f2c7dcfd213d
+                - WESTUS2:20240226T210509Z:0328316b-4f63-4979-a83c-231753ff03a5
             X-Msedge-Ref:
-                - 'Ref A: 0448A14C52A3416BA5AB3C731545FD54 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:55Z'
+                - 'Ref A: 72190B8DE57945F8BD02A17265FD6CB8 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:09Z'
             X-Powered-By:
                 - ASP.NET
         status: 200 OK
         code: 200
-        duration: 444.548639ms
+        duration: 579.060328ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -2476,7 +2476,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27webfrontend%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27webfrontend%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2486,7 +2486,7 @@ interactions:
         trailer: {}
         content_length: 670
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}},"tags":{"azd-service-name":"webfrontend","aspire-resource-name":"webfrontend"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -2495,7 +2495,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:56 GMT
+                - Mon, 26 Feb 2024 21:05:09 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2507,18 +2507,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - ca875541-df75-49e5-a800-66c75c8fc210
+                - d57ede0e-be88-4a41-a026-9ce3833e1cbb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11998"
+                - "11999"
             X-Ms-Request-Id:
-                - ca875541-df75-49e5-a800-66c75c8fc210
+                - d57ede0e-be88-4a41-a026-9ce3833e1cbb
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194556Z:ca875541-df75-49e5-a800-66c75c8fc210
+                - WESTUS2:20240226T210510Z:d57ede0e-be88-4a41-a026-9ce3833e1cbb
             X-Msedge-Ref:
-                - 'Ref A: 0AF4E5FCD4FD465DA83A9E985954DC34 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:56Z'
+                - 'Ref A: 29002BC568BE48B387ADA092D7788195 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:09Z'
         status: 200 OK
         code: 200
-        duration: 175.192313ms
+        duration: 163.94868ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -2541,7 +2541,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l4c10c9%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2551,7 +2551,7 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9","name":"rg-azdtest-l4c10c9","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"},"properties":{"provisioningState":"Succeeded"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -2560,7 +2560,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:56 GMT
+                - Mon, 26 Feb 2024 21:05:10 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2572,18 +2572,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - a45b398c-6003-4802-bf45-0ac5056e60a0
+                - 1c476ba4-d7bf-4c15-99aa-a811f3253f19
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11997"
+                - "11996"
             X-Ms-Request-Id:
-                - a45b398c-6003-4802-bf45-0ac5056e60a0
+                - 1c476ba4-d7bf-4c15-99aa-a811f3253f19
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194556Z:a45b398c-6003-4802-bf45-0ac5056e60a0
+                - WESTUS2:20240226T210510Z:1c476ba4-d7bf-4c15-99aa-a811f3253f19
             X-Msedge-Ref:
-                - 'Ref A: D6C845DFAD92466EBD8D8FA54F9B712A Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:56Z'
+                - 'Ref A: 8DD02B36E47E4BC083AC80053246E893 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:10Z'
         status: 200 OK
         code: 200
-        duration: 38.629218ms
+        duration: 40.468429ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -2606,7 +2606,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27webfrontend%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27webfrontend%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2616,7 +2616,7 @@ interactions:
         trailer: {}
         content_length: 670
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -2625,7 +2625,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:56 GMT
+                - Mon, 26 Feb 2024 21:05:10 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2637,18 +2637,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - aeb15420-74c1-41f2-b3bd-bb7dcff38457
+                - cd6dd4ba-04bc-4a7a-a6fb-b84c3f9b25ae
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - aeb15420-74c1-41f2-b3bd-bb7dcff38457
+                - cd6dd4ba-04bc-4a7a-a6fb-b84c3f9b25ae
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194556Z:aeb15420-74c1-41f2-b3bd-bb7dcff38457
+                - WESTUS2:20240226T210510Z:cd6dd4ba-04bc-4a7a-a6fb-b84c3f9b25ae
             X-Msedge-Ref:
-                - 'Ref A: 4512BC43B1BC43A4B40A5C46D8FBD8BB Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:56Z'
+                - 'Ref A: 0F8173308E704CF6A11AE91C3EEA05D8 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:10Z'
         status: 200 OK
         code: 200
-        duration: 237.356472ms
+        duration: 116.561577ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -2671,7 +2671,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend?api-version=2022-11-01-preview
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/webfrontend?api-version=2022-11-01-preview
         method: GET
       response:
         proto: HTTP/2.0
@@ -2679,20 +2679,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3915
+        content_length: 3916
         uncompressed: false
-        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:45:10.6566857","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:45:10.6566857"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"webfrontend--v4b3j5p","latestReadyRevisionName":"webfrontend--v4b3j5p","latestRevisionFqdn":"webfrontend--v4b3j5p.happybush-752e10b4.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"connectionstrings--cache"},{"name":"connectionstrings--markdown"},{"name":"connectionstrings--messages"},{"name":"connectionstrings--pubsub"},{"name":"connectionstrings--requestlog"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"webfrontend.happybush-752e10b4.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-webfrontend-1708717493","name":"webfrontend","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/webfrontend/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerapps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:04:19.562851","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:04:19.562851"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","workloadProfileName":null,"outboundIpAddresses":["172.175.21.8"],"latestRevisionName":"webfrontend--8r6gfli","latestReadyRevisionName":"webfrontend--8r6gfli","latestRevisionFqdn":"webfrontend--8r6gfli.mangoplant-0534793d.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"connectionstrings--cache"},{"name":"connectionstrings--markdown"},{"name":"connectionstrings--messages"},{"name":"connectionstrings--pubsub"},{"name":"connectionstrings--requestlog"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"webfrontend.mangoplant-0534793d.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrsoindfxt2muzw.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrsoindfxt2muzw.azurecr.io/azd-deploy-webfrontend-1708981443","name":"webfrontend","env":[{"name":"AZURE_CLIENT_ID","value":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/containerApps/webfrontend/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}}}'
         headers:
             Api-Supported-Versions:
                 - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "3915"
+                - "3916"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:56 GMT
+                - Mon, 26 Feb 2024 21:05:10 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2706,20 +2706,20 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 9a2eff7d-0da6-4158-8226-8be24d77d738
+                - 62ed1a17-609a-47c9-a8c1-67fef25962cf
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 9a2eff7d-0da6-4158-8226-8be24d77d738
+                - 62ed1a17-609a-47c9-a8c1-67fef25962cf
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194557Z:9a2eff7d-0da6-4158-8226-8be24d77d738
+                - WESTUS2:20240226T210510Z:62ed1a17-609a-47c9-a8c1-67fef25962cf
             X-Msedge-Ref:
-                - 'Ref A: EE4FEF856ED647CA888E96A54820BB86 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:56Z'
+                - 'Ref A: 3D63ADA040A642ACA4C8222AA0F39763 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:10Z'
             X-Powered-By:
                 - ASP.NET
         status: 200 OK
         code: 200
-        duration: 434.03303ms
+        duration: 438.862101ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -2742,7 +2742,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/resources?api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2750,18 +2750,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 4936
+        content_length: 4934
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/pubsub","name":"pubsub","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-l88c996","aspire-resource-name":"pubsub"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:42:16.8954514Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:42:16.8954514Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm","name":"storagegnxzs2f5m4idm","type":"Microsoft.Storage/storageAccounts","sku":{"name":"Standard_GRS","tier":"Standard"},"kind":"Storage","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996","aspire-resource-name":"storage"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:44:34.9263707Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:44:34.9263707Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ContainerRegistry/registries/acrgnxzs2f5m4idm","name":"acrgnxzs2f5m4idm","type":"Microsoft.ContainerRegistry/registries","sku":{"name":"Basic","tier":"Basic"},"location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:41:19.7556947Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:41:19.7556947Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm","name":"mi-gnxzs2f5m4idm","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.OperationalInsights/workspaces/law-gnxzs2f5m4idm","name":"law-gnxzs2f5m4idm","type":"Microsoft.OperationalInsights/workspaces","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/cache","name":"cache","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-l88c996","aspire-resource-name":"cache"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:42:16.9266975Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:42:16.9266975Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","name":"cae-gnxzs2f5m4idm","type":"Microsoft.App/managedEnvironments","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:41:39.9056782Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:41:39.9056782Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:45:10.6566857Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:45:10.6566857Z"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/pubsub","name":"pubsub","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-l4c10c9","aspire-resource-name":"pubsub"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:01:37.1633081Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:01:37.1633081Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.OperationalInsights/workspaces/law-soindfxt2muzw","name":"law-soindfxt2muzw","type":"Microsoft.OperationalInsights/workspaces","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:03:45.0704226Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:03:45.0704226Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/cache","name":"cache","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-l4c10c9","aspire-resource-name":"cache"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:01:37.1320581Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:01:37.1320581Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ContainerRegistry/registries/acrsoindfxt2muzw","name":"acrsoindfxt2muzw","type":"Microsoft.ContainerRegistry/registries","sku":{"name":"Basic","tier":"Basic"},"location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:00:58.9132152Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:00:58.9132152Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","name":"cae-soindfxt2muzw","type":"Microsoft.App/managedEnvironments","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:01:17.1288282Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:01:17.1288282Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw","name":"storagesoindfxt2muzw","type":"Microsoft.Storage/storageAccounts","sku":{"name":"Standard_GRS","tier":"Standard"},"kind":"Storage","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9","aspire-resource-name":"storage"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:04:19.562851Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:04:19.562851Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw","name":"mi-soindfxt2muzw","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"}}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "4936"
+                - "4934"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:45:57 GMT
+                - Mon, 26 Feb 2024 21:05:10 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2773,18 +2773,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - ee45e718-3845-41b4-9228-6b354254f5df
+                - 5e8780b0-428a-4016-b54c-ceaf2cc0908c
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11997"
             X-Ms-Request-Id:
-                - ee45e718-3845-41b4-9228-6b354254f5df
+                - 5e8780b0-428a-4016-b54c-ceaf2cc0908c
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194557Z:ee45e718-3845-41b4-9228-6b354254f5df
+                - WESTUS2:20240226T210510Z:5e8780b0-428a-4016-b54c-ceaf2cc0908c
             X-Msedge-Ref:
-                - 'Ref A: C0132A7A39E645A381F718AD3BF5D582 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:57Z'
+                - 'Ref A: 5989C44ED2E9450C90FB1867CCA1FEBC Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:10Z'
         status: 200 OK
         code: 200
-        duration: 113.930976ms
+        duration: 133.451003ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -2815,18 +2815,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 959721
+        content_length: 1172996
         uncompressed: false
-        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1Y7faoMwFMafxVw7MKUtw7voOWWwJjbJSUp7VzY3RImwWXQW3322ax9id9%2bf3wffhb21oavC%2bdRVbaC2LsM3Sy8MhSVnF1cZyqHbnb666kq8lj8sZTx6jhQdBjkenlh8I0zbPzrO15GpN5mEz167I0inlwqyzEADOvEb6TBRlIEmnyt6%2fzBcFVub9AW4matHSWJRgB4UyEHCvM05Gbc6ard68ejJg%2bgl4FrWMzOKpaKbT9gU33%2f%2fu9t7tITOFDtkaTg3TczsHgFVjoqM2D7Cu3X2L5imXw%3d%3d","value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l88c996-1708717227","location":"eastus2","name":"azdtest-l88c996-1708717227","properties":{"correlationId":"788803d5-d997-4a8f-bf79-f709132f8a66","dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","resourceName":"rg-azdtest-l88c996","resourceType":"Microsoft.Resources/resourceGroups"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Resources/deployments/resources","resourceName":"resources","resourceType":"Microsoft.Resources/deployments"}],"duration":"PT2M38.5872939S","mode":"Incremental","outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/cache"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/pubsub"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ContainerRegistry/registries/acrgnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ContainerRegistry/registries/acrgnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/faee5324-3278-5609-995a-8e845396fbe9"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.OperationalInsights/workspaces/law-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/blobServices/default"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/7bc4c3d5-404b-5a27-b547-08f357bed58b"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/a9bde9d1-b484-5092-9aaa-77577f0c97dd"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/aa646b75-ef6f-5e88-adff-bd4e630fcb69"}],"outputs":{"azurE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN":{"type":"String","value":"happybush-752e10b4.eastus2.azurecontainerapps.io"},"azurE_CONTAINER_APPS_ENVIRONMENT_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm"},"azurE_CONTAINER_REGISTRY_ENDPOINT":{"type":"String","value":"acrgnxzs2f5m4idm.azurecr.io"},"azurE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"},"azurE_LOG_ANALYTICS_WORKSPACE_NAME":{"type":"String","value":"law-gnxzs2f5m4idm"},"manageD_IDENTITY_CLIENT_ID":{"type":"String","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},"servicE_BINDING_MARKDOWN_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.blob.core.windows.net/"},"servicE_BINDING_MESSAGES_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.queue.core.windows.net/"},"servicE_BINDING_REQUESTLOG_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.table.core.windows.net/"}},"parameters":{"environmentName":{"type":"String","value":"azdtest-l88c996"},"inputs":{"type":"SecureObject"},"location":{"type":"String","value":"eastus2"}},"providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"locations":["eastus2"],"resourceType":"resourceGroups"},{"locations":[null],"resourceType":"deployments"}]}],"provisioningState":"Succeeded","templateHash":"14419117427229910140","timestamp":"2024-02-23T19:43:53.0492909Z"},"tags":{"azd-env-name":"azdtest-l88c996","azd-provision-param-hash":"6354240e3b61edb702891d88e5c50b42b4af01f4c1dec5d56a7532a298f4fb48"},"type":"Microsoft.Resources/deployments"}]}'
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1Y7faoMwFMafxVxbSDYHwzv1nMJYE5vkpKW7K50bTklgs1gtvvvs1j5E774%2fPz6%2bMzsE39X%2buO%2fq4Ck0lf9h6ZlhZsnZh4v01alb77%2b7%2bkK8VgNLmYieI0W7kxx3Cxb%2fESb0t07wJDLNMpfw2Wv3BtLpREGeG2hB881SOuSKctC0KRS9fxihypXlfQlu5ppRAj4pygb5pXkJOpGFUBZeBkVhMICP864o4TDO7IJN8fXrXVzdoiV0plwjS%2f2xbWNmtwioClRkstUtvFpn%2f4Np%2bgU%3d","value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l4c10c9-1708981207","location":"eastus2","name":"azdtest-l4c10c9-1708981207","properties":{"correlationId":"18b8d868-9ab3-44e5-91e6-04536c0cf51e","dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9","resourceName":"rg-azdtest-l4c10c9","resourceType":"Microsoft.Resources/resourceGroups"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Resources/deployments/resources","resourceName":"resources","resourceType":"Microsoft.Resources/deployments"}],"duration":"PT2M30.1684361S","mode":"Incremental","outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/cache"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/pubsub"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ContainerRegistry/registries/acrsoindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ContainerRegistry/registries/acrsoindfxt2muzw/providers/Microsoft.Authorization/roleAssignments/f11e9f84-10b6-5a7a-823a-ff920999efab"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.OperationalInsights/workspaces/law-soindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw/blobServices/default"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw/providers/Microsoft.Authorization/roleAssignments/375d2d03-b2cb-5480-8c5f-1ed90a8964a2"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw/providers/Microsoft.Authorization/roleAssignments/b7bc2b96-e891-5847-a299-e1b73a980306"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw/providers/Microsoft.Authorization/roleAssignments/e303f4d9-03e1-5676-8709-5c1e78da21ae"}],"outputs":{"azurE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN":{"type":"String","value":"mangoplant-0534793d.eastus2.azurecontainerapps.io"},"azurE_CONTAINER_APPS_ENVIRONMENT_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw"},"azurE_CONTAINER_REGISTRY_ENDPOINT":{"type":"String","value":"acrsoindfxt2muzw.azurecr.io"},"azurE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"},"azurE_LOG_ANALYTICS_WORKSPACE_NAME":{"type":"String","value":"law-soindfxt2muzw"},"manageD_IDENTITY_CLIENT_ID":{"type":"String","value":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"},"servicE_BINDING_MARKDOWN_ENDPOINT":{"type":"String","value":"https://storagesoindfxt2muzw.blob.core.windows.net/"},"servicE_BINDING_MESSAGES_ENDPOINT":{"type":"String","value":"https://storagesoindfxt2muzw.queue.core.windows.net/"},"servicE_BINDING_REQUESTLOG_ENDPOINT":{"type":"String","value":"https://storagesoindfxt2muzw.table.core.windows.net/"}},"parameters":{"environmentName":{"type":"String","value":"azdtest-l4c10c9"},"inputs":{"type":"SecureObject"},"location":{"type":"String","value":"eastus2"}},"providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"locations":["eastus2"],"resourceType":"resourceGroups"},{"locations":[null],"resourceType":"deployments"}]}],"provisioningState":"Succeeded","templateHash":"14419117427229910140","timestamp":"2024-02-26T21:03:24.5994655Z"},"tags":{"azd-env-name":"azdtest-l4c10c9","azd-provision-param-hash":"c6534960363d73a71040bdc189ecb233003bc8a557aebd182ec26315f8f83cd3"},"type":"Microsoft.Resources/deployments"}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "959721"
+                - "1172996"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:46:17 GMT
+                - Mon, 26 Feb 2024 21:05:31 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2838,18 +2838,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 9edcf1ed-be1f-4899-bb30-888b54f390a4
+                - ca71a97c-b377-4ada-a58a-98e1dcc785f2
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11998"
+                - "11999"
             X-Ms-Request-Id:
-                - 9edcf1ed-be1f-4899-bb30-888b54f390a4
+                - ca71a97c-b377-4ada-a58a-98e1dcc785f2
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194617Z:9edcf1ed-be1f-4899-bb30-888b54f390a4
+                - WESTUS2:20240226T210531Z:ca71a97c-b377-4ada-a58a-98e1dcc785f2
             X-Msedge-Ref:
-                - 'Ref A: 9C38FE87E04B4D2C9B29BA4F1BFF8D1D Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:13Z'
+                - 'Ref A: F30481FF8F7C44B29DF4B487E98802ED Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:26Z'
         status: 200 OK
         code: 200
-        duration: 4.125745602s
+        duration: 4.435874893s
     - id: 43
       request:
         proto: HTTP/1.1
@@ -2870,7 +2870,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1Y7faoMwFMafxVw7MKUtw7voOWWwJjbJSUp7VzY3RImwWXQW3322ax9id9%2bf3wffhb21oavC%2bdRVbaC2LsM3Sy8MhSVnF1cZyqHbnb666kq8lj8sZTx6jhQdBjkenlh8I0zbPzrO15GpN5mEz167I0inlwqyzEADOvEb6TBRlIEmnyt6%2fzBcFVub9AW4matHSWJRgB4UyEHCvM05Gbc6ard68ejJg%2bgl4FrWMzOKpaKbT9gU33%2f%2fu9t7tITOFDtkaTg3TczsHgFVjoqM2D7Cu3X2L5imXw%3d%3d
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1Y7faoMwFMafxVxbSDYHwzv1nMJYE5vkpKW7K50bTklgs1gtvvvs1j5E774%2fPz6%2bMzsE39X%2buO%2fq4Ck0lf9h6ZlhZsnZh4v01alb77%2b7%2bkK8VgNLmYieI0W7kxx3Cxb%2fESb0t07wJDLNMpfw2Wv3BtLpREGeG2hB881SOuSKctC0KRS9fxihypXlfQlu5ppRAj4pygb5pXkJOpGFUBZeBkVhMICP864o4TDO7IJN8fXrXVzdoiV0plwjS%2f2xbWNmtwioClRkstUtvFpn%2f4Np%2bgU%3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -2878,18 +2878,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2487770
+        content_length: 1780521
         uncompressed: false
-        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1ZDRToMwFIafhV5jUgYxhjugXdSth7U93YJ3iyJhJcUoC7iFd9c5SPYK3p3%2f%2b7%2bLP%2bdMXlvX1e647%2brWYWtL90XiM%2bGJRqMXl9OVQ7fZf3b1xViV3yQmgffgARaDOBV3xP8zVNvPXUAjT9llKljVS%2fPChJERsDRVrGGSbpfCcAqYMonbDPDtXQWQrzXtc2Z%2bPUuBJREcqoXApxAORSiyADT%2feJbI74WVA5ySUKCNBFYDGf1p67%2bYalY6N%2fhIYndsGp%2fs%2bPTl2xjettyofMNnonecccg4oErWM5yi0Vcwjj8%3d","value":[]}'
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1ZDdaoNAEIWfxb02sNZQinfqbIgkO7p%2fBnsXWluMskJr0CT47jWtQl6hd3O%2bc4Y5zI28tbar7PnYVa3VbV3abxLcCAuVNurpPtpy6LLjV1fdE7vyQgLiOS8O6mLg12JF3N%2bEbPvF8%2bjakfUm4vDZC%2fMK3Ig1QhRJaEDQfMMNo6gjEDqPUb9%2fSA%2fTvaJ9CmbK1ZSfxAUh6ad9D0%2bJz2OvyHOZcUieeS0GvIb%2bdJki8J6M7tz1X1Q1O5UavSWBPTeNSw5s%2fvKj9B9dZmSasYWoAwOGMUMtw%2f0CZ2nUHxjHHw%3d%3d","value":[]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "2487770"
+                - "1780521"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:46:22 GMT
+                - Mon, 26 Feb 2024 21:05:47 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2901,18 +2901,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 5f93f736-b642-4910-85b7-ad564999bfd2
+                - b6eea1cf-3cea-400f-aebd-fef01514def6
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 5f93f736-b642-4910-85b7-ad564999bfd2
+                - b6eea1cf-3cea-400f-aebd-fef01514def6
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194622Z:5f93f736-b642-4910-85b7-ad564999bfd2
+                - WESTUS2:20240226T210547Z:b6eea1cf-3cea-400f-aebd-fef01514def6
             X-Msedge-Ref:
-                - 'Ref A: 8A47655F42F747F087E2966E8173262C Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:17Z'
+                - 'Ref A: 8AF31F33615741D8B415A98354BCC123 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:31Z'
         status: 200 OK
         code: 200
-        duration: 4.844899545s
+        duration: 16.366690395s
     - id: 44
       request:
         proto: HTTP/1.1
@@ -2933,7 +2933,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1ZDRToMwFIafhV5jUgYxhjugXdSth7U93YJ3iyJhJcUoC7iFd9c5SPYK3p3%2f%2b7%2bLP%2bdMXlvX1e647%2brWYWtL90XiM%2bGJRqMXl9OVQ7fZf3b1xViV3yQmgffgARaDOBV3xP8zVNvPXUAjT9llKljVS%2fPChJERsDRVrGGSbpfCcAqYMonbDPDtXQWQrzXtc2Z%2bPUuBJREcqoXApxAORSiyADT%2feJbI74WVA5ySUKCNBFYDGf1p67%2bYalY6N%2fhIYndsGp%2fs%2bPTl2xjettyofMNnonecccg4oErWM5yi0Vcwjj8%3d
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1ZDdaoNAEIWfxb02sNZQinfqbIgkO7p%2fBnsXWluMskJr0CT47jWtQl6hd3O%2bc4Y5zI28tbar7PnYVa3VbV3abxLcCAuVNurpPtpy6LLjV1fdE7vyQgLiOS8O6mLg12JF3N%2bEbPvF8%2bjakfUm4vDZC%2fMK3Ig1QhRJaEDQfMMNo6gjEDqPUb9%2fSA%2fTvaJ9CmbK1ZSfxAUh6ad9D0%2bJz2OvyHOZcUieeS0GvIb%2bdJki8J6M7tz1X1Q1O5UavSWBPTeNSw5s%2fvKj9B9dZmSasYWoAwOGMUMtw%2f0CZ2nUHxjHHw%3d%3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -2941,18 +2941,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3021248
+        content_length: 3283326
         uncompressed: false
-        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1VJBbsIwEHwLPhcphoAqbk7WiApsE3udKNxQSylNlEhtUEIQf28MREL9QNXbznh2PR7vmbyWRXUojtvqUBZYZrvim8zOhDOD1oxcWeyaar39qg5OsdydyIzQwfNAYtqINh2Sp6tCl3V%2fRul0oLN5IGBfR3YDwka%2bhCDQkEPkxXNhuScxgAjjUOLbu6ZSrYxXK7CdLvNkm45lm1GFwleY1TKkiYk3QZLzqcj03HofawvlSQMfC0h90Xaaz%2f2QXJ7uvv%2bd7YS7uP%2fCdiuQjRREjQTRCOh%2bKqSo7WQT2cki5jHGwGoBLvlO0zJf4hV7Lm1mDWq2emEhl64gs%2bKY5w%2b8W6OetEujLC56eHtyt2G3lhscP0JutVrznjEJBy5%2fXXSHLjo35nL5AQ%3d%3d","value":[]}'
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=3VLLbsIwEPwWci5SQlJUuCWso%2fLwGr%2bC4IYorVKjpGqD8kD8e2MgEuqxvfXkndldW%2bOZk7PLsyLNjtsizTOVm3325YxPDgml0nJgy2xfFcvtZ5Haifm%2bdsaO13vqoVpXtFn3nYfLhMjLrucNg54wcUThreR6A1TzACGKBByAu0lMNXFRRcBVMkH18io8ZAvplgx0O2fanmlrUiHwAUJYYuox0eS1IJtEGdRSj5i%2b4I8oMbHi3mymYz6kRiiehPYERUaJgHYnRiL9Kubu2qcNCdBsIqZpiTD1nfPDTee%2fl7ki1s7fyXT%2f5GZDgTyiCmv6zl0GPKATDyVMa1StO0D8NiUeg13TOt%2b3joRaKhEupuGEoC2ccXY8HO54G82O1HPJtHru4FVmm9rryhX695BowZakY%2bSKAMEfD92g%2fS57zfn8DQ%3d%3d","value":[]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "3021248"
+                - "3283326"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:46:28 GMT
+                - Mon, 26 Feb 2024 21:05:53 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2964,18 +2964,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - dea99230-5f4b-439e-aa40-221c92b1c5c8
+                - f7e09b97-cde2-4024-87ff-1128abc43413
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11997"
             X-Ms-Request-Id:
-                - dea99230-5f4b-439e-aa40-221c92b1c5c8
+                - f7e09b97-cde2-4024-87ff-1128abc43413
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194628Z:dea99230-5f4b-439e-aa40-221c92b1c5c8
+                - WESTUS2:20240226T210553Z:f7e09b97-cde2-4024-87ff-1128abc43413
             X-Msedge-Ref:
-                - 'Ref A: 52BB321EBAF2413E9485F79BD4610CE1 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:22Z'
+                - 'Ref A: B291348B92D14C0BAF514F642E15B755 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:48Z'
         status: 200 OK
         code: 200
-        duration: 5.803223517s
+        duration: 5.481629176s
     - id: 45
       request:
         proto: HTTP/1.1
@@ -2996,7 +2996,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1VJBbsIwEHwLPhcphoAqbk7WiApsE3udKNxQSylNlEhtUEIQf28MREL9QNXbznh2PR7vmbyWRXUojtvqUBZYZrvim8zOhDOD1oxcWeyaar39qg5OsdydyIzQwfNAYtqINh2Sp6tCl3V%2fRul0oLN5IGBfR3YDwka%2bhCDQkEPkxXNhuScxgAjjUOLbu6ZSrYxXK7CdLvNkm45lm1GFwleY1TKkiYk3QZLzqcj03HofawvlSQMfC0h90Xaaz%2f2QXJ7uvv%2bd7YS7uP%2fCdiuQjRREjQTRCOh%2bKqSo7WQT2cki5jHGwGoBLvlO0zJf4hV7Lm1mDWq2emEhl64gs%2bKY5w%2b8W6OetEujLC56eHtyt2G3lhscP0JutVrznjEJBy5%2fXXSHLjo35nL5AQ%3d%3d
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=3VLLbsIwEPwWci5SQlJUuCWso%2fLwGr%2bC4IYorVKjpGqD8kD8e2MgEuqxvfXkndldW%2bOZk7PLsyLNjtsizTOVm3325YxPDgml0nJgy2xfFcvtZ5Haifm%2bdsaO13vqoVpXtFn3nYfLhMjLrucNg54wcUThreR6A1TzACGKBByAu0lMNXFRRcBVMkH18io8ZAvplgx0O2fanmlrUiHwAUJYYuox0eS1IJtEGdRSj5i%2b4I8oMbHi3mymYz6kRiiehPYERUaJgHYnRiL9Kubu2qcNCdBsIqZpiTD1nfPDTee%2fl7ki1s7fyXT%2f5GZDgTyiCmv6zl0GPKATDyVMa1StO0D8NiUeg13TOt%2b3joRaKhEupuGEoC2ccXY8HO54G82O1HPJtHru4FVmm9rryhX695BowZakY%2bSKAMEfD92g%2fS57zfn8DQ%3d%3d
         method: GET
       response:
         proto: HTTP/2.0
@@ -3004,18 +3004,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 271460
+        content_length: 1021766
         uncompressed: false
-        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=XZBRT4MwFIV%2fC32eCQxiDG%2bFdnFuvaz0dgu%2bLYqEQYpRFnAL%2f13r1sX41u%2bcc9OccyYvnelrc9z3dWewa0rzSeIz4VShVnMSm2Pbzq7oaMetaWOmHPvN%2fqOv7fWq%2fCIxCbwHD7AYxam4I7PfRN4Nzgv8yMubRSJYNUj9zISWEbAkyVnLpL9dCM19wIRJ3KaAr295ANla%2bUPG9E%2bu8YHRCA7VXOAyhEMRijQAxd%2bfJPJ70cgRTjQU2EQCq5FMM0K1wpyulzTlYB%2buwk23RZ2oVyrT%2bOjwUvO2wQXDvy7XebbhTlE7zjj8%2b%2biKdi475TR9Aw%3d%3d","value":[]}'
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=XVBda4MwFP0t5tlBnGUM39SbMmkTzZfFvZXNDatE2CzaFv%2f7zNqUsbd7vricc0FvvRkac9wPTW9U39bmG0UXRGKptHxEkTl2nX%2bDDu2IFa3N1NNQ7L%2bGxqY39QlFKPCePaaqiZ6rB%2bT%2fOkQ%2fOi3AK0%2b064TC58j1K1DNVwySREAHHJdrqglmKgGuypSp9w8RsHwr8ZiDXnwtpgd%2bYpCNSz5ghyykaVCVpSgoZE%2b05RM7x%2bHyGTOgI5p9FGupRLzN4pQwe7gKd94WdaTeyFyrFwevNe8bXGH4VyVa5AVxjNwRIOzfoxu0c9kp5%2fkH","value":[]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "271460"
+                - "1021766"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:46:30 GMT
+                - Mon, 26 Feb 2024 21:05:56 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3027,18 +3027,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - cc8a4b70-b660-42c8-9caf-5db00de4dd5e
+                - c9fd8f52-5c23-4751-b21e-5aff78af6341
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11998"
+                - "11997"
             X-Ms-Request-Id:
-                - cc8a4b70-b660-42c8-9caf-5db00de4dd5e
+                - c9fd8f52-5c23-4751-b21e-5aff78af6341
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194630Z:cc8a4b70-b660-42c8-9caf-5db00de4dd5e
+                - WESTUS2:20240226T210556Z:c9fd8f52-5c23-4751-b21e-5aff78af6341
             X-Msedge-Ref:
-                - 'Ref A: DC7E7680762D4A559BE9A848107A2843 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:28Z'
+                - 'Ref A: 76DD35FC934E429292F13CEE9433F535 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:54Z'
         status: 200 OK
         code: 200
-        duration: 1.460474281s
+        duration: 2.311097666s
     - id: 46
       request:
         proto: HTTP/1.1
@@ -3059,7 +3059,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=XZBRT4MwFIV%2fC32eCQxiDG%2bFdnFuvaz0dgu%2bLYqEQYpRFnAL%2f13r1sX41u%2bcc9OccyYvnelrc9z3dWewa0rzSeIz4VShVnMSm2Pbzq7oaMetaWOmHPvN%2fqOv7fWq%2fCIxCbwHD7AYxam4I7PfRN4Nzgv8yMubRSJYNUj9zISWEbAkyVnLpL9dCM19wIRJ3KaAr295ANla%2bUPG9E%2bu8YHRCA7VXOAyhEMRijQAxd%2bfJPJ70cgRTjQU2EQCq5FMM0K1wpyulzTlYB%2buwk23RZ2oVyrT%2bOjwUvO2wQXDvy7XebbhTlE7zjj8%2b%2biKdi475TR9Aw%3d%3d
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=XVBda4MwFP0t5tlBnGUM39SbMmkTzZfFvZXNDatE2CzaFv%2f7zNqUsbd7vricc0FvvRkac9wPTW9U39bmG0UXRGKptHxEkTl2nX%2bDDu2IFa3N1NNQ7L%2bGxqY39QlFKPCePaaqiZ6rB%2bT%2fOkQ%2fOi3AK0%2b064TC58j1K1DNVwySREAHHJdrqglmKgGuypSp9w8RsHwr8ZiDXnwtpgd%2bYpCNSz5ghyykaVCVpSgoZE%2b05RM7x%2bHyGTOgI5p9FGupRLzN4pQwe7gKd94WdaTeyFyrFwevNe8bXGH4VyVa5AVxjNwRIOzfoxu0c9kp5%2fkH
         method: GET
       response:
         proto: HTTP/2.0
@@ -3067,18 +3067,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 20482
+        content_length: 20512
         uncompressed: false
-        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=ZZBda4MwFIZ%2fi7luwUwpwzs1kY42ieZDsXdldZ2LRNgsthb%2f%2b5p1GWO7O8%2f7vueDcwXPvRlac9oPbW9krxvzAaIrqLCQStjKNOch378PrQ1smguIAPQePSrrM5nqJVh8JXg%2fOg%2fClcd1lhB0HAu1Q0QVIUVJwlGHCr%2fMiMI%2blQkqZJlSeXjhkLKt8EeG1C2nfTrVAZ00ZJKETOqRprAS5S6pOrwimmfKf80V6i8c4YCgOiTTLfN2XIJ5AXBsz34AkTl1nUNHsRKSx9unOMXUFv902%2b1EtRFMybXD%2bz9%2bBt8x%2bO1ixVmOnSIqjDD9s%2bgb7V%2ftffP8CQ%3d%3d","value":[]}'
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=ZZHLbsIwEEW%2fBa%2bplBCECruEcVQeHuPHBMEOtbSKjJKqDUoA8e%2bNoamqduU5994Zvy7suSyqvDjuqrwsbOn2xSebXNiaG0vGV8W%2bqVa7jyr3gcX%2bxCYs7D320G4acd48sP4tocu688LRsKddmgh4qxVtQZAaIiSJhgOoIEsF8QBtAspmU7QvrzpEuTRBLYHanGs919a8QVADhLjGPJT6XJ4032bWIRkaS7rxe5K51KpwPqdUjYTTVmWxX8Hycaah7UmRm6hJVbCJxJkP0W0TSaJGmEXs2mc89tccsElxPBw67CgmY3W8nMVTjr74p%2fvuTqSFkWSfOry%2f38%2fgO0a%2fXU5arninmDUHjn82%2bkb%2fD%2f581%2bsX","value":[]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "20482"
+                - "20512"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:46:31 GMT
+                - Mon, 26 Feb 2024 21:05:57 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3090,18 +3090,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - ead56de3-ba3a-467c-8a6e-ba06b19ce090
+                - 28118746-c628-4854-9e38-8d13dac7d1b9
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11998"
             X-Ms-Request-Id:
-                - ead56de3-ba3a-467c-8a6e-ba06b19ce090
+                - 28118746-c628-4854-9e38-8d13dac7d1b9
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194631Z:ead56de3-ba3a-467c-8a6e-ba06b19ce090
+                - WESTUS2:20240226T210557Z:28118746-c628-4854-9e38-8d13dac7d1b9
             X-Msedge-Ref:
-                - 'Ref A: B53B516DA21D4FBE906C7553B8AB2B5E Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:30Z'
+                - 'Ref A: 62991C3F529E4FF29E286E1C079AB005 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:56Z'
         status: 200 OK
         code: 200
-        duration: 846.91748ms
+        duration: 656.391703ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -3122,7 +3122,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=ZZBda4MwFIZ%2fi7luwUwpwzs1kY42ieZDsXdldZ2LRNgsthb%2f%2b5p1GWO7O8%2f7vueDcwXPvRlac9oPbW9krxvzAaIrqLCQStjKNOch378PrQ1smguIAPQePSrrM5nqJVh8JXg%2fOg%2fClcd1lhB0HAu1Q0QVIUVJwlGHCr%2fMiMI%2blQkqZJlSeXjhkLKt8EeG1C2nfTrVAZ00ZJKETOqRprAS5S6pOrwimmfKf80V6i8c4YCgOiTTLfN2XIJ5AXBsz34AkTl1nUNHsRKSx9unOMXUFv902%2b1EtRFMybXD%2bz9%2bBt8x%2bO1ixVmOnSIqjDD9s%2bgb7V%2ftffP8CQ%3d%3d
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=ZZHLbsIwEEW%2fBa%2bplBCECruEcVQeHuPHBMEOtbSKjJKqDUoA8e%2bNoamqduU5994Zvy7suSyqvDjuqrwsbOn2xSebXNiaG0vGV8W%2bqVa7jyr3gcX%2bxCYs7D320G4acd48sP4tocu688LRsKddmgh4qxVtQZAaIiSJhgOoIEsF8QBtAspmU7QvrzpEuTRBLYHanGs919a8QVADhLjGPJT6XJ4032bWIRkaS7rxe5K51KpwPqdUjYTTVmWxX8Hycaah7UmRm6hJVbCJxJkP0W0TSaJGmEXs2mc89tccsElxPBw67CgmY3W8nMVTjr74p%2fvuTqSFkWSfOry%2f38%2fgO0a%2fXU5arninmDUHjn82%2bkb%2fD%2f581%2bsX
         method: GET
       response:
         proto: HTTP/2.0
@@ -3141,7 +3141,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:46:31 GMT
+                - Mon, 26 Feb 2024 21:05:57 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3153,18 +3153,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 0b250137-5db1-424f-ac11-160cb79215bd
+                - 2544a6be-fafd-497f-87e9-5b12dbeb41a6
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11998"
             X-Ms-Request-Id:
-                - 0b250137-5db1-424f-ac11-160cb79215bd
+                - 2544a6be-fafd-497f-87e9-5b12dbeb41a6
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194631Z:0b250137-5db1-424f-ac11-160cb79215bd
+                - WESTUS2:20240226T210557Z:2544a6be-fafd-497f-87e9-5b12dbeb41a6
             X-Msedge-Ref:
-                - 'Ref A: B58E44FE2DE949759575CC81D5A9EDA9 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:31Z'
+                - 'Ref A: BD4FD83AD1C64D36872B6B3AD40D7CD5 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:57Z'
         status: 200 OK
         code: 200
-        duration: 421.72145ms
+        duration: 363.136872ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -3187,7 +3187,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l4c10c9%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3197,7 +3197,7 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9","name":"rg-azdtest-l4c10c9","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"},"properties":{"provisioningState":"Succeeded"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -3206,7 +3206,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:46:31 GMT
+                - Mon, 26 Feb 2024 21:05:57 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3218,18 +3218,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 8ba6ea60-3a6f-4758-b2c4-d1e7c52c45b1
+                - 2c2750c5-3b78-4af7-a421-128f422e251e
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 8ba6ea60-3a6f-4758-b2c4-d1e7c52c45b1
+                - 2c2750c5-3b78-4af7-a421-128f422e251e
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194631Z:8ba6ea60-3a6f-4758-b2c4-d1e7c52c45b1
+                - WESTUS2:20240226T210557Z:2c2750c5-3b78-4af7-a421-128f422e251e
             X-Msedge-Ref:
-                - 'Ref A: B7EF024240D94DA5BA9F5017F9B7DCA7 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:31Z'
+                - 'Ref A: F9E65629FF774AD1AA2FA73A4A83A8A3 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:57Z'
         status: 200 OK
         code: 200
-        duration: 50.082803ms
+        duration: 55.686101ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -3252,7 +3252,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27apiservice%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27apiservice%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3262,7 +3262,7 @@ interactions:
         trailer: {}
         content_length: 666
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"azd-service-name":"apiservice","aspire-resource-name":"apiservice"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -3271,7 +3271,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:46:31 GMT
+                - Mon, 26 Feb 2024 21:05:57 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3283,18 +3283,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3216ac99-0868-413e-bbd0-938026903ec9
+                - ce44ea0e-50f8-4660-8829-8b03ee40b4ee
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 3216ac99-0868-413e-bbd0-938026903ec9
+                - ce44ea0e-50f8-4660-8829-8b03ee40b4ee
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194632Z:3216ac99-0868-413e-bbd0-938026903ec9
+                - WESTUS2:20240226T210557Z:ce44ea0e-50f8-4660-8829-8b03ee40b4ee
             X-Msedge-Ref:
-                - 'Ref A: 33F73B22D03342A3A7FC2590916E0CE1 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:31Z'
+                - 'Ref A: 779F5A94B7EA4B71942F676AF2AFCBE3 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:57Z'
         status: 200 OK
         code: 200
-        duration: 250.065619ms
+        duration: 245.201587ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -3317,7 +3317,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l4c10c9%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3327,7 +3327,7 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9","name":"rg-azdtest-l4c10c9","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"},"properties":{"provisioningState":"Succeeded"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -3336,7 +3336,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:46:31 GMT
+                - Mon, 26 Feb 2024 21:05:57 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3348,18 +3348,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 09b1df61-bea3-422a-b391-dc3016a621fb
+                - cc9fd8eb-630f-41cc-b8a6-6055b25f838a
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11996"
             X-Ms-Request-Id:
-                - 09b1df61-bea3-422a-b391-dc3016a621fb
+                - cc9fd8eb-630f-41cc-b8a6-6055b25f838a
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194632Z:09b1df61-bea3-422a-b391-dc3016a621fb
+                - WESTUS2:20240226T210558Z:cc9fd8eb-630f-41cc-b8a6-6055b25f838a
             X-Msedge-Ref:
-                - 'Ref A: 4642745A215D4CAD93F16DCB9ACE8150 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:32Z'
+                - 'Ref A: 5B62A375A7BF4EF1A4CC972E938B6CB1 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:57Z'
         status: 200 OK
         code: 200
-        duration: 139.517076ms
+        duration: 89.303499ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -3382,7 +3382,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27apiservice%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27apiservice%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3392,7 +3392,7 @@ interactions:
         trailer: {}
         content_length: 666
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"azd-service-name":"apiservice","aspire-resource-name":"apiservice"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -3401,7 +3401,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:46:32 GMT
+                - Mon, 26 Feb 2024 21:05:58 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3413,18 +3413,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 72abd24c-77b4-42cd-8175-bc8e8ca349df
+                - 831a89f2-1cd0-4e4e-93f9-cdd3a91bf06b
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11998"
             X-Ms-Request-Id:
-                - 72abd24c-77b4-42cd-8175-bc8e8ca349df
+                - 831a89f2-1cd0-4e4e-93f9-cdd3a91bf06b
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194632Z:72abd24c-77b4-42cd-8175-bc8e8ca349df
+                - WESTUS2:20240226T210558Z:831a89f2-1cd0-4e4e-93f9-cdd3a91bf06b
             X-Msedge-Ref:
-                - 'Ref A: B83DC0A4E12947878B743C231C09E6B9 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:32Z'
+                - 'Ref A: 0E3ED9CA3F054BD9AE5179AC6881ED72 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:58Z'
         status: 200 OK
         code: 200
-        duration: 89.29166ms
+        duration: 234.390032ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -3447,7 +3447,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice?api-version=2022-11-01-preview
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/apiservice?api-version=2022-11-01-preview
         method: GET
       response:
         proto: HTTP/2.0
@@ -3455,20 +3455,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3091
+        content_length: 3092
         uncompressed: false
-        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:44:34.9263707","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:44:34.9263707"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"apiservice--sjvfox3","latestReadyRevisionName":"apiservice--sjvfox3","latestRevisionFqdn":"apiservice--sjvfox3.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","external":false,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-apiservice-1708717459","name":"apiservice","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/apiservice/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerapps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:03:45.0704226","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:03:45.0704226"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","workloadProfileName":null,"outboundIpAddresses":["172.175.21.8"],"latestRevisionName":"apiservice--54vuttn","latestReadyRevisionName":"apiservice--54vuttn","latestRevisionFqdn":"apiservice--54vuttn.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io","external":false,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrsoindfxt2muzw.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrsoindfxt2muzw.azurecr.io/azd-deploy-apiservice-1708981409","name":"apiservice","env":[{"name":"AZURE_CLIENT_ID","value":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/containerApps/apiservice/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}}}'
         headers:
             Api-Supported-Versions:
                 - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "3091"
+                - "3092"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:46:32 GMT
+                - Mon, 26 Feb 2024 21:05:58 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3482,20 +3482,20 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - b2c2b6ed-31a6-42a9-bae8-ec79b2a715ce
+                - 0f1a6f08-911d-42a2-8632-4abc029da0d8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11998"
             X-Ms-Request-Id:
-                - b2c2b6ed-31a6-42a9-bae8-ec79b2a715ce
+                - 0f1a6f08-911d-42a2-8632-4abc029da0d8
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194632Z:b2c2b6ed-31a6-42a9-bae8-ec79b2a715ce
+                - WESTUS2:20240226T210558Z:0f1a6f08-911d-42a2-8632-4abc029da0d8
             X-Msedge-Ref:
-                - 'Ref A: 9600142FE45044CCBA2264B46121385B Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:32Z'
+                - 'Ref A: B74D779E34884E3EBB6E43471FA4E232 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:58Z'
             X-Powered-By:
                 - ASP.NET
         status: 200 OK
         code: 200
-        duration: 460.378648ms
+        duration: 684.434128ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -3518,7 +3518,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27webfrontend%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27webfrontend%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3528,7 +3528,7 @@ interactions:
         trailer: {}
         content_length: 670
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}},"tags":{"azd-service-name":"webfrontend","aspire-resource-name":"webfrontend"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -3537,7 +3537,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:46:32 GMT
+                - Mon, 26 Feb 2024 21:05:59 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3549,18 +3549,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - acba897c-69f5-49ac-a8a5-3ebbe0d227c4
+                - 7b0f1a90-172a-43c2-90e9-73303d3da0c6
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11997"
+                - "11998"
             X-Ms-Request-Id:
-                - acba897c-69f5-49ac-a8a5-3ebbe0d227c4
+                - 7b0f1a90-172a-43c2-90e9-73303d3da0c6
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194633Z:acba897c-69f5-49ac-a8a5-3ebbe0d227c4
+                - WESTUS2:20240226T210559Z:7b0f1a90-172a-43c2-90e9-73303d3da0c6
             X-Msedge-Ref:
-                - 'Ref A: DCE32FCE0C94463EA9FD7691A011C11C Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:32Z'
+                - 'Ref A: 22CD0E0C68164A99970CDE95A1F04646 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:59Z'
         status: 200 OK
         code: 200
-        duration: 272.501372ms
+        duration: 267.420658ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -3583,7 +3583,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l4c10c9%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3593,7 +3593,7 @@ interactions:
         trailer: {}
         content_length: 288
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9","name":"rg-azdtest-l4c10c9","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"},"properties":{"provisioningState":"Succeeded"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -3602,7 +3602,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:46:32 GMT
+                - Mon, 26 Feb 2024 21:05:59 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3614,18 +3614,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 6da17a55-e969-4b60-b2e5-bc95aa75ce76
+                - 4d88bc32-6db9-49e7-a4f1-a1547b924f81
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11998"
             X-Ms-Request-Id:
-                - 6da17a55-e969-4b60-b2e5-bc95aa75ce76
+                - 4d88bc32-6db9-49e7-a4f1-a1547b924f81
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194633Z:6da17a55-e969-4b60-b2e5-bc95aa75ce76
+                - WESTUS2:20240226T210559Z:4d88bc32-6db9-49e7-a4f1-a1547b924f81
             X-Msedge-Ref:
-                - 'Ref A: 536E32E48E784AAE95D0DF83C4AE3378 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:33Z'
+                - 'Ref A: 225846431572492E825620D63892AEFC Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:59Z'
         status: 200 OK
         code: 200
-        duration: 87.118115ms
+        duration: 46.704544ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -3648,7 +3648,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27webfrontend%27&api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27webfrontend%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3658,7 +3658,7 @@ interactions:
         trailer: {}
         content_length: 670
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -3667,7 +3667,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:46:33 GMT
+                - Mon, 26 Feb 2024 21:05:59 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3679,18 +3679,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3353c390-7c77-4bb5-99da-ecb7429f0bcf
+                - b81615c2-2cc5-4fef-add7-50948849cdf2
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11998"
             X-Ms-Request-Id:
-                - 3353c390-7c77-4bb5-99da-ecb7429f0bcf
+                - b81615c2-2cc5-4fef-add7-50948849cdf2
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194633Z:3353c390-7c77-4bb5-99da-ecb7429f0bcf
+                - WESTUS2:20240226T210559Z:b81615c2-2cc5-4fef-add7-50948849cdf2
             X-Msedge-Ref:
-                - 'Ref A: AFAA43F0E3F641719126E30CEF14910C Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:33Z'
+                - 'Ref A: 84BACE09C3164704AFB0F5EF2EAAC5B3 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:59Z'
         status: 200 OK
         code: 200
-        duration: 230.517305ms
+        duration: 218.346958ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -3713,7 +3713,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend?api-version=2022-11-01-preview
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/webfrontend?api-version=2022-11-01-preview
         method: GET
       response:
         proto: HTTP/2.0
@@ -3721,20 +3721,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 3915
+        content_length: 3916
         uncompressed: false
-        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:45:10.6566857","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:45:10.6566857"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"webfrontend--v4b3j5p","latestReadyRevisionName":"webfrontend--v4b3j5p","latestRevisionFqdn":"webfrontend--v4b3j5p.happybush-752e10b4.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"connectionstrings--cache"},{"name":"connectionstrings--markdown"},{"name":"connectionstrings--messages"},{"name":"connectionstrings--pubsub"},{"name":"connectionstrings--requestlog"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"webfrontend.happybush-752e10b4.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-webfrontend-1708717493","name":"webfrontend","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/webfrontend/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerapps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:04:19.562851","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:04:19.562851"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","workloadProfileName":null,"outboundIpAddresses":["172.175.21.8"],"latestRevisionName":"webfrontend--8r6gfli","latestReadyRevisionName":"webfrontend--8r6gfli","latestRevisionFqdn":"webfrontend--8r6gfli.mangoplant-0534793d.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"connectionstrings--cache"},{"name":"connectionstrings--markdown"},{"name":"connectionstrings--messages"},{"name":"connectionstrings--pubsub"},{"name":"connectionstrings--requestlog"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"webfrontend.mangoplant-0534793d.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrsoindfxt2muzw.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrsoindfxt2muzw.azurecr.io/azd-deploy-webfrontend-1708981443","name":"webfrontend","env":[{"name":"AZURE_CLIENT_ID","value":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.mangoplant-0534793d.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/containerApps/webfrontend/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}}}'
         headers:
             Api-Supported-Versions:
                 - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "3915"
+                - "3916"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:46:33 GMT
+                - Mon, 26 Feb 2024 21:06:00 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3748,20 +3748,20 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 9808445a-f39c-4842-a5a3-3e91f53e6fed
+                - 95b12ffc-430c-43a4-ab70-77cae0017c33
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11998"
             X-Ms-Request-Id:
-                - 9808445a-f39c-4842-a5a3-3e91f53e6fed
+                - 95b12ffc-430c-43a4-ab70-77cae0017c33
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194633Z:9808445a-f39c-4842-a5a3-3e91f53e6fed
+                - WESTUS2:20240226T210600Z:95b12ffc-430c-43a4-ab70-77cae0017c33
             X-Msedge-Ref:
-                - 'Ref A: E9EC96DE26CA4FA9B46974499AA12B76 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:33Z'
+                - 'Ref A: 55E70633ECAF4CF9A6CC19B62CEBBF4F Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:05:59Z'
             X-Powered-By:
                 - ASP.NET
         status: 200 OK
         code: 200
-        duration: 498.135862ms
+        duration: 558.06979ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -3784,7 +3784,7 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?api-version=2021-04-01
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/resources?api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3792,18 +3792,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 4936
+        content_length: 4934
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/pubsub","name":"pubsub","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-l88c996","aspire-resource-name":"pubsub"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:42:16.8954514Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:42:16.8954514Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm","name":"storagegnxzs2f5m4idm","type":"Microsoft.Storage/storageAccounts","sku":{"name":"Standard_GRS","tier":"Standard"},"kind":"Storage","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996","aspire-resource-name":"storage"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:44:34.9263707Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:44:34.9263707Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ContainerRegistry/registries/acrgnxzs2f5m4idm","name":"acrgnxzs2f5m4idm","type":"Microsoft.ContainerRegistry/registries","sku":{"name":"Basic","tier":"Basic"},"location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:41:19.7556947Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:41:19.7556947Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm","name":"mi-gnxzs2f5m4idm","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.OperationalInsights/workspaces/law-gnxzs2f5m4idm","name":"law-gnxzs2f5m4idm","type":"Microsoft.OperationalInsights/workspaces","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/cache","name":"cache","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-l88c996","aspire-resource-name":"cache"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:42:16.9266975Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:42:16.9266975Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","name":"cae-gnxzs2f5m4idm","type":"Microsoft.App/managedEnvironments","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:41:39.9056782Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:41:39.9056782Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:45:10.6566857Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:45:10.6566857Z"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/pubsub","name":"pubsub","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-l4c10c9","aspire-resource-name":"pubsub"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:01:37.1633081Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:01:37.1633081Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.OperationalInsights/workspaces/law-soindfxt2muzw","name":"law-soindfxt2muzw","type":"Microsoft.OperationalInsights/workspaces","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:03:45.0704226Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:03:45.0704226Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/cache","name":"cache","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-l4c10c9","aspire-resource-name":"cache"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:01:37.1320581Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:01:37.1320581Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ContainerRegistry/registries/acrsoindfxt2muzw","name":"acrsoindfxt2muzw","type":"Microsoft.ContainerRegistry/registries","sku":{"name":"Basic","tier":"Basic"},"location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:00:58.9132152Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:00:58.9132152Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","name":"cae-soindfxt2muzw","type":"Microsoft.App/managedEnvironments","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:01:17.1288282Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:01:17.1288282Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw","name":"storagesoindfxt2muzw","type":"Microsoft.Storage/storageAccounts","sku":{"name":"Standard_GRS","tier":"Standard"},"kind":"Storage","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9","aspire-resource-name":"storage"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:04:19.562851Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:04:19.562851Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw","name":"mi-soindfxt2muzw","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"}}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "4936"
+                - "4934"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 23 Feb 2024 19:46:33 GMT
+                - Mon, 26 Feb 2024 21:06:00 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3815,19 +3815,813 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - d37c6b63-fdee-4922-9a72-be864a79447d
+                - 2b486fb3-79e2-4726-90e5-6bce6925d7e3
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - 2b486fb3-79e2-4726-90e5-6bce6925d7e3
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T210600Z:2b486fb3-79e2-4726-90e5-6bce6925d7e3
+            X-Msedge-Ref:
+                - 'Ref A: 485B0B359B864136967EAF7BEA3261DF Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:06:00Z'
+        status: 200 OK
+        code: 200
+        duration: 126.164369ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1172996
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1Y7faoMwFMafxVxbSDYHwzv1nMJYE5vkpKW7K50bTklgs1gtvvvs1j5E774%2fPz6%2bMzsE39X%2buO%2fq4Ck0lf9h6ZlhZsnZh4v01alb77%2b7%2bkK8VgNLmYieI0W7kxx3Cxb%2fESb0t07wJDLNMpfw2Wv3BtLpREGeG2hB881SOuSKctC0KRS9fxihypXlfQlu5ppRAj4pygb5pXkJOpGFUBZeBkVhMICP864o4TDO7IJN8fXrXVzdoiV0plwjS%2f2xbWNmtwioClRkstUtvFpn%2f4Np%2bgU%3d","value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l4c10c9-1708981207","location":"eastus2","name":"azdtest-l4c10c9-1708981207","properties":{"correlationId":"18b8d868-9ab3-44e5-91e6-04536c0cf51e","dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9","resourceName":"rg-azdtest-l4c10c9","resourceType":"Microsoft.Resources/resourceGroups"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Resources/deployments/resources","resourceName":"resources","resourceType":"Microsoft.Resources/deployments"}],"duration":"PT2M30.1684361S","mode":"Incremental","outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/cache"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/pubsub"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ContainerRegistry/registries/acrsoindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ContainerRegistry/registries/acrsoindfxt2muzw/providers/Microsoft.Authorization/roleAssignments/f11e9f84-10b6-5a7a-823a-ff920999efab"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.OperationalInsights/workspaces/law-soindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw/blobServices/default"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw/providers/Microsoft.Authorization/roleAssignments/375d2d03-b2cb-5480-8c5f-1ed90a8964a2"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw/providers/Microsoft.Authorization/roleAssignments/b7bc2b96-e891-5847-a299-e1b73a980306"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw/providers/Microsoft.Authorization/roleAssignments/e303f4d9-03e1-5676-8709-5c1e78da21ae"}],"outputs":{"azurE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN":{"type":"String","value":"mangoplant-0534793d.eastus2.azurecontainerapps.io"},"azurE_CONTAINER_APPS_ENVIRONMENT_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw"},"azurE_CONTAINER_REGISTRY_ENDPOINT":{"type":"String","value":"acrsoindfxt2muzw.azurecr.io"},"azurE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw"},"azurE_LOG_ANALYTICS_WORKSPACE_NAME":{"type":"String","value":"law-soindfxt2muzw"},"manageD_IDENTITY_CLIENT_ID":{"type":"String","value":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"},"servicE_BINDING_MARKDOWN_ENDPOINT":{"type":"String","value":"https://storagesoindfxt2muzw.blob.core.windows.net/"},"servicE_BINDING_MESSAGES_ENDPOINT":{"type":"String","value":"https://storagesoindfxt2muzw.queue.core.windows.net/"},"servicE_BINDING_REQUESTLOG_ENDPOINT":{"type":"String","value":"https://storagesoindfxt2muzw.table.core.windows.net/"}},"parameters":{"environmentName":{"type":"String","value":"azdtest-l4c10c9"},"inputs":{"type":"SecureObject"},"location":{"type":"String","value":"eastus2"}},"providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"locations":["eastus2"],"resourceType":"resourceGroups"},{"locations":[null],"resourceType":"deployments"}]}],"provisioningState":"Succeeded","templateHash":"14419117427229910140","timestamp":"2024-02-26T21:03:24.5994655Z"},"tags":{"azd-env-name":"azdtest-l4c10c9","azd-provision-param-hash":"c6534960363d73a71040bdc189ecb233003bc8a557aebd182ec26315f8f83cd3"},"type":"Microsoft.Resources/deployments"}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "1172996"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 21:06:14 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - 308e0554-93eb-43f8-a4f0-c86b09ba904e
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T210614Z:308e0554-93eb-43f8-a4f0-c86b09ba904e
+            X-Msedge-Ref:
+                - 'Ref A: 7AE5E5D321DA4B01A77BFF000C15C75E Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:06:10Z'
+        status: 200 OK
+        code: 200
+        duration: 3.852444348s
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1Y7faoMwFMafxVxbSDYHwzv1nMJYE5vkpKW7K50bTklgs1gtvvvs1j5E774%2fPz6%2bMzsE39X%2buO%2fq4Ck0lf9h6ZlhZsnZh4v01alb77%2b7%2bkK8VgNLmYieI0W7kxx3Cxb%2fESb0t07wJDLNMpfw2Wv3BtLpREGeG2hB881SOuSKctC0KRS9fxihypXlfQlu5ppRAj4pygb5pXkJOpGFUBZeBkVhMICP864o4TDO7IJN8fXrXVzdoiV0plwjS%2f2xbWNmtwioClRkstUtvFpn%2f4Np%2bgU%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1780521
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1ZDdaoNAEIWfxb02sNZQinfqbIgkO7p%2fBnsXWluMskJr0CT47jWtQl6hd3O%2bc4Y5zI28tbar7PnYVa3VbV3abxLcCAuVNurpPtpy6LLjV1fdE7vyQgLiOS8O6mLg12JF3N%2bEbPvF8%2bjakfUm4vDZC%2fMK3Ig1QhRJaEDQfMMNo6gjEDqPUb9%2fSA%2fTvaJ9CmbK1ZSfxAUh6ad9D0%2bJz2OvyHOZcUieeS0GvIb%2bdJki8J6M7tz1X1Q1O5UavSWBPTeNSw5s%2fvKj9B9dZmSasYWoAwOGMUMtw%2f0CZ2nUHxjHHw%3d%3d","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "1780521"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 21:06:18 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - d37c6b63-fdee-4922-9a72-be864a79447d
+                - 63a4c5df-8ddc-4e8e-960e-ec213e3cc754
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240223T194634Z:d37c6b63-fdee-4922-9a72-be864a79447d
+                - WESTUS2:20240226T210618Z:63a4c5df-8ddc-4e8e-960e-ec213e3cc754
             X-Msedge-Ref:
-                - 'Ref A: 3A838024CC814FD0B72D2BCD50BFF9E7 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:33Z'
+                - 'Ref A: 8782870ED217497499C046774995BBDF Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:06:14Z'
         status: 200 OK
         code: 200
-        duration: 129.102812ms
+        duration: 4.210784832s
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1ZDdaoNAEIWfxb02sNZQinfqbIgkO7p%2fBnsXWluMskJr0CT47jWtQl6hd3O%2bc4Y5zI28tbar7PnYVa3VbV3abxLcCAuVNurpPtpy6LLjV1fdE7vyQgLiOS8O6mLg12JF3N%2bEbPvF8%2bjakfUm4vDZC%2fMK3Ig1QhRJaEDQfMMNo6gjEDqPUb9%2fSA%2fTvaJ9CmbK1ZSfxAUh6ad9D0%2bJz2OvyHOZcUieeS0GvIb%2bdJki8J6M7tz1X1Q1O5UavSWBPTeNSw5s%2fvKj9B9dZmSasYWoAwOGMUMtw%2f0CZ2nUHxjHHw%3d%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3283326
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=3VLLbsIwEPwWci5SQlJUuCWso%2fLwGr%2bC4IYorVKjpGqD8kD8e2MgEuqxvfXkndldW%2bOZk7PLsyLNjtsizTOVm3325YxPDgml0nJgy2xfFcvtZ5Haifm%2bdsaO13vqoVpXtFn3nYfLhMjLrucNg54wcUThreR6A1TzACGKBByAu0lMNXFRRcBVMkH18io8ZAvplgx0O2fanmlrUiHwAUJYYuox0eS1IJtEGdRSj5i%2b4I8oMbHi3mymYz6kRiiehPYERUaJgHYnRiL9Kubu2qcNCdBsIqZpiTD1nfPDTee%2fl7ki1s7fyXT%2f5GZDgTyiCmv6zl0GPKATDyVMa1StO0D8NiUeg13TOt%2b3joRaKhEupuGEoC2ccXY8HO54G82O1HPJtHru4FVmm9rryhX695BowZakY%2bSKAMEfD92g%2fS57zfn8DQ%3d%3d","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3283326"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 21:06:23 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11996"
+            X-Ms-Request-Id:
+                - 19469181-c565-45eb-beb6-e35c0a0a8ce7
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T210623Z:19469181-c565-45eb-beb6-e35c0a0a8ce7
+            X-Msedge-Ref:
+                - 'Ref A: 61C3A488BECA4C1FB8D5456267DF43E3 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:06:18Z'
+        status: 200 OK
+        code: 200
+        duration: 4.890571144s
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=3VLLbsIwEPwWci5SQlJUuCWso%2fLwGr%2bC4IYorVKjpGqD8kD8e2MgEuqxvfXkndldW%2bOZk7PLsyLNjtsizTOVm3325YxPDgml0nJgy2xfFcvtZ5Haifm%2bdsaO13vqoVpXtFn3nYfLhMjLrucNg54wcUThreR6A1TzACGKBByAu0lMNXFRRcBVMkH18io8ZAvplgx0O2fanmlrUiHwAUJYYuox0eS1IJtEGdRSj5i%2b4I8oMbHi3mymYz6kRiiehPYERUaJgHYnRiL9Kubu2qcNCdBsIqZpiTD1nfPDTee%2fl7ki1s7fyXT%2f5GZDgTyiCmv6zl0GPKATDyVMa1StO0D8NiUeg13TOt%2b3joRaKhEupuGEoC2ccXY8HO54G82O1HPJtHru4FVmm9rryhX695BowZakY%2bSKAMEfD92g%2fS57zfn8DQ%3d%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1021766
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=XVBda4MwFP0t5tlBnGUM39SbMmkTzZfFvZXNDatE2CzaFv%2f7zNqUsbd7vricc0FvvRkac9wPTW9U39bmG0UXRGKptHxEkTl2nX%2bDDu2IFa3N1NNQ7L%2bGxqY39QlFKPCePaaqiZ6rB%2bT%2fOkQ%2fOi3AK0%2b064TC58j1K1DNVwySREAHHJdrqglmKgGuypSp9w8RsHwr8ZiDXnwtpgd%2bYpCNSz5ghyykaVCVpSgoZE%2b05RM7x%2bHyGTOgI5p9FGupRLzN4pQwe7gKd94WdaTeyFyrFwevNe8bXGH4VyVa5AVxjNwRIOzfoxu0c9kp5%2fkH","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "1021766"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 21:06:26 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 524e3ba2-705f-4181-b0ca-7f7467b53093
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T210626Z:524e3ba2-705f-4181-b0ca-7f7467b53093
+            X-Msedge-Ref:
+                - 'Ref A: F56DE75FA99B4ABB9991CFC1133C859F Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:06:23Z'
+        status: 200 OK
+        code: 200
+        duration: 2.792797172s
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=XVBda4MwFP0t5tlBnGUM39SbMmkTzZfFvZXNDatE2CzaFv%2f7zNqUsbd7vricc0FvvRkac9wPTW9U39bmG0UXRGKptHxEkTl2nX%2bDDu2IFa3N1NNQ7L%2bGxqY39QlFKPCePaaqiZ6rB%2bT%2fOkQ%2fOi3AK0%2b064TC58j1K1DNVwySREAHHJdrqglmKgGuypSp9w8RsHwr8ZiDXnwtpgd%2bYpCNSz5ghyykaVCVpSgoZE%2b05RM7x%2bHyGTOgI5p9FGupRLzN4pQwe7gKd94WdaTeyFyrFwevNe8bXGH4VyVa5AVxjNwRIOzfoxu0c9kp5%2fkH
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20512
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=ZZHLbsIwEEW%2fBa%2bplBCECruEcVQeHuPHBMEOtbSKjJKqDUoA8e%2bNoamqduU5994Zvy7suSyqvDjuqrwsbOn2xSebXNiaG0vGV8W%2bqVa7jyr3gcX%2bxCYs7D320G4acd48sP4tocu688LRsKddmgh4qxVtQZAaIiSJhgOoIEsF8QBtAspmU7QvrzpEuTRBLYHanGs919a8QVADhLjGPJT6XJ4032bWIRkaS7rxe5K51KpwPqdUjYTTVmWxX8Hycaah7UmRm6hJVbCJxJkP0W0TSaJGmEXs2mc89tccsElxPBw67CgmY3W8nMVTjr74p%2fvuTqSFkWSfOry%2f38%2fgO0a%2fXU5arninmDUHjn82%2bkb%2fD%2f581%2bsX","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "20512"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 21:06:27 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 20b75962-fff9-44d2-95e1-a4365e877455
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T210627Z:20b75962-fff9-44d2-95e1-a4365e877455
+            X-Msedge-Ref:
+                - 'Ref A: C44394DB4D6043438E723C2B40EE7D07 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:06:26Z'
+        status: 200 OK
+        code: 200
+        duration: 703.33949ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=ZZHLbsIwEEW%2fBa%2bplBCECruEcVQeHuPHBMEOtbSKjJKqDUoA8e%2bNoamqduU5994Zvy7suSyqvDjuqrwsbOn2xSebXNiaG0vGV8W%2bqVa7jyr3gcX%2bxCYs7D320G4acd48sP4tocu688LRsKddmgh4qxVtQZAaIiSJhgOoIEsF8QBtAspmU7QvrzpEuTRBLYHanGs919a8QVADhLjGPJT6XJ4032bWIRkaS7rxe5K51KpwPqdUjYTTVmWxX8Hycaah7UmRm6hJVbCJxJkP0W0TSaJGmEXs2mc89tccsElxPBw67CgmY3W8nMVTjr74p%2fvuTqSFkWSfOry%2f38%2fgO0a%2fXU5arninmDUHjn82%2bkb%2fD%2f581%2bsX
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 12
+        uncompressed: false
+        body: '{"value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "12"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 21:06:27 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - e03b0668-3a6d-486f-963e-8514d95e6063
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T210627Z:e03b0668-3a6d-486f-963e-8514d95e6063
+            X-Msedge-Ref:
+                - 'Ref A: 4E406B706EC44375800C02535D4431CD Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:06:27Z'
+        status: 200 OK
+        code: 200
+        duration: 480.020911ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/resources?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 4934
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/pubsub","name":"pubsub","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-l4c10c9","aspire-resource-name":"pubsub"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:01:37.1633081Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:01:37.1633081Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.OperationalInsights/workspaces/law-soindfxt2muzw","name":"law-soindfxt2muzw","type":"Microsoft.OperationalInsights/workspaces","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:03:45.0704226Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:03:45.0704226Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/cache","name":"cache","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-l4c10c9","aspire-resource-name":"cache"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:01:37.1320581Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:01:37.1320581Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ContainerRegistry/registries/acrsoindfxt2muzw","name":"acrsoindfxt2muzw","type":"Microsoft.ContainerRegistry/registries","sku":{"name":"Basic","tier":"Basic"},"location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:00:58.9132152Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:00:58.9132152Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/managedEnvironments/cae-soindfxt2muzw","name":"cae-soindfxt2muzw","type":"Microsoft.App/managedEnvironments","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:01:17.1288282Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:01:17.1288282Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.Storage/storageAccounts/storagesoindfxt2muzw","name":"storagesoindfxt2muzw","type":"Microsoft.Storage/storageAccounts","sku":{"name":"Standard_GRS","tier":"Standard"},"kind":"Storage","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9","aspire-resource-name":"storage"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw":{"principalId":"9974ddf0-b0df-4f34-9033-9029fb52ed28","clientId":"143a1c11-9bbd-43ea-8a19-f7dbd7c91632"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-26T21:04:19.562851Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-26T21:04:19.562851Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l4c10c9/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-soindfxt2muzw","name":"mi-soindfxt2muzw","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"eastus2","tags":{"azd-env-name":"azdtest-l4c10c9"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "4934"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 21:06:28 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - c34decde-ebf6-46d2-b329-9026381cbb55
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T210628Z:c34decde-ebf6-46d2-b329-9026381cbb55
+            X-Msedge-Ref:
+                - 'Ref A: 149D138CE6984788A1664F50B5695CCE Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:06:28Z'
+        status: 200 OK
+        code: 200
+        duration: 126.685238ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l4c10c9?api-version=2021-04-01
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 26 Feb 2024 21:06:30 GMT
+            Expires:
+                - "-1"
+            Location:
+                - https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SRzoyREFaRFRFU1Q6MkRMNEMxMEM5LUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2021-04-01&t=638445789922190117&c=MIIHADCCBeigAwIBAgITfARmPsJdo2ShuN-ImAAABGY-wjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUwHhcNMjQwMTMxMjIwNzA5WhcNMjUwMTI1MjIwNzA5WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOVFiSMi9Sg6cKnrBuPHbDk_Zwa1ZNYHwLVPJArEI9N2bLrgd1mU0ZdNVcdf6rtZCkUUuCe3vxnVTGwufpwH9GPWDgJOpJoL9wgKOzUDiHLUeiWPjrK1AoaQVprZgjnzXBIWiZC2tZjbUT9pOI_ixYJJPrsCfLt7HEccnhObROE1mo_hpiPDrtOQDaX-BboNceB8vI1wmSPApGpPRM9hBRQbXgqKFC8094UNsMVkWPCrsPvP5YlMBLARlGf2WTevGKRREjstkApf1Swi7uKnpyhhsidD1yREMU0mWY9wnZfAX0jpEp3p9jKVMPQ3L-m-nSZI4zrtbW0AnI0O3pAEwe0CAwEAAaOCA-0wggPpMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9DTzFQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA1LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MB0GA1UdDgQWBBT2vcy9ccvhGewsiHI1BQHsz3Wn8zAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBR61hmFKHlscXYeYPjzS--iBUIWHTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBADNBZjhX44bpBtC8kogZJGe4lYeHX95whfZ7X_CMSUuZRbQQ_b6raUpp8V8eF0YUa9b3Oa-DGrs5WfzogCuGcJPeoEVnDYzc1jlKubSIpGw73aGZzhbTjJeNf-Qe-5vTG-GcNzVtIcrwi93YSiK2LSbgrLpTL7T7znjePcGRRkCBjAslrV5SqufcsrpGmqvPAVKXRV-OIOzvXy6qmn9CHmdo0RGBXGIakbLMec_1SIS8NdPsB6i6XPjL2SDjqKTa5car7bVYlXEVsgL-000VF1t6x1II3VBNfsEJ81CdJyxaCJnwvWI6kHtCtJX9QYK3qZab9PfZRBvcetJoPdMFvBU&s=a2ckI6UjeUcTzru3NY3pxGGzmym56KliTSuFI8R6iNiPkYZvMopXkiQpaSqckixT6GPH39YDCJRgoehY034roYpIvPtaxBUQKb4uazgFjEz3XSHe2qdFDELtjHwS0XTbgqXhPJq7n_xzrgZh_Jaqci8RPlZoSojPwQ8v8FXIphyaClOvMpqPD_ES9qjrrqqwpcker62UF4aIf-T_Yg0SUaWKw1XVfXl42AXoZtBvoOQxiqwB1CmonCKGSOQkK6TPpnDp1DoA9xpd7HHkWnSG-KJupqtMFc4m96LgoneiQ-nJb-6CC_PdoccUjj5UZzooBzjEkH5Iw3kI1grTqwBhZQ&h=KSJpIS18r7Gr_ve5udxPrs35iLg9QSM44jnEzFeB_Uw
+            Pragma:
+                - no-cache
+            Retry-After:
+                - "0"
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+            X-Ms-Ratelimit-Remaining-Subscription-Deletes:
+                - "14999"
+            X-Ms-Request-Id:
+                - e1b09fc2-f7ff-40dc-9b13-bf33d2be0a1a
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T210630Z:e1b09fc2-f7ff-40dc-9b13-bf33d2be0a1a
+            X-Msedge-Ref:
+                - 'Ref A: 6B08D9BAF7804E1EBE05D0C8632806C7 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:06:28Z'
+        status: 202 Accepted
+        code: 202
+        duration: 2.179758844s
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SRzoyREFaRFRFU1Q6MkRMNEMxMEM5LUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2021-04-01&t=638445789922190117&c=MIIHADCCBeigAwIBAgITfARmPsJdo2ShuN-ImAAABGY-wjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUwHhcNMjQwMTMxMjIwNzA5WhcNMjUwMTI1MjIwNzA5WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOVFiSMi9Sg6cKnrBuPHbDk_Zwa1ZNYHwLVPJArEI9N2bLrgd1mU0ZdNVcdf6rtZCkUUuCe3vxnVTGwufpwH9GPWDgJOpJoL9wgKOzUDiHLUeiWPjrK1AoaQVprZgjnzXBIWiZC2tZjbUT9pOI_ixYJJPrsCfLt7HEccnhObROE1mo_hpiPDrtOQDaX-BboNceB8vI1wmSPApGpPRM9hBRQbXgqKFC8094UNsMVkWPCrsPvP5YlMBLARlGf2WTevGKRREjstkApf1Swi7uKnpyhhsidD1yREMU0mWY9wnZfAX0jpEp3p9jKVMPQ3L-m-nSZI4zrtbW0AnI0O3pAEwe0CAwEAAaOCA-0wggPpMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9DTzFQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA1LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MB0GA1UdDgQWBBT2vcy9ccvhGewsiHI1BQHsz3Wn8zAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBR61hmFKHlscXYeYPjzS--iBUIWHTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBADNBZjhX44bpBtC8kogZJGe4lYeHX95whfZ7X_CMSUuZRbQQ_b6raUpp8V8eF0YUa9b3Oa-DGrs5WfzogCuGcJPeoEVnDYzc1jlKubSIpGw73aGZzhbTjJeNf-Qe-5vTG-GcNzVtIcrwi93YSiK2LSbgrLpTL7T7znjePcGRRkCBjAslrV5SqufcsrpGmqvPAVKXRV-OIOzvXy6qmn9CHmdo0RGBXGIakbLMec_1SIS8NdPsB6i6XPjL2SDjqKTa5car7bVYlXEVsgL-000VF1t6x1II3VBNfsEJ81CdJyxaCJnwvWI6kHtCtJX9QYK3qZab9PfZRBvcetJoPdMFvBU&s=a2ckI6UjeUcTzru3NY3pxGGzmym56KliTSuFI8R6iNiPkYZvMopXkiQpaSqckixT6GPH39YDCJRgoehY034roYpIvPtaxBUQKb4uazgFjEz3XSHe2qdFDELtjHwS0XTbgqXhPJq7n_xzrgZh_Jaqci8RPlZoSojPwQ8v8FXIphyaClOvMpqPD_ES9qjrrqqwpcker62UF4aIf-T_Yg0SUaWKw1XVfXl42AXoZtBvoOQxiqwB1CmonCKGSOQkK6TPpnDp1DoA9xpd7HHkWnSG-KJupqtMFc4m96LgoneiQ-nJb-6CC_PdoccUjj5UZzooBzjEkH5Iw3kI1grTqwBhZQ&h=KSJpIS18r7Gr_ve5udxPrs35iLg9QSM44jnEzFeB_Uw
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "0"
+            Date:
+                - Mon, 26 Feb 2024 21:16:47 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - f2788cab-c812-48c9-9e0d-e69914bcbf0b
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T211647Z:f2788cab-c812-48c9-9e0d-e69914bcbf0b
+            X-Msedge-Ref:
+                - 'Ref A: 9458BD37113C4083B0E001C63C0C6F17 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:16:47Z'
+        status: 200 OK
+        code: 200
+        duration: 457.809434ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 346
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"location":"eastus2","properties":{"mode":"Incremental","parameters":{},"template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{},"variables":{},"resources":[],"outputs":{}}},"tags":{"azd-deploy-reason":"down","azd-env-name":"azdtest-l4c10c9"}}'
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Length:
+                - "346"
+            Content-Type:
+                - application/json
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l4c10c9-1708981207?api-version=2021-04-01
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l4c10c9-1708981207","name":"azdtest-l4c10c9-1708981207","type":"Microsoft.Resources/deployments","location":"eastus2","tags":{"azd-deploy-reason":"down","azd-env-name":"azdtest-l4c10c9"},"properties":{"templateHash":"14737569621737367585","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2024-02-26T21:16:49.5754497Z","duration":"PT0.0003539S","correlationId":"cfea6aee1a5738232ea9491e2e8b0dd5","providers":[],"dependencies":[]}}'
+        headers:
+            Azure-Asyncoperation:
+                - https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l4c10c9-1708981207/operationStatuses/08584926246768131317?api-version=2021-04-01
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "570"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 21:16:49 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+            X-Ms-Ratelimit-Remaining-Subscription-Writes:
+                - "1199"
+            X-Ms-Request-Id:
+                - 178330a4-fbaa-45ce-a9cd-1c60ba796dc9
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T211650Z:178330a4-fbaa-45ce-a9cd-1c60ba796dc9
+            X-Msedge-Ref:
+                - 'Ref A: DF4B991D2E8E4A7CA81F2D17706C1073 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:16:47Z'
+        status: 200 OK
+        code: 200
+        duration: 2.289931574s
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l4c10c9-1708981207/operationStatuses/08584926246768131317?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 22
+        uncompressed: false
+        body: '{"status":"Succeeded"}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "22"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 21:17:20 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - d8f8180c-309c-4acb-a03f-babe7fba6b47
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T211720Z:d8f8180c-309c-4acb-a03f-babe7fba6b47
+            X-Msedge-Ref:
+                - 'Ref A: 200DEB3706E34A99B11C842BE6088951 Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:17:20Z'
+        status: 200 OK
+        code: 200
+        duration: 387.969737ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l4c10c9-1708981207?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 605
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l4c10c9-1708981207","name":"azdtest-l4c10c9-1708981207","type":"Microsoft.Resources/deployments","location":"eastus2","tags":{"azd-deploy-reason":"down","azd-env-name":"azdtest-l4c10c9"},"properties":{"templateHash":"14737569621737367585","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T21:16:52.1586297Z","duration":"PT2.5835339S","correlationId":"cfea6aee1a5738232ea9491e2e8b0dd5","providers":[],"dependencies":[],"outputs":{},"outputResources":[]}}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "605"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Mon, 26 Feb 2024 21:17:20 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - cfea6aee1a5738232ea9491e2e8b0dd5
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11996"
+            X-Ms-Request-Id:
+                - 8cb75874-4c5f-4a89-8cb0-b76fa3879bf3
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240226T211721Z:8cb75874-4c5f-4a89-8cb0-b76fa3879bf3
+            X-Msedge-Ref:
+                - 'Ref A: E40F6678EA2C4B6D8BBCCFCA06773E6F Ref B: CO6AA3150217035 Ref C: 2024-02-26T21:17:20Z'
+        status: 200 OK
+        code: 200
+        duration: 449.723573ms
 ---
-env_name: azdtest-l88c996
+env_name: azdtest-l4c10c9
 subscription_id: faa080af-c1d8-40ad-9cce-e1a450ca5b57
-time: "1708717227"
+time: "1708981207"

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_VsServer/LiveDeployRefresh.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_VsServer/LiveDeployRefresh.yaml
@@ -1,0 +1,3832 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armsubscriptions/v1.0.0 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations?api-version=2021-01-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 33461
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastus","name":"eastus","type":"Region","displayName":"East US","regionalDisplayName":"(US) East US","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"US","longitude":"-79.8164","latitude":"37.3719","physicalLocation":"Virginia","pairedRegion":[{"name":"westus","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westus"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastus2","name":"eastus2","type":"Region","displayName":"East US 2","regionalDisplayName":"(US) East US 2","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"US","longitude":"-78.3889","latitude":"36.6681","physicalLocation":"Virginia","pairedRegion":[{"name":"centralus","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/centralus"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southcentralus","name":"southcentralus","type":"Region","displayName":"South Central US","regionalDisplayName":"(US) South Central US","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"US","longitude":"-98.5","latitude":"29.4167","physicalLocation":"Texas","pairedRegion":[{"name":"northcentralus","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/northcentralus"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westus2","name":"westus2","type":"Region","displayName":"West US 2","regionalDisplayName":"(US) West US 2","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"US","longitude":"-119.852","latitude":"47.233","physicalLocation":"Washington","pairedRegion":[{"name":"westcentralus","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westcentralus"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westus3","name":"westus3","type":"Region","displayName":"West US 3","regionalDisplayName":"(US) West US 3","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"US","longitude":"-112.074036","latitude":"33.448376","physicalLocation":"Phoenix","pairedRegion":[{"name":"eastus","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastus"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australiaeast","name":"australiaeast","type":"Region","displayName":"Australia East","regionalDisplayName":"(Asia Pacific) Australia East","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Asia Pacific","longitude":"151.2094","latitude":"-33.86","physicalLocation":"New South Wales","pairedRegion":[{"name":"australiasoutheast","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australiasoutheast"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southeastasia","name":"southeastasia","type":"Region","displayName":"Southeast Asia","regionalDisplayName":"(Asia Pacific) Southeast Asia","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Asia Pacific","longitude":"103.833","latitude":"1.283","physicalLocation":"Singapore","pairedRegion":[{"name":"eastasia","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastasia"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/northeurope","name":"northeurope","type":"Region","displayName":"North Europe","regionalDisplayName":"(Europe) North Europe","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"-6.2597","latitude":"53.3478","physicalLocation":"Ireland","pairedRegion":[{"name":"westeurope","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westeurope"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/swedencentral","name":"swedencentral","type":"Region","displayName":"Sweden Central","regionalDisplayName":"(Europe) Sweden Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"17.14127","latitude":"60.67488","physicalLocation":"Gävle","pairedRegion":[{"name":"swedensouth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/swedensouth"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/uksouth","name":"uksouth","type":"Region","displayName":"UK South","regionalDisplayName":"(Europe) UK South","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"-0.799","latitude":"50.941","physicalLocation":"London","pairedRegion":[{"name":"ukwest","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/ukwest"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westeurope","name":"westeurope","type":"Region","displayName":"West Europe","regionalDisplayName":"(Europe) West Europe","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"4.9","latitude":"52.3667","physicalLocation":"Netherlands","pairedRegion":[{"name":"northeurope","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/northeurope"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/centralus","name":"centralus","type":"Region","displayName":"Central US","regionalDisplayName":"(US) Central US","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"US","longitude":"-93.6208","latitude":"41.5908","physicalLocation":"Iowa","pairedRegion":[{"name":"eastus2","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastus2"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southafricanorth","name":"southafricanorth","type":"Region","displayName":"South Africa North","regionalDisplayName":"(Africa) South Africa North","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Africa","longitude":"28.21837","latitude":"-25.73134","physicalLocation":"Johannesburg","pairedRegion":[{"name":"southafricawest","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southafricawest"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/centralindia","name":"centralindia","type":"Region","displayName":"Central India","regionalDisplayName":"(Asia Pacific) Central India","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Asia Pacific","longitude":"73.9197","latitude":"18.5822","physicalLocation":"Pune","pairedRegion":[{"name":"southindia","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southindia"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastasia","name":"eastasia","type":"Region","displayName":"East Asia","regionalDisplayName":"(Asia Pacific) East Asia","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Asia Pacific","longitude":"114.188","latitude":"22.267","physicalLocation":"Hong Kong","pairedRegion":[{"name":"southeastasia","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southeastasia"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/japaneast","name":"japaneast","type":"Region","displayName":"Japan East","regionalDisplayName":"(Asia Pacific) Japan East","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Asia Pacific","longitude":"139.77","latitude":"35.68","physicalLocation":"Tokyo, Saitama","pairedRegion":[{"name":"japanwest","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/japanwest"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/koreacentral","name":"koreacentral","type":"Region","displayName":"Korea Central","regionalDisplayName":"(Asia Pacific) Korea Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Asia Pacific","longitude":"126.978","latitude":"37.5665","physicalLocation":"Seoul","pairedRegion":[{"name":"koreasouth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/koreasouth"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/canadacentral","name":"canadacentral","type":"Region","displayName":"Canada Central","regionalDisplayName":"(Canada) Canada Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Canada","longitude":"-79.383","latitude":"43.653","physicalLocation":"Toronto","pairedRegion":[{"name":"canadaeast","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/canadaeast"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/francecentral","name":"francecentral","type":"Region","displayName":"France Central","regionalDisplayName":"(Europe) France Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"2.373","latitude":"46.3772","physicalLocation":"Paris","pairedRegion":[{"name":"francesouth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/francesouth"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/germanywestcentral","name":"germanywestcentral","type":"Region","displayName":"Germany West Central","regionalDisplayName":"(Europe) Germany West Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"8.682127","latitude":"50.110924","physicalLocation":"Frankfurt","pairedRegion":[{"name":"germanynorth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/germanynorth"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/italynorth","name":"italynorth","type":"Region","displayName":"Italy North","regionalDisplayName":"(Europe) Italy North","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"9.18109","latitude":"45.46888","physicalLocation":"Milan","pairedRegion":[]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/norwayeast","name":"norwayeast","type":"Region","displayName":"Norway East","regionalDisplayName":"(Europe) Norway East","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"10.752245","latitude":"59.913868","physicalLocation":"Norway","pairedRegion":[{"name":"norwaywest","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/norwaywest"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/polandcentral","name":"polandcentral","type":"Region","displayName":"Poland Central","regionalDisplayName":"(Europe) Poland Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"21.01666","latitude":"52.23334","physicalLocation":"Warsaw","pairedRegion":[]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/switzerlandnorth","name":"switzerlandnorth","type":"Region","displayName":"Switzerland North","regionalDisplayName":"(Europe) Switzerland North","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"8.564572","latitude":"47.451542","physicalLocation":"Zurich","pairedRegion":[{"name":"switzerlandwest","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/switzerlandwest"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/uaenorth","name":"uaenorth","type":"Region","displayName":"UAE North","regionalDisplayName":"(Middle East) UAE North","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Middle East","longitude":"55.316666","latitude":"25.266666","physicalLocation":"Dubai","pairedRegion":[{"name":"uaecentral","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/uaecentral"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/brazilsouth","name":"brazilsouth","type":"Region","displayName":"Brazil South","regionalDisplayName":"(South America) Brazil South","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"South America","longitude":"-46.633","latitude":"-23.55","physicalLocation":"Sao Paulo State","pairedRegion":[{"name":"southcentralus","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southcentralus"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/centraluseuap","name":"centraluseuap","type":"Region","displayName":"Central US EUAP","regionalDisplayName":"(US) Central US EUAP","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"US","longitude":"-93.6208","latitude":"41.5908","physicalLocation":"","pairedRegion":[{"name":"eastus2euap","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastus2euap"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/israelcentral","name":"israelcentral","type":"Region","displayName":"Israel Central","regionalDisplayName":"(Middle East) Israel Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Middle East","longitude":"33.4506633","latitude":"31.2655698","physicalLocation":"Israel","pairedRegion":[]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/qatarcentral","name":"qatarcentral","type":"Region","displayName":"Qatar Central","regionalDisplayName":"(Middle East) Qatar Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Middle East","longitude":"51.439327","latitude":"25.551462","physicalLocation":"Doha","pairedRegion":[]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/centralusstage","name":"centralusstage","type":"Region","displayName":"Central US (Stage)","regionalDisplayName":"(US) Central US (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"US"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastusstage","name":"eastusstage","type":"Region","displayName":"East US (Stage)","regionalDisplayName":"(US) East US (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"US"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastus2stage","name":"eastus2stage","type":"Region","displayName":"East US 2 (Stage)","regionalDisplayName":"(US) East US 2 (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"US"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/northcentralusstage","name":"northcentralusstage","type":"Region","displayName":"North Central US (Stage)","regionalDisplayName":"(US) North Central US (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"US"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southcentralusstage","name":"southcentralusstage","type":"Region","displayName":"South Central US (Stage)","regionalDisplayName":"(US) South Central US (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"US"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westusstage","name":"westusstage","type":"Region","displayName":"West US (Stage)","regionalDisplayName":"(US) West US (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"US"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westus2stage","name":"westus2stage","type":"Region","displayName":"West US 2 (Stage)","regionalDisplayName":"(US) West US 2 (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"US"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/asia","name":"asia","type":"Region","displayName":"Asia","regionalDisplayName":"Asia","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/asiapacific","name":"asiapacific","type":"Region","displayName":"Asia Pacific","regionalDisplayName":"Asia Pacific","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australia","name":"australia","type":"Region","displayName":"Australia","regionalDisplayName":"Australia","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/brazil","name":"brazil","type":"Region","displayName":"Brazil","regionalDisplayName":"Brazil","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/canada","name":"canada","type":"Region","displayName":"Canada","regionalDisplayName":"Canada","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/europe","name":"europe","type":"Region","displayName":"Europe","regionalDisplayName":"Europe","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/france","name":"france","type":"Region","displayName":"France","regionalDisplayName":"France","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/germany","name":"germany","type":"Region","displayName":"Germany","regionalDisplayName":"Germany","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/global","name":"global","type":"Region","displayName":"Global","regionalDisplayName":"Global","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/india","name":"india","type":"Region","displayName":"India","regionalDisplayName":"India","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/japan","name":"japan","type":"Region","displayName":"Japan","regionalDisplayName":"Japan","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/korea","name":"korea","type":"Region","displayName":"Korea","regionalDisplayName":"Korea","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/norway","name":"norway","type":"Region","displayName":"Norway","regionalDisplayName":"Norway","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/singapore","name":"singapore","type":"Region","displayName":"Singapore","regionalDisplayName":"Singapore","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southafrica","name":"southafrica","type":"Region","displayName":"South Africa","regionalDisplayName":"South Africa","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/sweden","name":"sweden","type":"Region","displayName":"Sweden","regionalDisplayName":"Sweden","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/switzerland","name":"switzerland","type":"Region","displayName":"Switzerland","regionalDisplayName":"Switzerland","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/uae","name":"uae","type":"Region","displayName":"United Arab Emirates","regionalDisplayName":"United Arab Emirates","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/uk","name":"uk","type":"Region","displayName":"United Kingdom","regionalDisplayName":"United Kingdom","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/unitedstates","name":"unitedstates","type":"Region","displayName":"United States","regionalDisplayName":"United States","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/unitedstateseuap","name":"unitedstateseuap","type":"Region","displayName":"United States EUAP","regionalDisplayName":"United States EUAP","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastasiastage","name":"eastasiastage","type":"Region","displayName":"East Asia (Stage)","regionalDisplayName":"(Asia Pacific) East Asia (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"Asia Pacific"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southeastasiastage","name":"southeastasiastage","type":"Region","displayName":"Southeast Asia (Stage)","regionalDisplayName":"(Asia Pacific) Southeast Asia (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"Asia Pacific"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/brazilus","name":"brazilus","type":"Region","displayName":"Brazil US","regionalDisplayName":"(South America) Brazil US","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"South America","longitude":"0","latitude":"0","physicalLocation":"","pairedRegion":[{"name":"brazilsoutheast","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/brazilsoutheast"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastusstg","name":"eastusstg","type":"Region","displayName":"East US STG","regionalDisplayName":"(US) East US STG","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"US","longitude":"-79.8164","latitude":"37.3719","physicalLocation":"Virginia","pairedRegion":[{"name":"southcentralusstg","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southcentralusstg"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/northcentralus","name":"northcentralus","type":"Region","displayName":"North Central US","regionalDisplayName":"(US) North Central US","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"US","longitude":"-87.6278","latitude":"41.8819","physicalLocation":"Illinois","pairedRegion":[{"name":"southcentralus","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southcentralus"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westus","name":"westus","type":"Region","displayName":"West US","regionalDisplayName":"(US) West US","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"US","longitude":"-122.417","latitude":"37.783","physicalLocation":"California","pairedRegion":[{"name":"eastus","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastus"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/japanwest","name":"japanwest","type":"Region","displayName":"Japan West","regionalDisplayName":"(Asia Pacific) Japan West","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"135.5022","latitude":"34.6939","physicalLocation":"Osaka","pairedRegion":[{"name":"japaneast","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/japaneast"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/jioindiawest","name":"jioindiawest","type":"Region","displayName":"Jio India West","regionalDisplayName":"(Asia Pacific) Jio India West","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"70.05773","latitude":"22.470701","physicalLocation":"Jamnagar","pairedRegion":[{"name":"jioindiacentral","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/jioindiacentral"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastus2euap","name":"eastus2euap","type":"Region","displayName":"East US 2 EUAP","regionalDisplayName":"(US) East US 2 EUAP","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"US","longitude":"-78.3889","latitude":"36.6681","physicalLocation":"","pairedRegion":[{"name":"centraluseuap","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/centraluseuap"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southcentralusstg","name":"southcentralusstg","type":"Region","displayName":"South Central US STG","regionalDisplayName":"(US) South Central US STG","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"US","longitude":"-98.5","latitude":"29.4167","physicalLocation":"Texas","pairedRegion":[{"name":"eastusstg","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastusstg"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westcentralus","name":"westcentralus","type":"Region","displayName":"West Central US","regionalDisplayName":"(US) West Central US","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"US","longitude":"-110.234","latitude":"40.89","physicalLocation":"Wyoming","pairedRegion":[{"name":"westus2","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westus2"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southafricawest","name":"southafricawest","type":"Region","displayName":"South Africa West","regionalDisplayName":"(Africa) South Africa West","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Africa","longitude":"18.843266","latitude":"-34.075691","physicalLocation":"Cape Town","pairedRegion":[{"name":"southafricanorth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southafricanorth"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australiacentral","name":"australiacentral","type":"Region","displayName":"Australia Central","regionalDisplayName":"(Asia Pacific) Australia Central","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"149.1244","latitude":"-35.3075","physicalLocation":"Canberra","pairedRegion":[{"name":"australiacentral2","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australiacentral2"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australiacentral2","name":"australiacentral2","type":"Region","displayName":"Australia Central 2","regionalDisplayName":"(Asia Pacific) Australia Central 2","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"149.1244","latitude":"-35.3075","physicalLocation":"Canberra","pairedRegion":[{"name":"australiacentral","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australiacentral"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australiasoutheast","name":"australiasoutheast","type":"Region","displayName":"Australia Southeast","regionalDisplayName":"(Asia Pacific) Australia Southeast","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"144.9631","latitude":"-37.8136","physicalLocation":"Victoria","pairedRegion":[{"name":"australiaeast","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australiaeast"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/jioindiacentral","name":"jioindiacentral","type":"Region","displayName":"Jio India Central","regionalDisplayName":"(Asia Pacific) Jio India Central","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"79.08886","latitude":"21.146633","physicalLocation":"Nagpur","pairedRegion":[{"name":"jioindiawest","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/jioindiawest"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/koreasouth","name":"koreasouth","type":"Region","displayName":"Korea South","regionalDisplayName":"(Asia Pacific) Korea South","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"129.0756","latitude":"35.1796","physicalLocation":"Busan","pairedRegion":[{"name":"koreacentral","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/koreacentral"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southindia","name":"southindia","type":"Region","displayName":"South India","regionalDisplayName":"(Asia Pacific) South India","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"80.1636","latitude":"12.9822","physicalLocation":"Chennai","pairedRegion":[{"name":"centralindia","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/centralindia"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westindia","name":"westindia","type":"Region","displayName":"West India","regionalDisplayName":"(Asia Pacific) West India","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"72.868","latitude":"19.088","physicalLocation":"Mumbai","pairedRegion":[{"name":"southindia","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southindia"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/canadaeast","name":"canadaeast","type":"Region","displayName":"Canada East","regionalDisplayName":"(Canada) Canada East","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Canada","longitude":"-71.217","latitude":"46.817","physicalLocation":"Quebec","pairedRegion":[{"name":"canadacentral","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/canadacentral"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/francesouth","name":"francesouth","type":"Region","displayName":"France South","regionalDisplayName":"(Europe) France South","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Europe","longitude":"2.1972","latitude":"43.8345","physicalLocation":"Marseille","pairedRegion":[{"name":"francecentral","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/francecentral"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/germanynorth","name":"germanynorth","type":"Region","displayName":"Germany North","regionalDisplayName":"(Europe) Germany North","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Europe","longitude":"8.806422","latitude":"53.073635","physicalLocation":"Berlin","pairedRegion":[{"name":"germanywestcentral","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/germanywestcentral"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/norwaywest","name":"norwaywest","type":"Region","displayName":"Norway West","regionalDisplayName":"(Europe) Norway West","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Europe","longitude":"5.733107","latitude":"58.969975","physicalLocation":"Norway","pairedRegion":[{"name":"norwayeast","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/norwayeast"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/switzerlandwest","name":"switzerlandwest","type":"Region","displayName":"Switzerland West","regionalDisplayName":"(Europe) Switzerland West","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Europe","longitude":"6.143158","latitude":"46.204391","physicalLocation":"Geneva","pairedRegion":[{"name":"switzerlandnorth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/switzerlandnorth"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/ukwest","name":"ukwest","type":"Region","displayName":"UK West","regionalDisplayName":"(Europe) UK West","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Europe","longitude":"-3.084","latitude":"53.427","physicalLocation":"Cardiff","pairedRegion":[{"name":"uksouth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/uksouth"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/uaecentral","name":"uaecentral","type":"Region","displayName":"UAE Central","regionalDisplayName":"(Middle East) UAE Central","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Middle East","longitude":"54.366669","latitude":"24.466667","physicalLocation":"Abu Dhabi","pairedRegion":[{"name":"uaenorth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/uaenorth"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/brazilsoutheast","name":"brazilsoutheast","type":"Region","displayName":"Brazil Southeast","regionalDisplayName":"(South America) Brazil Southeast","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"South America","longitude":"-43.2075","latitude":"-22.90278","physicalLocation":"Rio","pairedRegion":[{"name":"brazilsouth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/brazilsouth"}]}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "33461"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:40:54 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 044ffa1f-01c3-4ade-82c9-f117a7bfbbbc
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 044ffa1f-01c3-4ade-82c9-f117a7bfbbbc
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194054Z:044ffa1f-01c3-4ade-82c9-f117a7bfbbbc
+            X-Msedge-Ref:
+                - 'Ref A: E90621D38C2043C2892E7F5824371E8A Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:40:52Z'
+        status: 200 OK
+        code: 200
+        duration: 2.522425503s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 954766
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1Y7faoMwFMafxVw7MKUtw7voOWWwJjbJSUp7VzY3RImwWXQW3322ax9id9%2bf3wffhb21oavC%2bdRVbaC2LsM3Sy8MhSVnF1cZyqHbnb666kq8lj8sZTx6jhQdBjkenlh8I0zbPzrO15GpN5mEz167I0inlwqyzEADOvEb6TBRlIEmnyt6%2fzBcFVub9AW4matHSWJRgB4UyEHCvM05Gbc6ard68ejJg%2bgl4FrWMzOKpaKbT9gU33%2f%2fu9t7tITOFDtkaTg3TczsHgFVjoqM2D7Cu3X2L5imXw%3d%3d","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "954766"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:40:58 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - a473f723-2498-4acd-a051-60c27bfbc4f9
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - a473f723-2498-4acd-a051-60c27bfbc4f9
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194058Z:a473f723-2498-4acd-a051-60c27bfbc4f9
+            X-Msedge-Ref:
+                - 'Ref A: 40845632B80347E1A398AEB4E1327307 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:40:54Z'
+        status: 200 OK
+        code: 200
+        duration: 4.028374863s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1Y7faoMwFMafxVw7MKUtw7voOWWwJjbJSUp7VzY3RImwWXQW3322ax9id9%2bf3wffhb21oavC%2bdRVbaC2LsM3Sy8MhSVnF1cZyqHbnb666kq8lj8sZTx6jhQdBjkenlh8I0zbPzrO15GpN5mEz167I0inlwqyzEADOvEb6TBRlIEmnyt6%2fzBcFVub9AW4matHSWJRgB4UyEHCvM05Gbc6ard68ejJg%2bgl4FrWMzOKpaKbT9gU33%2f%2fu9t7tITOFDtkaTg3TczsHgFVjoqM2D7Cu3X2L5imXw%3d%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2487770
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1ZDRToMwFIafhV5jUgYxhjugXdSth7U93YJ3iyJhJcUoC7iFd9c5SPYK3p3%2f%2b7%2bLP%2bdMXlvX1e647%2brWYWtL90XiM%2bGJRqMXl9OVQ7fZf3b1xViV3yQmgffgARaDOBV3xP8zVNvPXUAjT9llKljVS%2fPChJERsDRVrGGSbpfCcAqYMonbDPDtXQWQrzXtc2Z%2bPUuBJREcqoXApxAORSiyADT%2feJbI74WVA5ySUKCNBFYDGf1p67%2bYalY6N%2fhIYndsGp%2fs%2bPTl2xjettyofMNnonecccg4oErWM5yi0Vcwjj8%3d","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2487770"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:41:03 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 654bfd8b-dd96-4814-b538-8392ea28165b
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 654bfd8b-dd96-4814-b538-8392ea28165b
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194103Z:654bfd8b-dd96-4814-b538-8392ea28165b
+            X-Msedge-Ref:
+                - 'Ref A: 1D2143E7C0DB4881A91613F2F08FAB3C Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:40:58Z'
+        status: 200 OK
+        code: 200
+        duration: 4.494903935s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1ZDRToMwFIafhV5jUgYxhjugXdSth7U93YJ3iyJhJcUoC7iFd9c5SPYK3p3%2f%2b7%2bLP%2bdMXlvX1e647%2brWYWtL90XiM%2bGJRqMXl9OVQ7fZf3b1xViV3yQmgffgARaDOBV3xP8zVNvPXUAjT9llKljVS%2fPChJERsDRVrGGSbpfCcAqYMonbDPDtXQWQrzXtc2Z%2bPUuBJREcqoXApxAORSiyADT%2feJbI74WVA5ySUKCNBFYDGf1p67%2bYalY6N%2fhIYndsGp%2fs%2bPTl2xjettyofMNnonecccg4oErWM5yi0Vcwjj8%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3021248
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1VJBbsIwEHwLPhcphoAqbk7WiApsE3udKNxQSylNlEhtUEIQf28MREL9QNXbznh2PR7vmbyWRXUojtvqUBZYZrvim8zOhDOD1oxcWeyaar39qg5OsdydyIzQwfNAYtqINh2Sp6tCl3V%2fRul0oLN5IGBfR3YDwka%2bhCDQkEPkxXNhuScxgAjjUOLbu6ZSrYxXK7CdLvNkm45lm1GFwleY1TKkiYk3QZLzqcj03HofawvlSQMfC0h90Xaaz%2f2QXJ7uvv%2bd7YS7uP%2fCdiuQjRREjQTRCOh%2bKqSo7WQT2cki5jHGwGoBLvlO0zJf4hV7Lm1mDWq2emEhl64gs%2bKY5w%2b8W6OetEujLC56eHtyt2G3lhscP0JutVrznjEJBy5%2fXXSHLjo35nL5AQ%3d%3d","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3021248"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:41:09 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 4da9e988-9ad4-45df-8cce-1db4fe32d670
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 4da9e988-9ad4-45df-8cce-1db4fe32d670
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194109Z:4da9e988-9ad4-45df-8cce-1db4fe32d670
+            X-Msedge-Ref:
+                - 'Ref A: 8A68414D85394F7899A884B8C424EF98 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:41:03Z'
+        status: 200 OK
+        code: 200
+        duration: 5.422608116s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1VJBbsIwEHwLPhcphoAqbk7WiApsE3udKNxQSylNlEhtUEIQf28MREL9QNXbznh2PR7vmbyWRXUojtvqUBZYZrvim8zOhDOD1oxcWeyaar39qg5OsdydyIzQwfNAYtqINh2Sp6tCl3V%2fRul0oLN5IGBfR3YDwka%2bhCDQkEPkxXNhuScxgAjjUOLbu6ZSrYxXK7CdLvNkm45lm1GFwleY1TKkiYk3QZLzqcj03HofawvlSQMfC0h90Xaaz%2f2QXJ7uvv%2bd7YS7uP%2fCdiuQjRREjQTRCOh%2bKqSo7WQT2cki5jHGwGoBLvlO0zJf4hV7Lm1mDWq2emEhl64gs%2bKY5w%2b8W6OetEujLC56eHtyt2G3lhscP0JutVrznjEJBy5%2fXXSHLjo35nL5AQ%3d%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 271460
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=XZBRT4MwFIV%2fC32eCQxiDG%2bFdnFuvaz0dgu%2bLYqEQYpRFnAL%2f13r1sX41u%2bcc9OccyYvnelrc9z3dWewa0rzSeIz4VShVnMSm2Pbzq7oaMetaWOmHPvN%2fqOv7fWq%2fCIxCbwHD7AYxam4I7PfRN4Nzgv8yMubRSJYNUj9zISWEbAkyVnLpL9dCM19wIRJ3KaAr295ANla%2bUPG9E%2bu8YHRCA7VXOAyhEMRijQAxd%2bfJPJ70cgRTjQU2EQCq5FMM0K1wpyulzTlYB%2buwk23RZ2oVyrT%2bOjwUvO2wQXDvy7XebbhTlE7zjj8%2b%2biKdi475TR9Aw%3d%3d","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "271460"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:41:10 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 92376ea2-536e-4daf-a553-2a0b9dbe741e
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 92376ea2-536e-4daf-a553-2a0b9dbe741e
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194110Z:92376ea2-536e-4daf-a553-2a0b9dbe741e
+            X-Msedge-Ref:
+                - 'Ref A: CB372AE4B5574DA899AFB829329FFC7E Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:41:09Z'
+        status: 200 OK
+        code: 200
+        duration: 1.039660579s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=XZBRT4MwFIV%2fC32eCQxiDG%2bFdnFuvaz0dgu%2bLYqEQYpRFnAL%2f13r1sX41u%2bcc9OccyYvnelrc9z3dWewa0rzSeIz4VShVnMSm2Pbzq7oaMetaWOmHPvN%2fqOv7fWq%2fCIxCbwHD7AYxam4I7PfRN4Nzgv8yMubRSJYNUj9zISWEbAkyVnLpL9dCM19wIRJ3KaAr295ANla%2bUPG9E%2bu8YHRCA7VXOAyhEMRijQAxd%2bfJPJ70cgRTjQU2EQCq5FMM0K1wpyulzTlYB%2buwk23RZ2oVyrT%2bOjwUvO2wQXDvy7XebbhTlE7zjj8%2b%2biKdi475TR9Aw%3d%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20482
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=ZZBda4MwFIZ%2fi7luwUwpwzs1kY42ieZDsXdldZ2LRNgsthb%2f%2b5p1GWO7O8%2f7vueDcwXPvRlac9oPbW9krxvzAaIrqLCQStjKNOch378PrQ1smguIAPQePSrrM5nqJVh8JXg%2fOg%2fClcd1lhB0HAu1Q0QVIUVJwlGHCr%2fMiMI%2blQkqZJlSeXjhkLKt8EeG1C2nfTrVAZ00ZJKETOqRprAS5S6pOrwimmfKf80V6i8c4YCgOiTTLfN2XIJ5AXBsz34AkTl1nUNHsRKSx9unOMXUFv902%2b1EtRFMybXD%2bz9%2bBt8x%2bO1ixVmOnSIqjDD9s%2bgb7V%2ftffP8CQ%3d%3d","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "20482"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:41:11 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 6969bb01-72d9-4a06-aa09-ccc89bed37c8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 6969bb01-72d9-4a06-aa09-ccc89bed37c8
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194111Z:6969bb01-72d9-4a06-aa09-ccc89bed37c8
+            X-Msedge-Ref:
+                - 'Ref A: 314266C15A7641FEA59972350349825A Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:41:10Z'
+        status: 200 OK
+        code: 200
+        duration: 970.653731ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=ZZBda4MwFIZ%2fi7luwUwpwzs1kY42ieZDsXdldZ2LRNgsthb%2f%2b5p1GWO7O8%2f7vueDcwXPvRlac9oPbW9krxvzAaIrqLCQStjKNOch378PrQ1smguIAPQePSrrM5nqJVh8JXg%2fOg%2fClcd1lhB0HAu1Q0QVIUVJwlGHCr%2fMiMI%2blQkqZJlSeXjhkLKt8EeG1C2nfTrVAZ00ZJKETOqRprAS5S6pOrwimmfKf80V6i8c4YCgOiTTLfN2XIJ5AXBsz34AkTl1nUNHsRKSx9unOMXUFv902%2b1EtRFMybXD%2bz9%2bBt8x%2bO1ixVmOnSIqjDD9s%2bgb7V%2ftffP8CQ%3d%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 12
+        uncompressed: false
+        body: '{"value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "12"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:41:12 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - b9ede364-bbe8-48f5-895d-252e7aa74be6
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - b9ede364-bbe8-48f5-895d-252e7aa74be6
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194112Z:b9ede364-bbe8-48f5-895d-252e7aa74be6
+            X-Msedge-Ref:
+                - 'Ref A: D0A9F62389F8422F8206BB3A38604354 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:41:11Z'
+        status: 200 OK
+        code: 200
+        duration: 421.126749ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 15257
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"location":"eastus2","properties":{"mode":"Incremental","parameters":{"environmentName":{"value":"azdtest-l88c996"},"inputs":{"value":{}},"location":{"value":"eastus2"}},"template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","metadata":{"_generator":{"name":"bicep","version":"0.25.3.34343","templateHash":"14419117427229910140"}},"parameters":{"environmentName":{"type":"string","minLength":1,"maxLength":64,"metadata":{"description":"Name of the environment that can be used as part of naming resource convention, the name of the resource group for your application will use this name, prefixed with rg-"}},"location":{"type":"string","minLength":1,"metadata":{"description":"The location used for all deployed resources"}},"inputs":{"type":"secureObject","metadata":{"azd":{"type":"inputs"}}}},"variables":{"tags":{"azd-env-name":"[parameters(''environmentName'')]"}},"resources":[{"type":"Microsoft.Resources/resourceGroups","apiVersion":"2022-09-01","name":"[format(''rg-{0}'', parameters(''environmentName''))]","location":"[parameters(''location'')]","tags":"[variables(''tags'')]"},{"type":"Microsoft.Resources/deployments","apiVersion":"2022-09-01","name":"resources","resourceGroup":"[format(''rg-{0}'', parameters(''environmentName''))]","properties":{"expressionEvaluationOptions":{"scope":"inner"},"mode":"Incremental","parameters":{"location":{"value":"[parameters(''location'')]"},"tags":{"value":"[variables(''tags'')]"},"inputs":{"value":"[parameters(''inputs'')]"}},"template":{"$schema":"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","metadata":{"_generator":{"name":"bicep","version":"0.25.3.34343","templateHash":"17406160295075632591"}},"parameters":{"location":{"type":"string","defaultValue":"[resourceGroup().location]","metadata":{"description":"The location used for all deployed resources"}},"tags":{"type":"object","defaultValue":{},"metadata":{"description":"Tags that will be applied to all resources"}},"inputs":{"type":"secureObject","metadata":{"azd":{"type":"inputs"}}}},"variables":{"resourceToken":"[uniqueString(resourceGroup().id)]"},"resources":[{"type":"Microsoft.Storage/storageAccounts/blobServices","apiVersion":"2022-05-01","name":"[format(''{0}/{1}'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''), ''default'')]","dependsOn":["[resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]"]},{"type":"Microsoft.ManagedIdentity/userAssignedIdentities","apiVersion":"2023-01-31","name":"[format(''mi-{0}'', variables(''resourceToken''))]","location":"[parameters(''location'')]","tags":"[parameters(''tags'')]"},{"type":"Microsoft.ContainerRegistry/registries","apiVersion":"2023-07-01","name":"[replace(format(''acr-{0}'', variables(''resourceToken'')), ''-'', '''')]","location":"[parameters(''location'')]","sku":{"name":"Basic"},"properties":{"adminUserEnabled":true},"tags":"[parameters(''tags'')]"},{"type":"Microsoft.Authorization/roleAssignments","apiVersion":"2022-04-01","scope":"[format(''Microsoft.ContainerRegistry/registries/{0}'', replace(format(''acr-{0}'', variables(''resourceToken'')), ''-'', ''''))]","name":"[guid(resourceId(''Microsoft.ContainerRegistry/registries'', replace(format(''acr-{0}'', variables(''resourceToken'')), ''-'', '''')), resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''7f951dda-4ed3-4680-a7ca-43fe172d538d''))]","properties":{"principalId":"[reference(resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), ''2023-01-31'').principalId]","principalType":"ServicePrincipal","roleDefinitionId":"[subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''7f951dda-4ed3-4680-a7ca-43fe172d538d'')]"},"dependsOn":["[resourceId(''Microsoft.ContainerRegistry/registries'', replace(format(''acr-{0}'', variables(''resourceToken'')), ''-'', ''''))]","[resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken'')))]"]},{"type":"Microsoft.OperationalInsights/workspaces","apiVersion":"2022-10-01","name":"[format(''law-{0}'', variables(''resourceToken''))]","location":"[parameters(''location'')]","properties":{"sku":{"name":"PerGB2018"}},"tags":"[parameters(''tags'')]"},{"type":"Microsoft.App/managedEnvironments","apiVersion":"2023-05-01","name":"[format(''cae-{0}'', variables(''resourceToken''))]","location":"[parameters(''location'')]","properties":{"appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"[reference(resourceId(''Microsoft.OperationalInsights/workspaces'', format(''law-{0}'', variables(''resourceToken''))), ''2022-10-01'').customerId]","sharedKey":"[listKeys(resourceId(''Microsoft.OperationalInsights/workspaces'', format(''law-{0}'', variables(''resourceToken''))), ''2022-10-01'').primarySharedKey]"}}},"tags":"[parameters(''tags'')]","dependsOn":["[resourceId(''Microsoft.OperationalInsights/workspaces'', format(''law-{0}'', variables(''resourceToken'')))]"]},{"type":"Microsoft.App/containerApps","apiVersion":"2023-05-02-preview","name":"cache","location":"[parameters(''location'')]","properties":{"environmentId":"[resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken'')))]","configuration":{"service":{"type":"redis"}},"template":{"containers":[{"image":"redis","name":"redis"}],"scale":{"minReplicas":1}}},"tags":"[union(parameters(''tags''), createObject(''aspire-resource-name'', ''cache''))]","dependsOn":["[resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken'')))]"]},{"type":"Microsoft.App/containerApps","apiVersion":"2023-05-02-preview","name":"pubsub","location":"[parameters(''location'')]","properties":{"environmentId":"[resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken'')))]","configuration":{"service":{"type":"redis"}},"template":{"containers":[{"image":"redis","name":"redis"}],"scale":{"minReplicas":1}}},"tags":"[union(parameters(''tags''), createObject(''aspire-resource-name'', ''pubsub''))]","dependsOn":["[resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken'')))]"]},{"type":"Microsoft.Storage/storageAccounts","apiVersion":"2022-05-01","name":"[replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')]","location":"[parameters(''location'')]","kind":"Storage","sku":{"name":"Standard_GRS"},"tags":"[union(parameters(''tags''), createObject(''aspire-resource-name'', ''storage''))]"},{"type":"Microsoft.Authorization/roleAssignments","apiVersion":"2022-04-01","scope":"[format(''Microsoft.Storage/storageAccounts/{0}'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]","name":"[guid(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''ba92f5b4-2d11-453d-a403-e96b0029c9fe''))]","properties":{"principalId":"[reference(resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), ''2023-01-31'').principalId]","principalType":"ServicePrincipal","roleDefinitionId":"[subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''ba92f5b4-2d11-453d-a403-e96b0029c9fe'')]"},"dependsOn":["[resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken'')))]","[resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]"]},{"type":"Microsoft.Authorization/roleAssignments","apiVersion":"2022-04-01","scope":"[format(''Microsoft.Storage/storageAccounts/{0}'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]","name":"[guid(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''974c5e8b-45b9-4653-ba55-5f855dd0fb88''))]","properties":{"principalId":"[reference(resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), ''2023-01-31'').principalId]","principalType":"ServicePrincipal","roleDefinitionId":"[subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''974c5e8b-45b9-4653-ba55-5f855dd0fb88'')]"},"dependsOn":["[resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken'')))]","[resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]"]},{"type":"Microsoft.Authorization/roleAssignments","apiVersion":"2022-04-01","scope":"[format(''Microsoft.Storage/storageAccounts/{0}'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]","name":"[guid(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3''))]","properties":{"principalId":"[reference(resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), ''2023-01-31'').principalId]","principalType":"ServicePrincipal","roleDefinitionId":"[subscriptionResourceId(''Microsoft.Authorization/roleDefinitions'', ''0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'')]"},"dependsOn":["[resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken'')))]","[resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', ''''))]"]}],"outputs":{"MANAGED_IDENTITY_CLIENT_ID":{"type":"string","value":"[reference(resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken''))), ''2023-01-31'').clientId]"},"AZURE_LOG_ANALYTICS_WORKSPACE_NAME":{"type":"string","value":"[format(''law-{0}'', variables(''resourceToken''))]"},"AZURE_CONTAINER_REGISTRY_ENDPOINT":{"type":"string","value":"[reference(resourceId(''Microsoft.ContainerRegistry/registries'', replace(format(''acr-{0}'', variables(''resourceToken'')), ''-'', '''')), ''2023-07-01'').loginServer]"},"AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID":{"type":"string","value":"[resourceId(''Microsoft.ManagedIdentity/userAssignedIdentities'', format(''mi-{0}'', variables(''resourceToken'')))]"},"AZURE_CONTAINER_APPS_ENVIRONMENT_ID":{"type":"string","value":"[resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken'')))]"},"AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN":{"type":"string","value":"[reference(resourceId(''Microsoft.App/managedEnvironments'', format(''cae-{0}'', variables(''resourceToken''))), ''2023-05-01'').defaultDomain]"},"SERVICE_BINDING_MARKDOWN_ENDPOINT":{"type":"string","value":"[reference(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), ''2022-05-01'').primaryEndpoints.blob]"},"SERVICE_BINDING_REQUESTLOG_ENDPOINT":{"type":"string","value":"[reference(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), ''2022-05-01'').primaryEndpoints.table]"},"SERVICE_BINDING_MESSAGES_ENDPOINT":{"type":"string","value":"[reference(resourceId(''Microsoft.Storage/storageAccounts'', replace(format(''storage-{0}'', variables(''resourceToken'')), ''-'', '''')), ''2022-05-01'').primaryEndpoints.queue]"}}}},"dependsOn":["[subscriptionResourceId(''Microsoft.Resources/resourceGroups'', format(''rg-{0}'', parameters(''environmentName'')))]"]}],"outputs":{"MANAGED_IDENTITY_CLIENT_ID":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.MANAGED_IDENTITY_CLIENT_ID.value]"},"AZURE_LOG_ANALYTICS_WORKSPACE_NAME":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.AZURE_LOG_ANALYTICS_WORKSPACE_NAME.value]"},"AZURE_CONTAINER_REGISTRY_ENDPOINT":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT.value]"},"AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID.value]"},"AZURE_CONTAINER_APPS_ENVIRONMENT_ID":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID.value]"},"AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN.value]"},"SERVICE_BINDING_MARKDOWN_ENDPOINT":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.SERVICE_BINDING_MARKDOWN_ENDPOINT.value]"},"SERVICE_BINDING_REQUESTLOG_ENDPOINT":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.SERVICE_BINDING_REQUESTLOG_ENDPOINT.value]"},"SERVICE_BINDING_MESSAGES_ENDPOINT":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.SERVICE_BINDING_MESSAGES_ENDPOINT.value]"}}}},"tags":{"azd-env-name":"azdtest-l88c996","azd-provision-param-hash":"6354240e3b61edb702891d88e5c50b42b4af01f4c1dec5d56a7532a298f4fb48"}}'
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Length:
+                - "15257"
+            Content-Type:
+                - application/json
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l88c996-1708717227?api-version=2021-04-01
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1362
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l88c996-1708717227","name":"azdtest-l88c996-1708717227","type":"Microsoft.Resources/deployments","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996","azd-provision-param-hash":"6354240e3b61edb702891d88e5c50b42b4af01f4c1dec5d56a7532a298f4fb48"},"properties":{"templateHash":"14419117427229910140","parameters":{"environmentName":{"type":"String","value":"azdtest-l88c996"},"location":{"type":"String","value":"eastus2"},"inputs":{"type":"SecureObject"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2024-02-23T19:41:14.4628533Z","duration":"PT0.0008563S","correlationId":"788803d5-d997-4a8f-bf79-f709132f8a66","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["eastus2"]},{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","resourceType":"Microsoft.Resources/resourceGroups","resourceName":"rg-azdtest-l88c996"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources"}]}}'
+        headers:
+            Azure-Asyncoperation:
+                - https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l88c996-1708717227/operationStatuses/08584928896130978657?api-version=2021-04-01
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "1362"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:41:15 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 788803d5-d997-4a8f-bf79-f709132f8a66
+            X-Ms-Ratelimit-Remaining-Subscription-Writes:
+                - "1199"
+            X-Ms-Request-Id:
+                - 788803d5-d997-4a8f-bf79-f709132f8a66
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194115Z:788803d5-d997-4a8f-bf79-f709132f8a66
+            X-Msedge-Ref:
+                - 'Ref A: 850BFD8D28EC459C8AEEDE8E9391041E Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:41:12Z'
+        status: 201 Created
+        code: 201
+        duration: 2.99919948s
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l88c996-1708717227/operationStatuses/08584928896130978657?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 22
+        uncompressed: false
+        body: '{"status":"Succeeded"}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "22"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:44:17 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - f0df61ed-71e4-4532-8c27-729ffccf2142
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - f0df61ed-71e4-4532-8c27-729ffccf2142
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194417Z:f0df61ed-71e4-4532-8c27-729ffccf2142
+            X-Msedge-Ref:
+                - 'Ref A: 4CFF84E433134F1882880D314AB20C58 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:17Z'
+        status: 200 OK
+        code: 200
+        duration: 190.157062ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l88c996-1708717227?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 4954
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l88c996-1708717227","name":"azdtest-l88c996-1708717227","type":"Microsoft.Resources/deployments","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996","azd-provision-param-hash":"6354240e3b61edb702891d88e5c50b42b4af01f4c1dec5d56a7532a298f4fb48"},"properties":{"templateHash":"14419117427229910140","parameters":{"environmentName":{"type":"String","value":"azdtest-l88c996"},"location":{"type":"String","value":"eastus2"},"inputs":{"type":"SecureObject"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-23T19:43:53.0492909Z","duration":"PT2M38.5872939S","correlationId":"788803d5-d997-4a8f-bf79-f709132f8a66","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["eastus2"]},{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","resourceType":"Microsoft.Resources/resourceGroups","resourceName":"rg-azdtest-l88c996"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources"}],"outputs":{"manageD_IDENTITY_CLIENT_ID":{"type":"String","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},"azurE_LOG_ANALYTICS_WORKSPACE_NAME":{"type":"String","value":"law-gnxzs2f5m4idm"},"azurE_CONTAINER_REGISTRY_ENDPOINT":{"type":"String","value":"acrgnxzs2f5m4idm.azurecr.io"},"azurE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"},"azurE_CONTAINER_APPS_ENVIRONMENT_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm"},"azurE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN":{"type":"String","value":"happybush-752e10b4.eastus2.azurecontainerapps.io"},"servicE_BINDING_MARKDOWN_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.blob.core.windows.net/"},"servicE_BINDING_REQUESTLOG_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.table.core.windows.net/"},"servicE_BINDING_MESSAGES_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.queue.core.windows.net/"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/cache"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/pubsub"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ContainerRegistry/registries/acrgnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ContainerRegistry/registries/acrgnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/faee5324-3278-5609-995a-8e845396fbe9"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.OperationalInsights/workspaces/law-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/blobServices/default"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/7bc4c3d5-404b-5a27-b547-08f357bed58b"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/a9bde9d1-b484-5092-9aaa-77577f0c97dd"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/aa646b75-ef6f-5e88-adff-bd4e630fcb69"}]}}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "4954"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:44:17 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 69f17048-3483-43e5-85d4-d373e40ca035
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - 69f17048-3483-43e5-85d4-d373e40ca035
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194417Z:69f17048-3483-43e5-85d4-d373e40ca035
+            X-Msedge-Ref:
+                - 'Ref A: 6788482058404A76A1D021D36896BADC Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:17Z'
+        status: 200 OK
+        code: 200
+        duration: 384.323129ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 288
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "288"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:44:17 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 5f795794-7a37-48c8-9cd2-5b0fb27d1bac
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - 5f795794-7a37-48c8-9cd2-5b0fb27d1bac
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194417Z:5f795794-7a37-48c8-9cd2-5b0fb27d1bac
+            X-Msedge-Ref:
+                - 'Ref A: 74E485B13C1B4ACD884822E835726DA3 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:17Z'
+        status: 200 OK
+        code: 200
+        duration: 53.447345ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 288
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "288"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:44:18 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - dfe37988-d443-4877-91bb-cf5f5e275bd6
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - dfe37988-d443-4877-91bb-cf5f5e275bd6
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194418Z:dfe37988-d443-4877-91bb-cf5f5e275bd6
+            X-Msedge-Ref:
+                - 'Ref A: 91625CF16D2F417D9ACCA6CAE4232BCB Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:18Z'
+        status: 200 OK
+        code: 200
+        duration: 76.709511ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        transfer_encoding:
+            - chunked
+        trailer: {}
+        host: acrgnxzs2f5m4idm.azurecr.io
+        remote_addr: ""
+        request_uri: ""
+        body: access_token=SANITIZED&grant_type=access_token&service=acrgnxzs2f5m4idm.azurecr.io
+        form:
+            access_token:
+                - SANITIZED
+            grant_type:
+                - access_token
+            service:
+                - acrgnxzs2f5m4idm.azurecr.io
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Type:
+                - application/x-www-form-urlencoded
+            User-Agent:
+                - azsdk-go-azd-acr/0.0.0-dev.0 (commit 0000000000000000000000000000000000000000) (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://acrgnxzs2f5m4idm.azurecr.io:443/oauth2/exchange
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding:
+            - chunked
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"refresh_token":"SANITIZED"}'
+        headers:
+            Connection:
+                - keep-alive
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:44:19 GMT
+            Server:
+                - openresty
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Ms-Correlation-Request-Id:
+                - 0d7ebf54-5e4d-4ac5-b868-cc3e20455df4
+            X-Ms-Ratelimit-Remaining-Calls-Per-Second:
+                - "166.65"
+        status: 200 OK
+        code: 200
+        duration: 492.855676ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1273
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{}}},"location":"eastus2","properties":{"configuration":{"activeRevisionsMode":"single","ingress":{"allowInsecure":true,"external":false,"targetPort":8080,"transport":"http"},"registries":[{"identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm","server":"acrgnxzs2f5m4idm.azurecr.io"}]},"environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","template":{"containers":[{"env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-apiservice-1708717459","name":"apiservice"}],"scale":{"minReplicas":1}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"}}'
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Length:
+                - "1273"
+            Content-Type:
+                - application/json
+            User-Agent:
+                - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice?api-version=2022-11-01-preview
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2979
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:44:34.9263707Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:44:34.9263707Z"},"properties":{"provisioningState":"InProgress","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"","latestReadyRevisionName":"","latestRevisionFqdn":"","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","external":false,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-apiservice-1708717459","name":"apiservice","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/apiservice/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
+            Azure-Asyncoperation:
+                - https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/a651f0a6-e38d-43c6-aa76-e446ed34f3fe?api-version=2022-11-01-preview&azureAsyncOperation=true&t=638443142770357565&c=MIIHADCCBeigAwIBAgITfARmPsJdo2ShuN-ImAAABGY-wjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUwHhcNMjQwMTMxMjIwNzA5WhcNMjUwMTI1MjIwNzA5WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOVFiSMi9Sg6cKnrBuPHbDk_Zwa1ZNYHwLVPJArEI9N2bLrgd1mU0ZdNVcdf6rtZCkUUuCe3vxnVTGwufpwH9GPWDgJOpJoL9wgKOzUDiHLUeiWPjrK1AoaQVprZgjnzXBIWiZC2tZjbUT9pOI_ixYJJPrsCfLt7HEccnhObROE1mo_hpiPDrtOQDaX-BboNceB8vI1wmSPApGpPRM9hBRQbXgqKFC8094UNsMVkWPCrsPvP5YlMBLARlGf2WTevGKRREjstkApf1Swi7uKnpyhhsidD1yREMU0mWY9wnZfAX0jpEp3p9jKVMPQ3L-m-nSZI4zrtbW0AnI0O3pAEwe0CAwEAAaOCA-0wggPpMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9DTzFQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA1LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MB0GA1UdDgQWBBT2vcy9ccvhGewsiHI1BQHsz3Wn8zAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBR61hmFKHlscXYeYPjzS--iBUIWHTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBADNBZjhX44bpBtC8kogZJGe4lYeHX95whfZ7X_CMSUuZRbQQ_b6raUpp8V8eF0YUa9b3Oa-DGrs5WfzogCuGcJPeoEVnDYzc1jlKubSIpGw73aGZzhbTjJeNf-Qe-5vTG-GcNzVtIcrwi93YSiK2LSbgrLpTL7T7znjePcGRRkCBjAslrV5SqufcsrpGmqvPAVKXRV-OIOzvXy6qmn9CHmdo0RGBXGIakbLMec_1SIS8NdPsB6i6XPjL2SDjqKTa5car7bVYlXEVsgL-000VF1t6x1II3VBNfsEJ81CdJyxaCJnwvWI6kHtCtJX9QYK3qZab9PfZRBvcetJoPdMFvBU&s=CxpCKXA74prS2HiBMdIUNg__c8TONOppiAVTMlQ95COvNm4svecEUcpCXpEVPUh07PABZg8zSKbJ0KdKJwxh9eKJsB4USvHy8-36mPLGAFWURj8yIR9dukUHrn0629oqzpTzRx7-NzvenRnej1LVURwtmKSeRyjsqdsppSmpiJ0BI7l_jXyi8a1tm29B1MZrhh8df8WVO0zuPgYwIn6BwPUdDDHMSkSolHpI6I-Oltib5wsYO0-C1k93EoN8XJ9DAgWESep3zodDqt9mSmjKMxsYSssTx1LZshdMg6GZbGm8Jj6_Ij_WNBs9fQBuh_E3GKQ170OtQLOS-WIdCHN-eg&h=uQAxmHN8_62WefIDJneIYWv18BVU00sqxDIDhIhyL2Q
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2979"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:44:36 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Retry-After:
+                - "0"
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Async-Operation-Timeout:
+                - PT15M
+            X-Ms-Correlation-Request-Id:
+                - 7c1f7438-ffdd-466a-a856-5513f9386970
+            X-Ms-Ratelimit-Remaining-Subscription-Resource-Requests:
+                - "699"
+            X-Ms-Request-Id:
+                - 7c1f7438-ffdd-466a-a856-5513f9386970
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194437Z:7c1f7438-ffdd-466a-a856-5513f9386970
+            X-Msedge-Ref:
+                - 'Ref A: C1249D776F3D48E888DF690E938FBAA3 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:34Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 201 Created
+        code: 201
+        duration: 2.814389168s
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/a651f0a6-e38d-43c6-aa76-e446ed34f3fe?api-version=2022-11-01-preview&azureAsyncOperation=true&t=638443142770357565&c=MIIHADCCBeigAwIBAgITfARmPsJdo2ShuN-ImAAABGY-wjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUwHhcNMjQwMTMxMjIwNzA5WhcNMjUwMTI1MjIwNzA5WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOVFiSMi9Sg6cKnrBuPHbDk_Zwa1ZNYHwLVPJArEI9N2bLrgd1mU0ZdNVcdf6rtZCkUUuCe3vxnVTGwufpwH9GPWDgJOpJoL9wgKOzUDiHLUeiWPjrK1AoaQVprZgjnzXBIWiZC2tZjbUT9pOI_ixYJJPrsCfLt7HEccnhObROE1mo_hpiPDrtOQDaX-BboNceB8vI1wmSPApGpPRM9hBRQbXgqKFC8094UNsMVkWPCrsPvP5YlMBLARlGf2WTevGKRREjstkApf1Swi7uKnpyhhsidD1yREMU0mWY9wnZfAX0jpEp3p9jKVMPQ3L-m-nSZI4zrtbW0AnI0O3pAEwe0CAwEAAaOCA-0wggPpMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9DTzFQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA1LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MB0GA1UdDgQWBBT2vcy9ccvhGewsiHI1BQHsz3Wn8zAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBR61hmFKHlscXYeYPjzS--iBUIWHTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBADNBZjhX44bpBtC8kogZJGe4lYeHX95whfZ7X_CMSUuZRbQQ_b6raUpp8V8eF0YUa9b3Oa-DGrs5WfzogCuGcJPeoEVnDYzc1jlKubSIpGw73aGZzhbTjJeNf-Qe-5vTG-GcNzVtIcrwi93YSiK2LSbgrLpTL7T7znjePcGRRkCBjAslrV5SqufcsrpGmqvPAVKXRV-OIOzvXy6qmn9CHmdo0RGBXGIakbLMec_1SIS8NdPsB6i6XPjL2SDjqKTa5car7bVYlXEVsgL-000VF1t6x1II3VBNfsEJ81CdJyxaCJnwvWI6kHtCtJX9QYK3qZab9PfZRBvcetJoPdMFvBU&s=CxpCKXA74prS2HiBMdIUNg__c8TONOppiAVTMlQ95COvNm4svecEUcpCXpEVPUh07PABZg8zSKbJ0KdKJwxh9eKJsB4USvHy8-36mPLGAFWURj8yIR9dukUHrn0629oqzpTzRx7-NzvenRnej1LVURwtmKSeRyjsqdsppSmpiJ0BI7l_jXyi8a1tm29B1MZrhh8df8WVO0zuPgYwIn6BwPUdDDHMSkSolHpI6I-Oltib5wsYO0-C1k93EoN8XJ9DAgWESep3zodDqt9mSmjKMxsYSssTx1LZshdMg6GZbGm8Jj6_Ij_WNBs9fQBuh_E3GKQ170OtQLOS-WIdCHN-eg&h=uQAxmHN8_62WefIDJneIYWv18BVU00sqxDIDhIhyL2Q
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 278
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/a651f0a6-e38d-43c6-aa76-e446ed34f3fe","name":"a651f0a6-e38d-43c6-aa76-e446ed34f3fe","status":"Succeeded","startTime":"2024-02-23T19:44:35.7922444"}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "278"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:44:52 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 83d0b64e-9d9e-4f2f-b95e-08804c37b8e2
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 83d0b64e-9d9e-4f2f-b95e-08804c37b8e2
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194452Z:83d0b64e-9d9e-4f2f-b95e-08804c37b8e2
+            X-Msedge-Ref:
+                - 'Ref A: 30B16D5B82914D7CB20A267FAC8F9938 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:52Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 275.370641ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice?api-version=2022-11-01-preview
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3091
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:44:34.9263707","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:44:34.9263707"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"apiservice--sjvfox3","latestReadyRevisionName":"apiservice--sjvfox3","latestRevisionFqdn":"apiservice--sjvfox3.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","external":false,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-apiservice-1708717459","name":"apiservice","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/apiservice/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3091"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:44:52 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 45a234ab-7f3b-4777-a40e-de34ee7aefcb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 45a234ab-7f3b-4777-a40e-de34ee7aefcb
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194452Z:45a234ab-7f3b-4777-a40e-de34ee7aefcb
+            X-Msedge-Ref:
+                - 'Ref A: 912355F0A55F4AAE9D22681E2C62156D Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:52Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 425.163637ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice?api-version=2022-11-01-preview
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3091
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:44:34.9263707","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:44:34.9263707"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"apiservice--sjvfox3","latestReadyRevisionName":"apiservice--sjvfox3","latestRevisionFqdn":"apiservice--sjvfox3.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","external":false,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-apiservice-1708717459","name":"apiservice","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/apiservice/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3091"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:44:53 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 046b821c-3806-451f-a3b9-7fffef775a99
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - 046b821c-3806-451f-a3b9-7fffef775a99
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194453Z:046b821c-3806-451f-a3b9-7fffef775a99
+            X-Msedge-Ref:
+                - 'Ref A: FD1977043233452BBF5B13A8ECBF7420 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:52Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 489.524672ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 288
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "288"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:44:53 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 03c07d4e-a317-493b-a477-aa8286da9df4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 03c07d4e-a317-493b-a477-aa8286da9df4
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194453Z:03c07d4e-a317-493b-a477-aa8286da9df4
+            X-Msedge-Ref:
+                - 'Ref A: 7421B36ECBC940BB88AC3EAAEAA185AA Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:44:53Z'
+        status: 200 OK
+        code: 200
+        duration: 46.589323ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        transfer_encoding:
+            - chunked
+        trailer: {}
+        host: acrgnxzs2f5m4idm.azurecr.io
+        remote_addr: ""
+        request_uri: ""
+        body: access_token=SANITIZED&grant_type=access_token&service=acrgnxzs2f5m4idm.azurecr.io
+        form:
+            access_token:
+                - SANITIZED
+            grant_type:
+                - access_token
+            service:
+                - acrgnxzs2f5m4idm.azurecr.io
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Type:
+                - application/x-www-form-urlencoded
+            User-Agent:
+                - azsdk-go-azd-acr/0.0.0-dev.0 (commit 0000000000000000000000000000000000000000) (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://acrgnxzs2f5m4idm.azurecr.io:443/oauth2/exchange
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding:
+            - chunked
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"refresh_token":"SANITIZED"}'
+        headers:
+            Connection:
+                - keep-alive
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:44:53 GMT
+            Server:
+                - openresty
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Ms-Correlation-Request-Id:
+                - 29a93275-1c74-4cce-8ce2-a7f4c9ef71ba
+            X-Ms-Ratelimit-Remaining-Calls-Per-Second:
+                - "166.616667"
+        status: 200 OK
+        code: 200
+        duration: 81.529461ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Length:
+                - "0"
+            User-Agent:
+                - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/cache/listSecrets?api-version=2022-11-01-preview
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 250
+        uncompressed: false
+        body: '{"value":[{"name":"redis-config","value":"requirepass SANITIZED"}]}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "250"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:09 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 6713982f-74da-4601-912e-91ee1a93a828
+            X-Ms-Ratelimit-Remaining-Subscription-Writes:
+                - "1199"
+            X-Ms-Request-Id:
+                - 6713982f-74da-4601-912e-91ee1a93a828
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194509Z:6713982f-74da-4601-912e-91ee1a93a828
+            X-Msedge-Ref:
+                - 'Ref A: D2AB97F0DF4D4522A4956C10662CA69C Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:08Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 802.381148ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Length:
+                - "0"
+            User-Agent:
+                - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/pubsub/listSecrets?api-version=2022-11-01-preview
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 250
+        uncompressed: false
+        body: '{"value":[{"name":"redis-config","value":"requirepass SANITIZED"}]}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "250"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:09 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - c4796ab8-122a-475a-ae7d-15e7a348d7ba
+            X-Ms-Ratelimit-Remaining-Subscription-Writes:
+                - "1199"
+            X-Ms-Request-Id:
+                - c4796ab8-122a-475a-ae7d-15e7a348d7ba
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194509Z:c4796ab8-122a-475a-ae7d-15e7a348d7ba
+            X-Msedge-Ref:
+                - 'Ref A: FF6015962A0F4C32B270CF695A9B9256 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:09Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 581.607369ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2630
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{}}},"location":"eastus2","properties":{"configuration":{"activeRevisionsMode":"single","ingress":{"allowInsecure":false,"external":true,"targetPort":8080,"transport":"http"},"registries":[{"identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm","server":"acrgnxzs2f5m4idm.azurecr.io"}],"secrets":[{"name":"connectionstrings--cache","value":"cache:6379,password=0VqFkT9yYDKGBvb1I4HhfT88ISck5Zr2pwabko4vCoReFl3XvDHOAL0Bto8DSKjVOEHSvcPT3SkPy3zuIWTOpri81M66qs3zvKRCXb6qNSuX2ccClL38zHCrjrDUEFsZ"},{"name":"connectionstrings--markdown","value":"https://storagegnxzs2f5m4idm.blob.core.windows.net/"},{"name":"connectionstrings--messages","value":"https://storagegnxzs2f5m4idm.queue.core.windows.net/"},{"name":"connectionstrings--pubsub","value":"pubsub:6379,password=4HDzb2KindOAg2oGPXeiCWh1DXBFjrOS3i19ynWQJO5UFlsMSAHVdO5PHqkwURunqV3wlGgiR1OVo7xzzjtREGuNCAuijcBbrtSUpwOeWqudJ9FopETuxMyb3c3aVivf"},{"name":"connectionstrings--requestlog","value":"https://storagegnxzs2f5m4idm.table.core.windows.net/"}]},"environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","template":{"containers":[{"env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-webfrontend-1708717493","name":"webfrontend"}],"scale":{"minReplicas":1}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"}}'
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Length:
+                - "2630"
+            Content-Type:
+                - application/json
+            User-Agent:
+                - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend?api-version=2022-11-01-preview
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3809
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:45:10.6566857Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:45:10.6566857Z"},"properties":{"provisioningState":"InProgress","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"","latestReadyRevisionName":"","latestRevisionFqdn":"","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"connectionstrings--cache"},{"name":"connectionstrings--markdown"},{"name":"connectionstrings--messages"},{"name":"connectionstrings--pubsub"},{"name":"connectionstrings--requestlog"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"webfrontend.happybush-752e10b4.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-webfrontend-1708717493","name":"webfrontend","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/webfrontend/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
+            Azure-Asyncoperation:
+                - https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/80129667-daf6-446e-a53e-013923dd46e7?api-version=2022-11-01-preview&azureAsyncOperation=true&t=638443143123441960&c=MIIHADCCBeigAwIBAgITfARmPsJdo2ShuN-ImAAABGY-wjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUwHhcNMjQwMTMxMjIwNzA5WhcNMjUwMTI1MjIwNzA5WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOVFiSMi9Sg6cKnrBuPHbDk_Zwa1ZNYHwLVPJArEI9N2bLrgd1mU0ZdNVcdf6rtZCkUUuCe3vxnVTGwufpwH9GPWDgJOpJoL9wgKOzUDiHLUeiWPjrK1AoaQVprZgjnzXBIWiZC2tZjbUT9pOI_ixYJJPrsCfLt7HEccnhObROE1mo_hpiPDrtOQDaX-BboNceB8vI1wmSPApGpPRM9hBRQbXgqKFC8094UNsMVkWPCrsPvP5YlMBLARlGf2WTevGKRREjstkApf1Swi7uKnpyhhsidD1yREMU0mWY9wnZfAX0jpEp3p9jKVMPQ3L-m-nSZI4zrtbW0AnI0O3pAEwe0CAwEAAaOCA-0wggPpMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9DTzFQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA1LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MB0GA1UdDgQWBBT2vcy9ccvhGewsiHI1BQHsz3Wn8zAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBR61hmFKHlscXYeYPjzS--iBUIWHTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBADNBZjhX44bpBtC8kogZJGe4lYeHX95whfZ7X_CMSUuZRbQQ_b6raUpp8V8eF0YUa9b3Oa-DGrs5WfzogCuGcJPeoEVnDYzc1jlKubSIpGw73aGZzhbTjJeNf-Qe-5vTG-GcNzVtIcrwi93YSiK2LSbgrLpTL7T7znjePcGRRkCBjAslrV5SqufcsrpGmqvPAVKXRV-OIOzvXy6qmn9CHmdo0RGBXGIakbLMec_1SIS8NdPsB6i6XPjL2SDjqKTa5car7bVYlXEVsgL-000VF1t6x1II3VBNfsEJ81CdJyxaCJnwvWI6kHtCtJX9QYK3qZab9PfZRBvcetJoPdMFvBU&s=FicIiMAUJPnQ7FyhoB5mKjFaVJpoX2FbQs5mlKBtNJjlLCe8AtY1MiRTAjK15FLEmE1BPUHhkRtIDzsbL_KcYEdpcywxnsTf_V9yM5_ScFzhkTi6tQx8Orp-fHnw2IMcz1Ba5rIMbw8Guy4PJRKG5u6_36iCTFLMm9k1SOB-CBamGMqkLUxtMXL2e-1goTkWOASqPq4Q3VoPolqRDhwaEd_ClFvERkEJzJbJpNuFkkHIY7bjq_MgeCe2yOgdHYyUwBVPl4YF5N_Nr6tVRBV-MKRsHQfokY2z_JouMPkCnM8WSMevm57UQPYDg-500Dr9fjDUi0eC7DckpGW5Sxkveg&h=HQ2T7fy5c-oxHVabFlVVvdDsqTm6VsBMjMJtCRMzMiI
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3809"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:12 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Retry-After:
+                - "0"
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Async-Operation-Timeout:
+                - PT15M
+            X-Ms-Correlation-Request-Id:
+                - dad86f6d-9747-403f-8a8f-53280618c278
+            X-Ms-Ratelimit-Remaining-Subscription-Resource-Requests:
+                - "699"
+            X-Ms-Request-Id:
+                - dad86f6d-9747-403f-8a8f-53280618c278
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194512Z:dad86f6d-9747-403f-8a8f-53280618c278
+            X-Msedge-Ref:
+                - 'Ref A: 340B7DADA83240B18E2F18632B7903E0 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:10Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 201 Created
+        code: 201
+        duration: 2.321125667s
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/80129667-daf6-446e-a53e-013923dd46e7?api-version=2022-11-01-preview&azureAsyncOperation=true&t=638443143123441960&c=MIIHADCCBeigAwIBAgITfARmPsJdo2ShuN-ImAAABGY-wjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUwHhcNMjQwMTMxMjIwNzA5WhcNMjUwMTI1MjIwNzA5WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOVFiSMi9Sg6cKnrBuPHbDk_Zwa1ZNYHwLVPJArEI9N2bLrgd1mU0ZdNVcdf6rtZCkUUuCe3vxnVTGwufpwH9GPWDgJOpJoL9wgKOzUDiHLUeiWPjrK1AoaQVprZgjnzXBIWiZC2tZjbUT9pOI_ixYJJPrsCfLt7HEccnhObROE1mo_hpiPDrtOQDaX-BboNceB8vI1wmSPApGpPRM9hBRQbXgqKFC8094UNsMVkWPCrsPvP5YlMBLARlGf2WTevGKRREjstkApf1Swi7uKnpyhhsidD1yREMU0mWY9wnZfAX0jpEp3p9jKVMPQ3L-m-nSZI4zrtbW0AnI0O3pAEwe0CAwEAAaOCA-0wggPpMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHLBggrBgEFBQcBAQSCAb0wggG5MGMGCCsGAQUFBzAChldodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MFMGCCsGAQUFBzAChkdodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9DTzFQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDA1LmNydDBTBggrBgEFBQcwAoZHaHR0cDovL2NybDMuYW1lLmdibC9haWEvQ08xUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwNS5jcnQwUwYIKwYBBQUHMAKGR2h0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0NPMVBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3J0MB0GA1UdDgQWBBT2vcy9ccvhGewsiHI1BQHsz3Wn8zAOBgNVHQ8BAf8EBAMCBaAwggEmBgNVHR8EggEdMIIBGTCCARWgggERoIIBDYY_aHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JshjFodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDUuY3JsMBcGA1UdIAQQMA4wDAYKKwYBBAGCN3sBATAfBgNVHSMEGDAWgBR61hmFKHlscXYeYPjzS--iBUIWHTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBADNBZjhX44bpBtC8kogZJGe4lYeHX95whfZ7X_CMSUuZRbQQ_b6raUpp8V8eF0YUa9b3Oa-DGrs5WfzogCuGcJPeoEVnDYzc1jlKubSIpGw73aGZzhbTjJeNf-Qe-5vTG-GcNzVtIcrwi93YSiK2LSbgrLpTL7T7znjePcGRRkCBjAslrV5SqufcsrpGmqvPAVKXRV-OIOzvXy6qmn9CHmdo0RGBXGIakbLMec_1SIS8NdPsB6i6XPjL2SDjqKTa5car7bVYlXEVsgL-000VF1t6x1II3VBNfsEJ81CdJyxaCJnwvWI6kHtCtJX9QYK3qZab9PfZRBvcetJoPdMFvBU&s=FicIiMAUJPnQ7FyhoB5mKjFaVJpoX2FbQs5mlKBtNJjlLCe8AtY1MiRTAjK15FLEmE1BPUHhkRtIDzsbL_KcYEdpcywxnsTf_V9yM5_ScFzhkTi6tQx8Orp-fHnw2IMcz1Ba5rIMbw8Guy4PJRKG5u6_36iCTFLMm9k1SOB-CBamGMqkLUxtMXL2e-1goTkWOASqPq4Q3VoPolqRDhwaEd_ClFvERkEJzJbJpNuFkkHIY7bjq_MgeCe2yOgdHYyUwBVPl4YF5N_Nr6tVRBV-MKRsHQfokY2z_JouMPkCnM8WSMevm57UQPYDg-500Dr9fjDUi0eC7DckpGW5Sxkveg&h=HQ2T7fy5c-oxHVabFlVVvdDsqTm6VsBMjMJtCRMzMiI
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 278
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/80129667-daf6-446e-a53e-013923dd46e7","name":"80129667-daf6-446e-a53e-013923dd46e7","status":"Succeeded","startTime":"2024-02-23T19:45:11.3783127"}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "278"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:27 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3e75afe7-9834-4212-9dde-700180dcfb41
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 3e75afe7-9834-4212-9dde-700180dcfb41
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194527Z:3e75afe7-9834-4212-9dde-700180dcfb41
+            X-Msedge-Ref:
+                - 'Ref A: 1427FA829C13459780D0FF8A2D74C08E Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:27Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 267.864717ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend?api-version=2022-11-01-preview
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3915
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:45:10.6566857","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:45:10.6566857"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"webfrontend--v4b3j5p","latestReadyRevisionName":"webfrontend--v4b3j5p","latestRevisionFqdn":"webfrontend--v4b3j5p.happybush-752e10b4.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"connectionstrings--cache"},{"name":"connectionstrings--markdown"},{"name":"connectionstrings--messages"},{"name":"connectionstrings--pubsub"},{"name":"connectionstrings--requestlog"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"webfrontend.happybush-752e10b4.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-webfrontend-1708717493","name":"webfrontend","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/webfrontend/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3915"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:27 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - e608cf54-f6d9-41e2-8cf9-76a9e23433c1
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - e608cf54-f6d9-41e2-8cf9-76a9e23433c1
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194528Z:e608cf54-f6d9-41e2-8cf9-76a9e23433c1
+            X-Msedge-Ref:
+                - 'Ref A: 9570385D2E4D4FBA9CC799D111090FDD Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:27Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 358.806673ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend?api-version=2022-11-01-preview
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3915
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:45:10.6566857","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:45:10.6566857"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"webfrontend--v4b3j5p","latestReadyRevisionName":"webfrontend--v4b3j5p","latestRevisionFqdn":"webfrontend--v4b3j5p.happybush-752e10b4.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"connectionstrings--cache"},{"name":"connectionstrings--markdown"},{"name":"connectionstrings--messages"},{"name":"connectionstrings--pubsub"},{"name":"connectionstrings--requestlog"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"webfrontend.happybush-752e10b4.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-webfrontend-1708717493","name":"webfrontend","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/webfrontend/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3915"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:28 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 0a386fc1-a966-4437-9cdd-3220d1482084
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 0a386fc1-a966-4437-9cdd-3220d1482084
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194528Z:0a386fc1-a966-4437-9cdd-3220d1482084
+            X-Msedge-Ref:
+                - 'Ref A: 00B650FD2D5E444A8831E9BB2FB0668E Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:28Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 369.513046ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 288
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "288"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:28 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - f068ab56-690b-4f82-a15c-ecf68c52154e
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - f068ab56-690b-4f82-a15c-ecf68c52154e
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194528Z:f068ab56-690b-4f82-a15c-ecf68c52154e
+            X-Msedge-Ref:
+                - 'Ref A: E92E2CD635BA486EAB8854E628F9AA71 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:28Z'
+        status: 200 OK
+        code: 200
+        duration: 45.710654ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 959721
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1Y7faoMwFMafxVw7MKUtw7voOWWwJjbJSUp7VzY3RImwWXQW3322ax9id9%2bf3wffhb21oavC%2bdRVbaC2LsM3Sy8MhSVnF1cZyqHbnb666kq8lj8sZTx6jhQdBjkenlh8I0zbPzrO15GpN5mEz167I0inlwqyzEADOvEb6TBRlIEmnyt6%2fzBcFVub9AW4matHSWJRgB4UyEHCvM05Gbc6ard68ejJg%2bgl4FrWMzOKpaKbT9gU33%2f%2fu9t7tITOFDtkaTg3TczsHgFVjoqM2D7Cu3X2L5imXw%3d%3d","value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l88c996-1708717227","location":"eastus2","name":"azdtest-l88c996-1708717227","properties":{"correlationId":"788803d5-d997-4a8f-bf79-f709132f8a66","dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","resourceName":"rg-azdtest-l88c996","resourceType":"Microsoft.Resources/resourceGroups"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Resources/deployments/resources","resourceName":"resources","resourceType":"Microsoft.Resources/deployments"}],"duration":"PT2M38.5872939S","mode":"Incremental","outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/cache"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/pubsub"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ContainerRegistry/registries/acrgnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ContainerRegistry/registries/acrgnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/faee5324-3278-5609-995a-8e845396fbe9"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.OperationalInsights/workspaces/law-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/blobServices/default"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/7bc4c3d5-404b-5a27-b547-08f357bed58b"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/a9bde9d1-b484-5092-9aaa-77577f0c97dd"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/aa646b75-ef6f-5e88-adff-bd4e630fcb69"}],"outputs":{"azurE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN":{"type":"String","value":"happybush-752e10b4.eastus2.azurecontainerapps.io"},"azurE_CONTAINER_APPS_ENVIRONMENT_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm"},"azurE_CONTAINER_REGISTRY_ENDPOINT":{"type":"String","value":"acrgnxzs2f5m4idm.azurecr.io"},"azurE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"},"azurE_LOG_ANALYTICS_WORKSPACE_NAME":{"type":"String","value":"law-gnxzs2f5m4idm"},"manageD_IDENTITY_CLIENT_ID":{"type":"String","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},"servicE_BINDING_MARKDOWN_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.blob.core.windows.net/"},"servicE_BINDING_MESSAGES_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.queue.core.windows.net/"},"servicE_BINDING_REQUESTLOG_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.table.core.windows.net/"}},"parameters":{"environmentName":{"type":"String","value":"azdtest-l88c996"},"inputs":{"type":"SecureObject"},"location":{"type":"String","value":"eastus2"}},"providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"locations":["eastus2"],"resourceType":"resourceGroups"},{"locations":[null],"resourceType":"deployments"}]}],"provisioningState":"Succeeded","templateHash":"14419117427229910140","timestamp":"2024-02-23T19:43:53.0492909Z"},"tags":{"azd-env-name":"azdtest-l88c996","azd-provision-param-hash":"6354240e3b61edb702891d88e5c50b42b4af01f4c1dec5d56a7532a298f4fb48"},"type":"Microsoft.Resources/deployments"}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "959721"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:42 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 0d342dfe-c625-4efb-b86c-2dc37926e4d0
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - 0d342dfe-c625-4efb-b86c-2dc37926e4d0
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194542Z:0d342dfe-c625-4efb-b86c-2dc37926e4d0
+            X-Msedge-Ref:
+                - 'Ref A: DDC119CCA3374D0FA288CE7D6CB2F569 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:38Z'
+        status: 200 OK
+        code: 200
+        duration: 4.186568898s
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1Y7faoMwFMafxVw7MKUtw7voOWWwJjbJSUp7VzY3RImwWXQW3322ax9id9%2bf3wffhb21oavC%2bdRVbaC2LsM3Sy8MhSVnF1cZyqHbnb666kq8lj8sZTx6jhQdBjkenlh8I0zbPzrO15GpN5mEz167I0inlwqyzEADOvEb6TBRlIEmnyt6%2fzBcFVub9AW4matHSWJRgB4UyEHCvM05Gbc6ard68ejJg%2bgl4FrWMzOKpaKbT9gU33%2f%2fu9t7tITOFDtkaTg3TczsHgFVjoqM2D7Cu3X2L5imXw%3d%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2487770
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1ZDRToMwFIafhV5jUgYxhjugXdSth7U93YJ3iyJhJcUoC7iFd9c5SPYK3p3%2f%2b7%2bLP%2bdMXlvX1e647%2brWYWtL90XiM%2bGJRqMXl9OVQ7fZf3b1xViV3yQmgffgARaDOBV3xP8zVNvPXUAjT9llKljVS%2fPChJERsDRVrGGSbpfCcAqYMonbDPDtXQWQrzXtc2Z%2bPUuBJREcqoXApxAORSiyADT%2feJbI74WVA5ySUKCNBFYDGf1p67%2bYalY6N%2fhIYndsGp%2fs%2bPTl2xjettyofMNnonecccg4oErWM5yi0Vcwjj8%3d","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2487770"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:46 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - ff9142a8-d7e1-468a-ad6d-b5ad84f25c94
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - ff9142a8-d7e1-468a-ad6d-b5ad84f25c94
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194547Z:ff9142a8-d7e1-468a-ad6d-b5ad84f25c94
+            X-Msedge-Ref:
+                - 'Ref A: 2D12D932F9144F95AD3BF54CEF782679 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:42Z'
+        status: 200 OK
+        code: 200
+        duration: 4.505739314s
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1ZDRToMwFIafhV5jUgYxhjugXdSth7U93YJ3iyJhJcUoC7iFd9c5SPYK3p3%2f%2b7%2bLP%2bdMXlvX1e647%2brWYWtL90XiM%2bGJRqMXl9OVQ7fZf3b1xViV3yQmgffgARaDOBV3xP8zVNvPXUAjT9llKljVS%2fPChJERsDRVrGGSbpfCcAqYMonbDPDtXQWQrzXtc2Z%2bPUuBJREcqoXApxAORSiyADT%2feJbI74WVA5ySUKCNBFYDGf1p67%2bYalY6N%2fhIYndsGp%2fs%2bPTl2xjettyofMNnonecccg4oErWM5yi0Vcwjj8%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3021248
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1VJBbsIwEHwLPhcphoAqbk7WiApsE3udKNxQSylNlEhtUEIQf28MREL9QNXbznh2PR7vmbyWRXUojtvqUBZYZrvim8zOhDOD1oxcWeyaar39qg5OsdydyIzQwfNAYtqINh2Sp6tCl3V%2fRul0oLN5IGBfR3YDwka%2bhCDQkEPkxXNhuScxgAjjUOLbu6ZSrYxXK7CdLvNkm45lm1GFwleY1TKkiYk3QZLzqcj03HofawvlSQMfC0h90Xaaz%2f2QXJ7uvv%2bd7YS7uP%2fCdiuQjRREjQTRCOh%2bKqSo7WQT2cki5jHGwGoBLvlO0zJf4hV7Lm1mDWq2emEhl64gs%2bKY5w%2b8W6OetEujLC56eHtyt2G3lhscP0JutVrznjEJBy5%2fXXSHLjo35nL5AQ%3d%3d","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3021248"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:52 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - ecad1e69-944b-4d96-8901-e508c2462a27
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - ecad1e69-944b-4d96-8901-e508c2462a27
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194552Z:ecad1e69-944b-4d96-8901-e508c2462a27
+            X-Msedge-Ref:
+                - 'Ref A: 00BD0F39A7AE4DAC98645EF11ED57870 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:47Z'
+        status: 200 OK
+        code: 200
+        duration: 5.023060419s
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1VJBbsIwEHwLPhcphoAqbk7WiApsE3udKNxQSylNlEhtUEIQf28MREL9QNXbznh2PR7vmbyWRXUojtvqUBZYZrvim8zOhDOD1oxcWeyaar39qg5OsdydyIzQwfNAYtqINh2Sp6tCl3V%2fRul0oLN5IGBfR3YDwka%2bhCDQkEPkxXNhuScxgAjjUOLbu6ZSrYxXK7CdLvNkm45lm1GFwleY1TKkiYk3QZLzqcj03HofawvlSQMfC0h90Xaaz%2f2QXJ7uvv%2bd7YS7uP%2fCdiuQjRREjQTRCOh%2bKqSo7WQT2cki5jHGwGoBLvlO0zJf4hV7Lm1mDWq2emEhl64gs%2bKY5w%2b8W6OetEujLC56eHtyt2G3lhscP0JutVrznjEJBy5%2fXXSHLjo35nL5AQ%3d%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 271460
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=XZBRT4MwFIV%2fC32eCQxiDG%2bFdnFuvaz0dgu%2bLYqEQYpRFnAL%2f13r1sX41u%2bcc9OccyYvnelrc9z3dWewa0rzSeIz4VShVnMSm2Pbzq7oaMetaWOmHPvN%2fqOv7fWq%2fCIxCbwHD7AYxam4I7PfRN4Nzgv8yMubRSJYNUj9zISWEbAkyVnLpL9dCM19wIRJ3KaAr295ANla%2bUPG9E%2bu8YHRCA7VXOAyhEMRijQAxd%2bfJPJ70cgRTjQU2EQCq5FMM0K1wpyulzTlYB%2buwk23RZ2oVyrT%2bOjwUvO2wQXDvy7XebbhTlE7zjj8%2b%2biKdi475TR9Aw%3d%3d","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "271460"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:53 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - cb4c260c-287f-4d7c-bb2d-e63f40fc9b1d
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - cb4c260c-287f-4d7c-bb2d-e63f40fc9b1d
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194553Z:cb4c260c-287f-4d7c-bb2d-e63f40fc9b1d
+            X-Msedge-Ref:
+                - 'Ref A: 1BE2C8DD07F342E09B8814459F6C8BBE Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:52Z'
+        status: 200 OK
+        code: 200
+        duration: 1.256039934s
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=XZBRT4MwFIV%2fC32eCQxiDG%2bFdnFuvaz0dgu%2bLYqEQYpRFnAL%2f13r1sX41u%2bcc9OccyYvnelrc9z3dWewa0rzSeIz4VShVnMSm2Pbzq7oaMetaWOmHPvN%2fqOv7fWq%2fCIxCbwHD7AYxam4I7PfRN4Nzgv8yMubRSJYNUj9zISWEbAkyVnLpL9dCM19wIRJ3KaAr295ANla%2bUPG9E%2bu8YHRCA7VXOAyhEMRijQAxd%2bfJPJ70cgRTjQU2EQCq5FMM0K1wpyulzTlYB%2buwk23RZ2oVyrT%2bOjwUvO2wQXDvy7XebbhTlE7zjj8%2b%2biKdi475TR9Aw%3d%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20482
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=ZZBda4MwFIZ%2fi7luwUwpwzs1kY42ieZDsXdldZ2LRNgsthb%2f%2b5p1GWO7O8%2f7vueDcwXPvRlac9oPbW9krxvzAaIrqLCQStjKNOch378PrQ1smguIAPQePSrrM5nqJVh8JXg%2fOg%2fClcd1lhB0HAu1Q0QVIUVJwlGHCr%2fMiMI%2blQkqZJlSeXjhkLKt8EeG1C2nfTrVAZ00ZJKETOqRprAS5S6pOrwimmfKf80V6i8c4YCgOiTTLfN2XIJ5AXBsz34AkTl1nUNHsRKSx9unOMXUFv902%2b1EtRFMybXD%2bz9%2bBt8x%2bO1ixVmOnSIqjDD9s%2bgb7V%2ftffP8CQ%3d%3d","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "20482"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:54 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 0f9ee5c7-febf-4572-b57d-3fd621e91800
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 0f9ee5c7-febf-4572-b57d-3fd621e91800
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194554Z:0f9ee5c7-febf-4572-b57d-3fd621e91800
+            X-Msedge-Ref:
+                - 'Ref A: 284EBDCE567B41AE9FC3131EE7DE6771 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:53Z'
+        status: 200 OK
+        code: 200
+        duration: 726.824455ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=ZZBda4MwFIZ%2fi7luwUwpwzs1kY42ieZDsXdldZ2LRNgsthb%2f%2b5p1GWO7O8%2f7vueDcwXPvRlac9oPbW9krxvzAaIrqLCQStjKNOch378PrQ1smguIAPQePSrrM5nqJVh8JXg%2fOg%2fClcd1lhB0HAu1Q0QVIUVJwlGHCr%2fMiMI%2blQkqZJlSeXjhkLKt8EeG1C2nfTrVAZ00ZJKETOqRprAS5S6pOrwimmfKf80V6i8c4YCgOiTTLfN2XIJ5AXBsz34AkTl1nUNHsRKSx9unOMXUFv902%2b1EtRFMybXD%2bz9%2bBt8x%2bO1ixVmOnSIqjDD9s%2bgb7V%2ftffP8CQ%3d%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 12
+        uncompressed: false
+        body: '{"value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "12"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:54 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 9dec5d4b-efb5-409d-877d-2e71f1be6bd4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 9dec5d4b-efb5-409d-877d-2e71f1be6bd4
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194555Z:9dec5d4b-efb5-409d-877d-2e71f1be6bd4
+            X-Msedge-Ref:
+                - 'Ref A: AF844BCDF84A4F6F891CD1792529AC2E Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:54Z'
+        status: 200 OK
+        code: 200
+        duration: 403.973167ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 288
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "288"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:54 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3f04f47f-4a79-4e1f-af5d-aa1d4cffca25
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 3f04f47f-4a79-4e1f-af5d-aa1d4cffca25
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194555Z:3f04f47f-4a79-4e1f-af5d-aa1d4cffca25
+            X-Msedge-Ref:
+                - 'Ref A: 572B68A7E5054A1F8834208A2DDA76DA Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:55Z'
+        status: 200 OK
+        code: 200
+        duration: 49.378307ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27apiservice%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 666
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "666"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:55 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - fea03cb7-c6d2-4464-a6d1-425a2a59181a
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - fea03cb7-c6d2-4464-a6d1-425a2a59181a
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194555Z:fea03cb7-c6d2-4464-a6d1-425a2a59181a
+            X-Msedge-Ref:
+                - 'Ref A: 4A4B7285F02546548692C0E6AF0CE294 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:55Z'
+        status: 200 OK
+        code: 200
+        duration: 91.40507ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 288
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "288"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:55 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 6b423896-6bfa-4412-9602-b2f2b45f0659
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 6b423896-6bfa-4412-9602-b2f2b45f0659
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194555Z:6b423896-6bfa-4412-9602-b2f2b45f0659
+            X-Msedge-Ref:
+                - 'Ref A: 51F5B52F1AB84519BA9CD5CF30170A6A Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:55Z'
+        status: 200 OK
+        code: 200
+        duration: 49.171447ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27apiservice%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 666
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "666"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:55 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 53cafe6a-6cad-4cf1-ad20-2ae6931b2138
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 53cafe6a-6cad-4cf1-ad20-2ae6931b2138
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194555Z:53cafe6a-6cad-4cf1-ad20-2ae6931b2138
+            X-Msedge-Ref:
+                - 'Ref A: CC8D454131C8410399E8B2BE5B93A11A Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:55Z'
+        status: 200 OK
+        code: 200
+        duration: 259.796828ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice?api-version=2022-11-01-preview
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3091
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:44:34.9263707","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:44:34.9263707"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"apiservice--sjvfox3","latestReadyRevisionName":"apiservice--sjvfox3","latestRevisionFqdn":"apiservice--sjvfox3.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","external":false,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-apiservice-1708717459","name":"apiservice","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/apiservice/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3091"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:55 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 29aebb12-8c38-4f12-ae80-f2c7dcfd213d
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 29aebb12-8c38-4f12-ae80-f2c7dcfd213d
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194556Z:29aebb12-8c38-4f12-ae80-f2c7dcfd213d
+            X-Msedge-Ref:
+                - 'Ref A: 0448A14C52A3416BA5AB3C731545FD54 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:55Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 444.548639ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27webfrontend%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 670
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "670"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:56 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - ca875541-df75-49e5-a800-66c75c8fc210
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - ca875541-df75-49e5-a800-66c75c8fc210
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194556Z:ca875541-df75-49e5-a800-66c75c8fc210
+            X-Msedge-Ref:
+                - 'Ref A: 0AF4E5FCD4FD465DA83A9E985954DC34 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:56Z'
+        status: 200 OK
+        code: 200
+        duration: 175.192313ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 288
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "288"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:56 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - a45b398c-6003-4802-bf45-0ac5056e60a0
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11997"
+            X-Ms-Request-Id:
+                - a45b398c-6003-4802-bf45-0ac5056e60a0
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194556Z:a45b398c-6003-4802-bf45-0ac5056e60a0
+            X-Msedge-Ref:
+                - 'Ref A: D6C845DFAD92466EBD8D8FA54F9B712A Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:56Z'
+        status: 200 OK
+        code: 200
+        duration: 38.629218ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27webfrontend%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 670
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "670"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:56 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - aeb15420-74c1-41f2-b3bd-bb7dcff38457
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - aeb15420-74c1-41f2-b3bd-bb7dcff38457
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194556Z:aeb15420-74c1-41f2-b3bd-bb7dcff38457
+            X-Msedge-Ref:
+                - 'Ref A: 4512BC43B1BC43A4B40A5C46D8FBD8BB Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:56Z'
+        status: 200 OK
+        code: 200
+        duration: 237.356472ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend?api-version=2022-11-01-preview
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3915
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:45:10.6566857","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:45:10.6566857"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"webfrontend--v4b3j5p","latestReadyRevisionName":"webfrontend--v4b3j5p","latestRevisionFqdn":"webfrontend--v4b3j5p.happybush-752e10b4.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"connectionstrings--cache"},{"name":"connectionstrings--markdown"},{"name":"connectionstrings--messages"},{"name":"connectionstrings--pubsub"},{"name":"connectionstrings--requestlog"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"webfrontend.happybush-752e10b4.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-webfrontend-1708717493","name":"webfrontend","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/webfrontend/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3915"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:56 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 9a2eff7d-0da6-4158-8226-8be24d77d738
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 9a2eff7d-0da6-4158-8226-8be24d77d738
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194557Z:9a2eff7d-0da6-4158-8226-8be24d77d738
+            X-Msedge-Ref:
+                - 'Ref A: EE4FEF856ED647CA888E96A54820BB86 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:56Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 434.03303ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 4936
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/pubsub","name":"pubsub","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-l88c996","aspire-resource-name":"pubsub"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:42:16.8954514Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:42:16.8954514Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm","name":"storagegnxzs2f5m4idm","type":"Microsoft.Storage/storageAccounts","sku":{"name":"Standard_GRS","tier":"Standard"},"kind":"Storage","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996","aspire-resource-name":"storage"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:44:34.9263707Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:44:34.9263707Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ContainerRegistry/registries/acrgnxzs2f5m4idm","name":"acrgnxzs2f5m4idm","type":"Microsoft.ContainerRegistry/registries","sku":{"name":"Basic","tier":"Basic"},"location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:41:19.7556947Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:41:19.7556947Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm","name":"mi-gnxzs2f5m4idm","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.OperationalInsights/workspaces/law-gnxzs2f5m4idm","name":"law-gnxzs2f5m4idm","type":"Microsoft.OperationalInsights/workspaces","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/cache","name":"cache","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-l88c996","aspire-resource-name":"cache"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:42:16.9266975Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:42:16.9266975Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","name":"cae-gnxzs2f5m4idm","type":"Microsoft.App/managedEnvironments","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:41:39.9056782Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:41:39.9056782Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:45:10.6566857Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:45:10.6566857Z"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "4936"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:45:57 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - ee45e718-3845-41b4-9228-6b354254f5df
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - ee45e718-3845-41b4-9228-6b354254f5df
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194557Z:ee45e718-3845-41b4-9228-6b354254f5df
+            X-Msedge-Ref:
+                - 'Ref A: C0132A7A39E645A381F718AD3BF5D582 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:45:57Z'
+        status: 200 OK
+        code: 200
+        duration: 113.930976ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 959721
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1Y7faoMwFMafxVw7MKUtw7voOWWwJjbJSUp7VzY3RImwWXQW3322ax9id9%2bf3wffhb21oavC%2bdRVbaC2LsM3Sy8MhSVnF1cZyqHbnb666kq8lj8sZTx6jhQdBjkenlh8I0zbPzrO15GpN5mEz167I0inlwqyzEADOvEb6TBRlIEmnyt6%2fzBcFVub9AW4matHSWJRgB4UyEHCvM05Gbc6ard68ejJg%2bgl4FrWMzOKpaKbT9gU33%2f%2fu9t7tITOFDtkaTg3TczsHgFVjoqM2D7Cu3X2L5imXw%3d%3d","value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-l88c996-1708717227","location":"eastus2","name":"azdtest-l88c996-1708717227","properties":{"correlationId":"788803d5-d997-4a8f-bf79-f709132f8a66","dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","resourceName":"rg-azdtest-l88c996","resourceType":"Microsoft.Resources/resourceGroups"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Resources/deployments/resources","resourceName":"resources","resourceType":"Microsoft.Resources/deployments"}],"duration":"PT2M38.5872939S","mode":"Incremental","outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/cache"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/pubsub"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ContainerRegistry/registries/acrgnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ContainerRegistry/registries/acrgnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/faee5324-3278-5609-995a-8e845396fbe9"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.OperationalInsights/workspaces/law-gnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/blobServices/default"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/7bc4c3d5-404b-5a27-b547-08f357bed58b"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/a9bde9d1-b484-5092-9aaa-77577f0c97dd"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm/providers/Microsoft.Authorization/roleAssignments/aa646b75-ef6f-5e88-adff-bd4e630fcb69"}],"outputs":{"azurE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN":{"type":"String","value":"happybush-752e10b4.eastus2.azurecontainerapps.io"},"azurE_CONTAINER_APPS_ENVIRONMENT_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm"},"azurE_CONTAINER_REGISTRY_ENDPOINT":{"type":"String","value":"acrgnxzs2f5m4idm.azurecr.io"},"azurE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"},"azurE_LOG_ANALYTICS_WORKSPACE_NAME":{"type":"String","value":"law-gnxzs2f5m4idm"},"manageD_IDENTITY_CLIENT_ID":{"type":"String","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},"servicE_BINDING_MARKDOWN_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.blob.core.windows.net/"},"servicE_BINDING_MESSAGES_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.queue.core.windows.net/"},"servicE_BINDING_REQUESTLOG_ENDPOINT":{"type":"String","value":"https://storagegnxzs2f5m4idm.table.core.windows.net/"}},"parameters":{"environmentName":{"type":"String","value":"azdtest-l88c996"},"inputs":{"type":"SecureObject"},"location":{"type":"String","value":"eastus2"}},"providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"locations":["eastus2"],"resourceType":"resourceGroups"},{"locations":[null],"resourceType":"deployments"}]}],"provisioningState":"Succeeded","templateHash":"14419117427229910140","timestamp":"2024-02-23T19:43:53.0492909Z"},"tags":{"azd-env-name":"azdtest-l88c996","azd-provision-param-hash":"6354240e3b61edb702891d88e5c50b42b4af01f4c1dec5d56a7532a298f4fb48"},"type":"Microsoft.Resources/deployments"}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "959721"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:46:17 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 9edcf1ed-be1f-4899-bb30-888b54f390a4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - 9edcf1ed-be1f-4899-bb30-888b54f390a4
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194617Z:9edcf1ed-be1f-4899-bb30-888b54f390a4
+            X-Msedge-Ref:
+                - 'Ref A: 9C38FE87E04B4D2C9B29BA4F1BFF8D1D Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:13Z'
+        status: 200 OK
+        code: 200
+        duration: 4.125745602s
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1Y7faoMwFMafxVw7MKUtw7voOWWwJjbJSUp7VzY3RImwWXQW3322ax9id9%2bf3wffhb21oavC%2bdRVbaC2LsM3Sy8MhSVnF1cZyqHbnb666kq8lj8sZTx6jhQdBjkenlh8I0zbPzrO15GpN5mEz167I0inlwqyzEADOvEb6TBRlIEmnyt6%2fzBcFVub9AW4matHSWJRgB4UyEHCvM05Gbc6ard68ejJg%2bgl4FrWMzOKpaKbT9gU33%2f%2fu9t7tITOFDtkaTg3TczsHgFVjoqM2D7Cu3X2L5imXw%3d%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2487770
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1ZDRToMwFIafhV5jUgYxhjugXdSth7U93YJ3iyJhJcUoC7iFd9c5SPYK3p3%2f%2b7%2bLP%2bdMXlvX1e647%2brWYWtL90XiM%2bGJRqMXl9OVQ7fZf3b1xViV3yQmgffgARaDOBV3xP8zVNvPXUAjT9llKljVS%2fPChJERsDRVrGGSbpfCcAqYMonbDPDtXQWQrzXtc2Z%2bPUuBJREcqoXApxAORSiyADT%2feJbI74WVA5ySUKCNBFYDGf1p67%2bYalY6N%2fhIYndsGp%2fs%2bPTl2xjettyofMNnonecccg4oErWM5yi0Vcwjj8%3d","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2487770"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:46:22 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 5f93f736-b642-4910-85b7-ad564999bfd2
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 5f93f736-b642-4910-85b7-ad564999bfd2
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194622Z:5f93f736-b642-4910-85b7-ad564999bfd2
+            X-Msedge-Ref:
+                - 'Ref A: 8A47655F42F747F087E2966E8173262C Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:17Z'
+        status: 200 OK
+        code: 200
+        duration: 4.844899545s
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1ZDRToMwFIafhV5jUgYxhjugXdSth7U93YJ3iyJhJcUoC7iFd9c5SPYK3p3%2f%2b7%2bLP%2bdMXlvX1e647%2brWYWtL90XiM%2bGJRqMXl9OVQ7fZf3b1xViV3yQmgffgARaDOBV3xP8zVNvPXUAjT9llKljVS%2fPChJERsDRVrGGSbpfCcAqYMonbDPDtXQWQrzXtc2Z%2bPUuBJREcqoXApxAORSiyADT%2feJbI74WVA5ySUKCNBFYDGf1p67%2bYalY6N%2fhIYndsGp%2fs%2bPTl2xjettyofMNnonecccg4oErWM5yi0Vcwjj8%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3021248
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=1VJBbsIwEHwLPhcphoAqbk7WiApsE3udKNxQSylNlEhtUEIQf28MREL9QNXbznh2PR7vmbyWRXUojtvqUBZYZrvim8zOhDOD1oxcWeyaar39qg5OsdydyIzQwfNAYtqINh2Sp6tCl3V%2fRul0oLN5IGBfR3YDwka%2bhCDQkEPkxXNhuScxgAjjUOLbu6ZSrYxXK7CdLvNkm45lm1GFwleY1TKkiYk3QZLzqcj03HofawvlSQMfC0h90Xaaz%2f2QXJ7uvv%2bd7YS7uP%2fCdiuQjRREjQTRCOh%2bKqSo7WQT2cki5jHGwGoBLvlO0zJf4hV7Lm1mDWq2emEhl64gs%2bKY5w%2b8W6OetEujLC56eHtyt2G3lhscP0JutVrznjEJBy5%2fXXSHLjo35nL5AQ%3d%3d","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3021248"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:46:28 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - dea99230-5f4b-439e-aa40-221c92b1c5c8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - dea99230-5f4b-439e-aa40-221c92b1c5c8
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194628Z:dea99230-5f4b-439e-aa40-221c92b1c5c8
+            X-Msedge-Ref:
+                - 'Ref A: 52BB321EBAF2413E9485F79BD4610CE1 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:22Z'
+        status: 200 OK
+        code: 200
+        duration: 5.803223517s
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=1VJBbsIwEHwLPhcphoAqbk7WiApsE3udKNxQSylNlEhtUEIQf28MREL9QNXbznh2PR7vmbyWRXUojtvqUBZYZrvim8zOhDOD1oxcWeyaar39qg5OsdydyIzQwfNAYtqINh2Sp6tCl3V%2fRul0oLN5IGBfR3YDwka%2bhCDQkEPkxXNhuScxgAjjUOLbu6ZSrYxXK7CdLvNkm45lm1GFwleY1TKkiYk3QZLzqcj03HofawvlSQMfC0h90Xaaz%2f2QXJ7uvv%2bd7YS7uP%2fCdiuQjRREjQTRCOh%2bKqSo7WQT2cki5jHGwGoBLvlO0zJf4hV7Lm1mDWq2emEhl64gs%2bKY5w%2b8W6OetEujLC56eHtyt2G3lhscP0JutVrznjEJBy5%2fXXSHLjo35nL5AQ%3d%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 271460
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=XZBRT4MwFIV%2fC32eCQxiDG%2bFdnFuvaz0dgu%2bLYqEQYpRFnAL%2f13r1sX41u%2bcc9OccyYvnelrc9z3dWewa0rzSeIz4VShVnMSm2Pbzq7oaMetaWOmHPvN%2fqOv7fWq%2fCIxCbwHD7AYxam4I7PfRN4Nzgv8yMubRSJYNUj9zISWEbAkyVnLpL9dCM19wIRJ3KaAr295ANla%2bUPG9E%2bu8YHRCA7VXOAyhEMRijQAxd%2bfJPJ70cgRTjQU2EQCq5FMM0K1wpyulzTlYB%2buwk23RZ2oVyrT%2bOjwUvO2wQXDvy7XebbhTlE7zjj8%2b%2biKdi475TR9Aw%3d%3d","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "271460"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:46:30 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - cc8a4b70-b660-42c8-9caf-5db00de4dd5e
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - cc8a4b70-b660-42c8-9caf-5db00de4dd5e
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194630Z:cc8a4b70-b660-42c8-9caf-5db00de4dd5e
+            X-Msedge-Ref:
+                - 'Ref A: DC7E7680762D4A559BE9A848107A2843 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:28Z'
+        status: 200 OK
+        code: 200
+        duration: 1.460474281s
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=XZBRT4MwFIV%2fC32eCQxiDG%2bFdnFuvaz0dgu%2bLYqEQYpRFnAL%2f13r1sX41u%2bcc9OccyYvnelrc9z3dWewa0rzSeIz4VShVnMSm2Pbzq7oaMetaWOmHPvN%2fqOv7fWq%2fCIxCbwHD7AYxam4I7PfRN4Nzgv8yMubRSJYNUj9zISWEbAkyVnLpL9dCM19wIRJ3KaAr295ANla%2bUPG9E%2bu8YHRCA7VXOAyhEMRijQAxd%2bfJPJ70cgRTjQU2EQCq5FMM0K1wpyulzTlYB%2buwk23RZ2oVyrT%2bOjwUvO2wQXDvy7XebbhTlE7zjj8%2b%2biKdi475TR9Aw%3d%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20482
+        uncompressed: false
+        body: '{"nextLink":"https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01\u0026%24skiptoken=ZZBda4MwFIZ%2fi7luwUwpwzs1kY42ieZDsXdldZ2LRNgsthb%2f%2b5p1GWO7O8%2f7vueDcwXPvRlac9oPbW9krxvzAaIrqLCQStjKNOch378PrQ1smguIAPQePSrrM5nqJVh8JXg%2fOg%2fClcd1lhB0HAu1Q0QVIUVJwlGHCr%2fMiMI%2blQkqZJlSeXjhkLKt8EeG1C2nfTrVAZ00ZJKETOqRprAS5S6pOrwimmfKf80V6i8c4YCgOiTTLfN2XIJ5AXBsz34AkTl1nUNHsRKSx9unOMXUFv902%2b1EtRFMybXD%2bz9%2bBt8x%2bO1ixVmOnSIqjDD9s%2bgb7V%2ftffP8CQ%3d%3d","value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "20482"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:46:31 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - ead56de3-ba3a-467c-8a6e-ba06b19ce090
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - ead56de3-ba3a-467c-8a6e-ba06b19ce090
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194631Z:ead56de3-ba3a-467c-8a6e-ba06b19ce090
+            X-Msedge-Ref:
+                - 'Ref A: B53B516DA21D4FBE906C7553B8AB2B5E Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:30Z'
+        status: 200 OK
+        code: 200
+        duration: 846.91748ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01&%24skiptoken=ZZBda4MwFIZ%2fi7luwUwpwzs1kY42ieZDsXdldZ2LRNgsthb%2f%2b5p1GWO7O8%2f7vueDcwXPvRlac9oPbW9krxvzAaIrqLCQStjKNOch378PrQ1smguIAPQePSrrM5nqJVh8JXg%2fOg%2fClcd1lhB0HAu1Q0QVIUVJwlGHCr%2fMiMI%2blQkqZJlSeXjhkLKt8EeG1C2nfTrVAZ00ZJKETOqRprAS5S6pOrwimmfKf80V6i8c4YCgOiTTLfN2XIJ5AXBsz34AkTl1nUNHsRKSx9unOMXUFv902%2b1EtRFMybXD%2bz9%2bBt8x%2bO1ixVmOnSIqjDD9s%2bgb7V%2ftffP8CQ%3d%3d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 12
+        uncompressed: false
+        body: '{"value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "12"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:46:31 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 0b250137-5db1-424f-ac11-160cb79215bd
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 0b250137-5db1-424f-ac11-160cb79215bd
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194631Z:0b250137-5db1-424f-ac11-160cb79215bd
+            X-Msedge-Ref:
+                - 'Ref A: B58E44FE2DE949759575CC81D5A9EDA9 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:31Z'
+        status: 200 OK
+        code: 200
+        duration: 421.72145ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 288
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "288"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:46:31 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 8ba6ea60-3a6f-4758-b2c4-d1e7c52c45b1
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 8ba6ea60-3a6f-4758-b2c4-d1e7c52c45b1
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194631Z:8ba6ea60-3a6f-4758-b2c4-d1e7c52c45b1
+            X-Msedge-Ref:
+                - 'Ref A: B7EF024240D94DA5BA9F5017F9B7DCA7 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:31Z'
+        status: 200 OK
+        code: 200
+        duration: 50.082803ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27apiservice%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 666
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"azd-service-name":"apiservice","aspire-resource-name":"apiservice"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "666"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:46:31 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3216ac99-0868-413e-bbd0-938026903ec9
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 3216ac99-0868-413e-bbd0-938026903ec9
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194632Z:3216ac99-0868-413e-bbd0-938026903ec9
+            X-Msedge-Ref:
+                - 'Ref A: 33F73B22D03342A3A7FC2590916E0CE1 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:31Z'
+        status: 200 OK
+        code: 200
+        duration: 250.065619ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 288
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "288"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:46:31 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 09b1df61-bea3-422a-b391-dc3016a621fb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 09b1df61-bea3-422a-b391-dc3016a621fb
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194632Z:09b1df61-bea3-422a-b391-dc3016a621fb
+            X-Msedge-Ref:
+                - 'Ref A: 4642745A215D4CAD93F16DCB9ACE8150 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:32Z'
+        status: 200 OK
+        code: 200
+        duration: 139.517076ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27apiservice%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 666
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"azd-service-name":"apiservice","aspire-resource-name":"apiservice"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "666"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:46:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 72abd24c-77b4-42cd-8175-bc8e8ca349df
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - 72abd24c-77b4-42cd-8175-bc8e8ca349df
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194632Z:72abd24c-77b4-42cd-8175-bc8e8ca349df
+            X-Msedge-Ref:
+                - 'Ref A: B83DC0A4E12947878B743C231C09E6B9 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:32Z'
+        status: 200 OK
+        code: 200
+        duration: 89.29166ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice?api-version=2022-11-01-preview
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3091
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:44:34.9263707","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:44:34.9263707"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"apiservice--sjvfox3","latestReadyRevisionName":"apiservice--sjvfox3","latestRevisionFqdn":"apiservice--sjvfox3.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":null,"activeRevisionsMode":"Single","ingress":{"fqdn":"apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io","external":false,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":true,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-apiservice-1708717459","name":"apiservice","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/apiservice/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3091"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:46:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - b2c2b6ed-31a6-42a9-bae8-ec79b2a715ce
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - b2c2b6ed-31a6-42a9-bae8-ec79b2a715ce
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194632Z:b2c2b6ed-31a6-42a9-bae8-ec79b2a715ce
+            X-Msedge-Ref:
+                - 'Ref A: 9600142FE45044CCBA2264B46121385B Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:32Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 460.378648ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27webfrontend%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 670
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "670"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:46:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - acba897c-69f5-49ac-a8a5-3ebbe0d227c4
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11997"
+            X-Ms-Request-Id:
+                - acba897c-69f5-49ac-a8a5-3ebbe0d227c4
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194633Z:acba897c-69f5-49ac-a8a5-3ebbe0d227c4
+            X-Msedge-Ref:
+                - 'Ref A: DCE32FCE0C94463EA9FD7691A011C11C Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:32Z'
+        status: 200 OK
+        code: 200
+        duration: 272.501372ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-l88c996%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 288
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996","name":"rg-azdtest-l88c996","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"properties":{"provisioningState":"Succeeded"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "288"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:46:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 6da17a55-e969-4b60-b2e5-bc95aa75ce76
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 6da17a55-e969-4b60-b2e5-bc95aa75ce76
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194633Z:6da17a55-e969-4b60-b2e5-bc95aa75ce76
+            X-Msedge-Ref:
+                - 'Ref A: 536E32E48E784AAE95D0DF83C4AE3378 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:33Z'
+        status: 200 OK
+        code: 200
+        duration: 87.118115ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27webfrontend%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 670
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "670"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:46:33 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 3353c390-7c77-4bb5-99da-ecb7429f0bcf
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 3353c390-7c77-4bb5-99da-ecb7429f0bcf
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194633Z:3353c390-7c77-4bb5-99da-ecb7429f0bcf
+            X-Msedge-Ref:
+                - 'Ref A: AFAA43F0E3F641719126E30CEF14910C Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:33Z'
+        status: 200 OK
+        code: 200
+        duration: 230.517305ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armappcontainers.ContainerAppsClient/v2.0.0-beta.3 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend?api-version=2022-11-01-preview
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3915
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerapps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:45:10.6566857","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:45:10.6566857"},"properties":{"provisioningState":"Succeeded","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","workloadProfileName":null,"outboundIpAddresses":["20.57.100.116"],"latestRevisionName":"webfrontend--v4b3j5p","latestReadyRevisionName":"webfrontend--v4b3j5p","latestRevisionFqdn":"webfrontend--v4b3j5p.happybush-752e10b4.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"connectionstrings--cache"},{"name":"connectionstrings--markdown"},{"name":"connectionstrings--messages"},{"name":"connectionstrings--pubsub"},{"name":"connectionstrings--requestlog"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"webfrontend.happybush-752e10b4.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Http","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null},"registries":[{"server":"acrgnxzs2f5m4idm.azurecr.io","username":"","passwordSecretRef":"","identity":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm"}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","containers":[{"image":"acrgnxzs2f5m4idm.azurecr.io/azd-deploy-webfrontend-1708717493","name":"webfrontend","env":[{"name":"AZURE_CLIENT_ID","value":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES","value":"true"},{"name":"OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES","value":"true"},{"name":"services__apiservice__0","value":"http://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"services__apiservice__1","value":"https://apiservice.internal.happybush-752e10b4.eastus2.azurecontainerapps.io"},{"name":"ConnectionStrings__cache","secretRef":"connectionstrings--cache"},{"name":"ConnectionStrings__markdown","secretRef":"connectionstrings--markdown"},{"name":"ConnectionStrings__messages","secretRef":"connectionstrings--messages"},{"name":"ConnectionStrings__pubsub","secretRef":"connectionstrings--pubsub"},{"name":"ConnectionStrings__requestlog","secretRef":"connectionstrings--requestlog"}],"resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":1,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/containerApps/webfrontend/eventstream"},"identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}}}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3915"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:46:33 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 9808445a-f39c-4842-a5a3-3e91f53e6fed
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 9808445a-f39c-4842-a5a3-3e91f53e6fed
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194633Z:9808445a-f39c-4842-a5a3-3e91f53e6fed
+            X-Msedge-Ref:
+                - 'Ref A: E9EC96DE26CA4FA9B46974499AA12B76 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:33Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 498.135862ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.Client/v1.1.1 (go1.21.0; linux),azdev/0.0.0-dev.0 (Go go1.21.0; linux/amd64)
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/resources?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 4936
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/pubsub","name":"pubsub","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-l88c996","aspire-resource-name":"pubsub"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:42:16.8954514Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:42:16.8954514Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.Storage/storageAccounts/storagegnxzs2f5m4idm","name":"storagegnxzs2f5m4idm","type":"Microsoft.Storage/storageAccounts","sku":{"name":"Standard_GRS","tier":"Standard"},"kind":"Storage","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996","aspire-resource-name":"storage"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/apiservice","name":"apiservice","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"apiservice","azd-service-name":"apiservice"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:44:34.9263707Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:44:34.9263707Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ContainerRegistry/registries/acrgnxzs2f5m4idm","name":"acrgnxzs2f5m4idm","type":"Microsoft.ContainerRegistry/registries","sku":{"name":"Basic","tier":"Basic"},"location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:41:19.7556947Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:41:19.7556947Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm","name":"mi-gnxzs2f5m4idm","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.OperationalInsights/workspaces/law-gnxzs2f5m4idm","name":"law-gnxzs2f5m4idm","type":"Microsoft.OperationalInsights/workspaces","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/cache","name":"cache","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-l88c996","aspire-resource-name":"cache"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:42:16.9266975Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:42:16.9266975Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/managedEnvironments/cae-gnxzs2f5m4idm","name":"cae-gnxzs2f5m4idm","type":"Microsoft.App/managedEnvironments","location":"eastus2","tags":{"azd-env-name":"azdtest-l88c996"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:41:39.9056782Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:41:39.9056782Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-l88c996/providers/Microsoft.App/containerApps/webfrontend","name":"webfrontend","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"UserAssigned","userAssignedIdentities":{"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-l88c996/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-gnxzs2f5m4idm":{"principalId":"50199bc4-2d03-4131-bbf3-40ef279249e0","clientId":"2bbe3bb4-68d9-4f4a-8097-c57c856911be"}}},"tags":{"aspire-resource-name":"webfrontend","azd-service-name":"webfrontend"},"systemData":{"createdBy":"weilim@microsoft.com","createdByType":"User","createdAt":"2024-02-23T19:45:10.6566857Z","lastModifiedBy":"weilim@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-02-23T19:45:10.6566857Z"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "4936"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 23 Feb 2024 19:46:33 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - d37c6b63-fdee-4922-9a72-be864a79447d
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - d37c6b63-fdee-4922-9a72-be864a79447d
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240223T194634Z:d37c6b63-fdee-4922-9a72-be864a79447d
+            X-Msedge-Ref:
+                - 'Ref A: 3A838024CC814FD0B72D2BCD50BFF9E7 Ref B: CO6AA3150220053 Ref C: 2024-02-23T19:46:33Z'
+        status: 200 OK
+        code: 200
+        duration: 129.102812ms
+---
+env_name: azdtest-l88c996
+time: "1708717227"

--- a/cli/azd/test/functional/testdata/vs-server/tests/AzdServices.cs
+++ b/cli/azd/test/functional/testdata/vs-server/tests/AzdServices.cs
@@ -26,10 +26,25 @@ public class Environment {
     public Service[] Services { get; set; } = [];
 
     public Dictionary<string, string> Values { get; set; } = new Dictionary<string, string>();
+    public Resource[] Resources { get; set; } = [];
+    public DeploymentResult? LastDeployment { get; set; }
 
     public Environment(string name) {
         Name = name;
     }
+}
+
+public class DeploymentResult {
+    public string Success { get; set; } = "";
+	public string Message { get; set; } = "";
+	public string Time { get; set; } = "";
+	public string DeploymentId { get; set; } = "";
+}
+
+public class Resource {
+    public string Id { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string Type { get; set; } = "";
 }
 
 public class AspireHost {

--- a/cli/azd/test/functional/testdata/vs-server/tests/TestBase.cs
+++ b/cli/azd/test/functional/testdata/vs-server/tests/TestBase.cs
@@ -18,6 +18,9 @@ public class TestBase
 
     protected string _location = string.Empty;
 
+    // Environment name for live tests
+    protected string _envName = string.Empty;
+
 
     protected IEnvironmentService esSvc;
 
@@ -37,6 +40,7 @@ public class TestBase
         _subscriptionId = config["AZURE_SUBSCRIPTION_ID"] ?? "any";
         _rootDir = config["ROOT_DIR"] ?? System.IO.Directory.GetCurrentDirectory();
         _location = config["AZURE_LOCATION"] ?? "westus2";
+        _envName = config["AZURE_ENV_NAME"] ?? "vs-server-env";
 
         var host = $"ws://127.0.0.1:{_port}";
 

--- a/cli/azd/test/functional/vs_server_test.go
+++ b/cli/azd/test/functional/vs_server_test.go
@@ -144,6 +144,7 @@ func Test_CLI_VsServer(t *testing.T) {
 			if tt.IsLive {
 				// We don't currently have a way to deprovision using server mode.
 				// For now let's just clean up the resources.
+				cli.WorkingDirectory = testDir
 				_, _ = cli.RunCommand(ctx, "down", "--force", "--purge")
 			}
 		})

--- a/cli/azd/test/functional/vs_server_test.go
+++ b/cli/azd/test/functional/vs_server_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
 	"github.com/azure/azure-dev/cli/azd/test/azdcli"
+	"github.com/azure/azure-dev/cli/azd/test/ostest"
+	"github.com/azure/azure-dev/cli/azd/test/recording"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +37,12 @@ func Test_CLI_VsServer(t *testing.T) {
 
 	scanner := bufio.NewScanner(&stdout)
 	testStart := false
-	var tests []string
+
+	type vsServerTest struct {
+		Name   string
+		IsLive bool
+	}
+	var tests []vsServerTest
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.Contains(line, "The following Tests are available:") {
@@ -44,7 +51,14 @@ func Test_CLI_VsServer(t *testing.T) {
 		}
 
 		if testStart && strings.HasPrefix(line, "    ") {
-			tests = append(tests, strings.TrimSpace(line))
+			test := vsServerTest{}
+			name := strings.TrimSpace(line)
+
+			test.Name = name
+			if strings.HasPrefix(name, "Live") {
+				test.IsLive = true
+			}
+			tests = append(tests, test)
 		}
 	}
 
@@ -59,7 +73,7 @@ func Test_CLI_VsServer(t *testing.T) {
 
 	// For each test, copySample
 	for _, tt := range tests {
-		t.Run(tt, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			tt := tt
 			t.Parallel()
 
@@ -72,11 +86,23 @@ func Test_CLI_VsServer(t *testing.T) {
 			err = copySample(dir, "aspire-full")
 			require.NoError(t, err, "failed expanding sample")
 
-			cli := azdcli.NewCLI(t)
+			var session *recording.Session
+			envName := ""
+
+			if tt.IsLive {
+				session = recording.Start(t)
+				envName = randomOrStoredEnvName(session)
+			}
+
+			cli := azdcli.NewCLI(t, azdcli.WithSession(session))
 			/* #nosec G204 - Subprocess launched with a potential tainted input or cmd arguments false positive */
 			cmd := exec.CommandContext(ctx, cli.AzdPath, "vs-server", "--debug")
-			cmd.Env = append(cmd.Env, os.Environ()...)
+			cmd.Env = append(cli.Env, os.Environ()...)
 			cmd.Env = append(cmd.Env, "AZD_DEBUG_SERVER_DEBUG_ENDPOINTS=true")
+			pathString := ostest.CombinedPaths(cmd.Env)
+			if len(pathString) > 0 {
+				cmd.Env = append(cmd.Env, pathString)
+			}
 
 			var stdout bytes.Buffer
 			cmd.Stdout = io.MultiWriter(&stdout, &logWriter{initialTime: time.Now(), t: t, prefix: "[svr-out] "})
@@ -96,18 +122,25 @@ func Test_CLI_VsServer(t *testing.T) {
 				"dotnet", "test",
 				"--no-build",
 				"--no-restore",
-				"--filter", "Name="+tt)
+				"--filter", "Name="+tt.Name)
 			cmd.Dir = testDir
 			cmd.Env = append(cmd.Env, os.Environ()...)
 			cmd.Env = append(cmd.Env, "AZURE_SUBSCRIPTION_ID="+cfg.SubscriptionID)
 			cmd.Env = append(cmd.Env, "AZURE_LOCATION="+cfg.Location)
 			cmd.Env = append(cmd.Env, fmt.Sprintf("PORT=%d", svr.Port))
 			cmd.Env = append(cmd.Env, "ROOT_DIR="+dir)
+			if tt.IsLive {
+				cmd.Env = append(cmd.Env, "AZURE_ENV_NAME="+envName)
+			}
 
 			cmd.Stdout = &logWriter{initialTime: time.Now(), t: t, prefix: "[t-out] "}
 			cmd.Stderr = &logWriter{initialTime: time.Now(), t: t, prefix: "[t-err] "}
 			err = cmd.Run()
 			require.NoError(t, err)
+
+			if tt.IsLive {
+				_, _ = cli.RunCommand(ctx, "down", "--force", "--purge")
+			}
 		})
 	}
 }

--- a/cli/azd/test/functional/vs_server_test.go
+++ b/cli/azd/test/functional/vs_server_test.go
@@ -114,7 +114,12 @@ func Test_CLI_VsServer(t *testing.T) {
 			require.NoError(t, err)
 
 			// Wait for the server to start
-			time.Sleep(300 * time.Millisecond)
+			for i := 0; i < 5; i++ {
+				time.Sleep(300 * time.Millisecond)
+				if stdout.Len() > 0 {
+					break
+				}
+			}
 
 			var svr contracts.VsServerResult
 			err = json.Unmarshal(stdout.Bytes(), &svr)
@@ -144,7 +149,8 @@ func Test_CLI_VsServer(t *testing.T) {
 			if tt.IsLive {
 				// We don't currently have a way to deprovision using server mode.
 				// For now let's just clean up the resources.
-				cli.WorkingDirectory = testDir
+				cli.WorkingDirectory = dir
+				cli.Env = append(cli.Env, os.Environ()...)
 				_, _ = cli.RunCommand(ctx, "down", "--force", "--purge")
 			}
 		})

--- a/cli/azd/test/ostest/ostest.go
+++ b/cli/azd/test/ostest/ostest.go
@@ -3,6 +3,7 @@ package ostest
 import (
 	"errors"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -75,4 +76,22 @@ func Chdir(t *testing.T, dir string) {
 		err = os.Chdir(wd)
 		require.NoError(t, err)
 	})
+}
+
+// CombinedPaths collects all PATH strings from the provided environment variables, in the form of 'PATH=<path>',
+// and combines them into a single PATH string, also in the form of 'PATH=<collected paths>'.
+// It returns an empty string if no PATH strings are found.
+func CombinedPaths(environ []string) string {
+	pathStrings := []string{}
+	for _, env := range environ {
+		if strings.HasPrefix(env, "PATH=") {
+			pathStrings = append(pathStrings, env[5:])
+		}
+	}
+
+	if len(pathStrings) == 0 {
+		return ""
+	}
+
+	return "PATH=" + strings.Join(pathStrings, string(os.PathListSeparator))
 }

--- a/cli/azd/test/recording/sanitize.go
+++ b/cli/azd/test/recording/sanitize.go
@@ -48,6 +48,15 @@ func sanitizeContainerAppListSecrets(i *cassette.Interaction) error {
 
 		for i := range body.Value {
 			if body.Value[i].Name != nil {
+				if body.Value[i].Value != nil {
+					val := *body.Value[i].Value
+					// Redis requirepass. Sanitize the password, remove other config.
+					if strings.Contains(val, "requirepass ") {
+						body.Value[i].Value = convert.RefOf("requirepass SANITIZED")
+					}
+					continue
+				}
+
 				body.Value[i].Value = convert.RefOf("SANITIZED")
 			}
 		}


### PR DESCRIPTION
Expose provisioned resources in both `DeployAsync` and `RefreshEnvironmentAsync`.

Add acceptance tests for this scenario, which included surrounding test helper changes:

- Support multiple command recorders
- Add `dotnet publish <container>` as default global recording option
- Avoid `HTTPS_PROXY` passthrough in recordings

Fixes #3317