### PR TITLE
POC: Adds support for multiple containers for supported service targets (ACA/AKS)

### DIFF
--- a/cli/azd/cmd/middleware/hooks_test.go
+++ b/cli/azd/cmd/middleware/hooks_test.go
@@ -226,7 +226,7 @@ func Test_ServiceHooks_Registered(t *testing.T) {
 	}
 
 	serviceConfig := &project.ServiceConfig{
-		ComponentConfig: project.ComponentConfig{
+		ComponentConfig: &project.ComponentConfig{
 
 			Language:     "ts",
 			RelativePath: "./src/api",

--- a/cli/azd/cmd/middleware/hooks_test.go
+++ b/cli/azd/cmd/middleware/hooks_test.go
@@ -226,10 +226,13 @@ func Test_ServiceHooks_Registered(t *testing.T) {
 	}
 
 	serviceConfig := &project.ServiceConfig{
+		ComponentConfig: project.ComponentConfig{
+
+			Language:     "ts",
+			RelativePath: "./src/api",
+			Host:         "appservice",
+		},
 		EventDispatcher: ext.NewEventDispatcher[project.ServiceLifecycleEventArgs](project.ServiceEvents...),
-		Language:        "ts",
-		RelativePath:    "./src/api",
-		Host:            "appservice",
 		Hooks: map[string]*ext.HookConfig{
 			"predeploy": {
 				Shell: ext.ShellTypeBash,

--- a/cli/azd/pkg/azsdk/correlation_policy_test.go
+++ b/cli/azd/pkg/azsdk/correlation_policy_test.go
@@ -37,8 +37,11 @@ func Test_simpleCorrelationPolicy_Do(t *testing.T) {
 		correlationPolicyFunc func() policy.Policy
 	}{
 		{
-			name:                  "WithTraceId",
-			ctx:                   trace.ContextWithSpanContext(context.Background(), trace.SpanContext{}.WithTraceID(traceId)),
+			name: "WithTraceId",
+			ctx: trace.ContextWithSpanContext(
+				context.Background(),
+				trace.SpanContext{}.WithTraceID(traceId),
+			),
 			expect:                convert.RefOf(traceId.String()),
 			headerName:            cMsCorrelationIdHeader,
 			correlationPolicyFunc: NewMsCorrelationPolicy,
@@ -46,7 +49,10 @@ func Test_simpleCorrelationPolicy_Do(t *testing.T) {
 		{
 			name: "WithInvalidTraceId",
 			// nolint:lll
-			ctx:                   trace.ContextWithSpanContext(context.Background(), trace.SpanContext{}.WithTraceID(invalidTraceId)),
+			ctx: trace.ContextWithSpanContext(
+				context.Background(),
+				trace.SpanContext{}.WithTraceID(invalidTraceId),
+			),
 			expect:                convert.RefOf(""),
 			headerName:            cMsCorrelationIdHeader,
 			correlationPolicyFunc: NewMsCorrelationPolicy,
@@ -59,8 +65,11 @@ func Test_simpleCorrelationPolicy_Do(t *testing.T) {
 			correlationPolicyFunc: NewMsCorrelationPolicy,
 		},
 		{
-			name:                  "WithTraceId",
-			ctx:                   trace.ContextWithSpanContext(context.Background(), trace.SpanContext{}.WithTraceID(traceId)),
+			name: "WithTraceId",
+			ctx: trace.ContextWithSpanContext(
+				context.Background(),
+				trace.SpanContext{}.WithTraceID(traceId),
+			),
 			expect:                convert.RefOf(traceId.String()),
 			headerName:            cMsGraphCorrelationIdHeader,
 			correlationPolicyFunc: NewMsGraphCorrelationPolicy,
@@ -68,7 +77,10 @@ func Test_simpleCorrelationPolicy_Do(t *testing.T) {
 		{
 			name: "WithInvalidTraceId",
 			// nolint:lll
-			ctx:                   trace.ContextWithSpanContext(context.Background(), trace.SpanContext{}.WithTraceID(invalidTraceId)),
+			ctx: trace.ContextWithSpanContext(
+				context.Background(),
+				trace.SpanContext{}.WithTraceID(invalidTraceId),
+			),
 			expect:                convert.RefOf(""),
 			headerName:            cMsGraphCorrelationIdHeader,
 			correlationPolicyFunc: NewMsGraphCorrelationPolicy,

--- a/cli/azd/pkg/containerapps/container_app_test.go
+++ b/cli/azd/pkg/containerapps/container_app_test.go
@@ -138,13 +138,30 @@ func Test_ContainerApp_AddRevision(t *testing.T) {
 		clock.NewMock(),
 		mockContext.ArmClientOptions,
 	)
-	err := cas.AddRevision(
+
+	myApp, err := cas.Get(*mockContext.Context, subscriptionId, resourceGroup, appName)
+	require.NoError(t, err)
+	require.NotNil(t, myApp)
+
+	latestRevision, err := cas.GetRevision(
+		*mockContext.Context,
+		subscriptionId,
+		resourceGroup,
+		appName,
+		*myApp.Properties.LatestRevisionName,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, latestRevision)
+
+	latestRevision.Properties.Template.Containers[0].Image = &updatedImageName
+
+	err = cas.AddRevision(
 		*mockContext.Context,
 		subscriptionId,
 		resourceGroup,
 		appName,
 		containerApp,
-		revision,
+		latestRevision,
 	)
 	require.NoError(t, err)
 

--- a/cli/azd/pkg/containerapps/container_app_test.go
+++ b/cli/azd/pkg/containerapps/container_app_test.go
@@ -138,7 +138,14 @@ func Test_ContainerApp_AddRevision(t *testing.T) {
 		clock.NewMock(),
 		mockContext.ArmClientOptions,
 	)
-	err := cas.AddRevision(*mockContext.Context, subscriptionId, resourceGroup, appName, updatedImageName)
+	err := cas.AddRevision(
+		*mockContext.Context,
+		subscriptionId,
+		resourceGroup,
+		appName,
+		containerApp,
+		revision,
+	)
 	require.NoError(t, err)
 
 	// Verify lastest revision is read

--- a/cli/azd/pkg/helm/cli_test.go
+++ b/cli/azd/pkg/helm/cli_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,8 @@ func Test_Cli_AddRepo(t *testing.T) {
 				return exec.NewRunResult(0, "", ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.AddRepo(*mockContext.Context, repo)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -59,7 +61,8 @@ func Test_Cli_AddRepo(t *testing.T) {
 				return exec.NewRunResult(1, "", ""), errors.New("failed to add repo")
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.AddRepo(*mockContext.Context, repo)
 
 		require.True(t, ran)
@@ -84,7 +87,8 @@ func Test_Cli_UpdateRepo(t *testing.T) {
 				return exec.NewRunResult(0, "", ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.UpdateRepo(*mockContext.Context, "test")
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -110,7 +114,8 @@ func Test_Cli_UpdateRepo(t *testing.T) {
 				return exec.NewRunResult(1, "", ""), errors.New("failed to update repo")
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.UpdateRepo(*mockContext.Context, "test")
 
 		require.True(t, ran)
@@ -141,7 +146,8 @@ func Test_Cli_Install(t *testing.T) {
 				return exec.NewRunResult(0, "", ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.Install(*mockContext.Context, release)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -172,7 +178,8 @@ func Test_Cli_Install(t *testing.T) {
 				return exec.NewRunResult(0, "", ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.Install(*mockContext.Context, &releaseWithValues)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -200,7 +207,8 @@ func Test_Cli_Install(t *testing.T) {
 				return exec.NewRunResult(1, "", ""), errors.New("failed to install release")
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.Install(*mockContext.Context, release)
 
 		require.True(t, ran)
@@ -230,7 +238,8 @@ func Test_Cli_Upgrade(t *testing.T) {
 				return exec.NewRunResult(0, "", ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.Upgrade(*mockContext.Context, release)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -263,7 +272,8 @@ func Test_Cli_Upgrade(t *testing.T) {
 				return exec.NewRunResult(0, "", ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.Upgrade(*mockContext.Context, &releaseWithValues)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -298,7 +308,8 @@ func Test_Cli_Upgrade(t *testing.T) {
 				return exec.NewRunResult(0, "", ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.Upgrade(*mockContext.Context, &releaseWithVersion)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -333,7 +344,8 @@ func Test_Cli_Upgrade(t *testing.T) {
 				return exec.NewRunResult(0, "", ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.Upgrade(*mockContext.Context, &releaseWithNamespace)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -364,7 +376,8 @@ func Test_Cli_Upgrade(t *testing.T) {
 				return exec.NewRunResult(1, "", ""), errors.New("failed to upgrade release")
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.Upgrade(*mockContext.Context, release)
 
 		require.True(t, ran)
@@ -397,7 +410,8 @@ func Test_Cli_Status(t *testing.T) {
 				}`, ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		status, err := cli.Status(*mockContext.Context, release)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -434,7 +448,8 @@ func Test_Cli_Status(t *testing.T) {
 				}`, ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		status, err := cli.Status(*mockContext.Context, &releaseWithNamespace)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -464,7 +479,8 @@ func Test_Cli_Status(t *testing.T) {
 				return exec.NewRunResult(1, "", ""), errors.New("failed to get status")
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		_, err := cli.Status(*mockContext.Context, release)
 
 		require.True(t, ran)

--- a/cli/azd/pkg/helm/config.go
+++ b/cli/azd/pkg/helm/config.go
@@ -1,5 +1,7 @@
 package helm
 
+import "github.com/azure/azure-dev/cli/azd/pkg/osutil"
+
 type Config struct {
 	Repositories []*Repository `yaml:"repositories"`
 	Releases     []*Release    `yaml:"releases"`
@@ -11,9 +13,10 @@ type Repository struct {
 }
 
 type Release struct {
-	Name      string `yaml:"name"`
-	Chart     string `yaml:"chart"`
-	Version   string `yaml:"version"`
-	Namespace string `yaml:"namespace"`
-	Values    string `yaml:"values"`
+	Name      string                             `yaml:"name"`
+	Chart     string                             `yaml:"chart"`
+	Version   string                             `yaml:"version"`
+	Namespace string                             `yaml:"namespace"`
+	Values    string                             `yaml:"values"`
+	Overrides map[string]osutil.ExpandableString `yaml:"overrides"`
 }

--- a/cli/azd/pkg/kustomize/config.go
+++ b/cli/azd/pkg/kustomize/config.go
@@ -3,7 +3,7 @@ package kustomize
 import "github.com/azure/azure-dev/cli/azd/pkg/osutil"
 
 type Config struct {
-	Directory *osutil.ExpandableString            `yaml:"dir"`
-	Edits     []*osutil.ExpandableString          `yaml:"edits"`
-	Env       map[string]*osutil.ExpandableString `yaml:"env"`
+	Directory osutil.ExpandableString            `yaml:"dir"`
+	Edits     []osutil.ExpandableString          `yaml:"edits"`
+	Env       map[string]osutil.ExpandableString `yaml:"env"`
 }

--- a/cli/azd/pkg/kustomize/config.go
+++ b/cli/azd/pkg/kustomize/config.go
@@ -3,7 +3,7 @@ package kustomize
 import "github.com/azure/azure-dev/cli/azd/pkg/osutil"
 
 type Config struct {
-	Directory osutil.ExpandableString            `yaml:"dir"`
-	Edits     []osutil.ExpandableString          `yaml:"edits"`
-	Env       map[string]osutil.ExpandableString `yaml:"env"`
+	Directory *osutil.ExpandableString            `yaml:"dir"`
+	Edits     []*osutil.ExpandableString          `yaml:"edits"`
+	Env       map[string]*osutil.ExpandableString `yaml:"env"`
 }

--- a/cli/azd/pkg/osutil/expandable_string.go
+++ b/cli/azd/pkg/osutil/expandable_string.go
@@ -9,8 +9,8 @@ import (
 	"github.com/drone/envsubst"
 )
 
-func NewExpandableString(template string) ExpandableString {
-	return ExpandableString{
+func NewExpandableString(template string) *ExpandableString {
+	return &ExpandableString{
 		template: template,
 	}
 }
@@ -21,13 +21,13 @@ type ExpandableString struct {
 }
 
 // Envsubst evaluates the template, substituting values as [envsubst.Eval] would.
-func (e ExpandableString) Envsubst(mapping func(string) string) (string, error) {
+func (e *ExpandableString) Envsubst(mapping func(string) string) (string, error) {
 	return envsubst.Eval(e.template, mapping)
 }
 
 // MustEnvsubst evaluates the template, substituting values as [envsubst.Eval] would and panics if there
 // is an error (for example, the string is malformed).
-func (e ExpandableString) MustEnvsubst(mapping func(string) string) string {
+func (e *ExpandableString) MustEnvsubst(mapping func(string) string) string {
 	if v, err := envsubst.Eval(e.template, mapping); err != nil {
 		panic(fmt.Sprintf("MustEnvsubst: %v", err))
 	} else {
@@ -35,7 +35,7 @@ func (e ExpandableString) MustEnvsubst(mapping func(string) string) string {
 	}
 }
 
-func (e ExpandableString) MarshalYAML() (interface{}, error) {
+func (e *ExpandableString) MarshalYAML() (interface{}, error) {
 	return e.template, nil
 }
 

--- a/cli/azd/pkg/osutil/expandable_string.go
+++ b/cli/azd/pkg/osutil/expandable_string.go
@@ -7,43 +7,48 @@ import (
 	"fmt"
 
 	"github.com/drone/envsubst"
+	"gopkg.in/yaml.v3"
 )
 
 func NewExpandableString(template string) ExpandableString {
 	return ExpandableString{
-		template: template,
+		Template: template,
 	}
 }
 
 // ExpandableString is a string that has ${foo} style references inside which can be evaluated.
 type ExpandableString struct {
-	template string
+	Template string `yaml:",inline"`
 }
 
 // Envsubst evaluates the template, substituting values as [envsubst.Eval] would.
 func (e *ExpandableString) Envsubst(mapping func(string) string) (string, error) {
-	return envsubst.Eval(e.template, mapping)
+	return envsubst.Eval(e.Template, mapping)
 }
 
 // MustEnvsubst evaluates the template, substituting values as [envsubst.Eval] would and panics if there
 // is an error (for example, the string is malformed).
 func (e *ExpandableString) MustEnvsubst(mapping func(string) string) string {
-	if v, err := envsubst.Eval(e.template, mapping); err != nil {
+	if v, err := envsubst.Eval(e.Template, mapping); err != nil {
 		panic(fmt.Sprintf("MustEnvsubst: %v", err))
 	} else {
 		return v
 	}
 }
 
-func (e *ExpandableString) MarshalYAML() (interface{}, error) {
-	return e.template, nil
+func (e ExpandableString) MarshalText() ([]byte, error) {
+	return []byte(e.Template), nil
 }
 
-func (e *ExpandableString) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var s string
-	if err := unmarshal(&s); err != nil {
+func (e *ExpandableString) UnmarshalYAML(node *yaml.Node) error {
+	var value any
+	if err := node.Decode(&value); err != nil {
 		return err
 	}
-	e.template = s
+
+	if str, ok := value.(string); ok {
+		e.Template = str
+	}
+
 	return nil
 }

--- a/cli/azd/pkg/osutil/expandable_string.go
+++ b/cli/azd/pkg/osutil/expandable_string.go
@@ -9,8 +9,8 @@ import (
 	"github.com/drone/envsubst"
 )
 
-func NewExpandableString(template string) *ExpandableString {
-	return &ExpandableString{
+func NewExpandableString(template string) ExpandableString {
+	return ExpandableString{
 		template: template,
 	}
 }

--- a/cli/azd/pkg/osutil/expandable_string_test.go
+++ b/cli/azd/pkg/osutil/expandable_string_test.go
@@ -23,3 +23,24 @@ func TestExpandableStringYaml(t *testing.T) {
 
 	assert.Equal(t, "${foo}\n", string(marshalled))
 }
+
+func TestNestedObjectYaml(t *testing.T) {
+	c := Custom{
+		A: &ExpandableString{
+			template: "${foo}",
+		},
+		B: &ExpandableString{
+			template: "${bar}",
+		},
+	}
+
+	marshalled, err := yaml.Marshal(c)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "a: ${foo}\nb: ${bar}\n", string(marshalled))
+}
+
+type Custom struct {
+	A *ExpandableString `yaml:"a,omitempty"`
+	B *ExpandableString `yaml:"b,omitempty"`
+}

--- a/cli/azd/pkg/osutil/expandable_string_test.go
+++ b/cli/azd/pkg/osutil/expandable_string_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestExpandableStringYaml(t *testing.T) {
-	var e ExpandableString
+	var e *ExpandableString
 
 	err := yaml.Unmarshal([]byte(`"${foo}"`), &e)
 	assert.NoError(t, err)

--- a/cli/azd/pkg/osutil/expandable_string_test.go
+++ b/cli/azd/pkg/osutil/expandable_string_test.go
@@ -16,7 +16,7 @@ func TestExpandableStringYaml(t *testing.T) {
 	err := yaml.Unmarshal([]byte(`"${foo}"`), &e)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "${foo}", e.template)
+	assert.Equal(t, "${foo}", e.Template)
 
 	marshalled, err := yaml.Marshal(e)
 	assert.NoError(t, err)
@@ -25,22 +25,36 @@ func TestExpandableStringYaml(t *testing.T) {
 }
 
 func TestNestedObjectYaml(t *testing.T) {
-	c := Custom{
-		A: &ExpandableString{
-			template: "${foo}",
-		},
-		B: &ExpandableString{
-			template: "${bar}",
-		},
-	}
+	expected := "a: ${foo}\nb: ${bar}\n"
 
-	marshalled, err := yaml.Marshal(c)
+	var custom *Custom
+	err := yaml.Unmarshal([]byte(expected), &custom)
+	assert.NoError(t, err)
+	assert.Equal(t, "${foo}", custom.A.Template)
+	assert.Equal(t, "${bar}", custom.B.Template)
+
+	marshalled, err := yaml.Marshal(custom)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "a: ${foo}\nb: ${bar}\n", string(marshalled))
+	assert.Equal(t, expected, string(marshalled))
+}
+
+func TestNestedObjectWithEmpty(t *testing.T) {
+	expected := "{}\n"
+
+	var custom *Custom
+	err := yaml.Unmarshal([]byte(expected), &custom)
+	assert.NoError(t, err)
+	assert.NotNil(t, custom.A)
+	assert.NotNil(t, custom.B)
+
+	marshalled, err := yaml.Marshal(custom)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expected, string(marshalled))
 }
 
 type Custom struct {
-	A *ExpandableString `yaml:"a,omitempty"`
-	B *ExpandableString `yaml:"b,omitempty"`
+	A ExpandableString `yaml:"a,omitempty"`
+	B ExpandableString `yaml:"b,omitempty"`
 }

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -172,7 +172,7 @@ func (ch *ContainerHelper) Login(
 	ctx context.Context,
 	component *ComponentConfig,
 ) (string, error) {
-	loginServer, err := ch.RegistryName(ctx, component)
+	registryName, err := ch.RegistryName(ctx, component)
 	if err != nil {
 		return "", err
 	}
@@ -273,7 +273,7 @@ func (ch *ContainerHelper) Deploy(
 					log.Printf("logging into container registry '%s'\n", registryName)
 					task.SetProgress(NewServiceProgress("Logging into container registry"))
 
-					_, err = ch.Login(ctx, serviceConfig)
+					_, err = ch.Login(ctx, component)
 					if err != nil {
 						task.SetError(err)
 						return

--- a/cli/azd/pkg/project/container_helper_test.go
+++ b/cli/azd/pkg/project/container_helper_test.go
@@ -28,10 +28,12 @@ func Test_ContainerHelper_LocalImageTag(t *testing.T) {
 	projectName := "my-app"
 	serviceName := "web"
 	serviceConfig := &ServiceConfig{
-		Name: serviceName,
-		Host: "containerapp",
-		Project: &ProjectConfig{
-			Name: projectName,
+		ComponentConfig: ComponentConfig{
+			Name: serviceName,
+			Host: "containerapp",
+			Project: &ProjectConfig{
+				Name: projectName,
+			},
 		},
 	}
 	defaultImageName := fmt.Sprintf("%s/%s-%s", projectName, serviceName, envName)

--- a/cli/azd/pkg/project/container_helper_test.go
+++ b/cli/azd/pkg/project/container_helper_test.go
@@ -74,7 +74,7 @@ func Test_ContainerHelper_RemoteImageTag(t *testing.T) {
 		name              string
 		project           string
 		localImageTag     string
-		registry          osutil.ExpandableString
+		registry          *osutil.ExpandableString
 		expectedRemoteTag string
 		expectError       bool
 	}{
@@ -404,9 +404,9 @@ func Test_ContainerHelper_ConfiguredImage(t *testing.T) {
 		serviceName          string
 		sourceImage          string
 		env                  map[string]string
-		registry             osutil.ExpandableString
-		image                osutil.ExpandableString
-		tag                  osutil.ExpandableString
+		registry             *osutil.ExpandableString
+		image                *osutil.ExpandableString
+		tag                  *osutil.ExpandableString
 		expectedImage        docker.ContainerImage
 		expectError          bool
 		expectedErrorMessage string

--- a/cli/azd/pkg/project/container_helper_test.go
+++ b/cli/azd/pkg/project/container_helper_test.go
@@ -28,7 +28,7 @@ func Test_ContainerHelper_LocalImageTag(t *testing.T) {
 	projectName := "my-app"
 	serviceName := "web"
 	serviceConfig := &ServiceConfig{
-		ComponentConfig: ComponentConfig{
+		ComponentConfig: &ComponentConfig{
 			Name: serviceName,
 			Host: "containerapp",
 			Project: &ProjectConfig{
@@ -62,7 +62,7 @@ func Test_ContainerHelper_LocalImageTag(t *testing.T) {
 			containerHelper := NewContainerHelper(env, nil, clock.NewMock(), nil, nil)
 			serviceConfig.Docker = tt.dockerConfig
 
-			tag, err := containerHelper.LocalImageTag(*mockContext.Context, &serviceConfig.ComponentConfig)
+			tag, err := containerHelper.LocalImageTag(*mockContext.Context, serviceConfig.ComponentConfig)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, tag)
 		})
@@ -117,7 +117,7 @@ func Test_ContainerHelper_RemoteImageTag(t *testing.T) {
 
 			remoteTag, err := containerHelper.RemoteImageTag(
 				*mockContext.Context,
-				&serviceConfig.ComponentConfig,
+				serviceConfig.ComponentConfig,
 				tt.localImageTag,
 			)
 
@@ -141,7 +141,7 @@ func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {
 		envManager := &mockenv.MockEnvManager{}
 		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil)
 		serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
-		registryName, err := containerHelper.RegistryName(*mockContext.Context, &serviceConfig.ComponentConfig)
+		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig.ComponentConfig)
 
 		require.NoError(t, err)
 		require.Equal(t, "contoso.azurecr.io", registryName)
@@ -154,7 +154,7 @@ func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {
 		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil)
 		serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
 		serviceConfig.Docker.Registry = osutil.NewExpandableString("contoso.azurecr.io")
-		registryName, err := containerHelper.RegistryName(*mockContext.Context, &serviceConfig.ComponentConfig)
+		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig.ComponentConfig)
 
 		require.NoError(t, err)
 		require.Equal(t, "contoso.azurecr.io", registryName)
@@ -168,7 +168,7 @@ func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {
 		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil)
 		serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
 		serviceConfig.Docker.Registry = osutil.NewExpandableString("${MY_CUSTOM_REGISTRY}")
-		registryName, err := containerHelper.RegistryName(*mockContext.Context, &serviceConfig.ComponentConfig)
+		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig.ComponentConfig)
 
 		require.NoError(t, err)
 		require.Equal(t, "custom.azurecr.io", registryName)
@@ -180,7 +180,7 @@ func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {
 		envManager := &mockenv.MockEnvManager{}
 		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil)
 		serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
-		registryName, err := containerHelper.RegistryName(*mockContext.Context, &serviceConfig.ComponentConfig)
+		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig.ComponentConfig)
 
 		require.Error(t, err)
 		require.Empty(t, registryName)
@@ -355,7 +355,7 @@ func Test_ContainerHelper_Deploy(t *testing.T) {
 
 			deployTask := containerHelper.Deploy(
 				*mockContext.Context,
-				&serviceConfig.ComponentConfig,
+				serviceConfig.ComponentConfig,
 				packageOutput,
 				targetResource,
 				true,
@@ -525,7 +525,7 @@ func Test_ContainerHelper_ConfiguredImage(t *testing.T) {
 				env.DotenvSet(k, v)
 			}
 
-			image, err := containerHelper.GeneratedImage(*mockContext.Context, &serviceConfig.ComponentConfig)
+			image, err := containerHelper.GeneratedImage(*mockContext.Context, serviceConfig.ComponentConfig)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/cli/azd/pkg/project/container_helper_test.go
+++ b/cli/azd/pkg/project/container_helper_test.go
@@ -74,7 +74,7 @@ func Test_ContainerHelper_RemoteImageTag(t *testing.T) {
 		name              string
 		project           string
 		localImageTag     string
-		registry          *osutil.ExpandableString
+		registry          osutil.ExpandableString
 		expectedRemoteTag string
 		expectError       bool
 	}{
@@ -404,9 +404,9 @@ func Test_ContainerHelper_ConfiguredImage(t *testing.T) {
 		serviceName          string
 		sourceImage          string
 		env                  map[string]string
-		registry             *osutil.ExpandableString
-		image                *osutil.ExpandableString
-		tag                  *osutil.ExpandableString
+		registry             osutil.ExpandableString
+		image                osutil.ExpandableString
+		tag                  osutil.ExpandableString
 		expectedImage        docker.ContainerImage
 		expectError          bool
 		expectedErrorMessage string

--- a/cli/azd/pkg/project/dotnet_importer.go
+++ b/cli/azd/pkg/project/dotnet_importer.go
@@ -171,19 +171,16 @@ func (ai *DotNetImporter) Services(
 
 		// TODO(ellismg): Some of this code is duplicated from project.Parse, we should centralize this logic long term.
 		svc := &ServiceConfig{
-			RelativePath: relPath,
-			Language:     ServiceLanguageDotNet,
-			Host:         DotNetContainerAppTarget,
+			ComponentConfig: ComponentConfig{
+				RelativePath: relPath,
+				Language:     ServiceLanguageDotNet,
+				Host:         DotNetContainerAppTarget,
+			},
 		}
 
 		svc.Name = name
 		svc.Project = p
 		svc.EventDispatcher = ext.NewEventDispatcher[ServiceLifecycleEventArgs]()
-
-		svc.Infra.Provider, err = provisioning.ParseProvider(svc.Infra.Provider)
-		if err != nil {
-			return nil, fmt.Errorf("parsing service %s: %w", svc.Name, err)
-		}
 
 		svc.DotNetContainerApp = &DotNetContainerAppOptions{
 			Manifest:    manifest,
@@ -203,23 +200,20 @@ func (ai *DotNetImporter) Services(
 
 		// TODO(ellismg): Some of this code is duplicated from project.Parse, we should centralize this logic long term.
 		svc := &ServiceConfig{
-			RelativePath: relPath,
-			Language:     ServiceLanguageDocker,
-			Host:         DotNetContainerAppTarget,
-			Docker: DockerProjectOptions{
-				Path:    dockerfile.Path,
-				Context: dockerfile.Context,
+			ComponentConfig: ComponentConfig{
+				RelativePath: relPath,
+				Language:     ServiceLanguageDocker,
+				Host:         DotNetContainerAppTarget,
+				Docker: DockerProjectOptions{
+					Path:    dockerfile.Path,
+					Context: dockerfile.Context,
+				},
 			},
 		}
 
 		svc.Name = name
 		svc.Project = p
 		svc.EventDispatcher = ext.NewEventDispatcher[ServiceLifecycleEventArgs]()
-
-		svc.Infra.Provider, err = provisioning.ParseProvider(svc.Infra.Provider)
-		if err != nil {
-			return nil, fmt.Errorf("parsing service %s: %w", svc.Name, err)
-		}
 
 		svc.DotNetContainerApp = &DotNetContainerAppOptions{
 			Manifest:    manifest,

--- a/cli/azd/pkg/project/dotnet_importer.go
+++ b/cli/azd/pkg/project/dotnet_importer.go
@@ -171,7 +171,7 @@ func (ai *DotNetImporter) Services(
 
 		// TODO(ellismg): Some of this code is duplicated from project.Parse, we should centralize this logic long term.
 		svc := &ServiceConfig{
-			ComponentConfig: ComponentConfig{
+			ComponentConfig: &ComponentConfig{
 				RelativePath: relPath,
 				Language:     ServiceLanguageDotNet,
 				Host:         DotNetContainerAppTarget,
@@ -200,7 +200,7 @@ func (ai *DotNetImporter) Services(
 
 		// TODO(ellismg): Some of this code is duplicated from project.Parse, we should centralize this logic long term.
 		svc := &ServiceConfig{
-			ComponentConfig: ComponentConfig{
+			ComponentConfig: &ComponentConfig{
 				RelativePath: relPath,
 				Language:     ServiceLanguageDocker,
 				Host:         DotNetContainerAppTarget,

--- a/cli/azd/pkg/project/framework_service.go
+++ b/cli/azd/pkg/project/framework_service.go
@@ -66,7 +66,7 @@ type FrameworkService interface {
 
 	// Initializes the framework service for the specified service configuration
 	// This is useful if the framework needs to subscribe to any service events
-	Initialize(ctx context.Context, serviceConfig *ServiceConfig) error
+	Initialize(ctx context.Context, component *ComponentConfig) error
 
 	// Gets the requirements for the language or framework service.
 	// This enables more fine grain control on whether the language / framework
@@ -76,13 +76,13 @@ type FrameworkService interface {
 	// Restores dependencies for the framework service
 	Restore(
 		ctx context.Context,
-		serviceConfig *ServiceConfig,
+		component *ComponentConfig,
 	) *async.TaskWithProgress[*ServiceRestoreResult, ServiceProgress]
 
 	// Builds the source for the framework service
 	Build(
 		ctx context.Context,
-		serviceConfig *ServiceConfig,
+		component *ComponentConfig,
 		restoreOutput *ServiceRestoreResult,
 	) *async.TaskWithProgress[*ServiceBuildResult, ServiceProgress]
 
@@ -90,7 +90,7 @@ type FrameworkService interface {
 	// This may optionally perform a rebuild internally depending on the language/framework requirements
 	Package(
 		ctx context.Context,
-		serviceConfig *ServiceConfig,
+		component *ComponentConfig,
 		buildOutput *ServiceBuildResult,
 	) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress]
 }

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -33,14 +33,14 @@ import (
 )
 
 type DockerProjectOptions struct {
-	Path      string                  `yaml:"path,omitempty"      json:"path,omitempty"`
-	Context   string                  `yaml:"context,omitempty"   json:"context,omitempty"`
-	Platform  string                  `yaml:"platform,omitempty"  json:"platform,omitempty"`
-	Target    string                  `yaml:"target,omitempty"    json:"target,omitempty"`
-	Registry  osutil.ExpandableString `yaml:"registry,omitempty"  json:"registry,omitempty"`
-	Image     osutil.ExpandableString `yaml:"image,omitempty"     json:"image,omitempty"`
-	Tag       osutil.ExpandableString `yaml:"tag,omitempty"       json:"tag,omitempty"`
-	BuildArgs []string                `yaml:"buildArgs,omitempty" json:"buildArgs,omitempty"`
+	Path      string                   `yaml:"path,omitempty"      json:"path,omitempty"`
+	Context   string                   `yaml:"context,omitempty"   json:"context,omitempty"`
+	Platform  string                   `yaml:"platform,omitempty"  json:"platform,omitempty"`
+	Target    string                   `yaml:"target,omitempty"    json:"target,omitempty"`
+	Registry  *osutil.ExpandableString `yaml:"registry,omitempty"  json:"registry,omitempty"`
+	Image     *osutil.ExpandableString `yaml:"image,omitempty"     json:"image,omitempty"`
+	Tag       *osutil.ExpandableString `yaml:"tag,omitempty"       json:"tag,omitempty"`
+	BuildArgs []string                 `yaml:"buildArgs,omitempty" json:"buildArgs,omitempty"`
 }
 
 type dockerBuildResult struct {

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -49,12 +49,11 @@ type dockerBuildResult struct {
 }
 
 func (dbr *dockerBuildResult) ToString(currentIndentation string) string {
-	lines := []string{
-		fmt.Sprintf("%s- Image ID: %s", currentIndentation, output.WithLinkFormat(dbr.ImageId)),
-		fmt.Sprintf("%s- Image Name: %s", currentIndentation, output.WithLinkFormat(dbr.ImageName)),
-	}
+	builder := strings.Builder{}
+	builder.WriteString(fmt.Sprintf("%s- Image Hash: %s\n", currentIndentation, output.WithLinkFormat(dbr.ImageId)))
+	builder.WriteString(fmt.Sprintf("%s- Image Name: %s\n", currentIndentation, output.WithLinkFormat(dbr.ImageName)))
 
-	return strings.Join(lines, "\n")
+	return builder.String()
 }
 
 func (dbr *dockerBuildResult) MarshalJSON() ([]byte, error) {

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -371,7 +371,8 @@ func (p *dockerProject) packBuild(
 		// Always default to port 80 for consistency across languages
 		environ = append(environ, "ORYX_RUNTIME_PORT=80")
 
-		if component.OutputPath != "" && (component.Language == ServiceLanguageTypeScript || component.Language == ServiceLanguageJavaScript) {
+		if component.OutputPath != "" &&
+			(component.Language == ServiceLanguageTypeScript || component.Language == ServiceLanguageJavaScript) {
 			inDockerOutputPath := path.Join("/workspace", component.OutputPath)
 			// A dist folder has been set.
 			// We assume that the service is a front-end service, configuring a nginx web server to serve the static content

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -113,7 +113,7 @@ services:
 		mockContext.CommandRunner)
 	framework.SetSource(internalFramework)
 
-	buildTask := framework.Build(*mockContext.Context, service, nil)
+	buildTask := framework.Build(*mockContext.Context, &service.ComponentConfig, nil)
 	go func() {
 		for value := range buildTask.Progress() {
 			progressMessages = append(progressMessages, value.Message)
@@ -221,7 +221,7 @@ services:
 		mockContext.CommandRunner)
 	framework.SetSource(internalFramework)
 
-	buildTask := framework.Build(*mockContext.Context, service, nil)
+	buildTask := framework.Build(*mockContext.Context, &service.ComponentConfig, nil)
 	go func() {
 		for value := range buildTask.Progress() {
 			status = value.Message
@@ -427,7 +427,7 @@ func Test_DockerProject_Build(t *testing.T) {
 				dockerProject.SetSource(npmProject)
 			}
 
-			buildTask := dockerProject.Build(*mockContext.Context, serviceConfig, nil)
+			buildTask := dockerProject.Build(*mockContext.Context, &serviceConfig.ComponentConfig, nil)
 			logProgress(buildTask)
 			result, err := buildTask.Await()
 
@@ -553,7 +553,7 @@ func Test_DockerProject_Package(t *testing.T) {
 
 			packageTask := dockerProject.Package(
 				*mockContext.Context,
-				serviceConfig,
+				&serviceConfig.ComponentConfig,
 				&ServiceBuildResult{
 					BuildOutputPath: buildOutputPath,
 				},

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -113,7 +113,7 @@ services:
 		mockContext.CommandRunner)
 	framework.SetSource(internalFramework)
 
-	buildTask := framework.Build(*mockContext.Context, &service.ComponentConfig, nil)
+	buildTask := framework.Build(*mockContext.Context, service.ComponentConfig, nil)
 	go func() {
 		for value := range buildTask.Progress() {
 			progressMessages = append(progressMessages, value.Message)
@@ -221,7 +221,7 @@ services:
 		mockContext.CommandRunner)
 	framework.SetSource(internalFramework)
 
-	buildTask := framework.Build(*mockContext.Context, &service.ComponentConfig, nil)
+	buildTask := framework.Build(*mockContext.Context, service.ComponentConfig, nil)
 	go func() {
 		for value := range buildTask.Progress() {
 			status = value.Message
@@ -427,7 +427,7 @@ func Test_DockerProject_Build(t *testing.T) {
 				dockerProject.SetSource(npmProject)
 			}
 
-			buildTask := dockerProject.Build(*mockContext.Context, &serviceConfig.ComponentConfig, nil)
+			buildTask := dockerProject.Build(*mockContext.Context, serviceConfig.ComponentConfig, nil)
 			logProgress(buildTask)
 			result, err := buildTask.Await()
 
@@ -553,7 +553,7 @@ func Test_DockerProject_Package(t *testing.T) {
 
 			packageTask := dockerProject.Package(
 				*mockContext.Context,
-				&serviceConfig.ComponentConfig,
+				serviceConfig.ComponentConfig,
 				&ServiceBuildResult{
 					BuildOutputPath: buildOutputPath,
 				},

--- a/cli/azd/pkg/project/framework_service_dotnet_test.go
+++ b/cli/azd/pkg/project/framework_service_dotnet_test.go
@@ -41,7 +41,7 @@ func TestBicepOutputsWithDoubleUnderscoresAreConverted(t *testing.T) {
 	})
 
 	serviceConfig := &ServiceConfig{
-		ComponentConfig: ComponentConfig{
+		ComponentConfig: &ComponentConfig{
 			Project: &ProjectConfig{
 				Path: "/sample/path/for/test",
 			},
@@ -52,7 +52,7 @@ func TestBicepOutputsWithDoubleUnderscoresAreConverted(t *testing.T) {
 	dotNetCli := dotnet.NewDotNetCli(mockContext.CommandRunner)
 	dp := NewDotNetProject(dotNetCli, environment.New("test")).(*dotnetProject)
 
-	err := dp.setUserSecretsFromOutputs(*mockContext.Context, &serviceConfig.ComponentConfig, ServiceLifecycleEventArgs{
+	err := dp.setUserSecretsFromOutputs(*mockContext.Context, serviceConfig.ComponentConfig, ServiceLifecycleEventArgs{
 		Args: map[string]any{
 			"bicepOutput": map[string]provisioning.OutputParameter{
 				"EXAMPLE_OUTPUT":          {Type: "string", Value: "foo"},
@@ -100,7 +100,7 @@ func Test_DotNetProject_Init(t *testing.T) {
 
 	dotnetProject := NewDotNetProject(dotNetCli, env)
 
-	err = dotnetProject.Initialize(*mockContext.Context, &serviceConfig.ComponentConfig)
+	err = dotnetProject.Initialize(*mockContext.Context, serviceConfig.ComponentConfig)
 	require.NoError(t, err)
 
 	eventArgs := ServiceLifecycleEventArgs{
@@ -151,7 +151,7 @@ func Test_DotNetProject_Restore(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api/test.csproj", AppServiceTarget, ServiceLanguageCsharp)
 
 	dotnetProject := NewDotNetProject(dotNetCli, env)
-	restoreTask := dotnetProject.Restore(*mockContext.Context, &serviceConfig.ComponentConfig)
+	restoreTask := dotnetProject.Restore(*mockContext.Context, serviceConfig.ComponentConfig)
 	logProgress(restoreTask)
 
 	result, err := restoreTask.Await()
@@ -195,7 +195,7 @@ func Test_DotNetProject_Build(t *testing.T) {
 	require.NoError(t, err)
 
 	dotnetProject := NewDotNetProject(dotNetCli, env)
-	buildTask := dotnetProject.Build(*mockContext.Context, &serviceConfig.ComponentConfig, nil)
+	buildTask := dotnetProject.Build(*mockContext.Context, serviceConfig.ComponentConfig, nil)
 	logProgress(buildTask)
 
 	result, err := buildTask.Await()
@@ -251,7 +251,7 @@ func Test_DotNetProject_Package(t *testing.T) {
 	dotnetProject := NewDotNetProject(dotNetCli, env)
 	packageTask := dotnetProject.Package(
 		*mockContext.Context,
-		&serviceConfig.ComponentConfig,
+		serviceConfig.ComponentConfig,
 		&ServiceBuildResult{
 			BuildOutputPath: serviceConfig.Path(),
 		},

--- a/cli/azd/pkg/project/framework_service_dotnet_test.go
+++ b/cli/azd/pkg/project/framework_service_dotnet_test.go
@@ -52,7 +52,7 @@ func TestBicepOutputsWithDoubleUnderscoresAreConverted(t *testing.T) {
 	dotNetCli := dotnet.NewDotNetCli(mockContext.CommandRunner)
 	dp := NewDotNetProject(dotNetCli, environment.New("test")).(*dotnetProject)
 
-	err := dp.setUserSecretsFromOutputs(*mockContext.Context, serviceConfig, ServiceLifecycleEventArgs{
+	err := dp.setUserSecretsFromOutputs(*mockContext.Context, &serviceConfig.ComponentConfig, ServiceLifecycleEventArgs{
 		Args: map[string]any{
 			"bicepOutput": map[string]provisioning.OutputParameter{
 				"EXAMPLE_OUTPUT":          {Type: "string", Value: "foo"},
@@ -100,7 +100,7 @@ func Test_DotNetProject_Init(t *testing.T) {
 
 	dotnetProject := NewDotNetProject(dotNetCli, env)
 
-	err = dotnetProject.Initialize(*mockContext.Context, serviceConfig)
+	err = dotnetProject.Initialize(*mockContext.Context, &serviceConfig.ComponentConfig)
 	require.NoError(t, err)
 
 	eventArgs := ServiceLifecycleEventArgs{
@@ -151,7 +151,7 @@ func Test_DotNetProject_Restore(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api/test.csproj", AppServiceTarget, ServiceLanguageCsharp)
 
 	dotnetProject := NewDotNetProject(dotNetCli, env)
-	restoreTask := dotnetProject.Restore(*mockContext.Context, serviceConfig)
+	restoreTask := dotnetProject.Restore(*mockContext.Context, &serviceConfig.ComponentConfig)
 	logProgress(restoreTask)
 
 	result, err := restoreTask.Await()
@@ -195,7 +195,7 @@ func Test_DotNetProject_Build(t *testing.T) {
 	require.NoError(t, err)
 
 	dotnetProject := NewDotNetProject(dotNetCli, env)
-	buildTask := dotnetProject.Build(*mockContext.Context, serviceConfig, nil)
+	buildTask := dotnetProject.Build(*mockContext.Context, &serviceConfig.ComponentConfig, nil)
 	logProgress(buildTask)
 
 	result, err := buildTask.Await()
@@ -251,7 +251,7 @@ func Test_DotNetProject_Package(t *testing.T) {
 	dotnetProject := NewDotNetProject(dotNetCli, env)
 	packageTask := dotnetProject.Package(
 		*mockContext.Context,
-		serviceConfig,
+		&serviceConfig.ComponentConfig,
 		&ServiceBuildResult{
 			BuildOutputPath: serviceConfig.Path(),
 		},

--- a/cli/azd/pkg/project/framework_service_dotnet_test.go
+++ b/cli/azd/pkg/project/framework_service_dotnet_test.go
@@ -41,10 +41,12 @@ func TestBicepOutputsWithDoubleUnderscoresAreConverted(t *testing.T) {
 	})
 
 	serviceConfig := &ServiceConfig{
-		Project: &ProjectConfig{
-			Path: "/sample/path/for/test",
+		ComponentConfig: ComponentConfig{
+			Project: &ProjectConfig{
+				Path: "/sample/path/for/test",
+			},
+			RelativePath: "",
 		},
-		RelativePath: "",
 	}
 
 	dotNetCli := dotnet.NewDotNetCli(mockContext.CommandRunner)

--- a/cli/azd/pkg/project/framework_service_maven_test.go
+++ b/cli/azd/pkg/project/framework_service_maven_test.go
@@ -46,10 +46,10 @@ func Test_MavenProject(t *testing.T) {
 		javaCli := javac.NewCli(mockContext.CommandRunner)
 
 		mavenProject := NewMavenProject(env, mavenCli, javaCli)
-		err = mavenProject.Initialize(*mockContext.Context, serviceConfig)
+		err = mavenProject.Initialize(*mockContext.Context, &serviceConfig.ComponentConfig)
 		require.NoError(t, err)
 
-		restoreTask := mavenProject.Restore(*mockContext.Context, serviceConfig)
+		restoreTask := mavenProject.Restore(*mockContext.Context, &serviceConfig.ComponentConfig)
 		logProgress(restoreTask)
 
 		result, err := restoreTask.Await()
@@ -82,10 +82,10 @@ func Test_MavenProject(t *testing.T) {
 		javaCli := javac.NewCli(mockContext.CommandRunner)
 
 		mavenProject := NewMavenProject(env, mavenCli, javaCli)
-		err = mavenProject.Initialize(*mockContext.Context, serviceConfig)
+		err = mavenProject.Initialize(*mockContext.Context, &serviceConfig.ComponentConfig)
 		require.NoError(t, err)
 
-		buildTask := mavenProject.Build(*mockContext.Context, serviceConfig, nil)
+		buildTask := mavenProject.Build(*mockContext.Context, &serviceConfig.ComponentConfig, nil)
 		logProgress(buildTask)
 
 		result, err := buildTask.Await()
@@ -124,12 +124,12 @@ func Test_MavenProject(t *testing.T) {
 		require.NoError(t, err)
 
 		mavenProject := NewMavenProject(env, mavenCli, javaCli)
-		err = mavenProject.Initialize(*mockContext.Context, serviceConfig)
+		err = mavenProject.Initialize(*mockContext.Context, &serviceConfig.ComponentConfig)
 		require.NoError(t, err)
 
 		packageTask := mavenProject.Package(
 			*mockContext.Context,
-			serviceConfig,
+			&serviceConfig.ComponentConfig,
 			&ServiceBuildResult{
 				BuildOutputPath: serviceConfig.Path(),
 			},
@@ -295,12 +295,13 @@ func Test_MavenProject_Package(t *testing.T) {
 			mavenCli := maven.NewMavenCli(mockContext.CommandRunner)
 			javaCli := javac.NewCli(mockContext.CommandRunner)
 			mavenProject := NewMavenProject(env, mavenCli, javaCli)
-			err = mavenProject.Initialize(*mockContext.Context, tt.args.svc)
+			svc := tt.args.svc
+			err = mavenProject.Initialize(*mockContext.Context, &svc.ComponentConfig)
 			require.NoError(t, err)
 
 			packageTask := mavenProject.Package(
 				*mockContext.Context,
-				tt.args.svc,
+				&svc.ComponentConfig,
 				&ServiceBuildResult{},
 			)
 			logProgress(packageTask)

--- a/cli/azd/pkg/project/framework_service_maven_test.go
+++ b/cli/azd/pkg/project/framework_service_maven_test.go
@@ -165,11 +165,13 @@ func Test_MavenProject_Package(t *testing.T) {
 			"Default",
 			args{
 				&ServiceConfig{
-					Project:         &ProjectConfig{},
-					Name:            "api",
-					RelativePath:    "src/api",
-					Host:            AppServiceTarget,
-					Language:        ServiceLanguageJava,
+					ComponentConfig: ComponentConfig{
+						Project:      &ProjectConfig{},
+						Name:         "api",
+						RelativePath: "src/api",
+						Host:         AppServiceTarget,
+						Language:     ServiceLanguageJava,
+					},
 					EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
 				},
 				[]string{".jar"},
@@ -179,12 +181,14 @@ func Test_MavenProject_Package(t *testing.T) {
 		{
 			"SpecifyOutputDir",
 			args{&ServiceConfig{
-				Project:         &ProjectConfig{},
-				Name:            "api",
-				RelativePath:    "src/api",
-				OutputPath:      "mydir",
-				Host:            AppServiceTarget,
-				Language:        ServiceLanguageJava,
+				ComponentConfig: ComponentConfig{
+					Project:      &ProjectConfig{},
+					Name:         "api",
+					RelativePath: "src/api",
+					OutputPath:   "mydir",
+					Host:         AppServiceTarget,
+					Language:     ServiceLanguageJava,
+				},
 				EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
 			},
 				[]string{".war"},
@@ -194,12 +198,14 @@ func Test_MavenProject_Package(t *testing.T) {
 		{
 			"SpecifyOutputFile",
 			args{&ServiceConfig{
-				Project:         &ProjectConfig{},
-				Name:            "api",
-				RelativePath:    "src/api",
-				OutputPath:      "mydir/ear.ear",
-				Host:            AppServiceTarget,
-				Language:        ServiceLanguageJava,
+				ComponentConfig: ComponentConfig{
+					Project:      &ProjectConfig{},
+					Name:         "api",
+					RelativePath: "src/api",
+					OutputPath:   "mydir/ear.ear",
+					Host:         AppServiceTarget,
+					Language:     ServiceLanguageJava,
+				},
 				EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
 			},
 				[]string{".ear"},
@@ -209,11 +215,13 @@ func Test_MavenProject_Package(t *testing.T) {
 		{
 			"ErrNoArchive",
 			args{&ServiceConfig{
-				Project:         &ProjectConfig{},
-				Name:            "api",
-				RelativePath:    "src/api",
-				Host:            AppServiceTarget,
-				Language:        ServiceLanguageJava,
+				ComponentConfig: ComponentConfig{
+					Project:      &ProjectConfig{},
+					Name:         "api",
+					RelativePath: "src/api",
+					Host:         AppServiceTarget,
+					Language:     ServiceLanguageJava,
+				},
 				EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
 			},
 				[]string{},
@@ -223,12 +231,14 @@ func Test_MavenProject_Package(t *testing.T) {
 		{
 			"ErrMultipleArchives",
 			args{&ServiceConfig{
-				Project:         &ProjectConfig{},
-				Name:            "api",
-				RelativePath:    "src/api",
-				OutputPath:      "mydir",
-				Host:            AppServiceTarget,
-				Language:        ServiceLanguageJava,
+				ComponentConfig: ComponentConfig{
+					Project:      &ProjectConfig{},
+					Name:         "api",
+					RelativePath: "src/api",
+					OutputPath:   "mydir",
+					Host:         AppServiceTarget,
+					Language:     ServiceLanguageJava,
+				},
 				EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
 			},
 				[]string{".jar", ".war", ".ear"},

--- a/cli/azd/pkg/project/framework_service_maven_test.go
+++ b/cli/azd/pkg/project/framework_service_maven_test.go
@@ -46,10 +46,10 @@ func Test_MavenProject(t *testing.T) {
 		javaCli := javac.NewCli(mockContext.CommandRunner)
 
 		mavenProject := NewMavenProject(env, mavenCli, javaCli)
-		err = mavenProject.Initialize(*mockContext.Context, &serviceConfig.ComponentConfig)
+		err = mavenProject.Initialize(*mockContext.Context, serviceConfig.ComponentConfig)
 		require.NoError(t, err)
 
-		restoreTask := mavenProject.Restore(*mockContext.Context, &serviceConfig.ComponentConfig)
+		restoreTask := mavenProject.Restore(*mockContext.Context, serviceConfig.ComponentConfig)
 		logProgress(restoreTask)
 
 		result, err := restoreTask.Await()
@@ -82,10 +82,10 @@ func Test_MavenProject(t *testing.T) {
 		javaCli := javac.NewCli(mockContext.CommandRunner)
 
 		mavenProject := NewMavenProject(env, mavenCli, javaCli)
-		err = mavenProject.Initialize(*mockContext.Context, &serviceConfig.ComponentConfig)
+		err = mavenProject.Initialize(*mockContext.Context, serviceConfig.ComponentConfig)
 		require.NoError(t, err)
 
-		buildTask := mavenProject.Build(*mockContext.Context, &serviceConfig.ComponentConfig, nil)
+		buildTask := mavenProject.Build(*mockContext.Context, serviceConfig.ComponentConfig, nil)
 		logProgress(buildTask)
 
 		result, err := buildTask.Await()
@@ -124,12 +124,12 @@ func Test_MavenProject(t *testing.T) {
 		require.NoError(t, err)
 
 		mavenProject := NewMavenProject(env, mavenCli, javaCli)
-		err = mavenProject.Initialize(*mockContext.Context, &serviceConfig.ComponentConfig)
+		err = mavenProject.Initialize(*mockContext.Context, serviceConfig.ComponentConfig)
 		require.NoError(t, err)
 
 		packageTask := mavenProject.Package(
 			*mockContext.Context,
-			&serviceConfig.ComponentConfig,
+			serviceConfig.ComponentConfig,
 			&ServiceBuildResult{
 				BuildOutputPath: serviceConfig.Path(),
 			},
@@ -165,7 +165,7 @@ func Test_MavenProject_Package(t *testing.T) {
 			"Default",
 			args{
 				&ServiceConfig{
-					ComponentConfig: ComponentConfig{
+					ComponentConfig: &ComponentConfig{
 						Project:      &ProjectConfig{},
 						Name:         "api",
 						RelativePath: "src/api",
@@ -181,7 +181,7 @@ func Test_MavenProject_Package(t *testing.T) {
 		{
 			"SpecifyOutputDir",
 			args{&ServiceConfig{
-				ComponentConfig: ComponentConfig{
+				ComponentConfig: &ComponentConfig{
 					Project:      &ProjectConfig{},
 					Name:         "api",
 					RelativePath: "src/api",
@@ -198,7 +198,7 @@ func Test_MavenProject_Package(t *testing.T) {
 		{
 			"SpecifyOutputFile",
 			args{&ServiceConfig{
-				ComponentConfig: ComponentConfig{
+				ComponentConfig: &ComponentConfig{
 					Project:      &ProjectConfig{},
 					Name:         "api",
 					RelativePath: "src/api",
@@ -215,7 +215,7 @@ func Test_MavenProject_Package(t *testing.T) {
 		{
 			"ErrNoArchive",
 			args{&ServiceConfig{
-				ComponentConfig: ComponentConfig{
+				ComponentConfig: &ComponentConfig{
 					Project:      &ProjectConfig{},
 					Name:         "api",
 					RelativePath: "src/api",
@@ -231,7 +231,7 @@ func Test_MavenProject_Package(t *testing.T) {
 		{
 			"ErrMultipleArchives",
 			args{&ServiceConfig{
-				ComponentConfig: ComponentConfig{
+				ComponentConfig: &ComponentConfig{
 					Project:      &ProjectConfig{},
 					Name:         "api",
 					RelativePath: "src/api",
@@ -296,12 +296,12 @@ func Test_MavenProject_Package(t *testing.T) {
 			javaCli := javac.NewCli(mockContext.CommandRunner)
 			mavenProject := NewMavenProject(env, mavenCli, javaCli)
 			svc := tt.args.svc
-			err = mavenProject.Initialize(*mockContext.Context, &svc.ComponentConfig)
+			err = mavenProject.Initialize(*mockContext.Context, svc.ComponentConfig)
 			require.NoError(t, err)
 
 			packageTask := mavenProject.Package(
 				*mockContext.Context,
-				&svc.ComponentConfig,
+				svc.ComponentConfig,
 				&ServiceBuildResult{},
 			)
 			logProgress(packageTask)

--- a/cli/azd/pkg/project/framework_service_noop.go
+++ b/cli/azd/pkg/project/framework_service_noop.go
@@ -27,13 +27,13 @@ func (n *noOpProject) Requirements() FrameworkRequirements {
 	}
 }
 
-func (n *noOpProject) Initialize(ctx context.Context, serviceConfig *ServiceConfig) error {
+func (n *noOpProject) Initialize(ctx context.Context, component *ComponentConfig) error {
 	return nil
 }
 
 func (n *noOpProject) Restore(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 ) *async.TaskWithProgress[*ServiceRestoreResult, ServiceProgress] {
 	return async.RunTaskWithProgress(
 		func(task *async.TaskContextWithProgress[*ServiceRestoreResult, ServiceProgress]) {
@@ -44,7 +44,7 @@ func (n *noOpProject) Restore(
 
 func (n *noOpProject) Build(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	restoreOutput *ServiceRestoreResult,
 ) *async.TaskWithProgress[*ServiceBuildResult, ServiceProgress] {
 	return async.RunTaskWithProgress(
@@ -56,7 +56,7 @@ func (n *noOpProject) Build(
 
 func (n *noOpProject) Package(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	buildOutput *ServiceBuildResult,
 ) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress] {
 	return async.RunTaskWithProgress(

--- a/cli/azd/pkg/project/framework_service_npm_test.go
+++ b/cli/azd/pkg/project/framework_service_npm_test.go
@@ -34,7 +34,7 @@ func Test_NpmProject_Restore(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageTypeScript)
 
 	npmProject := NewNpmProject(npmCli, env)
-	restoreTask := npmProject.Restore(*mockContext.Context, &serviceConfig.ComponentConfig)
+	restoreTask := npmProject.Restore(*mockContext.Context, serviceConfig.ComponentConfig)
 	logProgress(restoreTask)
 
 	result, err := restoreTask.Await()
@@ -66,7 +66,7 @@ func Test_NpmProject_Build(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageTypeScript)
 
 	npmProject := NewNpmProject(npmCli, env)
-	buildTask := npmProject.Build(*mockContext.Context, &serviceConfig.ComponentConfig, nil)
+	buildTask := npmProject.Build(*mockContext.Context, serviceConfig.ComponentConfig, nil)
 	logProgress(buildTask)
 
 	result, err := buildTask.Await()
@@ -106,7 +106,7 @@ func Test_NpmProject_Package(t *testing.T) {
 	npmProject := NewNpmProject(npmCli, env)
 	packageTask := npmProject.Package(
 		*mockContext.Context,
-		&serviceConfig.ComponentConfig,
+		serviceConfig.ComponentConfig,
 		&ServiceBuildResult{
 			BuildOutputPath: serviceConfig.Path(),
 		},

--- a/cli/azd/pkg/project/framework_service_npm_test.go
+++ b/cli/azd/pkg/project/framework_service_npm_test.go
@@ -34,7 +34,7 @@ func Test_NpmProject_Restore(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageTypeScript)
 
 	npmProject := NewNpmProject(npmCli, env)
-	restoreTask := npmProject.Restore(*mockContext.Context, serviceConfig)
+	restoreTask := npmProject.Restore(*mockContext.Context, &serviceConfig.ComponentConfig)
 	logProgress(restoreTask)
 
 	result, err := restoreTask.Await()
@@ -66,7 +66,7 @@ func Test_NpmProject_Build(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageTypeScript)
 
 	npmProject := NewNpmProject(npmCli, env)
-	buildTask := npmProject.Build(*mockContext.Context, serviceConfig, nil)
+	buildTask := npmProject.Build(*mockContext.Context, &serviceConfig.ComponentConfig, nil)
 	logProgress(buildTask)
 
 	result, err := buildTask.Await()
@@ -106,7 +106,7 @@ func Test_NpmProject_Package(t *testing.T) {
 	npmProject := NewNpmProject(npmCli, env)
 	packageTask := npmProject.Package(
 		*mockContext.Context,
-		serviceConfig,
+		&serviceConfig.ComponentConfig,
 		&ServiceBuildResult{
 			BuildOutputPath: serviceConfig.Path(),
 		},

--- a/cli/azd/pkg/project/framework_service_python_test.go
+++ b/cli/azd/pkg/project/framework_service_python_test.go
@@ -59,7 +59,7 @@ func Test_PythonProject_Restore(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguagePython)
 
 	pythonProject := NewPythonProject(pythonCli, env)
-	restoreTask := pythonProject.Restore(*mockContext.Context, &serviceConfig.ComponentConfig)
+	restoreTask := pythonProject.Restore(*mockContext.Context, serviceConfig.ComponentConfig)
 	logProgress(restoreTask)
 
 	result, err := restoreTask.Await()
@@ -93,7 +93,7 @@ func Test_PythonProject_Build(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguagePython)
 
 	pythonProject := NewPythonProject(pythonCli, env)
-	buildTask := pythonProject.Build(*mockContext.Context, &serviceConfig.ComponentConfig, nil)
+	buildTask := pythonProject.Build(*mockContext.Context, serviceConfig.ComponentConfig, nil)
 	logProgress(buildTask)
 
 	result, err := buildTask.Await()
@@ -117,7 +117,7 @@ func Test_PythonProject_Package(t *testing.T) {
 	pythonProject := NewPythonProject(pythonCli, env)
 	packageTask := pythonProject.Package(
 		*mockContext.Context,
-		&serviceConfig.ComponentConfig,
+		serviceConfig.ComponentConfig,
 		&ServiceBuildResult{
 			BuildOutputPath: serviceConfig.Path(),
 		},

--- a/cli/azd/pkg/project/framework_service_python_test.go
+++ b/cli/azd/pkg/project/framework_service_python_test.go
@@ -59,7 +59,7 @@ func Test_PythonProject_Restore(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguagePython)
 
 	pythonProject := NewPythonProject(pythonCli, env)
-	restoreTask := pythonProject.Restore(*mockContext.Context, serviceConfig)
+	restoreTask := pythonProject.Restore(*mockContext.Context, &serviceConfig.ComponentConfig)
 	logProgress(restoreTask)
 
 	result, err := restoreTask.Await()
@@ -93,7 +93,7 @@ func Test_PythonProject_Build(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguagePython)
 
 	pythonProject := NewPythonProject(pythonCli, env)
-	buildTask := pythonProject.Build(*mockContext.Context, serviceConfig, nil)
+	buildTask := pythonProject.Build(*mockContext.Context, &serviceConfig.ComponentConfig, nil)
 	logProgress(buildTask)
 
 	result, err := buildTask.Await()
@@ -117,7 +117,7 @@ func Test_PythonProject_Package(t *testing.T) {
 	pythonProject := NewPythonProject(pythonCli, env)
 	packageTask := pythonProject.Package(
 		*mockContext.Context,
-		serviceConfig,
+		&serviceConfig.ComponentConfig,
 		&ServiceBuildResult{
 			BuildOutputPath: serviceConfig.Path(),
 		},

--- a/cli/azd/pkg/project/importer_test.go
+++ b/cli/azd/pkg/project/importer_test.go
@@ -45,7 +45,7 @@ func TestImportManagerHasService(t *testing.T) {
 	r, e := manager.HasService(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
 			"test": {
-				ComponentConfig: ComponentConfig{
+				ComponentConfig: &ComponentConfig{
 					Name:     "test",
 					Language: ServiceLanguageJava,
 				},
@@ -59,7 +59,7 @@ func TestImportManagerHasService(t *testing.T) {
 	r, e = manager.HasService(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
 			"test": {
-				ComponentConfig: ComponentConfig{
+				ComponentConfig: &ComponentConfig{
 					Name:     "test",
 					Language: ServiceLanguageJava,
 				},
@@ -102,7 +102,7 @@ func TestImportManagerHasServiceErrorNoMultipleServicesWithAppHost(t *testing.T)
 		Path: "path",
 		Services: map[string]*ServiceConfig{
 			"test": {
-				ComponentConfig: ComponentConfig{
+				ComponentConfig: &ComponentConfig{
 					Name:         "test",
 					Language:     ServiceLanguageDotNet,
 					RelativePath: "path",
@@ -112,7 +112,7 @@ func TestImportManagerHasServiceErrorNoMultipleServicesWithAppHost(t *testing.T)
 				},
 			},
 			"foo": {
-				ComponentConfig: ComponentConfig{
+				ComponentConfig: &ComponentConfig{
 					Name:         "foo",
 					Language:     ServiceLanguageDotNet,
 					RelativePath: "path2",
@@ -159,7 +159,7 @@ func TestImportManagerHasServiceErrorAppHostMustTargetContainerApp(t *testing.T)
 		Path: "path",
 		Services: map[string]*ServiceConfig{
 			"test": {
-				ComponentConfig: ComponentConfig{
+				ComponentConfig: &ComponentConfig{
 					Name:         "test",
 					Language:     ServiceLanguageDotNet,
 					Host:         StaticWebAppTarget,
@@ -341,7 +341,7 @@ func TestImportManagerProjectInfrastructureAspire(t *testing.T) {
 	r, e := manager.ProjectInfrastructure(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
 			"test": {
-				ComponentConfig: ComponentConfig{
+				ComponentConfig: &ComponentConfig{
 					Name:         "test",
 					Language:     ServiceLanguageDotNet,
 					Host:         ContainerAppTarget,
@@ -371,7 +371,7 @@ func TestImportManagerProjectInfrastructureAspire(t *testing.T) {
 	_, e = manager.ProjectInfrastructure(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
 			"test": {
-				ComponentConfig: ComponentConfig{
+				ComponentConfig: &ComponentConfig{
 					Name:         "test",
 					Language:     ServiceLanguageDotNet,
 					Host:         ContainerAppTarget,

--- a/cli/azd/pkg/project/importer_test.go
+++ b/cli/azd/pkg/project/importer_test.go
@@ -45,8 +45,10 @@ func TestImportManagerHasService(t *testing.T) {
 	r, e := manager.HasService(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
 			"test": {
-				Name:     "test",
-				Language: ServiceLanguageJava,
+				ComponentConfig: ComponentConfig{
+					Name:     "test",
+					Language: ServiceLanguageJava,
+				},
 			},
 		},
 	}, "test")
@@ -57,8 +59,10 @@ func TestImportManagerHasService(t *testing.T) {
 	r, e = manager.HasService(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
 			"test": {
-				Name:     "test",
-				Language: ServiceLanguageJava,
+				ComponentConfig: ComponentConfig{
+					Name:     "test",
+					Language: ServiceLanguageJava,
+				},
 			},
 		},
 	}, "other")
@@ -98,19 +102,23 @@ func TestImportManagerHasServiceErrorNoMultipleServicesWithAppHost(t *testing.T)
 		Path: "path",
 		Services: map[string]*ServiceConfig{
 			"test": {
-				Name:         "test",
-				Language:     ServiceLanguageDotNet,
-				RelativePath: "path",
-				Project: &ProjectConfig{
-					Path: "path",
+				ComponentConfig: ComponentConfig{
+					Name:         "test",
+					Language:     ServiceLanguageDotNet,
+					RelativePath: "path",
+					Project: &ProjectConfig{
+						Path: "path",
+					},
 				},
 			},
 			"foo": {
-				Name:         "foo",
-				Language:     ServiceLanguageDotNet,
-				RelativePath: "path2",
-				Project: &ProjectConfig{
-					Path: "path",
+				ComponentConfig: ComponentConfig{
+					Name:         "foo",
+					Language:     ServiceLanguageDotNet,
+					RelativePath: "path2",
+					Project: &ProjectConfig{
+						Path: "path",
+					},
 				},
 			},
 		},
@@ -151,12 +159,14 @@ func TestImportManagerHasServiceErrorAppHostMustTargetContainerApp(t *testing.T)
 		Path: "path",
 		Services: map[string]*ServiceConfig{
 			"test": {
-				Name:         "test",
-				Language:     ServiceLanguageDotNet,
-				Host:         StaticWebAppTarget,
-				RelativePath: "path",
-				Project: &ProjectConfig{
-					Path: "path",
+				ComponentConfig: ComponentConfig{
+					Name:         "test",
+					Language:     ServiceLanguageDotNet,
+					Host:         StaticWebAppTarget,
+					RelativePath: "path",
+					Project: &ProjectConfig{
+						Path: "path",
+					},
 				},
 			},
 		},
@@ -331,12 +341,14 @@ func TestImportManagerProjectInfrastructureAspire(t *testing.T) {
 	r, e := manager.ProjectInfrastructure(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
 			"test": {
-				Name:         "test",
-				Language:     ServiceLanguageDotNet,
-				Host:         ContainerAppTarget,
-				RelativePath: "path",
-				Project: &ProjectConfig{
-					Path: "path",
+				ComponentConfig: ComponentConfig{
+					Name:         "test",
+					Language:     ServiceLanguageDotNet,
+					Host:         ContainerAppTarget,
+					RelativePath: "path",
+					Project: &ProjectConfig{
+						Path: "path",
+					},
 				},
 			},
 		},

--- a/cli/azd/pkg/project/importer_test.go
+++ b/cli/azd/pkg/project/importer_test.go
@@ -371,12 +371,14 @@ func TestImportManagerProjectInfrastructureAspire(t *testing.T) {
 	_, e = manager.ProjectInfrastructure(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
 			"test": {
-				Name:         "test",
-				Language:     ServiceLanguageDotNet,
-				Host:         ContainerAppTarget,
-				RelativePath: "path",
-				Project: &ProjectConfig{
-					Path: "path",
+				ComponentConfig: ComponentConfig{
+					Name:         "test",
+					Language:     ServiceLanguageDotNet,
+					Host:         ContainerAppTarget,
+					RelativePath: "path",
+					Project: &ProjectConfig{
+						Path: "path",
+					},
 				},
 			},
 		},

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -98,11 +98,9 @@ func Parse(ctx context.Context, yamlContent string) (*ProjectConfig, error) {
 			return nil, fmt.Errorf("parsing service %s: %w", svc.Name, err)
 		}
 
-		if len(svc.Containers) == 0 {
-			svc.Containers = map[string]*ComponentConfig{}
-			svc.Containers["default"] = &ComponentConfig{
-				Project:      &projectConfig,
-				Service:      svc,
+		if len(svc.Components) == 0 {
+			svc.Components = map[string]*ComponentConfig{}
+			svc.Components["default"] = &ComponentConfig{
 				Name:         "default",
 				Host:         svc.Host,
 				RelativePath: svc.RelativePath,
@@ -111,6 +109,11 @@ func Parse(ctx context.Context, yamlContent string) (*ProjectConfig, error) {
 				Image:        svc.Image,
 				Docker:       svc.Docker,
 			}
+		}
+
+		for _, comp := range svc.Components {
+			comp.Service = svc
+			comp.Project = &projectConfig
 		}
 
 		// TODO: Move parsing/validation requirements for service targets into their respective components.

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -100,8 +100,8 @@ func Parse(ctx context.Context, yamlContent string) (*ProjectConfig, error) {
 
 		if len(svc.Components) == 0 {
 			svc.Components = map[string]*ComponentConfig{}
-			svc.Components["default"] = &ComponentConfig{
-				Name:         "default",
+			svc.Components[defaultComponentName] = &ComponentConfig{
+				Name:         defaultComponentName,
 				Host:         svc.Host,
 				RelativePath: svc.RelativePath,
 				Language:     svc.Language,
@@ -119,7 +119,9 @@ func Parse(ctx context.Context, yamlContent string) (*ProjectConfig, error) {
 		// TODO: Move parsing/validation requirements for service targets into their respective components.
 		// When working within container based applications users may be using external/pre-built images instead of source
 		// In this case it is valid to have not specified a language but would be required to specify a source image
-		if svc.Host == ContainerAppTarget && svc.Language == ServiceLanguageNone && svc.Image == "" {
+		if svc.Host == ContainerAppTarget &&
+			svc.Language == ServiceLanguageNone &&
+			svc.Image == "" && len(svc.Components) == 1 {
 			return nil, fmt.Errorf("parsing service %s: must specify language or image", svc.Name)
 		}
 	}

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -98,9 +98,19 @@ func Parse(ctx context.Context, yamlContent string) (*ProjectConfig, error) {
 			return nil, fmt.Errorf("parsing service %s: %w", svc.Name, err)
 		}
 
-		svc.Infra.Provider, err = provisioning.ParseProvider(svc.Infra.Provider)
-		if err != nil {
-			return nil, fmt.Errorf("parsing service %s: %w", svc.Name, err)
+		if len(svc.Containers) == 0 {
+			svc.Containers = map[string]*ComponentConfig{}
+			svc.Containers["default"] = &ComponentConfig{
+				Project:      &projectConfig,
+				Service:      svc,
+				Name:         "default",
+				Host:         svc.Host,
+				RelativePath: svc.RelativePath,
+				Language:     svc.Language,
+				OutputPath:   svc.OutputPath,
+				Image:        svc.Image,
+				Docker:       svc.Docker,
+			}
 		}
 
 		// TODO: Move parsing/validation requirements for service targets into their respective components.

--- a/cli/azd/pkg/project/project_manager.go
+++ b/cli/azd/pkg/project/project_manager.go
@@ -195,17 +195,19 @@ func (pm *projectManager) EnsureFrameworkTools(
 			continue
 		}
 
-		frameworkService, err := pm.serviceManager.GetFrameworkService(ctx, svc)
-		if err != nil {
-			return fmt.Errorf("getting framework service: %w", err)
-		}
+		for _, component := range svc.Components {
+			frameworkService, err := pm.serviceManager.GetFrameworkService(ctx, component)
+			if err != nil {
+				return fmt.Errorf("getting framework service: %w", err)
+			}
 
-		frameworkTools := frameworkService.RequiredExternalTools(ctx)
-		if err != nil {
-			return fmt.Errorf("getting service required tools: %w", err)
-		}
+			frameworkTools := frameworkService.RequiredExternalTools(ctx)
+			if err != nil {
+				return fmt.Errorf("getting service required tools: %w", err)
+			}
 
-		requiredTools = append(requiredTools, frameworkTools...)
+			requiredTools = append(requiredTools, frameworkTools...)
+		}
 	}
 
 	if err := tools.EnsureInstalled(ctx, tools.Unique(requiredTools)...); err != nil {

--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -279,22 +279,26 @@ func TestMinimalYaml(t *testing.T) {
 		{
 			"minimal-service",
 			ServiceConfig{
-				Name:         "ignored",
-				Language:     ServiceLanguagePython,
-				Host:         AppServiceTarget,
-				RelativePath: "./src",
+				ComponentConfig: ComponentConfig{
+					Name:         "ignored",
+					Language:     ServiceLanguagePython,
+					Host:         AppServiceTarget,
+					RelativePath: "./src",
+				},
 			},
 		},
 		{
 			"minimal-docker",
 			ServiceConfig{
-				Name:     "ignored",
-				Language: ServiceLanguageDotNet,
-				Host:     ContainerAppTarget,
-				Docker: DockerProjectOptions{
-					Path: "./Dockerfile",
+				ComponentConfig: ComponentConfig{
+					Name:     "ignored",
+					Language: ServiceLanguageDotNet,
+					Host:     ContainerAppTarget,
+					Docker: DockerProjectOptions{
+						Path: "./Dockerfile",
+					},
+					RelativePath: "./src",
 				},
-				RelativePath: "./src",
 			},
 		},
 	}

--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -279,7 +279,7 @@ func TestMinimalYaml(t *testing.T) {
 		{
 			"minimal-service",
 			ServiceConfig{
-				ComponentConfig: ComponentConfig{
+				ComponentConfig: &ComponentConfig{
 					Name:         "ignored",
 					Language:     ServiceLanguagePython,
 					Host:         AppServiceTarget,
@@ -290,7 +290,7 @@ func TestMinimalYaml(t *testing.T) {
 		{
 			"minimal-docker",
 			ServiceConfig{
-				ComponentConfig: ComponentConfig{
+				ComponentConfig: &ComponentConfig{
 					Name:     "ignored",
 					Language: ServiceLanguageDotNet,
 					Host:     ContainerAppTarget,

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -8,6 +8,8 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 )
 
+const defaultComponentName = "main"
+
 type ServiceConfig struct {
 	ComponentConfig `yaml:",inline"`
 
@@ -80,8 +82,8 @@ func (sc *ServiceConfig) MarshalYAML() (interface{}, error) {
 
 	// If there is only a single container and it maps to our "default" convention,
 	// then we can promote the container to the service level
-	if _, has := svc.Components["default"]; has && len(svc.Components) == 1 {
-		svc.ComponentConfig = *svc.Components["default"]
+	if _, has := svc.Components[defaultComponentName]; has && len(svc.Components) == 1 {
+		svc.ComponentConfig = *svc.Components[defaultComponentName]
 		svc.Components = nil
 	} else {
 		// Host can be ignored
@@ -103,7 +105,7 @@ func (sc *ServiceConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 
 	if len(svc.Components) == 0 {
 		svc.Components = map[string]*ComponentConfig{
-			"default": &svc.ComponentConfig,
+			defaultComponentName: &svc.ComponentConfig,
 		}
 	}
 

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -5,21 +5,43 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/apphost"
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 )
 
 type ServiceConfig struct {
-	// Reference to the parent project configuration
-	Project *ProjectConfig `yaml:"-"`
-	// The friendly name/key of the project from the azure.yaml file
-	Name string `yaml:"-"`
+	ComponentConfig `yaml:",inline"`
+
 	// The name used to override the default azure resource name
 	ResourceName osutil.ExpandableString `yaml:"resourceName,omitempty"`
-	// The relative path to the project folder from the project root
-	RelativePath string `yaml:"project"`
+	// The optional K8S / AKS options
+	K8s AksOptions `yaml:"k8s,omitempty"`
+	// The optional Azure Spring Apps options
+	Spring SpringOptions `yaml:"spring,omitempty"`
+	// Hook configuration for service
+	Hooks map[string]*ext.HookConfig `yaml:"hooks,omitempty"`
+	// Options specific to the DotNetContainerApp target. These are set by the importer and
+	// can not be controlled via the project file today.
+	DotNetContainerApp *DotNetContainerAppOptions `yaml:"-,omitempty"`
+	// The optional container configuration for container based applications
+	Containers map[string]*ComponentConfig `yaml:"containers,omitempty"`
+
+	*ext.EventDispatcher[ServiceLifecycleEventArgs] `yaml:"-"`
+
+	initialized bool
+}
+
+// ComponentConfig is the configuration for a container based projects
+type ComponentConfig struct {
+	// Reference to the parent project configuration
+	Project *ProjectConfig `yaml:"-"`
+	// Reference to the parent project configuration
+	Service *ServiceConfig `yaml:"-"`
 	// The azure hosting model to use, ex) appservice, function, containerapp
 	Host ServiceTargetKind `yaml:"host"`
+	// The friendly name/key of the project from the azure.yaml file
+	Name string `yaml:"-"`
+	// The relative path to the project folder from the project root
+	RelativePath string `yaml:"project"`
 	// The programming language of the project
 	Language ServiceLanguageKind `yaml:"language"`
 	// The output path for build artifacts
@@ -29,20 +51,19 @@ type ServiceConfig struct {
 	// The optional docker options for configuring the output image
 	Docker DockerProjectOptions `yaml:"docker,omitempty"`
 	// The optional K8S / AKS options
-	K8s AksOptions `yaml:"k8s,omitempty"`
-	// The optional Azure Spring Apps options
-	Spring SpringOptions `yaml:"spring,omitempty"`
-	// The infrastructure provisioning configuration
-	Infra provisioning.Options `yaml:"infra,omitempty"`
-	// Hook configuration for service
-	Hooks map[string]*ext.HookConfig `yaml:"hooks,omitempty"`
-	// Options specific to the DotNetContainerApp target. These are set by the importer and
-	// can not be controlled via the project file today.
-	DotNetContainerApp *DotNetContainerAppOptions `yaml:"-,omitempty"`
+}
 
-	*ext.EventDispatcher[ServiceLifecycleEventArgs] `yaml:"-"`
-
-	initialized bool
+type ServiceComponent interface {
+	Project() *ProjectConfig
+	Service() *ServiceConfig
+	Name() string
+	Path() string
+	Host() ServiceTargetKind
+	Language() ServiceLanguageKind
+	WithLanguage(language ServiceLanguageKind)
+	OutputPath() string
+	Image() string
+	Docker() *DockerProjectOptions
 }
 
 type DotNetContainerAppOptions struct {
@@ -58,3 +79,62 @@ func (sc *ServiceConfig) Path() string {
 	}
 	return filepath.Join(sc.Project.Path, sc.RelativePath)
 }
+
+// func (sc *ServiceConfig) MarshalYAML() (interface{}, error) {
+// 	type serviceConfig ServiceConfig
+
+// 	svc := serviceConfig(*sc)
+// 	svcBytes, err := yaml.Marshal(svc)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	componentBytes, err := yaml.Marshal(sc.ComponentConfig)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	var svcMap map[string]interface{}
+// 	if err := yaml.Unmarshal(svcBytes, &svcMap); err != nil {
+// 		return nil, err
+// 	}
+
+// 	var componentMap map[string]interface{}
+// 	if err := yaml.Unmarshal(componentBytes, &componentMap); err != nil {
+// 		return nil, err
+// 	}
+
+// 	for k, v := range componentMap {
+// 		svcMap[k] = v
+// 	}
+
+// 	yamlBytes, err := yaml.Marshal(svcMap)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	return string(yamlBytes), nil
+// }
+
+// func (sc *ServiceConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+// 	// Leverage the built-in unmarshaler to hydrate the service configuration
+// 	type serviceConfig ServiceConfig
+// 	var svc serviceConfig
+// 	if err := unmarshal(&svc); err != nil {
+// 		return err
+// 	}
+
+// 	// Reset the pointer
+// 	*sc = ServiceConfig(svc)
+
+// 	// Append the component configuration
+// 	var componentConfig ComponentConfig
+// 	if err := unmarshal(&componentConfig); err != nil {
+// 		return err
+// 	}
+
+// 	componentConfig.Service = sc
+// 	sc.ComponentConfig = componentConfig
+
+// 	return nil
+// }

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -11,7 +11,7 @@ import (
 const defaultComponentName = "main"
 
 type ServiceConfig struct {
-	ComponentConfig `yaml:",inline"`
+	*ComponentConfig `yaml:",inline"`
 
 	// The name used to override the default azure resource name
 	ResourceName osutil.ExpandableString `yaml:"resourceName,omitempty"`
@@ -83,7 +83,7 @@ func (sc *ServiceConfig) MarshalYAML() (interface{}, error) {
 	// If there is only a single container and it maps to our "default" convention,
 	// then we can promote the container to the service level
 	if _, has := svc.Components[defaultComponentName]; has && len(svc.Components) == 1 {
-		svc.ComponentConfig = *svc.Components[defaultComponentName]
+		svc.ComponentConfig = svc.Components[defaultComponentName]
 		svc.Components = nil
 	} else {
 		// Host can be ignored
@@ -105,7 +105,7 @@ func (sc *ServiceConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 
 	if len(svc.Components) == 0 {
 		svc.Components = map[string]*ComponentConfig{
-			defaultComponentName: &svc.ComponentConfig,
+			defaultComponentName: svc.ComponentConfig,
 		}
 	}
 

--- a/cli/azd/pkg/project/service_config_test.go
+++ b/cli/azd/pkg/project/service_config_test.go
@@ -212,14 +212,16 @@ func TestServiceConfigRaiseEventWithArgs(t *testing.T) {
 
 func createTestServiceConfig(path string, host ServiceTargetKind, language ServiceLanguageKind) *ServiceConfig {
 	return &ServiceConfig{
-		Name:         "api",
-		Host:         host,
-		Language:     language,
-		RelativePath: filepath.Join(path),
-		Project: &ProjectConfig{
-			Name:            "Test-App",
-			Path:            ".",
-			EventDispatcher: ext.NewEventDispatcher[ProjectLifecycleEventArgs](),
+		ComponentConfig: ComponentConfig{
+			Name:         "api",
+			Host:         host,
+			Language:     language,
+			RelativePath: filepath.Join(path),
+			Project: &ProjectConfig{
+				Name:            "Test-App",
+				Path:            ".",
+				EventDispatcher: ext.NewEventDispatcher[ProjectLifecycleEventArgs](),
+			},
 		},
 		EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
 	}

--- a/cli/azd/pkg/project/service_config_test.go
+++ b/cli/azd/pkg/project/service_config_test.go
@@ -238,9 +238,9 @@ func Test_ServiceConfig_Unmarshall(t *testing.T) {
 				require.Equal(t, "./src/api", proj.Services["api"].RelativePath)
 
 				// Expect the same values to be available in the container configuration
-				require.Equal(t, AksTarget, proj.Services["api"].Components["default"].Host)
-				require.Equal(t, ServiceLanguageJavaScript, proj.Services["api"].Components["default"].Language)
-				require.Equal(t, "./src/api", proj.Services["api"].Components["default"].RelativePath)
+				require.Equal(t, AksTarget, proj.Services["api"].Components[defaultComponentName].Host)
+				require.Equal(t, ServiceLanguageJavaScript, proj.Services["api"].Components[defaultComponentName].Language)
+				require.Equal(t, "./src/api", proj.Services["api"].Components[defaultComponentName].RelativePath)
 			},
 		},
 		{

--- a/cli/azd/pkg/project/service_config_test.go
+++ b/cli/azd/pkg/project/service_config_test.go
@@ -238,9 +238,9 @@ func Test_ServiceConfig_Unmarshall(t *testing.T) {
 				require.Equal(t, "./src/api", proj.Services["api"].RelativePath)
 
 				// Expect the same values to be available in the container configuration
-				require.Equal(t, AksTarget, proj.Services["api"].Containers["default"].Host)
-				require.Equal(t, ServiceLanguageJavaScript, proj.Services["api"].Containers["default"].Language)
-				require.Equal(t, "./src/api", proj.Services["api"].Containers["default"].RelativePath)
+				require.Equal(t, AksTarget, proj.Services["api"].Components["default"].Host)
+				require.Equal(t, ServiceLanguageJavaScript, proj.Services["api"].Components["default"].Language)
+				require.Equal(t, "./src/api", proj.Services["api"].Components["default"].RelativePath)
 			},
 		},
 		{
@@ -261,11 +261,11 @@ func Test_ServiceConfig_Unmarshall(t *testing.T) {
 			validateFn: func(t *testing.T, proj *ProjectConfig) {
 				require.Equal(t, "todo", proj.Services["todo"].Name)
 				require.Equal(t, AksTarget, proj.Services["todo"].Host)
-				require.Equal(t, 2, len(proj.Services["todo"].Containers))
-				require.Equal(t, ServiceLanguageJavaScript, proj.Services["todo"].Containers["api"].Language)
-				require.Equal(t, ServiceLanguageJavaScript, proj.Services["todo"].Containers["web"].Language)
-				require.Equal(t, "./src/api", proj.Services["todo"].Containers["api"].RelativePath)
-				require.Equal(t, "./src/web", proj.Services["todo"].Containers["web"].RelativePath)
+				require.Equal(t, 2, len(proj.Services["todo"].Components))
+				require.Equal(t, ServiceLanguageJavaScript, proj.Services["todo"].Components["api"].Language)
+				require.Equal(t, ServiceLanguageJavaScript, proj.Services["todo"].Components["web"].Language)
+				require.Equal(t, "./src/api", proj.Services["todo"].Components["api"].RelativePath)
+				require.Equal(t, "./src/web", proj.Services["todo"].Components["web"].RelativePath)
 			},
 		},
 	}
@@ -294,7 +294,7 @@ func Test_ServiceConfig_Marshall(t *testing.T) {
 				Name: "test-proj",
 				Services: map[string]*ServiceConfig{
 					"api": {
-						Containers: map[string]*ComponentConfig{
+						Components: map[string]*ComponentConfig{
 							"default": {
 								Host:         AksTarget,
 								Language:     ServiceLanguageJavaScript,
@@ -314,7 +314,7 @@ func Test_ServiceConfig_Marshall(t *testing.T) {
 						ComponentConfig: ComponentConfig{
 							Host: AksTarget,
 						},
-						Containers: map[string]*ComponentConfig{
+						Components: map[string]*ComponentConfig{
 							"api": {
 								Language:     ServiceLanguageJavaScript,
 								RelativePath: "./src/api",
@@ -337,7 +337,7 @@ func Test_ServiceConfig_Marshall(t *testing.T) {
 						ComponentConfig: ComponentConfig{
 							Host: AksTarget,
 						},
-						Containers: map[string]*ComponentConfig{
+						Components: map[string]*ComponentConfig{
 							"api": {
 								Language:     ServiceLanguageJavaScript,
 								RelativePath: "./src/api",
@@ -356,7 +356,7 @@ func Test_ServiceConfig_Marshall(t *testing.T) {
 						ComponentConfig: ComponentConfig{
 							Host: ContainerAppTarget,
 						},
-						Containers: map[string]*ComponentConfig{
+						Components: map[string]*ComponentConfig{
 							"main": {
 								Language:     ServiceLanguageJavaScript,
 								RelativePath: "./src/api",

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -201,7 +201,7 @@ func (sm *serviceManager) Restore(
 			ServiceEventRestore,
 			serviceConfig,
 			func() *async.TaskWithProgress[*ServiceRestoreResult, ServiceProgress] {
-				return async.RunTaskWithProgress[*ServiceRestoreResult, ServiceProgress](
+				return async.RunTaskWithProgress(
 					func(componentTask *async.TaskContextWithProgress[*ServiceRestoreResult, ServiceProgress]) {
 						componentResults := map[string]*ServiceRestoreResult{}
 
@@ -213,7 +213,7 @@ func (sm *serviceManager) Restore(
 							}
 
 							restoreTask := frameworkService.Restore(ctx, component)
-							syncProgress(rootTask, restoreTask.Progress())
+							syncProgress(componentTask, restoreTask.Progress())
 							restoreResult, err := restoreTask.Await()
 							if err != nil {
 								componentTask.SetError(err)
@@ -268,7 +268,7 @@ func (sm *serviceManager) Build(
 			ServiceEventBuild,
 			component,
 			func() *async.TaskWithProgress[*ServiceBuildResult, ServiceProgress] {
-				return async.RunTaskWithProgress[*ServiceBuildResult, ServiceProgress](
+				return async.RunTaskWithProgress(
 					func(componentTask *async.TaskContextWithProgress[*ServiceBuildResult, ServiceProgress]) {
 						componentResults := map[string]*ServiceBuildResult{}
 
@@ -280,7 +280,7 @@ func (sm *serviceManager) Build(
 							}
 
 							buildTask := frameworkService.Build(ctx, component, restoreOutput)
-							syncProgress(rootTask, buildTask.Progress())
+							syncProgress(componentTask, buildTask.Progress())
 							restoreResult, err := buildTask.Await()
 							if err != nil {
 								componentTask.SetError(err)
@@ -697,7 +697,7 @@ func runCommand[T comparable, P comparable](
 
 	err := serviceConfig.Invoke(ctx, eventName, eventArgs, func() error {
 		serviceTask := taskFunc()
-		go syncProgress(task, serviceTask.Progress())
+		syncProgress(task, serviceTask.Progress())
 
 		taskResult, err := serviceTask.Await()
 		if err != nil {

--- a/cli/azd/pkg/project/service_manager_test.go
+++ b/cli/azd/pkg/project/service_manager_test.go
@@ -227,7 +227,7 @@ func Test_ServiceManager_GetFrameworkService(t *testing.T) {
 		sm := createServiceManager(mockContext, env, ServiceOperationCache{})
 		serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
-		framework, err := sm.GetFrameworkService(*mockContext.Context, serviceConfig)
+		framework, err := sm.GetFrameworkService(*mockContext.Context, &serviceConfig.ComponentConfig)
 		require.NoError(t, err)
 		require.NotNil(t, framework)
 		require.IsType(t, new(fakeFramework), framework)
@@ -243,7 +243,7 @@ func Test_ServiceManager_GetFrameworkService(t *testing.T) {
 		serviceConfig := createTestServiceConfig("", ServiceTargetFake, ServiceLanguageNone)
 		serviceConfig.Image = "nginx"
 
-		framework, err := sm.GetFrameworkService(*mockContext.Context, serviceConfig)
+		framework, err := sm.GetFrameworkService(*mockContext.Context, &serviceConfig.ComponentConfig)
 		require.NoError(t, err)
 		require.NotNil(t, framework)
 		require.IsType(t, new(fakeFramework), framework)
@@ -259,7 +259,7 @@ func Test_ServiceManager_GetFrameworkService(t *testing.T) {
 		serviceConfig := createTestServiceConfig("", ServiceTargetFake, ServiceLanguageNone)
 
 		require.Panics(t, func() {
-			_, _ = sm.GetFrameworkService(*mockContext.Context, serviceConfig)
+			_, _ = sm.GetFrameworkService(*mockContext.Context, &serviceConfig.ComponentConfig)
 		})
 	})
 }
@@ -489,13 +489,13 @@ func (f *fakeFramework) RequiredExternalTools(ctx context.Context) []tools.Exter
 	return []tools.ExternalTool{&fakeTool{}}
 }
 
-func (f *fakeFramework) Initialize(ctx context.Context, serviceConfig *ServiceConfig) error {
+func (f *fakeFramework) Initialize(ctx context.Context, component *ComponentConfig) error {
 	return nil
 }
 
 func (f *fakeFramework) Restore(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 ) *async.TaskWithProgress[*ServiceRestoreResult, ServiceProgress] {
 	restoreCalled, ok := ctx.Value(frameworkRestoreCalled).(*bool)
 	if ok {
@@ -518,7 +518,7 @@ func (f *fakeFramework) Restore(
 
 func (f *fakeFramework) Build(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	restoreOutput *ServiceRestoreResult,
 ) *async.TaskWithProgress[*ServiceBuildResult, ServiceProgress] {
 	buildCalled, ok := ctx.Value(frameworkBuildCalled).(*bool)
@@ -543,7 +543,7 @@ func (f *fakeFramework) Build(
 
 func (f *fakeFramework) Package(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	buildOutput *ServiceBuildResult,
 ) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress] {
 	packageCalled, ok := ctx.Value(frameworkPackageCalled).(*bool)

--- a/cli/azd/pkg/project/service_models.go
+++ b/cli/azd/pkg/project/service_models.go
@@ -73,6 +73,16 @@ type ServicePackageResult struct {
 
 // Supports rendering messages for UX items
 func (spr *ServicePackageResult) ToString(currentIndentation string) string {
+	compositeResult, ok := spr.Details.(map[string]*ServicePackageResult)
+	if ok {
+		builder := strings.Builder{}
+		for name, componentResult := range compositeResult {
+			builder.WriteString(fmt.Sprintf("(%s) %s\n", name, componentResult.ToString(currentIndentation)))
+		}
+
+		return builder.String()
+	}
+
 	uxItem, ok := spr.Details.(ux.UxItem)
 	if ok {
 		return uxItem.ToString(currentIndentation)

--- a/cli/azd/pkg/project/service_models.go
+++ b/cli/azd/pkg/project/service_models.go
@@ -76,8 +76,9 @@ func (spr *ServicePackageResult) ToString(currentIndentation string) string {
 	compositeResult, ok := spr.Details.(map[string]*ServicePackageResult)
 	if ok {
 		builder := strings.Builder{}
+		componentIndentation := currentIndentation
 		for name, componentResult := range compositeResult {
-			builder.WriteString(fmt.Sprintf("(%s) %s\n", name, componentResult.ToString(currentIndentation)))
+			builder.WriteString(fmt.Sprintf("%s%s:\n%s", componentIndentation, output.WithBold(name), componentResult.ToString(componentIndentation+"  ")))
 		}
 
 		return builder.String()

--- a/cli/azd/pkg/project/service_models.go
+++ b/cli/azd/pkg/project/service_models.go
@@ -48,6 +48,24 @@ type ServiceBuildResult struct {
 
 // Supports rendering messages for UX items
 func (sbr *ServiceBuildResult) ToString(currentIndentation string) string {
+	compositeResult, ok := sbr.Details.(map[string]*ServiceBuildResult)
+	if ok {
+		builder := strings.Builder{}
+		componentIndentation := currentIndentation
+		for name, componentResult := range compositeResult {
+			builder.WriteString(
+				fmt.Sprintf(
+					"%s%s:\n%s",
+					componentIndentation,
+					output.WithBold(name),
+					componentResult.ToString(componentIndentation+"  "),
+				),
+			)
+		}
+
+		return builder.String()
+	}
+
 	uxItem, ok := sbr.Details.(ux.UxItem)
 	if ok {
 		return uxItem.ToString(currentIndentation)

--- a/cli/azd/pkg/project/service_models.go
+++ b/cli/azd/pkg/project/service_models.go
@@ -78,7 +78,14 @@ func (spr *ServicePackageResult) ToString(currentIndentation string) string {
 		builder := strings.Builder{}
 		componentIndentation := currentIndentation
 		for name, componentResult := range compositeResult {
-			builder.WriteString(fmt.Sprintf("%s%s:\n%s", componentIndentation, output.WithBold(name), componentResult.ToString(componentIndentation+"  ")))
+			builder.WriteString(
+				fmt.Sprintf(
+					"%s%s:\n%s",
+					componentIndentation,
+					output.WithBold(name),
+					componentResult.ToString(componentIndentation+"  "),
+				),
+			)
 		}
 
 		return builder.String()

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -800,7 +800,7 @@ func createAksServiceTarget(
 	userConfig config.Config,
 ) ServiceTarget {
 	kubeCtl := kubectl.NewKubectl(mockContext.CommandRunner)
-	helmCli := helm.NewCli(mockContext.CommandRunner)
+	helmCli := helm.NewCli(mockContext.CommandRunner, env)
 	kustomizeCli := kustomize.NewCli(mockContext.CommandRunner)
 	dockerCli := docker.NewDocker(mockContext.CommandRunner)
 	kubeLoginCli := kubelogin.NewCli(mockContext.CommandRunner)

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -120,9 +120,13 @@ func Test_Package_Deploy_HappyPath(t *testing.T) {
 		serviceConfig,
 		&ServicePackageResult{
 			PackagePath: "test-app/api-test:azd-deploy-0",
-			Details: &dockerPackageResult{
-				ImageHash:   "IMAGE_HASH",
-				TargetImage: "test-app/api-test:azd-deploy-0",
+			Details: map[string]*ServicePackageResult{
+				"main": {
+					Details: &dockerPackageResult{
+						ImageHash:   "IMAGE_HASH",
+						TargetImage: "test-app/api-test:azd-deploy-0",
+					},
+				},
 			},
 		},
 	)
@@ -131,7 +135,7 @@ func Test_Package_Deploy_HappyPath(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, packageResult)
-	require.IsType(t, new(dockerPackageResult), packageResult.Details)
+	require.Len(t, packageResult.Details, 1)
 
 	scope := environment.NewTargetResource("SUB_ID", "RG_ID", "", string(infra.AzureResourceTypeManagedCluster))
 	deployTask := serviceTarget.Deploy(*mockContext.Context, serviceConfig, packageResult, scope)
@@ -141,7 +145,7 @@ func Test_Package_Deploy_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, deployResult)
 	require.Equal(t, AksTarget, deployResult.Kind)
-	require.IsType(t, new(kubectl.Deployment), deployResult.Details)
+	require.IsType(t, []*kubectl.Deployment{}, deployResult.Details)
 	require.Greater(t, len(deployResult.Endpoints), 0)
 	// New env variable is created
 	require.Equal(t, "REGISTRY.azurecr.io/test-app/api-test:azd-deploy-0", env.Dotenv()["SERVICE_API_IMAGE_NAME"])
@@ -283,7 +287,12 @@ func Test_Deploy_Helm(t *testing.T) {
 	require.NoError(t, err)
 
 	packageResult := &ServicePackageResult{
-		PackagePath: "",
+		PackagePath: "test-app/api-test:azd-deploy-0",
+		Details: map[string]*ServicePackageResult{
+			"main": {
+				PackagePath: "",
+			},
+		},
 	}
 
 	scope := environment.NewTargetResource("SUB_ID", "RG_ID", "", string(infra.AzureResourceTypeManagedCluster))
@@ -345,7 +354,12 @@ func Test_Deploy_Kustomize(t *testing.T) {
 	require.NoError(t, err)
 
 	packageResult := &ServicePackageResult{
-		PackagePath: "",
+		PackagePath: "test-app/api-test:azd-deploy-0",
+		Details: map[string]*ServicePackageResult{
+			"main": {
+				PackagePath: "",
+			},
+		},
 	}
 
 	scope := environment.NewTargetResource("SUB_ID", "RG_ID", "", string(infra.AzureResourceTypeManagedCluster))

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -326,7 +326,7 @@ func Test_Deploy_Kustomize(t *testing.T) {
 	serviceConfig.RelativePath = ""
 	serviceConfig.K8s.Kustomize = &kustomize.Config{
 		Directory: osutil.NewExpandableString("./kustomize/overlays/dev"),
-		Edits: []*osutil.ExpandableString{
+		Edits: []osutil.ExpandableString{
 			osutil.NewExpandableString("set image todo-api=${SERVICE_API_IMAGE_NAME}"),
 		},
 	}

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -326,7 +326,7 @@ func Test_Deploy_Kustomize(t *testing.T) {
 	serviceConfig.RelativePath = ""
 	serviceConfig.K8s.Kustomize = &kustomize.Config{
 		Directory: osutil.NewExpandableString("./kustomize/overlays/dev"),
-		Edits: []osutil.ExpandableString{
+		Edits: []*osutil.ExpandableString{
 			osutil.NewExpandableString("set image todo-api=${SERVICE_API_IMAGE_NAME}"),
 		},
 	}

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -88,9 +88,13 @@ func Test_ContainerApp_Deploy(t *testing.T) {
 		serviceConfig,
 		&ServicePackageResult{
 			PackagePath: "test-app/api-test:azd-deploy-0",
-			Details: &dockerPackageResult{
-				ImageHash:   "IMAGE_HASH",
-				TargetImage: "test-app/api-test:azd-deploy-0",
+			Details: map[string]*ServicePackageResult{
+				"main": {
+					Details: &dockerPackageResult{
+						ImageHash:   "IMAGE_HASH",
+						TargetImage: "test-app/api-test:azd-deploy-0",
+					},
+				},
 			},
 		},
 	)
@@ -99,7 +103,7 @@ func Test_ContainerApp_Deploy(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, packageResult)
-	require.IsType(t, new(dockerPackageResult), packageResult.Details)
+	require.IsType(t, map[string]*ServicePackageResult{}, packageResult.Details)
 
 	scope := environment.NewTargetResource(
 		"SUBSCRIPTION_ID",
@@ -195,6 +199,7 @@ func setupMocksForContainerApps(mockContext *mocks.MockContext) {
 			Template: &armappcontainers.Template{
 				Containers: []*armappcontainers.Container{
 					{
+						Name:  convert.RefOf(defaultComponentName),
 						Image: &originalImageName,
 					},
 				},
@@ -207,6 +212,7 @@ func setupMocksForContainerApps(mockContext *mocks.MockContext) {
 			Template: &armappcontainers.Template{
 				Containers: []*armappcontainers.Container{
 					{
+						Name:  convert.RefOf(defaultComponentName),
 						Image: &updatedRevisionName,
 					},
 				},

--- a/cli/azd/pkg/project/testdata/TestMinimalYaml-minimal-docker.snap
+++ b/cli/azd/pkg/project/testdata/TestMinimalYaml-minimal-docker.snap
@@ -1,8 +1,8 @@
 name: minimal
 services:
     minimal-docker:
-        project: ./src
         host: containerapp
+        project: ./src
         language: dotnet
         docker:
             path: ./Dockerfile

--- a/cli/azd/pkg/project/testdata/TestMinimalYaml-minimal-service.snap
+++ b/cli/azd/pkg/project/testdata/TestMinimalYaml-minimal-service.snap
@@ -1,7 +1,7 @@
 name: minimal
 services:
     minimal-service:
-        project: ./src
         host: appservice
+        project: ./src
         language: python
 

--- a/cli/azd/pkg/project/testdata/Test_ServiceConfig_Marshall-Multiple_Containers.snap
+++ b/cli/azd/pkg/project/testdata/Test_ServiceConfig_Marshall-Multiple_Containers.snap
@@ -1,0 +1,12 @@
+name: test-proj
+services:
+    todo:
+        host: aks
+        containers:
+            api:
+                project: ./src/api
+                language: js
+            web:
+                project: ./src/web
+                language: js
+

--- a/cli/azd/pkg/project/testdata/Test_ServiceConfig_Marshall-Multiple_containers_with_other_configuration.snap
+++ b/cli/azd/pkg/project/testdata/Test_ServiceConfig_Marshall-Multiple_containers_with_other_configuration.snap
@@ -1,0 +1,16 @@
+name: test-proj
+services:
+    todo:
+        host: containerapp
+        containers:
+            main:
+                project: ./src/api
+                language: js
+                docker:
+                    path: ./Dockerfile
+                    registry: docker.io
+                    image: test-image
+                    tag: latest
+            sidecar:
+                image: docker.io/sidecar:latest
+

--- a/cli/azd/pkg/project/testdata/Test_ServiceConfig_Marshall-Single_container_with_non-default_name.snap
+++ b/cli/azd/pkg/project/testdata/Test_ServiceConfig_Marshall-Single_container_with_non-default_name.snap
@@ -1,0 +1,9 @@
+name: test-proj
+services:
+    todo:
+        host: aks
+        containers:
+            api:
+                project: ./src/api
+                language: js
+

--- a/cli/azd/pkg/project/testdata/Test_ServiceConfig_Marshall-Standard_Project.snap
+++ b/cli/azd/pkg/project/testdata/Test_ServiceConfig_Marshall-Standard_Project.snap
@@ -1,0 +1,7 @@
+name: test-proj
+services:
+    api:
+        host: aks
+        project: ./src/api
+        language: js
+


### PR DESCRIPTION
Resolves #3236, #3239

Adds support to configure multiple containers within either ACA/AKS service targets and deploy them as an atomic unit.

Implementation is based on [this gist](https://gist.github.com/wbreza/67fdc3054025311fdf147f303f04dc4e)

## Use Case: Develop a Helm chart that references multiple containers

Custom variation of Todo AKS template is available @ https://github.com/wbreza/todo-nodejs-mongo-aks/tree/helm

The following will deploy a single service named `todo` that contains multiple containers that are built from source.
The `web` and `api` containers will be built, pushed to the container registry then referenced in a local helm chart.

> [!NOTE]
> This example uses helm but will work in any AKS configuration

```yaml
# azure.yaml

name: todo-nodejs-mongo-aks
metadata:
  template: todo-nodejs-mongo-aks@0.0.1-beta
services:
  todo:
    host: aks
    # Specify the multiple containers that will be deployed when this `todo` service is deployed.
    containers:
      web:
        project: ./src/web
        dist: build
        language: js
      api:
        project: ./src/api
        language: js
    k8s:
      helm:
        releases:
          - name: todo
            # Reference the local helm chart and values.yaml
            chart: ./charts/todo
            values: ./charts/todo/values.yaml
            namespace: todo-helm
            # Override/set additional values in addition to values.yaml
            overrides:
              cluster.clientId: ${AZURE_AKS_IDENTITY_CLIENT_ID}
              keyvault.endpoint: ${AZURE_KEY_VAULT_ENDPOINT}
              appInsights.connectionString: ${APPLICATIONINSIGHTS_CONNECTION_STRING}
              api.image: ${SERVICE_API_IMAGE_NAME}
              web.image: ${SERVICE_WEB_IMAGE_NAME}
```
### Helm Configuration

The helm chart organization of multiple resource components.

<img width="250" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/4d830b70-51a7-42e4-bdcd-db1b776614e6">

Helm chart `values.yaml` contains the baseline configuration for the chart

```yaml
# values.yaml

api:
  port: 3100
web:
  port: 3000
```

## Use Case: Deploy multiple sidecar containers to a single Azure Container App

Custom variation of Todo ACA template is available @ https://github.com/wbreza/todo-nodejs-mongo-aca/tree/multi-container-poc

In the following example a Todo application with 2 container apps is deployed.

- `web` container app contains a single container with standard configuration
- `api` container app contains multiple containers leveraging the new `containers` configuration section
  - Includes a `main` container as well as a `sidecar`

> [!IMPORTANT] 
> During the deployment a single revision is added referencing both containers

```yaml
# azure.yaml

name: todo-nodejs-mongo-aca
metadata:
  template: todo-nodejs-mongo-aca@0.0.1-beta
services:
  web:
    project: ./src/web
    language: js
    host: containerapp
  api:
    host: containerapp
    # Configure multiple containers that will be build, tagged and pushed as part of deployment
    containers: 
      main: 
        project: ./src/api
        language: js
      sidecar:
        project: ./src/sidecar
        language: js
```

**Azure Portal after deployment**
 
<img width="677" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/df001c00-0bc9-48dd-87b1-85f473a5d723">
