### PR TITLE
Extend Resource Type Validation to Include Container App Jobs

### DIFF
--- a/cli/azd/pkg/infra/azure_resource_types.go
+++ b/cli/azd/pkg/infra/azure_resource_types.go
@@ -15,6 +15,7 @@ const (
 	AzureResourceTypeCDNProfile              AzureResourceType = "Microsoft.Cdn/profiles"
 	AzureResourceTypeCosmosDb                AzureResourceType = "Microsoft.DocumentDB/databaseAccounts"
 	AzureResourceTypeContainerApp            AzureResourceType = "Microsoft.App/containerApps"
+	AzureResourceTypeContainerAppJob         AzureResourceType = "Microsoft.App/jobs"
 	AzureResourceTypeSpringApp               AzureResourceType = "Microsoft.AppPlatform/Spring"
 	AzureResourceTypeContainerAppEnvironment AzureResourceType = "Microsoft.App/managedEnvironments"
 	AzureResourceTypeDeployment              AzureResourceType = "Microsoft.Resources/deployments"
@@ -72,6 +73,8 @@ func GetResourceTypeDisplayName(resourceType AzureResourceType) string {
 		return "Static Web App"
 	case AzureResourceTypeContainerApp:
 		return "Container App"
+	case AzureResourceTypeContainerAppJob:
+		return "Container App Job"
 	case AzureResourceTypeContainerAppEnvironment:
 		return "Container Apps Environment"
 	case AzureResourceTypeServiceBusNamespace:

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -163,10 +163,13 @@ func (at *containerAppTarget) validateTargetResource(
 	}
 
 	if targetResource.ResourceType() != "" {
-		if err := checkResourceType(targetResource, infra.AzureResourceTypeContainerApp); err != nil {
-			return err
-		}
-	}
+        // Check if the resource type is either AzureResourceTypeContainerApp or AzureResourceTypeContainerAppJob
+        if err := checkResourceType(targetResource, infra.AzureResourceTypeContainerApp); err != nil {
+            if err := checkResourceType(targetResource, infra.AzureResourceTypeContainerAppJob); err != nil {
+                return err
+            }
+        }
+    }
 
 	return nil
 }

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -163,13 +163,13 @@ func (at *containerAppTarget) validateTargetResource(
 	}
 
 	if targetResource.ResourceType() != "" {
-        // Check if the resource type is either AzureResourceTypeContainerApp or AzureResourceTypeContainerAppJob
-        if err := checkResourceType(targetResource, infra.AzureResourceTypeContainerApp); err != nil {
-            if err := checkResourceType(targetResource, infra.AzureResourceTypeContainerAppJob); err != nil {
-                return err
-            }
-        }
-    }
+		// Check if the resource type is either AzureResourceTypeContainerApp or AzureResourceTypeContainerAppJob
+		if err := checkResourceType(targetResource, infra.AzureResourceTypeContainerApp); err != nil {
+			if err := checkResourceType(targetResource, infra.AzureResourceTypeContainerAppJob); err != nil {
+				return err
+			}
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Overview
This pull request enhances the validation logic within the `validateTargetResource` function of the container app deployment process. Previously, our validation was limited to `AzureResourceTypeContainerApp` resource types. We've now expanded this to also include `AzureResourceTypeContainerAppJob`, catering to scenarios involving both container apps and container app jobs within Azure.

re: #2743 

## Changes
- Modified the `validateTargetResource` function to check for `AzureResourceTypeContainerAppJob` in addition to the existing `AzureResourceTypeContainerApp`.
- Implemented a nested conditional check within the resource type validation to ensure either of the resource types is correctly identified and validated without changing the function signature of `checkResourceType`.

## Impact
This update ensures our deployment tooling can accurately validate target resources for both container apps and container app jobs, enhancing its flexibility and coverage. It's a crucial step towards supporting a wider array of Azure resources, thereby improving our automation capabilities in cloud environments.

## Testing
- TODO: Updated unit tests to cover the new logic introduced for resource type validation.
- TODO: Conducted integration testing with both resource types to ensure the validation behaves as expected without introducing regressions.

Please review the changes and provide your feedback.
