### PR TITLE
vs-server: Add `--use-tls` for serving over TLS

### DIFF
--- a/cli/azd/cmd/vs_server.go
+++ b/cli/azd/cmd/vs_server.go
@@ -4,12 +4,23 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"net"
 	"os"
+	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/vsrpc"
@@ -22,11 +33,13 @@ import (
 type vsServerFlags struct {
 	global *internal.GlobalCommandOptions
 	port   int
+	useTls bool
 }
 
 func (s *vsServerFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	s.global = global
-	local.IntVar(&s.port, "port", 0, "Port to listen on (0 for random port)")
+	local.IntVar(&s.port, "port", 0, "Port to listen on (0 for random port).")
+	local.BoolVar(&s.useTls, "use-tls", false, "Use TLS to secure the connection.")
 }
 
 func newVsServerFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *vsServerFlags {
@@ -61,7 +74,7 @@ func newVsServerAction(rootContainer *ioc.NestedContainer, flags *vsServerFlags)
 func (s *vsServerAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", s.flags.port))
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	var versionRes contracts.VersionResult
@@ -76,6 +89,22 @@ func (s *vsServerAction) Run(ctx context.Context) (*actions.ActionResult, error)
 		VersionResult: versionRes,
 	}
 
+	if s.flags.useTls {
+		cert, derBytes, err := generateCertificate()
+		if err != nil {
+			return nil, err
+		}
+
+		config := &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			NextProtos:   []string{"http/1.1"},
+			Certificates: []tls.Certificate{cert},
+		}
+
+		listener = tls.NewListener(listener, config)
+		res.CertificateBytes = to.Ptr(base64.StdEncoding.EncodeToString(derBytes))
+	}
+
 	resString, err := json.Marshal(res)
 	if err != nil {
 		return nil, err
@@ -84,4 +113,64 @@ func (s *vsServerAction) Run(ctx context.Context) (*actions.ActionResult, error)
 	fmt.Printf("%s\n", string(resString))
 
 	return nil, vsrpc.NewServer(s.rootContainer).Serve(listener)
+}
+
+// generateCertificate generates a self-signed certificate for use in the server. It returns the tls.Certificate (for use
+// in constructing a *tls.Config, so you use it with tls.NewListener()) and the raw bytes of the DER-encoded certificate.
+func generateCertificate() (tls.Certificate, []byte, error) {
+	// Derived from https://go.dev/src/crypto/tls/generate_cert.go
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return tls.Certificate{}, nil, err
+	}
+	keyUsage := x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return tls.Certificate{}, nil, err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Azure Developer CLI"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(7 * 24 * time.Hour),
+
+		KeyUsage:              keyUsage,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	var certBuf bytes.Buffer
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return tls.Certificate{}, nil, err
+	}
+
+	if err := pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
+		return tls.Certificate{}, nil, err
+	}
+
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return tls.Certificate{}, nil, err
+	}
+
+	var keyBuf bytes.Buffer
+
+	if err := pem.Encode(&keyBuf, &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}); err != nil {
+		return tls.Certificate{}, nil, err
+	}
+
+	cert, err := tls.X509KeyPair(certBuf.Bytes(), keyBuf.Bytes())
+	if err != nil {
+		return tls.Certificate{}, nil, err
+	}
+
+	return cert, derBytes, nil
 }

--- a/cli/azd/internal/vsrpc/server.go
+++ b/cli/azd/internal/vsrpc/server.go
@@ -87,6 +87,7 @@ func (s *Server) Serve(l net.Listener) error {
 		ReadHeaderTimeout: 1 * time.Second,
 		Handler:           mux,
 	}
+
 	return server.Serve(l)
 }
 

