### PR TITLE
vs-server: Validate correct number of arguments for RPCs

### DIFF
--- a/cli/azd/internal/vsrpc/handler.go
+++ b/cli/azd/internal/vsrpc/handler.go
@@ -17,6 +17,15 @@ const (
 	// requestCanceledErrorCode is the error code that is used when a request is cancelled. StreamJsonRpc understands this
 	// error code and causes the Task to throw a TaskCanceledException instead of a normal RemoteInvocationException error.
 	requestCanceledErrorCode jsonrpc2.Code = -32800
+
+	// arityZero is the count of arguments in a zero argument function.
+	arityZero = 0
+	// arityOne is the count of arguments in an one argument function.
+	arityOne = 1
+	// arityTwo is the count of arguments in a two argument function.
+	arityTwo = 2
+	// arityThree is the count of arguments in a zero argument function.
+	arityThree = 3
 )
 
 // Handler is the type of function that handles incoming RPC requests.
@@ -25,6 +34,10 @@ type Handler func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replie
 // HandlerAction0 is a helper for creating a Handler from a function that takes no arguments and returns an error.
 func HandlerAction0(f func(context.Context) error) Handler {
 	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		if err := verifyArity(req, arityZero); err != nil {
+			return reply(ctx, nil, err)
+		}
+
 		err := func() (err error) {
 			defer capturePanic(&err)
 			err = f(ctx)
@@ -44,6 +57,10 @@ func HandlerAction0(f func(context.Context) error) Handler {
 // HandlerAction1 is a helper for creating a Handler from a function that takes one argument and returns an error.
 func HandlerAction1[T1 any](f func(context.Context, T1) error) Handler {
 	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		if err := verifyArity(req, arityOne); err != nil {
+			return reply(ctx, nil, err)
+		}
+
 		t1, err := unmarshalArg[T1](conn, req, 0)
 		if err != nil {
 			return reply(ctx, nil, err)
@@ -68,6 +85,10 @@ func HandlerAction1[T1 any](f func(context.Context, T1) error) Handler {
 // HandlerAction2 is a helper for creating a Handler from a function that takes two arguments and returns an error.
 func HandlerAction2[T1 any, T2 any](f func(context.Context, T1, T2) error) Handler {
 	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		if err := verifyArity(req, arityTwo); err != nil {
+			return reply(ctx, nil, err)
+		}
+
 		t1, err := unmarshalArg[T1](conn, req, 0)
 		if err != nil {
 			return reply(ctx, nil, err)
@@ -97,6 +118,10 @@ func HandlerAction2[T1 any, T2 any](f func(context.Context, T1, T2) error) Handl
 // HandlerAction3 is a helper for creating a Handler from a function that takes two arguments and returns an error.
 func HandlerAction3[T1 any, T2 any, T3 any](f func(context.Context, T1, T2, T3) error) Handler {
 	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		if err := verifyArity(req, arityThree); err != nil {
+			return reply(ctx, nil, err)
+		}
+
 		t1, err := unmarshalArg[T1](conn, req, 0)
 		if err != nil {
 			return reply(ctx, nil, err)
@@ -131,6 +156,10 @@ func HandlerAction3[T1 any, T2 any, T3 any](f func(context.Context, T1, T2, T3) 
 // HandlerFunc0 is a helper for creating a Handler from a function that takes no arguments and returns a value and an error.
 func HandlerFunc0[TRet any](f func(context.Context) (TRet, error)) Handler {
 	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		if err := verifyArity(req, arityZero); err != nil {
+			return reply(ctx, nil, err)
+		}
+
 		ret, err := func() (ret TRet, err error) {
 			defer capturePanic(&err)
 			ret, err = f(ctx)
@@ -150,6 +179,10 @@ func HandlerFunc0[TRet any](f func(context.Context) (TRet, error)) Handler {
 // HandlerFunc1 is a helper for creating a Handler from a function that takes one argument and returns a value and an error.
 func HandlerFunc1[T1 any, TRet any](f func(context.Context, T1) (TRet, error)) Handler {
 	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		if err := verifyArity(req, arityOne); err != nil {
+			return reply(ctx, nil, err)
+		}
+
 		t1, err := unmarshalArg[T1](conn, req, 0)
 		if err != nil {
 			return reply(ctx, nil, err)
@@ -174,6 +207,10 @@ func HandlerFunc1[T1 any, TRet any](f func(context.Context, T1) (TRet, error)) H
 // HandlerFunc2 is a helper for creating a Handler from a function that takes two arguments and returns a value and an error.
 func HandlerFunc2[T1 any, T2 any, TRet any](f func(context.Context, T1, T2) (TRet, error)) Handler {
 	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		if err := verifyArity(req, arityTwo); err != nil {
+			return reply(ctx, nil, err)
+		}
+
 		t1, err := unmarshalArg[T1](conn, req, 0)
 		if err != nil {
 			return reply(ctx, nil, err)
@@ -204,6 +241,10 @@ func HandlerFunc2[T1 any, T2 any, TRet any](f func(context.Context, T1, T2) (TRe
 // error.
 func HandlerFunc3[T1 any, T2 any, T3 any, TRet any](f func(context.Context, T1, T2, T3) (TRet, error)) Handler {
 	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		if err := verifyArity(req, arityThree); err != nil {
+			return reply(ctx, nil, err)
+		}
+
 		t1, err := unmarshalArg[T1](conn, req, 0)
 		if err != nil {
 			return reply(ctx, nil, err)
@@ -260,6 +301,23 @@ func unmarshalArg[T any](conn jsonrpc2.Conn, req jsonrpc2.Request, index int) (T
 	}
 
 	return arg, nil
+}
+
+// verifyArity returns a error if the number of parameters in a request does not match the expected number. The error
+// is of type *jsonrpc2.Error with a code of jsonrpc2.InvalidParams.
+func verifyArity(req jsonrpc2.Request, expected int) error {
+	var args []json.RawMessage
+	if err := json.Unmarshal(req.Params(), &args); err != nil {
+		return jsonrpc2.NewError(
+			jsonrpc2.InvalidParams, fmt.Sprintf("unmarshalling params as array: %s", err.Error()))
+	}
+
+	if len(args) != expected {
+		return jsonrpc2.NewError(
+			jsonrpc2.InvalidParams, fmt.Sprintf("expected %d params for %s, got %d", expected, req.Method(), len(args)))
+	}
+
+	return nil
 }
 
 // capturePanic is a helper for capturing panics and converting them to an error. It is expected to be called via `defer`:


### PR DESCRIPTION
Our handler logic for RPCs ensured that the client at least as many arguments as an RPC required, but any extra arguments from the caller would be silently ignored.

This change ensures that when a caller passes more arguments than expected we correctly return an error, as we would if the caller passed too few.