### PR TITLE
Updates install strategy for kubectl

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -38,12 +38,12 @@ RUN export DEBIAN_FRONTEND=noninteractive \
           tee /etc/apt/sources.list.d/hashicorp.list \
      && apt update && apt-get install terraform \
      # kubectl CLI
-     && apt-get update \
-     && mkdir -p /etc/apt/keyrings \
-     && curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg \
-     && echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list \
-     && apt-get update \
-     && apt-get install -y kubectl \
+     && curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+     && curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256" \
+     && echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check \
+     && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl \
+     && kubectl version --client \
+     && kubectl version --client --output=yaml \
      # Helm CLI
      && curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \
      && chmod 700 get_helm.sh \


### PR DESCRIPTION
Updates the install strategy used for `kubectl` CLI.  Does not require any version pinning and will always install latest.

Follows the `curl` based install from [official docs](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-kubectl-binary-with-curl-on-linux)