### PR TITLE
Fixes service config handlers referencing stale components

### DIFF
--- a/cli/azd/cmd/cobra_builder.go
+++ b/cli/azd/cmd/cobra_builder.go
@@ -27,14 +27,12 @@ const cDocsFlagName = "docs"
 // CobraBuilder manages the construction of the cobra command tree from nested ActionDescriptors
 type CobraBuilder struct {
 	container *ioc.NestedContainer
-	runner    *middleware.MiddlewareRunner
 }
 
 // Creates a new instance of the Cobra builder
 func NewCobraBuilder(container *ioc.NestedContainer, runner *middleware.MiddlewareRunner) *CobraBuilder {
 	return &CobraBuilder{
 		container: container,
-		runner:    runner,
 	}
 }
 
@@ -105,11 +103,6 @@ func (cb *CobraBuilder) configureActionResolver(cmd *cobra.Command, descriptor *
 		ctx := tools.WithInstalledCheckCache(cmd.Context())
 		ioc.RegisterInstance(cb.container, ctx)
 
-		// Register any required middleware registered for the current action descriptor
-		if err := cb.registerMiddleware(descriptor); err != nil {
-			return err
-		}
-
 		// Create new container scope for the current command
 		cmdContainer, err := cb.container.NewScope()
 		if err != nil {
@@ -122,6 +115,17 @@ func (cb *CobraBuilder) configureActionResolver(cmd *cobra.Command, descriptor *
 		ioc.RegisterInstance(cmdContainer, args)
 		ioc.RegisterInstance(cmdContainer, cmdContainer)
 		ioc.RegisterInstance[ioc.ServiceLocator](cmdContainer, cmdContainer)
+
+		// Resolve the middleware runner from the container
+		var middlewareRunner *middleware.MiddlewareRunner
+		if err := cmdContainer.Resolve(&middlewareRunner); err != nil {
+			return fmt.Errorf("failed resolving middleware runner, %w", err)
+		}
+
+		// Register any required middleware registered for the current action descriptor
+		if err := cb.registerMiddleware(middlewareRunner, descriptor); err != nil {
+			return err
+		}
 
 		actionName := createActionName(cmd)
 		var action actions.Action
@@ -149,7 +153,7 @@ func (cb *CobraBuilder) configureActionResolver(cmd *cobra.Command, descriptor *
 		// Set the container that should be used for resolving middleware components
 		runOptions.WithContainer(cmdContainer)
 		// Run the middleware chain with action
-		actionResult, err := cb.runner.RunAction(ctx, runOptions, action)
+		actionResult, err := middlewareRunner.RunAction(ctx, runOptions, action)
 
 		// At this point, we know that there might be an error, so we can silence cobra from showing it after us.
 		cmd.SilenceErrors = true
@@ -373,7 +377,7 @@ func (cb *CobraBuilder) bindCommand(cmd *cobra.Command, descriptor *actions.Acti
 // Registers all middleware components for the current command and any parent descriptors
 // Middleware components are insure to run in the order that they were registered from the
 // root registration, down through action groups and ultimately individual actions
-func (cb *CobraBuilder) registerMiddleware(descriptor *actions.ActionDescriptor) error {
+func (cb *CobraBuilder) registerMiddleware(middlewareRunner *middleware.MiddlewareRunner, descriptor *actions.ActionDescriptor) error {
 	chain := []*actions.MiddlewareRegistration{}
 	current := descriptor
 
@@ -404,7 +408,7 @@ func (cb *CobraBuilder) registerMiddleware(descriptor *actions.ActionDescriptor)
 	// higher up the command structure are resolved before lower registrations
 	for i := len(chain) - 1; i > -1; i-- {
 		registration := chain[i]
-		if err := cb.runner.Use(registration.Name, registration.Resolver); err != nil {
+		if err := middlewareRunner.Use(registration.Name, registration.Resolver); err != nil {
 			return err
 		}
 	}

--- a/cli/azd/cmd/cobra_builder_test.go
+++ b/cli/azd/cmd/cobra_builder_test.go
@@ -35,7 +35,7 @@ func Test_BuildAndRunSimpleCommand(t *testing.T) {
 		},
 	})
 
-	builder := NewCobraBuilder(container, middleware.NewMiddlewareRunner(container))
+	builder := NewCobraBuilder(container)
 	cmd, err := builder.BuildCommand(root)
 
 	require.NotNil(t, cmd)
@@ -58,7 +58,7 @@ func Test_BuildAndRunSimpleAction(t *testing.T) {
 		FlagsResolver:  newTestFlags,
 	})
 
-	builder := NewCobraBuilder(container, middleware.NewMiddlewareRunner(container))
+	builder := NewCobraBuilder(container)
 	cmd, err := builder.BuildCommand(root)
 
 	require.NotNil(t, cmd)
@@ -79,7 +79,7 @@ func Test_BuildAndRunSimpleActionWithMiddleware(t *testing.T) {
 		FlagsResolver:  newTestFlags,
 	}).UseMiddleware("A", newTestMiddlewareA)
 
-	builder := NewCobraBuilder(container, middleware.NewMiddlewareRunner(container))
+	builder := NewCobraBuilder(container)
 	cmd, err := builder.BuildCommand(root)
 
 	require.NotNil(t, cmd)
@@ -112,7 +112,7 @@ func Test_BuildAndRunActionWithNestedMiddleware(t *testing.T) {
 		FlagsResolver:  newTestFlags,
 	}).UseMiddleware("B", newTestMiddlewareB)
 
-	builder := NewCobraBuilder(container, middleware.NewMiddlewareRunner(container))
+	builder := NewCobraBuilder(container)
 	cmd, err := builder.BuildCommand(root)
 
 	require.NotNil(t, cmd)
@@ -154,7 +154,7 @@ func Test_BuildAndRunActionWithNestedAndConditionalMiddleware(t *testing.T) {
 			return false
 		})
 
-	builder := NewCobraBuilder(container, middleware.NewMiddlewareRunner(container))
+	builder := NewCobraBuilder(container)
 	cmd, err := builder.BuildCommand(root)
 
 	require.NotNil(t, cmd)
@@ -191,7 +191,7 @@ func Test_BuildCommandsWithAutomaticHelpAndOutputFlags(t *testing.T) {
 		},
 	})
 