--- a/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/Settings.Template.cs
+++ b/cli/azd/internal/vsrpc/testdata/dotnet-azd-client/Settings.Template.cs
@@ -2,6 +2,8 @@
 // Checked in.
 /*
 public static class Settings {
+    // The Base 64 encoded certificate of the remote server.
+    public const string ServerCertBase64 = "";
     // The name of the environment to create and use as part of the RunLifecycle function.
     public const string EnvironmentName = "";
     // The Root Path to the Aspire solution to use as part of the RunLifecycle function. The test expects this to be

--- a/cli/azd/pkg/contracts/vs_server.go
+++ b/cli/azd/pkg/contracts/vs_server.go
@@ -3,5 +3,10 @@ package contracts
 type VsServerResult struct {
 	Port int `json:"port"`
 	Pid  int `json:"pid"`
+	// The certificate that the server uses to secure the TLS connection. This is the base 64 encoding of the raw bytes of
+	// the DER encoded certificate. The client should use this to verify the server's identity. In .NET, You can use
+	// `X509Certificate2.ctor(byte[])` to construct a certificate from these bytes, after Base64 decoding. When TLS is not
+	// used, this will be null.
+	CertificateBytes *string `json:"certificateBytes,omitempty"`
 	VersionResult
 }

--- a/cli/azd/test/functional/testdata/vs-server/tests/TestBase.cs
+++ b/cli/azd/test/functional/testdata/vs-server/tests/TestBase.cs
@@ -41,19 +41,33 @@ public class TestBase
         _rootDir = config["ROOT_DIR"] ?? System.IO.Directory.GetCurrentDirectory();
         _location = config["AZURE_LOCATION"] ?? "westus2";
         _envName = config["AZURE_ENV_NAME"] ?? "vs-server-env";
+        certBytes = config["CERTIFICATE_BYTES"] ?? throw new InvalidOperationException("CERTIFICATE_BYTES is not set");
 
-        var host = $"ws://127.0.0.1:{_port}";
+        var host = $"wss://127.0.0.1:{_port}";
+        var expectedCert = new X509Certificate2(Convert.FromBase64String(_certBytes));
 
         ClientWebSocket wsClientES = new ClientWebSocket();
+        wsClientES.Options.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => {
+            return certificate != null && certificate.Equals(expectedCert);
+        };
         await wsClientES.ConnectAsync(new Uri($"{host}/EnvironmentService/v1.0"), CancellationToken.None);
 
         ClientWebSocket wsClientAS = new ClientWebSocket();
+        wsClientAS.Options.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => {
+            return certificate != null && certificate.Equals(expectedCert);
+        };
         await wsClientAS.ConnectAsync(new Uri($"{host}/AspireService/v1.0"), CancellationToken.None);
 
         ClientWebSocket wsClientSS = new ClientWebSocket();
+        wsClientSS.Options.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => {
+            return certificate != null && certificate.Equals(expectedCert);
+        };
         await wsClientSS.ConnectAsync(new Uri($"{host}/ServerService/v1.0"), CancellationToken.None);
 
         ClientWebSocket wsClientDS = new ClientWebSocket();
+        wsClientDS.Options.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => {
+            return certificate != null && certificate.Equals(expectedCert);
+        };
         await wsClientDS.ConnectAsync(new Uri($"{host}/TestDebugService/v1.0"), CancellationToken.None);
 
         esSvc = JsonRpc.Attach<IEnvironmentService>(new WebSocketMessageHandler(wsClientES));

--- a/cli/azd/test/functional/vs_server_test.go
+++ b/cli/azd/test/functional/vs_server_test.go
@@ -215,7 +215,7 @@ func Test_CLI_VsServer(t *testing.T) {
 
 			cli := azdcli.NewCLI(t, azdcli.WithSession(session))
 			/* #nosec G204 - Subprocess launched with a potential tainted input or cmd arguments false positive */
-			cmd := exec.CommandContext(ctx, cli.AzdPath, "vs-server")
+			cmd := exec.CommandContext(ctx, cli.AzdPath, "vs-server", "--use-tls")
 			cmd.Env = append(cli.Env, os.Environ()...)
 			cmd.Env = append(cmd.Env, "AZD_DEBUG_SERVER_DEBUG_ENDPOINTS=true")
 			pathString := ostest.CombinedPaths(cmd.Env)
@@ -252,6 +252,7 @@ func Test_CLI_VsServer(t *testing.T) {
 			cmd.Env = append(cmd.Env, "AZURE_SUBSCRIPTION_ID="+subscriptionId)
 			cmd.Env = append(cmd.Env, "AZURE_LOCATION="+cfg.Location)
 			cmd.Env = append(cmd.Env, fmt.Sprintf("PORT=%d", svr.Port))
+			cmd.Env = append(cmd.Env, "CERTIFICATE_BYTES="+*svr.CertificateBytes)
 			cmd.Env = append(cmd.Env, "ROOT_DIR="+dir)
 			if tt.IsLive {
 				cmd.Env = append(cmd.Env, "AZURE_ENV_NAME="+envName)


### PR DESCRIPTION
While communication only happens over localhost, we'd still like the use TLS on the endpoint to prevent other processes from sniffing local traffic and to allow the client to validate that it is talking to the server it expects (which it can do by ensuring the certificate presented during the TLS Handshake matches what is expected).

With this change, `azd vs-server` gains a new parameter, `--use-tls`. When set, it generates a self-signed 2048 RSA certificate on each run and uses it to expose its endpoints over TLS. This certificate is ephemeral and re-generated each time the server is launched. The lifetime of the generated certificate is short (7 days) per guidence from the security team. This means the server will need to be recycled after seven days because the certificate it is using will no longer be valid, but that should be fine for our current integrations.

The raw bytes of the certificate are returned in the new `certificateBytes` property of the JSON object that is printed to
`stdout` by `azd vs-server`. This is a Base 64 encoding of the certificate.

.NET Consumers may use `new X509Certificate2(Convert.FromBase64String(...))` to get a .NET object representing the certificate. Since the certificate is self signed, by default, ClientWebSocket will fail to connect to the server, so a consumer must provide a custom `RemoteCertificateValidationCallback` delegate that validates the certificate and allows it.

This value is not present when TLS is not enabled (so the caller can also use it's existence to decide if it should use `ws://` or `wss://` when trying to talk to the server).

Fixes #3684