### PR TITLE
Remove `azcore.TokenCredential` from DI graph.

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/cmd/middleware"
@@ -488,13 +487,6 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 			BuildArmClientOptions()
 	})
 
-	container.MustRegisterSingleton(func(
-		credential azcore.TokenCredential,
-		armClientOptions *arm.ClientOptions,
-	) (*armresourcegraph.Client, error) {
-		return armresourcegraph.NewClient(credential, armClientOptions)
-	})
-
 	container.MustRegisterSingleton(templates.NewTemplateManager)
 	container.MustRegisterSingleton(templates.NewSourceManager)
 	container.MustRegisterScoped(project.NewResourceManager)
@@ -553,10 +545,6 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 
 	container.MustRegisterSingleton(func(subManager *account.SubscriptionsManager) account.SubscriptionTenantResolver {
 		return subManager
-	})
-
-	container.MustRegisterScoped(func(ctx context.Context, authManager *auth.Manager) (azcore.TokenCredential, error) {
-		return authManager.CredentialForCurrentUser(ctx, nil)
 	})
 
 	// Tools

--- a/cli/azd/internal/vsrpc/debug_service.go
+++ b/cli/azd/internal/vsrpc/debug_service.go
@@ -80,7 +80,7 @@ func (s *debugService) FetchTokenAsync(ctx context.Context, sessionId Session) (
 	}
 
 	var c struct {
-		cred azcore.TokenCredential `container:"type"`
+		credProvider auth.MultiTenantCredentialProvider `container:"type"`
 	}
 
 	container, err := session.newContainer()
@@ -92,7 +92,12 @@ func (s *debugService) FetchTokenAsync(ctx context.Context, sessionId Session) (
 		return azcore.AccessToken{}, err
 	}
 
