### PR TITLE
Consider configured subscription in `TokenCredential` registration.

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -785,9 +785,6 @@ func (w *workflowCmdAdapter) ExecuteContext(ctx context.Context) error {
 	return w.cmd.ExecuteContext(childCtx)
 }
 
-type envAwareCredential struct {
-}
-
 // tokenCredentialFunc is an implementation of azcore.TokenCredential backed by a function
 type tokenCredentialFunc func(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error)
 

--- a/cli/azd/internal/vsrpc/debug_service.go
+++ b/cli/azd/internal/vsrpc/debug_service.go
@@ -42,7 +42,7 @@ func (s *debugService) TestCancelAsync(ctx context.Context, timeoutMs int) (bool
 }
 
 // TestCancelAsync is the server implementation of:
-// ValueTask<bool> TestIObserver(int, CancellationToken);
+// ValueTask<bool> TestIObserverAsync(int, CancellationToken);
 //
 // It emits a sequence of integers to the observer, from 0 to max, and then completes the observer, before returning.
 func (s *debugService) TestIObserverAsync(ctx context.Context, max int, observer IObserver[int]) error {
@@ -53,10 +53,19 @@ func (s *debugService) TestIObserverAsync(ctx context.Context, max int, observer
 	return nil
 }
 
+// TestCancelAsync is the server implementation of:
+// ValueTask TestPanicAsyncAsync(string, CancellationToken);
+//
+// It causes a go panic with the given message and is used to test the panic capturing machinary in the RPC server.
+func (s *debugService) TestPanicAsync(ctx context.Context, message string) error {
+	panic(message)
+}
+
 // ServeHTTP implements http.Handler.
 func (s *debugService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	serveRpc(w, r, map[string]Handler{
 		"TestCancelAsync":    HandlerFunc1(s.TestCancelAsync),
 		"TestIObserverAsync": HandlerAction2(s.TestIObserverAsync),
+		"TestPanicAsync":     HandlerAction1(s.TestPanicAsync),
 	})
 }

--- a/cli/azd/internal/vsrpc/debug_service.go
+++ b/cli/azd/internal/vsrpc/debug_service.go
@@ -53,19 +53,10 @@ func (s *debugService) TestIObserverAsync(ctx context.Context, max int, observer
 	return nil
 }
 
-// TestCancelAsync is the server implementation of:
-// ValueTask TestPanicAsyncAsync(string, CancellationToken);
-//
-// It causes a go panic with the given message and is used to test the panic capturing machinary in the RPC server.
-func (s *debugService) TestPanicAsync(ctx context.Context, message string) error {
-	panic(message)
-}
-
 // ServeHTTP implements http.Handler.
 func (s *debugService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	serveRpc(w, r, map[string]Handler{
 		"TestCancelAsync":    HandlerFunc1(s.TestCancelAsync),
 		"TestIObserverAsync": HandlerAction2(s.TestIObserverAsync),
-		"TestPanicAsync":     HandlerAction1(s.TestPanicAsync),
 	})
 }


### PR DESCRIPTION
This change updates our registration of `TokenCredential` in our IoC container to consider the value of `AZURE_SUBSCRIPTION_ID` when it is set in the environment. When set, we now fetch the tenant that this subscription belongs to and use that as the default tenant for auth requests. This is required for subscriptions which are in a non default teant for the user.

Fixes: #3485