### PR TITLE
Add -NoProfile to PowerShell installer instructions

### DIFF
--- a/cli/installer/README.md
+++ b/cli/installer/README.md
@@ -21,7 +21,7 @@ choco install azd
 The install script downloads and installs the MSI package on the machine with default parameters.
 
 ```powershell
-powershell -NoProfile -ex AllSigned -c "Invoke-RestMethod 'https://aka.ms/install-azd.ps1' | Invoke-Expression"
+powershell -nop -ex AllSigned -c "Invoke-RestMethod 'https://aka.ms/install-azd.ps1' | Invoke-Expression"
 ```
 
 #### MSI installation

--- a/cli/installer/README.md
+++ b/cli/installer/README.md
@@ -21,7 +21,7 @@ choco install azd
 The install script downloads and installs the MSI package on the machine with default parameters.
 
 ```powershell
-powershell -ex AllSigned -c "Invoke-RestMethod 'https://aka.ms/install-azd.ps1' | Invoke-Expression"
+powershell -NoProfile -ex AllSigned -c "Invoke-RestMethod 'https://aka.ms/install-azd.ps1' | Invoke-Expression"
 ```
 
 #### MSI installation


### PR DESCRIPTION
The `-ex AllSigned` parameter causes the snippet to fail if the user has a profile.ps1 that isn't signed (usually the case). Adding `-NoProfile` up front ensure the script is executed in a session without the user's profile.