### PR TITLE
Add secure() for secrets

### DIFF
--- a/templates/common/infra/bicep/core/host/container-app-upsert.bicep
+++ b/templates/common/infra/bicep/core/host/container-app-upsert.bicep
@@ -56,7 +56,8 @@ param identityName string = ''
 param imageName string = ''
 
 @description('The secrets required for the container')
-param secrets array = []
+@secure()
+param secrets object = {}
 
 @description('The environment variables for the container')
 param env array = []

--- a/templates/common/infra/bicep/core/host/container-app.bicep
+++ b/templates/common/infra/bicep/core/host/container-app.bicep
@@ -63,7 +63,8 @@ param ingressEnabled bool = true
 param revisionMode string = 'Single'
 
 @description('The secrets required for the container')
-param secrets array = []
+@secure()
+param secrets object = {}
 
 @description('The service binds associated with the container')
 param serviceBinds array = []
@@ -123,7 +124,10 @@ resource app 'Microsoft.App/containerApps@2023-05-02-preview' = {
         appProtocol: daprAppProtocol
         appPort: ingressEnabled ? targetPort : 0
       } : { enabled: false }
-      secrets: secrets
+      secrets: [for secret in items(secrets): {
+        name: secret.key
+        value: secret.value
+      }]
       service: !empty(serviceType) ? { type: serviceType } : null
       registries: usePrivateRegistry ? [
         {


### PR DESCRIPTION
This PR makes it so that you can securely pass secrets into the container-app modules, by wrapping it in a secure() decorator. Unfortunately, we can't mark arrays as `@secure`, so you have to instead pass in an object of the secret key/values, and we turn that back into the expected array format.

Note that I haven't tested these exact modules since I'm working off a fork of the modules (my use case isn't compatible with the azd modules.. will file an issue about that).
You can see my change here, which works:
https://github.com/Azure-Samples/langfuse-on-azure/pull/9

I don't think any of the TODO templates utilize secrets for container apps, so not sure there's a test to do on the azd template side.
