### PR TITLE
skip test

### DIFF
--- a/cli/azd/test/functional/aspire_test.go
+++ b/cli/azd/test/functional/aspire_test.go
@@ -224,6 +224,7 @@ func Test_CLI_Aspire_DetectGen(t *testing.T) {
 
 // Test_CLI_Aspire_Deploy tests the full deployment of an Aspire project.
 func Test_CLI_Aspire_Deploy(t *testing.T) {
+	t.Skip("depends on new aspire release")
 	if cfg.CI && os.Getenv("AZURE_RECORD_MODE") != "live" {
 		t.Skip("skipping live test")
 	}


### PR DESCRIPTION
Can't test p5 yet. So skipping the test for now.
We could also switch to Aspire daily, but it could bring other issues, as that would target p6.
We could switch to P5 branch directly, but that would need to change as soon as p5 is released.

So, I am proposing to skip the p5 tests after p5 is released, then we update test cases for p5 to ensure we don't break it