### PR TITLE
Update the infra/core modules to AVM modules

### DIFF
--- a/templates/todo/common/infra/bicep/app/apim-api-settings.bicep
+++ b/templates/todo/common/infra/bicep/app/apim-api-settings.bicep
@@ -1,0 +1,97 @@
+param name string
+
+@description('Resource name to uniquely identify this API within the API Management service instance')
+@minLength(1)
+param apiName string
+
+@description('Relative URL uniquely identifying this API and all of its resource paths within the API Management service instance. It is appended to the API endpoint base URL specified during the service instance creation to form a public URL for this API.')
+@minLength(1)
+param apiPath string
+param applicationInsightsName string
+
+@description('Resource name for backend Web App or Function App')
+param apiAppName string = ''
+
+resource restApi 'Microsoft.ApiManagement/service/apis@2021-12-01-preview' existing = {
+  name: apiName
+  parent: apimService
+}
+
+resource apiDiagnostics 'Microsoft.ApiManagement/service/apis/diagnostics@2021-12-01-preview' = {
+  name: 'applicationinsights'
+  parent: restApi
+  properties: {
+    alwaysLog: 'allErrors'
+    backend: {
+      request: {
+        body: {
+          bytes: 1024
+        }
+      }
+      response: {
+        body: {
+          bytes: 1024
+        }
+      }
+    }
+    frontend: {
+      request: {
+        body: {
+          bytes: 1024
+        }
+      }
+      response: {
+        body: {
+          bytes: 1024
+        }
+      }
+    }
+    httpCorrelationProtocol: 'W3C'
+    logClientIp: true
+    loggerId: apimLogger.id
+    metrics: true
+    sampling: {
+      percentage: 100
+      samplingType: 'fixed'
+    }
+    verbosity: 'verbose'
+  }
+}
+
+resource apimService 'Microsoft.ApiManagement/service@2021-08-01' existing = {
+  name: name
+}
+
+// Necessary due to https://github.com/Azure/bicep/issues/9594
+// placeholderName is never deployed, it is merely used to make the child name validation pass
+var appNameForBicep = !empty(apiAppName) ? apiAppName : 'placeholderName'
+
+resource apiAppProperties 'Microsoft.Web/sites/config@2022-03-01' = if (!empty(apiAppName)) {
+  name: '${appNameForBicep}/web'
+  kind: 'string'
+  properties: {
+      apiManagementConfig: {
+        id: '${apimService.id}/apis/${apiName}'
+      }
+  }
+}
+
+resource apimLogger 'Microsoft.ApiManagement/service/loggers@2021-12-01-preview' = if (!empty(applicationInsightsName)) {
+  name: 'app-insights-logger'
+  parent: apimService
+  properties: {
+    credentials: {
+      instrumentationKey: applicationInsights.properties.InstrumentationKey
+    }
+    description: 'Logger to Azure Application Insights'
+    isBuffered: false
+    loggerType: 'applicationInsights'
+    resourceId: applicationInsights.id
+  }
+}
+
+resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing = if (!empty(applicationInsightsName)) {
+  name: applicationInsightsName
+}
+
+output SERVICE_API_URI string = '${apimService.properties.gatewayUrl}/${apiPath}'

