### PR TITLE
vs-server: Support External Auth

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -531,7 +531,13 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.MustRegisterSingleton(config.NewUserConfigManager)
 	container.MustRegisterSingleton(config.NewManager)
 	container.MustRegisterSingleton(config.NewFileConfigManager)
-	container.MustRegisterSingleton(auth.NewManager)
+	container.MustRegisterScoped(func() auth.ExternalAuthConfiguration {
+		return auth.ExternalAuthConfiguration{
+			Endpoint: os.Getenv("AZD_AUTH_ENDPOINT"),
+			Key:      os.Getenv("AZD_AUTH_KEY"),
+		}
+	})
+	container.MustRegisterScoped(auth.NewManager)
 	container.MustRegisterSingleton(azcli.NewUserProfileService)
 	container.MustRegisterSingleton(account.NewSubscriptionsService)
 	container.MustRegisterSingleton(account.NewManager)
@@ -549,7 +555,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		return subManager
 	})
 
-	container.MustRegisterSingleton(func(ctx context.Context, authManager *auth.Manager) (azcore.TokenCredential, error) {
+	container.MustRegisterScoped(func(ctx context.Context, authManager *auth.Manager) (azcore.TokenCredential, error) {
 		return authManager.CredentialForCurrentUser(ctx, nil)
 	})
 

--- a/cli/azd/docs/external-authentication.md
+++ b/cli/azd/docs/external-authentication.md
@@ -48,7 +48,7 @@ The server should take this request and fetch a token using the given configuati
 
 ```jsonc
 {
-  "result": "success",
+  "status": "success",
   "token": "<string>", // the access token.
   "expiresOn": "<string>" // the expiration time of the token, expressed in RFC3339 format.
 }
@@ -58,7 +58,7 @@ The server should take this request and fetch a token using the given configuati
 
 ```jsonc
 {
-  "result": "error",
+  "status": "error",
   "code": "string", // one of "GetTokenError" or "NotSignedInError"
   "message": "string" // a human readable error message.
 }

--- a/cli/azd/internal/vsrpc/debug_service.go
+++ b/cli/azd/internal/vsrpc/debug_service.go
@@ -8,6 +8,11 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/azure/azure-dev/cli/azd/pkg/auth"
+	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
 )
 
 // debugService is the RPC server for the '/TestDebugService/v1.0' endpoint. It is only exposed when
@@ -17,11 +22,14 @@ type debugService struct {
 	// When non-nil, TestCancelAsync will call `Done` on this wait group before waiting to observe
 	// cancellation. This allows test code to orchestrate when it sends the cancellation message and to
 	// know the RPC is ready to observe it.
-	wg *sync.WaitGroup
+	wg     *sync.WaitGroup
+	server *Server
 }
 
-func newDebugService() *debugService {
-	return &debugService{}
+func newDebugService(server *Server) *debugService {
+	return &debugService{
+		server: server,
+	}
 }
 
 // TestCancelAsync is the server implementation of:
@@ -41,8 +49,8 @@ func (s *debugService) TestCancelAsync(ctx context.Context, timeoutMs int) (bool
 	}
 }
 
-// TestCancelAsync is the server implementation of:
-// ValueTask<bool> TestIObserver(int, CancellationToken);
+// TestIObserverAsync is the server implementation of:
+// ValueTask<bool> TestIObserverAsync(int, CancellationToken);
 //
 // It emits a sequence of integers to the observer, from 0 to max, and then completes the observer, before returning.
 func (s *debugService) TestIObserverAsync(ctx context.Context, max int, observer IObserver[int]) error {
@@ -53,8 +61,40 @@ func (s *debugService) TestIObserverAsync(ctx context.Context, max int, observer
 	return nil
 }
 
+// TestPanicAsync is the server implementation of:
+// ValueTask<AccessToken> TestPanicAsync(string, CancellationToken);
+//
+// It causes a go `panic` with a given message string message.
 func (s *debugService) TestPanicAsync(ctx context.Context, message string) error {
 	panic(message)
+}
+
+// FetchTokenAsync is the server implementation of:
+// ValueTask<AccessToken> FetchTokenAsync(Session, CancellationToken);
+//
+// It fetches an access token for the current user and returns it.
+func (s *debugService) FetchTokenAsync(ctx context.Context, sessionId Session) (azcore.AccessToken, error) {
+	session, err := s.server.validateSession(ctx, sessionId)
+	if err != nil {
+		return azcore.AccessToken{}, err
+	}
+
+	var c struct {
+		cred azcore.TokenCredential `container:"type"`
+	}
+
+	container, err := session.newContainer()
+	if err != nil {
+		return azcore.AccessToken{}, err
+	}
+
+	if err := container.Fill(&c); err != nil {
+		return azcore.AccessToken{}, err
+	}
+
+	return c.cred.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: auth.LoginScopes(cloud.AzurePublic()),
+	})
 }
 
 // ServeHTTP implements http.Handler.
