### PR TITLE
Update key vault template with toggle switches to disable public network access

### DIFF
--- a/templates/common/infra/bicep/core/security/keyvault.bicep
+++ b/templates/common/infra/bicep/core/security/keyvault.bicep
@@ -3,6 +3,18 @@ param name string
 param location string = resourceGroup().location
 param tags object = {}
 
+// Allow public network access to Key Vault
+param allowPublicNetworkAccess bool = true
+
+// Allow all Azure services to bypass Key Vault network rules
+param allowAzureServicesAccess bool = true
+
+param networkAcls object = {
+  bypass: allowAzureServicesAccess ? 'AzureServices' : 'None'
+  defaultAction: allowPublicNetworkAccess ? 'Allow' : 'Deny'
+  ipRules: []
+  virtualNetworkRules: []
+}
 param principalId string = ''
 
 resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
@@ -12,6 +24,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
   properties: {
     tenantId: subscription().tenantId
     sku: { family: 'A', name: 'standard' }
+    networkAcls: networkAcls
     accessPolicies: !empty(principalId) ? [
       {
         objectId: principalId


### PR DESCRIPTION
I've left public network access on (default) to avoid breaking changes, but this PR will add a switch to turn on/off public network access and by default set Azure services to join

https://microsoft.sharepoint.com/teams/AzureTenantBaseline2/SitePages/Key-Vault-must-have-public-access-disabled.aspx (Internal) reference on this security policy