### PR TITLE
Add support for custom User Assigned Identities against Aspire Projects

### DIFF
--- a/cli/azd/pkg/apphost/generate_types.go
+++ b/cli/azd/pkg/apphost/generate_types.go
@@ -76,6 +76,7 @@ type genProject struct {
 	Path     string
 	Env      map[string]string
 	Bindings custommaps.WithOrder[Binding]
+	UserAssignedIdentities []UserAssignedIdentity
 }
 
 type genAppConfig struct{}
@@ -147,12 +148,13 @@ type genBicepTemplateContext struct {
 }
 
 type genContainerAppManifestTemplateContext struct {
-	Name            string
-	Ingress         *genContainerAppIngress
-	Env             map[string]string
-	Secrets         map[string]string
-	KeyVaultSecrets map[string]string
-	Dapr            *genContainerAppManifestTemplateContextDapr
+	Name                   string
+	Ingress                *genContainerAppIngress
+	Env                    map[string]string
+	Secrets                map[string]string
+	KeyVaultSecrets        map[string]string
+	UserAssignedIdentities []*UserAssignedIdentity
+	Dapr                   *genContainerAppManifestTemplateContextDapr
 }
 
 type genProjectFileContext struct {

--- a/cli/azd/pkg/apphost/manifest.go
+++ b/cli/azd/pkg/apphost/manifest.go
@@ -77,6 +77,9 @@ type Resource struct {
 	// For a bicep.v0 resource, defines the input parameters for the bicep file.
 	Params map[string]any `json:"params,omitempty"`
 
+	// UserAssignedIdentities is optionally present on a project.v0 resource.
+	UserAssignedIdentities []UserAssignedIdentity `json:userAssignedIdentities,omitempty`
+
 	// parameter.v0 uses value field to define the value of the parameter.
 	Value string
 
@@ -109,6 +112,12 @@ type Binding struct {
 	Protocol   string `json:"protocol"`
 	Transport  string `json:"transport"`
 	External   bool   `json:"external"`
+}
+
+type UserAssignedIdentity struct {
+	EnvPrefix  string `json:"env"`
+	ClientId   string `json:"clientId"`
+	ResourceId string `json:"resourceId"`
 }
 
 type Volume struct {

--- a/cli/azd/pkg/apphost/testdata/TestAspireProjectUserAssignedIdentities-api.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireProjectUserAssignedIdentities-api.snap
@@ -1,0 +1,41 @@
+location: {{ .Env.AZURE_LOCATION }}
+identity:
+  type: UserAssigned
+  userAssignedIdentities:
+    /subscriptions/<subscription_id>/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-user: {}
+    '{{ .Env.IDENTITIES_RESOURCEID }}': {}
+    ? "{{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}"
+    : {}
+properties:
+  environmentId: {{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_ID }}
+  configuration:
+    activeRevisionsMode: single
+    ingress:
+      external: false
+      targetPort: {{ .TargetPort }}
+      transport: http
+      allowInsecure: true
+    registries:
+    - server: {{ .Env.AZURE_CONTAINER_REGISTRY_ENDPOINT }}
+      identity: {{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}
+  template:
+    containers:
+    - image: {{ .Image }}
+      name: api
+      env:
+      - name: AZURE_CLIENT_ID
+        value: {{ .Env.MANAGED_IDENTITY_CLIENT_ID }}
+      - name: OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES
+        value: "true"
+      - name: OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES
+        value: "true"
+      - name: TEST2_CLIENT_ID
+        value: '{{ .Env.IDENTITIES_CLIENTID }}'
+      - name: TEST_CLIENT_ID
+        value: 00000000-0000-0000-0000-000000000000
+    scale:
+      minReplicas: 1
+tags:
+  azd-service-name: api
+  aspire-resource-name: api
+

--- a/cli/azd/pkg/apphost/testdata/TestAspireProjectUserAssignedIdentities-api.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireProjectUserAssignedIdentities-api.snap
@@ -12,7 +12,7 @@ properties:
     activeRevisionsMode: single
     ingress:
       external: false
-      targetPort: {{ .TargetPort }}
+      targetPort: {{ targetPortOrDefault 8080 }}
       transport: http
       allowInsecure: true
     registries:

--- a/cli/azd/pkg/apphost/testdata/TestAspireProjectUserAssignedIdentities-main.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireProjectUserAssignedIdentities-main.bicep.snap
@@ -1,0 +1,48 @@
+targetScope = 'subscription'
+
+@minLength(1)
+@maxLength(64)
+@description('Name of the environment that can be used as part of naming resource convention, the name of the resource group for your application will use this name, prefixed with rg-')
+param environmentName string
+
+@minLength(1)
+@description('The location used for all deployed resources')
+param location string
+
+
+var tags = {
+  'azd-env-name': environmentName
+}
+
+resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module resources 'resources.bicep' = {
+  scope: rg
+  name: 'resources'
+  params: {
+    location: location
+    tags: tags
+  }
+}
+
+module identities 'identities/test.bicep' = {
+  name: 'identities'
+  scope: rg
+  params: {
+    location: location
+  }
+}
+output MANAGED_IDENTITY_CLIENT_ID string = resources.outputs.MANAGED_IDENTITY_CLIENT_ID
+output MANAGED_IDENTITY_NAME string = resources.outputs.MANAGED_IDENTITY_NAME
+output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = resources.outputs.AZURE_LOG_ANALYTICS_WORKSPACE_NAME
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = resources.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = resources.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = resources.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = resources.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN
+
+output IDENTITIES_CLIENTID string = identities.outputs.clientId
+output IDENTITIES_RESOURCEID string = identities.outputs.resourceId

--- a/cli/azd/pkg/apphost/testdata/aspire-project-uai.json
+++ b/cli/azd/pkg/apphost/testdata/aspire-project-uai.json
@@ -1,0 +1,40 @@
+{
+  "resources": {
+    "identities": {
+      "type": "azure.bicep.v0",
+      "path": "test.bicep"
+    },
+    "api": {
+      "type": "project.v0",
+      "path": "..\\MyBlog.Api\\MyBlog.Api.csproj",
+      "env": {
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true"
+      },
+      "bindings": {
+        "http": {
+          "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http"
+        },
+        "https": {
+          "scheme": "https",
+          "protocol": "tcp",
+          "transport": "http"
+        }
+      },
+      "userAssignedIdentities": [
+        {
+          "clientId": "00000000-0000-0000-0000-000000000000",
+          "resourceId": "/subscriptions/\u003Csubscription_id\u003E/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-user",
+          "env": "TEST"
+        },
+        {
+          "clientId": "{identities.outputs.clientId}",
+          "resourceId": "{identities.outputs.resourceId}",
+          "env": "TEST2"
+        }
+      ]
+    }
+  }
+}

--- a/cli/azd/resources/apphost/templates/containerApp.tmpl.yamlt
+++ b/cli/azd/resources/apphost/templates/containerApp.tmpl.yamlt
@@ -3,6 +3,11 @@ location: {{ "{{ .Env.AZURE_LOCATION }}" }}
 identity:
   type: UserAssigned
   userAssignedIdentities:
+{{- if (gt (len .UserAssignedIdentities) 0) }}
+{{- range $name, $value := .UserAssignedIdentities }}
+    {{ $value.ResourceId }}: {}
+{{- end}}
+{{- end}}
     ? {{ `"{{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}"` }}
     : {}
 properties:


### PR DESCRIPTION
See https://github.com/dotnet/aspire/pull/3339  for more information.

This change adds support to azd to consume a new `userAssignedIdentities` property in the Aspire manifest.

An example being:
```json
"userAssignedIdentities": [
  {
    "clientId": "00000000-0000-0000-0000-000000000000",
    "resourceId": "/subscriptions/\u003Csubscription_id\u003E/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-user",
    "env": "TEST"
  },
  {
    "clientId": "{identities.outputs.clientId}",
    "resourceId": "{identities.outputs.resourceId}",
    "env": "TEST2"
  }
]
```

The change adds support for:
1. Detection of template strings within this new property
2. The generation of environment variables to support the Client IDs
3. The addition of the userAssignedIdentities in the container's yaml