-	cobraBuilder := NewCobraBuilder(container, middleware.NewMiddlewareRunner(container))
+	cobraBuilder := NewCobraBuilder(container)
 	cmd, err := cobraBuilder.BuildCommand(root)
 
 	require.NoError(t, err)
@@ -239,7 +239,7 @@ func Test_RunDocsFlow(t *testing.T) {
 		calledUrl = url
 	}
 
-	cobraBuilder := NewCobraBuilder(container, middleware.NewMiddlewareRunner(container))
+	cobraBuilder := NewCobraBuilder(container)
 	cmd, err := cobraBuilder.BuildCommand(root)
 
 	require.NoError(t, err)
@@ -273,7 +273,7 @@ func Test_RunDocsAndHelpFlow(t *testing.T) {
 		calledUrl = url
 	}
 
-	cobraBuilder := NewCobraBuilder(container, middleware.NewMiddlewareRunner(container))
+	cobraBuilder := NewCobraBuilder(container)
 	cmd, err := cobraBuilder.BuildCommand(root)
 
 	require.NoError(t, err)

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -97,7 +97,6 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	// Core bootstrapping registrations
 	ioc.RegisterInstance(container, container)
 	container.MustRegisterSingleton(NewCobraBuilder)
-	container.MustRegisterScoped(middleware.NewMiddlewareRunner)
 
 	// Standard Registrations
 	container.MustRegisterTransient(output.GetCommandFormatter)
@@ -347,8 +346,6 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	)
 
 	// Project Config
