### PR TITLE
init: add --from-code flag

### DIFF
--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -63,6 +63,7 @@ func (i *initFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOpt
 		"template",
 		"t",
 		"",
+		//nolint:lll
 		"Initializes a new application from a template. You can use Full URI, <owner>/<repository>, or <repository> if it's part of the azure-samples organization.",
 	)
 	local.StringVarP(

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -53,6 +53,7 @@ type initFlags struct {
 	subscription   string
 	location       string
 	global         *internal.GlobalCommandOptions
+	fromCode       bool
 	internal.EnvFlag
 }
 
@@ -62,8 +63,7 @@ func (i *initFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOpt
 		"template",
 		"t",
 		"",
-		//nolint:lll
-		"The template to use when you initialize the project. You can use Full URI, <owner>/<repository>, or <repository> if it's part of the azure-samples organization.",
+		"Initializes a new application from a template. You can use Full URI, <owner>/<repository>, or <repository> if it's part of the azure-samples organization.",
 	)
 	local.StringVarP(
 		&i.templateBranch,
@@ -77,6 +77,13 @@ func (i *initFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOpt
 		"s",
 		"",
 		"Name or ID of an Azure subscription to use for the new environment",
+	)
+	local.BoolVarP(
+		&i.fromCode,
+		"from-code",
+		"",
+		false,
+		"Initializes a new application from your existing code.",
 	)
 	local.StringVarP(&i.location, "location", "l", "", "Azure location for the new environment")
 	i.EnvFlag.Bind(local, global)
@@ -159,8 +166,15 @@ func (i *initAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		initTypeSelect = initAppTemplate
 	}
 
-	if i.flags.templatePath == "" && existingProject {
-		// no explicit --template, and azure.yaml exists, only initialize environment
+	if i.flags.fromCode {
+		if i.flags.templatePath != "" {
+			return nil, errors.New("only one of init modes: --template, or --from-code should be set")
+		}
+		initTypeSelect = initFromApp
+	}
+
+	if i.flags.templatePath == "" && !i.flags.fromCode && existingProject {
+		// only initialize environment when no mode is set explicitly
 		initTypeSelect = initEnvironment
 	}
 
@@ -384,8 +398,8 @@ func getCmdInitHelpDescription(*cobra.Command) string {
 	return generateCmdHelpDescription("Initialize a new application in your current directory.",
 		[]string{
 			formatHelpNote(
-				fmt.Sprintf("Running %s without a template will prompt "+
-					"you to start with a minimal template or select from a curated list of presets.",
+				fmt.Sprintf("Running %s without flags specified will prompt "+
+					"you to initialize using your existing code, or from a template.",
 					output.WithHighLightFormat("init"),
 				)),
 			formatHelpNote(

--- a/cli/azd/cmd/testdata/TestUsage-azd-init.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-init.snap
@@ -11,7 +11,7 @@ Flags
     -b, --branch string       	: The template branch to initialize from. Must be used with a template argument (--template or -t).
         --docs                	: Opens the documentation for azd init in your web browser.
     -e, --environment string  	: The name of the environment to use.
-        --from-code           	: Initializes a new application from existing code.
+        --from-code           	: Initializes a new application from your existing code.
     -h, --help                	: Gets help for init.
     -l, --location string     	: Azure location for the new environment
     -s, --subscription string 	: Name or ID of an Azure subscription to use for the new environment

--- a/cli/azd/cmd/testdata/TestUsage-azd-init.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-init.snap
@@ -1,7 +1,7 @@
 
 Initialize a new application in your current directory.
 
-  • Running init without a template will prompt you to start with a minimal template or select from a curated list of presets.
+  • Running init without flags specified will prompt you to initialize using your existing code, or from a template.
   • To view all available sample templates, including those submitted by the azd community, visit: https://azure.github.io/awesome-azd.
 
 Usage
@@ -11,10 +11,11 @@ Flags
     -b, --branch string       	: The template branch to initialize from. Must be used with a template argument (--template or -t).
         --docs                	: Opens the documentation for azd init in your web browser.
     -e, --environment string  	: The name of the environment to use.
+        --from-code           	: Initializes a new application from existing code.
     -h, --help                	: Gets help for init.
     -l, --location string     	: Azure location for the new environment
     -s, --subscription string 	: Name or ID of an Azure subscription to use for the new environment
-    -t, --template string     	: The template to use when you initialize the project. You can use Full URI, <owner>/<repository>, or <repository> if it's part of the azure-samples organization.
+    -t, --template string     	: Initializes a new application from a template. You can use Full URI, <owner>/<repository>, or <repository> if it's part of the azure-samples organization.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.


### PR DESCRIPTION
Add a flag to `init` for initializing from existing code.

Fixes #3361