@@ -63,5 +103,6 @@ func (s *debugService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"TestCancelAsync":    HandlerFunc1(s.TestCancelAsync),
 		"TestIObserverAsync": HandlerAction2(s.TestIObserverAsync),
 		"TestPanicAsync":     HandlerAction1(s.TestPanicAsync),
+		"FetchTokenAsync":    HandlerFunc1(s.FetchTokenAsync),
 	})
 }

--- a/cli/azd/internal/vsrpc/models.go
+++ b/cli/azd/internal/vsrpc/models.go
@@ -59,6 +59,17 @@ type ProgressMessage struct {
 	AdditionalInfoLink string
 }
 
+type InitializeServerOptions struct {
+	// When non nil, AuthenticationEndpoint is the endpoint to connect to for authentication. It is in the same form as
+	// expected by the AZD_AUTH_ENDPOINT environment variable. Note that both AuthenticationEndpoint and AuthenticationKey
+	// need to be set for external authentication to be used.
+	AuthenticationEndpoint *string `json:",omitempty"`
+	// When non nil, AuthenticationKey is the key to use for authenticating to the server. It is in the same form as
+	// expected by the AZD_AUTH_KEY environment variable. Note that both AuthenticationEndpoint and AuthenticationKey
+	// need to be set for external authentication to be used.
+	AuthenticationKey *string `json:",omitempty"`
+}
+
 func newInfoProgressMessage(message string) ProgressMessage {
 	return ProgressMessage{
 		Message:  message,

--- a/cli/azd/internal/vsrpc/server.go
+++ b/cli/azd/internal/vsrpc/server.go
@@ -60,7 +60,7 @@ func (s *Server) Serve(l net.Listener) error {
 	// IObservers. This is useful for both developers unit testing in VS Code (where they can set this value in launch.json
 	// as well as tests where we can set this value with t.SetEnv()).
 	if on, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_SERVER_DEBUG_ENDPOINTS")); err == nil && on {
-		mux.Handle("/TestDebugService/v1.0", newDebugService())
+		mux.Handle("/TestDebugService/v1.0", newDebugService(s))
 	}
 
 	// Run upload periodically in the background while the server is running.

--- a/cli/azd/internal/vsrpc/server_session.go
+++ b/cli/azd/internal/vsrpc/server_session.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
@@ -29,6 +30,8 @@ type serverSession struct {
 	rootPath string
 	// root container points to server.rootContainer
 	rootContainer *ioc.NestedContainer
+	authEndpoint  string
+	authKey       string
 }
 
 // newSession creates a new session and returns the session ID and session. newSession is safe to call by multiple
@@ -149,6 +152,13 @@ func (s *serverSession) newContainer() (*container, error) {
 
 	c.MustRegisterScoped(func() *lazy.Lazy[*azdcontext.AzdContext] {
 		return lazy.From(azdCtx)
+	})
+
+	c.MustRegisterScoped(func() auth.ExternalAuthConfiguration {
+		return auth.ExternalAuthConfiguration{
+			Endpoint: s.authEndpoint,
+			Key:      s.authKey,
+		}
 	})
 
 	return &container{

--- a/cli/azd/internal/vsrpc/server_test.go
+++ b/cli/azd/internal/vsrpc/server_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestArity(t *testing.T) {
-	debugServer := httptest.NewServer(newDebugService())
+	debugServer := httptest.NewServer(newDebugService(nil))
 	defer debugServer.Close()
 
 	// Connect to the server and start running a JSON-RPC 2.0 connection so we can send and recieve messages.
@@ -53,7 +53,7 @@ func TestCancellation(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	debugService := newDebugService()
+	debugService := newDebugService(nil)
 	debugService.wg = &wg
 	debugServer := httptest.NewServer(debugService)
 	defer debugServer.Close()
@@ -105,7 +105,7 @@ func TestCancellation(t *testing.T) {
 }
 
 func TestObserverable(t *testing.T) {
-	debugServer := httptest.NewServer(newDebugService())
+	debugServer := httptest.NewServer(newDebugService(nil))
 	defer debugServer.Close()
 
 	// Connect to the server and start running a JSON-RPC 2.0 connection so we can send and recieve messages.
@@ -167,7 +167,7 @@ func TestObserverable(t *testing.T) {
 }
 
 func TestPanic(t *testing.T) {
-	debugServer := httptest.NewServer(newDebugService())
+	debugServer := httptest.NewServer(newDebugService(nil))
 	defer debugServer.Close()
 
 	// Connect to the server and start running a JSON-RPC 2.0 connection so we can send and recieve messages.

--- a/cli/azd/pkg/auth/remote_credential.go
+++ b/cli/azd/pkg/auth/remote_credential.go
@@ -86,16 +86,19 @@ func (rc *RemoteCredential) GetToken(ctx context.Context, options policy.TokenRe
 		return azcore.AccessToken{}, fmt.Errorf("unmarshalling response: %w", err)
 	}
 
-	if tokenResp.Status != "success" {
+	switch tokenResp.Status {
+	case "success":
+		return azcore.AccessToken{
+			Token:     *tokenResp.Token,
+			ExpiresOn: *tokenResp.ExpiresOn,
+		}, nil
+	case "error":
 		return azcore.AccessToken{}, fmt.Errorf("RemoteCredential: failed to acquire token: code: %s message: %s",
 			*tokenResp.Code,
 			*tokenResp.Message)
+	default:
+		return azcore.AccessToken{}, fmt.Errorf("RemoteCredential: unexpected status: %s", tokenResp.Status)
 	}
-
-	return azcore.AccessToken{
-		Token:     *tokenResp.Token,
-		ExpiresOn: *tokenResp.ExpiresOn,
-	}, nil
 }
 
 var _ = azcore.TokenCredential(&RemoteCredential{})

--- a/cli/azd/pkg/devcentersdk/developer_client_test.go
+++ b/cli/azd/pkg/devcentersdk/developer_client_test.go
@@ -26,6 +26,7 @@ func Test_DevCenter_Client(t *testing.T) {
 		cloud.AzurePublic(),
 		http.DefaultClient,
 		mockContext.Console,
+		auth.ExternalAuthConfiguration{},
 	)
 	require.NoError(t, err)
 

--- a/cli/azd/test/functional/remote_state_test.go
+++ b/cli/azd/test/functional/remote_state_test.go
@@ -77,6 +77,7 @@ func createBlobClient(
 		config.NewUserConfigManager(fileConfigManager),
 		cloud.AzurePublic(),
 		httpClient, mockContext.Console,
+		auth.ExternalAuthConfiguration{},
 	)
 	require.NoError(t, err)
 

--- a/cli/azd/test/functional/testdata/vs-server/tests/AcceptanceTests.cs
+++ b/cli/azd/test/functional/testdata/vs-server/tests/AcceptanceTests.cs
@@ -15,7 +15,7 @@ public class AcceptanceTests : TestBase
     public async Task ManageEnvironments()
     {
         IObserver<ProgressMessage> observer = new WriterObserver<ProgressMessage>();
-        var session = await svrSvc.InitializeAsync(_rootDir, CancellationToken.None);
+        var session = await svrSvc.InitializeAsync(_rootDir, new InitializeServerOptions(), CancellationToken.None);
         var result = await asSvc.GetAspireHostAsync(session, "Production", observer, CancellationToken.None);
         var environments = (await esSvc.GetEnvironmentsAsync(session, observer, CancellationToken.None)).ToList();
         environments.ShouldBeEmpty();
@@ -105,7 +105,7 @@ public class AcceptanceTests : TestBase
     [Test]
     public async Task LiveDeployRefresh() {
         IObserver<ProgressMessage> observer = new WriterObserver<ProgressMessage>();
-        var session = await svrSvc.InitializeAsync(_rootDir, CancellationToken.None);
+        var session = await svrSvc.InitializeAsync(_rootDir, new InitializeServerOptions(), CancellationToken.None);
         var result = await asSvc.GetAspireHostAsync(session, "Production", observer, CancellationToken.None);
 
         Environment e = new Environment(_envName) {

--- a/cli/azd/test/functional/testdata/vs-server/tests/AzdServices.cs
+++ b/cli/azd/test/functional/testdata/vs-server/tests/AzdServices.cs
@@ -67,6 +67,11 @@ public class Session {
     public string Id { get; set; } = "";
 }
 
+public class InitializeServerOptions {
+    public string AuthenticationEndpoint { get; set; } = null;
+    public string AuthenticationKey { get; set; } = null;
+}
+
 public class ProgressMessage
 {
     public ProgressMessage(
@@ -110,7 +115,7 @@ public interface IDebugService {
 }
 
 public interface IServerService {
-    ValueTask<Session> InitializeAsync(string rootPath, CancellationToken cancellationToken);
+    ValueTask<Session> InitializeAsync(string rootPath, InitializeServerOptions options, CancellationToken cancellationToken);
     ValueTask StopAsync(CancellationToken cancellationToken);
 }
 

--- a/cli/azd/test/functional/vs_server_test.go
+++ b/cli/azd/test/functional/vs_server_test.go
@@ -10,6 +10,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,12 +19,124 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
 	"github.com/azure/azure-dev/cli/azd/test/azdcli"
 	"github.com/azure/azure-dev/cli/azd/test/ostest"
 	"github.com/azure/azure-dev/cli/azd/test/recording"
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
+	"go.lsp.dev/jsonrpc2"
 )
+
+func Test_CLI_VsServerExternalAuth(t *testing.T) {
+	ctx, cancel := newTestContext(t)
+	defer cancel()
+
+	cli := azdcli.NewCLI(t)
+	/* #nosec G204 - Subprocess launched with a potential tainted input or cmd arguments false positive */
+	cmd := exec.CommandContext(ctx, cli.AzdPath, "vs-server")
+	cmd.Env = append(cli.Env, os.Environ()...)
+	cmd.Env = append(cmd.Env, "AZD_DEBUG_SERVER_DEBUG_ENDPOINTS=true")
+	pathString := ostest.CombinedPaths(cmd.Env)
+	if len(pathString) > 0 {
+		cmd.Env = append(cmd.Env, pathString)
+	}
+
+	var stdout bytes.Buffer
+	cmd.Stdout = io.MultiWriter(&stdout, &logWriter{initialTime: time.Now(), t: t, prefix: "[svr-out] "})
+	cmd.Stderr = &logWriter{initialTime: time.Now(), t: t, prefix: "[svr-err] "}
+	err := cmd.Start()
+	require.NoError(t, err)
+
+	// Wait for the server to start
+	for i := 0; i < 5; i++ {
+		time.Sleep(300 * time.Millisecond)
+		if stdout.Len() > 0 {
+			break
+		}
+	}
+
+	var svr contracts.VsServerResult
+	err = json.Unmarshal(stdout.Bytes(), &svr)
+	require.NoError(t, err, "value: %s", stdout.String())
+
+	ssConn, _, err := websocket.DefaultDialer.Dial(fmt.Sprintf("ws://127.0.0.1:%d/ServerService/v1.0", svr.Port), nil)
+	require.NoError(t, err)
+
+	ssRpcConn := jsonrpc2.NewConn(newWebSocketStream(ssConn))
+	ssRpcConn.Go(ctx, nil)
+
+	dsConn, _, err := websocket.DefaultDialer.Dial(fmt.Sprintf("ws://127.0.0.1:%d/TestDebugService/v1.0", svr.Port), nil)
+	require.NoError(t, err)
+
+	dsRpcConn := jsonrpc2.NewConn(newWebSocketStream(dsConn))
+	dsRpcConn.Go(ctx, nil)
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	mockAuthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authToken := r.Header.Get("Authorization")
+		var resultToken string
+
+		switch authToken {
+		case "Bearer test-key-1":
+			resultToken = "test-token-1"
+		case "Bearer test-key-2":
+			resultToken = "test-token-2"
+		default:
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		_, err := w.Write([]byte(fmt.Sprintf(`{"status": "success", "token": "%s", "expiresOn": "%s"}`,
+			resultToken, time.Now().Add(1*time.Hour).Format(time.RFC3339))))
+		require.NoError(t, err)
+	}))
+
+	defer mockAuthServer.Close()
+
+	// Create two sessions - they both use the same external auth server, but with different
+	// access keys.  The server will return a different token for each key, allowing us to confirm that
+	// the access information is being scoped per session.
+	var session1 any
+	var session2 any
+
+	_, err = ssRpcConn.Call(ctx, "InitializeAsync",
+		[]any{cwd,
+			map[string]string{
+				"AuthenticationEndpoint": mockAuthServer.URL,
+				"AuthenticationKey":      "test-key-1",
+			},
+		}, &session1)
+	require.NoError(t, err)
+
+	_, err = ssRpcConn.Call(ctx, "InitializeAsync",
+		[]any{cwd,
+			map[string]string{
+				"AuthenticationEndpoint": mockAuthServer.URL,
+				"AuthenticationKey":      "test-key-2",
+			},
+		}, &session2)
+	require.NoError(t, err)
+
+	// Now, fetch the tokens and ensure we get the correct one for each session.
+	var token1 azcore.AccessToken
+	var token2 azcore.AccessToken
+
+	_, err = dsRpcConn.Call(ctx, "FetchTokenAsync",
+		[]any{session1}, &token1)
+
+	require.NoError(t, err)
+	require.Equal(t, "test-token-1", token1.Token)
+
+	_, err = dsRpcConn.Call(ctx, "FetchTokenAsync",
+		[]any{session2}, &token2)
+
+	require.NoError(t, err)
+	require.Equal(t, "test-token-2", token2.Token)
+}
 
 func Test_CLI_VsServer(t *testing.T) {
 	testDir := filepath.Join("testdata", "vs-server", "tests")
@@ -155,4 +269,48 @@ func Test_CLI_VsServer(t *testing.T) {
 			}
 		})
 	}
+}
+
+// wsStream adapts the websocket.Conn to jsonrpc2.Stream interface
+type wsStream struct {
+	c *websocket.Conn
+}
+
+// Close implements jsonrpc2.Stream.
+func (*wsStream) Close() error {
+	return nil
+}
+
+// Read implements jsonrpc2.Stream.
+func (s *wsStream) Read(ctx context.Context) (jsonrpc2.Message, int64, error) {
+	mt, data, err := s.c.ReadMessage()
+	if err != nil {
+		return nil, 0, err
+	}
+	if mt != websocket.TextMessage {
+		return nil, 0, fmt.Errorf("unexpected message type: %v", mt)
+	}
+	msg, err := jsonrpc2.DecodeMessage(data)
+	if err != nil {
+		return nil, 0, err
+	}
+	return msg, int64(len(data)), nil
+}
+
+// Write implements jsonrpc2.Stream.
+func (s *wsStream) Write(ctx context.Context, msg jsonrpc2.Message) (int64, error) {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return 0, fmt.Errorf("marshaling message: %w", err)
+	}
+
+	if err := s.c.WriteMessage(websocket.TextMessage, data); err != nil {
+		return 0, err
+	}
+
+	return int64(len(data)), nil
+}
+
+func newWebSocketStream(c *websocket.Conn) *wsStream {
+	return &wsStream{c: c}
 }


### PR DESCRIPTION
This change adds support for clients using the vs-server to provide an external authentication server (as described in
cli/azd/docs/external-authentication.md) when initializing a session. When a client does, all auth requests for that session will use the configured server, allowing the client to fetch a token on behalf of `azd`.  Visual Studio will use this to request a token using the current signed in user, instead of forcing users to also run `azd auth login`.

This configuation is optional - when not provided, `azd` will continue to use the user signed in via `azd auth login`.

The `InitializeServerAsync` RPC gains a new argument - `InitializeServerOptions` which allows the values that would normally be set via `AZD_AUTH_ENDPOINT` and `AZD_AUTH_KEY` environment variables. The `vs-server` no longer respects these environment variables.

Fixes #3320