### PR TITLE
When OneAuth is enabled, log in OS account by default on DevBox

### DIFF
--- a/cli/azd/cmd/auth_login.go
+++ b/cli/azd/cmd/auth_login.go
@@ -492,7 +492,7 @@ func (la *loginAction) login(ctx context.Context) error {
 	}
 
 	if oneauth.Supported && !la.flags.browser {
-		err = la.authManager.LoginWithOneAuth(ctx, la.flags.tenantID, la.flags.scopes)
+		err = la.authManager.LoginWithOneAuth(ctx, la.flags.tenantID, la.flags.scopes, false)
 	} else {
 		_, err = la.authManager.LoginInteractive(ctx, la.flags.scopes,
 			&auth.LoginInteractiveOptions{

--- a/cli/azd/pkg/auth/manager_test.go
+++ b/cli/azd/pkg/auth/manager_test.go
@@ -10,10 +10,12 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"reflect"
 	"testing"
 
 	_ "embed"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
@@ -21,6 +23,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/github"
+	"github.com/azure/azure-dev/cli/azd/pkg/oneauth"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
 	"github.com/stretchr/testify/require"
@@ -202,6 +205,38 @@ func TestCloudShellCredentialSupport(t *testing.T) {
 	cred, err := m.CredentialForCurrentUser(context.Background(), nil)
 	require.NoError(t, err)
 	require.IsType(t, new(CloudShellCredential), cred)
+}
+
+func TestDevBoxIntegration(t *testing.T) {
+	loggedIn := false
+	expected := &azidentity.ClientSecretCredential{} // arbitrary type; expecting no attempt to get a token
+	setDuringTest := func(varPtr, value any) {
+		before := reflect.ValueOf(varPtr).Elem().Interface()
+		reflect.ValueOf(varPtr).Elem().Set(reflect.ValueOf(value))
+		t.Cleanup(func() { reflect.ValueOf(varPtr).Elem().Set(reflect.ValueOf(before)) })
+	}
+	setDuringTest(&oneauth.LogIn, func(string, string, string) (string, error) {
+		return "", errors.New("should have called LogInSilently instead of LogIn")
+	})
+	setDuringTest(&oneauth.LogInSilently, func(string) (string, error) {
+		loggedIn = true
+		return "fakeAccountID", nil
+	})
+	setDuringTest(&oneauth.NewCredential, func(string, string, oneauth.CredentialOptions) (azcore.TokenCredential, error) {
+		return expected, nil
+	})
+	setDuringTest(&oneauth.Supported, true)
+	t.Setenv("IsDevBox", "True")
+	m := Manager{
+		cloud:             cloud.AzurePublic(),
+		configManager:     newMemoryConfigManager(),
+		userConfigManager: newMemoryUserConfigManager(),
+	}
+
+	actual, err := m.CredentialForCurrentUser(context.Background(), nil)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+	require.True(t, loggedIn)
 }
 
 func TestLoginInteractive(t *testing.T) {

--- a/cli/azd/pkg/oneauth/bridge/bridge.h
+++ b/cli/azd/pkg/oneauth/bridge/bridge.h
@@ -44,6 +44,10 @@ extern "C"
     // - allowPrompt: whether to display an interactive login window when necessary
     __declspec(dllexport) WrappedAuthResult *Authenticate(const char *authority, const char *scope, const char *accountID, bool allowPrompt);
 
+    // SignInSilently authenticates an account inferred from the OS e.g. the active Windows user, without displaying UI.
+    // It returns an error when that's impossible.
+    __declspec(dllexport) WrappedAuthResult *SignInSilently();
+
     // Logout disassociates all accounts from the application.
     __declspec(dllexport) void Logout();
 

--- a/cli/azd/pkg/oneauth/oneauth.go
+++ b/cli/azd/pkg/oneauth/oneauth.go
@@ -20,6 +20,10 @@ func LogIn(authority, clientID, scope string) (string, error) {
 	return "", errNotSupported
 }
 
+func LogInSilently(clientID string) (string, error) {
+	return "", errNotSupported
+}
+
 func Logout(clientID string) error {
 	return errNotSupported
 }

--- a/cli/azd/pkg/oneauth/oneauth.go
+++ b/cli/azd/pkg/oneauth/oneauth.go
@@ -11,25 +11,25 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
-// Supported indicates whether this build includes OneAuth integration.
-const Supported = false
+var (
+	// functions are defined as variables to make them easily replaceable in tests
 
-var errNotSupported = errors.New("this build doesn't support OneAuth authentication")
+	LogIn = func(authority, clientID, scope string) (string, error) {
+		return "", errNotSupported
+	}
+	LogInSilently = func(clientID string) (string, error) {
+		return "", errNotSupported
+	}
+	Logout = func(clientID string) error {
+		return errNotSupported
+	}
+	NewCredential = func(authority, clientID string, opts CredentialOptions) (azcore.TokenCredential, error) {
+		return nil, errNotSupported
+	}
+	Shutdown = func() {}
 
-func LogIn(authority, clientID, scope string) (string, error) {
-	return "", errNotSupported
-}
+	// Supported indicates whether this build includes OneAuth integration.
+	Supported = false
 
-func LogInSilently(clientID string) (string, error) {
-	return "", errNotSupported
-}
-
-func Logout(clientID string) error {
-	return errNotSupported
-}
-
-func NewCredential(authority, clientID string, opts CredentialOptions) (azcore.TokenCredential, error) {
-	return nil, errNotSupported
-}
-
-func Shutdown() {}
+	errNotSupported = errors.New("this build doesn't support OneAuth authentication")
+)

--- a/cli/azd/pkg/oneauth/oneauth_windows.go
+++ b/cli/azd/pkg/oneauth/oneauth_windows.go
@@ -58,7 +58,7 @@ func goLog(s *C.char) {
 }
 
 // Supported indicates whether this build includes OneAuth integration.
-const Supported = true
+var Supported = true
 
 var (
 	//go:embed bridge/_build/Release/bridge.dll
@@ -81,7 +81,7 @@ var (
 	startup        *windows.Proc
 )
 
-func Shutdown() {
+var Shutdown = func() {
 	if started.CompareAndSwap(true, false) {
 		shutdown.Call()
 	}
@@ -100,7 +100,7 @@ type credential struct {
 }
 
 // NewCredential creates a new credential that acquires tokens via OneAuth.
-func NewCredential(authority, clientID string, opts CredentialOptions) (azcore.TokenCredential, error) {
+var NewCredential = func(authority, clientID string, opts CredentialOptions) (azcore.TokenCredential, error) {
 	cred := &credential{
 		authority:     authority,
 		clientID:      clientID,
@@ -120,12 +120,12 @@ func (c *credential) GetToken(ctx context.Context, opts policy.TokenRequestOptio
 	return ar.token, err
 }
 
-func LogIn(authority, clientID, scope string) (string, error) {
+var LogIn = func(authority, clientID, scope string) (string, error) {
 	ar, err := authn(authority, clientID, "", scope, false)
 	return ar.homeAccountID, err
 }
 
-func Logout(clientID string) error {
+var Logout = func(clientID string) error {
 	err := start(clientID)
 	if err == nil {
 		logout.Call()
@@ -134,7 +134,7 @@ func Logout(clientID string) error {
 }
 
 // LogInSilently attempts to log in the active Windows user and return that user's account ID. It never displays UI.
-func LogInSilently(clientID string) (string, error) {
+var LogInSilently = func(clientID string) (string, error) {
 	err := start(clientID)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
With this change, when all these conditions are true:
- a user runs a command requiring authentication
- azd has no account logged in
- azd has OneAuth integration enabled
- azd is running on DevBox

azd will attempt to log in the current OS user without displaying UI. If that fails, it will output the usual "run `azd auth login`" message.