### PR TITLE
Use Apple Silicon in scheduled builds

### DIFF
--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -22,11 +22,81 @@ extends:
   parameters:
     stages:
     - template: /eng/pipelines/templates/stages/build-and-test.yml
+      parameters:
+        BuildMatrix:
+          Windows:
+            Pool: $(WINDOWSPOOL)
+            OSVmImage: $(WINDOWSVMIMAGE)
+            OS: windows
+            ImageKey: image
+            UploadArtifact: true
+            Variables:
+              BuildTarget: azd-windows-amd64.exe
+              BuildOutputName: azd.exe
+              BuildTestMsi: true
+              AZURE_DEV_CI_OS: win
+              Codeql.Enabled: true
+              Codeql.SkipTaskAutoInjection: false
+              Codeql.BuildIdentifier: cli_windows
+          Linux:
+            Pool: $(LINUXPOOL)
+            OSVmImage: $(LINUXVMIMAGE)
+            OS: linux
+            ImageKey: image
+            UploadArtifact: true
+            Variables:
+                BuildTarget: azd-linux-amd64
+                BuildOutputName: azd
+                SetExecutableBit: true
+                SetShieldInfo: true
+                BuildLinuxPackages: true
+                AZURE_DEV_CI_OS: lin
+                Codeql.Enabled: true
+                Codeql.SkipTaskAutoInjection: false
+                Codeql.BuildIdentifier: cli_linux
+          Mac:
+            Pool: Azure Pipelines
+            OSVmImage: $(MACVMIMAGE)
+            OS: macOS
+            ImageKey: vmImage
+            UploadArtifact: true
+            Variables:
+              BuildTarget: azd-darwin-amd64
+              BuildOutputName: azd
+              MacLocalSign: false
+              SetExecutableBit: true
+              AZURE_DEV_CI_OS: mac
+              # CodeQL on macOS not supported by the Azure DevOps task as-of current.
+              # Codeql.BuildIdentifier: cli_darwin
+
+          ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+            # Only run this build during scheduled pipeline executions
+            MacAppleSilicon:
+              Pool: Azure Pipelines
+              OSVmImage: $(MACVMIMAGEM1)
+              OS: macOS
+              ImageKey: vmImage
+              UploadArtifact: false
+              Variables:
+                BuildTarget: azd-darwin-amd64
+                BuildOutputName: azd
+                MacLocalSign: false
+                SetExecutableBit: true
+                AZURE_DEV_CI_OS: mac-arm64
 
     - template: /eng/pipelines/templates/stages/code-coverage-upload.yml
-
-    - template: /eng/pipelines/templates/stages/sign.yml
+      parameters:
+        DownloadArtifacts:
+          - cover-win
+          - cover-lin
+          - cover-mac
+          - ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+            - cover-mac-arm64
 
     - template: /eng/pipelines/templates/stages/verify-installers.yml
 
-    - template: /eng/pipelines/templates/stages/publish.yml
+    - ${{ if ne(variables['Build.Reason'], 'Schedule') }}:
+
+      - template: /eng/pipelines/templates/stages/sign.yml
+
+      - template: /eng/pipelines/templates/stages/publish.yml

--- a/eng/pipelines/templates/jobs/build-cli.yml
+++ b/eng/pipelines/templates/jobs/build-cli.yml
@@ -13,6 +13,9 @@ parameters:
   - name: Variables
     type: object
     default: {}
+  - name: UploadArtifact
+    type: boolean
+    default: true
 
 jobs: 
   - job: BuildCLI_${{ parameters.NameSuffix }}
@@ -72,14 +75,10 @@ jobs:
           ShouldBuildForRelease: true
 
       - template: /eng/pipelines/templates/steps/install-terraform.yml
+
       - template: /eng/pipelines/templates/steps/install-kubectl.yml
 
-      - task: DockerInstaller@0
-        displayName: Docker Installer
-        condition: and(succeeded(), contains('${{ parameters.OS }}', 'macOS'))
-        inputs:
-          dockerVersion: 17.09.0-ce
-          releaseType: stable
+      - template: /eng/pipelines/templates/steps/install-docker.yml
 
       # Live testing uses dotnet 8.0.x in the WebApp project deployment
       - task: UseDotNet@2
@@ -198,11 +197,12 @@ jobs:
         artifact: shield-standalone
         displayName: Upload standalone shield json
 
-      - output: pipelineArtifact
-        path: $(Build.ArtifactStagingDirectory)/build-output
-        artifact: $(BuildTarget)
-        condition: succeeded()
-        displayName: Upload azd binary to artifact store
+      - ${{ if eq(parameters.UploadArtifact, true) }}:
+        - output: pipelineArtifact
+          path: $(Build.ArtifactStagingDirectory)/build-output
+          artifact: $(BuildTarget)
+          condition: succeeded()
+          displayName: Upload azd binary to artifact store
 
       - output: pipelineArtifact
         path: cli/installer/windows/bin/Release

--- a/eng/pipelines/templates/stages/build-and-test.yml
+++ b/eng/pipelines/templates/stages/build-and-test.yml
@@ -1,48 +1,6 @@
 parameters: 
   - name: BuildMatrix
     type: object
