### PR TITLE
Adopt env variables used by postgres add-on

### DIFF
--- a/cli/azd/resources/scaffold/templates/host-containerapp.bicept
+++ b/cli/azd/resources/scaffold/templates/host-containerapp.bicept
@@ -170,23 +170,23 @@ resource app 'Microsoft.App/containerApps@2023-05-02-preview' = {
             {{- end}}
             {{- if .DbPostgres}}
             {
-              name: 'DB_HOST'
+              name: 'POSTGRES_HOST'
               value: databaseHost
             }
             {
-              name: 'DB_USER'
+              name: 'POSTGRES_USERNAME'
               value: databaseUser
             }
             {
-              name: 'DB_NAME'
+              name: 'POSTGRES_DATABASE'
               value: databaseName
             }
             {
-              name: 'DB_PASS'
+              name: 'POSTGRES_PASSWORD'
               secretRef: 'db-pass'
             }
             {
-              name: 'DB_PORT'
+              name: 'POSTGRES_PORT'
               value: '5432'
             }
             {{- end}}


### PR DESCRIPTION
Update environment variables for postgres to match the standard variable names when a postgres ACA add-on is used, based on user feedback.