-	return c.cred.GetToken(ctx, policy.TokenRequestOptions{
+	cred, err := c.credProvider.GetTokenCredential(ctx, "")
+	if err != nil {
+		return azcore.AccessToken{}, err
+	}
+
+	return cred.GetToken(ctx, policy.TokenRequestOptions{
 		Scopes: auth.LoginScopes(cloud.AzurePublic()),
 	})
 }

--- a/cli/azd/pkg/auth/credential_providers.go
+++ b/cli/azd/pkg/auth/credential_providers.go
@@ -10,7 +10,6 @@ import (
 // MultiTenantCredentialProvider provides token credentials for different tenants.
 //
 // Only use this if you need to perform multi-tenant operations.
-// A default azcore.TokenCredential is registered in application that is scoped to the correct environment tenant.
 type MultiTenantCredentialProvider interface {
 	// Gets an authenticated token credential for the given tenant. If tenantId is empty, uses the default home tenant.
 	GetTokenCredential(ctx context.Context, tenantId string) (azcore.TokenCredential, error)

--- a/cli/azd/pkg/azsdk/storage/storage_blob_client.go
+++ b/cli/azd/pkg/azsdk/storage/storage_blob_client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
 )
 
@@ -164,7 +165,7 @@ func (bc *blobClient) ensureContainerExists(ctx context.Context) error {
 
 // createClient creates a new blob client and caches it for future use
 func NewBlobSdkClient(
-	credential azcore.TokenCredential,
+	credentialProvider auth.MultiTenantCredentialProvider,
 	accountConfig *AccountConfig,
 	coreClientOptions *azcore.ClientOptions,
 	cloud *cloud.Cloud,
@@ -175,6 +176,12 @@ func NewBlobSdkClient(
 
 	if accountConfig.Endpoint == "" {
 		accountConfig.Endpoint = cloud.StorageEndpointSuffix
+	}
+
+	// Use home tenant ID
+	credential, err := credentialProvider.GetTokenCredential(context.Background(), "")
+	if err != nil {
+		return nil, err
 	}
 
 	serviceUrl := fmt.Sprintf("https://%s.blob.%s", accountConfig.AccountName, accountConfig.Endpoint)

--- a/cli/azd/pkg/devcenter/platform.go
+++ b/cli/azd/pkg/devcenter/platform.go
@@ -5,14 +5,14 @@ import (
 	"os"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
-	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
+	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/devcentersdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
@@ -166,17 +166,23 @@ func (p *Platform) ConfigureContainer(container *ioc.NestedContainer) error {
 
 	// Other devcenter components
 	container.MustRegisterSingleton(func(
-		credential azcore.TokenCredential,
-		httpClient httputil.HttpClient,
-		resourceGraphClient *armresourcegraph.Client,
+		credentialProvider auth.MultiTenantCredentialProvider,
+		policyClientOptions *azcore.ClientOptions,
+		armClientOptions *arm.ClientOptions,
 		cloud *cloud.Cloud,
 	) (devcentersdk.DevCenterClient, error) {
-		options := azsdk.NewClientOptionsBuilderFactory(httpClient, "azd", cloud).
-			NewClientOptionsBuilder().
-			WithPerCallPolicy(azsdk.NewMsCorrelationPolicy()).
-			BuildCoreClientOptions()
+		// Use home tenant ID
+		cred, err := credentialProvider.GetTokenCredential(context.Background(), "")
+		if err != nil {
+			return nil, err
+		}
 
-		return devcentersdk.NewDevCenterClient(credential, options, resourceGraphClient, cloud)
+		resourceGraphClient, err := armresourcegraph.NewClient(cred, armClientOptions)
+		if err != nil {
+			return nil, err
+		}
+
+		return devcentersdk.NewDevCenterClient(cred, policyClientOptions, resourceGraphClient, cloud)
 	})
 
 	return nil

--- a/cli/azd/pkg/environment/manager_test.go
+++ b/cli/azd/pkg/environment/manager_test.go
@@ -362,6 +362,10 @@ func registerContainerComponents(t *testing.T, mockContext *mocks.MockContext) {
 	mockContext.Container.MustRegisterSingleton(func() httputil.UserAgent {
 		return httputil.UserAgent(internal.UserAgent())
 	})
+	mockContext.Container.MustRegisterSingleton(func() auth.MultiTenantCredentialProvider {
+		return mockContext.MultiTenantCredentialProvider
+	})
+
 	mockContext.Container.MustRegisterSingleton(NewManager)
 	mockContext.Container.MustRegisterSingleton(NewLocalFileDataStore)
 	mockContext.Container.MustRegisterNamedSingleton(string(RemoteKindAzureBlobStorage), NewStorageBlobDataStore)

--- a/cli/azd/test/functional/remote_state_test.go
+++ b/cli/azd/test/functional/remote_state_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk/storage"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
-	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/test/azdcli"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -70,25 +69,12 @@ func createBlobClient(
 	storageConfig *storage.AccountConfig,
 	httpClient auth.HttpClient,
 ) storage.BlobClient {
-	fileConfigManager := config.NewFileConfigManager(config.NewManager())
-
-	authManager, err := auth.NewManager(
-		fileConfigManager,
-		config.NewUserConfigManager(fileConfigManager),
-		cloud.AzurePublic(),
-		httpClient, mockContext.Console,
-		auth.ExternalAuthConfiguration{},
-	)
-	require.NoError(t, err)
-
-	credentials, err := authManager.CredentialForCurrentUser(*mockContext.Context, nil)
-	require.NoError(t, err)
-
 	coreClientOptions := azsdk.NewClientOptionsBuilderFactory(httpClient, "azd", cloud.AzurePublic()).
 		NewClientOptionsBuilder().
 		BuildCoreClientOptions()
 
-	sdkClient, err := storage.NewBlobSdkClient(credentials, storageConfig, coreClientOptions, cloud.AzurePublic())
+	sdkClient, err := storage.NewBlobSdkClient(
+		mockContext.MultiTenantCredentialProvider, storageConfig, coreClientOptions, cloud.AzurePublic())
 	require.NoError(t, err)
 	require.NotNil(t, sdkClient)
 

--- a/cli/azd/test/mocks/mock_context.go
+++ b/cli/azd/test/mocks/mock_context.go
@@ -71,9 +71,6 @@ func registerCommonMocks(mockContext *MockContext) {
 	mockContext.Container.MustRegisterSingleton(func() ioc.ServiceLocator {
 		return mockContext.Container
 	})
-	mockContext.Container.MustRegisterSingleton(func() azcore.TokenCredential {
-		return mockContext.Credentials
-	})
 	mockContext.Container.MustRegisterSingleton(func() httputil.HttpClient {
 		return mockContext.HttpClient
 	})


### PR DESCRIPTION
With this change, we avoid registering a tenant-specific `azcore.TokenCredential` in the DI graph and fix consuming code using the wrong tenant for their respective use cases. We do this to expose important implementation details of which tenant or subscription should be used to produce an `azcore.TokenCredential` (which by definition, is always tenant-specific). Such a detail is quite important in a multitenant application.

This change slightly reduces ease of writing code since the consumer needs to know about `auth.MultiTenantCredentialProvider` or `account.SubscriptionCredentialProvider`. In a follow-up change, I plan to simplify these details.

Fixes #3485