### PR TITLE
Updates resolution strategy for AKS endpoints

### DIFF
--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -273,7 +273,7 @@ func (t *aksTarget) Deploy(
 
 			if len(endpoints) > 0 {
 				// The AKS endpoints contain some additional identifying information
-				// Split on common to pull out the URL as the first segment
+				// Regex is used to pull the URL ignoring the additional metadata
 				// The last endpoint in the array will be the most publicly exposed
 				matches := endpointRegex.FindStringSubmatch(endpoints[len(endpoints)-1])
 				if len(matches) > 1 {

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -38,6 +38,8 @@ var (
 	featureHelm      alpha.FeatureId = alpha.MustFeatureKey("aks.helm")
 	featureKustomize alpha.FeatureId = alpha.MustFeatureKey("aks.kustomize")
 
+	// Finds URLS in the endpoints that contain additional metadata
+	// Example: http://10.0.101.18:80 (Service: todo-api, Type: ClusterIP)
 	endpointRegex = regexp.MustCompile(`^(.*?)\s*(?:\(.*?\))?$`)
 )
 

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -36,6 +37,8 @@ const (
 var (
 	featureHelm      alpha.FeatureId = alpha.MustFeatureKey("aks.helm")
 	featureKustomize alpha.FeatureId = alpha.MustFeatureKey("aks.kustomize")
+
+	endpointRegex = regexp.MustCompile(`^(.*?)\s*(?:\(.*?\))?$`)
 )
 
 // The AKS configuration options
@@ -270,11 +273,13 @@ func (t *aksTarget) Deploy(
 				// The AKS endpoints contain some additional identifying information
 				// Split on common to pull out the URL as the first segment
 				// The last endpoint in the array will be the most publicly exposed
-				endpointParts := strings.Split(endpoints[len(endpoints)-1], ",")
-				t.env.SetServiceProperty(serviceConfig.Name, "ENDPOINT_URL", endpointParts[0])
-				if err := t.envManager.Save(ctx, t.env); err != nil {
-					task.SetError(fmt.Errorf("failed updating environment with endpoint url, %w", err))
-					return
+				matches := endpointRegex.FindStringSubmatch(endpoints[len(endpoints)-1])
+				if len(matches) > 1 {
+					t.env.SetServiceProperty(serviceConfig.Name, "ENDPOINT_URL", matches[1])
+					if err := t.envManager.Save(ctx, t.env); err != nil {
+						task.SetError(fmt.Errorf("failed updating environment with endpoint url, %w", err))
+						return
+					}
 				}
 			}
 


### PR DESCRIPTION
Resolves an issue in the AKS endpoint resolution strategy.  After removing the comma  between the endpoint URL and types this caused an issue parsing the endpoint used later in template validation.