### PR TITLE
fix for multiple inputs per resource and deterministic generation from map

### DIFF
--- a/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-main.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-main.bicep.snap
@@ -13,7 +13,10 @@ param location string
 @metadata({azd: {
   type: 'inputs'
   autoGenerate: {
-    mysqlabstract: { 'pas-sw-ord': { len: 10 } }
+    mysqlabstract: {
+      'pas-sw-ord': { len: 10 }
+      password: { len: 10 }
+    }
   }}
 })
 param inputs object

--- a/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-main.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-main.bicep.snap
@@ -13,7 +13,9 @@ param location string
 @metadata({azd: {
   type: 'inputs'
   autoGenerate: {
-    mysqlabstract: { password: { len: 10 } }
+    mysqlabstract: {
+      password: { len: 10 }
+    }
   }}
 })
 param inputs object

--- a/cli/azd/resources/apphost/templates/main.bicept
+++ b/cli/azd/resources/apphost/templates/main.bicept
@@ -18,8 +18,12 @@ param principalId string = ''
 @metadata({azd: {
   type: 'inputs'
   autoGenerate: {
-{{- range $param, $value := .AutoGenInputs }}
-    {{$param}}: { {{$value.Name }}: { len: {{$value.Len }} } }
+{{- range $resource, $params := .AutoGenInputs }}
+    {{$resource}}: { 
+{{- range $p := $params }}
+      {{$p.Name }}: { len: {{$p.Len }} }
+{{- end}}
+    }
 {{- end}}
   }}
 })


### PR DESCRIPTION
fix: https://github.com/Azure/azure-dev/issues/3505

explanation:
  There were 2 issues:
- Writing multiple auto-gen inputs from un-ordered map[string] was causing indeterministic result for the snapshot
- When having more than one auto-gen input, there was only one written to the bicep file.  This is b/c azd handles auto-gen inputs internally with a `map[string]input` , using a string key like `resource.paramName` to be unique.  But, for writing the metadata, azd splits the key into resource and paramName, and a new structur `map[string][]input` is required to be constructed.