### PR TITLE
Re-enable provision preview in template tests

### DIFF
--- a/templates/tests/test-templates.sh
+++ b/templates/tests/test-templates.sh
@@ -102,8 +102,8 @@ function deployTemplate {
         azd env new "$3" --subscription "$4" --location "$5" --no-prompt
     fi
 
-    # echo "Create provision preview for $3..."
-    # azd provision -e "$3" --preview
+    echo "Create provision preview for $3..."
+    azd provision -e "$3" --preview
 
     echo "Provisioning infrastructure for $3..."
     azd provision -e "$3"


### PR DESCRIPTION
Re-enable provision preview to run after fixing #3449 