-    default:
-      Windows:
-        Pool: $(WINDOWSPOOL)
-        OSVmImage: $(WINDOWSVMIMAGE)
-        OS: windows
-        ImageKey: image
-        Variables: 
-          BuildTarget: azd-windows-amd64.exe
-          BuildOutputName: azd.exe
-          BuildTestMsi: true
-          AZURE_DEV_CI_OS: win
-          Codeql.Enabled: true
-          Codeql.SkipTaskAutoInjection: false
-          Codeql.BuildIdentifier: cli_windows
-      Linux:
-        Pool: $(LINUXPOOL)
-        OSVmImage: $(LINUXVMIMAGE)
-        OS: linux
-        ImageKey: image
-        Variables: 
-            BuildTarget: azd-linux-amd64
-            BuildOutputName: azd
-            SetExecutableBit: true
-            SetShieldInfo: true
-            BuildLinuxPackages: true
-            AZURE_DEV_CI_OS: lin
-            Codeql.Enabled: true
-            Codeql.SkipTaskAutoInjection: false
-            Codeql.BuildIdentifier: cli_linux
-      Mac:
-        Pool: Azure Pipelines
-        OSVmImage: $(MACVMIMAGE)
-        OS: macOS
-        ImageKey: vmImage
-        Variables: 
-          BuildTarget: azd-darwin-amd64
-          BuildOutputName: azd
-          MacLocalSign: false
-          SetExecutableBit: true
-          AZURE_DEV_CI_OS: mac
-          # CodeQL on macOS not supported by the Azure DevOps task as-of current.
-          # Codeql.BuildIdentifier: cli_darwin
   - name: CrossBuildMatrix
     type: object
     default:
@@ -93,6 +51,7 @@ stages:
             ImageKey: ${{ build.value.ImageKey }}
             OSVmImage: ${{ build.value.OSVmImage }} 
             OS: ${{ build.value.OS }}
+            UploadArtifact: ${{ build.value.UploadArtifact}}
             Variables: ${{ build.value.Variables }}
 
       # This is separated today because Skip.LiveTest is a queue-time variable

--- a/eng/pipelines/templates/stages/code-coverage-upload.yml
+++ b/eng/pipelines/templates/stages/code-coverage-upload.yml
@@ -1,3 +1,10 @@
+parameters:
+  - name: DownloadArtifacts
+    type: object
+    default:
+      - cover-win
+      - cover-lin
+      - cover-mac
 stages: 
 - stage: CodeCoverage_Upload
   condition: and(succeeded(), ne(variables['Skip.LiveTest'], 'true'))
@@ -17,10 +24,8 @@ stages:
       - template: /eng/pipelines/templates/steps/setup-go.yml
       - template: /eng/pipelines/templates/steps/download-artifacts.yml
         parameters:
-          Artifacts:
-          - cover-win
-          - cover-lin
-          - cover-mac
+          Artifacts: ${{ parameters.DownloadArtifacts }}
+
       - pwsh: |
           New-Item -ItemType Directory -Force -Path cover
           New-Item -ItemType Directory -Force -Path cover-int

--- a/eng/pipelines/templates/steps/install-docker.yml
+++ b/eng/pipelines/templates/steps/install-docker.yml
@@ -1,0 +1,34 @@
+parameters: 
+  DockerVersion: 25.0.4
+  ReleaseType: stable
+steps: 
+  - pwsh: |
+      if ($IsMacOS -and (arch) -eq 'arm64') {
+        Write-Host "Circumventing DockerInstaller@0 because it does not support Apple Silicon"
+        $tempDir = [System.IO.Path]::GetTempPath()
+        # https://download.docker.com/mac/static/stable/aarch64/docker-17.09.0-ce.tgz
+        $filename = "docker-${{ parameters.DockerVersion }}.tgz"
+        $url = "https://download.docker.com/mac/static/${{ parameters.ReleaseType }}/aarch64/$filename"
+
+        Write-Host "Downloading $url"
+        curl -L "$url" -o "$tempDir/$filename"
+
+        Write-Host "Extracting and installing docker to /usr/local/bin"
+        sudo rm -rf /usr/local/bin/docker
+        sudo tar -C "$tempDir" -xvzf "$tempDir/$filename" docker/docker
+        sudo mv "$tempDir/docker/docker" /usr/local/bin
+
+        docker --version
+        exit $LASTEXITCODE
+      } else {
+        Write-Host "Use tools"
+        Write-Host "##vso[task.setvariable variable=DEFAULT_DOCKER_SETUP]true"
+      }
+    displayName: Docker Installer (Apple Silicon installer)
+
+  - task: DockerInstaller@0
+    displayName: Docker Installer
+    condition: eq(variables['DEFAULT_DOCKER_SETUP'], 'true')
+    inputs:
+      dockerVersion: ${{ parameters.DockerVersion }}
+      releaseType: ${{ parameters.ReleaseType }}

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -22,6 +22,8 @@ variables:
     value: macos-11
   - name: MACVMIMAGE12
     value: macos-12
+  - name: MACVMIMAGEM1
+    value: macos-13-arm64
 
   # Values required for pool.os field in 1es pipeline templates. Variable form 
   # cannot be used, instead those values must be written directly into pool.os.


### PR DESCRIPTION
Example scheduled build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3681487&view=logs&j=90dd592b-3d52-543c-a8c6-c88386b77a8c&t=721351df-310a-597d-818d-c5a9c6e01ca8

Note: We move up to a more recent version of Docker. The docker installer task requires a specific version number ("latest" or something similar does not work).