### PR TITLE
Refactor DefaultClientOptionsBuilder

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -378,12 +378,11 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	)
 
 	container.MustRegisterSingleton(func(
-		ctx context.Context,
 		credential azcore.TokenCredential,
 		httpClient httputil.HttpClient,
 	) (*armresourcegraph.Client, error) {
 		options := azsdk.
-			DefaultClientOptionsBuilder(ctx, httpClient, "azd").
+			DefaultClientOptionsBuilder(httpClient, "azd").
 			BuildArmClientOptions()
 
 		return armresourcegraph.NewClient(credential, options)

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -471,11 +471,17 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		rootOptions *internal.GlobalCommandOptions,
 		credentialProvider account.SubscriptionCredentialProvider,
 		httpClient httputil.HttpClient,
+		armClientOptions *arm.ClientOptions,
 	) azcli.AzCli {
-		return azcli.NewAzCli(credentialProvider, httpClient, azcli.NewAzCliArgs{
-			EnableDebug:     rootOptions.EnableDebugLogging,
-			EnableTelemetry: rootOptions.EnableTelemetry,
-		})
+		return azcli.NewAzCli(
+			credentialProvider,
+			httpClient,
+			azcli.NewAzCliArgs{
+				EnableDebug:     rootOptions.EnableDebugLogging,
+				EnableTelemetry: rootOptions.EnableTelemetry,
+			},
+			armClientOptions,
+		)
 	})
 	container.MustRegisterSingleton(azapi.NewDeployments)
 	container.MustRegisterSingleton(azapi.NewDeploymentOperations)

--- a/cli/azd/pkg/account/manager_test.go
+++ b/cli/azd/pkg/account/manager_test.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
@@ -17,6 +19,12 @@ import (
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
 	"github.com/stretchr/testify/require"
 )
