### PR TITLE
Additional Known Parameters for Aspire Bicep files

### DIFF
--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -653,16 +653,20 @@ func (b *infraGenerator) addBicep(name string, comp *Resource) error {
 }
 
 const (
-	knownParameterKeyVault      string = "keyVaultName"
-	knownParameterPrincipalId   string = "principalId"
-	knownParameterPrincipalType string = "principalType"
-	knownParameterPrincipalName string = "principalName"
-	knownParameterLogAnalytics  string = "logAnalyticsWorkspaceId"
+	knownParameterKeyVault        string = "keyVaultName"
+	knownParameterPrincipalId     string = "principalId"
+	knownParameterPrincipalType   string = "principalType"
+	knownParameterPrincipalName   string = "principalName"
+	knownParameterLogAnalytics    string = "logAnalyticsWorkspaceId"
+	knownParameterTags            string = "tags"
+	knownParameterEnvironmentName string = "environmentName"
 
-	knownInjectedValuePrincipalId   string = "resources.outputs.MANAGED_IDENTITY_PRINCIPAL_ID"
-	knownInjectedValuePrincipalType string = "'ServicePrincipal'"
-	knownInjectedValuePrincipalName string = "resources.outputs.MANAGED_IDENTITY_NAME"
-	knownInjectedValueLogAnalytics  string = "resources.outputs.AZURE_LOG_ANALYTICS_WORKSPACE_ID"
+	knownInjectedValuePrincipalId     string = "resources.outputs.MANAGED_IDENTITY_PRINCIPAL_ID"
+	knownInjectedValuePrincipalType   string = "'ServicePrincipal'"
+	knownInjectedValuePrincipalName   string = "resources.outputs.MANAGED_IDENTITY_NAME"
+	knownInjectedValueLogAnalytics    string = "resources.outputs.AZURE_LOG_ANALYTICS_WORKSPACE_ID"
+	knownInjectedValueTags            string = "tags"
+	knownInjectedValueEnvironmentName string = "environmentName"
 )
 
 // injectValueForBicepParameter checks for aspire-manifest and azd conventions rules for auto injecting values for
@@ -701,6 +705,12 @@ func injectValueForBicepParameter(resourceName, p string, parameter any) (string
 	}
 	if p == knownParameterLogAnalytics {
 		return knownInjectedValueLogAnalytics, true, nil
+	}
+	if p == knownParameterTags {
+		return knownInjectedValueTags, true, nil
+	}
+	if p == knownParameterEnvironmentName {
+		return knownInjectedValueEnvironmentName, true, nil
 	}
 	return finalParamValue, false, nil
 }

--- a/cli/azd/pkg/apphost/generate_test.go
+++ b/cli/azd/pkg/apphost/generate_test.go
@@ -419,6 +419,38 @@ func TestInjectValueForBicepParameter(t *testing.T) {
 	require.Equal(t, expectedParameter, value)
 	require.True(t, inject)
 
+	param = knownParameterEnvironmentName
+	expectedParameter = `"exampleParameter"`
+
+	value, inject, err = injectValueForBicepParameter(resourceName, param, "exampleParameter")
+	require.NoError(t, err)
+	require.Equal(t, expectedParameter, value)
+	require.False(t, inject)
+
+	param = knownParameterEnvironmentName
+	expectedParameter = knownInjectedValueEnvironmentName
+
+	value, inject, err = injectValueForBicepParameter(resourceName, param, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedParameter, value)
+	require.True(t, inject)
+
+	param = knownParameterTags
+	expectedParameter = `"exampleParameter"`
+
+	value, inject, err = injectValueForBicepParameter(resourceName, param, "exampleParameter")
+	require.NoError(t, err)
+	require.Equal(t, expectedParameter, value)
+	require.False(t, inject)
+
+	param = knownParameterTags
+	expectedParameter = knownInjectedValueTags
+
+	value, inject, err = injectValueForBicepParameter(resourceName, param, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedParameter, value)
+	require.True(t, inject)
+
 	param = knownParameterLogAnalytics
 	expectedParameter = `"exampleParameter"`
 

--- a/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-main.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-main.bicep.snap
@@ -86,6 +86,8 @@ module test 'test/test.bicep' = {
   scope: rg
   params: {
     location: location
+    environmentName: environmentName
+    tags: tags
     test: parameter
     values: ['one','two']
   }

--- a/cli/azd/pkg/apphost/testdata/aspire-bicep.json
+++ b/cli/azd/pkg/apphost/testdata/aspire-bicep.json
@@ -16,7 +16,9 @@
           "values": [
             "one",
             "two"
-          ]
+          ],
+          "tags": "",
+          "environmentName": ""
         }
       },
       "administrator-login": {


### PR DESCRIPTION
This is a mini change to allow the use of 2 additional known parameters from Aspire's Bicep tool which adds some more flexibility to custom Bicep:

- environmentName
- tags

When using infra synth the output expected is:

```
module customresource 'my-custom-bicep/custom.bicep' = {
  name: 'customresource'
  scope: rg
  params: {
    location: location
    environmentName: environmentName
    principalId: resources.outputs.MANAGED_IDENTITY_PRINCIPAL_ID
    tags: tags
  }
}
```

This allows us to use the environment name in automated deployments between test/live given the lack of support within azd currently. See https://github.com/Azure/azure-dev/discussions/3184 for more info on that discussion.

Note: I haven't added this to Aspire's KnownParameters as some new CDK is supposedly changing how that works, but I'm assuming that it will stay relatively similar on the azd side.