--- a/templates/todo/common/infra/bicep/app/applicationinsights-dashboard.bicep
+++ b/templates/todo/common/infra/bicep/app/applicationinsights-dashboard.bicep
@@ -1,0 +1,1236 @@
+metadata description = 'Creates a dashboard for an Application Insights instance.'
+param name string
+param applicationInsightsName string
+param location string = resourceGroup().location
+param tags object = {}
+
+// 2020-09-01-preview because that is the latest valid version
+resource applicationInsightsDashboard 'Microsoft.Portal/dashboards@2020-09-01-preview' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    lenses: [
+      {
+        order: 0
+        parts: [
+          {
+            position: {
+              x: 0
+              y: 0
+              colSpan: 2
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'id'
+                  value: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                }
+                {
+                  name: 'Version'
+                  value: '1.0'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/AspNetOverviewPinnedPart'
+              asset: {
+                idInputName: 'id'
+                type: 'ApplicationInsights'
+              }
+              defaultMenuItemId: 'overview'
+            }
+          }
+          {
+            position: {
+              x: 2
+              y: 0
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'Version'
+                  value: '1.0'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/ProactiveDetectionAsyncPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+              defaultMenuItemId: 'ProactiveDetection'
+            }
+          }
+          {
+            position: {
+              x: 3
+              y: 0
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'ResourceId'
+                  value: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/QuickPulseButtonSmallPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+            }
+          }
+          {
+            position: {
+              x: 4
+              y: 0
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'TimeContext'
+                  value: {
+                    durationMs: 86400000
+                    endTime: null
+                    createdTime: '2018-05-04T01:20:33.345Z'
+                    isInitialTime: true
+                    grain: 1
+                    useDashboardTimeRange: false
+                  }
+                }
+                {
+                  name: 'Version'
+                  value: '1.0'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/AvailabilityNavButtonPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+            }
+          }
+          {
+            position: {
+              x: 5
+              y: 0
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'TimeContext'
+                  value: {
+                    durationMs: 86400000
+                    endTime: null
+                    createdTime: '2018-05-08T18:47:35.237Z'
+                    isInitialTime: true
+                    grain: 1
+                    useDashboardTimeRange: false
+                  }
+                }
+                {
+                  name: 'ConfigurationId'
+                  value: '78ce933e-e864-4b05-a27b-71fd55a6afad'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/AppMapButtonPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+            }
+          }
+          {
+            position: {
+              x: 0
+              y: 1
+              colSpan: 3
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: []
+              type: 'Extension/HubsExtension/PartType/MarkdownPart'
+              settings: {
+                content: {
+                  settings: {
+                    content: '# Usage'
+                    title: ''
+                    subtitle: ''
+                  }
+                }
+              }
+            }
+          }
+          {
+            position: {
+              x: 3
+              y: 1
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'TimeContext'
+                  value: {
+                    durationMs: 86400000
+                    endTime: null
+                    createdTime: '2018-05-04T01:22:35.782Z'
+                    isInitialTime: true
+                    grain: 1
+                    useDashboardTimeRange: false
+                  }
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/UsageUsersOverviewPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+            }
+          }
+          {
+            position: {
+              x: 4
+              y: 1
+              colSpan: 3
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: []
+              type: 'Extension/HubsExtension/PartType/MarkdownPart'
+              settings: {
+                content: {
+                  settings: {
+                    content: '# Reliability'
+                    title: ''
+                    subtitle: ''
+                  }
+                }
+              }
+            }
+          }
+          {
+            position: {
+              x: 7
+              y: 1
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ResourceId'
+                  value: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                }
+                {
+                  name: 'DataModel'
+                  value: {
+                    version: '1.0.0'
+                    timeContext: {
+                      durationMs: 86400000
+                      createdTime: '2018-05-04T23:42:40.072Z'
+                      isInitialTime: false
+                      grain: 1
+                      useDashboardTimeRange: false
+                    }
+                  }
+                  isOptional: true
+                }
+                {
+                  name: 'ConfigurationId'
+                  value: '8a02f7bf-ac0f-40e1-afe9-f0e72cfee77f'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/CuratedBladeFailuresPinnedPart'
+              isAdapter: true
+              asset: {
+                idInputName: 'ResourceId'
+                type: 'ApplicationInsights'
+              }
+              defaultMenuItemId: 'failures'
+            }
+          }
+          {
+            position: {
+              x: 8
+              y: 1
+              colSpan: 3
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: []
+              type: 'Extension/HubsExtension/PartType/MarkdownPart'
+              settings: {
+                content: {
+                  settings: {
+                    content: '# Responsiveness\r\n'
+                    title: ''
+                    subtitle: ''
+                  }
+                }
+              }
+            }
+          }
+          {
+            position: {
+              x: 11
+              y: 1
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ResourceId'
+                  value: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                }
+                {
+                  name: 'DataModel'
+                  value: {
+                    version: '1.0.0'
+                    timeContext: {
+                      durationMs: 86400000
+                      createdTime: '2018-05-04T23:43:37.804Z'
+                      isInitialTime: false
+                      grain: 1
+                      useDashboardTimeRange: false
+                    }
+                  }
+                  isOptional: true
+                }
+                {
+                  name: 'ConfigurationId'
+                  value: '2a8ede4f-2bee-4b9c-aed9-2db0e8a01865'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/CuratedBladePerformancePinnedPart'
+              isAdapter: true
+              asset: {
+                idInputName: 'ResourceId'
+                type: 'ApplicationInsights'
+              }
+              defaultMenuItemId: 'performance'
+            }
+          }
+          {
+            position: {
+              x: 12
+              y: 1
+              colSpan: 3
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: []
+              type: 'Extension/HubsExtension/PartType/MarkdownPart'
+              settings: {
+                content: {
+                  settings: {
+                    content: '# Browser'
+                    title: ''
+                    subtitle: ''
+                  }
+                }
+              }
+            }
+          }
+          {
+            position: {
+              x: 15
+              y: 1
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'MetricsExplorerJsonDefinitionId'
+                  value: 'BrowserPerformanceTimelineMetrics'
+                }
+                {
+                  name: 'TimeContext'
+                  value: {
+                    durationMs: 86400000
+                    createdTime: '2018-05-08T12:16:27.534Z'
+                    isInitialTime: false
+                    grain: 1
+                    useDashboardTimeRange: false
+                  }
+                }
+                {
+                  name: 'CurrentFilter'
+                  value: {
+                    eventTypes: [
+                      4
+                      1
+                      3
+                      5
+                      2
+                      6
+                      13
+                    ]
+                    typeFacets: {}
+                    isPermissive: false
+                  }
+                }
+                {
+                  name: 'id'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'Version'
+                  value: '1.0'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/MetricsExplorerBladePinnedPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+              defaultMenuItemId: 'browser'
+            }
+          }
+          {
+            position: {
+              x: 0
+              y: 2
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'sessions/count'
+                          aggregationType: 5
+                          namespace: 'microsoft.insights/components/kusto'
+                          metricVisualization: {
+                            displayName: 'Sessions'
+                            color: '#47BDF5'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'users/count'
+                          aggregationType: 5
+                          namespace: 'microsoft.insights/components/kusto'
+                          metricVisualization: {
+                            displayName: 'Users'
+                            color: '#7E58FF'
+                          }
+                        }
+                      ]
+                      title: 'Unique sessions and users'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                      openBladeOnClick: {
+                        openBlade: true
+                        destinationBlade: {
+                          extensionName: 'HubsExtension'
+                          bladeName: 'ResourceMenuBlade'
+                          parameters: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                            menuid: 'segmentationUsers'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 4
+              y: 2
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'requests/failed'
+                          aggregationType: 7
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Failed requests'
+                            color: '#EC008C'
+                          }
+                        }
+                      ]
+                      title: 'Failed requests'
+                      visualization: {
+                        chartType: 3
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                      openBladeOnClick: {
+                        openBlade: true
+                        destinationBlade: {
+                          extensionName: 'HubsExtension'
+                          bladeName: 'ResourceMenuBlade'
+                          parameters: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                            menuid: 'failures'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 8
+              y: 2
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'requests/duration'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Server response time'
+                            color: '#00BCF2'
+                          }
+                        }
+                      ]
+                      title: 'Server response time'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                      openBladeOnClick: {
+                        openBlade: true
+                        destinationBlade: {
+                          extensionName: 'HubsExtension'
+                          bladeName: 'ResourceMenuBlade'
+                          parameters: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                            menuid: 'performance'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 12
+              y: 2
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'browserTimings/networkDuration'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Page load network connect time'
+                            color: '#7E58FF'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'browserTimings/processingDuration'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Client processing time'
+                            color: '#44F1C8'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'browserTimings/sendDuration'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Send request time'
+                            color: '#EB9371'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'browserTimings/receiveDuration'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Receiving response time'
+                            color: '#0672F1'
+                          }
+                        }
+                      ]
+                      title: 'Average page load time breakdown'
+                      visualization: {
+                        chartType: 3
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 0
+              y: 5
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'availabilityResults/availabilityPercentage'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Availability'
+                            color: '#47BDF5'
+                          }
+                        }
+                      ]
+                      title: 'Average availability'
+                      visualization: {
+                        chartType: 3
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                      openBladeOnClick: {
+                        openBlade: true
+                        destinationBlade: {
+                          extensionName: 'HubsExtension'
+                          bladeName: 'ResourceMenuBlade'
+                          parameters: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                            menuid: 'availability'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 4
+              y: 5
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'exceptions/server'
+                          aggregationType: 7
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Server exceptions'
+                            color: '#47BDF5'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'dependencies/failed'
+                          aggregationType: 7
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Dependency failures'
+                            color: '#7E58FF'
+                          }
+                        }
+                      ]
+                      title: 'Server exceptions and Dependency failures'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 8
+              y: 5
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'performanceCounters/processorCpuPercentage'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Processor time'
+                            color: '#47BDF5'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'performanceCounters/processCpuPercentage'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Process CPU'
+                            color: '#7E58FF'
+                          }
+                        }
+                      ]
+                      title: 'Average processor and process CPU utilization'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 12
+              y: 5
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'exceptions/browser'
+                          aggregationType: 7
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Browser exceptions'
+                            color: '#47BDF5'
+                          }
+                        }
+                      ]
+                      title: 'Browser exceptions'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 0
+              y: 8
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'availabilityResults/count'
+                          aggregationType: 7
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Availability test results count'
+                            color: '#47BDF5'
+                          }
+                        }
+                      ]
+                      title: 'Availability test results count'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 4
+              y: 8
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'performanceCounters/processIOBytesPerSecond'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Process IO rate'
+                            color: '#47BDF5'
+                          }
+                        }
+                      ]
+                      title: 'Average process I/O rate'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 8
+              y: 8
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'performanceCounters/memoryAvailableBytes'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Available memory'
+                            color: '#47BDF5'
+                          }
+                        }
+                      ]
+                      title: 'Average available memory'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+
+resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing = {
+  name: applicationInsightsName
+}

