### PR TITLE
set build args for dockerfile

### DIFF
--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -85,10 +85,11 @@ func Dockerfiles(manifest *Manifest) map[string]genDockerfile {
 		switch comp.Type {
 		case "dockerfile.v0":
 			res[name] = genDockerfile{
-				Path:     *comp.Path,
-				Context:  *comp.Context,
-				Env:      comp.Env,
-				Bindings: comp.Bindings,
+				Path:      *comp.Path,
+				Context:   *comp.Context,
+				Env:       comp.Env,
+				Bindings:  comp.Bindings,
+				BuildArgs: comp.BuildArgs,
 			}
 		}
 	}
@@ -413,7 +414,7 @@ func (b *infraGenerator) LoadManifest(m *Manifest) error {
 				return err
 			}
 		case "dockerfile.v0":
-			b.addDockerfile(name, *comp.Path, *comp.Context, comp.Env, comp.Bindings)
+			b.addDockerfile(name, *comp.Path, *comp.Context, comp.Env, comp.Bindings, comp.BuildArgs)
 		case "redis.v0":
 			b.addContainerAppService(name, RedisContainerAppService)
 		case "azure.keyvault.v0":
@@ -855,16 +856,18 @@ func (b *infraGenerator) addDaprStateStoreComponent(name string) {
 }
 
 func (b *infraGenerator) addDockerfile(
-	name string, path string, context string, env map[string]string, bindings map[string]*Binding,
+	name string, path string, context string, env map[string]string,
+	bindings map[string]*Binding, buildArgs map[string]string,
 ) {
 	b.requireCluster()
 	b.requireContainerRegistry()
 
 	b.dockerfiles[name] = genDockerfile{
-		Path:     path,
-		Context:  context,
-		Env:      env,
-		Bindings: bindings,
+		Path:      path,
+		Context:   context,
+		Env:       env,
+		Bindings:  bindings,
+		BuildArgs: buildArgs,
 	}
 }
 

--- a/cli/azd/pkg/apphost/generate_types.go
+++ b/cli/azd/pkg/apphost/generate_types.go
@@ -51,10 +51,11 @@ type genContainer struct {
 }
 
 type genDockerfile struct {
-	Path     string
-	Context  string
-	Env      map[string]string
-	Bindings map[string]*Binding
+	Path      string
+	Context   string
+	Env       map[string]string
+	Bindings  map[string]*Binding
+	BuildArgs map[string]string
 }
 
 type genProject struct {

--- a/cli/azd/pkg/apphost/manifest.go
+++ b/cli/azd/pkg/apphost/manifest.go
@@ -32,6 +32,9 @@ type Resource struct {
 	// Context is present on a dockerfile.v0 resource and is the path to the context directory.
 	Context *string `json:"context,omitempty"`
 
+	// BuildArgs is present on a dockerfile.v0 resource and is the --build-arg for building the docker image.
+	BuildArgs map[string]string `json:"buildArgs,omitempty"`
+
 	// Parent is present on a resource which is a child of another. It is the name of the parent resource. For example, a
 	// postgres.database.v0 is a child of a postgres.server.v0, and so it would have a parent of which is the name of
 	// the server resource.

--- a/cli/azd/pkg/apphost/testdata/aspire-docker.json
+++ b/cli/azd/pkg/apphost/testdata/aspire-docker.json
@@ -4,6 +4,12 @@
       "type": "dockerfile.v0",
       "path": "../NodeApp/Dockerfile",
       "context": "../NodeApp",
+      "buildArgs": {
+        "SOME_STRING": "Test",
+        "SOME_BOOL": "True",
+        "SOME_NUMBER": "7",
+        "SOME_NONVALUE": null
+      },
       "env": {
         "NODE_ENV": "development",
         "PORT": "{nodeapp.bindings.http.port}",

--- a/cli/azd/pkg/project/dotnet_importer.go
+++ b/cli/azd/pkg/project/dotnet_importer.go
@@ -146,6 +146,23 @@ func (ai *DotNetImporter) ProjectInfrastructure(ctx context.Context, svcConfig *
 	}, nil
 }
 
+// mapToStringSlice converts a map of strings to a slice of strings.
+// Each key-value pair in the map is converted to a string in the format "key:value",
+// where the separator is specified by the `separator` parameter.
+// If the value is an empty string, only the key is included in the resulting slice.
+// The resulting slice is returned.
+func mapToStringSlice(m map[string]string, separator string) []string {
+	var result []string
+	for key, value := range m {
+		if value == "" {
+			result = append(result, key)
+		} else {
+			result = append(result, key+separator+value)
+		}
+	}
+	return result
+}
+
 func (ai *DotNetImporter) Services(
 	ctx context.Context, p *ProjectConfig, svcConfig *ServiceConfig,
 ) (map[string]*ServiceConfig, error) {
@@ -201,8 +218,9 @@ func (ai *DotNetImporter) Services(
 			Language:     ServiceLanguageDocker,
 			Host:         DotNetContainerAppTarget,
 			Docker: DockerProjectOptions{
-				Path:    dockerfile.Path,
-				Context: dockerfile.Context,
+				Path:      dockerfile.Path,
+				Context:   dockerfile.Context,
+				BuildArgs: mapToStringSlice(dockerfile.BuildArgs, "="),
 			},
 		}
 

--- a/cli/azd/pkg/project/dotnet_importer_test.go
+++ b/cli/azd/pkg/project/dotnet_importer_test.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ func TestMapToStringSlice(t *testing.T) {
 	m1 := make(map[string]string)
 	expected1 := []string(nil)
 	result1 := mapToStringSlice(m1, ":")
+	slices.Sort(result1)
 	assert.Equal(t, expected1, result1)
 
 	// Test case 2: Map with values
@@ -21,6 +23,7 @@ func TestMapToStringSlice(t *testing.T) {
 	}
 	expected2 := []string{"key1:value1", "key2:value2", "key3:value3"}
 	result2 := mapToStringSlice(m2, ":")
+	slices.Sort(result2)
 	assert.Equal(t, expected2, result2)
 
 	// Test case 3: Map with empty values
@@ -31,5 +34,6 @@ func TestMapToStringSlice(t *testing.T) {
 	}
 	expected3 := []string{"key1", "key2", "key3"}
 	result3 := mapToStringSlice(m3, ":")
+	slices.Sort(result3)
 	assert.Equal(t, expected3, result3)
 }

--- a/cli/azd/pkg/project/dotnet_importer_test.go
+++ b/cli/azd/pkg/project/dotnet_importer_test.go
@@ -1,0 +1,35 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapToStringSlice(t *testing.T) {
+	// Test case 1: Empty map
+	m1 := make(map[string]string)
+	expected1 := []string(nil)
+	result1 := mapToStringSlice(m1, ":")
+	assert.Equal(t, expected1, result1)
+
+	// Test case 2: Map with values
+	m2 := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	}
+	expected2 := []string{"key1:value1", "key2:value2", "key3:value3"}
+	result2 := mapToStringSlice(m2, ":")
+	assert.Equal(t, expected2, result2)
+
+	// Test case 3: Map with empty values
+	m3 := map[string]string{
+		"key1": "",
+		"key2": "",
+		"key3": "",
+	}
+	expected3 := []string{"key1", "key2", "key3"}
+	result3 := mapToStringSlice(m3, ":")
+	assert.Equal(t, expected3, result3)
+}


### PR DESCRIPTION
fix: https://github.com/Azure/azure-dev/issues/3432

Updating netAspire generator to use the build args from the dockerfile resource 

Notes: 
   Requires netAspire preview5