+
+func armClientOptions(httpTransport *mockhttp.MockHttpClient) *arm.ClientOptions {
+	return &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{Transport: httpTransport},
+	}
+}
 
 func Test_GetAccountDefaults(t *testing.T) {
 	defaultSubscription := Subscription{
@@ -43,7 +51,7 @@ func Test_GetAccountDefaults(t *testing.T) {
 			NewSubscriptionsManagerWithCache(
 				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
-					mockHttp,
+					armClientOptions(mockHttp),
 				),
 				NewBypassSubscriptionsCache(),
 			),
@@ -68,7 +76,7 @@ func Test_GetAccountDefaults(t *testing.T) {
 			NewSubscriptionsManagerWithCache(
 				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
-					mockHttp,
+					armClientOptions(mockHttp),
 				),
 				NewBypassSubscriptionsCache(),
 			),
@@ -102,7 +110,7 @@ func Test_GetAccountDefaults(t *testing.T) {
 			NewSubscriptionsManagerWithCache(
 				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
-					mockHttp,
+					armClientOptions(mockHttp),
 				),
 				NewBypassSubscriptionsCache(),
 			),
@@ -136,7 +144,7 @@ func Test_GetAccountDefaults(t *testing.T) {
 			NewSubscriptionsManagerWithCache(
 				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
-					mockHttp,
+					armClientOptions(mockHttp),
 				),
 				NewBypassSubscriptionsCache(),
 			),
@@ -158,7 +166,7 @@ func Test_GetSubscriptionsWithDefaultSet(t *testing.T) {
 		manager, err := NewManager(mockConfig, NewSubscriptionsManagerWithCache(
 			NewSubscriptionsService(
 				&mocks.MockMultiTenantCredentialProvider{},
-				mockHttp,
+				armClientOptions(mockHttp),
 			),
 			NewBypassSubscriptionsCache()))
 		require.NoError(t, err)
@@ -193,7 +201,7 @@ func Test_GetSubscriptionsWithDefaultSet(t *testing.T) {
 			NewSubscriptionsManagerWithCache(
 				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
-					mockHttp,
+					armClientOptions(mockHttp),
 				),
 				NewBypassSubscriptionsCache(),
 			),
@@ -222,7 +230,7 @@ func Test_GetSubscriptionsWithDefaultSet(t *testing.T) {
 			NewSubscriptionsManagerWithCache(
 				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
-					mockHttp,
+					armClientOptions(mockHttp),
 				),
 				NewBypassSubscriptionsCache(),
 			))
@@ -260,7 +268,7 @@ func Test_GetLocations(t *testing.T) {
 			NewSubscriptionsManagerWithCache(
 				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
-					mockHttp,
+					armClientOptions(mockHttp),
 				),
 				NewBypassSubscriptionsCache(),
 			),
@@ -281,7 +289,7 @@ func Test_GetLocations(t *testing.T) {
 		manager, err := NewManager(mockConfig, NewSubscriptionsManagerWithCache(
 			NewSubscriptionsService(
 				&mocks.MockMultiTenantCredentialProvider{},
-				mockHttp,
+				armClientOptions(mockHttp),
 			),
 			NewBypassSubscriptionsCache()))
 		require.NoError(t, err)
@@ -301,7 +309,7 @@ func Test_GetLocations(t *testing.T) {
 		manager, err := NewManager(mockConfig, NewSubscriptionsManagerWithCache(
 			NewSubscriptionsService(
 				&mocks.MockMultiTenantCredentialProvider{},
-				mockHttp,
+				armClientOptions(mockHttp),
 			),
 			NewBypassSubscriptionsCache()))
 		require.NoError(t, err)
@@ -329,7 +337,7 @@ func Test_SetDefaultSubscription(t *testing.T) {
 		manager, err := NewManager(mockConfig, NewSubscriptionsManagerWithCache(
 			NewSubscriptionsService(
 				&mocks.MockMultiTenantCredentialProvider{},
-				mockHttp,
+				armClientOptions(mockHttp),
 			),
 			NewBypassSubscriptionsCache()))
 		require.NoError(t, err)
@@ -355,7 +363,7 @@ func Test_SetDefaultSubscription(t *testing.T) {
 		manager, err := NewManager(mockConfig, NewSubscriptionsManagerWithCache(
 			NewSubscriptionsService(
 				&mocks.MockMultiTenantCredentialProvider{},
-				mockHttp,
+				armClientOptions(mockHttp),
 			),
 			NewBypassSubscriptionsCache()))
 		require.NoError(t, err)
@@ -394,7 +402,7 @@ func Test_SetDefaultLocation(t *testing.T) {
 			NewSubscriptionsManagerWithCache(
 				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
-					mockHttp,
+					armClientOptions(mockHttp),
 				),
 				NewBypassSubscriptionsCache(),
 			),
@@ -418,7 +426,7 @@ func Test_SetDefaultLocation(t *testing.T) {
 		manager, err := NewManager(mockConfig, NewSubscriptionsManagerWithCache(
 			NewSubscriptionsService(
 				&mocks.MockMultiTenantCredentialProvider{},
-				mockHttp,
+				armClientOptions(mockHttp),
 			),
 			NewBypassSubscriptionsCache()))
 		require.NoError(t, err)
@@ -445,7 +453,7 @@ func Test_Clear(t *testing.T) {
 	manager, err := NewManager(mockConfig, NewSubscriptionsManagerWithCache(
 		NewSubscriptionsService(
 			&mocks.MockMultiTenantCredentialProvider{},
-			mockHttp,
+			armClientOptions(mockHttp),
 		),
 		NewBypassSubscriptionsCache()))
 	require.NoError(t, err)
@@ -496,7 +504,7 @@ func Test_HasDefaults(t *testing.T) {
 			NewSubscriptionsManagerWithCache(
 				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
-					mockHttp,
+					armClientOptions(mockHttp),
 				),
 				NewBypassSubscriptionsCache(),
 			),
@@ -515,7 +523,7 @@ func Test_HasDefaults(t *testing.T) {
 			NewSubscriptionsManagerWithCache(
 				NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
-					mockHttp,
+					armClientOptions(mockHttp),
 				),
 				NewBypassSubscriptionsCache(),
 			),

--- a/cli/azd/pkg/account/subscriptions_manager_test.go
+++ b/cli/azd/pkg/account/subscriptions_manager_test.go
@@ -159,7 +159,7 @@ func TestSubscriptionsManager_ListSubscriptions(t *testing.T) {
 			subManager := &SubscriptionsManager{
 				service: NewSubscriptionsService(
 					&mocks.MockMultiTenantCredentialProvider{},
-					mockHttp,
+					armClientOptions(mockHttp),
 				),
 				cache:         NewBypassSubscriptionsCache(),
 				principalInfo: principalInfo,

--- a/cli/azd/pkg/azapi/deployments.go
+++ b/cli/azd/pkg/azapi/deployments.go
@@ -218,7 +218,7 @@ func (ds *deployments) createDeploymentsClient(
 		return nil, err
 	}
 
-	options := ds.clientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := ds.clientOptionsBuilder().BuildArmClientOptions()
 	client, err := armresources.NewDeploymentsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating deployments client: %w", err)
@@ -528,9 +528,9 @@ func createDeploymentError(err error) error {
 	return err
 }
 
-func (ds *deployments) clientOptionsBuilder(ctx context.Context) *azsdk.ClientOptionsBuilder {
+func (ds *deployments) clientOptionsBuilder() *azsdk.ClientOptionsBuilder {
 	return azsdk.NewClientOptionsBuilder().
 		WithTransport(ds.httpClient).
 		WithPerCallPolicy(azsdk.NewUserAgentPolicy(ds.userAgent)).
-		WithPerCallPolicy(azsdk.NewMsCorrelationPolicy(ctx))
+		WithPerCallPolicy(azsdk.NewMsCorrelationPolicy())
 }

--- a/cli/azd/pkg/azapi/deployments.go
+++ b/cli/azd/pkg/azapi/deployments.go
@@ -11,13 +11,11 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	azdinternal "github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
-	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
 type Deployments interface {
@@ -88,18 +86,16 @@ var (
 
 type deployments struct {
 	credentialProvider account.SubscriptionCredentialProvider
-	httpClient         httputil.HttpClient
-	userAgent          string
+	armClientOptions   *arm.ClientOptions
 }
 
 func NewDeployments(
 	credentialProvider account.SubscriptionCredentialProvider,
-	httpClient httputil.HttpClient,
+	armClientOptions *arm.ClientOptions,
 ) Deployments {
 	return &deployments{
 		credentialProvider: credentialProvider,
-		httpClient:         httpClient,
-		userAgent:          azdinternal.UserAgent(),
+		armClientOptions:   armClientOptions,
 	}
 }
 
@@ -218,8 +214,7 @@ func (ds *deployments) createDeploymentsClient(
 		return nil, err
 	}
 
-	options := ds.clientOptionsBuilder().BuildArmClientOptions()
-	client, err := armresources.NewDeploymentsClient(subscriptionId, credential, options)
+	client, err := armresources.NewDeploymentsClient(subscriptionId, credential, ds.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating deployments client: %w", err)
 	}
@@ -526,11 +521,4 @@ func createDeploymentError(err error) error {
 	}
 
 	return err
-}
-
-func (ds *deployments) clientOptionsBuilder() *azsdk.ClientOptionsBuilder {
-	return azsdk.NewClientOptionsBuilder().
-		WithTransport(ds.httpClient).
-		WithPerCallPolicy(azsdk.NewUserAgentPolicy(ds.userAgent)).
-		WithPerCallPolicy(azsdk.NewMsCorrelationPolicy())
 }

--- a/cli/azd/pkg/azapi/deployments_operations.go
+++ b/cli/azd/pkg/azapi/deployments_operations.go
@@ -9,11 +9,9 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	azdinternal "github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
-	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
 type DeploymentOperations interface {
@@ -32,19 +30,17 @@ type DeploymentOperations interface {
 
 func NewDeploymentOperations(
 	credentialProvider account.SubscriptionCredentialProvider,
-	httpClient httputil.HttpClient,
+	armClientOptions *arm.ClientOptions,
 ) DeploymentOperations {
 	return &deploymentOperations{
 		credentialProvider: credentialProvider,
-		httpClient:         httpClient,
-		userAgent:          azdinternal.UserAgent(),
+		armClientOptions:   armClientOptions,
 	}
 }
 
 type deploymentOperations struct {
 	credentialProvider account.SubscriptionCredentialProvider
-	httpClient         httputil.HttpClient
-	userAgent          string
+	armClientOptions   *arm.ClientOptions
 }
 
 func (dp *deploymentOperations) createDeploymentsOperationsClient(
@@ -56,8 +52,7 @@ func (dp *deploymentOperations) createDeploymentsOperationsClient(
 		return nil, err
 	}
 
-	options := dp.clientOptionsBuilder(ctx).BuildArmClientOptions()
-	client, err := armresources.NewDeploymentOperationsClient(subscriptionId, credential, options)
+	client, err := armresources.NewDeploymentOperationsClient(subscriptionId, credential, dp.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating deployments client: %w", err)
 	}
@@ -122,11 +117,4 @@ func (dp *deploymentOperations) ListResourceGroupDeploymentOperations(
 	}
 
 	return result, nil
-}
-
-func (dp *deploymentOperations) clientOptionsBuilder(ctx context.Context) *azsdk.ClientOptionsBuilder {
-	return azsdk.NewClientOptionsBuilder().
-		WithTransport(dp.httpClient).
-		WithPerCallPolicy(azsdk.NewUserAgentPolicy(dp.userAgent)).
-		WithPerCallPolicy(azsdk.NewMsCorrelationPolicy())
 }

--- a/cli/azd/pkg/azapi/deployments_operations.go
+++ b/cli/azd/pkg/azapi/deployments_operations.go
@@ -128,5 +128,5 @@ func (dp *deploymentOperations) clientOptionsBuilder(ctx context.Context) *azsdk
 	return azsdk.NewClientOptionsBuilder().
 		WithTransport(dp.httpClient).
 		WithPerCallPolicy(azsdk.NewUserAgentPolicy(dp.userAgent)).
-		WithPerCallPolicy(azsdk.NewMsCorrelationPolicy(ctx))
+		WithPerCallPolicy(azsdk.NewMsCorrelationPolicy())
 }

--- a/cli/azd/pkg/azd/default.go
+++ b/cli/azd/pkg/azd/default.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk/storage"
 	"github.com/azure/azure-dev/cli/azd/pkg/cosmosdb"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
@@ -109,7 +108,6 @@ func (p *DefaultPlatform) ConfigureContainer(container *ioc.NestedContainer) err
 	container.MustRegisterSingleton(storage.NewBlobSdkClient)
 
 	// cosmosdb
-	ioc.RegisterInstance(container, &arm.ClientOptions{})
 	container.MustRegisterSingleton(cosmosdb.NewCosmosDbService)
 
 	// sqldb

--- a/cli/azd/pkg/azsdk/azsdk.go
+++ b/cli/azd/pkg/azsdk/azsdk.go
@@ -1,14 +1,25 @@
 package azsdk
 
 import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
-func DefaultClientOptionsBuilder(
-	httpClient httputil.HttpClient,
-	userAgent string) *ClientOptionsBuilder {
+type ClientOptionsBuilderFactory struct {
+	defaultTransport policy.Transporter
+	defaultUserAgent string
+}
+
+func NewClientOptionsBuilderFactory(httpClient httputil.HttpClient, userAgent string) *ClientOptionsBuilderFactory {
+	return &ClientOptionsBuilderFactory{
+		defaultTransport: httpClient,
+		defaultUserAgent: userAgent,
+	}
+}
+
+func (c *ClientOptionsBuilderFactory) NewClientOptionsBuilder() *ClientOptionsBuilder {
 	return NewClientOptionsBuilder().
-		WithTransport(httpClient).
-		WithPerCallPolicy(NewUserAgentPolicy(userAgent)).
+		WithTransport(c.defaultTransport).
+		WithPerCallPolicy(NewUserAgentPolicy(c.defaultUserAgent)).
 		WithPerCallPolicy(NewMsCorrelationPolicy())
 }

--- a/cli/azd/pkg/azsdk/azsdk.go
+++ b/cli/azd/pkg/azsdk/azsdk.go
@@ -1,17 +1,14 @@
 package azsdk
 
 import (
-	"context"
-
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
 func DefaultClientOptionsBuilder(
-	ctx context.Context,
 	httpClient httputil.HttpClient,
 	userAgent string) *ClientOptionsBuilder {
 	return NewClientOptionsBuilder().
 		WithTransport(httpClient).
 		WithPerCallPolicy(NewUserAgentPolicy(userAgent)).
-		WithPerCallPolicy(NewMsCorrelationPolicy(ctx))
+		WithPerCallPolicy(NewMsCorrelationPolicy())
 }

--- a/cli/azd/pkg/azsdk/correlation_policy_test.go
+++ b/cli/azd/pkg/azsdk/correlation_policy_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
@@ -27,26 +28,57 @@ func init() {
 	}
 }
 
-func Test_msCorrelationPolicy_Do(t *testing.T) {
+func Test_simpleCorrelationPolicy_Do(t *testing.T) {
 	tests := []struct {
-		name   string
-		ctx    context.Context
-		expect *string
+		name                  string
+		ctx                   context.Context
+		expect                *string
+		headerName            string
+		correlationPolicyFunc func() policy.Policy
 	}{
 		{
-			name:   "WithTraceId",
-			ctx:    trace.ContextWithSpanContext(context.Background(), trace.SpanContext{}.WithTraceID(traceId)),
-			expect: convert.RefOf(traceId.String()),
+			name:                  "WithTraceId",
+			ctx:                   trace.ContextWithSpanContext(context.Background(), trace.SpanContext{}.WithTraceID(traceId)),
+			expect:                convert.RefOf(traceId.String()),
+			headerName:            cMsCorrelationIdHeader,
+			correlationPolicyFunc: NewMsCorrelationPolicy,
 		},
 		{
-			name:   "WithInvalidTraceId",
-			ctx:    trace.ContextWithSpanContext(context.Background(), trace.SpanContext{}.WithTraceID(invalidTraceId)),
-			expect: convert.RefOf(""),
+			name: "WithInvalidTraceId",
+			// nolint:lll
+			ctx:                   trace.ContextWithSpanContext(context.Background(), trace.SpanContext{}.WithTraceID(invalidTraceId)),
+			expect:                convert.RefOf(""),
+			headerName:            cMsCorrelationIdHeader,
+			correlationPolicyFunc: NewMsCorrelationPolicy,
 		},
 		{
-			name:   "WithoutTraceId",
-			ctx:    context.Background(),
-			expect: nil,
+			name:                  "WithoutTraceId",
+			ctx:                   context.Background(),
+			expect:                nil,
+			headerName:            cMsCorrelationIdHeader,
+			correlationPolicyFunc: NewMsCorrelationPolicy,
+		},
+		{
+			name:                  "WithTraceId",
+			ctx:                   trace.ContextWithSpanContext(context.Background(), trace.SpanContext{}.WithTraceID(traceId)),
+			expect:                convert.RefOf(traceId.String()),
+			headerName:            cMsGraphCorrelationIdHeader,
+			correlationPolicyFunc: NewMsGraphCorrelationPolicy,
+		},
+		{
+			name: "WithInvalidTraceId",
+			// nolint:lll
+			ctx:                   trace.ContextWithSpanContext(context.Background(), trace.SpanContext{}.WithTraceID(invalidTraceId)),
+			expect:                convert.RefOf(""),
+			headerName:            cMsGraphCorrelationIdHeader,
+			correlationPolicyFunc: NewMsGraphCorrelationPolicy,
+		},
+		{
+			name:                  "WithoutTraceId",
+			ctx:                   context.Background(),
+			expect:                nil,
+			headerName:            cMsGraphCorrelationIdHeader,
+			correlationPolicyFunc: NewMsGraphCorrelationPolicy,
 		},
 	}
 	for _, tt := range tests {
@@ -60,7 +92,7 @@ func Test_msCorrelationPolicy_Do(t *testing.T) {
 
 			clientOptions := NewClientOptionsBuilder().
 				WithTransport(httpClient).
-				WithPerCallPolicy(NewMsCorrelationPolicy(tt.ctx)).
+				WithPerCallPolicy(tt.correlationPolicyFunc()).
 				BuildArmClientOptions()
 
 			client, err := armresources.NewClient("SUBSCRIPTION_ID", &mocks.MockCredentials{}, clientOptions)
@@ -72,10 +104,10 @@ func Test_msCorrelationPolicy_Do(t *testing.T) {
 			_, _ = client.GetByID(ctx, "RESOURCE_ID", "", nil)
 
 			if tt.expect != nil {
-				require.Equal(t, response.Request.Header.Get(cMsCorrelationIdHeader), *tt.expect)
+				require.Equal(t, *tt.expect, response.Request.Header.Get(tt.headerName))
 			} else {
 				for header := range response.Request.Header {
-					if header == cMsCorrelationIdHeader {
+					if header == tt.headerName {
 						require.Fail(t, "should not contain correlation id header")
 					}
 				}

--- a/cli/azd/pkg/azsdk/storage/storage_blob_client.go
+++ b/cli/azd/pkg/azsdk/storage/storage_blob_client.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
-	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
 // AccountConfig contains the configuration for connecting to a storage account
@@ -171,15 +169,10 @@ func (bc *blobClient) ensureContainerExists(ctx context.Context) error {
 func NewBlobSdkClient(
 	credential azcore.TokenCredential,
 	accountConfig *AccountConfig,
-	httpClient httputil.HttpClient,
-	userAgent httputil.UserAgent,
+	coreClientOptions *azcore.ClientOptions,
 ) (*azblob.Client, error) {
-	coreOptions := azsdk.
-		DefaultClientOptionsBuilder(httpClient, string(userAgent)).
-		BuildCoreClientOptions()
-
 	blobOptions := &azblob.ClientOptions{
-		ClientOptions: *coreOptions,
+		ClientOptions: *coreClientOptions,
 	}
 
 	if accountConfig.Endpoint == "" {

--- a/cli/azd/pkg/azsdk/storage/storage_blob_client.go
+++ b/cli/azd/pkg/azsdk/storage/storage_blob_client.go
@@ -169,14 +169,13 @@ func (bc *blobClient) ensureContainerExists(ctx context.Context) error {
 
 // createClient creates a new blob client and caches it for future use
 func NewBlobSdkClient(
-	ctx context.Context,
 	credential azcore.TokenCredential,
 	accountConfig *AccountConfig,
 	httpClient httputil.HttpClient,
 	userAgent httputil.UserAgent,
 ) (*azblob.Client, error) {
 	coreOptions := azsdk.
-		DefaultClientOptionsBuilder(ctx, httpClient, string(userAgent)).
+		DefaultClientOptionsBuilder(httpClient, string(userAgent)).
 		BuildCoreClientOptions()
 
 	blobOptions := &azblob.ClientOptions{

--- a/cli/azd/pkg/azsdk/user_agent_policy_test.go
+++ b/cli/azd/pkg/azsdk/user_agent_policy_test.go
@@ -21,9 +21,8 @@ func TestOverrideUserAgent(t *testing.T) {
 		return mocks.CreateEmptyHttpResponse(request, http.StatusOK)
 	})
 
-	clientOptions := NewClientOptionsBuilder().
-		WithTransport(mockContext.HttpClient).
-		WithPerCallPolicy(NewUserAgentPolicy(expectedUserAgent)).
+	clientOptions := NewClientOptionsBuilderFactory(mockContext.HttpClient, expectedUserAgent).
+		NewClientOptionsBuilder().
 		BuildArmClientOptions()
 
 	client, err := armresources.NewClient("SUBSCRIPTION_ID", &mocks.MockCredentials{}, clientOptions)

--- a/cli/azd/pkg/azsdk/zip_deploy_client_test.go
+++ b/cli/azd/pkg/azsdk/zip_deploy_client_test.go
@@ -20,11 +20,7 @@ func TestZipDeploy(t *testing.T) {
 		registerDeployMocks(mockContext)
 		registerPollingMocks(mockContext)
 
-		options := NewClientOptionsBuilder().
-			WithTransport(mockContext.HttpClient).
-			BuildArmClientOptions()
-
-		client, err := NewZipDeployClient("SUBSCRIPTION_ID", &mocks.MockCredentials{}, options)
+		client, err := NewZipDeployClient("SUBSCRIPTION_ID", &mocks.MockCredentials{}, mockContext.ArmClientOptions)
 		require.NoError(t, err)
 
 		zipFile := bytes.NewBuffer([]byte{})
@@ -45,11 +41,7 @@ func TestZipDeploy(t *testing.T) {
 		registerDeployMocks(mockContext)
 		registerPollingErrorMocks(mockContext)
 
-		options := NewClientOptionsBuilder().
-			WithTransport(mockContext.HttpClient).
-			BuildArmClientOptions()
-
-		client, err := NewZipDeployClient("SUBSCRIPTION_ID", &mocks.MockCredentials{}, options)
+		client, err := NewZipDeployClient("SUBSCRIPTION_ID", &mocks.MockCredentials{}, mockContext.ArmClientOptions)
 		require.NoError(t, err)
 
 		zipFile := bytes.NewBuffer([]byte{})
@@ -69,11 +61,7 @@ func TestZipDeploy(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		registerConflictMocks(mockContext)
 
-		options := NewClientOptionsBuilder().
-			WithTransport(mockContext.HttpClient).
-			BuildArmClientOptions()
-
-		client, err := NewZipDeployClient("SUBSCRIPTION_ID", &mocks.MockCredentials{}, options)
+		client, err := NewZipDeployClient("SUBSCRIPTION_ID", &mocks.MockCredentials{}, mockContext.ArmClientOptions)
 		require.NoError(t, err)
 
 		zipFile := bytes.NewBuffer([]byte{})

--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -326,7 +326,7 @@ func (cas *containerAppService) createContainerAppsClient(
 		return nil, err
 	}
 
-	options := azsdk.DefaultClientOptionsBuilder(ctx, cas.httpClient, cas.userAgent).BuildArmClientOptions()
+	options := azsdk.DefaultClientOptionsBuilder(cas.httpClient, cas.userAgent).BuildArmClientOptions()
 	client, err := armappcontainers.NewContainerAppsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating ContainerApps client: %w", err)
@@ -344,7 +344,7 @@ func (cas *containerAppService) createRevisionsClient(
 		return nil, err
 	}
 
-	options := azsdk.DefaultClientOptionsBuilder(ctx, cas.httpClient, cas.userAgent).BuildArmClientOptions()
+	options := azsdk.DefaultClientOptionsBuilder(cas.httpClient, cas.userAgent).BuildArmClientOptions()
 	client, err := armappcontainers.NewContainerAppsRevisionsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating ContainerApps client: %w", err)

--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v2"
 	azdinternal "github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
-	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/benbjohnson/clock"
@@ -51,12 +51,14 @@ func NewContainerAppService(
 	credentialProvider account.SubscriptionCredentialProvider,
 	httpClient httputil.HttpClient,
 	clock clock.Clock,
+	armClientOptions *arm.ClientOptions,
 ) ContainerAppService {
 	return &containerAppService{
 		credentialProvider: credentialProvider,
 		httpClient:         httpClient,
 		userAgent:          azdinternal.UserAgent(),
 		clock:              clock,
+		armClientOptions:   armClientOptions,
 	}
 }
 
@@ -65,6 +67,7 @@ type containerAppService struct {
 	httpClient         httputil.HttpClient
 	userAgent          string
 	clock              clock.Clock
+	armClientOptions   *arm.ClientOptions
 }
 
 type ContainerAppIngressConfiguration struct {
@@ -326,8 +329,7 @@ func (cas *containerAppService) createContainerAppsClient(
 		return nil, err
 	}
 
-	options := azsdk.DefaultClientOptionsBuilder(cas.httpClient, cas.userAgent).BuildArmClientOptions()
-	client, err := armappcontainers.NewContainerAppsClient(subscriptionId, credential, options)
+	client, err := armappcontainers.NewContainerAppsClient(subscriptionId, credential, cas.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating ContainerApps client: %w", err)
 	}
@@ -344,8 +346,7 @@ func (cas *containerAppService) createRevisionsClient(
 		return nil, err
 	}
 
-	options := azsdk.DefaultClientOptionsBuilder(cas.httpClient, cas.userAgent).BuildArmClientOptions()
-	client, err := armappcontainers.NewContainerAppsRevisionsClient(subscriptionId, credential, options)
+	client, err := armappcontainers.NewContainerAppsRevisionsClient(subscriptionId, credential, cas.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating ContainerApps client: %w", err)
 	}

--- a/cli/azd/pkg/containerapps/container_app_test.go
+++ b/cli/azd/pkg/containerapps/container_app_test.go
@@ -37,7 +37,7 @@ func Test_ContainerApp_GetIngressConfiguration(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	mockRequest := mockazsdk.MockContainerAppGet(mockContext, subscriptionId, resourceGroup, appName, containerApp)
 
-	cas := NewContainerAppService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, clock.NewMock())
+	cas := NewContainerAppService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, clock.NewMock(), mockContext.ArmClientOptions)
 	ingressConfig, err := cas.GetIngressConfiguration(*mockContext.Context, subscriptionId, resourceGroup, appName)
 	require.NoError(t, err)
 	require.NotNil(t, ingressConfig)
@@ -127,7 +127,7 @@ func Test_ContainerApp_AddRevision(t *testing.T) {
 		containerApp,
 	)
 
-	cas := NewContainerAppService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, clock.NewMock())
+	cas := NewContainerAppService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, clock.NewMock(), mockContext.ArmClientOptions)
 	err := cas.AddRevision(*mockContext.Context, subscriptionId, resourceGroup, appName, updatedImageName)
 	require.NoError(t, err)
 

--- a/cli/azd/pkg/containerapps/container_app_test.go
+++ b/cli/azd/pkg/containerapps/container_app_test.go
@@ -37,7 +37,12 @@ func Test_ContainerApp_GetIngressConfiguration(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	mockRequest := mockazsdk.MockContainerAppGet(mockContext, subscriptionId, resourceGroup, appName, containerApp)
 
-	cas := NewContainerAppService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, clock.NewMock(), mockContext.ArmClientOptions)
+	cas := NewContainerAppService(
+		mockContext.SubscriptionCredentialProvider,
+		mockContext.HttpClient,
+		clock.NewMock(),
+		mockContext.ArmClientOptions,
+	)
 	ingressConfig, err := cas.GetIngressConfiguration(*mockContext.Context, subscriptionId, resourceGroup, appName)
 	require.NoError(t, err)
 	require.NotNil(t, ingressConfig)
@@ -127,7 +132,12 @@ func Test_ContainerApp_AddRevision(t *testing.T) {
 		containerApp,
 	)
 
-	cas := NewContainerAppService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, clock.NewMock(), mockContext.ArmClientOptions)
+	cas := NewContainerAppService(
+		mockContext.SubscriptionCredentialProvider,
+		mockContext.HttpClient,
+		clock.NewMock(),
+		mockContext.ArmClientOptions,
+	)
 	err := cas.AddRevision(*mockContext.Context, subscriptionId, resourceGroup, appName, updatedImageName)
 	require.NoError(t, err)
 

--- a/cli/azd/pkg/devcenter/environment_store_test.go
+++ b/cli/azd/pkg/devcenter/environment_store_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
-	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/devcentersdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
@@ -234,20 +233,12 @@ func newEnvironmentStoreForTest(
 	devCenterConfig *Config,
 	manager Manager,
 ) environment.RemoteDataStore {
-	coreOptions := azsdk.
-		DefaultClientOptionsBuilder(mockContext.HttpClient, "azd").
-		BuildCoreClientOptions()
-
-	armOptions := azsdk.
-		DefaultClientOptionsBuilder(mockContext.HttpClient, "azd").
-		BuildArmClientOptions()
-
-	resourceGraphClient, err := armresourcegraph.NewClient(mockContext.Credentials, armOptions)
+	resourceGraphClient, err := armresourcegraph.NewClient(mockContext.Credentials, mockContext.ArmClientOptions)
 	require.NoError(t, err)
 
 	devCenterClient, err := devcentersdk.NewDevCenterClient(
 		mockContext.Credentials,
-		coreOptions,
+		mockContext.CoreClientOptions,
 		resourceGraphClient,
 	)
 

--- a/cli/azd/pkg/devcenter/environment_store_test.go
+++ b/cli/azd/pkg/devcenter/environment_store_test.go
@@ -235,11 +235,11 @@ func newEnvironmentStoreForTest(
 	manager Manager,
 ) environment.RemoteDataStore {
 	coreOptions := azsdk.
-		DefaultClientOptionsBuilder(*mockContext.Context, mockContext.HttpClient, "azd").
+		DefaultClientOptionsBuilder(mockContext.HttpClient, "azd").
 		BuildCoreClientOptions()
 
 	armOptions := azsdk.
-		DefaultClientOptionsBuilder(*mockContext.Context, mockContext.HttpClient, "azd").
+		DefaultClientOptionsBuilder(mockContext.HttpClient, "azd").
 		BuildArmClientOptions()
 
 	resourceGraphClient, err := armresourcegraph.NewClient(mockContext.Credentials, armOptions)

--- a/cli/azd/pkg/devcenter/platform.go
+++ b/cli/azd/pkg/devcenter/platform.go
@@ -165,13 +165,12 @@ func (p *Platform) ConfigureContainer(container *ioc.NestedContainer) error {
 
 	// Other devcenter components
 	container.MustRegisterSingleton(func(
-		ctx context.Context,
 		credential azcore.TokenCredential,
 		httpClient httputil.HttpClient,
 		resourceGraphClient *armresourcegraph.Client,
 	) (devcentersdk.DevCenterClient, error) {
 		options := azsdk.
-			DefaultClientOptionsBuilder(ctx, httpClient, "azd").
+			DefaultClientOptionsBuilder(httpClient, "azd").
 			BuildCoreClientOptions()
 
 		return devcentersdk.NewDevCenterClient(credential, options, resourceGraphClient)

--- a/cli/azd/pkg/devcenter/platform.go
+++ b/cli/azd/pkg/devcenter/platform.go
@@ -169,8 +169,9 @@ func (p *Platform) ConfigureContainer(container *ioc.NestedContainer) error {
 		httpClient httputil.HttpClient,
 		resourceGraphClient *armresourcegraph.Client,
 	) (devcentersdk.DevCenterClient, error) {
-		options := azsdk.
-			DefaultClientOptionsBuilder(httpClient, "azd").
+		options := azsdk.NewClientOptionsBuilderFactory(httpClient, "azd").
+			NewClientOptionsBuilder().
+			WithPerCallPolicy(azsdk.NewMsCorrelationPolicy()).
 			BuildCoreClientOptions()
 
 		return devcentersdk.NewDevCenterClient(credential, options, resourceGraphClient)

--- a/cli/azd/pkg/devcenter/prompter_test.go
+++ b/cli/azd/pkg/devcenter/prompter_test.go
@@ -412,11 +412,11 @@ func Test_Prompt_Parameters(t *testing.T) {
 
 func newPrompterForTest(t *testing.T, mockContext *mocks.MockContext, config *Config, manager Manager) *Prompter {
 	coreOptions := azsdk.
-		DefaultClientOptionsBuilder(*mockContext.Context, mockContext.HttpClient, "azd").
+		DefaultClientOptionsBuilder(mockContext.HttpClient, "azd").
 		BuildCoreClientOptions()
 
 	armOptions := azsdk.
-		DefaultClientOptionsBuilder(*mockContext.Context, mockContext.HttpClient, "azd").
+		DefaultClientOptionsBuilder(mockContext.HttpClient, "azd").
 		BuildArmClientOptions()
 
 	resourceGraphClient, err := armresourcegraph.NewClient(mockContext.Credentials, armOptions)

--- a/cli/azd/pkg/devcenter/prompter_test.go
+++ b/cli/azd/pkg/devcenter/prompter_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
-	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/devcentersdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -411,20 +410,12 @@ func Test_Prompt_Parameters(t *testing.T) {
 }
 
 func newPrompterForTest(t *testing.T, mockContext *mocks.MockContext, config *Config, manager Manager) *Prompter {
-	coreOptions := azsdk.
-		DefaultClientOptionsBuilder(mockContext.HttpClient, "azd").
-		BuildCoreClientOptions()
-
-	armOptions := azsdk.
-		DefaultClientOptionsBuilder(mockContext.HttpClient, "azd").
-		BuildArmClientOptions()
-
-	resourceGraphClient, err := armresourcegraph.NewClient(mockContext.Credentials, armOptions)
+	resourceGraphClient, err := armresourcegraph.NewClient(mockContext.Credentials, mockContext.ArmClientOptions)
 	require.NoError(t, err)
 
 	devCenterClient, err := devcentersdk.NewDevCenterClient(
 		mockContext.Credentials,
-		coreOptions,
+		mockContext.CoreClientOptions,
 		resourceGraphClient,
 	)
 

--- a/cli/azd/pkg/devcenter/provision_provider_test.go
+++ b/cli/azd/pkg/devcenter/provision_provider_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
-	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/devcentersdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
@@ -436,20 +435,12 @@ func newProvisionProviderForTest(
 	env *environment.Environment,
 	manager Manager,
 ) provisioning.Provider {
-	coreOptions := azsdk.
-		DefaultClientOptionsBuilder(mockContext.HttpClient, "azd").
-		BuildCoreClientOptions()
-
-	armOptions := azsdk.
-		DefaultClientOptionsBuilder(mockContext.HttpClient, "azd").
-		BuildArmClientOptions()
-
-	resourceGraphClient, err := armresourcegraph.NewClient(mockContext.Credentials, armOptions)
+	resourceGraphClient, err := armresourcegraph.NewClient(mockContext.Credentials, mockContext.ArmClientOptions)
 	require.NoError(t, err)
 
 	devCenterClient, err := devcentersdk.NewDevCenterClient(
 		mockContext.Credentials,
-		coreOptions,
+		mockContext.CoreClientOptions,
 		resourceGraphClient,
 	)
 

--- a/cli/azd/pkg/devcenter/provision_provider_test.go
+++ b/cli/azd/pkg/devcenter/provision_provider_test.go
@@ -437,11 +437,11 @@ func newProvisionProviderForTest(
 	manager Manager,
 ) provisioning.Provider {
 	coreOptions := azsdk.
-		DefaultClientOptionsBuilder(*mockContext.Context, mockContext.HttpClient, "azd").
+		DefaultClientOptionsBuilder(mockContext.HttpClient, "azd").
 		BuildCoreClientOptions()
 
 	armOptions := azsdk.
-		DefaultClientOptionsBuilder(*mockContext.Context, mockContext.HttpClient, "azd").
+		DefaultClientOptionsBuilder(mockContext.HttpClient, "azd").
 		BuildArmClientOptions()
 
 	resourceGraphClient, err := armresourcegraph.NewClient(mockContext.Credentials, armOptions)

--- a/cli/azd/pkg/devcenter/provision_provider_test.go
+++ b/cli/azd/pkg/devcenter/provision_provider_test.go
@@ -446,7 +446,12 @@ func newProvisionProviderForTest(
 
 	require.NoError(t, err)
 
-	azCli := azcli.NewAzCli(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, azcli.NewAzCliArgs{}, mockContext.ArmClientOptions)
+	azCli := azcli.NewAzCli(
+		mockContext.SubscriptionCredentialProvider,
+		mockContext.HttpClient,
+		azcli.NewAzCliArgs{},
+		mockContext.ArmClientOptions,
+	)
 	resourceManager := infra.NewAzureResourceManager(
 		azCli,
 		azapi.NewDeploymentOperations(mockContext.SubscriptionCredentialProvider, mockContext.ArmClientOptions),

--- a/cli/azd/pkg/devcenter/provision_provider_test.go
+++ b/cli/azd/pkg/devcenter/provision_provider_test.go
@@ -446,10 +446,10 @@ func newProvisionProviderForTest(
 
 	require.NoError(t, err)
 
-	azCli := azcli.NewAzCli(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, azcli.NewAzCliArgs{})
+	azCli := azcli.NewAzCli(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient, azcli.NewAzCliArgs{}, mockContext.ArmClientOptions)
 	resourceManager := infra.NewAzureResourceManager(
 		azCli,
-		azapi.NewDeploymentOperations(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient),
+		azapi.NewDeploymentOperations(mockContext.SubscriptionCredentialProvider, mockContext.ArmClientOptions),
 	)
 
 	if manager == nil {

--- a/cli/azd/pkg/devcenter/template_source_test.go
+++ b/cli/azd/pkg/devcenter/template_source_test.go
@@ -202,11 +202,11 @@ func newTemplateSourceForTest(
 	manager Manager,
 ) *TemplateSource {
 	coreOptions := azsdk.
-		DefaultClientOptionsBuilder(*mockContext.Context, mockContext.HttpClient, "azd").
+		DefaultClientOptionsBuilder(mockContext.HttpClient, "azd").
 		BuildCoreClientOptions()
 
 	armOptions := azsdk.
-		DefaultClientOptionsBuilder(*mockContext.Context, mockContext.HttpClient, "azd").
+		DefaultClientOptionsBuilder(mockContext.HttpClient, "azd").
 		BuildArmClientOptions()
 
 	resourceGraphClient, err := armresourcegraph.NewClient(mockContext.Credentials, armOptions)

--- a/cli/azd/pkg/devcenter/template_source_test.go
+++ b/cli/azd/pkg/devcenter/template_source_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
-	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/devcentersdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/templates"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -201,20 +200,12 @@ func newTemplateSourceForTest(
 	config *Config,
 	manager Manager,
 ) *TemplateSource {
-	coreOptions := azsdk.
-		DefaultClientOptionsBuilder(mockContext.HttpClient, "azd").
-		BuildCoreClientOptions()
-
-	armOptions := azsdk.
-		DefaultClientOptionsBuilder(mockContext.HttpClient, "azd").
-		BuildArmClientOptions()
-
-	resourceGraphClient, err := armresourcegraph.NewClient(mockContext.Credentials, armOptions)
+	resourceGraphClient, err := armresourcegraph.NewClient(mockContext.Credentials, mockContext.ArmClientOptions)
 	require.NoError(t, err)
 
 	devCenterClient, err := devcentersdk.NewDevCenterClient(
 		mockContext.Credentials,
-		coreOptions,
+		mockContext.CoreClientOptions,
 		resourceGraphClient,
 	)
 

--- a/cli/azd/pkg/devcentersdk/developer_client_test.go
+++ b/cli/azd/pkg/devcentersdk/developer_client_test.go
@@ -32,11 +32,11 @@ func Test_DevCenter_Client(t *testing.T) {
 	require.NoError(t, err)
 
 	options := azsdk.
-		DefaultClientOptionsBuilder(*mockContext.Context, http.DefaultClient, "azd").
+		DefaultClientOptionsBuilder(http.DefaultClient, "azd").
 		BuildCoreClientOptions()
 
 	armOptions := azsdk.
-		DefaultClientOptionsBuilder(*mockContext.Context, http.DefaultClient, "azd").
+		DefaultClientOptionsBuilder(http.DefaultClient, "azd").
 		BuildArmClientOptions()
 
 	resourceGraphClient, err := armresourcegraph.NewClient(credentials, armOptions)

--- a/cli/azd/pkg/devcentersdk/developer_client_test.go
+++ b/cli/azd/pkg/devcentersdk/developer_client_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
-	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
@@ -31,18 +30,10 @@ func Test_DevCenter_Client(t *testing.T) {
 	credentials, err := authManager.CredentialForCurrentUser(*mockContext.Context, nil)
 	require.NoError(t, err)
 
-	options := azsdk.
-		DefaultClientOptionsBuilder(http.DefaultClient, "azd").
-		BuildCoreClientOptions()
-
-	armOptions := azsdk.
-		DefaultClientOptionsBuilder(http.DefaultClient, "azd").
-		BuildArmClientOptions()
-
-	resourceGraphClient, err := armresourcegraph.NewClient(credentials, armOptions)
+	resourceGraphClient, err := armresourcegraph.NewClient(credentials, mockContext.ArmClientOptions)
 	require.NoError(t, err)
 
-	client, err := NewDevCenterClient(credentials, options, resourceGraphClient)
+	client, err := NewDevCenterClient(credentials, mockContext.CoreClientOptions, resourceGraphClient)
 	require.NoError(t, err)
 
 	// Get dev center list

--- a/cli/azd/pkg/devcentersdk/permissions_request_builder.go
+++ b/cli/azd/pkg/devcentersdk/permissions_request_builder.go
@@ -33,7 +33,7 @@ func (c *PermissionListRequestBuilder) Get(ctx context.Context) ([]*armauthoriza
 		return nil, err
 	}
 
-	options := azsdk.DefaultClientOptionsBuilder(ctx, c.client.options.Transport, "azd").BuildArmClientOptions()
+	options := azsdk.DefaultClientOptionsBuilder(c.client.options.Transport, "azd").BuildArmClientOptions()
 	permissionsClient, err := armauthorization.NewPermissionsClient(project.SubscriptionId, c.client.credential, options)
 	if err != nil {
 		return nil, err

--- a/cli/azd/pkg/devcentersdk/permissions_request_builder.go
+++ b/cli/azd/pkg/devcentersdk/permissions_request_builder.go
@@ -33,7 +33,10 @@ func (c *PermissionListRequestBuilder) Get(ctx context.Context) ([]*armauthoriza
 		return nil, err
 	}
 
-	options := azsdk.DefaultClientOptionsBuilder(c.client.options.Transport, "azd").BuildArmClientOptions()
+	options := azsdk.NewClientOptionsBuilderFactory(c.client.options.Transport, "azd").
+		NewClientOptionsBuilder().
+		WithPerCallPolicy(azsdk.NewMsCorrelationPolicy()).
+		BuildArmClientOptions()
 	permissionsClient, err := armauthorization.NewPermissionsClient(project.SubscriptionId, c.client.credential, options)
 	if err != nil {
 		return nil, err

--- a/cli/azd/pkg/environment/manager_test.go
+++ b/cli/azd/pkg/environment/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk/storage"
@@ -364,6 +365,9 @@ func registerContainerComponents(t *testing.T, mockContext *mocks.MockContext) {
 	mockContext.Container.MustRegisterSingleton(NewLocalFileDataStore)
 	mockContext.Container.MustRegisterNamedSingleton(string(RemoteKindAzureBlobStorage), NewStorageBlobDataStore)
 
+	mockContext.Container.MustRegisterSingleton(func() *azcore.ClientOptions {
+		return mockContext.CoreClientOptions
+	})
 	mockContext.Container.MustRegisterSingleton(storage.NewBlobSdkClient)
 	mockContext.Container.MustRegisterSingleton(config.NewManager)
 	mockContext.Container.MustRegisterSingleton(storage.NewBlobClient)

--- a/cli/azd/pkg/graphsdk/util_test.go
+++ b/cli/azd/pkg/graphsdk/util_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
-	"github.com/azure/azure-dev/cli/azd/test/mocks/mockgraphsdk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,8 +44,7 @@ func TestNewPipeline(t *testing.T) {
 		},
 	}
 
-	clientOptions := mockgraphsdk.CreateDefaultClientOptions(mockContext)
-	pipeline := graphsdk.NewPipeline(&credential, graphsdk.ServiceConfig, clientOptions)
+	pipeline := graphsdk.NewPipeline(&credential, graphsdk.ServiceConfig, mockContext.CoreClientOptions)
 	require.False(t, ran)
 	require.NotNil(t, pipeline)
 

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -392,7 +392,8 @@ func createBicepProvider(t *testing.T, mockContext *mocks.MockContext) *BicepPro
 				func(_ context.Context, _ string) (azcore.TokenCredential, error) {
 					return mockContext.Credentials, nil
 				}),
-			mockContext.HttpClient,
+			mockContext.ArmClientOptions,
+			mockContext.CoreClientOptions,
 		),
 	)
 
@@ -937,7 +938,8 @@ func TestUserDefinedTypes(t *testing.T) {
 				func(_ context.Context, _ string) (azcore.TokenCredential, error) {
 					return mockContext.Credentials, nil
 				}),
-			mockContext.HttpClient,
+			mockContext.ArmClientOptions,
+			mockContext.CoreClientOptions,
 		),
 	)
 	bicepProvider, gooCast := provider.(*BicepProvider)

--- a/cli/azd/pkg/keyvault/keyvault.go
+++ b/cli/azd/pkg/keyvault/keyvault.go
@@ -159,7 +159,7 @@ func (kvs *keyVaultService) createKeyVaultClient(
 		return nil, err
 	}
 
-	options := azsdk.DefaultClientOptionsBuilder(ctx, kvs.httpClient, kvs.userAgent).BuildArmClientOptions()
+	options := azsdk.DefaultClientOptionsBuilder(kvs.httpClient, kvs.userAgent).BuildArmClientOptions()
 	client, err := armkeyvault.NewVaultsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
@@ -180,7 +180,7 @@ func (kvs *keyVaultService) createSecretsDataClient(
 		return nil, err
 	}
 
-	coreOptions := azsdk.DefaultClientOptionsBuilder(ctx, kvs.httpClient, kvs.userAgent).BuildCoreClientOptions()
+	coreOptions := azsdk.DefaultClientOptionsBuilder(kvs.httpClient, kvs.userAgent).BuildCoreClientOptions()
 	options := &azsecrets.ClientOptions{
 		ClientOptions:                        *coreOptions,
 		DisableChallengeResourceVerification: false,

--- a/cli/azd/pkg/pipeline/github_provider_test.go
+++ b/cli/azd/pkg/pipeline/github_provider_test.go
@@ -121,7 +121,11 @@ func createGitHubCiProvider(t *testing.T, mockContext *mocks.MockContext) CiProv
 	return NewGitHubCiProvider(
 		env,
 		mockContext.SubscriptionCredentialProvider,
-		azcli.NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.ArmClientOptions, mockContext.CoreClientOptions),
+		azcli.NewAdService(
+			mockContext.SubscriptionCredentialProvider,
+			mockContext.ArmClientOptions,
+			mockContext.CoreClientOptions,
+		),
 		ghCli,
 		git.NewGitCli(mockContext.CommandRunner),
 		mockContext.Console,

--- a/cli/azd/pkg/pipeline/github_provider_test.go
+++ b/cli/azd/pkg/pipeline/github_provider_test.go
@@ -121,7 +121,7 @@ func createGitHubCiProvider(t *testing.T, mockContext *mocks.MockContext) CiProv
 	return NewGitHubCiProvider(
 		env,
 		mockContext.SubscriptionCredentialProvider,
-		azcli.NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient),
+		azcli.NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.ArmClientOptions, mockContext.CoreClientOptions),
 		ghCli,
 		git.NewGitCli(mockContext.CommandRunner),
 		mockContext.Console,

--- a/cli/azd/pkg/pipeline/pipeline_manager_test.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager_test.go
@@ -412,7 +412,11 @@ func createPipelineManager(
 	envManager := &mockenv.MockEnvManager{}
 	envManager.On("Save", mock.Anything, env).Return(nil)
 
-	adService := azcli.NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient)
+	adService := azcli.NewAdService(
+		mockContext.SubscriptionCredentialProvider,
+		mockContext.ArmClientOptions,
+		mockContext.CoreClientOptions,
+	)
 
 	// Singletons
 	ioc.RegisterInstance(mockContext.Container, *mockContext.Context)

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -823,8 +823,13 @@ func createAksServiceTarget(
 		On("GetTargetResource", *mockContext.Context, "SUBSCRIPTION_ID", serviceConfig).
 		Return(targetResource, nil)
 
-	managedClustersService := azcli.NewManagedClustersService(credentialProvider, mockContext.HttpClient)
-	containerRegistryService := azcli.NewContainerRegistryService(credentialProvider, mockContext.HttpClient, dockerCli)
+	managedClustersService := azcli.NewManagedClustersService(credentialProvider, mockContext.ArmClientOptions)
+	containerRegistryService := azcli.NewContainerRegistryService(
+		credentialProvider,
+		dockerCli,
+		mockContext.ArmClientOptions,
+		mockContext.CoreClientOptions,
+	)
 	containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), containerRegistryService, dockerCli)
 
 	if userConfig == nil {

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -133,7 +133,7 @@ func createContainerAppServiceTarget(
 	envManager := &mockenv.MockEnvManager{}
 	envManager.On("Save", *mockContext.Context, env).Return(nil)
 
-	containerAppService := containerapps.NewContainerAppService(credentialProvider, mockContext.HttpClient, clock.NewMock())
+	containerAppService := containerapps.NewContainerAppService(credentialProvider, mockContext.HttpClient, clock.NewMock(), mockContext.ArmClientOptions)
 	containerRegistryService := azcli.NewContainerRegistryService(credentialProvider, mockContext.HttpClient, dockerCli)
 	containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), containerRegistryService, dockerCli)
 	azCli := mockazcli.NewAzCliFromMockContext(mockContext)

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -133,8 +133,18 @@ func createContainerAppServiceTarget(
 	envManager := &mockenv.MockEnvManager{}
 	envManager.On("Save", *mockContext.Context, env).Return(nil)
 
-	containerAppService := containerapps.NewContainerAppService(credentialProvider, mockContext.HttpClient, clock.NewMock(), mockContext.ArmClientOptions)
-	containerRegistryService := azcli.NewContainerRegistryService(credentialProvider, mockContext.HttpClient, dockerCli)
+	containerAppService := containerapps.NewContainerAppService(
+		credentialProvider,
+		mockContext.HttpClient,
+		clock.NewMock(),
+		mockContext.ArmClientOptions,
+	)
+	containerRegistryService := azcli.NewContainerRegistryService(
+		credentialProvider,
+		dockerCli,
+		mockContext.ArmClientOptions,
+		mockContext.CoreClientOptions,
+	)
 	containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), containerRegistryService, dockerCli)
 	azCli := mockazcli.NewAzCliFromMockContext(mockContext)
 	depOpService := mockazcli.NewDeploymentOperationsServiceFromMockContext(mockContext)

--- a/cli/azd/pkg/tools/azcli/ad.go
+++ b/cli/azd/pkg/tools/azcli/ad.go
@@ -580,7 +580,7 @@ func (ad *adService) createRoleDefinitionsClient(
 		return nil, err
 	}
 
-	options := clientOptionsBuilder(ctx, ad.httpClient, ad.userAgent).BuildArmClientOptions()
+	options := clientOptionsBuilder(ad.httpClient, ad.userAgent).BuildArmClientOptions()
 	client, err := armauthorization.NewRoleDefinitionsClient(credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating ARM Role Definitions client: %w", err)
@@ -599,7 +599,7 @@ func (ad *adService) createRoleAssignmentsClient(
 		return nil, err
 	}
 
-	options := clientOptionsBuilder(ctx, ad.httpClient, ad.userAgent).BuildArmClientOptions()
+	options := clientOptionsBuilder(ad.httpClient, ad.userAgent).BuildArmClientOptions()
 	client, err := armauthorization.NewRoleAssignmentsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating ARM Role Assignments client: %w", err)
@@ -622,7 +622,7 @@ func (ad *adService) getOrCreateGraphClient(
 		return nil, err
 	}
 
-	options := clientOptionsBuilder(ctx, ad.httpClient, ad.userAgent).BuildCoreClientOptions()
+	options := clientOptionsBuilder(ad.httpClient, ad.userAgent).BuildCoreClientOptions()
 	client, err := graphsdk.NewGraphClient(credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Graph Users client: %w", err)

--- a/cli/azd/pkg/tools/azcli/ad.go
+++ b/cli/azd/pkg/tools/azcli/ad.go
@@ -9,13 +9,12 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization"
-	azdinternal "github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/google/uuid"
 	"github.com/sethvargo/go-retry"
 )
@@ -74,21 +73,22 @@ type AdService interface {
 
 type adService struct {
 	credentialProvider account.SubscriptionCredentialProvider
-	httpClient         httputil.HttpClient
-	userAgent          string
 	clientCache        map[string]*graphsdk.GraphClient
+	armClientOptions   *arm.ClientOptions
+	coreClientOptions  *azcore.ClientOptions
 }
 
 // Creates a new instance of the AdService
 func NewAdService(
 	credentialProvider account.SubscriptionCredentialProvider,
-	httpClient httputil.HttpClient,
+	armClientOptions *arm.ClientOptions,
+	coreClientOptions *azcore.ClientOptions,
 ) AdService {
 	return &adService{
 		credentialProvider: credentialProvider,
-		httpClient:         httpClient,
-		userAgent:          azdinternal.UserAgent(),
 		clientCache:        map[string]*graphsdk.GraphClient{},
+		armClientOptions:   armClientOptions,
+		coreClientOptions:  coreClientOptions,
 	}
 }
 
@@ -580,8 +580,7 @@ func (ad *adService) createRoleDefinitionsClient(
 		return nil, err
 	}
 
-	options := clientOptionsBuilder(ad.httpClient, ad.userAgent).BuildArmClientOptions()
-	client, err := armauthorization.NewRoleDefinitionsClient(credential, options)
+	client, err := armauthorization.NewRoleDefinitionsClient(credential, ad.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating ARM Role Definitions client: %w", err)
 	}
@@ -599,8 +598,7 @@ func (ad *adService) createRoleAssignmentsClient(
 		return nil, err
 	}
 
-	options := clientOptionsBuilder(ad.httpClient, ad.userAgent).BuildArmClientOptions()
-	client, err := armauthorization.NewRoleAssignmentsClient(subscriptionId, credential, options)
+	client, err := armauthorization.NewRoleAssignmentsClient(subscriptionId, credential, ad.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating ARM Role Assignments client: %w", err)
 	}
@@ -622,8 +620,7 @@ func (ad *adService) getOrCreateGraphClient(
 		return nil, err
 	}
 
-	options := clientOptionsBuilder(ad.httpClient, ad.userAgent).BuildCoreClientOptions()
-	client, err := graphsdk.NewGraphClient(credential, options)
+	client, err := graphsdk.NewGraphClient(credential, ad.coreClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating Graph Users client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/ad_test.go
+++ b/cli/azd/pkg/tools/azcli/ad_test.go
@@ -68,7 +68,11 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 		mockgraphsdk.RegisterRoleDefinitionListMock(mockContext, http.StatusOK, roleDefinitions)
 		mockgraphsdk.RegisterRoleAssignmentPutMock(mockContext, http.StatusCreated)
 
-		adService := NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient)
+		adService := NewAdService(
+			mockContext.SubscriptionCredentialProvider,
+			mockContext.ArmClientOptions,
+			mockContext.CoreClientOptions,
+		)
 		servicePrincipal, err := adService.CreateOrUpdateServicePrincipal(
 			*mockContext.Context,
 			expectedServicePrincipalCredential.SubscriptionId,
@@ -109,7 +113,11 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 		mockgraphsdk.RegisterRoleDefinitionListMock(mockContext, http.StatusOK, roleDefinitions)
 		mockgraphsdk.RegisterRoleAssignmentPutMock(mockContext, http.StatusCreated)
 
-		adService := NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient)
+		adService := NewAdService(
+			mockContext.SubscriptionCredentialProvider,
+			mockContext.ArmClientOptions,
+			mockContext.CoreClientOptions,
+		)
 		servicePrincipal, err := adService.CreateOrUpdateServicePrincipal(
 			*mockContext.Context,
 			expectedServicePrincipalCredential.SubscriptionId,
@@ -147,7 +155,11 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 		// Note how role assignment returns a 409 conflict
 		mockgraphsdk.RegisterRoleAssignmentPutMock(mockContext, http.StatusConflict)
 
-		adService := NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient)
+		adService := NewAdService(
+			mockContext.SubscriptionCredentialProvider,
+			mockContext.ArmClientOptions,
+			mockContext.CoreClientOptions,
+		)
 		servicePrincipal, err := adService.CreateOrUpdateServicePrincipal(
 			*mockContext.Context,
 			expectedServicePrincipalCredential.SubscriptionId,
@@ -180,7 +192,11 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 		// Note how retrieval of matching role assignments is empty
 		mockgraphsdk.RegisterRoleDefinitionListMock(mockContext, http.StatusOK, []*armauthorization.RoleDefinition{})
 
-		adService := NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient)
+		adService := NewAdService(
+			mockContext.SubscriptionCredentialProvider,
+			mockContext.ArmClientOptions,
+			mockContext.CoreClientOptions,
+		)
 		servicePrincipal, err := adService.CreateOrUpdateServicePrincipal(
 			*mockContext.Context,
 			expectedServicePrincipalCredential.SubscriptionId,
@@ -200,7 +216,11 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 		// Note that the application creation returns an unauthorized error
 		mockgraphsdk.RegisterApplicationCreateItemMock(mockContext, http.StatusUnauthorized, nil)
 
-		adService := NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient)
+		adService := NewAdService(
+			mockContext.SubscriptionCredentialProvider,
+			mockContext.ArmClientOptions,
+			mockContext.CoreClientOptions,
+		)
 		servicePrincipal, err := adService.CreateOrUpdateServicePrincipal(
 			*mockContext.Context,
 			expectedServicePrincipalCredential.SubscriptionId,
@@ -224,7 +244,11 @@ func Test_ApplyFederatedCredentials(t *testing.T) {
 	t.Run("AppNotFound", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		mockgraphsdk.RegisterApplicationGetItemByAppIdMock(mockContext, http.StatusNotFound, *mockApplication.AppId, nil)
-		adService := NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient)
+		adService := NewAdService(
+			mockContext.SubscriptionCredentialProvider,
+			mockContext.ArmClientOptions,
+			mockContext.CoreClientOptions,
+		)
 
 		credentials, err := adService.ApplyFederatedCredentials(
 			*mockContext.Context,
@@ -276,7 +300,11 @@ func Test_ApplyFederatedCredentials(t *testing.T) {
 			http.StatusCreated,
 			&graphsdk.FederatedIdentityCredential{},
 		)
-		adService := NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient)
+		adService := NewAdService(
+			mockContext.SubscriptionCredentialProvider,
+			mockContext.ArmClientOptions,
+			mockContext.CoreClientOptions,
+		)
 
 		credentials, err := adService.ApplyFederatedCredentials(
 			*mockContext.Context,
@@ -337,7 +365,11 @@ func Test_ApplyFederatedCredentials(t *testing.T) {
 			http.StatusCreated,
 			&graphsdk.FederatedIdentityCredential{},
 		)
-		adService := NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient)
+		adService := NewAdService(
+			mockContext.SubscriptionCredentialProvider,
+			mockContext.ArmClientOptions,
+			mockContext.CoreClientOptions,
+		)
 
 		credentials, err := adService.ApplyFederatedCredentials(
 			*mockContext.Context,
@@ -379,7 +411,11 @@ func Test_ApplyFederatedCredentials(t *testing.T) {
 			mockApplication,
 		)
 		mockgraphsdk.RegisterFederatedCredentialsListMock(mockContext, *mockApplication.Id, http.StatusOK, mockCredentials)
-		adService := NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient)
+		adService := NewAdService(
+			mockContext.SubscriptionCredentialProvider,
+			mockContext.ArmClientOptions,
+			mockContext.CoreClientOptions,
+		)
 
 		credentials, err := adService.ApplyFederatedCredentials(
 			*mockContext.Context,
@@ -438,7 +474,11 @@ func Test_ResetPasswordCredentials(t *testing.T) {
 			mockApplicationPassword,
 		)
 
-		adService := NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient)
+		adService := NewAdService(
+			mockContext.SubscriptionCredentialProvider,
+			mockContext.ArmClientOptions,
+			mockContext.CoreClientOptions,
+		)
 		credentials, err := adService.ResetPasswordCredentials(
 			*mockContext.Context,
 			"SUBSCRIPTION_ID",
@@ -456,7 +496,11 @@ func Test_ResetPasswordCredentials(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		mockgraphsdk.RegisterApplicationGetItemByAppIdMock(mockContext, http.StatusOK, *mockApplication.AppId, nil)
 
-		adService := NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient)
+		adService := NewAdService(
+			mockContext.SubscriptionCredentialProvider,
+			mockContext.ArmClientOptions,
+			mockContext.CoreClientOptions,
+		)
 		credentials, err := adService.ResetPasswordCredentials(
 			*mockContext.Context,
 			"SUBSCRIPTION_ID",
@@ -478,7 +522,11 @@ func Test_ResetPasswordCredentials(t *testing.T) {
 		mockgraphsdk.RegisterServicePrincipalListMock(mockContext, http.StatusOK, mockServicePrincipals)
 		mockgraphsdk.RegisterApplicationRemovePasswordMock(mockContext, http.StatusBadRequest, *mockApplication.Id)
 
-		adService := NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient)
+		adService := NewAdService(
+			mockContext.SubscriptionCredentialProvider,
+			mockContext.ArmClientOptions,
+			mockContext.CoreClientOptions,
+		)
 		credentials, err := adService.ResetPasswordCredentials(
 			*mockContext.Context,
 			"SUBSCRIPTION_ID",
@@ -501,7 +549,11 @@ func Test_ResetPasswordCredentials(t *testing.T) {
 		mockgraphsdk.RegisterApplicationRemovePasswordMock(mockContext, http.StatusNoContent, *mockApplication.Id)
 		mockgraphsdk.RegisterApplicationAddPasswordMock(mockContext, http.StatusBadRequest, *mockApplication.Id, nil)
 
-		adService := NewAdService(mockContext.SubscriptionCredentialProvider, mockContext.HttpClient)
+		adService := NewAdService(
+			mockContext.SubscriptionCredentialProvider,
+			mockContext.ArmClientOptions,
+			mockContext.CoreClientOptions,
+		)
 		credentials, err := adService.ResetPasswordCredentials(
 			*mockContext.Context,
 			"SUBSCRIPTION_ID",

--- a/cli/azd/pkg/tools/azcli/apim.go
+++ b/cli/azd/pkg/tools/azcli/apim.go
@@ -66,8 +66,7 @@ func (cli *azCli) createApimDeletedClient(
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder().BuildArmClientOptions()
-	apimClient, err := armapimanagement.NewDeletedServicesClient(subscriptionId, credential, options)
+	apimClient, err := armapimanagement.NewDeletedServicesClient(subscriptionId, credential, cli.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
 	}
@@ -85,8 +84,7 @@ func (cli *azCli) createApimClient(
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder().BuildArmClientOptions()
-	apimClient, err := armapimanagement.NewServiceClient(subscriptionId, credential, options)
+	apimClient, err := armapimanagement.NewServiceClient(subscriptionId, credential, cli.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/apim.go
+++ b/cli/azd/pkg/tools/azcli/apim.go
@@ -66,7 +66,7 @@ func (cli *azCli) createApimDeletedClient(
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder().BuildArmClientOptions()
 	apimClient, err := armapimanagement.NewDeletedServicesClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
@@ -85,7 +85,7 @@ func (cli *azCli) createApimClient(
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder().BuildArmClientOptions()
 	apimClient, err := armapimanagement.NewServiceClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)

--- a/cli/azd/pkg/tools/azcli/appconfig.go
+++ b/cli/azd/pkg/tools/azcli/appconfig.go
@@ -74,7 +74,11 @@ func (cli *azCli) createAppConfigClient(
 		return nil, err
 	}
 
-	appConfigStoresClient, err := armappconfiguration.NewConfigurationStoresClient(subscriptionId, credential, cli.armClientOptions)
+	appConfigStoresClient, err := armappconfiguration.NewConfigurationStoresClient(
+		subscriptionId,
+		credential,
+		cli.armClientOptions,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/appconfig.go
+++ b/cli/azd/pkg/tools/azcli/appconfig.go
@@ -74,7 +74,7 @@ func (cli *azCli) createAppConfigClient(
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder().BuildArmClientOptions()
 	appConfigStoresClient, err := armappconfiguration.NewConfigurationStoresClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)

--- a/cli/azd/pkg/tools/azcli/appconfig.go
+++ b/cli/azd/pkg/tools/azcli/appconfig.go
@@ -74,8 +74,7 @@ func (cli *azCli) createAppConfigClient(
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder().BuildArmClientOptions()
-	appConfigStoresClient, err := armappconfiguration.NewConfigurationStoresClient(subscriptionId, credential, options)
+	appConfigStoresClient, err := armappconfiguration.NewConfigurationStoresClient(subscriptionId, credential, cli.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -207,19 +207,18 @@ func (cli *azCli) UserAgent() string {
 	return cli.userAgent
 }
 
-func (cli *azCli) clientOptionsBuilder(ctx context.Context) *azsdk.ClientOptionsBuilder {
+func (cli *azCli) clientOptionsBuilder() *azsdk.ClientOptionsBuilder {
 	return azsdk.NewClientOptionsBuilder().
 		WithTransport(cli.httpClient).
 		WithPerCallPolicy(azsdk.NewUserAgentPolicy(cli.UserAgent())).
-		WithPerCallPolicy(azsdk.NewMsCorrelationPolicy(ctx))
+		WithPerCallPolicy(azsdk.NewMsCorrelationPolicy())
 }
 
 func clientOptionsBuilder(
-	ctx context.Context,
 	httpClient httputil.HttpClient,
 	userAgent string) *azsdk.ClientOptionsBuilder {
 	return azsdk.NewClientOptionsBuilder().
 		WithTransport(httpClient).
 		WithPerCallPolicy(azsdk.NewUserAgentPolicy(userAgent)).
-		WithPerCallPolicy(azsdk.NewMsCorrelationPolicy(ctx))
+		WithPerCallPolicy(azsdk.NewMsCorrelationPolicy())
 }

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -8,10 +8,9 @@ import (
 	"errors"
 	"io"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices"
-	azdinternal "github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
-	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
@@ -23,13 +22,6 @@ var (
 )
 
 type AzCli interface {
-	// SetUserAgent sets the user agent that's sent with each call to the Azure
-	// CLI via the `AZURE_HTTP_USER_AGENT` environment variable.
-	SetUserAgent(userAgent string)
-
-	// UserAgent gets the currently configured user agent
-	UserAgent() string
-
 	GetResource(
 		ctx context.Context,
 		subscriptionId string,
@@ -176,18 +168,18 @@ func NewAzCli(
 	credentialProvider account.SubscriptionCredentialProvider,
 	httpClient httputil.HttpClient,
 	args NewAzCliArgs,
+	armClientOptions *arm.ClientOptions,
 ) AzCli {
 	return &azCli{
 		credentialProvider: credentialProvider,
 		enableDebug:        args.EnableDebug,
 		enableTelemetry:    args.EnableTelemetry,
 		httpClient:         httpClient,
-		userAgent:          azdinternal.UserAgent(),
+		armClientOptions:   armClientOptions,
 	}
 }
 
 type azCli struct {
-	userAgent       string
 	enableDebug     bool
 	enableTelemetry bool
 
@@ -195,30 +187,6 @@ type azCli struct {
 	httpClient httputil.HttpClient
 
 	credentialProvider account.SubscriptionCredentialProvider
-}
 
-// SetUserAgent sets the user agent that's sent with each call to the Azure
-// CLI via the `AZURE_HTTP_USER_AGENT` environment variable.
-func (cli *azCli) SetUserAgent(userAgent string) {
-	cli.userAgent = userAgent
-}
-
-func (cli *azCli) UserAgent() string {
-	return cli.userAgent
-}
-
-func (cli *azCli) clientOptionsBuilder() *azsdk.ClientOptionsBuilder {
-	return azsdk.NewClientOptionsBuilder().
-		WithTransport(cli.httpClient).
-		WithPerCallPolicy(azsdk.NewUserAgentPolicy(cli.UserAgent())).
-		WithPerCallPolicy(azsdk.NewMsCorrelationPolicy())
-}
-
-func clientOptionsBuilder(
-	httpClient httputil.HttpClient,
-	userAgent string) *azsdk.ClientOptionsBuilder {
-	return azsdk.NewClientOptionsBuilder().
-		WithTransport(httpClient).
-		WithPerCallPolicy(azsdk.NewUserAgentPolicy(userAgent)).
-		WithPerCallPolicy(azsdk.NewMsCorrelationPolicy())
+	armClientOptions *arm.ClientOptions
 }

--- a/cli/azd/pkg/tools/azcli/azcli_test.go
+++ b/cli/azd/pkg/tools/azcli/azcli_test.go
@@ -94,5 +94,6 @@ func newAzCliFromMockContext(mockContext *mocks.MockContext) AzCli {
 		}),
 		mockContext.HttpClient,
 		NewAzCliArgs{},
+		mockContext.ArmClientOptions,
 	)
 }

--- a/cli/azd/pkg/tools/azcli/cognitive_service.go
+++ b/cli/azd/pkg/tools/azcli/cognitive_service.go
@@ -54,8 +54,7 @@ func (cli *azCli) createCognitiveAccountClient(
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder().BuildArmClientOptions()
-	client, err := armcognitiveservices.NewAccountsClient(subscriptionId, credential, options)
+	client, err := armcognitiveservices.NewAccountsClient(subscriptionId, credential, cli.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
 	}
@@ -70,8 +69,7 @@ func (cli *azCli) createDeletedCognitiveAccountClient(
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder().BuildArmClientOptions()
-	client, err := armcognitiveservices.NewDeletedAccountsClient(subscriptionId, credential, options)
+	client, err := armcognitiveservices.NewDeletedAccountsClient(subscriptionId, credential, cli.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/cognitive_service.go
+++ b/cli/azd/pkg/tools/azcli/cognitive_service.go
@@ -54,7 +54,7 @@ func (cli *azCli) createCognitiveAccountClient(
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder().BuildArmClientOptions()
 	client, err := armcognitiveservices.NewAccountsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
@@ -70,7 +70,7 @@ func (cli *azCli) createDeletedCognitiveAccountClient(
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder().BuildArmClientOptions()
 	client, err := armcognitiveservices.NewDeletedAccountsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)

--- a/cli/azd/pkg/tools/azcli/container_registry.go
+++ b/cli/azd/pkg/tools/azcli/container_registry.go
@@ -232,7 +232,7 @@ func (crs *containerRegistryService) createRegistriesClient(
 		return nil, err
 	}
 
-	options := clientOptionsBuilder(ctx, crs.httpClient, crs.userAgent).BuildArmClientOptions()
+	options := clientOptionsBuilder(crs.httpClient, crs.userAgent).BuildArmClientOptions()
 	client, err := armcontainerregistry.NewRegistriesClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating registries client: %w", err)
@@ -258,7 +258,7 @@ func (crs *containerRegistryService) getAcrToken(
 	}
 
 	// Implementation based on docs @ https://azure.github.io/acr/AAD-OAuth.html
-	options := clientOptionsBuilder(ctx, crs.httpClient, crs.userAgent).BuildCoreClientOptions()
+	options := clientOptionsBuilder(crs.httpClient, crs.userAgent).BuildCoreClientOptions()
 	pipeline := azruntime.NewPipeline("azd-acr", internal.Version, azruntime.PipelineOptions{}, options)
 
 	formData := url.Values{}

--- a/cli/azd/pkg/tools/azcli/container_registry.go
+++ b/cli/azd/pkg/tools/azcli/container_registry.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
@@ -48,21 +50,22 @@ type ContainerRegistryService interface {
 type containerRegistryService struct {
 	credentialProvider account.SubscriptionCredentialProvider
 	docker             docker.Docker
-	httpClient         httputil.HttpClient
-	userAgent          string
+	armClientOptions   *arm.ClientOptions
+	coreClientOptions  *azcore.ClientOptions
 }
 
 // Creates a new instance of the ContainerRegistryService
 func NewContainerRegistryService(
 	credentialProvider account.SubscriptionCredentialProvider,
-	httpClient httputil.HttpClient,
 	docker docker.Docker,
+	armClientOptions *arm.ClientOptions,
+	coreClientOptions *azcore.ClientOptions,
 ) ContainerRegistryService {
 	return &containerRegistryService{
 		credentialProvider: credentialProvider,
 		docker:             docker,
-		httpClient:         httpClient,
-		userAgent:          internal.UserAgent(),
+		armClientOptions:   armClientOptions,
+		coreClientOptions:  coreClientOptions,
 	}
 }
 
@@ -232,8 +235,7 @@ func (crs *containerRegistryService) createRegistriesClient(
 		return nil, err
 	}
 
-	options := clientOptionsBuilder(crs.httpClient, crs.userAgent).BuildArmClientOptions()
-	client, err := armcontainerregistry.NewRegistriesClient(subscriptionId, credential, options)
+	client, err := armcontainerregistry.NewRegistriesClient(subscriptionId, credential, crs.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating registries client: %w", err)
 	}
@@ -258,8 +260,7 @@ func (crs *containerRegistryService) getAcrToken(
 	}
 
 	// Implementation based on docs @ https://azure.github.io/acr/AAD-OAuth.html
-	options := clientOptionsBuilder(crs.httpClient, crs.userAgent).BuildCoreClientOptions()
-	pipeline := azruntime.NewPipeline("azd-acr", internal.Version, azruntime.PipelineOptions{}, options)
+	pipeline := azruntime.NewPipeline("azd-acr", internal.Version, azruntime.PipelineOptions{}, crs.coreClientOptions)
 
 	formData := url.Values{}
 	formData.Set("grant_type", "access_token")

--- a/cli/azd/pkg/tools/azcli/managed_clusters.go
+++ b/cli/azd/pkg/tools/azcli/managed_clusters.go
@@ -95,7 +95,7 @@ func (cs *managedClustersService) createManagedClusterClient(
 		return nil, err
 	}
 
-	options := clientOptionsBuilder(ctx, cs.httpClient, cs.userAgent).BuildArmClientOptions()
+	options := clientOptionsBuilder(cs.httpClient, cs.userAgent).BuildArmClientOptions()
 
 	client, err := armcontainerservice.NewManagedClustersClient(subscriptionId, credential, options)
 	if err != nil {

--- a/cli/azd/pkg/tools/azcli/managed_clusters.go
+++ b/cli/azd/pkg/tools/azcli/managed_clusters.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2"
-	azdinternal "github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
 // ManagedClustersService provides actions on top of Azure Kubernetes Service (AKS) Managed Clusters
@@ -30,19 +29,17 @@ type ManagedClustersService interface {
 
 type managedClustersService struct {
 	credentialProvider account.SubscriptionCredentialProvider
-	httpClient         httputil.HttpClient
-	userAgent          string
+	armClientOptions   *arm.ClientOptions
 }
 
 // Creates a new instance of the ManagedClustersService
 func NewManagedClustersService(
 	credentialProvider account.SubscriptionCredentialProvider,
-	httpClient httputil.HttpClient,
+	armClientOptions *arm.ClientOptions,
 ) ManagedClustersService {
 	return &managedClustersService{
 		credentialProvider: credentialProvider,
-		httpClient:         httpClient,
-		userAgent:          azdinternal.UserAgent(),
+		armClientOptions:   armClientOptions,
 	}
 }
 
@@ -95,9 +92,7 @@ func (cs *managedClustersService) createManagedClusterClient(
 		return nil, err
 	}
 
-	options := clientOptionsBuilder(cs.httpClient, cs.userAgent).BuildArmClientOptions()
-
-	client, err := armcontainerservice.NewManagedClustersClient(subscriptionId, credential, options)
+	client, err := armcontainerservice.NewManagedClustersClient(subscriptionId, credential, cs.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating managed clusters client, %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/managed_hsm.go
+++ b/cli/azd/pkg/tools/azcli/managed_hsm.go
@@ -77,7 +77,7 @@ func (cli *azCli) createManagedHSMClient(
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder().BuildArmClientOptions()
 	client, err := armkeyvault.NewManagedHsmsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)

--- a/cli/azd/pkg/tools/azcli/managed_hsm.go
+++ b/cli/azd/pkg/tools/azcli/managed_hsm.go
@@ -77,8 +77,7 @@ func (cli *azCli) createManagedHSMClient(
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder().BuildArmClientOptions()
-	client, err := armkeyvault.NewManagedHsmsClient(subscriptionId, credential, options)
+	client, err := armkeyvault.NewManagedHsmsClient(subscriptionId, credential, cli.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/resources.go
+++ b/cli/azd/pkg/tools/azcli/resources.go
@@ -162,7 +162,7 @@ func (cli *azCli) createResourcesClient(ctx context.Context, subscriptionId stri
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder().BuildArmClientOptions()
 	client, err := armresources.NewClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
@@ -180,7 +180,7 @@ func (cli *azCli) createResourceGroupClient(
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder().BuildArmClientOptions()
 	client, err := armresources.NewResourceGroupsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating ResourceGroup client: %w", err)

--- a/cli/azd/pkg/tools/azcli/resources.go
+++ b/cli/azd/pkg/tools/azcli/resources.go
@@ -162,8 +162,7 @@ func (cli *azCli) createResourcesClient(ctx context.Context, subscriptionId stri
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder().BuildArmClientOptions()
-	client, err := armresources.NewClient(subscriptionId, credential, options)
+	client, err := armresources.NewClient(subscriptionId, credential, cli.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating Resource client: %w", err)
 	}
@@ -180,8 +179,7 @@ func (cli *azCli) createResourceGroupClient(
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder().BuildArmClientOptions()
-	client, err := armresources.NewResourceGroupsClient(subscriptionId, credential, options)
+	client, err := armresources.NewResourceGroupsClient(subscriptionId, credential, cli.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating ResourceGroup client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/spring_app.go
+++ b/cli/azd/pkg/tools/azcli/spring_app.go
@@ -212,7 +212,7 @@ func (ss *springService) createSpringAppClient(
 		return nil, err
 	}
 
-	options := clientOptionsBuilder(ctx, ss.httpClient, ss.userAgent).BuildArmClientOptions()
+	options := clientOptionsBuilder(ss.httpClient, ss.userAgent).BuildArmClientOptions()
 	client, err := armappplatform.NewAppsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating SpringApp client: %w", err)
@@ -230,7 +230,7 @@ func (ss *springService) createSpringAppDeploymentClient(
 		return nil, err
 	}
 
-	options := clientOptionsBuilder(ctx, ss.httpClient, ss.userAgent).BuildArmClientOptions()
+	options := clientOptionsBuilder(ss.httpClient, ss.userAgent).BuildArmClientOptions()
 	client, err := armappplatform.NewDeploymentsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating SpringAppDeployment client: %w", err)

--- a/cli/azd/pkg/tools/azcli/spring_app.go
+++ b/cli/azd/pkg/tools/azcli/spring_app.go
@@ -7,12 +7,11 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appplatform/armappplatform/v2"
 	"github.com/Azure/azure-storage-file-go/azfile"
-	azdinternal "github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
 // SpringService provides artifacts upload/deploy and query to Azure Spring Apps (ASA)
@@ -57,19 +56,17 @@ type SpringService interface {
 
 type springService struct {
 	credentialProvider account.SubscriptionCredentialProvider
-	httpClient         httputil.HttpClient
-	userAgent          string
+	armClientOptions   *arm.ClientOptions
 }
 
 // Creates a new instance of the NewSpringService
 func NewSpringService(
 	credentialProvider account.SubscriptionCredentialProvider,
-	httpClient httputil.HttpClient,
+	armClientOptions *arm.ClientOptions,
 ) SpringService {
 	return &springService{
 		credentialProvider: credentialProvider,
-		httpClient:         httpClient,
-		userAgent:          azdinternal.UserAgent(),
+		armClientOptions:   armClientOptions,
 	}
 }
 
@@ -212,8 +209,7 @@ func (ss *springService) createSpringAppClient(
 		return nil, err
 	}
 
-	options := clientOptionsBuilder(ss.httpClient, ss.userAgent).BuildArmClientOptions()
-	client, err := armappplatform.NewAppsClient(subscriptionId, credential, options)
+	client, err := armappplatform.NewAppsClient(subscriptionId, credential, ss.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating SpringApp client: %w", err)
 	}
@@ -230,8 +226,7 @@ func (ss *springService) createSpringAppDeploymentClient(
 		return nil, err
 	}
 
-	options := clientOptionsBuilder(ss.httpClient, ss.userAgent).BuildArmClientOptions()
-	client, err := armappplatform.NewDeploymentsClient(subscriptionId, credential, options)
+	client, err := armappplatform.NewDeploymentsClient(subscriptionId, credential, ss.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating SpringAppDeployment client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/static_webapp.go
+++ b/cli/azd/pkg/tools/azcli/static_webapp.go
@@ -94,8 +94,7 @@ func (cli *azCli) createStaticSitesClient(
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder().BuildArmClientOptions()
-	client, err := armappservice.NewStaticSitesClient(subscriptionId, credential, options)
+	client, err := armappservice.NewStaticSitesClient(subscriptionId, credential, cli.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating Static Sites client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/static_webapp.go
+++ b/cli/azd/pkg/tools/azcli/static_webapp.go
@@ -94,7 +94,7 @@ func (cli *azCli) createStaticSitesClient(
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder().BuildArmClientOptions()
 	client, err := armappservice.NewStaticSitesClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating Static Sites client: %w", err)

--- a/cli/azd/pkg/tools/azcli/user_profile.go
+++ b/cli/azd/pkg/tools/azcli/user_profile.go
@@ -31,8 +31,8 @@ func NewUserProfileService(
 }
 
 func (u *UserProfileService) createGraphClient(ctx context.Context, tenantId string) (*graphsdk.GraphClient, error) {
-	options := clientOptionsBuilder(ctx, u.httpClient, u.userAgent).
-		WithPerCallPolicy(azsdk.NewMsGraphCorrelationPolicy(ctx)).
+	options := clientOptionsBuilder(u.httpClient, u.userAgent).
+		WithPerCallPolicy(azsdk.NewMsGraphCorrelationPolicy()).
 		BuildCoreClientOptions()
 	cred, err := u.credentialProvider.GetTokenCredential(ctx, tenantId)
 	if err != nil {

--- a/cli/azd/pkg/tools/azcli/user_profile_test.go
+++ b/cli/azd/pkg/tools/azcli/user_profile_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
@@ -27,11 +28,15 @@ func Test_GetUserAccessToken(t *testing.T) {
 	}
 
 	mockContext := mocks.NewMockContext(context.Background())
-	userProfile := NewUserProfileService(&mocks.MockMultiTenantCredentialProvider{
-		TokenMap: map[string]mocks.MockCredentials{
-			"": mockCredential,
+	clientOptionsBuilderFactory := azsdk.NewClientOptionsBuilderFactory(mockContext.HttpClient, "azd")
+	userProfile := NewUserProfileService(
+		&mocks.MockMultiTenantCredentialProvider{
+			TokenMap: map[string]mocks.MockCredentials{
+				"": mockCredential,
+			},
 		},
-	}, mockContext.HttpClient)
+		clientOptionsBuilderFactory,
+	)
 
 	actual, err := userProfile.GetAccessToken(*mockContext.Context, "")
 	require.NoError(t, err)
@@ -52,7 +57,8 @@ func Test_GetSignedInUserId(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		registerGetMeGraphMock(mockContext, http.StatusOK, &mockUserProfile)
 
-		userProfile := NewUserProfileService(&mocks.MockMultiTenantCredentialProvider{}, mockContext.HttpClient)
+		clientOptionsBuilderFactory := azsdk.NewClientOptionsBuilderFactory(mockContext.HttpClient, "azd")
+		userProfile := NewUserProfileService(&mocks.MockMultiTenantCredentialProvider{}, clientOptionsBuilderFactory)
 
 		userId, err := userProfile.GetSignedInUserId(*mockContext.Context, "")
 		require.NoError(t, err)
@@ -63,7 +69,8 @@ func Test_GetSignedInUserId(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		registerGetMeGraphMock(mockContext, http.StatusBadRequest, nil)
 
-		userProfile := NewUserProfileService(&mocks.MockMultiTenantCredentialProvider{}, mockContext.HttpClient)
+		clientOptionsBuilderFactory := azsdk.NewClientOptionsBuilderFactory(mockContext.HttpClient, "azd")
+		userProfile := NewUserProfileService(&mocks.MockMultiTenantCredentialProvider{}, clientOptionsBuilderFactory)
 
 		userId, err := userProfile.GetSignedInUserId(*mockContext.Context, "")
 		require.Error(t, err)

--- a/cli/azd/pkg/tools/azcli/webapp.go
+++ b/cli/azd/pkg/tools/azcli/webapp.go
@@ -61,8 +61,7 @@ func (cli *azCli) createWebAppsClient(ctx context.Context, subscriptionId string
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder().BuildArmClientOptions()
-	client, err := armappservice.NewWebAppsClient(subscriptionId, credential, options)
+	client, err := armappservice.NewWebAppsClient(subscriptionId, credential, cli.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating WebApps client: %w", err)
 	}
@@ -76,8 +75,7 @@ func (cli *azCli) createZipDeployClient(ctx context.Context, subscriptionId stri
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder().BuildArmClientOptions()
-	client, err := azsdk.NewZipDeployClient(subscriptionId, credential, options)
+	client, err := azsdk.NewZipDeployClient(subscriptionId, credential, cli.armClientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("creating WebApps client: %w", err)
 	}

--- a/cli/azd/pkg/tools/azcli/webapp.go
+++ b/cli/azd/pkg/tools/azcli/webapp.go
@@ -61,7 +61,7 @@ func (cli *azCli) createWebAppsClient(ctx context.Context, subscriptionId string
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder().BuildArmClientOptions()
 	client, err := armappservice.NewWebAppsClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating WebApps client: %w", err)
@@ -76,7 +76,7 @@ func (cli *azCli) createZipDeployClient(ctx context.Context, subscriptionId stri
 		return nil, err
 	}
 
-	options := cli.clientOptionsBuilder(ctx).BuildArmClientOptions()
+	options := cli.clientOptionsBuilder().BuildArmClientOptions()
 	client, err := azsdk.NewZipDeployClient(subscriptionId, credential, options)
 	if err != nil {
 		return nil, fmt.Errorf("creating WebApps client: %w", err)

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
@@ -172,18 +173,26 @@ func Test_CLI_InfraCreateAndDelete(t *testing.T) {
 		client = http.DefaultClient
 	}
 
+	armClientOptions := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: client,
+		},
+	}
 	azCli := azcli.NewAzCli(mockaccount.SubscriptionCredentialProviderFunc(
 		func(_ context.Context, _ string) (azcore.TokenCredential, error) {
 			return cred, nil
 		}),
 		client,
-		azcli.NewAzCliArgs{})
+		azcli.NewAzCliArgs{},
+		armClientOptions,
+	)
 	deploymentOperations := azapi.NewDeploymentOperations(
 		mockaccount.SubscriptionCredentialProviderFunc(
 			func(_ context.Context, _ string) (azcore.TokenCredential, error) {
 				return cred, nil
 			}),
-		client)
+		armClientOptions,
+	)
 
 	// Verify that resource groups are created with tag
 	resourceManager := infra.NewAzureResourceManager(azCli, deploymentOperations)
@@ -379,19 +388,27 @@ func Test_CLI_InfraCreateAndDeleteUpperCase(t *testing.T) {
 	if err != nil {
 		t.Fatal("could not create credential")
 	}
+	armClientOptions := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: client,
+		},
+	}
 
 	azCli := azcli.NewAzCli(mockaccount.SubscriptionCredentialProviderFunc(
 		func(_ context.Context, _ string) (azcore.TokenCredential, error) {
 			return cred, nil
 		}),
 		client,
-		azcli.NewAzCliArgs{})
+		azcli.NewAzCliArgs{},
+		armClientOptions,
+	)
 	deploymentOperations := azapi.NewDeploymentOperations(
 		mockaccount.SubscriptionCredentialProviderFunc(
 			func(_ context.Context, _ string) (azcore.TokenCredential, error) {
 				return cred, nil
 			}),
-		client)
+		armClientOptions,
+	)
 
 	// Verify that resource groups are created with tag
 	resourceManager := infra.NewAzureResourceManager(azCli, deploymentOperations)

--- a/cli/azd/test/functional/remote_state_test.go
+++ b/cli/azd/test/functional/remote_state_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
+	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk/storage"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
@@ -80,7 +81,11 @@ func createBlobClient(
 	credentials, err := authManager.CredentialForCurrentUser(*mockContext.Context, nil)
 	require.NoError(t, err)
 
-	sdkClient, err := storage.NewBlobSdkClient(credentials, storageConfig, httpClient, "azd")
+	coreClientOptions := azsdk.NewClientOptionsBuilderFactory(httpClient, "azd").
+		NewClientOptionsBuilder().
+		BuildCoreClientOptions()
+
+	sdkClient, err := storage.NewBlobSdkClient(credentials, storageConfig, coreClientOptions)
 	require.NoError(t, err)
 	require.NotNil(t, sdkClient)
 

--- a/cli/azd/test/functional/remote_state_test.go
+++ b/cli/azd/test/functional/remote_state_test.go
@@ -80,7 +80,7 @@ func createBlobClient(
 	credentials, err := authManager.CredentialForCurrentUser(*mockContext.Context, nil)
 	require.NoError(t, err)
 
-	sdkClient, err := storage.NewBlobSdkClient(*mockContext.Context, credentials, storageConfig, httpClient, "azd")
+	sdkClient, err := storage.NewBlobSdkClient(credentials, storageConfig, httpClient, "azd")
 	require.NoError(t, err)
 	require.NotNil(t, sdkClient)
 

--- a/cli/azd/test/mocks/mock_context.go
+++ b/cli/azd/test/mocks/mock_context.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
@@ -38,7 +40,10 @@ func NewMockContext(ctx context.Context) *MockContext {
 	configManager := mockconfig.NewMockConfigManager()
 	config := config.NewEmptyConfig()
 
-	clientOptions := azcore.ClientOptions{Transport: httpClient}
+	clientOptions := azcore.ClientOptions{
+		Transport:       httpClient,
+		PerCallPolicies: []policy.Policy{NewMockUserAgentPolicy(internal.UserAgent())},
+	}
 	armOptions := arm.ClientOptions{ClientOptions: clientOptions}
 
 	mockContext := &MockContext{

--- a/cli/azd/test/mocks/mock_context.go
+++ b/cli/azd/test/mocks/mock_context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
@@ -21,6 +22,8 @@ type MockContext struct {
 	Context                        *context.Context
 	Console                        *mockinput.MockConsole
 	HttpClient                     *mockhttp.MockHttpClient
+	CoreClientOptions              *azcore.ClientOptions
+	ArmClientOptions               *arm.ClientOptions
 	CommandRunner                  *mockexec.MockCommandRunner
 	ConfigManager                  *mockconfig.MockConfigManager
 	Container                      *ioc.NestedContainer
@@ -35,12 +38,17 @@ func NewMockContext(ctx context.Context) *MockContext {
 	configManager := mockconfig.NewMockConfigManager()
 	config := config.NewEmptyConfig()
 
+	clientOptions := azcore.ClientOptions{Transport: httpClient}
+	armOptions := arm.ClientOptions{ClientOptions: clientOptions}
+
 	mockContext := &MockContext{
 		Credentials:                    &MockCredentials{},
 		Context:                        &ctx,
 		Console:                        mockinput.NewMockConsole(),
 		CommandRunner:                  mockexec.NewMockCommandRunner(),
 		HttpClient:                     httpClient,
+		CoreClientOptions:              &clientOptions,
+		ArmClientOptions:               &armOptions,
 		ConfigManager:                  configManager,
 		SubscriptionCredentialProvider: &MockSubscriptionCredentialProvider{},
 		MultiTenantCredentialProvider:  &MockMultiTenantCredentialProvider{},

--- a/cli/azd/test/mocks/mock_user_agent_policy.go
+++ b/cli/azd/test/mocks/mock_user_agent_policy.go
@@ -1,0 +1,35 @@
+package mocks
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+// This is a mock of the UserAgentPolicy used in the azsdk package. Importing
+// the azsdk package would cause a circular dependency so we have to mock it.
+
+const userAgentHeaderName = "User-Agent"
+
+type mockUserAgentPolicy struct {
+	userAgent string
+}
+
+func NewMockUserAgentPolicy(userAgent string) *mockUserAgentPolicy {
+	return &mockUserAgentPolicy{userAgent: userAgent}
+}
+
+func (p *mockUserAgentPolicy) Do(req *policy.Request) (*http.Response, error) {
+	if strings.TrimSpace(p.userAgent) != "" {
+		rawRequest := req.Raw()
+		userAgent, ok := rawRequest.Header[userAgentHeaderName]
+		if !ok {
+			userAgent = []string{}
+		}
+		userAgent = append(userAgent, p.userAgent)
+		rawRequest.Header.Set(userAgentHeaderName, strings.Join(userAgent, ","))
+	}
+
+	return req.Next()
+}

--- a/cli/azd/test/mocks/mockazcli/mocks.go
+++ b/cli/azd/test/mocks/mockazcli/mocks.go
@@ -19,6 +19,7 @@ func NewAzCliFromMockContext(mockContext *mocks.MockContext) azcli.AzCli {
 		}),
 		mockContext.HttpClient,
 		azcli.NewAzCliArgs{},
+		mockContext.ArmClientOptions,
 	)
 }
 
@@ -28,7 +29,8 @@ func NewDeploymentOperationsServiceFromMockContext(
 		mockaccount.SubscriptionCredentialProviderFunc(func(_ context.Context, _ string) (azcore.TokenCredential, error) {
 			return mockContext.Credentials, nil
 		}),
-		mockContext.HttpClient)
+		mockContext.ArmClientOptions,
+	)
 }
 
 func NewDeploymentsServiceFromMockContext(
@@ -37,5 +39,6 @@ func NewDeploymentsServiceFromMockContext(
 		mockaccount.SubscriptionCredentialProviderFunc(func(_ context.Context, _ string) (azcore.TokenCredential, error) {
 			return mockContext.Credentials, nil
 		}),
-		mockContext.HttpClient)
+		mockContext.ArmClientOptions,
+	)
 }

--- a/cli/azd/test/mocks/mockgraphsdk/mocks.go
+++ b/cli/azd/test/mocks/mockgraphsdk/mocks.go
@@ -6,23 +6,19 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization"
-	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 )
 
 func CreateGraphClient(mockContext *mocks.MockContext) (*graphsdk.GraphClient, error) {
-	clientOptions := CreateDefaultClientOptions(mockContext)
-	clientOptions.Retry.RetryDelay = -1
+	clientOptions := &azcore.ClientOptions{
+		Transport: mockContext.HttpClient,
+		Retry:     policy.RetryOptions{RetryDelay: -1},
+	}
 	return graphsdk.NewGraphClient(mockContext.Credentials, clientOptions)
-}
-
-func CreateDefaultClientOptions(mockContext *mocks.MockContext) *azcore.ClientOptions {
-	return azsdk.NewClientOptionsBuilder().
-		WithTransport(mockContext.HttpClient).
-		BuildCoreClientOptions()
 }
 
 func RegisterApplicationListMock(mockContext *mocks.MockContext, statusCode int, applications []graphsdk.Application) {


### PR DESCRIPTION
Remove DefaultClientOptionsBuilder and consolidate similar client options production to a more central location.

There are a few places where the user agent is hardcoded as `azd` so the `ClientOptionsBuilderFactory` had to be referenced specifically in those cases. In other cases there are custom policies so a factory must be injected so that correct policies can be added as needed. Does it need to be this way or can we use the globally defined user agent? 