### PR TITLE
set app insights key when running web locally

### DIFF
--- a/templates/todo/projects/csharp-cosmos-sql/.vscode/tasks.json
+++ b/templates/todo/projects/csharp-cosmos-sql/.vscode/tasks.json
@@ -67,7 +67,7 @@
             "label": "Web npm start",
             "detail": "Helper task--use 'Start Web' task to ensure environment is set up correctly",
             "type": "shell",
-            "command": "npm run dev",
+            "command": "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" npm run dev",
             "options": {
                 "cwd": "${workspaceFolder}/src/web/",
                 "env": {

--- a/templates/todo/projects/csharp-sql-swa-func/.vscode/tasks.json
+++ b/templates/todo/projects/csharp-sql-swa-func/.vscode/tasks.json
@@ -89,7 +89,7 @@
             "label": "Web npm start",
             "detail": "Helper task--use 'Start Web' task to ensure environment is set up correctly",
             "type": "shell",
-            "command": "npm run dev",
+            "command": "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" npm run dev",
             "options": {
                 "cwd": "${workspaceFolder}/src/web/",
                 "env": {

--- a/templates/todo/projects/csharp-sql/.vscode/tasks.json
+++ b/templates/todo/projects/csharp-sql/.vscode/tasks.json
@@ -67,7 +67,7 @@
             "label": "Web npm start",
             "detail": "Helper task--use 'Start Web' task to ensure environment is set up correctly",
             "type": "shell",
-            "command": "npm run dev",
+            "command": "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" npm run dev",
             "options": {
                 "cwd": "${workspaceFolder}/src/web/",
                 "env": {

--- a/templates/todo/projects/java-mongo-aca/.vscode/tasks.json
+++ b/templates/todo/projects/java-mongo-aca/.vscode/tasks.json
@@ -59,7 +59,7 @@
             "label": "Web npm start",
             "detail": "Helper task--use 'Start Web' task to ensure environment is set up correctly",
             "type": "shell",
-            "command": "npm run dev",
+            "command": "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" npm run dev",
             "options": {
                 "cwd": "${workspaceFolder}/src/web/",
                 "env": {

--- a/templates/todo/projects/java-mongo/.vscode/tasks.json
+++ b/templates/todo/projects/java-mongo/.vscode/tasks.json
@@ -59,7 +59,7 @@
             "label": "Web npm start",
             "detail": "Helper task--use 'Start Web' task to ensure environment is set up correctly",
             "type": "shell",
-            "command": "npm run dev",
+            "command": "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" npm run dev",
             "options": {
                 "cwd": "${workspaceFolder}/src/web/",
                 "env": {

--- a/templates/todo/projects/java-postgresql/.vscode/tasks.json
+++ b/templates/todo/projects/java-postgresql/.vscode/tasks.json
@@ -56,7 +56,7 @@
             "label": "Web npm start",
             "detail": "Helper task--use 'Start Web' task to ensure environment is set up correctly",
             "type": "shell",
-            "command": "npm run dev",
+            "command": "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" npm run dev",
             "options": {
                 "cwd": "${workspaceFolder}/src/web/",
                 "env": {

--- a/templates/todo/projects/nodejs-mongo-aca/.vscode/tasks.json
+++ b/templates/todo/projects/nodejs-mongo-aca/.vscode/tasks.json
@@ -23,7 +23,7 @@
             "label": "Web npm start",
             "detail": "Helper task--use 'Start Web' task to ensure environment is set up correctly",
             "type": "shell",
-            "command": "npm run dev",
+            "command": "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" npm run dev",
             "options": {
                 "cwd": "${workspaceFolder}/src/web/",
                 "env": {

--- a/templates/todo/projects/nodejs-mongo-aks/.vscode/tasks.json
+++ b/templates/todo/projects/nodejs-mongo-aks/.vscode/tasks.json
@@ -23,7 +23,7 @@
             "label": "Web npm start",
             "detail": "Helper task--use 'Start Web' task to ensure environment is set up correctly",
             "type": "shell",
-            "command": "npm run dev",
+            "command": "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" npm run dev",
             "options": {
                 "cwd": "${workspaceFolder}/src/web/",
                 "env": {

--- a/templates/todo/projects/nodejs-mongo-swa-func/.vscode/tasks.json
+++ b/templates/todo/projects/nodejs-mongo-swa-func/.vscode/tasks.json
@@ -23,7 +23,7 @@
             "label": "Web npm start",
             "detail": "Helper task--use 'Start Web' task to ensure environment is set up correctly",
             "type": "shell",
-            "command": "npm run dev",
+            "command": "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" npm run dev",
             "options": {
                 "cwd": "${workspaceFolder}/src/web/",
                 "env": {

--- a/templates/todo/projects/nodejs-mongo/.vscode/tasks.json
+++ b/templates/todo/projects/nodejs-mongo/.vscode/tasks.json
@@ -23,7 +23,7 @@
             "label": "Web npm start",
             "detail": "Helper task--use 'Start Web' task to ensure environment is set up correctly",
             "type": "shell",
-            "command": "npm run dev",
+            "command": "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" npm run dev",
             "options": {
                 "cwd": "${workspaceFolder}/src/web/",
                 "env": {

--- a/templates/todo/projects/python-mongo-aca/.vscode/tasks.json
+++ b/templates/todo/projects/python-mongo-aca/.vscode/tasks.json
@@ -23,7 +23,7 @@
             "label": "Web npm start",
             "detail": "Helper task--use 'Start Web' task to ensure environment is set up correctly",
             "type": "shell",
-            "command": "npm run dev",
+            "command": "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" npm run dev",
             "options": {
                 "cwd": "${workspaceFolder}/src/web/",
                 "env": {

--- a/templates/todo/projects/python-mongo-swa-func/.vscode/tasks.json
+++ b/templates/todo/projects/python-mongo-swa-func/.vscode/tasks.json
@@ -23,7 +23,7 @@
             "label": "Web npm start",
             "detail": "Helper task--use 'Start Web' task to ensure environment is set up correctly",
             "type": "shell",
-            "command": "npm run dev",
+            "command": "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" npm run dev",
             "options": {
                 "cwd": "${workspaceFolder}/src/web/",
                 "env": {

--- a/templates/todo/projects/python-mongo/.vscode/tasks.json
+++ b/templates/todo/projects/python-mongo/.vscode/tasks.json
@@ -23,7 +23,7 @@
             "label": "Web npm start",
             "detail": "Helper task--use 'Start Web' task to ensure environment is set up correctly",
             "type": "shell",
-            "command": "npm run dev",
+            "command": "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" npm run dev",
             "options": {
                 "cwd": "${workspaceFolder}/src/web/",
                 "env": {


### PR DESCRIPTION
After removing `VITE_APPLICATIONINSIGHTS_CONNECTION_STRING` from the bicep outpus (because there is already `APPLICATIONINSIGHTS_CONNECTION_STRING`), we need to create the mapping to a VITE env var to launch locally

fix: https://github.com/Azure/azure-dev/issues/3646
fix: https://github.com/Azure/azure-dev/issues/3644