### PR TITLE
Remove workaround for WiX msbuild task load

### DIFF
--- a/cli/installer/windows/azd.wixproj
+++ b/cli/installer/windows/azd.wixproj
@@ -62,8 +62,4 @@
     <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
         <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
     </Target>
-    <!-- Work around MSBuild regression: https://github.com/dotnet/msbuild/issues/8645 -->
-    <UsingTask TaskName="GenerateCompileWithObjectPath" AssemblyFile="$(WixTasksPath)" Override="true" Runtime="CLR4"/>
-    <UsingTask TaskName="ResolveWixReferences" AssemblyFile="$(WixTasksPath)" Override="true" Runtime="CLR4"/>
-    <UsingTask TaskName="WixAssignCulture" AssemblyFile="$(WixTasksPath)" Override="true" Runtime="CLR4"/>
 </Project>

--- a/cli/installer/windows/azd.wixproj
+++ b/cli/installer/windows/azd.wixproj
@@ -63,7 +63,7 @@
         <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
     </Target>
     <!-- Work around MSBuild regression: https://github.com/dotnet/msbuild/issues/8645 -->
-    <UsingTask TaskName="GenerateCompileWithObjectPath" AssemblyFile="$(WixTasksPath)" Override="true" Runtime="CLR2"/>
-    <UsingTask TaskName="ResolveWixReferences" AssemblyFile="$(WixTasksPath)" Override="true" Runtime="CLR2"/>
-    <UsingTask TaskName="WixAssignCulture" AssemblyFile="$(WixTasksPath)" Override="true" Runtime="CLR2"/>
+    <UsingTask TaskName="GenerateCompileWithObjectPath" AssemblyFile="$(WixTasksPath)" Override="true" Runtime="CLR4"/>
+    <UsingTask TaskName="ResolveWixReferences" AssemblyFile="$(WixTasksPath)" Override="true" Runtime="CLR4"/>
+    <UsingTask TaskName="WixAssignCulture" AssemblyFile="$(WixTasksPath)" Override="true" Runtime="CLR4"/>
 </Project>


### PR DESCRIPTION
Alternative fix that may be the right one.