--- a/templates/todo/projects/csharp-sql/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/csharp-sql/.repo/bicep/infra/main.bicep
@@ -24,9 +24,13 @@ param sqlServerName string = ''
 param sqlDatabaseName string = ''
 param webServiceName string = ''
 param apimServiceName string = ''
+param connectionStringKey string = 'AZURE-SQL-CONNECTION-STRING'
 
 @description('Flag to use Azure API Management to mediate the calls between the Web frontend and the backend API')
 param useAPIM bool = false
+
+// @description('API Management SKU to use if APIM is enabled')
+// param apimSku string = 'Consumption'
 
 @description('Id of the user or app to assign application roles')
 param principalId string = ''
@@ -38,10 +42,13 @@ param sqlAdminPassword string
 @secure()
 @description('Application user password')
 param appUserPassword string
-
+param appUser string = 'appUser'
+param sqlAdmin string = 'sqlAdmin'
 var abbrs = loadJsonContent('../../../../../../common/infra/bicep/abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
 var tags = { 'azd-env-name': environmentName }
+var appInsightResourceId = resourceId(subscription().subscriptionId, rg.name,
+'Microsoft.Insights/components', applicationInsights.outputs.name)
 
 // Organize resources in a resource group
 resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
@@ -51,151 +58,312 @@ resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
 }
 
 // The application frontend
