### PR TITLE
Don't set AKS context during provision preview

### DIFF
--- a/cli/azd/internal/cmd/provision.go
+++ b/cli/azd/internal/cmd/provision.go
@@ -245,11 +245,9 @@ func (p *ProvisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 	var deployResult *provisioning.DeployResult
 	var deployPreviewResult *provisioning.DeployPreviewResult
 
-	projectEventArgs := project.ProjectLifecycleEventArgs{
-		Project: p.projectConfig,
-	}
-
-	err = p.projectConfig.Invoke(ctx, project.ProjectEventProvision, projectEventArgs, func() error {
+	// If we are in preview mode we don't want to invoke the project lifecycle event
+	// Register the call for provisioning
+	provisionFunc := func() error {
 		var err error
 		if previewMode {
 			deployPreviewResult, err = p.provisionManager.Preview(ctx)
@@ -257,7 +255,19 @@ func (p *ProvisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 			deployResult, err = p.provisionManager.Deploy(ctx)
 		}
 		return err
-	})
+	}
+
+	// When in standard provision mode invoke the function through the project config invocation
+	// that will automatically trigger any registered handlers
+	if previewMode {
+		err = provisionFunc()
+	} else {
+		projectEventArgs := project.ProjectLifecycleEventArgs{
+			Project: p.projectConfig,
+		}
+
+		err = p.projectConfig.Invoke(ctx, project.ProjectEventProvision, projectEventArgs, provisionFunc)
+	}
 
 	if err != nil {
 		if p.formatter.Kind() == output.JsonFormat {

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -139,7 +139,13 @@ func (t *aksTarget) Initialize(ctx context.Context, serviceConfig *ServiceConfig
 	err := serviceConfig.Project.AddHandler(
 		"postprovision",
 		func(ctx context.Context, args ProjectLifecycleEventArgs) error {
-			return t.setK8sContext(ctx, serviceConfig, "postprovision")
+			// Only set the k8s context if we are not in preview mode
+			previewMode, has := args.Args["preview"]
+			if !has || !previewMode.(bool) {
+				return t.setK8sContext(ctx, serviceConfig, "postprovision")
+			}
+
+			return nil
 		},
 	)
 


### PR DESCRIPTION
Resolves #3447 

When calling `azd provision` with `--preview` AKS service target should not attempt to set the K8s context since resources are not expected to exist at this stage. 