### PR TITLE
Update runtime version for WiX msbuild task overrides

### DIFF
--- a/cli/installer/windows/azd.wixproj
+++ b/cli/installer/windows/azd.wixproj
@@ -63,7 +63,7 @@
         <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
     </Target>
     <!-- Work around MSBuild regression: https://github.com/dotnet/msbuild/issues/8645 -->
-    <UsingTask TaskName="GenerateCompileWithObjectPath" AssemblyFile="$(WixTasksPath)" Override="true" Runtime="CLR2"/>
-    <UsingTask TaskName="ResolveWixReferences" AssemblyFile="$(WixTasksPath)" Override="true" Runtime="CLR2"/>
-    <UsingTask TaskName="WixAssignCulture" AssemblyFile="$(WixTasksPath)" Override="true" Runtime="CLR2"/>
+    <UsingTask TaskName="GenerateCompileWithObjectPath" AssemblyFile="$(WixTasksPath)" Override="true" Runtime="CLR4"/>
+    <UsingTask TaskName="ResolveWixReferences" AssemblyFile="$(WixTasksPath)" Override="true" Runtime="CLR4"/>
+    <UsingTask TaskName="WixAssignCulture" AssemblyFile="$(WixTasksPath)" Override="true" Runtime="CLR4"/>
 </Project>


### PR DESCRIPTION
When running msbuild with version 17.9+, an error is issued when the runtime used is older than the runtime built by the assembly. This fixes the build issue in CI.

`WixTasks.dll` is built with .NET Framework 4.5, using .NET 4 runtime is suitable.

```
// Assembly WixTasks, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad
// MVID: 490251A0-A276-4FFD-95C1-FE22B2EE7BB7
// Assembly references:
// mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
// System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
// Microsoft.Build.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
// Microsoft.Build.Utilities.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
// Microsoft.Deployment.WindowsInstaller, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad
// System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
// wix, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad

[assembly: TargetFramework(".NETFramework,Version=v4.5", FrameworkDisplayName = ".NET Framework 4.5")]
[assembly: AssemblyVersion("3.0.0.0")]
```