-module web '../../../../../common/infra/bicep/app/web-appservice.bicep' = {
+module web 'br/public:avm/res/web/site:0.3.2' = {
   name: 'web'
   scope: rg
   params: {
+    kind: 'app'
     name: !empty(webServiceName) ? webServiceName : '${abbrs.webSitesAppService}web-${resourceToken}'
+    serverFarmResourceId: appServicePlan.outputs.resourceId
+    tags: union(tags, { 'azd-service-name': 'web' })
     location: location
-    tags: tags
-    applicationInsightsName: monitoring.outputs.applicationInsightsName
-    appServicePlanId: appServicePlan.outputs.id
+    appInsightResourceId: appInsightResourceId
+    siteConfig: {
+      appCommandLine: './entrypoint.sh -o ./env-config.js && pm2 serve /home/site/wwwroot --no-daemon --spa'
+      linuxFxVersion: 'node|18-lts'
+      alwaysOn: true
+    }
   }
 }
 
-module webAppSettings '../../../../../../common/infra/bicep/core/host/appservice-appsettings.bicep' = {
+// Set environment variables for the frontend
+module webAppSettings 'br/public:avm/res/web/site:0.2.0' = {
   name: 'web-appsettings'
   scope: rg
   params: {
-    name: web.outputs.SERVICE_WEB_NAME
-    appSettings: {
-      REACT_APP_API_BASE_URL: useAPIM ? apimApi.outputs.SERVICE_API_URI : api.outputs.SERVICE_API_URI
-      REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING: monitoring.outputs.applicationInsightsConnectionString
+    kind: 'app'
+    name: web.outputs.name
+    serverFarmResourceId: appServicePlan.outputs.resourceId
+    tags: union(tags, { 'azd-service-name': 'web' })
+    appSettingsKeyValuePairs: {
+      REACT_APP_API_BASE_URL: useAPIM ? 'https://${apim.outputs.name}.azure-api.net/todo' : 'https://${api.outputs.defaultHostname}'
+      REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.outputs.connectionString
     }
   }
 }
 
 // The application backend
-module api '../../../../../common/infra/bicep/app/api-appservice-dotnet.bicep' = {
+module api 'br/public:avm/res/web/site:0.2.0' = {
   name: 'api'
   scope: rg
   params: {
+    kind: 'app'
     name: !empty(apiServiceName) ? apiServiceName : '${abbrs.webSitesAppService}api-${resourceToken}'
+    serverFarmResourceId: appServicePlan.outputs.resourceId
+    tags: union(tags, { 'azd-service-name': 'api' })
     location: location
-    tags: tags
-    applicationInsightsName: monitoring.outputs.applicationInsightsName
-    appServicePlanId: appServicePlan.outputs.id
-    keyVaultName: keyVault.outputs.name
-    allowedOrigins: [ web.outputs.SERVICE_WEB_URI ]
-    appSettings: {
-      AZURE_SQL_CONNECTION_STRING_KEY: sqlServer.outputs.connectionStringKey
+    appInsightResourceId: appInsightResourceId
+    managedIdentities: {
+      systemAssigned: true
+    }
+    siteConfig: {
+      cors: {
+        allowedOrigins: [ 'https://portal.azure.com', 'https://ms.portal.azure.com' ,'https://${web.outputs.defaultHostname}' ]
+      }
+      linuxFxVersion: 'dotnetcore|8.0'
+      alwaysOn: true
+      appCommandLine: ''
+    }
+    appSettingsKeyValuePairs: {
+      AZURE_SQL_CONNECTION_STRING_KEY: connectionStringKey
+      AZURE_KEY_VAULT_ENDPOINT: keyVault.outputs.uri
+      SCM_DO_BUILD_DURING_DEPLOYMENT: 'False'
+      ENABLE_ORYX_BUILD: 'True'
     }
   }
 }
 
 // Give the API access to KeyVault
-module apiKeyVaultAccess '../../../../../../common/infra/bicep/core/security/keyvault-access.bicep' = {
-  name: 'api-keyvault-access'
+module accessKeyVault 'br/public:avm/res/key-vault/vault:0.3.5' = {
+  name: 'accesskeyvault'
   scope: rg
   params: {
-    keyVaultName: keyVault.outputs.name
-    principalId: api.outputs.SERVICE_API_IDENTITY_PRINCIPAL_ID
-  }
-}
-
-// The application database
-module sqlServer '../../../../../common/infra/bicep/app/sqlserver.bicep' = {
-  name: 'sql'
-  scope: rg
-  params: {
-    name: !empty(sqlServerName) ? sqlServerName : '${abbrs.sqlServers}${resourceToken}'
-    databaseName: sqlDatabaseName
-    location: location
-    tags: tags
-    sqlAdminPassword: sqlAdminPassword
-    appUserPassword: appUserPassword
-    keyVaultName: keyVault.outputs.name
-  }
-}
-
-// Create an App Service Plan to group applications under the same payment plan and SKU
-module appServicePlan '../../../../../../common/infra/bicep/core/host/appserviceplan.bicep' = {
-  name: 'appserviceplan'
-  scope: rg
-  params: {
-    name: !empty(appServicePlanName) ? appServicePlanName : '${abbrs.webServerFarms}${resourceToken}'
-    location: location
-    tags: tags
-    sku: {
-      name: 'B1'
+    name: keyVault.outputs.name
+    enableRbacAuthorization: false
+    accessPolicies: [
+      {
+        objectId: principalId
+        permissions: {
+          secrets: [ 'get', 'list' ]
+        }
+      }
+      {
+        objectId: api.outputs.systemAssignedMIPrincipalId
+        permissions: {
+          secrets: [ 'get', 'list' ]
+        }
+      }
+    ]
+    secrets:{
+      secureList: [
+        {
+          name: 'sqlAdmin'
+          value: sqlAdminPassword
+        }
+        {
+          name: 'appUser'
+          value: appUserPassword 
+        }
+        {
+          name: connectionStringKey
+          value: 'Server=${sqlService.outputs.name}${environment().suffixes.sqlServerHostname}; Database=${!empty(sqlDatabaseName) ? sqlDatabaseName : 'Todo'}; User=${appUser}; Password=${appUserPassword}'
+        }
+      ]
     }
   }
 }
 
-// Store secrets in a keyvault
-module keyVault '../../../../../../common/infra/bicep/core/security/keyvault.bicep' = {
+// The application database
+module sqlService 'br/public:avm/res/sql/server:0.2.0' = {
+  name: 'sqlservice'
+  scope: rg
+  params: {
+    name: !empty(sqlServerName) ? sqlServerName : '${abbrs.sqlServers}${resourceToken}'
+    administratorLogin: sqlAdmin
+    administratorLoginPassword: sqlAdminPassword
+    location: location
+    tags: tags
+    publicNetworkAccess: 'Enabled'
+    databases: [
+      {
+        name: !empty(sqlDatabaseName) ? sqlDatabaseName : 'Todo'
+      }
+    ]
+    firewallRules:[
+      {
+        name: 'Azure Services'
+        startIpAddress: '0.0.0.1'
+        endIpAddress: '255.255.255.254'
+      }
+    ]
+  }
+}
+
+module deploymentScript 'br/public:avm/res/resources/deployment-script:0.1.3' = {
+  name: 'deployment-script'
+  scope: rg
+  params: {
+    kind: 'AzureCLI'
+    name: 'deployment-script'
+    azCliVersion: '2.37.0'
+    location: location
+    retentionInterval: 'PT1H'
+    timeout: 'PT5M'
+    cleanupPreference: 'OnSuccess'
+    environmentVariables:{
+      secureList: [
+        {
+          name: 'APPUSERNAME'
+          value: appUser
+        }
+        {
+          name: 'APPUSERPASSWORD'
+          secureValue: appUserPassword
+        }
+        {
+          name: 'DBNAME'
+          value: !empty(sqlDatabaseName) ? sqlDatabaseName : 'Todo'
+        }
+        {
+          name: 'DBSERVER'
+          value: '${sqlService.outputs.name}${environment().suffixes.sqlServerHostname}'
+        }
+        {
+          name: 'SQLCMDPASSWORD'
+          secureValue: sqlAdminPassword
+        }
+        {
+          name: 'SQLADMIN'
+          value: sqlAdmin
+        }
+      ]
+    }
+    scriptContent: '''
+wget https://github.com/microsoft/go-sqlcmd/releases/download/v0.8.1/sqlcmd-v0.8.1-linux-x64.tar.bz2
+tar x -f sqlcmd-v0.8.1-linux-x64.tar.bz2 -C .
+
+cat <<SCRIPT_END > ./initDb.sql
+drop user if exists ${APPUSERNAME}
+go
+create user ${APPUSERNAME} with password = '${APPUSERPASSWORD}'
+go
+alter role db_owner add member ${APPUSERNAME}
+go
+SCRIPT_END
+
+./sqlcmd -S ${DBSERVER} -d ${DBNAME} -U ${SQLADMIN} -i ./initDb.sql
+    '''
+  }
+}
+
+// Create an App Service Plan to group applications under the same payment plan and SKU
+module appServicePlan 'br/public:avm/res/web/serverfarm:0.1.0' = {
+  name: 'appserviceplan'
+  scope: rg
+  params: {
+    name: !empty(appServicePlanName) ? appServicePlanName : '${abbrs.webServerFarms}${resourceToken}'
+    sku: {
+      capacity: 1
+      family: 'B'
+      name: 'B1'
+      size: 'B1'
+      tier: 'Basic'
+    }
+    location: location
+    tags: tags
+    reserved: true
+    kind: 'Linux'
+  }
+}
+
+// // Store secrets in a keyvault
+module keyVault 'br/public:avm/res/key-vault/vault:0.3.5' = {
   name: 'keyvault'
   scope: rg
   params: {
     name: !empty(keyVaultName) ? keyVaultName : '${abbrs.keyVaultVaults}${resourceToken}'
     location: location
     tags: tags
-    principalId: principalId
+    enableRbacAuthorization: false
   }
 }
 
-// Monitor application with Azure Monitor
-module monitoring '../../../../../../common/infra/bicep/core/monitor/monitoring.bicep' = {
-  name: 'monitoring'
+// Monitor application with Azure loganalytics
+module loganalytics 'br/public:avm/res/operational-insights/workspace:0.3.4' = {
+  name: 'loganalytics'
   scope: rg
   params: {
+    name: !empty(logAnalyticsName) ? logAnalyticsName : '${abbrs.operationalInsightsWorkspaces}${resourceToken}'
     location: location
-    tags: tags
-    logAnalyticsName: !empty(logAnalyticsName) ? logAnalyticsName : '${abbrs.operationalInsightsWorkspaces}${resourceToken}'
-    applicationInsightsName: !empty(applicationInsightsName) ? applicationInsightsName : '${abbrs.insightsComponents}${resourceToken}'
-    applicationInsightsDashboardName: !empty(applicationInsightsDashboardName) ? applicationInsightsDashboardName : '${abbrs.portalDashboards}${resourceToken}'
+  }
+}
+
+// Monitor application with Azure applicationInsights
+module applicationInsights 'br/public:avm/res/insights/component:0.3.0' = {
+  name: 'applicationInsights'
+  scope: rg
+  params: {
+    name: !empty(applicationInsightsName) ? applicationInsightsName : '${abbrs.insightsComponents}${resourceToken}'
+    workspaceResourceId: loganalytics.outputs.resourceId
+    location: location
+  }
+}
+
+// Monitor application with Azure applicationInsightsDashboard
+module applicationInsightsDashboard '../../../../../common/infra/bicep/app/applicationinsights-dashboard.bicep' = {
+  name: 'application-insights-dashboard'
+  scope: rg
+  params: {
+    name: !empty(applicationInsightsDashboardName) ? applicationInsightsDashboardName : '${abbrs.portalDashboards}${resourceToken}'
+    location: location
+    applicationInsightsName: applicationInsights.outputs.name
   }
 }
 
 // Creates Azure API Management (APIM) service to mediate the requests between the frontend and the backend API
-module apim '../../../../../../common/infra/bicep/core/gateway/apim.bicep' = if (useAPIM) {
+module apim 'br/public:avm/res/api-management/service:0.1.3' = if (useAPIM) {
   name: 'apim-deployment'
   scope: rg
   params: {
     name: !empty(apimServiceName) ? apimServiceName : '${abbrs.apiManagementService}${resourceToken}'
+    publisherEmail: 'noreply@microsoft.com'
+    publisherName: 'n/a'
     location: location
     tags: tags
-    applicationInsightsName: monitoring.outputs.applicationInsightsName
+    apis: [
+      {
+        name: 'todo-api'
+        path: 'todo'
+        displayName: 'Simple Todo API'
+        apiDescription: 'This is a simple Todo API'
+        serviceUrl: 'https://${api.outputs.defaultHostname}'
+        subscriptionRequired: false
+        value: loadTextContent('../../../../../api/common/openapi.yaml')
+        policies: [
+          {
+            value: replace(loadTextContent('../../../../../../common/infra/shared/gateway/apim/apim-api-policy.xml'), '{origin}', 'https://${web.outputs.defaultHostname}')
+            format: 'rawxml'
+          }
+        ]
+      }
+    ]
   }
 }
 
 // Configures the API in the Azure API Management (APIM) service
-module apimApi '../../../../../common/infra/bicep/app/apim-api.bicep' = if (useAPIM) {
-  name: 'apim-api-deployment'
+module apimsettings '../../../../../common/infra/bicep/app/apim-api-settings.bicep' = if (useAPIM) {
   scope: rg
+  name: 'apim-api-settings'
   params: {
-    name: useAPIM ? apim.outputs.apimServiceName : ''
+    apiAppName: api.outputs.name
     apiName: 'todo-api'
-    apiDisplayName: 'Simple Todo API'
-    apiDescription: 'This is a simple Todo API'
+    name: useAPIM ? apim.outputs.name : ''
     apiPath: 'todo'
-    webFrontendUrl: web.outputs.SERVICE_WEB_URI
-    apiBackendUrl: api.outputs.SERVICE_API_URI
-    apiAppName: api.outputs.SERVICE_API_NAME
+    applicationInsightsName: applicationInsights.outputs.name
   }
 }
 
 // Data outputs
-output AZURE_SQL_CONNECTION_STRING_KEY string = sqlServer.outputs.connectionStringKey
+output AZURE_SQL_CONNECTION_STRING_KEY string = connectionStringKey
 
 // App outputs
-output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.applicationInsightsConnectionString
-output AZURE_KEY_VAULT_ENDPOINT string = keyVault.outputs.endpoint
+output APPLICATIONINSIGHTS_CONNECTION_STRING string = applicationInsights.outputs.connectionString
+output AZURE_KEY_VAULT_ENDPOINT string = keyVault.outputs.uri
 output AZURE_KEY_VAULT_NAME string = keyVault.outputs.name
 output AZURE_LOCATION string = location
 output AZURE_TENANT_ID string = tenant().tenantId
-output REACT_APP_API_BASE_URL string = useAPIM ? apimApi.outputs.SERVICE_API_URI : api.outputs.SERVICE_API_URI
-output REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.applicationInsightsConnectionString
-output REACT_APP_WEB_BASE_URL string = web.outputs.SERVICE_WEB_URI
+output REACT_APP_API_BASE_URL string = useAPIM ? 'https://${apim.outputs.name}.azure-api.net/todo' : 'https://${api.outputs.defaultHostname}'
+output REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING string = applicationInsights.outputs.connectionString
+output REACT_APP_WEB_BASE_URL string = 'https://${web.outputs.defaultHostname}'
 output USE_APIM bool = useAPIM
-output SERVICE_API_ENDPOINTS array = useAPIM ? [ apimApi.outputs.SERVICE_API_URI, api.outputs.SERVICE_API_URI ]: []
+output SERVICE_API_ENDPOINTS array = useAPIM ? [ 'https://${apim.outputs.name}.azure-api.net/todo', 'https://${api.outputs.defaultHostname}' ]: []

--- a/templates/todo/projects/csharp-sql/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/csharp-sql/.repo/bicep/repo.yaml
@@ -81,6 +81,16 @@ repo:
         patterns:
           - "apim-api.bicep"
 
+      - from: ../../../api/common/openapi.yaml
+        to: ../src/api/wwwroot/openapi.yaml
+        patterns:
+          - "**/main.bicep"
+
+      - from: ../../../common/infra/shared/gateway/apim/apim-api-policy.xml
+        to: ./app/apim-api-policy.xml
+        patterns:
+          - "**/main.bicep"
+
   assets:
     # Common assets
 
@@ -105,6 +115,12 @@ repo:
 
     - from: ../../../../common/infra/bicep/app/sqlserver.bicep
       to: ./infra/app/db.bicep
+
+    - from: ../../../../common/infra/bicep/app/applicationinsights-dashboard.bicep
+      to: ./infra/app/applicationinsights-dashboard.bicep
+
+    - from: ../../../../common/infra/bicep/app/apim-api-settings.bicep
+      to: ./infra/app/apim-api-settings.bicep
 
     - from: ./../../
       to: ./


### PR DESCRIPTION
Update the infra/core modules to AVM modules for `todo-csharp-sql`.

**1. Modules not replaced by AVM**
- **Monitoring (app insights)** : Missing the feature `Microsoft.Portal/dashboards`.
AVM issue link: https://github.com/Azure/bicep-registry-modules/issues/1130
- **APIM**: Missing features `Microsoft.ApiManagement/service/loggers` and `Microsoft.ApiManagement/service/apis/diagnostics`.
AVM issue link: https://github.com/Azure/bicep-registry-modules/issues/1124

**2. Modules replaced by AVM**

- **App Service**
- **Key Vault**
- **App Service Plan**
- **SqlService**

@jongio for notification.