### PR TITLE
Don't advertise the unified container in PR builds.

### DIFF
--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -1525,12 +1525,6 @@ stages:
 
               * $msiReleaseUrl
 
-              ### Container
-
-              ``````
-              docker run -it $(azdev-acr-host)/azure-dev:pr-$(PRNumber)
-              ``````
-
               ## Documentation
 
               <details>


### PR DESCRIPTION
Long term we hope to stop building this container - but we aren't yet sure who we might impact by doing so, so it will be a gradual effort.

To start, we can at least stop linking to it in our per PR build message - that way folks are less likely to notice it and take a dependency on it and if someone points out that it is missing we can ask them what they are using it for today and advise them on how to move away from it and onto something we'd like to support long term.

Contributes To: #3494