### PR TITLE
Update search-services.bicep set disableLocalAuth compatibility

### DIFF
--- a/templates/common/infra/bicep/core/search/search-services.bicep
+++ b/templates/common/infra/bicep/core/search/search-services.bicep
@@ -47,7 +47,7 @@ resource search 'Microsoft.Search/searchServices@2021-04-01-preview' = {
   // The free tier does not support managed identity
   identity: searchIdentityProvider
   properties: {
-    authOptions: authOptions
+    authOptions: disableLocalAuth ? null : authOptions
     disableLocalAuth: disableLocalAuth
     disabledDataExfiltrationOptions: disabledDataExfiltrationOptions
     encryptionWithCmk: encryptionWithCmk


### PR DESCRIPTION
In order to remove the security alert "Protect Azure AI Search Instances by only allowing RBAC API Access", I needed to set disableLocalAuth to true. However, I discovered that authOptions must be null in that case, *not* an empty object, the default value. So this PR explicitly sets authOptions to null when disableLocalAuth is true.

Here's a full PR that uses this change:

https://github.com/Azure-Samples/azure-search-openai-demo/pull/1502/files

