### PR TITLE
Adds support for external container registries

### DIFF
--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -286,7 +286,7 @@ func (ch *ContainerHelper) Deploy(
 						errSuggestion := &azcli.ErrorWithSuggestion{
 							Err: err,
 							//nolint:lll
-							Suggestion: "When pushing to an external registry, ensure you have have successfully authenticated by calling 'docker login' and run 'azd deploy' again",
+							Suggestion: "When pushing to an external registry, ensure you have successfully authenticated by calling 'docker login' and run 'azd deploy' again",
 						}
 
 						task.SetError(errSuggestion)


### PR DESCRIPTION
Resolves #3241 

Allows pushing container images to external container registries.  

> [!IMPORTANT]
> Do to the various configurations and complexities of using each external container registry users will need to manually authenticate to the registry prior to calling `azd deploy`

## Prerequisites:

- Run `docker login` and authenticate to your external container registry following the setup/configuration of your registry provider

## Use Case: Pull from external container registry

```yaml
# azure.yaml

name: todo-nodejs-mongo-aca
metadata:
  template: todo-nodejs-mongo-aca@0.0.1-beta
services:
  nginx:
    image: docker.io/wbreza/nginx:latest
    host: containerapp
```

In this example during `azd deploy` the container will be pulled from `docker.io/wbreza/nginx:latest` and directly referenced by the container app service.

> [!IMPORTANT]
> Your containerapp infra configuration must configure credentials when pulling containers from private container registries.

## Use Case: Pull, tag & push to external registry on `azd deploy`

Given a project with the following configuration:

```yaml
# azure.yaml

name: todo-nodejs-mongo-aca
metadata:
  template: todo-nodejs-mongo-aca@0.0.1-beta
services:
  nginx:
    image: nginx
    host: containerapp
    docker:
      registry: docker.io/wbreza
      image: nginx
      tag: latest   
```

During a call to `azd deploy` the `nginx` image will be pulled from the configured `image`.  In this case it is a public image on docker hub.  The container/image will be retagged and pushed to the docker hub registry at `docker.io/wbreza`

## Use Case: Build, tag & push to external registry on `azd deploy`

Given a project with the following configuration:

```yaml
# azure.yaml

name: todo-nodejs-mongo-aca
metadata:
  template: todo-nodejs-mongo-aca@0.0.1-beta
services:
  api:
    project: ./src/api
    host: containerapp
    docker:
      registry: docker.io/wbreza
      image: todo-api
```

During `azd deploy` the container source will be built, tagged and push to `docker.io/wbreza`
