### PR TITLE
vs-server: Treat `panics` in handlers as RPC errors instead of crashing

### DIFF
--- a/cli/azd/internal/vsrpc/debug_service.go
+++ b/cli/azd/internal/vsrpc/debug_service.go
@@ -53,10 +53,15 @@ func (s *debugService) TestIObserverAsync(ctx context.Context, max int, observer
 	return nil
 }
 
+func (s *debugService) TestPanicAsync(ctx context.Context, message string) error {
+	panic(message)
+}
+
 // ServeHTTP implements http.Handler.
 func (s *debugService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	serveRpc(w, r, map[string]Handler{
 		"TestCancelAsync":    HandlerFunc1(s.TestCancelAsync),
 		"TestIObserverAsync": HandlerAction2(s.TestIObserverAsync),
+		"TestPanicAsync":     HandlerAction1(s.TestPanicAsync),
 	})
 }

--- a/cli/azd/internal/vsrpc/server_test.go
+++ b/cli/azd/internal/vsrpc/server_test.go
@@ -132,3 +132,28 @@ func TestObserverable(t *testing.T) {
 	// The onCompleted message takes no parameters and the args value is empty.
 	require.Len(t, onCompletedParams[0], 0)
 }
+
+func TestPanic(t *testing.T) {
+	debugServer := httptest.NewServer(newDebugService())
+	defer debugServer.Close()
+
+	// Connect to the server and start running a JSON-RPC 2.0 connection so we can send and recieve messages.
+	serverUrl, err := url.Parse(debugServer.URL)
+	require.NoError(t, err)
+	serverUrl.Scheme = "ws"
+
+	wsConn, _, err := websocket.DefaultDialer.Dial(serverUrl.String(), nil)
+	require.NoError(t, err)
+
+	rpcConn := jsonrpc2.NewConn(newWebSocketStream(wsConn))
+	rpcConn.Go(context.Background(), nil)
+
+	_, err = rpcConn.Call(context.Background(), "TestPanicAsync", []any{"this is the panic office."}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "this is the panic office.")
+
+	// Ensure the server is still running and we can make another call.
+	_, err = rpcConn.Call(context.Background(), "TestPanicAsync", []any{"this is the panic office, again."}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "this is the panic office, again.")
+}


### PR DESCRIPTION
This change modifies the behavior of the RPC server such that if a handler panics, instead of tearing down the entire process we have the RPC in question return an RPC error (with the Code set to `InternalError`).

In theory `azd` does not panic during any of these handlers. In practice, sometimes we make mistakes an getting an error back instead of `azd` crashing an the RPC failing when the connection is terminated is a much nicer experience and also ensures the error message makes its way back to to the caller.