### PR TITLE
Updates `azd` to use default http client/transport

### DIFF
--- a/cli/azd/cmd/deps.go
+++ b/cli/azd/cmd/deps.go
@@ -12,7 +12,7 @@ import (
 )
 
 func createHttpClient() *http.Client {
-	return &http.Client{}
+	return http.DefaultClient
 }
 
 func createClock() clock.Clock {

--- a/cli/azd/cmd/deps_record.go
+++ b/cli/azd/cmd/deps_record.go
@@ -32,12 +32,9 @@ func createHttpClient() *http.Client {
 		http.DefaultTransport = transport
 	}
 
-	client := &http.Client{
-		Transport: transport,
-	}
+	http.DefaultClient.Transport = transport
 
-	http.DefaultClient = client
-	return client
+	return http.DefaultClient
 }
 
 func createClock() clock.Clock {

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_DevCenter_Init_Up_Down.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_DevCenter_Init_Up_Down.yaml
@@ -26,7 +26,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - azsdk-go-armresourcegraph.Client/v0.7.1 (go1.21.6; Windows_NT),azd
+                - azsdk-go-armresourcegraph.Client/v0.7.1 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
         url: https://management.azure.com:443/providers/Microsoft.ResourceGraph/resources?api-version=2021-06-01-preview
         method: POST
       response:
@@ -35,18 +37,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 8615
+        content_length: 12868
         uncompressed: false
-        body: '{"totalRecords":14,"count":14,"data":[{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioClient","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSVendors","properties":{"provisioningState":"Succeeded","description":"Project for vendors","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/basic","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"basic","properties":{"provisioningState":"Succeeded","description":"project with basic image","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"MicroBuild","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourceGroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DevDivAzureService","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourceGroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"LanguageAndFrameworkServices","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourceGroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSCode","properties":{"provisioningState":"Succeeded","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourceGroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ServerlessPaaS","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourceGroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"PMUXDesign","properties":{"provisioningState":"Succeeded","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourceGroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"NuGet","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourceGroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DataAndAI","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Contoso-Demo","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Contoso-Demo","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-1","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-2","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"}],"facets":[],"resultTruncated":"false"}'
+        body: '{"totalRecords":21,"count":21,"data":[{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioClient","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSVendors","properties":{"provisioningState":"Succeeded","description":"Project for vendors","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/basic","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"basic","properties":{"provisioningState":"Succeeded","description":"project with basic image","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"MicroBuild","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourceGroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DevDivAzureService","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourceGroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"LanguageAndFrameworkServices","properties":{"provisioningState":"Succeeded","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourceGroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSCode","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourceGroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ServerlessPaaS","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourceGroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"PMUXDesign","properties":{"provisioningState":"Succeeded","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourceGroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"NuGet","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/projects/dcprj-pv44d74rp44bs","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"dcprj-pv44d74rp44bs","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-pv44d74rp44bs.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/devcenters/dc-pv44d74rp44bs"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/projects/rltestproj","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"rltestproj","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-pv44d74rp44bs.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/devcenters/dc-pv44d74rp44bs"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project1","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ade-project1","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-ade-fidalgo-dev2.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/ade-fidalgo-dev2"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project2","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ade-project2","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-ade-fidalgo-dev2.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/ade-fidalgo-dev2"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/Inventory-Management-Project","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Inventory-Management-Project","properties":{"provisioningState":"Succeeded","description":"Inventory Management project","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-logistics-system-devcenter.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/Logistics-System-DevCenter"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourceGroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DataAndAI","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-shihua8/providers/Microsoft.DevCenter/projects/xshProject-1","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"xshProject-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-contoso-nhtvx54bj4kb4.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-shihua8/providers/Microsoft.DevCenter/devcenters/dc-contoso-nhtvx54bj4kb4"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-shihua8/providers/Microsoft.DevCenter/projects/xshProject-2","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"xshProject-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-contoso-nhtvx54bj4kb4.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-shihua8/providers/Microsoft.DevCenter/devcenters/dc-contoso-nhtvx54bj4kb4"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Contoso-Demo","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Contoso-Demo","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-1","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-2","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"}],"facets":[],"resultTruncated":"false"}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "8615"
+                - "12868"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:32 GMT
+                - Tue, 05 Mar 2024 22:26:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -58,26 +60,26 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 68f9d8e4-1f28-4996-8969-cc584a2d5d00
+                - 62077d4f-3335-aa1d-4444-f17148f228b8
             X-Ms-Ratelimit-Remaining-Tenant-Reads:
                 - "11999"
             X-Ms-Ratelimit-Remaining-Tenant-Resource-Requests:
                 - "14"
             X-Ms-Request-Id:
-                - 68f9d8e4-1f28-4996-8969-cc584a2d5d00
+                - 173cc91e-16fe-403d-990c-24034d86c024
             X-Ms-Resource-Graph-Request-Duration:
-                - "0:00:00:00.6858326"
+                - "0:00:00:00.5227662"
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193732Z:68f9d8e4-1f28-4996-8969-cc584a2d5d00
+                - WESTUS2:20240305T222602Z:173cc91e-16fe-403d-990c-24034d86c024
             X-Ms-User-Quota-Remaining:
                 - "14"
             X-Ms-User-Quota-Resets-After:
                 - "00:00:05"
             X-Msedge-Ref:
-                - 'Ref A: 32D30B6B267047B2AA11ACD1D9B6059E Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:31Z'
+                - 'Ref A: 44A19BF7E5534A4299E89CD830E87257 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:01Z'
         status: 200 OK
         code: 200
-        duration: 840.0147ms
+        duration: 712.2316ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -101,8 +103,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourcegroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/basic/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -121,7 +123,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:32 GMT
+                - Tue, 05 Mar 2024 22:26:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -135,18 +137,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - e6741d43-dea1-4bb6-8b5b-c0cfbce7ecfd
+                - 27b16a5c-65ac-4d14-befd-a3886c8eddf6
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193732Z:bef010cd-d19d-4dc4-b583-fb78f17e2375
+                - WESTUS2:20240305T222602Z:73761d97-ae62-462c-98be-c20e984bd53e
             X-Msedge-Ref:
-                - 'Ref A: 4EE2666E2E6A46608180D9A8C1A252F8 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+                - 'Ref A: 4145F0E2F0E74322B432D278146E943F Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
         status: 200 OK
         code: 200
-        duration: 379.5165ms
+        duration: 413.6844ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -170,8 +172,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourcegroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourcegroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -190,7 +192,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:32 GMT
+                - Tue, 05 Mar 2024 22:26:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -204,18 +206,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 140cf611-1489-4da7-912d-17ef16d24ffa
+                - 4078a188-cbb1-4fb8-980e-1b57e95585ba
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193732Z:6c978ba3-9329-4e8c-85a5-1241a449f540
+                - WESTUS2:20240305T222602Z:d278ea75-9d97-449f-addb-2a401f33099c
             X-Msedge-Ref:
-                - 'Ref A: 91689A8BF0254E75BE98DFDCC7EFA532 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+                - 'Ref A: C95CF69E03CE485383C207410065DAE1 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
         status: 200 OK
         code: 200
-        duration: 384.9654ms
+        duration: 411.2054ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -239,8 +241,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -259,7 +261,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:32 GMT
+                - Tue, 05 Mar 2024 22:26:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -273,18 +275,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11998"
             X-Ms-Request-Id:
-                - 0c2ac6a0-7770-4562-9a5e-4d6a0ec44e32
+                - 1278095c-0e7b-473e-8ec0-5d52a24b228c
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193732Z:a4206ee5-285e-4f16-9b5b-e547ac967b82
+                - WESTUS2:20240305T222602Z:20c6e4b3-5af5-46f1-b427-9db36edd4a2a
             X-Msedge-Ref:
-                - 'Ref A: D8569A2A3651473C95F34964C2462A1D Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+                - 'Ref A: 67DD029DC70C45789504DC44B8F6CAE9 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
         status: 200 OK
         code: 200
-        duration: 433.3025ms
+        duration: 419.5076ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -308,8 +310,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourcegroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourcegroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -328,7 +330,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:32 GMT
+                - Tue, 05 Mar 2024 22:26:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -342,18 +344,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - f66be0e1-8ff6-4772-baf2-7bf4eaf405f8
+                - b3e3ed2d-b3cd-4589-91eb-6460d7e689f7
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193732Z:8682a156-5f10-4ce3-ba3a-98c2ec2ec1bc
+                - WESTUS2:20240305T222602Z:9fe83102-1a5d-4395-bfa8-69ddc6d35955
             X-Msedge-Ref:
-                - 'Ref A: B22465D9B34F46D3BDB4D93BB88835CD Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+                - 'Ref A: 66D6A0839A12460B881172343F65D183 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
         status: 200 OK
         code: 200
-        duration: 431.5628ms
+        duration: 426.6151ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -377,8 +379,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project2/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -386,18 +388,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 990
+        content_length: 82
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "990"
+                - "82"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:32 GMT
+                - Tue, 05 Mar 2024 22:26:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -411,18 +413,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11998"
+                - "11999"
             X-Ms-Request-Id:
-                - ef986f39-2ada-43b3-bd85-d2c51f95e739
+                - 183206fd-8acc-42c5-acdf-4694a7aaa330
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193732Z:0d2db4bf-8b91-43d0-8d11-ef6f986a92e8
+                - WESTUS2:20240305T222602Z:a8e70da9-7178-400b-b54e-7a48fda4fd47
             X-Msedge-Ref:
-                - 'Ref A: 9CA5D2818EE54B679D3122F143A4CBCB Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+                - 'Ref A: 019CA8B1E3914234AFEB28BFE2750509 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
         status: 200 OK
         code: 200
-        duration: 432.139ms
+        duration: 429.363ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -446,8 +448,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Contoso-Demo/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-demo-test101/providers/Microsoft.DevCenter/projects/rltestproj/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -455,18 +457,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2328
+        content_length: 82
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "2328"
+                - "82"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:32 GMT
+                - Tue, 05 Mar 2024 22:26:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -480,18 +482,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11998"
             X-Ms-Request-Id:
-                - 782b9277-5753-4092-b7aa-7266c39896d1
+                - 2074c41f-2dd6-4583-b911-a5a28473711a
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193732Z:5e46c64d-ef9b-43ab-ac02-3e1fe5fb16bd
+                - WESTUS2:20240305T222602Z:5ff5d364-7f46-428c-bdf6-f9c48bc9cb1f
             X-Msedge-Ref:
-                - 'Ref A: 60EE775FBD87489C8C4E4DACF394FADC Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+                - 'Ref A: B3D1412902614DA692793AFC15C79637 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
         status: 200 OK
         code: 200
-        duration: 454.6ms
+        duration: 429.8813ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -515,8 +517,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourcegroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourcegroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -535,7 +537,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:32 GMT
+                - Tue, 05 Mar 2024 22:26:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -549,18 +551,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 9fd9c3e7-f907-49a4-9cb1-66bdda2bc921
+                - 79ca8d38-7b5b-4328-8629-7d22a7b01392
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193732Z:a789c9f2-1d15-42aa-bc0e-976421a061cb
+                - WESTUS2:20240305T222602Z:38ea4bdc-4dfa-401c-8694-379d789e77d7
             X-Msedge-Ref:
-                - 'Ref A: E7DAB5C37DCE4BF89A0C981017767C48 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+                - 'Ref A: 00F27B2A7CEB498092A13462EC8275F0 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
         status: 200 OK
         code: 200
-        duration: 456.5003ms
+        duration: 416.6136ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -584,8 +586,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-1/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/Inventory-Management-Project/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -593,18 +595,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2328
+        content_length: 82
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "2328"
+                - "82"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:32 GMT
+                - Tue, 05 Mar 2024 22:26:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -618,18 +620,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 1e5d57c8-f4d1-4034-849c-e68ec8549f1e
+                - caa18529-985a-48af-a359-598afdfbe701
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193732Z:208c395e-684c-46ce-9008-a9d09c47cd6b
+                - WESTUS2:20240305T222602Z:c48ff7cf-c517-4eee-a04c-2ee37a7ffd5b
             X-Msedge-Ref:
-                - 'Ref A: AE78C6AA23EB4C5D8BB72D67D3D17ACF Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+                - 'Ref A: E3616E55CE544BB9827D6EB3CB69DB9E Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
         status: 200 OK
         code: 200
-        duration: 476.6393ms
+        duration: 435.2929ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -653,8 +655,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/basic/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -673,7 +675,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:32 GMT
+                - Tue, 05 Mar 2024 22:26:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -687,18 +689,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11998"
+                - "11999"
             X-Ms-Request-Id:
-                - 8118d2de-056f-429d-89f1-3e6f84950426
+                - bc098b3c-0c1e-401c-b39e-4511c97e0d5e
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193732Z:1f9699ac-b08d-4c67-a2ea-b35dea2d2b27
+                - WESTUS2:20240305T222602Z:db8094da-413c-46d5-9ffc-cf4a157de3c7
             X-Msedge-Ref:
-                - 'Ref A: 4B2EA5574AFC4FA5AF64898BEB5509FC Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+                - 'Ref A: D625BFABD07D4A67AB984146C49F17E3 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
         status: 200 OK
         code: 200
-        duration: 482.4223ms
+        duration: 427.6255ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -722,8 +724,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourcegroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourcegroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -742,7 +744,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:32 GMT
+                - Tue, 05 Mar 2024 22:26:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -756,18 +758,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 16bc85a7-9fe2-4cdb-8231-957f8d9a1a23
+                - f4e30b0a-f4dd-4ff2-9eaa-c940d72eaf02
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193732Z:a1edf255-6e9f-4b75-b9c6-36fb02e11447
+                - WESTUS2:20240305T222602Z:b01db46b-275a-4893-bb5f-91aeb6a460ef
             X-Msedge-Ref:
-                - 'Ref A: 4976B23BEC6B4034925C275853E16666 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+                - 'Ref A: C901669C24384F47BA541FC312269003 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
         status: 200 OK
         code: 200
-        duration: 491.9096ms
+        duration: 428.0448ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -791,7 +793,7 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
         url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
@@ -811,7 +813,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:32 GMT
+                - Tue, 05 Mar 2024 22:26:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -825,18 +827,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - f2e30063-ce36-4a65-98dd-4065b5a27ac5
+                - 9c32fefd-1661-42f6-b52b-6e25fbf72502
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193732Z:137fa10d-4989-4262-963e-082f676110b1
+                - WESTUS2:20240305T222602Z:87a33bf4-42fd-49e5-8d3e-1bbb936e1b18
             X-Msedge-Ref:
-                - 'Ref A: 3AC193C57F354FE38E89A2E6BA1FF536 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+                - 'Ref A: AF66C8A8858E41E5AEC9B875EB826063 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
         status: 200 OK
         code: 200
-        duration: 497.9907ms
+        duration: 441.4886ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -860,8 +862,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-2/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourcegroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -869,18 +871,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2328
+        content_length: 990
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "2328"
+                - "990"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:32 GMT
+                - Tue, 05 Mar 2024 22:26:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -894,18 +896,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - bef25fd4-ea8b-47db-9938-18ccff5ef6c7
+                - 20b4eddf-1462-4551-85be-37ce1f8e854d
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193732Z:af91e355-5ff0-42c4-9e3a-a95bde92ff0b
+                - WESTUS2:20240305T222602Z:a3a450a8-4112-4a54-80e4-fb23f9828fd0
             X-Msedge-Ref:
-                - 'Ref A: B35A8FBA104E49ED8717611794CEDA40 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+                - 'Ref A: DE68AD93C49D4F79AC7D6D92537CCCE2 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
         status: 200 OK
         code: 200
-        duration: 517.084ms
+        duration: 428.8537ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -929,8 +931,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourcegroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-shihua8/providers/Microsoft.DevCenter/projects/xshProject-1/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -938,18 +940,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 990
+        content_length: 552
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "990"
+                - "552"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:32 GMT
+                - Tue, 05 Mar 2024 22:26:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -963,18 +965,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 8e0b2002-8c12-47be-bf10-5b502995d36e
+                - 30ee380a-c8d0-4c5e-8537-4d63053453ad
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193732Z:c7714685-cd7d-49eb-88f6-64eff0842300
+                - WESTUS2:20240305T222602Z:6b9b2c1f-cecf-4abd-bacc-fe22d41ec6e1
             X-Msedge-Ref:
-                - 'Ref A: 961F8D7ABD554452BF3C4589D8390B13 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+                - 'Ref A: 47F0240605BD43A59CD46E9CC7F5F731 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
         status: 200 OK
         code: 200
-        duration: 529.1689ms
+        duration: 452.8015ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -998,8 +1000,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourcegroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourcegroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -1018,7 +1020,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:32 GMT
+                - Tue, 05 Mar 2024 22:26:01 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1032,19 +1034,502 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - f1436512-09a3-4f67-852d-c22cffdd0d82
+                - ced50bf6-42e3-47ef-9f76-dc18397df412
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193732Z:a5e9b19b-55fb-4298-bc5f-b79e7d23ec39
+                - WESTUS2:20240305T222602Z:ce8be272-6522-4b16-88e8-77e0eab41c7d
             X-Msedge-Ref:
-                - 'Ref A: 1A1FD2A7964F4A11826517B0898F86B9 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:32Z'
+                - 'Ref A: FAEDD90ECB9A457F87287557282F4750 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
         status: 200 OK
         code: 200
-        duration: 604.5548ms
+        duration: 434.167ms
     - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Contoso-Demo/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2328
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2328"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:01 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - aec752ea-a7de-4c31-9f43-cf37bd44c17d
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222602Z:428b049e-b492-4a79-a7a1-9875edd43793
+            X-Msedge-Ref:
+                - 'Ref A: B1EAE5608DBC4B60A37F2F5407AE39BB Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
+        status: 200 OK
+        code: 200
+        duration: 458.4378ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-2/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2328
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2328"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:01 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 7e60023e-4b9f-455f-9168-6082025dc044
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222602Z:3ff2b062-5bf3-4c25-93b8-d7664a659f4a
+            X-Msedge-Ref:
+                - 'Ref A: FDF8F64282744EAFB981CFF84AC34D00 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
+        status: 200 OK
+        code: 200
+        duration: 451.6617ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-shihua8/providers/Microsoft.DevCenter/projects/xshProject-2/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 552
+        uncompressed: false
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "552"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:01 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 076fed99-2597-4f7f-8324-dc109b52e2fc
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222602Z:e849e1cf-0f35-4b41-b903-ad8219fed636
+            X-Msedge-Ref:
+                - 'Ref A: 6B9A1454206C4C08BD019DC0DCFE83E8 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
+        status: 200 OK
+        code: 200
+        duration: 450.5782ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-1/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2328
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2328"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:01 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11996"
+            X-Ms-Request-Id:
+                - 397c32f0-58e4-457b-865e-f277eeba16f8
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222602Z:af03164a-b164-471f-b200-5e8f19b9825d
+            X-Msedge-Ref:
+                - 'Ref A: D5912343A3BB4F808AF0619585FA05B7 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
+        status: 200 OK
+        code: 200
+        duration: 474.118ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project1/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 82
+        uncompressed: false
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "82"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:01 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - e7c13381-06ff-4940-807b-b600f20c94f1
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222602Z:5f99a45d-90a1-4126-bab4-4adda50a286e
+            X-Msedge-Ref:
+                - 'Ref A: 2841A6B8184A4F198B0DDD215358F081 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
+        status: 200 OK
+        code: 200
+        duration: 463.937ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-demo-test101/providers/Microsoft.DevCenter/projects/dcprj-pv44d74rp44bs/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 82
+        uncompressed: false
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "82"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:01 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 9b2bb100-3b30-4219-b119-462f035e4b33
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222602Z:0ec94f88-2f13-4ef6-b127-b8eccf405cf6
+            X-Msedge-Ref:
+                - 'Ref A: 0E6859A768DF410A88DEE4B7C34A9607 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
+        status: 200 OK
+        code: 200
+        duration: 460.9177ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourcegroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:01 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - e4e648a1-2518-4550-acad-99b59a06b35f
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222602Z:44979eae-3b28-484d-8a6e-09806e114243
+            X-Msedge-Ref:
+                - 'Ref A: 9D462E3D7CEA4108919CD9D91CC8B42E Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:02Z'
+        status: 200 OK
+        code: 200
+        duration: 499.1898ms
+    - id: 22
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1064,6 +1549,8 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
         url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/environmentDefinitions?api-version=2023-04-01
         method: GET
       response:
@@ -1242,237 +1729,23 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:34 GMT
+                - Tue, 05 Mar 2024 22:26:04 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 7359bd73-e812-48bc-bca8-c35b834f095d
+                - e110d23d-1654-4ef2-bf45-3888e3f70d5b
             X-Ms-Correlation-Request-Id:
-                - 84d38064-993c-4e60-af24-acf8428f6ff6
-            X-Rate-Limit-Limit:
-                - 1m
-            X-Rate-Limit-Remaining:
-                - "298"
-            X-Rate-Limit-Reset:
-                - "2024-02-26T19:38:33.7359520Z"
-        status: 200 OK
-        code: 200
-        duration: 1.3284849s
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept-Encoding:
-                - gzip
-            Authorization:
-                - SANITIZED
-            User-Agent:
-                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Contoso-Demo/environmentDefinitions?api-version=2023-04-01
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: |-
-            {
-              "value": [
-                {
-                  "id": "/projects/Contoso-Demo/catalogs/example/environmentDefinitions/function-app-with-cosmos_azd-template",
-                  "name": "Function-App-with-Cosmos_AZD-template",
-                  "catalogName": "Example",
-                  "description": "Deploys an Azure Function App with Cosmos, it is compatible with azd.",
-                  "parameters": [
-                    {
-                      "id": "runtimeType",
-                      "name": "Runtime Type",
-                      "description": "Runtime Type of the Function App runtime,eg python or nodejs",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": true,
-                      "allowed": [
-                        "python",
-                        "nodejs"
-                      ]
-                    },
-                    {
-                      "id": "repoUrl",
-                      "name": "Repository URL",
-                      "description": "Path the the application source code",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": false,
-                      "allowed": [
-                        "https://github.com/azure-samples/todo-nodejs-mongo-swa-func",
-                        "https://github.com/azure-samples/todo-python-mongo-swa-func"
-                      ]
-                    }
-                  ],
-                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the Function App runtime,eg python or nodejs\",\"enum\":[\"python\",\"nodejs\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-nodejs-mongo-swa-func\",\"https://github.com/azure-samples/todo-python-mongo-swa-func\"]}},\"required\":[\"runtimeType\"]}",
-                  "templatePath": "Environment-Definitions/ARMTemplates/Function-App-with-Cosmos_AZD-template/azuredeploy.json"
-                },
-                {
-                  "id": "/projects/Contoso-Demo/catalogs/example/environmentDefinitions/webapp",
-                  "name": "WebApp",
-                  "catalogName": "Example",
-                  "description": "Deploys an Azure Web App without a data store",
-                  "parameters": [],
-                  "parametersSchema": "{\"type\":\"object\"}",
-                  "templatePath": "Environment-Definitions/ARMTemplates/WebApp/azuredeploy.json"
-                },
-                {
-                  "id": "/projects/Contoso-Demo/catalogs/example/environmentDefinitions/sandbox",
-                  "name": "Sandbox",
-                  "catalogName": "Example",
-                  "description": "Deploys a sandbox environment",
-                  "parameters": [],
-                  "parametersSchema": "{\"type\":\"object\"}",
-                  "templatePath": "Environment-Definitions/ARMTemplates/Sandbox/azuredeploy.json"
-                },
-                {
-                  "id": "/projects/Contoso-Demo/catalogs/example/environmentDefinitions/container-app-with-cosmos_azd-template",
-                  "name": "Container-App-with-Cosmos_AZD-template",
-                  "catalogName": "Example",
-                  "description": "Deploys an Azure Container App with Cosmos, it is compatible with azd.",
-                  "parameters": [
-                    {
-                      "id": "runtimeType",
-                      "name": "Runtime Type",
-                      "description": "Runtime Type of the container App runtime,eg python, nodejs or java.",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": true,
-                      "allowed": [
-                        "python",
-                        "nodejs",
-                        "java"
-                      ]
-                    },
-                    {
-                      "id": "repoUrl",
-                      "name": "Repository URL",
-                      "description": "Path the the application source code",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": false,
-                      "allowed": [
-                        "https://github.com/azure-samples/todo-java-mongo-aca",
-                        "https://github.com/azure-samples/todo-nodejs-mongo-aca",
-                        "https://github.com/azure-samples/todo-python-mongo-aca"
-                      ]
-                    }
-                  ],
-                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the container App runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo-aca\",\"https://github.com/azure-samples/todo-nodejs-mongo-aca\",\"https://github.com/azure-samples/todo-python-mongo-aca\"]}},\"required\":[\"runtimeType\"]}",
-                  "templatePath": "Environment-Definitions/ARMTemplates/Container-App-with-Cosmos_AZD-template/azuredeploy.json"
-                },
-                {
-                  "id": "/projects/Contoso-Demo/catalogs/wbreza/environmentDefinitions/helloworld",
-                  "name": "HelloWorld",
-                  "catalogName": "wbreza",
-                  "description": "Deploys an Azure App Service within App Service Plan",
-                  "parameters": [
-                    {
-                      "id": "environmentName",
-                      "name": "Environment Name",
-                      "description": "Name of the environment",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": false
-                    },
-                    {
-                      "id": "repoUrl",
-                      "name": "Repository URL",
-                      "description": "Path the the application source code",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": false,
-                      "allowed": [
-                        "https://github.com/wbreza/azd-hello-world"
-                      ]
-                    }
-                  ],
-                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"environmentName\":{\"title\":\"Environment Name\",\"description\":\"Name of the environment\"},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/wbreza/azd-hello-world\"]}}}",
-                  "templatePath": "EnvironmentDefinitions/HelloWorld/azuredeploy.json"
-                },
-                {
-                  "id": "/projects/Contoso-Demo/catalogs/example/environmentDefinitions/app-service-with-cosmos_azd-template",
-                  "name": "App-Service-with-Cosmos_AZD-template",
-                  "catalogName": "Example",
-                  "description": "Deploys an Azure App Service with Cosmos, it is compatible with azd.",
-                  "parameters": [
-                    {
-                      "id": "runtimeType",
-                      "name": "Runtime Type",
-                      "description": "Runtime Type of the App Service runtime,eg python, nodejs or java.",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": true,
-                      "allowed": [
-                        "python",
-                        "nodejs",
-                        "java"
-                      ]
-                    },
-                    {
-                      "id": "repoUrl",
-                      "name": "Repository URL",
-                      "description": "Path the the application source code",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": false,
-                      "allowed": [
-                        "https://github.com/azure-samples/todo-java-mongo",
-                        "https://github.com/azure-samples/todo-nodejs-mongo",
-                        "https://github.com/azure-samples/todo-python-mongo"
-                      ]
-                    }
-                  ],
-                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the App Service runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo\",\"https://github.com/azure-samples/todo-nodejs-mongo\",\"https://github.com/azure-samples/todo-python-mongo\"]}},\"required\":[\"runtimeType\"]}",
-                  "templatePath": "Environment-Definitions/ARMTemplates/App-Service-with-Cosmos_AZD-template/azuredeploy.json"
-                }
-              ]
-            }
-        headers:
-            Access-Control-Allow-Origin:
-                - '*'
-            Access-Control-Expose-Headers:
-                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
-            Access-Control-Max-Age:
-                - "86400"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Mon, 26 Feb 2024 19:37:34 GMT
-            Strict-Transport-Security:
-                - max-age=15724800; includeSubDomains
-            X-Ms-Client-Request-Id:
-                - 1439a90b-7884-43a1-9732-1b4c3786cf0e
-            X-Ms-Correlation-Request-Id:
-                - 18ddb8b9-eb14-4e63-9521-03a2fbce9408
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
                 - "299"
             X-Rate-Limit-Reset:
-                - "2024-02-26T19:38:33.7359520Z"
+                - "2024-03-05T22:27:03.6818180Z"
         status: 200 OK
         code: 200
-        duration: 1.3332792s
-    - id: 17
+        duration: 1.3351876s
+    - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1492,6 +1765,8 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
         url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-2/environmentDefinitions?api-version=2023-04-01
         method: GET
       response:
@@ -1670,436 +1945,22 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:34 GMT
+                - Tue, 05 Mar 2024 22:26:04 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 4be6b13b-39db-431e-8b62-53cf87e6c0b3
+                - 64b2717c-97f4-4f2d-845d-24f6998569af
             X-Ms-Correlation-Request-Id:
-                - 4b7ccd57-d54b-47de-9ba0-b0dfbd99e23c
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
-                - "299"
+                - "298"
             X-Rate-Limit-Reset:
-                - "2024-02-26T19:38:33.7198478Z"
+                - "2024-03-05T22:27:03.6818180Z"
         status: 200 OK
         code: 200
-        duration: 1.6123605s
-    - id: 18
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: management.azure.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Accept-Encoding:
-                - gzip
-            Authorization:
-                - SANITIZED
-            User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
-            X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourcegroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 990
-        uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "990"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Mon, 26 Feb 2024 19:37:35 GMT
-            Expires:
-                - "-1"
-            Pragma:
-                - no-cache
-            Set-Cookie:
-                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
-            Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains
-            X-Cache:
-                - CONFIG_NOCACHE
-            X-Content-Type-Options:
-                - nosniff
-            X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-            X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
-            X-Ms-Request-Id:
-                - 1e2f16fb-fd74-489c-ace5-0d1a080cdfd4
-            X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193735Z:12d7a70d-ea15-4937-bd55-04fdbb4900ff
-            X-Msedge-Ref:
-                - 'Ref A: B9F1DD41B85F4C4787B86CE91896DA8E Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
-        status: 200 OK
-        code: 200
-        duration: 123.7636ms
-    - id: 19
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: management.azure.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Accept-Encoding:
-                - gzip
-            Authorization:
-                - SANITIZED
-            User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
-            X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 990
-        uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "990"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Mon, 26 Feb 2024 19:37:35 GMT
-            Expires:
-                - "-1"
-            Pragma:
-                - no-cache
-            Set-Cookie:
-                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
-            Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains
-            X-Cache:
-                - CONFIG_NOCACHE
-            X-Content-Type-Options:
-                - nosniff
-            X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-            X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
-            X-Ms-Request-Id:
-                - b9028c47-2782-4e57-b643-6930c056ed39
-            X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193735Z:49e15898-f92e-4dc3-bebc-4892cd12d13f
-            X-Msedge-Ref:
-                - 'Ref A: 08E33DA1791A4D298E6947D516C2B652 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
-        status: 200 OK
-        code: 200
-        duration: 124.8661ms
-    - id: 20
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: management.azure.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Accept-Encoding:
-                - gzip
-            Authorization:
-                - SANITIZED
-            User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
-            X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourcegroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 990
-        uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "990"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Mon, 26 Feb 2024 19:37:35 GMT
-            Expires:
-                - "-1"
-            Pragma:
-                - no-cache
-            Set-Cookie:
-                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
-            Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains
-            X-Cache:
-                - CONFIG_NOCACHE
-            X-Content-Type-Options:
-                - nosniff
-            X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-            X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
-            X-Ms-Request-Id:
-                - bf0f28d6-12aa-4689-9d58-25bb4b895f48
-            X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193736Z:9438bab5-1846-4b85-b4a8-179af6a408fa
-            X-Msedge-Ref:
-                - 'Ref A: 094FC8A8875949AB873A6435BD6BDCA1 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
-        status: 200 OK
-        code: 200
-        duration: 132.4907ms
-    - id: 21
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: management.azure.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Accept-Encoding:
-                - gzip
-            Authorization:
-                - SANITIZED
-            User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
-            X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourcegroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 990
-        uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "990"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Mon, 26 Feb 2024 19:37:35 GMT
-            Expires:
-                - "-1"
-            Pragma:
-                - no-cache
-            Set-Cookie:
-                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
-            Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains
-            X-Cache:
-                - CONFIG_NOCACHE
-            X-Content-Type-Options:
-                - nosniff
-            X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-            X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
-            X-Ms-Request-Id:
-                - 798a9b8c-0ac0-4cc2-886d-0b62be1b458e
-            X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193736Z:9ffba7bc-a79f-413d-8bc0-acf5add23292
-            X-Msedge-Ref:
-                - 'Ref A: C81D923721C0467487044C43D16C87F2 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
-        status: 200 OK
-        code: 200
-        duration: 131.5596ms
-    - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: management.azure.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Accept-Encoding:
-                - gzip
-            Authorization:
-                - SANITIZED
-            User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
-            X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/basic/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 990
-        uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "990"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Mon, 26 Feb 2024 19:37:35 GMT
-            Expires:
-                - "-1"
-            Pragma:
-                - no-cache
-            Set-Cookie:
-                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
-            Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains
-            X-Cache:
-                - CONFIG_NOCACHE
-            X-Content-Type-Options:
-                - nosniff
-            X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-            X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
-            X-Ms-Request-Id:
-                - 294d3076-4cb2-465c-8e4e-25c21ed0cfc5
-            X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193736Z:d2ef4716-4d30-4aa1-92a6-cc92ea8aaa49
-            X-Msedge-Ref:
-                - 'Ref A: 075F50BD69AD45FC8C8343F34FE1377F Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
-        status: 200 OK
-        code: 200
-        duration: 141.5191ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: management.azure.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Accept-Encoding:
-                - gzip
-            Authorization:
-                - SANITIZED
-            User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
-            X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 990
-        uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "990"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Mon, 26 Feb 2024 19:37:35 GMT
-            Expires:
-                - "-1"
-            Pragma:
-                - no-cache
-            Set-Cookie:
-                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
-            Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains
-            X-Cache:
-                - CONFIG_NOCACHE
-            X-Content-Type-Options:
-                - nosniff
-            X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-            X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
-            X-Ms-Request-Id:
-                - c5c6097f-161c-4f38-b054-62ceed393ab8
-            X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193736Z:f32d16ba-214a-42f8-8b0f-c53cba5f062f
-            X-Msedge-Ref:
-                - 'Ref A: AD2FCE5C7B304E65B10D34101220713D Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
-        status: 200 OK
-        code: 200
-        duration: 140.6441ms
+        duration: 1.3397023s
     - id: 24
       request:
         proto: HTTP/1.1
@@ -2108,23 +1969,21 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: management.azure.com
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
         remote_addr: ""
         request_uri: ""
         body: ""
         form: {}
         headers:
-            Accept:
-                - application/json
             Accept-Encoding:
                 - gzip
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-2/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Contoso-Demo/environmentDefinitions?api-version=2023-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2132,43 +1991,192 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2328
-        uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        content_length: -1
+        uncompressed: true
+        body: |-
+            {
+              "value": [
+                {
+                  "id": "/projects/Contoso-Demo/catalogs/example/environmentDefinitions/function-app-with-cosmos_azd-template",
+                  "name": "Function-App-with-Cosmos_AZD-template",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure Function App with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the Function App runtime,eg python or nodejs",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-nodejs-mongo-swa-func",
+                        "https://github.com/azure-samples/todo-python-mongo-swa-func"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the Function App runtime,eg python or nodejs\",\"enum\":[\"python\",\"nodejs\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-nodejs-mongo-swa-func\",\"https://github.com/azure-samples/todo-python-mongo-swa-func\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Function-App-with-Cosmos_AZD-template/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Contoso-Demo/catalogs/example/environmentDefinitions/webapp",
+                  "name": "WebApp",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure Web App without a data store",
+                  "parameters": [],
+                  "parametersSchema": "{\"type\":\"object\"}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/WebApp/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Contoso-Demo/catalogs/example/environmentDefinitions/sandbox",
+                  "name": "Sandbox",
+                  "catalogName": "Example",
+                  "description": "Deploys a sandbox environment",
+                  "parameters": [],
+                  "parametersSchema": "{\"type\":\"object\"}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Sandbox/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Contoso-Demo/catalogs/example/environmentDefinitions/container-app-with-cosmos_azd-template",
+                  "name": "Container-App-with-Cosmos_AZD-template",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure Container App with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the container App runtime,eg python, nodejs or java.",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs",
+                        "java"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-java-mongo-aca",
+                        "https://github.com/azure-samples/todo-nodejs-mongo-aca",
+                        "https://github.com/azure-samples/todo-python-mongo-aca"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the container App runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo-aca\",\"https://github.com/azure-samples/todo-nodejs-mongo-aca\",\"https://github.com/azure-samples/todo-python-mongo-aca\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Container-App-with-Cosmos_AZD-template/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Contoso-Demo/catalogs/wbreza/environmentDefinitions/helloworld",
+                  "name": "HelloWorld",
+                  "catalogName": "wbreza",
+                  "description": "Deploys an Azure App Service within App Service Plan",
+                  "parameters": [
+                    {
+                      "id": "environmentName",
+                      "name": "Environment Name",
+                      "description": "Name of the environment",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/wbreza/azd-hello-world"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"environmentName\":{\"title\":\"Environment Name\",\"description\":\"Name of the environment\"},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/wbreza/azd-hello-world\"]}}}",
+                  "templatePath": "EnvironmentDefinitions/HelloWorld/azuredeploy.json"
+                },
+                {
+                  "id": "/projects/Contoso-Demo/catalogs/example/environmentDefinitions/app-service-with-cosmos_azd-template",
+                  "name": "App-Service-with-Cosmos_AZD-template",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure App Service with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the App Service runtime,eg python, nodejs or java.",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs",
+                        "java"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-java-mongo",
+                        "https://github.com/azure-samples/todo-nodejs-mongo",
+                        "https://github.com/azure-samples/todo-python-mongo"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the App Service runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo\",\"https://github.com/azure-samples/todo-nodejs-mongo\",\"https://github.com/azure-samples/todo-python-mongo\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/App-Service-with-Cosmos_AZD-template/azuredeploy.json"
+                }
+              ]
+            }
         headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "2328"
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:35 GMT
-            Expires:
-                - "-1"
-            Pragma:
-                - no-cache
-            Set-Cookie:
-                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+                - Tue, 05 Mar 2024 22:26:04 GMT
             Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains
-            X-Cache:
-                - CONFIG_NOCACHE
-            X-Content-Type-Options:
-                - nosniff
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - 4aaf1c7c-517a-4c09-b7d0-14fedfec8c17
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-            X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11997"
-            X-Ms-Request-Id:
-                - fbccb4eb-e000-4842-81dc-74b7ade4cbf0
-            X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193736Z:125935fb-e482-45a6-874a-17071b0f1174
-            X-Msedge-Ref:
-                - 'Ref A: 248733D0BE3449C38D0572275B43D402 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "299"
+            X-Rate-Limit-Reset:
+                - "2024-03-05T22:27:03.7102688Z"
         status: 200 OK
         code: 200
-        duration: 149.5436ms
+        duration: 1.345819s
     - id: 25
       request:
         proto: HTTP/1.1
@@ -2192,8 +2200,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Contoso-Demo/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourcegroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2201,18 +2209,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2328
+        content_length: 990
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "2328"
+                - "990"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:35 GMT
+                - Tue, 05 Mar 2024 22:26:04 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2226,18 +2234,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11998"
             X-Ms-Request-Id:
-                - 0536ce13-cb25-4594-bb35-05cfa7366267
+                - 6b32541f-8e06-4695-bf8e-03fcce23031d
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193736Z:b16dd151-afb6-45e2-9111-5b3d7a456c8c
+                - WESTUS2:20240305T222605Z:a270e143-b7f8-479e-a3b3-276dc25344c6
             X-Msedge-Ref:
-                - 'Ref A: C977743089E44E069240259B388C0187 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+                - 'Ref A: D3D844A6A2434D71804E87422E7B688F Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
         status: 200 OK
         code: 200
-        duration: 150.9427ms
+        duration: 113.3008ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -2261,8 +2269,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-1/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourcegroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2270,18 +2278,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2328
+        content_length: 990
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "2328"
+                - "990"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:35 GMT
+                - Tue, 05 Mar 2024 22:26:04 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2295,18 +2303,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - c25bf3e0-1f4c-43d5-970f-2eb48dd4ea5d
+                - b29bc1b1-091b-4ea3-b38e-66a8d74eb2c7
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193736Z:7f162909-089e-48f5-a0ef-d8185ddd85a3
+                - WESTUS2:20240305T222605Z:e35431aa-cd13-4f78-8486-2bc6911b95bc
             X-Msedge-Ref:
-                - 'Ref A: 272B165A1D8149F6AB9158C8A29944B3 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+                - 'Ref A: F634473BB994499A9FC6B22CCA1E716F Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
         status: 200 OK
         code: 200
-        duration: 148.6605ms
+        duration: 118.5352ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -2330,8 +2338,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourcegroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-shihua8/providers/Microsoft.DevCenter/projects/xshProject-2/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2339,18 +2347,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 990
+        content_length: 552
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "990"
+                - "552"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:35 GMT
+                - Tue, 05 Mar 2024 22:26:04 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2364,18 +2372,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - e4a5f705-755b-484a-873a-d3675bf0834a
+                - 5e8366e4-d7d0-439d-a6eb-49e25dfdf9a6
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193736Z:a9601eb2-54f0-4601-849c-ac1897c669d5
+                - WESTUS2:20240305T222605Z:8e6d3d80-b97c-43b3-9733-4ed1b4904d05
             X-Msedge-Ref:
-                - 'Ref A: F41E729BE3C74B92987CA08C09F5A975 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+                - 'Ref A: E652749739074969BF38857F92AC5913 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
         status: 200 OK
         code: 200
-        duration: 152.891ms
+        duration: 112.8258ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -2399,8 +2407,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourcegroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourcegroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2419,7 +2427,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:35 GMT
+                - Tue, 05 Mar 2024 22:26:04 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2433,18 +2441,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - ab129ec1-2125-45ac-831e-e28495b6e9fa
+                - dce2c24f-797d-46d6-a277-d014c5ded3fe
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193736Z:3514626d-984c-4a18-8bc2-3de5c03131e9
+                - WESTUS2:20240305T222605Z:136e415c-342c-4cd6-864c-260dfcb0e63c
             X-Msedge-Ref:
-                - 'Ref A: 2EB60F97DA284BA8BF80310BD6438363 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+                - 'Ref A: AD2D240496B648ADA99E22C2C0A8DE6B Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
         status: 200 OK
         code: 200
-        duration: 170.2127ms
+        duration: 119.9559ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -2468,7 +2476,7 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
         url: https://management.azure.com:443/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourcegroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
@@ -2488,7 +2496,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:35 GMT
+                - Tue, 05 Mar 2024 22:26:04 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2502,18 +2510,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 1340761c-e0c7-4247-bb95-5a416cfd8816
+                - 5b6e0729-1899-4eb0-af47-2a5e6a0f982b
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193736Z:582fd482-606b-45f1-92b2-f1f409a5914e
+                - WESTUS2:20240305T222605Z:bae4a970-ed97-4038-90de-9bfaada6adf6
             X-Msedge-Ref:
-                - 'Ref A: 908C5A94144D4F68ABAF5EB7D952B7E5 Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+                - 'Ref A: A5E204F001AA43849A5142C4BB9BFB44 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
         status: 200 OK
         code: 200
-        duration: 170.1154ms
+        duration: 119.1261ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -2537,8 +2545,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
-        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/Inventory-Management-Project/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2546,18 +2554,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 990
+        content_length: 82
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "990"
+                - "82"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:35 GMT
+                - Tue, 05 Mar 2024 22:26:04 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2571,18 +2579,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11998"
             X-Ms-Request-Id:
-                - cde29130-44b4-45c2-8f4f-95b2b6687e3b
+                - 22a06ba4-1c79-40a6-aa87-7996d6dfca3d
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193736Z:5011b49c-1ba8-4932-8de3-9671862794fd
+                - WESTUS2:20240305T222605Z:b9483282-e11e-4861-a774-4a136a2843e6
             X-Msedge-Ref:
-                - 'Ref A: 87F166304C714076BE47FCDF1CC03D8F Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+                - 'Ref A: 584B9683D3B245519126B3CCFD1C4F1B Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
         status: 200 OK
         code: 200
-        duration: 175.0971ms
+        duration: 141.7689ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -2606,7 +2614,628 @@ interactions:
             User-Agent:
                 - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-shihua8/providers/Microsoft.DevCenter/projects/xshProject-1/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 552
+        uncompressed: false
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "552"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:04 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 3e3a010a-59af-4673-9750-632f755379f1
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222605Z:e7f0fa75-b8c8-4ed3-90a2-b045c59a911e
+            X-Msedge-Ref:
+                - 'Ref A: D517DECF8E9F49A1870378DD8E1A5402 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
+        status: 200 OK
+        code: 200
+        duration: 131.4916ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project1/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 82
+        uncompressed: false
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "82"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:04 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - 6da735a1-5258-4e69-bef1-09a14f57a139
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222605Z:14b3c967-9ea6-4600-aac9-d515b19bcba8
+            X-Msedge-Ref:
+                - 'Ref A: 1608F38BD71B4678816C87E48F05E902 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
+        status: 200 OK
+        code: 200
+        duration: 143.8699ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourcegroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:04 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - d8297374-fd1a-432e-8441-67bbc14b8173
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222605Z:c70cb3a2-0b5d-49ed-8a83-65d273931c94
+            X-Msedge-Ref:
+                - 'Ref A: C2F6840CB7424AEB9E6AA9CD8148FB7E Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
+        status: 200 OK
+        code: 200
+        duration: 123.9226ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-demo-test101/providers/Microsoft.DevCenter/projects/dcprj-pv44d74rp44bs/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 82
+        uncompressed: false
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "82"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:04 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - ecb48476-de0f-4f20-8d74-3d48a41f9875
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222605Z:67a9b7bb-86b9-4609-9ccb-f6746ed45f2a
+            X-Msedge-Ref:
+                - 'Ref A: 65A07986737B43DE80D28D103591E1F4 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
+        status: 200 OK
+        code: 200
+        duration: 133.4962ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project2/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 82
+        uncompressed: false
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "82"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:04 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 8586a69c-c185-47ca-a245-3967e1a27910
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222605Z:33be0a99-204d-45df-937c-80d9097dbab0
+            X-Msedge-Ref:
+                - 'Ref A: E8577B17C79D40E9BD820BD7C1AD4609 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
+        status: 200 OK
+        code: 200
+        duration: 145.4277ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-demo-test101/providers/Microsoft.DevCenter/projects/rltestproj/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 82
+        uncompressed: false
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "82"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:04 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 5d56782f-7699-411c-ba89-1a32e3f3e583
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222605Z:116a636c-3dec-4973-adb5-1c3b03789ac1
+            X-Msedge-Ref:
+                - 'Ref A: 52B773A9ED484A96A3CD54C7D9E2343B Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
+        status: 200 OK
+        code: 200
+        duration: 142.2028ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:04 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 02529752-7cb7-44bf-b9b8-35fb1762e031
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222605Z:4889fe4d-5a66-489c-995e-541142b4f78f
+            X-Msedge-Ref:
+                - 'Ref A: 453DC3B1C7DD44929D5A1165482C5891 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
+        status: 200 OK
+        code: 200
+        duration: 128.3853ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourcegroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:04 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 71758a21-2017-4438-8fcd-236d9b53ccaf
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222605Z:15c845b1-819e-46cb-b44b-4da5ffd9b61d
+            X-Msedge-Ref:
+                - 'Ref A: 4845BD741A5B46508517EB5AEF92EE82 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
+        status: 200 OK
+        code: 200
+        duration: 128.84ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:04 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 9eaf3997-4c6d-48ac-8e9c-dd90057d7e5e
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222605Z:39432f79-5209-43f1-abc5-9fd0af04ab62
+            X-Msedge-Ref:
+                - 'Ref A: A1DA73EE676E4437808E7988E8BC9720 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
+        status: 200 OK
+        code: 200
+        duration: 133.7509ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
         url: https://management.azure.com:443/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourcegroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
@@ -2626,7 +3255,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:35 GMT
+                - Tue, 05 Mar 2024 22:26:04 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2640,19 +3269,364 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3acbc1075ef07304f1a9328bd4faa9c4
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 711727c2-f476-422a-9a30-e33931304d8d
+                - c3c3fd5c-6b94-453a-a163-1ee883b609ba
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193736Z:d49498af-da96-4adc-a5fb-cb0f0ffabd96
+                - WESTUS2:20240305T222605Z:594f90f4-55db-4062-b80a-6c528ec1c7b4
             X-Msedge-Ref:
-                - 'Ref A: F793800369D54CB09B7B2189DA36FB3C Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:35Z'
+                - 'Ref A: 025766A6D99E4C7DB4CAB4F2C41E87E4 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
         status: 200 OK
         code: 200
-        duration: 190.6537ms
-    - id: 32
+        duration: 142.2547ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Contoso-Demo/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2328
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2328"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:04 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 6d9e84f5-e2f2-4c67-a1ae-275f8dda6733
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222605Z:3356fd3a-bef9-459d-aac1-2e8779c722ab
+            X-Msedge-Ref:
+                - 'Ref A: 45358463156D4F8EA25BDCDBAE2A66E0 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
+        status: 200 OK
+        code: 200
+        duration: 144.814ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-2/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2328
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2328"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:04 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11998"
+            X-Ms-Request-Id:
+                - cf42d81f-8d2d-4911-9b95-c85ad250e33b
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222605Z:b75ef673-bb53-49e9-8d8c-a3a4436274b1
+            X-Msedge-Ref:
+                - 'Ref A: F8547366E70B425E946B2F51B5BA4CC3 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
+        status: 200 OK
+        code: 200
+        duration: 151.1951ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-1/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2328
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write","Microsoft.Authorization/elevateAccess/Action","Microsoft.Blueprint/blueprintAssignments/write","Microsoft.Blueprint/blueprintAssignments/delete","Microsoft.Compute/galleries/share/action","Microsoft.Purview/consents/write","Microsoft.Purview/consents/delete"],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2328"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:04 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 1d181d7f-9401-48df-beba-b148d4fa8ae3
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222605Z:fe43c5cb-b95f-42f8-8898-8cdee34b96f4
+            X-Msedge-Ref:
+                - 'Ref A: 1DB06328B2384B87905B9EC2E0FDD149 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
+        status: 200 OK
+        code: 200
+        duration: 155.9393ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:04 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 9fb72a38-3033-4df0-9920-19be2637d4ee
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222605Z:ff61d365-2e08-4448-a33e-8250ec7d2da2
+            X-Msedge-Ref:
+                - 'Ref A: C87EE005077D47DA9F009278E043D97C Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
+        status: 200 OK
+        code: 200
+        duration: 163.821ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/basic/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Tue, 05 Mar 2024 22:26:04 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - f8068333-2a79-427a-ac9c-f364620dae84
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20240305T222605Z:aa66ffbe-7055-4f1d-be6a-76e87a7226b8
+            X-Msedge-Ref:
+                - 'Ref A: 65CF438F588D409B91E36E5076D13CD1 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:05Z'
+        status: 200 OK
+        code: 200
+        duration: 274.0146ms
+    - id: 46
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2672,6 +3646,8 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 62077d4f3335aa1d4444f17148f228b8
         url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/environments?api-version=2023-04-01
         method: GET
       response:
@@ -2686,15 +3662,28 @@ interactions:
             {
               "value": [
                 {
-                  "name": "azdtest-w19ee8a",
+                  "name": "wabrez-ade-demo-01",
                   "environmentType": "Dev",
                   "user": "19a2053b-445a-4023-95d3-c339051e0f32",
                   "provisioningState": "Succeeded",
-                  "resourceGroupId": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w19ee8a",
+                  "resourceGroupId": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-wabrez-ade-demo-01",
                   "catalogName": "wbreza",
                   "environmentDefinitionName": "HelloWorld",
                   "parameters": {
-                    "environmentName": "azdtest-w19ee8a",
+                    "environmentName": "wabrez-ade-demo01",
+                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
+                  }
+                },
+                {
+                  "name": "wabrez-spn-test",
+                  "environmentType": "Dev",
+                  "user": "3b00f8af-ca10-45e3-8cb9-ef8083ea6a10",
+                  "provisioningState": "Succeeded",
+                  "resourceGroupId": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-wabrez-spn-test",
+                  "catalogName": "wbreza",
+                  "environmentDefinitionName": "HelloWorld",
+                  "parameters": {
+                    "environmentName": "wabrez-spn-test",
                     "repoUrl": "https://github.com/wbreza/azd-hello-world"
                   }
                 }
@@ -2710,23 +3699,23 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:36 GMT
+                - Tue, 05 Mar 2024 22:26:06 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - b4954822-e4a0-4e8c-9289-195fea05279a
+                - ded43089-7563-4194-b803-8bdab82c761f
             X-Ms-Correlation-Request-Id:
-                - f87b6c86-7409-47dd-a349-163ca91472a2
+                - 62077d4f3335aa1d4444f17148f228b8
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
                 - "297"
             X-Rate-Limit-Reset:
-                - "2024-02-26T19:38:33.7359520Z"
+                - "2024-03-05T22:27:03.6818180Z"
         status: 200 OK
         code: 200
-        duration: 791.4647ms
-    - id: 33
+        duration: 697.5556ms
+    - id: 47
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2751,7 +3740,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - azsdk-go-armresourcegraph.Client/v0.7.1 (go1.21.6; Windows_NT),azd
+                - azsdk-go-armresourcegraph.Client/v0.7.1 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
+            X-Ms-Correlation-Request-Id:
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
         url: https://management.azure.com:443/providers/Microsoft.ResourceGraph/resources?api-version=2021-06-01-preview
         method: POST
       response:
@@ -2760,18 +3751,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 8615
+        content_length: 12868
         uncompressed: false
-        body: '{"totalRecords":14,"count":14,"data":[{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioClient","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSVendors","properties":{"provisioningState":"Succeeded","description":"Project for vendors","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/basic","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"basic","properties":{"provisioningState":"Succeeded","description":"project with basic image","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"MicroBuild","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourceGroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DevDivAzureService","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourceGroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"LanguageAndFrameworkServices","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourceGroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSCode","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourceGroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ServerlessPaaS","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourceGroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"PMUXDesign","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourceGroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"NuGet","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourceGroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DataAndAI","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Contoso-Demo","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Contoso-Demo","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-1","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-2","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"}],"facets":[],"resultTruncated":"false"}'
+        body: '{"totalRecords":21,"count":21,"data":[{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioClient","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSVendors","properties":{"provisioningState":"Succeeded","description":"Project for vendors","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/basic","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"basic","properties":{"provisioningState":"Succeeded","description":"project with basic image","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"MicroBuild","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourceGroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DevDivAzureService","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourceGroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"LanguageAndFrameworkServices","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourceGroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSCode","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourceGroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ServerlessPaaS","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourceGroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"PMUXDesign","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourceGroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"NuGet","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/projects/dcprj-pv44d74rp44bs","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"dcprj-pv44d74rp44bs","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-pv44d74rp44bs.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/devcenters/dc-pv44d74rp44bs"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/projects/rltestproj","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"rltestproj","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-pv44d74rp44bs.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/devcenters/dc-pv44d74rp44bs"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project1","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ade-project1","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-ade-fidalgo-dev2.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/ade-fidalgo-dev2"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project2","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ade-project2","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-ade-fidalgo-dev2.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/ade-fidalgo-dev2"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/Inventory-Management-Project","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Inventory-Management-Project","properties":{"provisioningState":"Succeeded","description":"Inventory Management project","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-logistics-system-devcenter.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/Logistics-System-DevCenter"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourceGroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DataAndAI","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-shihua8/providers/Microsoft.DevCenter/projects/xshProject-1","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"xshProject-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-contoso-nhtvx54bj4kb4.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-shihua8/providers/Microsoft.DevCenter/devcenters/dc-contoso-nhtvx54bj4kb4"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-shihua8/providers/Microsoft.DevCenter/projects/xshProject-2","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"xshProject-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-contoso-nhtvx54bj4kb4.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-shihua8/providers/Microsoft.DevCenter/devcenters/dc-contoso-nhtvx54bj4kb4"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Contoso-Demo","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Contoso-Demo","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-1","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-2","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"}],"facets":[],"resultTruncated":"false"}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "8615"
+                - "12868"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:37 GMT
+                - Tue, 05 Mar 2024 22:26:06 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2783,27 +3774,27 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - f7975e48-dd3d-4599-9f55-889ea9fac528
+                - 61eeecda-9d7b-ba8c-6a3a-bd13b61b96e7
             X-Ms-Ratelimit-Remaining-Tenant-Reads:
                 - "11999"
             X-Ms-Ratelimit-Remaining-Tenant-Resource-Requests:
                 - "14"
             X-Ms-Request-Id:
-                - f7975e48-dd3d-4599-9f55-889ea9fac528
+                - 2d920927-5015-457d-b3c5-146d92678946
             X-Ms-Resource-Graph-Request-Duration:
-                - "0:00:00:00.4395981"
+                - "0:00:00:00.2087392"
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T193737Z:f7975e48-dd3d-4599-9f55-889ea9fac528
+                - WESTCENTRALUS:20240305T222607Z:2d920927-5015-457d-b3c5-146d92678946
             X-Ms-User-Quota-Remaining:
                 - "14"
             X-Ms-User-Quota-Resets-After:
                 - "00:00:05"
             X-Msedge-Ref:
-                - 'Ref A: 5AFD1B39EE2F4A099AC7546303EEB2EF Ref B: CO6AA3150219021 Ref C: 2024-02-26T19:37:37Z'
+                - 'Ref A: 21A88D180A18451EA80A189E0AC16EF0 Ref B: CO6AA3150219019 Ref C: 2024-03-05T22:26:06Z'
         status: 200 OK
         code: 200
-        duration: 477.5477ms
-    - id: 34
+        duration: 406.6237ms
+    - id: 48
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2823,6 +3814,8 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
         url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/environmentTypes?api-version=2023-04-01
         method: GET
       response:
@@ -2863,23 +3856,23 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:38 GMT
+                - Tue, 05 Mar 2024 22:26:07 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 43290825-4af1-45ce-9bee-0d0ad5e3bec2
+                - 8e17d0c1-182d-4e08-b20f-ebd3c1541bbb
             X-Ms-Correlation-Request-Id:
-                - e725a046-13c3-4534-aab5-73bbdaecd50a
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
                 - "299"
             X-Rate-Limit-Reset:
-                - "2024-02-26T19:38:38.3647570Z"
+                - "2024-03-05T22:27:07.7083865Z"
         status: 200 OK
         code: 200
-        duration: 781.8033ms
-    - id: 35
+        duration: 485.3465ms
+    - id: 49
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2899,6 +3892,8 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
         url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/catalogs/wbreza/environmentDefinitions/HelloWorld?api-version=2023-04-01
         method: GET
       response:
@@ -2949,23 +3944,23 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:41 GMT
+                - Tue, 05 Mar 2024 22:26:09 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - c661085c-79d5-49f1-bcc5-07e2dbece5e5
+                - f2837854-b6d4-4d64-bbac-a943d3b9b6c7
             X-Ms-Correlation-Request-Id:
-                - 8e4c578c-b0f3-4873-ac4c-a0944ce4e3df
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
                 - "298"
             X-Rate-Limit-Reset:
-                - "2024-02-26T19:38:33.7198478Z"
+                - "2024-03-05T22:27:03.7102688Z"
         status: 200 OK
         code: 200
-        duration: 1.0721088s
-    - id: 36
+        duration: 608.3405ms
+    - id: 50
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2985,7 +3980,9 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w4789fc?api-version=2023-04-01
+            X-Ms-Correlation-Request-Id:
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w98cb42?api-version=2023-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3000,7 +3997,7 @@ interactions:
               "status": "Failed",
               "error": {
                 "code": "EnvironmentNotFound",
-                "message": "The environment azdtest-w4789fc cannot be found.",
+                "message": "The environment azdtest-w98cb42 cannot be found.",
                 "details": [],
                 "additionalInfo": []
               }
@@ -3017,23 +4014,23 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:41 GMT
+                - Tue, 05 Mar 2024 22:26:10 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 8918a95e-9f4f-4919-b52d-81d0f6f4301b
+                - f5264acc-ee84-4f4b-a8fa-df7d89a1938c
             X-Ms-Correlation-Request-Id:
-                - 1cce2430-a5b7-45d1-95e2-b15c849c2353
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
                 - "296"
             X-Rate-Limit-Reset:
-                - "2024-02-26T19:38:33.7359520Z"
+                - "2024-03-05T22:27:03.6818180Z"
         status: 404 Not Found
         code: 404
-        duration: 108.3127ms
-    - id: 37
+        duration: 112.735ms
+    - id: 51
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3045,7 +4042,7 @@ interactions:
         host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com
         remote_addr: ""
         request_uri: ""
-        body: '{"catalogName":"wbreza","environmentDefinitionName":"HelloWorld","environmentType":"Dev","parameters":{"environmentName":"azdtest-w4789fc","repoUrl":"https://github.com/wbreza/azd-hello-world"}}'
+        body: '{"catalogName":"wbreza","environmentDefinitionName":"HelloWorld","environmentType":"Dev","parameters":{"environmentName":"azdtest-w98cb42","repoUrl":"https://github.com/wbreza/azd-hello-world"}}'
         form: {}
         headers:
             Accept-Encoding:
@@ -3056,7 +4053,9 @@ interactions:
                 - application/json
             User-Agent:
                 - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w4789fc?api-version=2023-04-01
+            X-Ms-Correlation-Request-Id:
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w98cb42?api-version=2023-04-01
         method: PUT
       response:
         proto: HTTP/2.0
@@ -3068,14 +4067,14 @@ interactions:
         uncompressed: false
         body: |-
             {
-              "name": "azdtest-w4789fc",
+              "name": "azdtest-w98cb42",
               "environmentType": "Dev",
               "user": "19a2053b-445a-4023-95d3-c339051e0f32",
               "provisioningState": "Creating",
               "catalogName": "wbreza",
               "environmentDefinitionName": "HelloWorld",
               "parameters": {
-                "environmentName": "azdtest-w4789fc",
+                "environmentName": "azdtest-w98cb42",
                 "repoUrl": "https://github.com/wbreza/azd-hello-world"
               }
             }
@@ -3091,27 +4090,27 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:37:44 GMT
+                - Tue, 05 Mar 2024 22:26:10 GMT
             Location:
-                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/66faedc4-b93b-4b50-97eb-64a53c861b98?api-version=2023-04-01&monitor=true
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/ff271f59-3c3b-4626-898f-7357537312ac?api-version=2023-04-01&monitor=true
             Operation-Location:
-                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/66faedc4-b93b-4b50-97eb-64a53c861b98?api-version=2023-04-01
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/ff271f59-3c3b-4626-898f-7357537312ac?api-version=2023-04-01
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 55b50c3e-ea78-4a09-8b15-08b27a367424
+                - 719ce4e3-b189-4550-94a0-e2590adebf2b
             X-Ms-Correlation-Request-Id:
-                - a792229e-e8e3-48f6-b63c-5ccd14d46f3f
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
                 - "298"
             X-Rate-Limit-Reset:
-                - "2024-02-26T19:38:38.3647570Z"
+                - "2024-03-05T22:27:07.7083865Z"
         status: 201 Created
         code: 201
-        duration: 2.9544595s
-    - id: 38
+        duration: 827.6059ms
+    - id: 52
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3131,7 +4130,9 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/project-1/operationstatuses/66faedc4-b93b-4b50-97eb-64a53c861b98?api-version=2023-04-01
+            X-Ms-Correlation-Request-Id:
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/project-1/operationstatuses/ff271f59-3c3b-4626-898f-7357537312ac?api-version=2023-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3143,11 +4144,11 @@ interactions:
         uncompressed: true
         body: |-
             {
-              "id": "/projects/project-1/operationStatuses/66faedc4-b93b-4b50-97eb-64a53c861b98",
-              "name": "66faedc4-b93b-4b50-97eb-64a53c861b98",
+              "id": "/projects/project-1/operationStatuses/ff271f59-3c3b-4626-898f-7357537312ac",
+              "name": "ff271f59-3c3b-4626-898f-7357537312ac",
               "status": "Succeeded",
-              "startTime": "2024-02-26T19:37:43.0095229+00:00",
-              "endTime": "2024-02-26T19:41:19.7367454+00:00"
+              "startTime": "2024-03-05T22:26:10.803237+00:00",
+              "endTime": "2024-03-05T22:30:31.8468183+00:00"
             }
         headers:
             Access-Control-Allow-Origin:
@@ -3159,29 +4160,29 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:41:47 GMT
+                - Tue, 05 Mar 2024 22:30:42 GMT
             Location:
-                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/66faedc4-b93b-4b50-97eb-64a53c861b98?api-version=2023-04-01&monitor=true
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/ff271f59-3c3b-4626-898f-7357537312ac?api-version=2023-04-01&monitor=true
             Operation-Location:
-                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/66faedc4-b93b-4b50-97eb-64a53c861b98?api-version=2023-04-01
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/ff271f59-3c3b-4626-898f-7357537312ac?api-version=2023-04-01
             Retry-After:
                 - "30"
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 14a1e451-b2f2-4b5b-8d79-1c56540e79cb
+                - 796b430e-31f6-4cc6-ab97-0809ad9e418a
             X-Ms-Correlation-Request-Id:
-                - 8e488f1a-5814-4d7c-88a8-ffd700e10b88
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
                 - "299"
             X-Rate-Limit-Reset:
-                - "2024-02-26T19:42:47.2817354Z"
+                - "2024-03-05T22:31:42.3995221Z"
         status: 200 OK
         code: 200
-        duration: 147.4086ms
-    - id: 39
+        duration: 143.8526ms
+    - id: 53
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3201,7 +4202,9 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w4789fc?api-version=2023-04-01
+            X-Ms-Correlation-Request-Id:
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w98cb42?api-version=2023-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3213,15 +4216,15 @@ interactions:
         uncompressed: true
         body: |-
             {
-              "name": "azdtest-w4789fc",
+              "name": "azdtest-w98cb42",
               "environmentType": "Dev",
               "user": "19a2053b-445a-4023-95d3-c339051e0f32",
               "provisioningState": "Succeeded",
-              "resourceGroupId": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc",
+              "resourceGroupId": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42",
               "catalogName": "wbreza",
               "environmentDefinitionName": "HelloWorld",
               "parameters": {
-                "environmentName": "azdtest-w4789fc",
+                "environmentName": "azdtest-w98cb42",
                 "repoUrl": "https://github.com/wbreza/azd-hello-world"
               }
             }
@@ -3235,23 +4238,23 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:41:48 GMT
+                - Tue, 05 Mar 2024 22:30:42 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 47b8e77c-e9bf-46c3-a38a-a8052d27de27
+                - ca21a7e7-f480-4edd-b2d4-c2e9b05170a4
             X-Ms-Correlation-Request-Id:
-                - e1518b35-6ae3-4385-8f3f-917d5e20dacb
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
                 - "299"
             X-Rate-Limit-Reset:
-                - "2024-02-26T19:42:48.1726074Z"
+                - "2024-03-05T22:31:42.5549859Z"
         status: 200 OK
         code: 200
-        duration: 877.4358ms
-    - id: 40
+        duration: 115.7973ms
+    - id: 54
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3271,7 +4274,9 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w4789fc?api-version=2023-04-01
+            X-Ms-Correlation-Request-Id:
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w98cb42?api-version=2023-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3283,15 +4288,15 @@ interactions:
         uncompressed: true
         body: |-
             {
-              "name": "azdtest-w4789fc",
+              "name": "azdtest-w98cb42",
               "environmentType": "Dev",
               "user": "19a2053b-445a-4023-95d3-c339051e0f32",
               "provisioningState": "Succeeded",
-              "resourceGroupId": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc",
+              "resourceGroupId": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42",
               "catalogName": "wbreza",
               "environmentDefinitionName": "HelloWorld",
               "parameters": {
-                "environmentName": "azdtest-w4789fc",
+                "environmentName": "azdtest-w98cb42",
                 "repoUrl": "https://github.com/wbreza/azd-hello-world"
               }
             }
@@ -3305,23 +4310,23 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:41:48 GMT
+                - Tue, 05 Mar 2024 22:30:43 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 3a60cbe0-96d2-4e7a-862d-796417207b96
+                - b80873b8-462c-4066-abcc-f6e71afca9c3
             X-Ms-Correlation-Request-Id:
-                - 81ed031b-2e45-4177-9a41-b5e67ce81b13
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
                 - "298"
             X-Rate-Limit-Reset:
-                - "2024-02-26T19:42:17.1172344Z"
+                - "2024-03-05T22:31:12.2505384Z"
         status: 200 OK
         code: 200
-        duration: 129.2514ms
-    - id: 41
+        duration: 795.45ms
+    - id: 55
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3344,8 +4349,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - baa93f9791f77e8989aa1ed042639dbb
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/?api-version=2021-04-01
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/?api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3353,18 +4358,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 13713
+        content_length: 13694
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/app-helloworld-4y6ae2hdnphbq-appSettings","name":"app-helloworld-4y6ae2hdnphbq-appSettings","type":"Microsoft.Resources/deployments","properties":{"templateHash":"1502109241172037927","parameters":{"name":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"appSettings":{"type":"Object","value":{"SCM_DO_BUILD_DURING_DEPLOYMENT":"True","ENABLE_ORYX_BUILD":"True"}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:40:01.4134974Z","duration":"PT13.6022714S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"sites/config","locations":[null]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/appsettings"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/app-helloworld-4y6ae2hdnphbq-app-module","name":"app-helloworld-4y6ae2hdnphbq-app-module","type":"Microsoft.Resources/deployments","properties":{"templateHash":"3548910797978781823","parameters":{"name":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w4789fc","azd-service-name":"helloworld"}},"applicationInsightsName":{"type":"String","value":""},"appServicePlanId":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"},"keyVaultName":{"type":"String","value":""},"managedIdentity":{"type":"Bool","value":false},"runtimeName":{"type":"String","value":"node"},"runtimeNameAndVersion":{"type":"String","value":"node|18-lts"},"runtimeVersion":{"type":"String","value":"18-lts"},"kind":{"type":"String","value":"app,linux"},"allowedOrigins":{"type":"Array","value":[]},"alwaysOn":{"type":"Bool","value":true},"appCommandLine":{"type":"String","value":""},"clientAffinityEnabled":{"type":"Bool","value":false},"enableOryxBuild":{"type":"Bool","value":true},"functionAppScaleLimit":{"type":"Int","value":-1},"linuxFxVersion":{"type":"String","value":"node|18-lts"},"minimumElasticInstanceCount":{"type":"Int","value":-1},"numberOfWorkers":{"type":"Int","value":-1},"scmDoBuildDuringDeployment":{"type":"Bool","value":true},"use32BitWorkerProcess":{"type":"Bool","value":false},"ftpsState":{"type":"String","value":"FtpsOnly"},"healthCheckPath":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:40:05.3286583Z","duration":"PT37.9814816S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"sites/config","locations":[null]},{"resourceType":"sites/basicPublishingCredentialsPolicies","locations":[null]},{"resourceType":"sites","locations":["eastus2"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-4y6ae2hdnphbq"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/logs","resourceType":"Microsoft.Web/sites/config","resourceName":"app-helloworld-4y6ae2hdnphbq/logs"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-4y6ae2hdnphbq"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/ftp","resourceType":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","resourceName":"app-helloworld-4y6ae2hdnphbq/ftp"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-4y6ae2hdnphbq"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/scm","resourceType":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","resourceName":"app-helloworld-4y6ae2hdnphbq/scm"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-4y6ae2hdnphbq"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/app-helloworld-4y6ae2hdnphbq-appSettings","resourceType":"Microsoft.Resources/deployments","resourceName":"app-helloworld-4y6ae2hdnphbq-appSettings"}],"outputs":{"identityPrincipalId":{"type":"String","value":""},"name":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"uri":{"type":"String","value":"https://app-helloworld-4y6ae2hdnphbq.azurewebsites.net"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/logs"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/helloworld","name":"helloworld","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12313645452229774503","parameters":{"name":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w4789fc"}},"appCommandLine":{"type":"String","value":""},"appServicePlanId":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"},"serviceName":{"type":"String","value":"helloworld"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:40:16.4892974Z","duration":"PT52.443231S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"servicE_HELLOWORLD_IDENTITY_PRINCIPAL_ID":{"type":"String","value":""},"servicE_HELLOWORLD_NAME":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"servicE_HELLOWORLD_URI":{"type":"String","value":"https://app-helloworld-4y6ae2hdnphbq.azurewebsites.net"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/logs"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/appserviceplan","name":"appserviceplan","type":"Microsoft.Resources/deployments","properties":{"templateHash":"7476659406584400671","parameters":{"name":{"type":"String","value":"plan-4y6ae2hdnphbq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w4789fc"}},"kind":{"type":"String","value":""},"reserved":{"type":"Bool","value":true},"sku":{"type":"Object","value":{"name":"B1"}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:39:14.509538Z","duration":"PT6.5263397S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"serverfarms","locations":["eastus2"]}]}],"dependencies":[],"outputs":{"id":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"},"name":{"type":"String","value":"plan-4y6ae2hdnphbq"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/project-1.azdtest-w4789fc.133534499416341033","name":"project-1.azdtest-w4789fc.133534499416341033","type":"Microsoft.Resources/deployments","tags":{"AdeEnvironmentName":"azdtest-w4789fc","AdeProjectName":"project-1","AdeDevCenterName":"dc-wabrez-od3kzvk4mwe72","AdeEnvironmentTypeName":"Dev"},"properties":{"templateLink":{"uri":"https://d55vj9m1o8u4cm4o.blob.core.windows.net/templates/project-1.azdtest-w4789fc.133534499416341033/EnvironmentDefinitions/HelloWorld/azuredeploy.json","contentVersion":"1.0.0.0"},"templateHash":"17645299908346333518","parameters":{"repoUrl":{"type":"String","value":"https://github.com/wbreza/azd-hello-world"},"environmentName":{"type":"String","value":"azdtest-w4789fc"},"location":{"type":"String","value":"eastus2"},"serviceName":{"type":"String","value":""},"appServicePlanName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:40:27.6950264Z","duration":"PT1M20.8125551S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/appserviceplan","resourceType":"Microsoft.Resources/deployments","resourceName":"appserviceplan"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/appserviceplan","resourceType":"Microsoft.Resources/deployments","resourceName":"appserviceplan","apiVersion":"2022-09-01"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/helloworld","resourceType":"Microsoft.Resources/deployments","resourceName":"helloworld"}],"outputs":{"azurE_LOCATION":{"type":"String","value":"eastus2"},"azurE_TENANT_ID":{"type":"String","value":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"servicE_API_ENDPOINTS":{"type":"Array","value":["https://app-helloworld-4y6ae2hdnphbq.azurewebsites.net"]}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/logs"}]}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/app-helloworld-teq3fxi34ib7k-appSettings","name":"app-helloworld-teq3fxi34ib7k-appSettings","type":"Microsoft.Resources/deployments","properties":{"templateHash":"1502109241172037927","parameters":{"name":{"type":"String","value":"app-helloworld-teq3fxi34ib7k"},"appSettings":{"type":"Object","value":{"SCM_DO_BUILD_DURING_DEPLOYMENT":"True","ENABLE_ORYX_BUILD":"True"}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-03-05T22:29:23.5949257Z","duration":"PT11.415251S","correlationId":"61eeecda9d7bba8c6a3abd13b61b96e7","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"sites/config","locations":[null]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/config/appsettings"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/app-helloworld-teq3fxi34ib7k-app-module","name":"app-helloworld-teq3fxi34ib7k-app-module","type":"Microsoft.Resources/deployments","properties":{"templateHash":"3548910797978781823","parameters":{"name":{"type":"String","value":"app-helloworld-teq3fxi34ib7k"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w98cb42","azd-service-name":"helloworld"}},"applicationInsightsName":{"type":"String","value":""},"appServicePlanId":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/serverfarms/plan-teq3fxi34ib7k"},"keyVaultName":{"type":"String","value":""},"managedIdentity":{"type":"Bool","value":false},"runtimeName":{"type":"String","value":"node"},"runtimeNameAndVersion":{"type":"String","value":"node|18-lts"},"runtimeVersion":{"type":"String","value":"18-lts"},"kind":{"type":"String","value":"app,linux"},"allowedOrigins":{"type":"Array","value":[]},"alwaysOn":{"type":"Bool","value":true},"appCommandLine":{"type":"String","value":""},"clientAffinityEnabled":{"type":"Bool","value":false},"enableOryxBuild":{"type":"Bool","value":true},"functionAppScaleLimit":{"type":"Int","value":-1},"linuxFxVersion":{"type":"String","value":"node|18-lts"},"minimumElasticInstanceCount":{"type":"Int","value":-1},"numberOfWorkers":{"type":"Int","value":-1},"scmDoBuildDuringDeployment":{"type":"Bool","value":true},"use32BitWorkerProcess":{"type":"Bool","value":false},"ftpsState":{"type":"String","value":"FtpsOnly"},"healthCheckPath":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-03-05T22:29:27.6884475Z","duration":"PT36.5480266S","correlationId":"61eeecda9d7bba8c6a3abd13b61b96e7","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"sites/config","locations":[null]},{"resourceType":"sites/basicPublishingCredentialsPolicies","locations":[null]},{"resourceType":"sites","locations":["eastus2"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-teq3fxi34ib7k"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/config/logs","resourceType":"Microsoft.Web/sites/config","resourceName":"app-helloworld-teq3fxi34ib7k/logs"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-teq3fxi34ib7k"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/basicPublishingCredentialsPolicies/ftp","resourceType":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","resourceName":"app-helloworld-teq3fxi34ib7k/ftp"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-teq3fxi34ib7k"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/basicPublishingCredentialsPolicies/scm","resourceType":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","resourceName":"app-helloworld-teq3fxi34ib7k/scm"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-teq3fxi34ib7k"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/app-helloworld-teq3fxi34ib7k-appSettings","resourceType":"Microsoft.Resources/deployments","resourceName":"app-helloworld-teq3fxi34ib7k-appSettings"}],"outputs":{"identityPrincipalId":{"type":"String","value":""},"name":{"type":"String","value":"app-helloworld-teq3fxi34ib7k"},"uri":{"type":"String","value":"https://app-helloworld-teq3fxi34ib7k.azurewebsites.net"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/config/logs"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/helloworld","name":"helloworld","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12313645452229774503","parameters":{"name":{"type":"String","value":"app-helloworld-teq3fxi34ib7k"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w98cb42"}},"appCommandLine":{"type":"String","value":""},"appServicePlanId":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/serverfarms/plan-teq3fxi34ib7k"},"serviceName":{"type":"String","value":"helloworld"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-03-05T22:29:37.9642707Z","duration":"PT48.0717999S","correlationId":"61eeecda9d7bba8c6a3abd13b61b96e7","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"servicE_HELLOWORLD_IDENTITY_PRINCIPAL_ID":{"type":"String","value":""},"servicE_HELLOWORLD_NAME":{"type":"String","value":"app-helloworld-teq3fxi34ib7k"},"servicE_HELLOWORLD_URI":{"type":"String","value":"https://app-helloworld-teq3fxi34ib7k.azurewebsites.net"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/config/logs"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/appserviceplan","name":"appserviceplan","type":"Microsoft.Resources/deployments","properties":{"templateHash":"7476659406584400671","parameters":{"name":{"type":"String","value":"plan-teq3fxi34ib7k"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w98cb42"}},"kind":{"type":"String","value":""},"reserved":{"type":"Bool","value":true},"sku":{"type":"Object","value":{"name":"B1"}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-03-05T22:28:39.0560361Z","duration":"PT6.0158516S","correlationId":"61eeecda9d7bba8c6a3abd13b61b96e7","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"serverfarms","locations":["eastus2"]}]}],"dependencies":[],"outputs":{"id":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/serverfarms/plan-teq3fxi34ib7k"},"name":{"type":"String","value":"plan-teq3fxi34ib7k"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/serverfarms/plan-teq3fxi34ib7k"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/project-1.azdtest-w98cb42.133541513056703349","name":"project-1.azdtest-w98cb42.133541513056703349","type":"Microsoft.Resources/deployments","tags":{"AdeEnvironmentName":"azdtest-w98cb42","AdeProjectName":"project-1","AdeDevCenterName":"dc-wabrez-od3kzvk4mwe72","AdeEnvironmentTypeName":"Dev"},"properties":{"templateLink":{"uri":"https://d55vj9m1o8u4cm4o.blob.core.windows.net/templates/project-1.azdtest-w98cb42.133541513056703349/EnvironmentDefinitions/HelloWorld/azuredeploy.json","contentVersion":"1.0.0.0"},"templateHash":"17645299908346333518","parameters":{"repoUrl":{"type":"String","value":"https://github.com/wbreza/azd-hello-world"},"environmentName":{"type":"String","value":"azdtest-w98cb42"},"location":{"type":"String","value":"eastus2"},"serviceName":{"type":"String","value":""},"appServicePlanName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-03-05T22:29:53.6837662Z","duration":"PT1M23.9222617S","correlationId":"61eeecda9d7bba8c6a3abd13b61b96e7","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/appserviceplan","resourceType":"Microsoft.Resources/deployments","resourceName":"appserviceplan"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/appserviceplan","resourceType":"Microsoft.Resources/deployments","resourceName":"appserviceplan","apiVersion":"2022-09-01"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/helloworld","resourceType":"Microsoft.Resources/deployments","resourceName":"helloworld"}],"outputs":{"azurE_LOCATION":{"type":"String","value":"eastus2"},"azurE_TENANT_ID":{"type":"String","value":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"servicE_API_ENDPOINTS":{"type":"Array","value":["https://app-helloworld-teq3fxi34ib7k.azurewebsites.net"]}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/serverfarms/plan-teq3fxi34ib7k"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/config/logs"}]}}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "13713"
+                - "13694"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:41:49 GMT
+                - Tue, 05 Mar 2024 22:30:44 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3376,19 +4381,19 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - baa93f9791f77e8989aa1ed042639dbb
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 42ec1337-6d92-4096-98e2-1897e154f257
+                - 1d5682f5-0969-4823-a40b-ff4da1f7b50e
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T194149Z:42ec1337-6d92-4096-98e2-1897e154f257
+                - WESTUS2:20240305T223044Z:1d5682f5-0969-4823-a40b-ff4da1f7b50e
             X-Msedge-Ref:
-                - 'Ref A: 40A2B5F02FA04E3F93F075622A5FB1C8 Ref B: CO6AA3150217053 Ref C: 2024-02-26T19:41:49Z'
+                - 'Ref A: E1D757B9C92A4139BFC6ACF1B741BD9C Ref B: CO6AA3150217051 Ref C: 2024-03-05T22:30:43Z'
         status: 200 OK
         code: 200
-        duration: 987.2808ms
-    - id: 42
+        duration: 716.0273ms
+    - id: 56
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3411,8 +4416,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armresources.Client/v1.1.1 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - baa93f9791f77e8989aa1ed042639dbb
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27helloworld%27&api-version=2021-04-01
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27helloworld%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3422,7 +4427,7 @@ interactions:
         trailer: {}
         content_length: 403
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","name":"app-helloworld-4y6ae2hdnphbq","type":"Microsoft.Web/sites","kind":"app,linux","managedBy":"","location":"eastus2","tags":{"project":"Project-1","env":"dev","azd-env-name":"wabrez-devcenter","azd-service-name":"helloworld"}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k","name":"app-helloworld-teq3fxi34ib7k","type":"Microsoft.Web/sites","kind":"app,linux","managedBy":"","location":"eastus2","tags":{"project":"Project-1","env":"dev","azd-env-name":"wabrez-devcenter","azd-service-name":"helloworld"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -3431,7 +4436,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:41:49 GMT
+                - Tue, 05 Mar 2024 22:30:44 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3443,19 +4448,19 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - baa93f9791f77e8989aa1ed042639dbb
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11996"
             X-Ms-Request-Id:
-                - 4c719731-8eca-4695-b986-80ef1e4efe63
+                - cc7efbfe-3f9a-4c4a-be79-6906fc62b85b
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T194150Z:4c719731-8eca-4695-b986-80ef1e4efe63
+                - WESTUS2:20240305T223044Z:cc7efbfe-3f9a-4c4a-be79-6906fc62b85b
             X-Msedge-Ref:
-                - 'Ref A: 9750A5DEC90A4089B67FB01AD03AC067 Ref B: CO6AA3150217053 Ref C: 2024-02-26T19:41:49Z'
+                - 'Ref A: F22836B02FC7462FADA86405D6A29759 Ref B: CO6AA3150217051 Ref C: 2024-03-05T22:30:44Z'
         status: 200 OK
         code: 200
-        duration: 263.4773ms
-    - id: 43
+        duration: 187.5777ms
+    - id: 57
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3464,11 +4469,11 @@ interactions:
         transfer_encoding:
             - chunked
         trailer: {}
-        host: app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net
+        host: app-helloworld-teq3fxi34ib7k.scm.azurewebsites.net
         remote_addr: ""
         request_uri: ""
         body: !!binary |
-            UEsDBBQACAAIALRcWlgAAAAAAAAAAAAAAAAKAAkALmdpdGlnbm9yZVVUBQABhOjcZXRVTW
+            UEsDBBQACAAIAERzZVgAAAAAAAAAAAAAAAAKAAkALmdpdGlnbm9yZVVUBQABAJznZXRVTW
             /cNhC981cMsIfUC0hqektvddwEDdy0sHspimJBkbMy19SQ4AzXq/z6gtRH7Li5rPVmHkcz
             j2/kHdyGgZUvP/vWh0FRHBuLfR4K2qtJJ3qFMaWQZuwxkX5OUDu4cXqgwOIMJIwhCcMPDy
             KRf+46ChZP3IY0dDq6bs63DzL6K7WAf35s3v27//8/Jw5UXnGXSdyIYLVoFZ0t3Udn1b5l
@@ -3484,8 +4489,8 @@ interactions:
             X7aXFAuyhe/VpHcATygBBz750B7whLyB1hCjlBTOGERsre81pJk4U9BdmvbaodbC7Hiyzz
             9D4MFTfvmre7uX6zGajhHMsHsGhUU6XVc8aYkL+dew1360j3mM6YfGE+X4+Wt3h1yIfMeB
             0uq+OOmbEPl5q6mUiP4eYaboPRfhXH1qjt5wXBRJ/uoTS53K5goqY2rXbwy5ecED5kMsWG
-            DDqJO2oj5f+L0b5llPKh4voV/y8AAP//UEsHCBcl+6EvAwAAegYAAFBLAwQUAAgACAC0XF
-            pYAAAAAAAAAAAAAAAACQAJAFJFQURNRS5tZFVUBQABhOjcZXyTQW/iOhSF9/yKIyG9Rxel
+            DDqJO2oj5f+L0b5llPKh4voV/y8AAP//UEsHCBcl+6EvAwAAegYAAFBLAwQUAAgACABEc2
+            VYAAAAAAAAAAAAAAAACQAJAFJFQURNRS5tZFVUBQABAJznZXyTQW/iOhSF9/yKIyG9Rxel
             RW/xOqwmTaNOJAiIpBppNsQkF2LJ2B77Gsr8+pEDnbaqOjsn997v3OOcDFGYlnCU3KE6Wf
             KNk5aRPVtH3mOVlRWSZT4YDIcoiYONpyGWjhz9DNJLJj8YXJ8po8ndePL/eHIVXyznGH0Z
             38WnfmRmGqGQ6YN0Ru9J82CQOhJMEKjHpA/1eQvuCFujlDlKvUNj9FbughMsjZ5GpTr58b
@@ -3496,14 +4501,14 @@ interactions:
             WLf5CavZWK3gBc0NjEas/ZXPqac1+flDeZbWIEpWbTF+rxTSs91zFLLbmzUgSLV5tvlDwL
             x71Kf+oRL/seSBkbEwtP7hBZMxF002HjzNGTw1fUHbOd3tz0I53xPP1vcntbj1F1hMvFwY
             odIRZ9j19Y0vEu8ZTj2JEjnExAIzTYnWDCeYn48/0OAAD//1BLBwihoHHtDQIAAKUDAABQ
-            SwMEFAAIAAgAtFxaWAAAAAAAAAAAAAAAAAgACQBpbmRleC5qc1VUBQABhOjcZUyQUWsiMR
+            SwMEFAAIAAgARHNlWAAAAAAAAAAAAAAAAAgACQBpbmRleC5qc1VUBQABAJznZUyQUWsiMR
             SF3/MrzsLCRBhmhH0U92VX2kKhRS19NThXDcTceG9GCup/L5lR6FO4J/ec8yVti5djYsk+
             7iF06r1QhyN3fSA1frgCfSUhVeyEj6juUzUzpm3xT8gNZhexuO+5lILfuuw5mi1HzUXB/J
             FjJ6P1P+18JDgI95mQGQcXu0B4WqwHFtKsRc4HgjBnfCxfjUup2VO2VVvVsEKnGkI6wfwv
             LgZAmRql2NnqmULgGp8softVTWbmVppHouFhcyThLak2FM/N+9tyjesVf6bT6Ui4ym78mU
             KgJGcScBy9ZWuACV4zRVvEGvYHSCniQE3gvd2sRrdXSB9jyXwE/b6U47a5830HAAD//1BL
-            BwjQN+xoCwEAAJIBAABQSwMEFAAIAAgAtFxaWAAAAAAAAAAAAAAAABEACQBwYWNrYWdlLW
-            xvY2suanNvblVUBQABhOjcZcR8aZOiXtLv+/kUHf3Wa7HJ4sT9TwSiKCiLggjeuHODTUD2
+            BwjQN+xoCwEAAJIBAABQSwMEFAAIAAgARHNlWAAAAAAAAAAAAAAAABEACQBwYWNrYWdlLW
+            xvY2suanNvblVUBQABAJznZcR8aZOiXtLv+/kUHf3Wa7HJ4sT9TwSiKCiLggjeuHODTUD2
             fbnPzGd/Qq2u0uqyirK7n3lRURwO/JBf5sk8JzMP//9v3759j/TQ/v73b9+L2IqHUWzZwy
             If2k2S2Xk+DOPIib//r9N1lZ3lXhydLgWfoCfwcjaITf/gBbby0oucz2d2WnqZnX//+7ci
             K+3zuUQ3fd05nzs9+du37y9H/X/H+dp3f8u5J/BMO8rPQBwjv5637MSOLDsyvavnn3ueH3
@@ -3641,18 +4646,18 @@ interactions:
             kky7cdKJ8n5HtoaRLxbxbAp0BVf4FaDEmqy1kruNCMj9iiU4ebVey4Tnrx/cWf49ENI6AQ
             LD87++9YITfm7sVgcLtLeibri+ulVC8EiUZbWZtbKLxtVGB6w2roFJShp7tqUG6GE7YLq1
             0IXkstNSbUMyUrxxrXWG2MweENX0i4mCt+r2t9Pfv/723wEAAP//UEsHCHbot40uHAAAn2
-            MAAFBLAwQUAAgACAC0XFpYAAAAAAAAAAAAAAAADAAJAHBhY2thZ2UuanNvblVUBQABhOjc
+            MAAFBLAwQUAAgACABEc2VYAAAAAAAAAAAAAAAADAAJAHBhY2thZ2UuanNvblVUBQABAJzn
             ZVyPTUsDQQyG7/srwpzdsQsepDfBHnoQRPcsLJugI91kmKSlIvvfJTP1A69vnvcjnx1A4G
             mhsIVggtKzIPWmPZ1zIdV+EX6VcOXciYomYUc3cYibpiLpXFK2y2XXfDAKCjztnke4e9w3
             0j5y7VkEjwdq2jKlasOkdp0Y6RzftZ1arIYt+EoXbCrmsG+EH7gDWKthOtqbFAdawCHNxF
             orH/bj99pMjMRzoj/Jl2edfLmJw20cflORTvf/TGu3fgUAAP//UEsHCNa/M9vCAAAAOQEA
-            AFBLAQIUABQACAAIALRcWlgXJfuhLwMAAHoGAAAKAAkAAAAAAAAAAAAAAAAAAAAuZ2l0aW
-            dub3JlVVQFAAGE6NxlUEsBAhQAFAAIAAgAtFxaWKGgce0NAgAApQMAAAkACQAAAAAAAAAA
-            AAAAcAMAAFJFQURNRS5tZFVUBQABhOjcZVBLAQIUABQACAAIALRcWljQN+xoCwEAAJIBAA
-            AIAAkAAAAAAAAAAAAAAL0FAABpbmRleC5qc1VUBQABhOjcZVBLAQIUABQACAAIALRcWlh2
-            6LeNLhwAAJ9jAAARAAkAAAAAAAAAAAAAAAcHAABwYWNrYWdlLWxvY2suanNvblVUBQABhO
-            jcZVBLAQIUABQACAAIALRcWljWvzPbwgAAADkBAAAMAAkAAAAAAAAAAAAAAH0jAABwYWNr
-            YWdlLmpzb25VVAUAAYTo3GVQSwUGAAAAAAUABQBLAQAAgiQAAAAA
+            AFBLAQIUABQACAAIAERzZVgXJfuhLwMAAHoGAAAKAAkAAAAAAAAAAAAAAAAAAAAuZ2l0aW
+            dub3JlVVQFAAEAnOdlUEsBAhQAFAAIAAgARHNlWKGgce0NAgAApQMAAAkACQAAAAAAAAAA
+            AAAAcAMAAFJFQURNRS5tZFVUBQABAJznZVBLAQIUABQACAAIAERzZVjQN+xoCwEAAJIBAA
+            AIAAkAAAAAAAAAAAAAAL0FAABpbmRleC5qc1VUBQABAJznZVBLAQIUABQACAAIAERzZVh2
+            6LeNLhwAAJ9jAAARAAkAAAAAAAAAAAAAAAcHAABwYWNrYWdlLWxvY2suanNvblVUBQABAJ
+            znZVBLAQIUABQACAAIAERzZVjWvzPbwgAAADkBAAAMAAkAAAAAAAAAAAAAAH0jAABwYWNr
+            YWdlLmpzb25VVAUAAQCc52VQSwUGAAAAAAUABQBLAQAAgiQAAAAA
         form: {}
         headers:
             Accept:
@@ -3666,8 +4671,8 @@ interactions:
             User-Agent:
                 - azsdk-go-zip-deploy/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - baa93f9791f77e8989aa1ed042639dbb
-        url: https://app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net:443/api/zipdeploy?isAsync=true
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
+        url: https://app-helloworld-teq3fxi34ib7k.scm.azurewebsites.net:443/api/zipdeploy?isAsync=true
         method: POST
       response:
         proto: HTTP/1.1
@@ -3682,22 +4687,22 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Mon, 26 Feb 2024 19:42:20 GMT
+                - Tue, 05 Mar 2024 22:31:11 GMT
             Location:
-                - https://app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net:443/api/deployments/latest?deployer=Push-Deployer&time=2024-02-26_19-42-20Z
+                - https://app-helloworld-teq3fxi34ib7k.scm.azurewebsites.net:443/api/deployments/latest?deployer=Push-Deployer&time=2024-03-05_22-31-11Z
             Retryafter:
                 - "30"
             Scm-Deployment-Id:
-                - cefdc91c-a6b4-442e-a683-ea05ce33cd8f
+                - 63c7d1b8-c5a1-4158-bc4b-898e1d480bed
             Server:
                 - Kestrel
             Set-Cookie:
-                - ARRAffinity=58203501dbaee15c4cd518c7b7697694be4cbec1031fdad6f0532854f9ed447a;Path=/;HttpOnly;Secure;Domain=app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net
-                - ARRAffinitySameSite=58203501dbaee15c4cd518c7b7697694be4cbec1031fdad6f0532854f9ed447a;Path=/;HttpOnly;SameSite=None;Secure;Domain=app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net
+                - ARRAffinity=fcfd6c307c3c0cbadc4831ee1be1a88a5a4f58c7aab38c63e7a0d57ac028cc6f;Path=/;HttpOnly;Secure;Domain=app-helloworld-teq3fxi34ib7k.scm.azurewebsites.net
+                - ARRAffinitySameSite=fcfd6c307c3c0cbadc4831ee1be1a88a5a4f58c7aab38c63e7a0d57ac028cc6f;Path=/;HttpOnly;SameSite=None;Secure;Domain=app-helloworld-teq3fxi34ib7k.scm.azurewebsites.net
         status: 202 Accepted
         code: 202
-        duration: 30.9969845s
-    - id: 44
+        duration: 27.424277s
+    - id: 58
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3705,7 +4710,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net:443
+        host: app-helloworld-teq3fxi34ib7k.scm.azurewebsites.net:443
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -3718,8 +4723,8 @@ interactions:
             User-Agent:
                 - azsdk-go-zip-deploy/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - baa93f9791f77e8989aa1ed042639dbb
-        url: https://app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net:443/api/deployments/latest?deployer=Push-Deployer&time=2024-02-26_19-42-20Z
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
+        url: https://app-helloworld-teq3fxi34ib7k.scm.azurewebsites.net:443/api/deployments/latest?deployer=Push-Deployer&time=2024-03-05_22-31-11Z
         method: GET
       response:
         proto: HTTP/1.1
@@ -3730,23 +4735,23 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cefdc91c-a6b4-442e-a683-ea05ce33cd8f","status":4,"status_text":"","author_email":"N/A","author":"N/A","deployer":"Push-Deployer","message":"Created via a push deployment","progress":"","received_time":"2024-02-26T19:42:31.5437278Z","start_time":"2024-02-26T19:42:33.2397Z","end_time":"2024-02-26T19:42:40.8062946Z","last_success_end_time":"2024-02-26T19:42:40.8062946Z","complete":true,"active":true,"is_temp":false,"is_readonly":true,"url":"https://app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net/api/deployments/cefdc91c-a6b4-442e-a683-ea05ce33cd8f","log_url":"https://app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net/api/deployments/cefdc91c-a6b4-442e-a683-ea05ce33cd8f/log","site_name":"app-helloworld-4y6ae2hdnphbq","build_summary":{"errors":[],"warnings":[]}}'
+        body: '{"id":"63c7d1b8-c5a1-4158-bc4b-898e1d480bed","status":4,"status_text":"","author_email":"N/A","author":"N/A","deployer":"Push-Deployer","message":"Created via a push deployment","progress":"","received_time":"2024-03-05T22:31:15.565897Z","start_time":"2024-03-05T22:31:16.8381562Z","end_time":"2024-03-05T22:31:52.0282749Z","last_success_end_time":"2024-03-05T22:31:52.0282749Z","complete":true,"active":true,"is_temp":false,"is_readonly":true,"url":"https://app-helloworld-teq3fxi34ib7k.scm.azurewebsites.net/api/deployments/63c7d1b8-c5a1-4158-bc4b-898e1d480bed","log_url":"https://app-helloworld-teq3fxi34ib7k.scm.azurewebsites.net/api/deployments/63c7d1b8-c5a1-4158-bc4b-898e1d480bed/log","site_name":"app-helloworld-teq3fxi34ib7k","build_summary":{"errors":[],"warnings":[]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:42:47 GMT
+                - Tue, 05 Mar 2024 22:31:54 GMT
             Server:
                 - Kestrel
             Set-Cookie:
-                - ARRAffinity=58203501dbaee15c4cd518c7b7697694be4cbec1031fdad6f0532854f9ed447a;Path=/;HttpOnly;Secure;Domain=app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net
-                - ARRAffinitySameSite=58203501dbaee15c4cd518c7b7697694be4cbec1031fdad6f0532854f9ed447a;Path=/;HttpOnly;SameSite=None;Secure;Domain=app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net
+                - ARRAffinity=fcfd6c307c3c0cbadc4831ee1be1a88a5a4f58c7aab38c63e7a0d57ac028cc6f;Path=/;HttpOnly;Secure;Domain=app-helloworld-teq3fxi34ib7k.scm.azurewebsites.net
+                - ARRAffinitySameSite=fcfd6c307c3c0cbadc4831ee1be1a88a5a4f58c7aab38c63e7a0d57ac028cc6f;Path=/;HttpOnly;SameSite=None;Secure;Domain=app-helloworld-teq3fxi34ib7k.scm.azurewebsites.net
             Vary:
                 - Accept-Encoding
         status: 200 OK
         code: 200
-        duration: 1.3659085s
-    - id: 45
+        duration: 268.301ms
+    - id: 59
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3769,8 +4774,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armappservice/v1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - baa93f9791f77e8989aa1ed042639dbb
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq?api-version=2021-03-01
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k?api-version=2021-03-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3778,20 +4783,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 7266
+        content_length: 7344
         uncompressed: false
-        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","name":"app-helloworld-4y6ae2hdnphbq","type":"Microsoft.Web/sites","kind":"app,linux","location":"East US 2","tags":{"azd-env-name":"wabrez-devcenter","azd-service-name":"helloworld","env":"dev","project":"Project-1"},"properties":{"name":"app-helloworld-4y6ae2hdnphbq","state":"Running","hostNames":["app-helloworld-4y6ae2hdnphbq.azurewebsites.net"],"webSpace":"project-1-azdtest-w4789fc-EastUS2webspace-Linux","selfLink":"https://waws-prod-bn1-067.api.azurewebsites.windows.net:454/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/webspaces/project-1-azdtest-w4789fc-EastUS2webspace-Linux/sites/app-helloworld-4y6ae2hdnphbq","repositorySiteName":"app-helloworld-4y6ae2hdnphbq","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"afdEnabled":false,"enabledHostNames":["app-helloworld-4y6ae2hdnphbq.azurewebsites.net","app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"node|18-lts"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"app-helloworld-4y6ae2hdnphbq.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"app-helloworld-4y6ae2hdnphbq.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq","reserved":true,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2024-02-26T19:39:50.7233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"node|18-lts","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null},"daprConfig":null,"deploymentId":"app-helloworld-4y6ae2hdnphbq","slotName":null,"trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","kind":"app,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"40.70.147.13","possibleInboundIpAddresses":"40.70.147.13","ftpUsername":"app-helloworld-4y6ae2hdnphbq\\$app-helloworld-4y6ae2hdnphbq","ftpsHostName":"ftps://waws-prod-bn1-067.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"104.208.138.157,104.46.127.127,52.251.126.49,104.209.194.156,40.70.147.13","possibleOutboundIpAddresses":"104.208.138.157,104.46.127.127,52.251.126.49,104.209.194.156,52.251.115.213,104.209.219.240,52.251.114.9,13.77.69.217,40.123.55.50,20.7.100.98,20.7.100.108,20.7.100.134,20.7.100.139,20.7.100.160,20.7.100.206,20.22.16.191,20.22.17.198,20.22.17.229,20.22.18.73,20.22.18.236,20.22.19.80,40.70.147.13","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bn1-067","cloningInfo":null,"hostingEnvironmentId":null,"tags":{"azd-env-name":"wabrez-devcenter","azd-service-name":"helloworld","env":"dev","project":"Project-1"},"resourceGroup":"project-1-azdtest-w4789fc","defaultHostName":"app-helloworld-4y6ae2hdnphbq.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs","inFlightFeatures":["SiteContainers"],"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null}}'
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k","name":"app-helloworld-teq3fxi34ib7k","type":"Microsoft.Web/sites","kind":"app,linux","location":"East US 2","tags":{"azd-env-name":"wabrez-devcenter","azd-service-name":"helloworld","env":"dev","project":"Project-1"},"properties":{"name":"app-helloworld-teq3fxi34ib7k","state":"Running","hostNames":["app-helloworld-teq3fxi34ib7k.azurewebsites.net"],"webSpace":"project-1-azdtest-w98cb42-EastUS2webspace-Linux","selfLink":"https://waws-prod-bn1-209.api.azurewebsites.windows.net:454/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/webspaces/project-1-azdtest-w98cb42-EastUS2webspace-Linux/sites/app-helloworld-teq3fxi34ib7k","repositorySiteName":"app-helloworld-teq3fxi34ib7k","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"afdEnabled":false,"enabledHostNames":["app-helloworld-teq3fxi34ib7k.azurewebsites.net","app-helloworld-teq3fxi34ib7k.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"node|18-lts"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"app-helloworld-teq3fxi34ib7k.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"app-helloworld-teq3fxi34ib7k.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/serverfarms/plan-teq3fxi34ib7k","reserved":true,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2024-03-05T22:29:12.8566667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"node|18-lts","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null},"functionAppConfig":null,"daprConfig":null,"deploymentId":"app-helloworld-teq3fxi34ib7k","slotName":null,"trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","kind":"app,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.119.144.11","possibleInboundIpAddresses":"20.119.144.11","ftpUsername":"app-helloworld-teq3fxi34ib7k\\$app-helloworld-teq3fxi34ib7k","ftpsHostName":"ftps://waws-prod-bn1-209.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.75.65.117,20.75.70.177,20.190.208.192,20.190.211.94,20.190.211.173,20.75.69.153,20.119.144.11","possibleOutboundIpAddresses":"20.75.65.117,20.75.70.177,20.190.208.192,20.190.211.94,20.190.211.173,20.75.69.153,20.96.64.234,20.96.66.215,20.96.67.179,20.96.67.205,20.96.68.95,20.96.69.0,20.96.71.193,20.96.71.225,20.22.27.210,20.22.28.203,20.22.30.21,20.190.215.95,20.190.209.206,20.22.26.17,20.22.30.69,20.22.30.221,20.22.31.9,20.22.31.68,20.119.144.11","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bn1-209","cloningInfo":null,"hostingEnvironmentId":null,"tags":{"azd-env-name":"wabrez-devcenter","azd-service-name":"helloworld","env":"dev","project":"Project-1"},"resourceGroup":"project-1-azdtest-w98cb42","defaultHostName":"app-helloworld-teq3fxi34ib7k.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs","inFlightFeatures":["SiteContainers"],"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null}}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "7266"
+                - "7344"
             Content-Type:
                 - application/json
             Date:
-                - Mon, 26 Feb 2024 19:42:48 GMT
+                - Tue, 05 Mar 2024 22:31:54 GMT
             Etag:
-                - '"1DA68EB903AE635"'
+                - '"1DA6F4C8CA3638B"'
             Expires:
                 - "-1"
             Pragma:
@@ -3805,21 +4810,21 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - baa93f9791f77e8989aa1ed042639dbb
+                - 61eeecda9d7bba8c6a3abd13b61b96e7
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - c6490f23-163a-427e-a3ea-26157513af9d
+                - 589bb603-ec75-4f1c-ae79-33f0f258bf09
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T194248Z:6fb54ea1-c656-482c-a1df-eec88284be66
+                - WESTUS2:20240305T223155Z:b466b93a-7c31-4f72-906c-2b0adc0ca778
             X-Msedge-Ref:
-                - 'Ref A: E827ABF943974621AEAB5F30766F5603 Ref B: CO6AA3150217053 Ref C: 2024-02-26T19:42:48Z'
+                - 'Ref A: 53C5C6EB6AC5420A8719CA46034DD867 Ref B: CO6AA3150217051 Ref C: 2024-03-05T22:31:54Z'
             X-Powered-By:
                 - ASP.NET
         status: 200 OK
         code: 200
-        duration: 584.6043ms
-    - id: 46
+        duration: 403.4201ms
+    - id: 60
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3844,7 +4849,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - azsdk-go-armresourcegraph.Client/v0.7.1 (go1.21.6; Windows_NT),azd
+                - azsdk-go-armresourcegraph.Client/v0.7.1 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
+            X-Ms-Correlation-Request-Id:
+                - 97e3f06dc1981a47cf1677a919887bca
         url: https://management.azure.com:443/providers/Microsoft.ResourceGraph/resources?api-version=2021-06-01-preview
         method: POST
       response:
@@ -3853,18 +4860,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 8615
+        content_length: 12868
         uncompressed: false
-        body: '{"totalRecords":14,"count":14,"data":[{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioClient","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSVendors","properties":{"provisioningState":"Succeeded","description":"Project for vendors","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/basic","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"basic","properties":{"provisioningState":"Succeeded","description":"project with basic image","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"MicroBuild","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourceGroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DevDivAzureService","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourceGroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"LanguageAndFrameworkServices","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourceGroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSCode","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourceGroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ServerlessPaaS","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourceGroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"PMUXDesign","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourceGroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"NuGet","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourceGroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DataAndAI","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Contoso-Demo","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Contoso-Demo","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-1","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-2","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"}],"facets":[],"resultTruncated":"false"}'
+        body: '{"totalRecords":21,"count":21,"data":[{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioClient","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSVendors","properties":{"provisioningState":"Succeeded","description":"Project for vendors","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/basic","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"basic","properties":{"provisioningState":"Succeeded","description":"project with basic image","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"MicroBuild","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourceGroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DevDivAzureService","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourceGroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"LanguageAndFrameworkServices","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourceGroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSCode","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourceGroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ServerlessPaaS","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourceGroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"PMUXDesign","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourceGroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"NuGet","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/projects/dcprj-pv44d74rp44bs","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"dcprj-pv44d74rp44bs","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-pv44d74rp44bs.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/devcenters/dc-pv44d74rp44bs"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/projects/rltestproj","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"rltestproj","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-pv44d74rp44bs.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/devcenters/dc-pv44d74rp44bs"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project1","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ade-project1","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-ade-fidalgo-dev2.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/ade-fidalgo-dev2"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project2","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ade-project2","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-ade-fidalgo-dev2.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/ade-fidalgo-dev2"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/Inventory-Management-Project","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Inventory-Management-Project","properties":{"provisioningState":"Succeeded","description":"Inventory Management project","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-logistics-system-devcenter.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/Logistics-System-DevCenter"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourceGroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DataAndAI","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-shihua8/providers/Microsoft.DevCenter/projects/xshProject-1","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"xshProject-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-contoso-nhtvx54bj4kb4.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-shihua8/providers/Microsoft.DevCenter/devcenters/dc-contoso-nhtvx54bj4kb4"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-shihua8/providers/Microsoft.DevCenter/projects/xshProject-2","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"xshProject-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-contoso-nhtvx54bj4kb4.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-shihua8/providers/Microsoft.DevCenter/devcenters/dc-contoso-nhtvx54bj4kb4"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Contoso-Demo","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Contoso-Demo","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-1","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/projects/Project-2","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter/providers/Microsoft.DevCenter/devcenters/dc-wabrez-od3kzvk4mwe72"},"type":"microsoft.devcenter/projects"}],"facets":[],"resultTruncated":"false"}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "8615"
+                - "12868"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:42:50 GMT
+                - Tue, 05 Mar 2024 22:31:56 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3876,27 +4883,27 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 3925c80f-5248-4874-aede-ca510b484267
+                - 97e3f06d-c198-1a47-cf16-77a919887bca
             X-Ms-Ratelimit-Remaining-Tenant-Reads:
-                - "11998"
+                - "11999"
             X-Ms-Ratelimit-Remaining-Tenant-Resource-Requests:
                 - "14"
             X-Ms-Request-Id:
-                - 3925c80f-5248-4874-aede-ca510b484267
+                - c3a56e1e-332f-4fb6-b296-71296c44d65b
             X-Ms-Resource-Graph-Request-Duration:
-                - "0:00:00:00.3140579"
+                - "0:00:00:00.3481486"
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T194250Z:3925c80f-5248-4874-aede-ca510b484267
+                - WESTUS2:20240305T223156Z:c3a56e1e-332f-4fb6-b296-71296c44d65b
             X-Ms-User-Quota-Remaining:
                 - "14"
             X-Ms-User-Quota-Resets-After:
                 - "00:00:05"
             X-Msedge-Ref:
-                - 'Ref A: 01C49FDD14354A8BB130CEA7B1EE25E6 Ref B: CO6AA3150217053 Ref C: 2024-02-26T19:42:50Z'
+                - 'Ref A: 4A69E87879E54E98B2B9CE1829B5B0EE Ref B: CO6AA3150217051 Ref C: 2024-03-05T22:31:56Z'
         status: 200 OK
         code: 200
-        duration: 562.9374ms
-    - id: 47
+        duration: 396.6712ms
+    - id: 61
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3916,7 +4923,9 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w4789fc?api-version=2023-04-01
+            X-Ms-Correlation-Request-Id:
+                - 97e3f06dc1981a47cf1677a919887bca
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w98cb42?api-version=2023-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3928,15 +4937,15 @@ interactions:
         uncompressed: true
         body: |-
             {
-              "name": "azdtest-w4789fc",
+              "name": "azdtest-w98cb42",
               "environmentType": "Dev",
               "user": "19a2053b-445a-4023-95d3-c339051e0f32",
               "provisioningState": "Succeeded",
-              "resourceGroupId": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc",
+              "resourceGroupId": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42",
               "catalogName": "wbreza",
               "environmentDefinitionName": "HelloWorld",
               "parameters": {
-                "environmentName": "azdtest-w4789fc",
+                "environmentName": "azdtest-w98cb42",
                 "repoUrl": "https://github.com/wbreza/azd-hello-world"
               }
             }
@@ -3950,23 +4959,23 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:42:51 GMT
+                - Tue, 05 Mar 2024 22:31:57 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - c472e3e6-ab7a-47c1-905b-cf92f89a9a31
+                - 1f90fb39-0edd-40d8-8764-eb8754956083
             X-Ms-Correlation-Request-Id:
-                - 73b2e1e4-c56b-4e0f-83a8-40a70cbcf363
+                - 97e3f06dc1981a47cf1677a919887bca
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
                 - "299"
             X-Rate-Limit-Reset:
-                - "2024-02-26T19:43:51.4958571Z"
+                - "2024-03-05T22:32:57.2106587Z"
         status: 200 OK
         code: 200
-        duration: 707.215ms
-    - id: 48
+        duration: 563.1959ms
+    - id: 62
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3989,8 +4998,8 @@ interactions:
             User-Agent:
                 - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - 89a6dd550f0c0aac637bbf734451b612
-        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/?api-version=2021-04-01
+                - 97e3f06dc1981a47cf1677a919887bca
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/?api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3998,18 +5007,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 13713
+        content_length: 13694
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/app-helloworld-4y6ae2hdnphbq-appSettings","name":"app-helloworld-4y6ae2hdnphbq-appSettings","type":"Microsoft.Resources/deployments","properties":{"templateHash":"1502109241172037927","parameters":{"name":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"appSettings":{"type":"Object","value":{"SCM_DO_BUILD_DURING_DEPLOYMENT":"True","ENABLE_ORYX_BUILD":"True"}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:40:01.4134974Z","duration":"PT13.6022714S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"sites/config","locations":[null]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/appsettings"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/app-helloworld-4y6ae2hdnphbq-app-module","name":"app-helloworld-4y6ae2hdnphbq-app-module","type":"Microsoft.Resources/deployments","properties":{"templateHash":"3548910797978781823","parameters":{"name":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w4789fc","azd-service-name":"helloworld"}},"applicationInsightsName":{"type":"String","value":""},"appServicePlanId":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"},"keyVaultName":{"type":"String","value":""},"managedIdentity":{"type":"Bool","value":false},"runtimeName":{"type":"String","value":"node"},"runtimeNameAndVersion":{"type":"String","value":"node|18-lts"},"runtimeVersion":{"type":"String","value":"18-lts"},"kind":{"type":"String","value":"app,linux"},"allowedOrigins":{"type":"Array","value":[]},"alwaysOn":{"type":"Bool","value":true},"appCommandLine":{"type":"String","value":""},"clientAffinityEnabled":{"type":"Bool","value":false},"enableOryxBuild":{"type":"Bool","value":true},"functionAppScaleLimit":{"type":"Int","value":-1},"linuxFxVersion":{"type":"String","value":"node|18-lts"},"minimumElasticInstanceCount":{"type":"Int","value":-1},"numberOfWorkers":{"type":"Int","value":-1},"scmDoBuildDuringDeployment":{"type":"Bool","value":true},"use32BitWorkerProcess":{"type":"Bool","value":false},"ftpsState":{"type":"String","value":"FtpsOnly"},"healthCheckPath":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:40:05.3286583Z","duration":"PT37.9814816S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"sites/config","locations":[null]},{"resourceType":"sites/basicPublishingCredentialsPolicies","locations":[null]},{"resourceType":"sites","locations":["eastus2"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-4y6ae2hdnphbq"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/logs","resourceType":"Microsoft.Web/sites/config","resourceName":"app-helloworld-4y6ae2hdnphbq/logs"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-4y6ae2hdnphbq"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/ftp","resourceType":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","resourceName":"app-helloworld-4y6ae2hdnphbq/ftp"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-4y6ae2hdnphbq"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/scm","resourceType":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","resourceName":"app-helloworld-4y6ae2hdnphbq/scm"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-4y6ae2hdnphbq"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/app-helloworld-4y6ae2hdnphbq-appSettings","resourceType":"Microsoft.Resources/deployments","resourceName":"app-helloworld-4y6ae2hdnphbq-appSettings"}],"outputs":{"identityPrincipalId":{"type":"String","value":""},"name":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"uri":{"type":"String","value":"https://app-helloworld-4y6ae2hdnphbq.azurewebsites.net"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/logs"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/helloworld","name":"helloworld","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12313645452229774503","parameters":{"name":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w4789fc"}},"appCommandLine":{"type":"String","value":""},"appServicePlanId":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"},"serviceName":{"type":"String","value":"helloworld"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:40:16.4892974Z","duration":"PT52.443231S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"servicE_HELLOWORLD_IDENTITY_PRINCIPAL_ID":{"type":"String","value":""},"servicE_HELLOWORLD_NAME":{"type":"String","value":"app-helloworld-4y6ae2hdnphbq"},"servicE_HELLOWORLD_URI":{"type":"String","value":"https://app-helloworld-4y6ae2hdnphbq.azurewebsites.net"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/logs"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/appserviceplan","name":"appserviceplan","type":"Microsoft.Resources/deployments","properties":{"templateHash":"7476659406584400671","parameters":{"name":{"type":"String","value":"plan-4y6ae2hdnphbq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w4789fc"}},"kind":{"type":"String","value":""},"reserved":{"type":"Bool","value":true},"sku":{"type":"Object","value":{"name":"B1"}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:39:14.509538Z","duration":"PT6.5263397S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"serverfarms","locations":["eastus2"]}]}],"dependencies":[],"outputs":{"id":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"},"name":{"type":"String","value":"plan-4y6ae2hdnphbq"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/project-1.azdtest-w4789fc.133534499416341033","name":"project-1.azdtest-w4789fc.133534499416341033","type":"Microsoft.Resources/deployments","tags":{"AdeEnvironmentName":"azdtest-w4789fc","AdeProjectName":"project-1","AdeDevCenterName":"dc-wabrez-od3kzvk4mwe72","AdeEnvironmentTypeName":"Dev"},"properties":{"templateLink":{"uri":"https://d55vj9m1o8u4cm4o.blob.core.windows.net/templates/project-1.azdtest-w4789fc.133534499416341033/EnvironmentDefinitions/HelloWorld/azuredeploy.json","contentVersion":"1.0.0.0"},"templateHash":"17645299908346333518","parameters":{"repoUrl":{"type":"String","value":"https://github.com/wbreza/azd-hello-world"},"environmentName":{"type":"String","value":"azdtest-w4789fc"},"location":{"type":"String","value":"eastus2"},"serviceName":{"type":"String","value":""},"appServicePlanName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-02-26T19:40:27.6950264Z","duration":"PT1M20.8125551S","correlationId":"a792229e-e8e3-48f6-b63c-5ccd14d46f3f","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/appserviceplan","resourceType":"Microsoft.Resources/deployments","resourceName":"appserviceplan"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/appserviceplan","resourceType":"Microsoft.Resources/deployments","resourceName":"appserviceplan","apiVersion":"2022-09-01"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Resources/deployments/helloworld","resourceType":"Microsoft.Resources/deployments","resourceName":"helloworld"}],"outputs":{"azurE_LOCATION":{"type":"String","value":"eastus2"},"azurE_TENANT_ID":{"type":"String","value":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"servicE_API_ENDPOINTS":{"type":"Array","value":["https://app-helloworld-4y6ae2hdnphbq.azurewebsites.net"]}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/serverfarms/plan-4y6ae2hdnphbq"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w4789fc/providers/Microsoft.Web/sites/app-helloworld-4y6ae2hdnphbq/config/logs"}]}}]}'
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/app-helloworld-teq3fxi34ib7k-appSettings","name":"app-helloworld-teq3fxi34ib7k-appSettings","type":"Microsoft.Resources/deployments","properties":{"templateHash":"1502109241172037927","parameters":{"name":{"type":"String","value":"app-helloworld-teq3fxi34ib7k"},"appSettings":{"type":"Object","value":{"SCM_DO_BUILD_DURING_DEPLOYMENT":"True","ENABLE_ORYX_BUILD":"True"}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-03-05T22:29:23.5949257Z","duration":"PT11.415251S","correlationId":"61eeecda9d7bba8c6a3abd13b61b96e7","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"sites/config","locations":[null]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/config/appsettings"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/app-helloworld-teq3fxi34ib7k-app-module","name":"app-helloworld-teq3fxi34ib7k-app-module","type":"Microsoft.Resources/deployments","properties":{"templateHash":"3548910797978781823","parameters":{"name":{"type":"String","value":"app-helloworld-teq3fxi34ib7k"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w98cb42","azd-service-name":"helloworld"}},"applicationInsightsName":{"type":"String","value":""},"appServicePlanId":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/serverfarms/plan-teq3fxi34ib7k"},"keyVaultName":{"type":"String","value":""},"managedIdentity":{"type":"Bool","value":false},"runtimeName":{"type":"String","value":"node"},"runtimeNameAndVersion":{"type":"String","value":"node|18-lts"},"runtimeVersion":{"type":"String","value":"18-lts"},"kind":{"type":"String","value":"app,linux"},"allowedOrigins":{"type":"Array","value":[]},"alwaysOn":{"type":"Bool","value":true},"appCommandLine":{"type":"String","value":""},"clientAffinityEnabled":{"type":"Bool","value":false},"enableOryxBuild":{"type":"Bool","value":true},"functionAppScaleLimit":{"type":"Int","value":-1},"linuxFxVersion":{"type":"String","value":"node|18-lts"},"minimumElasticInstanceCount":{"type":"Int","value":-1},"numberOfWorkers":{"type":"Int","value":-1},"scmDoBuildDuringDeployment":{"type":"Bool","value":true},"use32BitWorkerProcess":{"type":"Bool","value":false},"ftpsState":{"type":"String","value":"FtpsOnly"},"healthCheckPath":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-03-05T22:29:27.6884475Z","duration":"PT36.5480266S","correlationId":"61eeecda9d7bba8c6a3abd13b61b96e7","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"sites/config","locations":[null]},{"resourceType":"sites/basicPublishingCredentialsPolicies","locations":[null]},{"resourceType":"sites","locations":["eastus2"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-teq3fxi34ib7k"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/config/logs","resourceType":"Microsoft.Web/sites/config","resourceName":"app-helloworld-teq3fxi34ib7k/logs"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-teq3fxi34ib7k"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/basicPublishingCredentialsPolicies/ftp","resourceType":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","resourceName":"app-helloworld-teq3fxi34ib7k/ftp"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-teq3fxi34ib7k"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/basicPublishingCredentialsPolicies/scm","resourceType":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","resourceName":"app-helloworld-teq3fxi34ib7k/scm"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-teq3fxi34ib7k"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/app-helloworld-teq3fxi34ib7k-appSettings","resourceType":"Microsoft.Resources/deployments","resourceName":"app-helloworld-teq3fxi34ib7k-appSettings"}],"outputs":{"identityPrincipalId":{"type":"String","value":""},"name":{"type":"String","value":"app-helloworld-teq3fxi34ib7k"},"uri":{"type":"String","value":"https://app-helloworld-teq3fxi34ib7k.azurewebsites.net"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/config/logs"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/helloworld","name":"helloworld","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12313645452229774503","parameters":{"name":{"type":"String","value":"app-helloworld-teq3fxi34ib7k"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w98cb42"}},"appCommandLine":{"type":"String","value":""},"appServicePlanId":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/serverfarms/plan-teq3fxi34ib7k"},"serviceName":{"type":"String","value":"helloworld"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-03-05T22:29:37.9642707Z","duration":"PT48.0717999S","correlationId":"61eeecda9d7bba8c6a3abd13b61b96e7","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"servicE_HELLOWORLD_IDENTITY_PRINCIPAL_ID":{"type":"String","value":""},"servicE_HELLOWORLD_NAME":{"type":"String","value":"app-helloworld-teq3fxi34ib7k"},"servicE_HELLOWORLD_URI":{"type":"String","value":"https://app-helloworld-teq3fxi34ib7k.azurewebsites.net"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/config/logs"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/appserviceplan","name":"appserviceplan","type":"Microsoft.Resources/deployments","properties":{"templateHash":"7476659406584400671","parameters":{"name":{"type":"String","value":"plan-teq3fxi34ib7k"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-w98cb42"}},"kind":{"type":"String","value":""},"reserved":{"type":"Bool","value":true},"sku":{"type":"Object","value":{"name":"B1"}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-03-05T22:28:39.0560361Z","duration":"PT6.0158516S","correlationId":"61eeecda9d7bba8c6a3abd13b61b96e7","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"serverfarms","locations":["eastus2"]}]}],"dependencies":[],"outputs":{"id":{"type":"String","value":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/serverfarms/plan-teq3fxi34ib7k"},"name":{"type":"String","value":"plan-teq3fxi34ib7k"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/serverfarms/plan-teq3fxi34ib7k"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/project-1.azdtest-w98cb42.133541513056703349","name":"project-1.azdtest-w98cb42.133541513056703349","type":"Microsoft.Resources/deployments","tags":{"AdeEnvironmentName":"azdtest-w98cb42","AdeProjectName":"project-1","AdeDevCenterName":"dc-wabrez-od3kzvk4mwe72","AdeEnvironmentTypeName":"Dev"},"properties":{"templateLink":{"uri":"https://d55vj9m1o8u4cm4o.blob.core.windows.net/templates/project-1.azdtest-w98cb42.133541513056703349/EnvironmentDefinitions/HelloWorld/azuredeploy.json","contentVersion":"1.0.0.0"},"templateHash":"17645299908346333518","parameters":{"repoUrl":{"type":"String","value":"https://github.com/wbreza/azd-hello-world"},"environmentName":{"type":"String","value":"azdtest-w98cb42"},"location":{"type":"String","value":"eastus2"},"serviceName":{"type":"String","value":""},"appServicePlanName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-03-05T22:29:53.6837662Z","duration":"PT1M23.9222617S","correlationId":"61eeecda9d7bba8c6a3abd13b61b96e7","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/appserviceplan","resourceType":"Microsoft.Resources/deployments","resourceName":"appserviceplan"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/appserviceplan","resourceType":"Microsoft.Resources/deployments","resourceName":"appserviceplan","apiVersion":"2022-09-01"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Resources/deployments/helloworld","resourceType":"Microsoft.Resources/deployments","resourceName":"helloworld"}],"outputs":{"azurE_LOCATION":{"type":"String","value":"eastus2"},"azurE_TENANT_ID":{"type":"String","value":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"servicE_API_ENDPOINTS":{"type":"Array","value":["https://app-helloworld-teq3fxi34ib7k.azurewebsites.net"]}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/serverfarms/plan-teq3fxi34ib7k"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/config/appsettings"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/project-1-azdtest-w98cb42/providers/Microsoft.Web/sites/app-helloworld-teq3fxi34ib7k/config/logs"}]}}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "13713"
+                - "13694"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:42:52 GMT
+                - Tue, 05 Mar 2024 22:31:57 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -4021,19 +5030,19 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 89a6dd550f0c0aac637bbf734451b612
+                - 97e3f06dc1981a47cf1677a919887bca
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11996"
+                - "11999"
             X-Ms-Request-Id:
-                - c9ba5318-0aae-48cb-af31-c1e80965b008
+                - ec037996-47a1-4bb0-a1dd-c29da381917c
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240226T194252Z:c9ba5318-0aae-48cb-af31-c1e80965b008
+                - WESTUS2:20240305T223157Z:ec037996-47a1-4bb0-a1dd-c29da381917c
             X-Msedge-Ref:
-                - 'Ref A: 3A6507CBBF3B40A0BA512C2D2B171EEC Ref B: CO6AA3150217053 Ref C: 2024-02-26T19:42:52Z'
+                - 'Ref A: 1E57882479824525BAC481DB515F4098 Ref B: CO6AA3150217051 Ref C: 2024-03-05T22:31:57Z'
         status: 200 OK
         code: 200
-        duration: 550.9765ms
-    - id: 49
+        duration: 539.6686ms
+    - id: 63
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4053,7 +5062,9 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w4789fc?api-version=2023-04-01
+            X-Ms-Correlation-Request-Id:
+                - 97e3f06dc1981a47cf1677a919887bca
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-w98cb42?api-version=2023-04-01
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4065,10 +5076,10 @@ interactions:
         uncompressed: false
         body: |-
             {
-              "id": "/projects/project-1/operationStatuses/82a5d0b5-6b7a-4fff-863b-bc1297aeb486",
-              "name": "82a5d0b5-6b7a-4fff-863b-bc1297aeb486",
+              "id": "/projects/project-1/operationStatuses/20808810-9e7c-4f20-b01e-bd4bf7d4f2ca",
+              "name": "20808810-9e7c-4f20-b01e-bd4bf7d4f2ca",
               "status": "NotStarted",
-              "resourceId": "/projects/project-1/users/19a2053b-445a-4023-95d3-c339051e0f32/environments/azdtest-w4789fc"
+              "resourceId": "/projects/project-1/users/19a2053b-445a-4023-95d3-c339051e0f32/environments/azdtest-w98cb42"
             }
         headers:
             Access-Control-Allow-Origin:
@@ -4082,27 +5093,27 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:42:55 GMT
+                - Tue, 05 Mar 2024 22:31:58 GMT
             Location:
-                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/82a5d0b5-6b7a-4fff-863b-bc1297aeb486?api-version=2023-04-01&monitor=true
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/20808810-9e7c-4f20-b01e-bd4bf7d4f2ca?api-version=2023-04-01&monitor=true
             Operation-Location:
-                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/82a5d0b5-6b7a-4fff-863b-bc1297aeb486?api-version=2023-04-01
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/20808810-9e7c-4f20-b01e-bd4bf7d4f2ca?api-version=2023-04-01
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - cf755848-eb18-43b7-b657-bb9e18c7dcbf
+                - 6c146fab-a97e-4350-ae3d-5ad16f82fc6b
             X-Ms-Correlation-Request-Id:
-                - bbd4869f-2ad8-4143-a5d6-688ec25c6936
+                - 97e3f06dc1981a47cf1677a919887bca
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
                 - "299"
             X-Rate-Limit-Reset:
-                - "2024-02-26T19:43:53.4750476Z"
+                - "2024-03-05T22:32:58.4427792Z"
         status: 202 Accepted
         code: 202
-        duration: 2.3481616s
-    - id: 50
+        duration: 973.1271ms
+    - id: 64
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4122,7 +5133,9 @@ interactions:
                 - SANITIZED
             User-Agent:
                 - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azd
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/project-1/operationstatuses/82a5d0b5-6b7a-4fff-863b-bc1297aeb486?api-version=2023-04-01
+            X-Ms-Correlation-Request-Id:
+                - 97e3f06dc1981a47cf1677a919887bca
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com:443/projects/project-1/operationstatuses/20808810-9e7c-4f20-b01e-bd4bf7d4f2ca?api-version=2023-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -4134,11 +5147,11 @@ interactions:
         uncompressed: true
         body: |-
             {
-              "id": "/projects/project-1/operationStatuses/82a5d0b5-6b7a-4fff-863b-bc1297aeb486",
-              "name": "82a5d0b5-6b7a-4fff-863b-bc1297aeb486",
+              "id": "/projects/project-1/operationStatuses/20808810-9e7c-4f20-b01e-bd4bf7d4f2ca",
+              "name": "20808810-9e7c-4f20-b01e-bd4bf7d4f2ca",
               "status": "Succeeded",
-              "startTime": "2024-02-26T19:42:53.8066979+00:00",
-              "endTime": "2024-02-26T19:43:44.1206993+00:00"
+              "startTime": "2024-03-05T22:31:58.648318+00:00",
+              "endTime": "2024-03-05T22:32:53.4675884+00:00"
             }
         headers:
             Access-Control-Allow-Origin:
@@ -4150,28 +5163,28 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Mon, 26 Feb 2024 19:43:55 GMT
+                - Tue, 05 Mar 2024 22:32:59 GMT
             Location:
-                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/82a5d0b5-6b7a-4fff-863b-bc1297aeb486?api-version=2023-04-01&monitor=true
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/20808810-9e7c-4f20-b01e-bd4bf7d4f2ca?api-version=2023-04-01&monitor=true
             Operation-Location:
-                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/82a5d0b5-6b7a-4fff-863b-bc1297aeb486?api-version=2023-04-01
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-wabrez-od3kzvk4mwe72.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/20808810-9e7c-4f20-b01e-bd4bf7d4f2ca?api-version=2023-04-01
             Retry-After:
                 - "30"
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 544c4ed9-347e-4662-bc36-2c735fe8db72
+                - 0eb3835d-b5dd-40a9-95c3-1e360dbabb68
             X-Ms-Correlation-Request-Id:
-                - 4df969f3-08f4-4170-8604-de075d6acc61
+                - 97e3f06dc1981a47cf1677a919887bca
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
                 - "299"
             X-Rate-Limit-Reset:
-                - "2024-02-26T19:44:55.5410830Z"
+                - "2024-03-05T22:33:59.2529063Z"
         status: 200 OK
         code: 200
-        duration: 137.8488ms
+        duration: 111.5718ms
 ---
-env_name: azdtest-w4789fc
-time: "1708976237"
+env_name: azdtest-w98cb42
+time: "1709677542"


### PR DESCRIPTION
Updates `azd` to always return the `http.DefaultClient`.
Any transport/proxy settings required for the record/playback are also set on the default client

> [!NOTE]
> What this means though is that somewhere in the app it is not using the correct http client instance.  The recorder is catching more requests with this change than previously.