### PR TITLE
vsrpc: Expose spinner updates in VS

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -118,7 +118,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		isTerminal := cmd.OutOrStdout() == os.Stdout &&
 			cmd.InOrStdin() == os.Stdin && input.IsTerminal(os.Stdout.Fd(), os.Stdin.Fd())
 
-		return input.NewConsole(rootOptions.NoPrompt, isTerminal, writer, input.ConsoleHandles{
+		return input.NewConsole(rootOptions.NoPrompt, isTerminal, input.Writers{Output: os.Stdout}, input.ConsoleHandles{
 			Stdin:  cmd.InOrStdin(),
 			Stdout: cmd.OutOrStdout(),
 			Stderr: cmd.ErrOrStderr(),

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -118,7 +118,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		isTerminal := cmd.OutOrStdout() == os.Stdout &&
 			cmd.InOrStdin() == os.Stdin && input.IsTerminal(os.Stdout.Fd(), os.Stdin.Fd())
 
-		return input.NewConsole(rootOptions.NoPrompt, isTerminal, input.Writers{Output: os.Stdout}, input.ConsoleHandles{
+		return input.NewConsole(rootOptions.NoPrompt, isTerminal, input.Writers{Output: writer}, input.ConsoleHandles{
 			Stdin:  cmd.InOrStdin(),
 			Stdout: cmd.OutOrStdout(),
 			Stderr: cmd.ErrOrStderr(),

--- a/cli/azd/internal/repository/detect_confirm_test.go
+++ b/cli/azd/internal/repository/detect_confirm_test.go
@@ -194,7 +194,7 @@ func Test_detectConfirm_confirm(t *testing.T) {
 				console: input.NewConsole(
 					false,
 					false,
-					os.Stdout,
+					input.Writers{Output: os.Stdout},
 					input.ConsoleHandles{
 						Stderr: os.Stderr,
 						Stdin:  strings.NewReader(strings.Join(tt.interactions, "\n") + "\n"),

--- a/cli/azd/internal/repository/infra_confirm_test.go
+++ b/cli/azd/internal/repository/infra_confirm_test.go
@@ -204,7 +204,7 @@ func TestInitializer_infraSpecFromDetect(t *testing.T) {
 				console: input.NewConsole(
 					false,
 					false,
-					os.Stdout,
+					input.Writers{Output: os.Stdout},
 					input.ConsoleHandles{
 						Stderr: os.Stderr,
 						Stdin:  strings.NewReader(strings.Join(tt.interactions, "\n") + "\n"),

--- a/cli/azd/internal/vsrpc/environment_service_deploy.go
+++ b/cli/azd/internal/vsrpc/environment_service_deploy.go
@@ -36,6 +36,7 @@ func (s *environmentService) DeployAsync(
 	}
 
 	spinnerWriter := &lineWriter{
+		trimLineEndings: true,
 		next: &messageWriter{
 			ctx:      ctx,
 			observer: observer,

--- a/cli/azd/internal/vsrpc/message_writer.go
+++ b/cli/azd/internal/vsrpc/message_writer.go
@@ -19,7 +19,7 @@ type messageWriter struct {
 
 // Write implements io.Writer.
 func (mw *messageWriter) Write(p []byte) (int, error) {
-	err := mw.observer.OnNext(mw.ctx, mw.messageTemplate.Fill(string(p)))
+	err := mw.observer.OnNext(mw.ctx, mw.messageTemplate.WithMessage(string(p)))
 	if err != nil {
 		return 0, err
 	}

--- a/cli/azd/internal/vsrpc/message_writer.go
+++ b/cli/azd/internal/vsrpc/message_writer.go
@@ -11,8 +11,9 @@ import (
 
 // messageWriter is an io.Writer that writes to an IObserver[ProgressMessage], emitting a message for each write.
 type messageWriter struct {
-	ctx      context.Context
-	observer IObserver[ProgressMessage]
+	ctx             context.Context
+	observer        IObserver[ProgressMessage]
+	messageTemplate ProgressMessage
 }
 
 // lineWriter is an io.Writer that writes to another io.Writer, emitting a message for each line written.
@@ -61,7 +62,7 @@ func (mw *lineWriter) Flush(ctx context.Context) error {
 
 // Write implements io.Writer.
 func (mw *messageWriter) Write(p []byte) (int, error) {
-	err := mw.observer.OnNext(mw.ctx, newInfoProgressMessage(string(p)))
+	err := mw.observer.OnNext(mw.ctx, mw.messageTemplate.Fill(string(p)))
 	if err != nil {
 		return 0, err
 	}

--- a/cli/azd/internal/vsrpc/message_writer_test.go
+++ b/cli/azd/internal/vsrpc/message_writer_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package vsrpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type writeCapturer struct {
+	writes []string
+}
+
+func (lc *writeCapturer) Write(p []byte) (int, error) {
+	lc.writes = append(lc.writes, string(p))
+	return len(p), nil
+}
+
+func Test_lineWriter_Write(t *testing.T) {
+	tests := []struct {
+		name            string
+		inputs          []string
+		trimLineEndings bool
+		want            []string
+	}{
+		{
+			name: "no trimming",
+			inputs: []string{
+				"single sentence\n",
+				"split ",
+				"sentence\n"},
+			trimLineEndings: false,
+			want: []string{
+				"single sentence\n",
+				"split sentence\n"},
+		},
+		{
+			name: "trim LF",
+			inputs: []string{
+				"single sentence\n",
+				"split ",
+				"sentence\n"},
+			trimLineEndings: true,
+			want: []string{
+				"single sentence",
+				"split sentence"},
+		},
+		{
+			name: "trim CRLF",
+			inputs: []string{
+				"single sentence\r\n",
+				"split ",
+				"sentence\r\n"},
+			trimLineEndings: true,
+			want: []string{
+				"single sentence",
+				"split sentence"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			captured := &writeCapturer{}
+			lw := &lineWriter{
+				next:            captured,
+				trimLineEndings: tt.trimLineEndings,
+			}
+
+			for _, input := range tt.inputs {
+				_, err := lw.Write([]byte(input))
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tt.want, captured.writes)
+		})
+	}
+}

--- a/cli/azd/internal/vsrpc/models.go
+++ b/cli/azd/internal/vsrpc/models.go
@@ -68,6 +68,12 @@ func newInfoProgressMessage(message string) ProgressMessage {
 	}
 }
 
+func (m ProgressMessage) Fill(message string) ProgressMessage {
+	m.Message = message
+	m.Time = time.Now()
+	return m
+}
+
 type MessageSeverity int
 
 const (

--- a/cli/azd/internal/vsrpc/models.go
+++ b/cli/azd/internal/vsrpc/models.go
@@ -68,7 +68,8 @@ func newInfoProgressMessage(message string) ProgressMessage {
 	}
 }
 
-func (m ProgressMessage) Fill(message string) ProgressMessage {
+// WithMessage returns a new ProgressMessage with the given message and timestamp set to now.
+func (m ProgressMessage) WithMessage(message string) ProgressMessage {
 	m.Message = message
 	m.Time = time.Now()
 	return m

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -667,7 +667,7 @@ type Writers struct {
 	// The writer to write output to.
 	Output io.Writer
 
-	// The writer to write spinner output to. If nil, the spinner will write to the Writer.
+	// The writer to write spinner output to. If nil, the spinner will write to Output.
 	Spinner io.Writer
 }
 

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -662,24 +662,42 @@ func watchTerminalInterrupt(c *AskerConsole) {
 	}()
 }
 
-// Creates a new console with the specified writer, handles and formatter.
-func NewConsole(noPrompt bool, isTerminal bool, w io.Writer, handles ConsoleHandles, formatter output.Formatter) Console {
+// Writers that back the underlying console.
+type Writers struct {
+	// The writer to write output to.
+	Output io.Writer
+
+	// The writer to write spinner output to. If nil, the spinner will write to the Writer.
+	Spinner io.Writer
+}
+
+// Creates a new console with the specified writers, handles and formatter.
+func NewConsole(
+	noPrompt bool,
+	isTerminal bool,
+	writers Writers,
+	handles ConsoleHandles,
+	formatter output.Formatter) Console {
 	asker := NewAsker(noPrompt, isTerminal, handles.Stdout, handles.Stdin)
 
 	c := &AskerConsole{
 		asker:         asker,
 		handles:       handles,
-		defaultWriter: w,
-		writer:        w,
+		defaultWriter: writers.Output,
+		writer:        writers.Output,
 		formatter:     formatter,
 		isTerminal:    isTerminal,
 		currentIndent: atomic.NewString(""),
 		noPrompt:      noPrompt,
 	}
 
+	if writers.Spinner == nil {
+		writers.Spinner = writers.Output
+	}
+
 	spinnerConfig := yacspin.Config{
 		Frequency:    200 * time.Millisecond,
-		Writer:       c.writer,
+		Writer:       writers.Spinner,
 		Suffix:       " ",
 		TerminalMode: spinnerTerminalMode(isTerminal),
 	}

--- a/cli/azd/pkg/input/console_test.go
+++ b/cli/azd/pkg/input/console_test.go
@@ -45,7 +45,7 @@ func TestAskerConsole_Spinner_NonTty(t *testing.T) {
 	c := NewConsole(
 		false,
 		false,
-		lines,
+		Writers{Output: lines},
 		ConsoleHandles{
 			Stderr: os.Stderr,
 			Stdin:  os.Stdin,

--- a/cli/azd/test/functional/testdata/vs-server/tests/AcceptanceTests.cs
+++ b/cli/azd/test/functional/testdata/vs-server/tests/AcceptanceTests.cs
@@ -129,6 +129,16 @@ public class AcceptanceTests : TestBase
         var recorder = new Recorder<ProgressMessage>();
         var envResult = await esSvc.DeployAsync(session, e.Name, recorder, CancellationToken.None);
         recorder.Values.ShouldNotBeEmpty();
+        bool importMessagesLogged = false;
+        foreach (var msg in recorder.Values)
+        {
+            if (msg.Kind == MessageKind.Important) {
+                importMessagesLogged = true;
+            }
+            Console.WriteLine(msg.ToString());
+        }
+        importMessagesLogged.ShouldBeTrue();
+
         envResult.LastDeployment.ShouldNotBeNull();
         envResult.LastDeployment.DeploymentId.ShouldNotBeEmpty();
         envResult.Resources.ShouldNotBeEmpty();

--- a/cli/azd/test/functional/testdata/vs-server/tests/AcceptanceTests.cs
+++ b/cli/azd/test/functional/testdata/vs-server/tests/AcceptanceTests.cs
@@ -129,15 +129,15 @@ public class AcceptanceTests : TestBase
         var recorder = new Recorder<ProgressMessage>();
         var envResult = await esSvc.DeployAsync(session, e.Name, recorder, CancellationToken.None);
         recorder.Values.ShouldNotBeEmpty();
-        bool importMessagesLogged = false;
+        bool importantMessagesLogged = false;
         foreach (var msg in recorder.Values)
         {
             if (msg.Kind == MessageKind.Important) {
-                importMessagesLogged = true;
+                importantMessagesLogged = true;
             }
             Console.WriteLine(msg.ToString());
         }
-        importMessagesLogged.ShouldBeTrue();
+        importantMessagesLogged.ShouldBeTrue();
 
         envResult.LastDeployment.ShouldNotBeNull();
         envResult.LastDeployment.DeploymentId.ShouldNotBeEmpty();

--- a/cli/azd/test/functional/testdata/vs-server/tests/AzdServices.cs
+++ b/cli/azd/test/functional/testdata/vs-server/tests/AzdServices.cs
@@ -87,7 +87,7 @@ public class ProgressMessage
     public string Code;
     public string AdditionalInfoLink;
 
-    public override string ToString() => $"{Time}: {Severity} {Message}";
+    public override string ToString() => $"{Time}: {Kind} : {Severity} {Message}";
 }
 
 public enum MessageSeverity

--- a/cli/azd/test/functional/vs_server_test.go
+++ b/cli/azd/test/functional/vs_server_test.go
@@ -99,7 +99,7 @@ func Test_CLI_VsServer(t *testing.T) {
 
 			cli := azdcli.NewCLI(t, azdcli.WithSession(session))
 			/* #nosec G204 - Subprocess launched with a potential tainted input or cmd arguments false positive */
-			cmd := exec.CommandContext(ctx, cli.AzdPath, "vs-server", "--debug")
+			cmd := exec.CommandContext(ctx, cli.AzdPath, "vs-server")
 			cmd.Env = append(cli.Env, os.Environ()...)
 			cmd.Env = append(cmd.Env, "AZD_DEBUG_SERVER_DEBUG_ENDPOINTS=true")
 			pathString := ostest.CombinedPaths(cmd.Env)


### PR DESCRIPTION
Expose spinner updates to VS.

Progress messages that are marked as Important are prominently displayed in VS as a spinner:
![image](https://github.com/Azure/azure-dev/assets/2322434/8db23706-af72-4808-8cac-697e13c10dde)

While doing this, `lineWriter` is updated to support line-ending trimming and reduced memory allocations by reusing pre-allocated buffers.

Fixes #3313