-	// Required to be singleton (shared) because the project/service holds important event handlers
-	// from both hooks and internal that are used during azd lifecycle calls.
 	container.MustRegisterScoped(
 		func(lazyConfig *lazy.Lazy[*project.ProjectConfig]) (*project.ProjectConfig, error) {
 			return lazyConfig.GetValue()
@@ -356,8 +353,6 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	)
 
 	// Lazy loads the project config from the Azd Context when it becomes available
-	// Required to be singleton (shared) because the project/service holds important event handlers
-	// from both hooks and internal that are used during azd lifecycle calls.
 	container.MustRegisterScoped(
 		func(
 			ctx context.Context,

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -97,7 +97,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	// Core bootstrapping registrations
 	ioc.RegisterInstance(container, container)
 	container.MustRegisterSingleton(NewCobraBuilder)
-	container.MustRegisterSingleton(middleware.NewMiddlewareRunner)
+	container.MustRegisterScoped(middleware.NewMiddlewareRunner)
 
 	// Standard Registrations
 	container.MustRegisterTransient(output.GetCommandFormatter)
@@ -349,7 +349,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	// Project Config
 	// Required to be singleton (shared) because the project/service holds important event handlers
 	// from both hooks and internal that are used during azd lifecycle calls.
-	container.MustRegisterSingleton(
+	container.MustRegisterScoped(
 		func(lazyConfig *lazy.Lazy[*project.ProjectConfig]) (*project.ProjectConfig, error) {
 			return lazyConfig.GetValue()
 		},
@@ -358,7 +358,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	// Lazy loads the project config from the Azd Context when it becomes available
 	// Required to be singleton (shared) because the project/service holds important event handlers
 	// from both hooks and internal that are used during azd lifecycle calls.
-	container.MustRegisterSingleton(
+	container.MustRegisterScoped(
 		func(
 			ctx context.Context,
 			lazyAzdContext *lazy.Lazy[*azdcontext.AzdContext],
@@ -511,7 +511,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 			return resourceManager, err
 		})
 	})
-	container.MustRegisterSingleton(project.NewProjectManager)
+	container.MustRegisterScoped(project.NewProjectManager)
 	// Currently caches manifest across command executions
 	container.MustRegisterSingleton(project.NewDotNetImporter)
 	container.MustRegisterScoped(project.NewImportManager)
@@ -661,7 +661,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		lazyProjectConfig *lazy.Lazy[*project.ProjectConfig],
 		userConfigManager config.UserConfigManager,
 	) *lazy.Lazy[*platform.Config] {
-		return lazy.NewLazy[*platform.Config](func() (*platform.Config, error) {
+		return lazy.NewLazy(func() (*platform.Config, error) {
 			// First check `azure.yaml` for platform configuration section
 			projectConfig, err := lazyProjectConfig.GetValue()
 			if err == nil && projectConfig != nil && projectConfig.Platform != nil {

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -463,7 +463,7 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 		return nil, fmt.Errorf("getting deployment: %w", err)
 	}
 
-	if err := ef.provisionManager.UpdateEnvironment(ctx, ef.env, getStateResult.State.Outputs); err != nil {
+	if err := ef.provisionManager.UpdateEnvironment(ctx, getStateResult.State.Outputs); err != nil {
 		return nil, err
 	}
 

--- a/cli/azd/cmd/middleware/hooks.go
+++ b/cli/azd/cmd/middleware/hooks.go
@@ -6,7 +6,6 @@ import (
 	"log"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
@@ -52,8 +51,6 @@ func NewHooksMiddleware(
 
 // Runs the Hooks middleware
 func (m *HooksMiddleware) Run(ctx context.Context, next NextFn) (*actions.ActionResult, error) {
-	ctx, _ = getServiceHooksRegistered(ctx)
-
 	env, err := m.lazyEnv.GetValue()
 	if err != nil {
 		log.Println("azd environment is not available, skipping all hook registrations.")
@@ -133,12 +130,6 @@ func (m *HooksMiddleware) registerServiceHooks(
 	env *environment.Environment,
 	projectConfig *project.ProjectConfig,
 ) error {
-	// Check if service hooks have already been registered higher up the chain
-	ctx, serviceHooksRegistered := getServiceHooksRegistered(ctx)
-	if *serviceHooksRegistered {
-		return nil
-	}
-
 	envManager, err := m.lazyEnvManager.GetValue()
 	if err != nil {
 		return fmt.Errorf("failed getting environment manager, %w", err)
@@ -189,9 +180,6 @@ func (m *HooksMiddleware) registerServiceHooks(
 		}
 	}
 
-	// Set context value that the service hooks have been registered
-	*serviceHooksRegistered = true
-
 	return nil
 }
 
@@ -205,17 +193,4 @@ func (m *HooksMiddleware) createServiceEventHandler(
 	return func(ctx context.Context, eventArgs project.ServiceLifecycleEventArgs) error {
 		return hooksRunner.RunHooks(ctx, hookType, nil, hookName)
 	}
-}
-
-// Gets a value that returns whether or not service hooks have already been registered
-// for the current project config
-// Optionally constructs a new go context that stores a pointer to this value
-func getServiceHooksRegistered(ctx context.Context) (context.Context, *bool) {
-	serviceHooksRegistered, ok := ctx.Value(serviceHooksRegisteredContextKey).(*bool)
-	if !ok {
-		serviceHooksRegistered = convert.RefOf(false)
-		ctx = context.WithValue(ctx, serviceHooksRegisteredContextKey, serviceHooksRegistered)
-	}
-
-	return ctx, serviceHooksRegistered
 }

--- a/cli/azd/cmd/middleware/hooks.go
+++ b/cli/azd/cmd/middleware/hooks.go
@@ -14,10 +14,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 )
 
-type contextKey string
-
-var serviceHooksRegisteredContextKey contextKey = "service-hooks-registered"
-
 type HooksMiddleware struct {
 	lazyEnvManager    *lazy.Lazy[environment.Manager]
 	lazyEnv           *lazy.Lazy[*environment.Environment]

--- a/cli/azd/pkg/ext/event_dispatcher.go
+++ b/cli/azd/pkg/ext/event_dispatcher.go
@@ -41,6 +41,16 @@ func (ed *EventDispatcher[T]) AddHandler(name Event, handler EventHandlerFn[T]) 
 	}
 
 	events := ed.handlers[name]
+	newHandler := fmt.Sprintf("%v", handler)
+
+	// Ensure the handler is not already registered
+	for _, ref := range events {
+		existingHandler := fmt.Sprintf("%v", ref)
+		if existingHandler == newHandler {
+			return nil
+		}
+	}
+
 	events = append(events, handler)
 	ed.handlers[name] = events
 

--- a/cli/azd/pkg/ext/event_dispatcher.go
+++ b/cli/azd/pkg/ext/event_dispatcher.go
@@ -41,16 +41,6 @@ func (ed *EventDispatcher[T]) AddHandler(name Event, handler EventHandlerFn[T]) 
 	}
 
 	events := ed.handlers[name]
-	newHandler := fmt.Sprintf("%v", handler)
-
-	// Ensure the handler is not already registered
-	for _, ref := range events {
-		existingHandler := fmt.Sprintf("%v", ref)
-		if existingHandler == newHandler {
-			return nil
-		}
-	}
-
 	events = append(events, handler)
 	ed.handlers[name] = events
 

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -82,7 +82,7 @@ func (m *Manager) Deploy(ctx context.Context) (*DeployResult, error) {
 		m.console.StopSpinner(ctx, "Didn't find new changes.", input.StepSkipped)
 	}
 
-	if err := m.UpdateEnvironment(ctx, m.env, deployResult.Deployment.Outputs); err != nil {
+	if err := m.UpdateEnvironment(ctx, deployResult.Deployment.Outputs); err != nil {
 		return nil, fmt.Errorf("updating environment with deployment outputs: %w", err)
 	}
 
@@ -149,7 +149,6 @@ func (m *Manager) Destroy(ctx context.Context, options DestroyOptions) (*Destroy
 
 func (m *Manager) UpdateEnvironment(
 	ctx context.Context,
-	env *environment.Environment,
 	outputs map[string]OutputParameter,
 ) error {
 	if len(outputs) > 0 {
@@ -160,13 +159,13 @@ func (m *Manager) UpdateEnvironment(
 				if err != nil {
 					return fmt.Errorf("invalid value for output parameter '%s' (%s): %w", key, string(param.Type), err)
 				}
-				env.DotenvSet(key, string(bytes))
+				m.env.DotenvSet(key, string(bytes))
 			} else {
-				env.DotenvSet(key, fmt.Sprintf("%v", param.Value))
+				m.env.DotenvSet(key, fmt.Sprintf("%v", param.Value))
 			}
 		}
 
-		if err := m.envManager.Save(ctx, env); err != nil {
+		if err := m.envManager.Save(ctx, m.env); err != nil {
 			return fmt.Errorf("writing environment: %w", err)
 		}
 	}

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -41,8 +41,6 @@ type ServiceConfig struct {
 	DotNetContainerApp *DotNetContainerAppOptions `yaml:"-,omitempty"`
 
 	*ext.EventDispatcher[ServiceLifecycleEventArgs] `yaml:"-"`
-
-	initialized bool
 }
 
 type DotNetContainerAppOptions struct {


### PR DESCRIPTION
Resolves #3499 

Fixes an issue where an event handler bound in one command within an `up` workflow could incorrectly fire when the event is raised in another command.

## Why is this happening?

The `project.ProjectConfig` instance has a singleton lifetime which means the same instance was shared between commands within an `up` workflow.  Some of our service targets (ex. AKS) registers event handler such as `postprovision` during its initialization process.  This event registration is stored within the `ProjectConfig` mentioned above.

This was causing multiple event handlers to be registered for the service target and some of them were referencing scoped components from other commands.  Transient service target AKS was referencing scoped environment from previous commands.

When the `postprovision` event was finally raised it now contained event handlers from the `azd package` command of the workflow in addition to event handlers registered during `azd provision` command.  This was causing the event handler from referencing stale scoped components like the environment.

## How was this fixed

To resolve this `project.ProjectConfig` was changed to a lifetime scope which means that a new instance will be created for each command within a workflow.  The previous fix of depending on Lazy + the hook fixes allow us to move this to a scoped lifetime.

The middleware runner is now created/used during the scoped command allowing it to be removed from the container all together.

This also allows the removal of a weird work around in which needed to check for double registrations the hooks middleware.