### PR TITLE
1ES container templates

### DIFF
--- a/cli/installer/fpm/fpm.Dockerfile
+++ b/cli/installer/fpm/fpm.Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/cbl-mariner/base/ruby:3
 
-RUN gem install fpm
+RUN tdnf install -y tar && gem install fpm
 
 WORKDIR /work
 

--- a/cli/installer/fpm/fpm.Dockerfile
+++ b/cli/installer/fpm/fpm.Dockerfile
@@ -1,10 +1,6 @@
-ARG prefix=''
-ARG base='ubuntu:22.04'
-FROM ${prefix}${base}
+FROM mcr.microsoft.com/cbl-mariner/base/ruby:3
 
-RUN apt update && \ 
-    DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends --no-install-suggests -y ruby binutils rpm && \
-    gem install fpm
+RUN gem install fpm
 
 WORKDIR /work
 

--- a/cli/installer/fpm/fpm.Dockerfile
+++ b/cli/installer/fpm/fpm.Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/cbl-mariner/base/ruby:3
 
-RUN tdnf install -y tar && gem install fpm
+RUN tdnf install -y tar rpm-build && gem install fpm
 
 WORKDIR /work
 

--- a/eng/pipelines/templates/jobs/verify-installers.yml
+++ b/eng/pipelines/templates/jobs/verify-installers.yml
@@ -29,7 +29,7 @@ jobs:
       ${{ insert }}: ${{ parameters.Variables }}
       BaseUrl: http://127.0.0.1:8080
 
-    timeoutInMinutes: 10
+    timeoutInMinutes: 15
 
     steps:
       - checkout: self

--- a/eng/pipelines/templates/stages/publish.yml
+++ b/eng/pipelines/templates/stages/publish.yml
@@ -64,15 +64,15 @@ stages:
                       Write-Host "###vso[task.setvariable variable=StorageUploadLocations]$publishUploadLocations"
                     displayName: Set StorageUploadLocations
 
-                  # - template: /eng/pipelines/templates/steps/publish-cli.yml
-                  #   parameters:
-                  #     CreateGitHubRelease: true
-                  #     PublishUploadLocations: $(StorageUploadLocations)
-                  #     PublishShield: true
-                  #     PublishUpdatedDocs: true
-                  #     UploadMsi: true
-                  #     PublishBrewFormula: true
-                  #     PublishArm64Binaries: true
+                  - template: /eng/pipelines/templates/steps/publish-cli.yml
+                    parameters:
+                      CreateGitHubRelease: true
+                      PublishUploadLocations: $(StorageUploadLocations)
+                      PublishShield: true
+                      PublishUpdatedDocs: true
+                      UploadMsi: true
+                      PublishBrewFormula: true
+                      PublishArm64Binaries: true
 
         - deployment: Publish_Container
           dependsOn: Publish_Release
@@ -125,222 +125,222 @@ stages:
                       DockerImageTags: $(DockerImageTags)
                       ReleaseSyndicatedDockerContainer: true
 
-    #     - deployment: Publish_Choco
-    #       dependsOn: Publish_Release
-    #       condition: >-
-    #         and(
-    #           succeeded(),
-    #           ne('true', variables['Skip.Publish'])
-    #         )
-    #       environment: azure-dev
+        - deployment: Publish_Choco
+          dependsOn: Publish_Release
+          condition: >-
+            and(
+              succeeded(),
+              ne('true', variables['Skip.Publish'])
+            )
+          environment: azure-dev
 
-    #       pool:
-    #         name: azsdk-pool-mms-win-2022-general
-    #         image: azsdk-pool-mms-win-2022-1espt
-    #         os: windows
+          pool:
+            name: azsdk-pool-mms-win-2022-general
+            image: azsdk-pool-mms-win-2022-1espt
+            os: windows
 
-    #       templateContext:
-    #         inputs:
-    #           - input: checkout
-    #             repository: self
+          templateContext:
+            inputs:
+              - input: checkout
+                repository: self
 
-    #       strategy:
-    #         runOnce:
-    #           deploy:
-    #             steps:
-    #               - task: PowerShell@2
-    #                 inputs:
-    #                   pwsh: true
-    #                   targetType: filePath
-    #                   filePath: eng/scripts/Set-CliVersionVariable.ps1
-    #                 displayName: Set CLI_VERSION
+          strategy:
+            runOnce:
+              deploy:
+                steps:
+                  - task: PowerShell@2
+                    inputs:
+                      pwsh: true
+                      targetType: filePath
+                      filePath: eng/scripts/Set-CliVersionVariable.ps1
+                    displayName: Set CLI_VERSION
 
-    #               - template: /eng/pipelines/templates/steps/publish-cli-choco.yml
-    #                 parameters:
-    #                   CliVersion: $(CLI_VERSION)
+                  - template: /eng/pipelines/templates/steps/publish-cli-choco.yml
+                    parameters:
+                      CliVersion: $(CLI_VERSION)
 
-    #     - deployment: Publish_WinGet
-    #       dependsOn: Publish_Release
-    #       condition: >-
-    #         and(
-    #           succeeded(),
-    #           ne('true', variables['Skip.Publish'])
-    #         )
-    #       environment: azure-dev
+        - deployment: Publish_WinGet
+          dependsOn: Publish_Release
+          condition: >-
+            and(
+              succeeded(),
+              ne('true', variables['Skip.Publish'])
+            )
+          environment: azure-dev
 
-    #       pool:
-    #         name: azsdk-pool-mms-win-2022-general
-    #         image: azsdk-pool-mms-win-2022-1espt
-    #         os: windows
+          pool:
+            name: azsdk-pool-mms-win-2022-general
+            image: azsdk-pool-mms-win-2022-1espt
+            os: windows
 
-    #       templateContext:
-    #         inputs:
-    #           - input: checkout
-    #             repository: self
+          templateContext:
+            inputs:
+              - input: checkout
+                repository: self
 
-    #       strategy:
-    #         runOnce:
-    #           deploy:
-    #             steps:
-    #               - task: PowerShell@2
-    #                 inputs:
-    #                   pwsh: true
-    #                   targetType: filePath
-    #                   filePath: eng/scripts/Set-CliVersionVariable.ps1
-    #                 displayName: Set CLI_VERSION
+          strategy:
+            runOnce:
+              deploy:
+                steps:
+                  - task: PowerShell@2
+                    inputs:
+                      pwsh: true
+                      targetType: filePath
+                      filePath: eng/scripts/Set-CliVersionVariable.ps1
+                    displayName: Set CLI_VERSION
 
-    #               - template: /eng/pipelines/templates/steps/publish-cli-winget.yml
-    #                 parameters:
-    #                   CliVersion: $(CLI_VERSION)
+                  - template: /eng/pipelines/templates/steps/publish-cli-winget.yml
+                    parameters:
+                      CliVersion: $(CLI_VERSION)
 
-    #     - deployment: Increment_Version
-    #       condition: >-
-    #         and(
-    #           succeeded(),
-    #           ne('true', variables['Skip.IncrementVersion'])
-    #         )
-    #       dependsOn: Publish_Release
-    #       environment: azure-dev
+        - deployment: Increment_Version
+          condition: >-
+            and(
+              succeeded(),
+              ne('true', variables['Skip.IncrementVersion'])
+            )
+          dependsOn: Publish_Release
+          environment: azure-dev
 
-    #       pool:
-    #         name: azsdk-pool-mms-ubuntu-2004-general
-    #         image: azsdk-pool-mms-ubuntu-2004-1espt
-    #         os: linux
+          pool:
+            name: azsdk-pool-mms-ubuntu-2004-general
+            image: azsdk-pool-mms-ubuntu-2004-1espt
+            os: linux
 
-    #       templateContext:
-    #         inputs:
-    #           - input: checkout
-    #             repository: self
+          templateContext:
+            inputs:
+              - input: checkout
+                repository: self
 
-    #       strategy:
-    #         runOnce:
-    #           deploy:
-    #             steps:
-    #               - task: PowerShell@2
-    #                 inputs:
-    #                   pwsh: true
-    #                   targetType: filePath
-    #                   filePath: eng/scripts/Update-CliVersion.ps1
-    #                 displayName: Increment CLI version
+          strategy:
+            runOnce:
+              deploy:
+                steps:
+                  - task: PowerShell@2
+                    inputs:
+                      pwsh: true
+                      targetType: filePath
+                      filePath: eng/scripts/Update-CliVersion.ps1
+                    displayName: Increment CLI version
 
-    #               - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
-    #                 parameters:
-    #                   PRBranchName: cli-version-increment-$(Build.BuildId)
-    #                   CommitMsg: Increment CLI version after release
-    #                   PRTitle: Increment CLI version after release
+                  - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
+                    parameters:
+                      PRBranchName: cli-version-increment-$(Build.BuildId)
+                      CommitMsg: Increment CLI version after release
+                      PRTitle: Increment CLI version after release
 
-    # - stage: PublishVersionTxt
-    #   dependsOn: PublishCLI
+    - stage: PublishVersionTxt
+      dependsOn: PublishCLI
 
-    #   condition: >-
-    #     and(
-    #       succeeded(),
-    #       ne(variables['Skip.Release'], 'true'),
-    #       or(
-    #         eq('Manual', variables['BuildReasonOverride']),
-    #         and(
-    #           eq('', variables['BuildReasonOverride']),
-    #           eq('Manual', variables['Build.Reason'])
-    #         )
-    #       )
-    #     )
+      condition: >-
+        and(
+          succeeded(),
+          ne(variables['Skip.Release'], 'true'),
+          or(
+            eq('Manual', variables['BuildReasonOverride']),
+            and(
+              eq('', variables['BuildReasonOverride']),
+              eq('Manual', variables['Build.Reason'])
+            )
+          )
+        )
 
-    #   variables:
-    #     - template: /eng/pipelines/templates/variables/image.yml
-    #     - template: /eng/pipelines/templates/variables/globals.yml
+      variables:
+        - template: /eng/pipelines/templates/variables/image.yml
+        - template: /eng/pipelines/templates/variables/globals.yml
 
-    #   jobs:
-    #     - deployment: Upload_Version_Txt
-    #       condition: >-
-    #         and(
-    #           succeeded(),
-    #           ne('true', variables['Skip.Publish'])
-    #         )
-    #       environment: azure-dev
+      jobs:
+        - deployment: Upload_Version_Txt
+          condition: >-
+            and(
+              succeeded(),
+              ne('true', variables['Skip.Publish'])
+            )
+          environment: azure-dev
 
-    #       pool:
-    #         name: azsdk-pool-mms-win-2022-general
-    #         image: azsdk-pool-mms-win-2022-1espt
-    #         os: windows
+          pool:
+            name: azsdk-pool-mms-win-2022-general
+            image: azsdk-pool-mms-win-2022-1espt
+            os: windows
 
-    #       templateContext:
-    #         inputs:
-    #           - input: checkout
-    #             repository: self
+          templateContext:
+            inputs:
+              - input: checkout
+                repository: self
 
-    #       strategy:
-    #         runOnce:
-    #           deploy:
-    #             steps:
-    #               - task: PowerShell@2
-    #                 inputs:
-    #                   pwsh: true
-    #                   targetType: filePath
-    #                   filePath: eng/scripts/Set-CliVersionVariable.ps1
-    #                 displayName: Set CLI_VERSION
+          strategy:
+            runOnce:
+              deploy:
+                steps:
+                  - task: PowerShell@2
+                    inputs:
+                      pwsh: true
+                      targetType: filePath
+                      filePath: eng/scripts/Set-CliVersionVariable.ps1
+                    displayName: Set CLI_VERSION
 
-    #               - task: PowerShell@2
-    #                 displayName: Set MSI_VERSION
-    #                 inputs:
-    #                   pwsh: true
-    #                   targetType: filePath
-    #                   filePath: eng/scripts/Get-MsiVersion.ps1
-    #                   arguments: >-
-    #                     -CliVersion '$(CLI_VERSION)'
-    #                     -DevOpsOutput
+                  - task: PowerShell@2
+                    displayName: Set MSI_VERSION
+                    inputs:
+                      pwsh: true
+                      targetType: filePath
+                      filePath: eng/scripts/Get-MsiVersion.ps1
+                      arguments: >-
+                        -CliVersion '$(CLI_VERSION)'
+                        -DevOpsOutput
 
-    #               - task: PowerShell@2
-    #                 displayName: Wait for WinGet package
-    #                 inputs:
-    #                   pwsh: true
-    #                   targetType: filePath
-    #                   filePath: eng/scripts/Wait-WinGetPackage.ps1
-    #                   arguments: >-
-    #                     -PackageName 'Microsoft.Azd'
-    #                     -PackageVersion '$(MSI_VERSION)'
+                  - task: PowerShell@2
+                    displayName: Wait for WinGet package
+                    inputs:
+                      pwsh: true
+                      targetType: filePath
+                      filePath: eng/scripts/Wait-WinGetPackage.ps1
+                      arguments: >-
+                        -PackageName 'Microsoft.Azd'
+                        -PackageVersion '$(MSI_VERSION)'
 
-    #               - task: PowerShell@2
-    #                 displayName: Wait for Choco package
-    #                 inputs:
-    #                   pwsh: true
-    #                   targetType: filePath
-    #                   filePath: eng/scripts/Wait-ChocoPackage.ps1
-    #                   arguments: >-
-    #                     -PackageName 'azd'
-    #                     -PackageVersion '$(MSI_VERSION)'
+                  - task: PowerShell@2
+                    displayName: Wait for Choco package
+                    inputs:
+                      pwsh: true
+                      targetType: filePath
+                      filePath: eng/scripts/Wait-ChocoPackage.ps1
+                      arguments: >-
+                        -PackageName 'azd'
+                        -PackageVersion '$(MSI_VERSION)'
 
-    #               - pwsh: |
-    #                   New-Item -ItemType Directory -Path release
-    #                   Write-Output $(CLI_VERSION) | Out-File -Encoding utf8 -FilePath ./release/version.txt
-    #                 displayName: Write version.txt file for release
+                  - pwsh: |
+                      New-Item -ItemType Directory -Path release
+                      Write-Output $(CLI_VERSION) | Out-File -Encoding utf8 -FilePath ./release/version.txt
+                    displayName: Write version.txt file for release
 
-    #               - pwsh: |
-    #                   $isPublishingGa = eng/scripts/Test-ShouldReleasePackageVersion.ps1 `
-    #                     -CliVersion '$(CLI_VERSION)'
+                  - pwsh: |
+                      $isPublishingGa = eng/scripts/Test-ShouldReleasePackageVersion.ps1 `
+                        -CliVersion '$(CLI_VERSION)'
 
-    #                   $publishUploadLocations = @('release/latest')
-    #                   if ($isPublishingGa) {
-    #                     $publishUploadLocations += @('release/stable')
-    #                   }
+                      $publishUploadLocations = @('release/latest')
+                      if ($isPublishingGa) {
+                        $publishUploadLocations += @('release/stable')
+                      }
 
-    #                   Get-ChildItem release/
+                      Get-ChildItem release/
 
-    #                   foreach ($folder in $publishUploadLocations) {
-    #                     Write-Host "Upload to azd/standalone/$folder"
-    #                     az storage blob upload-batch `
-    #                       --account-name '$(azdev-storage-account-name)' `
-    #                       --account-key '$(azdev-storage-account-key)' `
-    #                       --auth-mode key `
-    #                       -s release/ `
-    #                       -d "azd/standalone/$folder" `
-    #                       --overwrite
+                      foreach ($folder in $publishUploadLocations) {
+                        Write-Host "Upload to azd/standalone/$folder"
+                        az storage blob upload-batch `
+                          --account-name '$(azdev-storage-account-name)' `
+                          --account-key '$(azdev-storage-account-key)' `
+                          --auth-mode key `
+                          -s release/ `
+                          -d "azd/standalone/$folder" `
+                          --overwrite
 
-    #                     if ($LASTEXITCODE) {
-    #                       Write-Error "Upload failed"
-    #                       exit 1
-    #                     }
-    #                   }
-    #                 displayName: Upload version.txt to storage account
+                        if ($LASTEXITCODE) {
+                          Write-Error "Upload failed"
+                          exit 1
+                        }
+                      }
+                    displayName: Upload version.txt to storage account
 
   - stage: PublishIntegration
     dependsOn: Sign
@@ -382,21 +382,20 @@ stages:
                 filePath: eng/scripts/Set-CliVersionVariable.ps1
               displayName: Set CLI_VERSION
 
-            # - template: /eng/pipelines/templates/steps/publish-cli.yml
-            #   parameters:
-            #     CreateGitHubRelease: false
-            #     PublishUploadLocations: release/daily;daily/archive/$(Build.BuildId)-$(Build.SourceVersion)
-            #     PublishShield: false
-            #     UploadMsi: true
-            #     PublishArm64Binaries: true
+            - template: /eng/pipelines/templates/steps/publish-cli.yml
+              parameters:
+                CreateGitHubRelease: false
+                PublishUploadLocations: release/daily;daily/archive/$(Build.BuildId)-$(Build.SourceVersion)
+                PublishShield: false
+                UploadMsi: true
+                PublishArm64Binaries: true
 
             - template: /eng/pipelines/templates/steps/publish-cli-container.yml
               parameters:
                 DockerImageTags: daily;$(CLI_VERSION)
                 ReleaseSyndicatedDockerContainer: false
                 # Artifacts are already downloaded in publish-cli.yml
-                # TODO: Set to false before merging
-                DownloadArtifacts: true
+                DownloadArtifacts: false
 
       - job: Publish_For_PR
         condition: >-

--- a/eng/pipelines/templates/stages/publish.yml
+++ b/eng/pipelines/templates/stages/publish.yml
@@ -382,20 +382,21 @@ stages:
                 filePath: eng/scripts/Set-CliVersionVariable.ps1
               displayName: Set CLI_VERSION
 
-            - template: /eng/pipelines/templates/steps/publish-cli.yml
-              parameters:
-                CreateGitHubRelease: false
-                PublishUploadLocations: release/daily;daily/archive/$(Build.BuildId)-$(Build.SourceVersion)
-                PublishShield: false
-                UploadMsi: true
-                PublishArm64Binaries: true
+            # - template: /eng/pipelines/templates/steps/publish-cli.yml
+            #   parameters:
+            #     CreateGitHubRelease: false
+            #     PublishUploadLocations: release/daily;daily/archive/$(Build.BuildId)-$(Build.SourceVersion)
+            #     PublishShield: false
+            #     UploadMsi: true
+            #     PublishArm64Binaries: true
 
             - template: /eng/pipelines/templates/steps/publish-cli-container.yml
               parameters:
                 DockerImageTags: daily;$(CLI_VERSION)
                 ReleaseSyndicatedDockerContainer: false
                 # Artifacts are already downloaded in publish-cli.yml
-                DownloadArtifacts: false
+                # TODO: Set to false before merging
+                DownloadArtifacts: true
 
       - job: Publish_For_PR
         condition: >-

--- a/eng/pipelines/templates/stages/publish.yml
+++ b/eng/pipelines/templates/stages/publish.yml
@@ -308,7 +308,7 @@ stages:
                       }
                     displayName: Upload version.txt to storage account
 
-  - stage: Publish_Integration
+  - stage: PublishIntegration
     dependsOn: Sign
 
     variables: 
@@ -409,14 +409,20 @@ stages:
               PublishArm64Binaries: true
 
               ${{ if eq(variables['Build.Repository.Name'], 'Azure/azure-dev') }}:
-                PublishContainer: true
-                DockerImageTags: pr-$(PRNumber)
                 StorageAccountName: $(azdev-storage-account-name)
                 StorageAccountKey: $(azdev-storage-account-key)
               ${{ else }}:
-                PublishContainer: false
                 StorageAccountName: $(azdev-storage-account-name-pr)
                 StorageAccountKey: $(azdev-storage-account-key-pr)
+
+
+          - ${{ if eq(variables['Build.Repository.Name'], 'Azure/azure-dev') }}:
+            - template: /eng/pipelines/templates/steps/publish-cli-container.yml
+              parameters:
+                DockerImageTags: pr-$(PRNumber)
+                ReleaseSyndicatedDockerContainer: false
+                # Artifacts are already downloaded in publish-cli.yml
+                DownloadArtifacts: false
 
 
           - pwsh: |

--- a/eng/pipelines/templates/stages/publish.yml
+++ b/eng/pipelines/templates/stages/publish.yml
@@ -84,9 +84,9 @@ stages:
           environment: azure-dev
 
           pool:
-            name: azsdk-pool-mms-win-2022-general
-            image: azsdk-pool-mms-win-2022-1espt
-            os: windows
+            name: azsdk-pool-mms-ubuntu-2004-general
+            image: azsdk-pool-mms-ubuntu-2004-1espt
+            os: linux
 
           templateContext:
             inputs:

--- a/eng/pipelines/templates/stages/publish.yml
+++ b/eng/pipelines/templates/stages/publish.yml
@@ -64,6 +64,47 @@ stages:
                       Write-Host "###vso[task.setvariable variable=StorageUploadLocations]$publishUploadLocations"
                     displayName: Set StorageUploadLocations
 
+                  # - template: /eng/pipelines/templates/steps/publish-cli.yml
+                  #   parameters:
+                  #     CreateGitHubRelease: true
+                  #     PublishUploadLocations: $(StorageUploadLocations)
+                  #     PublishShield: true
+                  #     PublishUpdatedDocs: true
+                  #     UploadMsi: true
+                  #     PublishBrewFormula: true
+                  #     PublishArm64Binaries: true
+
+        - deployment: Publish_Container
+          dependsOn: Publish_Release
+          condition: >-
+            and(
+              succeeded(),
+              ne('true', variables['Skip.Publish'])
+            )
+          environment: azure-dev
+
+          pool:
+            name: azsdk-pool-mms-win-2022-general
+            image: azsdk-pool-mms-win-2022-1espt
+            os: windows
+
+          templateContext:
+            inputs:
+              - input: checkout
+                repository: self
+
+
+          strategy:
+            runOnce:
+              deploy:
+                steps:
+                  - task: PowerShell@2
+                    inputs:
+                      pwsh: true
+                      targetType: filePath
+                      filePath: eng/scripts/Set-CliVersionVariable.ps1
+                    displayName: Set CLI_VERSION
+
                   - pwsh: |
                       # Initial tag
                       $dockerTags = '$(CLI_VERSION)'
@@ -79,234 +120,227 @@ stages:
                       Write-Host "###vso[task.setvariable variable=DockerImageTags]$dockerTags"
                     displayName: Set DockerImageTags
 
-                  - template: /eng/pipelines/templates/steps/publish-cli.yml
+                  - template: /eng/pipelines/templates/steps/publish-cli-container.yml
                     parameters:
-                      CreateGitHubRelease: true
-                      PublishUploadLocations: $(StorageUploadLocations)
-                      PublishShield: true
                       DockerImageTags: $(DockerImageTags)
                       ReleaseSyndicatedDockerContainer: true
-                      PublishUpdatedDocs: true
-                      UploadMsi: true
-                      PublishBrewFormula: true
-                      PublishArm64Binaries: true
 
-        - deployment: Publish_Choco
-          dependsOn: Publish_Release
-          condition: >-
-            and(
-              succeeded(),
-              ne('true', variables['Skip.Publish'])
-            )
-          environment: azure-dev
+    #     - deployment: Publish_Choco
+    #       dependsOn: Publish_Release
+    #       condition: >-
+    #         and(
+    #           succeeded(),
+    #           ne('true', variables['Skip.Publish'])
+    #         )
+    #       environment: azure-dev
 
-          pool:
-            name: azsdk-pool-mms-win-2022-general
-            image: azsdk-pool-mms-win-2022-1espt
-            os: windows
+    #       pool:
+    #         name: azsdk-pool-mms-win-2022-general
+    #         image: azsdk-pool-mms-win-2022-1espt
+    #         os: windows
 
-          templateContext:
-            inputs:
-              - input: checkout
-                repository: self
+    #       templateContext:
+    #         inputs:
+    #           - input: checkout
+    #             repository: self
 
-          strategy:
-            runOnce:
-              deploy:
-                steps:
-                  - task: PowerShell@2
-                    inputs:
-                      pwsh: true
-                      targetType: filePath
-                      filePath: eng/scripts/Set-CliVersionVariable.ps1
-                    displayName: Set CLI_VERSION
+    #       strategy:
+    #         runOnce:
+    #           deploy:
+    #             steps:
+    #               - task: PowerShell@2
+    #                 inputs:
+    #                   pwsh: true
+    #                   targetType: filePath
+    #                   filePath: eng/scripts/Set-CliVersionVariable.ps1
+    #                 displayName: Set CLI_VERSION
 
-                  - template: /eng/pipelines/templates/steps/publish-cli-choco.yml
-                    parameters:
-                      CliVersion: $(CLI_VERSION)
+    #               - template: /eng/pipelines/templates/steps/publish-cli-choco.yml
+    #                 parameters:
+    #                   CliVersion: $(CLI_VERSION)
 
-        - deployment: Publish_WinGet
-          dependsOn: Publish_Release
-          condition: >-
-            and(
-              succeeded(),
-              ne('true', variables['Skip.Publish'])
-            )
-          environment: azure-dev
+    #     - deployment: Publish_WinGet
+    #       dependsOn: Publish_Release
+    #       condition: >-
+    #         and(
+    #           succeeded(),
+    #           ne('true', variables['Skip.Publish'])
+    #         )
+    #       environment: azure-dev
 
-          pool:
-            name: azsdk-pool-mms-win-2022-general
-            image: azsdk-pool-mms-win-2022-1espt
-            os: windows
+    #       pool:
+    #         name: azsdk-pool-mms-win-2022-general
+    #         image: azsdk-pool-mms-win-2022-1espt
+    #         os: windows
 
-          templateContext:
-            inputs:
-              - input: checkout
-                repository: self
+    #       templateContext:
+    #         inputs:
+    #           - input: checkout
+    #             repository: self
 
-          strategy:
-            runOnce:
-              deploy:
-                steps:
-                  - task: PowerShell@2
-                    inputs:
-                      pwsh: true
-                      targetType: filePath
-                      filePath: eng/scripts/Set-CliVersionVariable.ps1
-                    displayName: Set CLI_VERSION
+    #       strategy:
+    #         runOnce:
+    #           deploy:
+    #             steps:
+    #               - task: PowerShell@2
+    #                 inputs:
+    #                   pwsh: true
+    #                   targetType: filePath
+    #                   filePath: eng/scripts/Set-CliVersionVariable.ps1
+    #                 displayName: Set CLI_VERSION
 
-                  - template: /eng/pipelines/templates/steps/publish-cli-winget.yml
-                    parameters:
-                      CliVersion: $(CLI_VERSION)
+    #               - template: /eng/pipelines/templates/steps/publish-cli-winget.yml
+    #                 parameters:
+    #                   CliVersion: $(CLI_VERSION)
 
-        - deployment: Increment_Version
-          condition: >-
-            and(
-              succeeded(),
-              ne('true', variables['Skip.IncrementVersion'])
-            )
-          dependsOn: Publish_Release
-          environment: azure-dev
+    #     - deployment: Increment_Version
+    #       condition: >-
+    #         and(
+    #           succeeded(),
+    #           ne('true', variables['Skip.IncrementVersion'])
+    #         )
+    #       dependsOn: Publish_Release
+    #       environment: azure-dev
 
-          pool:
-            name: azsdk-pool-mms-ubuntu-2004-general
-            image: azsdk-pool-mms-ubuntu-2004-1espt
-            os: linux
+    #       pool:
+    #         name: azsdk-pool-mms-ubuntu-2004-general
+    #         image: azsdk-pool-mms-ubuntu-2004-1espt
+    #         os: linux
 
-          templateContext:
-            inputs:
-              - input: checkout
-                repository: self
+    #       templateContext:
+    #         inputs:
+    #           - input: checkout
+    #             repository: self
 
-          strategy:
-            runOnce:
-              deploy:
-                steps:
-                  - task: PowerShell@2
-                    inputs:
-                      pwsh: true
-                      targetType: filePath
-                      filePath: eng/scripts/Update-CliVersion.ps1
-                    displayName: Increment CLI version
+    #       strategy:
+    #         runOnce:
+    #           deploy:
+    #             steps:
+    #               - task: PowerShell@2
+    #                 inputs:
+    #                   pwsh: true
+    #                   targetType: filePath
+    #                   filePath: eng/scripts/Update-CliVersion.ps1
+    #                 displayName: Increment CLI version
 
-                  - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
-                    parameters:
-                      PRBranchName: cli-version-increment-$(Build.BuildId)
-                      CommitMsg: Increment CLI version after release
-                      PRTitle: Increment CLI version after release
+    #               - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
+    #                 parameters:
+    #                   PRBranchName: cli-version-increment-$(Build.BuildId)
+    #                   CommitMsg: Increment CLI version after release
+    #                   PRTitle: Increment CLI version after release
 
-    - stage: PublishVersionTxt
-      dependsOn: PublishCLI
+    # - stage: PublishVersionTxt
+    #   dependsOn: PublishCLI
 
-      condition: >-
-        and(
-          succeeded(),
-          ne(variables['Skip.Release'], 'true'),
-          or(
-            eq('Manual', variables['BuildReasonOverride']),
-            and(
-              eq('', variables['BuildReasonOverride']),
-              eq('Manual', variables['Build.Reason'])
-            )
-          )
-        )
+    #   condition: >-
+    #     and(
+    #       succeeded(),
+    #       ne(variables['Skip.Release'], 'true'),
+    #       or(
+    #         eq('Manual', variables['BuildReasonOverride']),
+    #         and(
+    #           eq('', variables['BuildReasonOverride']),
+    #           eq('Manual', variables['Build.Reason'])
+    #         )
+    #       )
+    #     )
 
-      variables: 
-        - template: /eng/pipelines/templates/variables/image.yml
-        - template: /eng/pipelines/templates/variables/globals.yml
+    #   variables:
+    #     - template: /eng/pipelines/templates/variables/image.yml
+    #     - template: /eng/pipelines/templates/variables/globals.yml
 
-      jobs:
-        - deployment: Upload_Version_Txt
-          condition: >-
-            and(
-              succeeded(),
-              ne('true', variables['Skip.Publish'])
-            )
-          environment: azure-dev
+    #   jobs:
+    #     - deployment: Upload_Version_Txt
+    #       condition: >-
+    #         and(
+    #           succeeded(),
+    #           ne('true', variables['Skip.Publish'])
+    #         )
+    #       environment: azure-dev
 
-          pool:
-            name: azsdk-pool-mms-win-2022-general
-            image: azsdk-pool-mms-win-2022-1espt
-            os: windows
+    #       pool:
+    #         name: azsdk-pool-mms-win-2022-general
+    #         image: azsdk-pool-mms-win-2022-1espt
+    #         os: windows
 
-          templateContext:
-            inputs:
-              - input: checkout
-                repository: self
+    #       templateContext:
+    #         inputs:
+    #           - input: checkout
+    #             repository: self
 
-          strategy:
-            runOnce:
-              deploy:
-                steps:
-                  - task: PowerShell@2
-                    inputs:
-                      pwsh: true
-                      targetType: filePath
-                      filePath: eng/scripts/Set-CliVersionVariable.ps1
-                    displayName: Set CLI_VERSION
+    #       strategy:
+    #         runOnce:
+    #           deploy:
+    #             steps:
+    #               - task: PowerShell@2
+    #                 inputs:
+    #                   pwsh: true
+    #                   targetType: filePath
+    #                   filePath: eng/scripts/Set-CliVersionVariable.ps1
+    #                 displayName: Set CLI_VERSION
 
-                  - task: PowerShell@2
-                    displayName: Set MSI_VERSION
-                    inputs:
-                      pwsh: true
-                      targetType: filePath
-                      filePath: eng/scripts/Get-MsiVersion.ps1
-                      arguments: >-
-                        -CliVersion '$(CLI_VERSION)'
-                        -DevOpsOutput
+    #               - task: PowerShell@2
+    #                 displayName: Set MSI_VERSION
+    #                 inputs:
+    #                   pwsh: true
+    #                   targetType: filePath
+    #                   filePath: eng/scripts/Get-MsiVersion.ps1
+    #                   arguments: >-
+    #                     -CliVersion '$(CLI_VERSION)'
+    #                     -DevOpsOutput
 
-                  - task: PowerShell@2
-                    displayName: Wait for WinGet package
-                    inputs:
-                      pwsh: true
-                      targetType: filePath
-                      filePath: eng/scripts/Wait-WinGetPackage.ps1
-                      arguments: >-
-                        -PackageName 'Microsoft.Azd'
-                        -PackageVersion '$(MSI_VERSION)'
+    #               - task: PowerShell@2
+    #                 displayName: Wait for WinGet package
+    #                 inputs:
+    #                   pwsh: true
+    #                   targetType: filePath
+    #                   filePath: eng/scripts/Wait-WinGetPackage.ps1
+    #                   arguments: >-
+    #                     -PackageName 'Microsoft.Azd'
+    #                     -PackageVersion '$(MSI_VERSION)'
 
-                  - task: PowerShell@2
-                    displayName: Wait for Choco package
-                    inputs:
-                      pwsh: true
-                      targetType: filePath
-                      filePath: eng/scripts/Wait-ChocoPackage.ps1
-                      arguments: >-
-                        -PackageName 'azd'
-                        -PackageVersion '$(MSI_VERSION)'
+    #               - task: PowerShell@2
+    #                 displayName: Wait for Choco package
+    #                 inputs:
+    #                   pwsh: true
+    #                   targetType: filePath
+    #                   filePath: eng/scripts/Wait-ChocoPackage.ps1
+    #                   arguments: >-
+    #                     -PackageName 'azd'
+    #                     -PackageVersion '$(MSI_VERSION)'
 
-                  - pwsh: |
-                      New-Item -ItemType Directory -Path release
-                      Write-Output $(CLI_VERSION) | Out-File -Encoding utf8 -FilePath ./release/version.txt
-                    displayName: Write version.txt file for release
+    #               - pwsh: |
+    #                   New-Item -ItemType Directory -Path release
+    #                   Write-Output $(CLI_VERSION) | Out-File -Encoding utf8 -FilePath ./release/version.txt
+    #                 displayName: Write version.txt file for release
 
-                  - pwsh: |
-                      $isPublishingGa = eng/scripts/Test-ShouldReleasePackageVersion.ps1 `
-                        -CliVersion '$(CLI_VERSION)'
+    #               - pwsh: |
+    #                   $isPublishingGa = eng/scripts/Test-ShouldReleasePackageVersion.ps1 `
+    #                     -CliVersion '$(CLI_VERSION)'
 
-                      $publishUploadLocations = @('release/latest')
-                      if ($isPublishingGa) {
-                        $publishUploadLocations += @('release/stable')
-                      }
+    #                   $publishUploadLocations = @('release/latest')
+    #                   if ($isPublishingGa) {
+    #                     $publishUploadLocations += @('release/stable')
+    #                   }
 
-                      Get-ChildItem release/
+    #                   Get-ChildItem release/
 
-                      foreach ($folder in $publishUploadLocations) {
-                        Write-Host "Upload to azd/standalone/$folder"
-                        az storage blob upload-batch `
-                          --account-name '$(azdev-storage-account-name)' `
-                          --account-key '$(azdev-storage-account-key)' `
-                          --auth-mode key `
-                          -s release/ `
-                          -d "azd/standalone/$folder" `
-                          --overwrite
+    #                   foreach ($folder in $publishUploadLocations) {
+    #                     Write-Host "Upload to azd/standalone/$folder"
+    #                     az storage blob upload-batch `
+    #                       --account-name '$(azdev-storage-account-name)' `
+    #                       --account-key '$(azdev-storage-account-key)' `
+    #                       --auth-mode key `
+    #                       -s release/ `
+    #                       -d "azd/standalone/$folder" `
+    #                       --overwrite
 
-                        if ($LASTEXITCODE) {
-                          Write-Error "Upload failed"
-                          exit 1
-                        }
-                      }
-                    displayName: Upload version.txt to storage account
+    #                     if ($LASTEXITCODE) {
+    #                       Write-Error "Upload failed"
+    #                       exit 1
+    #                     }
+    #                   }
+    #                 displayName: Upload version.txt to storage account
 
   - stage: PublishIntegration
     dependsOn: Sign
@@ -353,9 +387,15 @@ stages:
                 CreateGitHubRelease: false
                 PublishUploadLocations: release/daily;daily/archive/$(Build.BuildId)-$(Build.SourceVersion)
                 PublishShield: false
-                DockerImageTags: daily;$(CLI_VERSION)
                 UploadMsi: true
                 PublishArm64Binaries: true
+
+            - template: /eng/pipelines/templates/steps/publish-cli-container.yml
+              parameters:
+                DockerImageTags: daily;$(CLI_VERSION)
+                ReleaseSyndicatedDockerContainer: false
+                # Artifacts are already downloaded in publish-cli.yml
+                DownloadArtifacts: false
 
       - job: Publish_For_PR
         condition: >-

--- a/eng/pipelines/templates/steps/build-linux-packages.yml
+++ b/eng/pipelines/templates/steps/build-linux-packages.yml
@@ -17,6 +17,7 @@ steps:
       path: $(Build.SourcesDirectory)/cli/installer/fpm
       dockerfile: $(Build.SourcesDirectory)/cli/installer/fpm/fpm.Dockerfile
       enableNetwork: true
+      useBuildKit: true
 
   - task: PowerShell@2
     condition: ${{ parameters.Condition }}

--- a/eng/pipelines/templates/steps/build-linux-packages.yml
+++ b/eng/pipelines/templates/steps/build-linux-packages.yml
@@ -13,14 +13,10 @@ steps:
     displayName: Build fpm container (1ES)
     inputs:
       image: fpm
-      path: cli/installer/fpm
+      path: $(Build.SourcesDirectory)/cli/installer/fpm
       dockerfile: cli/instatller/fpm/fpm.Dockerfile
       enableNetwork: true
-
-  # - pwsh: docker build . -f fpm.Dockerfile -t fpm --build-arg prefix="$(docker-mirror-tag-prefix)/"
-  #   condition: ${{ parameters.Condition }}
-  #   workingDirectory: cli/installer/fpm
-  #   displayName: Build fpm container
+      useBuildKit: true
 
   - task: PowerShell@2
     condition: ${{ parameters.Condition }}

--- a/eng/pipelines/templates/steps/build-linux-packages.yml
+++ b/eng/pipelines/templates/steps/build-linux-packages.yml
@@ -13,8 +13,8 @@ steps:
     displayName: Build fpm container (1ES)
     inputs:
       image: fpm
-      path: $(Build.SourcesDirectory)/cli/installer/fpm
-      dockerfile: $(Build.SourcesDirectory)/cli/instatller/fpm/fpm.Dockerfile
+      context: $(Build.SourcesDirectory)/cli/installer/fpm
+      dockerfile: fpm.Dockerfile
       enableNetwork: true
       useBuildKit: true
 

--- a/eng/pipelines/templates/steps/build-linux-packages.yml
+++ b/eng/pipelines/templates/steps/build-linux-packages.yml
@@ -8,10 +8,19 @@ steps:
     condition: ${{ parameters.Condition }}
     displayName: Copy binary to fpm working directory
 
-  - pwsh: docker build . -f fpm.Dockerfile -t fpm --build-arg prefix="$(docker-mirror-tag-prefix)/"
-    condition: ${{ parameters.Condition }}
-    workingDirectory: cli/installer/fpm
-    displayName: Build fpm container
+
+  - task: 1ES.BuildContainerImage@1
+    displayName: Build fpm container (1ES)
+    inputs:
+      image: fpm
+      path: cli/installer/fpm
+      dockerfile: cli/instatller/fpm/fpm.Dockerfile
+      enableNetwork: true
+
+  # - pwsh: docker build . -f fpm.Dockerfile -t fpm --build-arg prefix="$(docker-mirror-tag-prefix)/"
+  #   condition: ${{ parameters.Condition }}
+  #   workingDirectory: cli/installer/fpm
+  #   displayName: Build fpm container
 
   - task: PowerShell@2
     condition: ${{ parameters.Condition }}

--- a/eng/pipelines/templates/steps/build-linux-packages.yml
+++ b/eng/pipelines/templates/steps/build-linux-packages.yml
@@ -14,7 +14,7 @@ steps:
     inputs:
       image: fpm
       path: $(Build.SourcesDirectory)/cli/installer/fpm
-      dockerfile: cli/instatller/fpm/fpm.Dockerfile
+      dockerfile: $(Build.SourcesDirectory)/cli/instatller/fpm/fpm.Dockerfile
       enableNetwork: true
       useBuildKit: true
 

--- a/eng/pipelines/templates/steps/build-linux-packages.yml
+++ b/eng/pipelines/templates/steps/build-linux-packages.yml
@@ -14,7 +14,7 @@ steps:
     inputs:
       image: fpm
       path: $(Build.SourcesDirectory)/cli/installer/fpm/
-      dockerfile: fpm.Dockerfile
+      dockerfile: $(Build.SourcesDirectory)/cli/installer/fpm/fpm.Dockerfile
       enableNetwork: true
       useBuildKit: true
 

--- a/eng/pipelines/templates/steps/build-linux-packages.yml
+++ b/eng/pipelines/templates/steps/build-linux-packages.yml
@@ -13,10 +13,9 @@ steps:
     displayName: Build fpm container (1ES)
     inputs:
       image: fpm
-      path: $(Build.SourcesDirectory)/cli/installer/fpm/
+      path: $(Build.SourcesDirectory)/cli/installer/fpm
       dockerfile: $(Build.SourcesDirectory)/cli/installer/fpm/fpm.Dockerfile
       enableNetwork: true
-      useBuildKit: true
 
   - task: PowerShell@2
     condition: ${{ parameters.Condition }}

--- a/eng/pipelines/templates/steps/build-linux-packages.yml
+++ b/eng/pipelines/templates/steps/build-linux-packages.yml
@@ -13,7 +13,7 @@ steps:
     displayName: Build fpm container (1ES)
     inputs:
       image: fpm
-      context: $(Build.SourcesDirectory)/cli/installer/fpm
+      path: $(Build.SourcesDirectory)/cli/installer/fpm/
       dockerfile: fpm.Dockerfile
       enableNetwork: true
       useBuildKit: true

--- a/eng/pipelines/templates/steps/build-linux-packages.yml
+++ b/eng/pipelines/templates/steps/build-linux-packages.yml
@@ -12,7 +12,8 @@ steps:
   - task: 1ES.BuildContainerImage@1
     displayName: Build fpm container (1ES)
     inputs:
-      image: fpm
+      # Use "latest" tag because build_docker_image.py fails if there is no tag
+      image: fpm:latest
       path: $(Build.SourcesDirectory)/cli/installer/fpm
       dockerfile: $(Build.SourcesDirectory)/cli/installer/fpm/fpm.Dockerfile
       enableNetwork: true

--- a/eng/pipelines/templates/steps/build-linux-packages.yml
+++ b/eng/pipelines/templates/steps/build-linux-packages.yml
@@ -10,6 +10,7 @@ steps:
 
 
   - task: 1ES.BuildContainerImage@1
+    condition: ${{ parameters.Condition }}
     displayName: Build fpm container (1ES)
     inputs:
       # Use "latest" tag because build_docker_image.py fails if there is no tag

--- a/eng/pipelines/templates/steps/publish-cli-container.yml
+++ b/eng/pipelines/templates/steps/publish-cli-container.yml
@@ -16,7 +16,7 @@ parameters:
     default: $(azdev-acr-host-test)
   - name: SyndicatedAcrHost
     type: string
-    default: not-valid
+    default:  $(azdev-acr-host-test)
     # TODO: Uncomment before merging
     # default: $(azdev-acr-syndicated-host)
 
@@ -42,8 +42,10 @@ steps:
       scriptLocation: inlineScript
       inlineScript: |
         az acr login --name ${{ parameters.AcrHost}}
-        # TODO: only if publishing to syndicated host
-        # az acr login --name ${{ parameters.SyndicatedAcrHost }}
+
+        if ($${{ parameters.ReleaseSyndicatedDockerContainer }}) {
+          az acr login --name ${{ parameters.SyndicatedAcrHost }}
+        }
 
   - pwsh: |
       New-Item -ItemType Directory -Path cli/bin
@@ -65,32 +67,20 @@ steps:
       foreach ($tag in $tags) {
         $items += "${{ parameters.AcrHost }}/azure-dev:$tag"
       }
+
+      if ($${{ parameters.ReleaseSyndicatedDockerContainer }}) {
+        foreach ($tag in $tags) {
+          $items += "${{ parameters.SyndicatedAcrHost }}/public/azure-dev-cli-apps:$tag"
+        }
+      }
+
       $imageNames = $items -join ','
       Write-Host "Image Names: $imageNames"
       Write-Host "##vso[task.setvariable variable=ImageNames]$imageNames"
-
     displayName: Tag release container
-
-  # - ${{ if eq('true', parameters.ReleaseSyndicatedDockerContainer) }}:
-  #   - pwsh: |
-  #       $tags = "${{ parameters.DockerImageTags }}" -split ';'
-  #       foreach ($tag in $tags) {
-  #         Write-Host "docker tag release:latest ${{ parameters.SyndicatedAcrHost }}/public/azure-dev-cli-apps:$tag"
-  #         docker tag release:latest ${{ parameters.SyndicatedAcrHost }}/public/azure-dev-cli-apps:$tag
-  #       }
-  #     displayName: Tag release for syndication
-
-  # - pwsh: |
-  #     docker push ${{ parameters.AcrHost }}/azure-dev --all-tags
-  #   displayName: Push container tags (latest)
 
   - task: 1ES.PushContainerImage@1
     displayName: Push container tags
     inputs:
       localImage: release:latest
       remoteImage: $(ImageNames)
-
-  # - ${{ if eq('true', parameters.ReleaseSyndicatedDockerContainer) }}:
-  #   - pwsh: |
-  #       docker push ${{ parameters.SyndicatedAcrHost }}/public/azure-dev-cli-apps --all-tags
-  #     displayName: Push container tags (syndicated release)

--- a/eng/pipelines/templates/steps/publish-cli-container.yml
+++ b/eng/pipelines/templates/steps/publish-cli-container.yml
@@ -1,0 +1,96 @@
+parameters:
+  - name: DockerImageTags
+    type: string
+  - name: ReleaseSyndicatedDockerContainer
+    type: boolean
+    default: false
+
+  # Download artifacts if not already downloaded in a previous step
+  - name: DownloadArtifacts
+    type: boolean
+    default: true
+
+  # TODO: use service connection and az CLI auth
+  - name: AcrHost
+    type: string
+    default: $(azdev-acr-host-test)
+  - name: SyndicatedAcrHost
+    type: string
+    default: not-valid
+    # TODO: Uncomment before merging
+    # default: $(azdev-acr-syndicated-host)
+
+steps: 
+  # TODO: Docker stuff should be handled as per: https://github.com/Azure/azure-sdk-tools/commit/2623b00fc5b660d48e2301977602ddd8f934ac4a
+
+  - ${{ if eq('true', parameters.DownloadArtifacts) }}:
+    # Linux binary is not signed today so download from output artifacts
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifact: azd-linux-amd64
+        # Copy the item from artifacts straight to where it will go
+        path: release-staging
+
+  - bash: chmod +x release-staging/azd-linux-amd64
+    displayName: Set execute bit for the mac and linux release
+
+  - task: AzureCLI@2
+    displayName: Docker Auth
+    inputs:
+      azureSubscription: azdev-publishing_rg
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        az acr login --name ${{ parameters.AcrHost}}
+        # TODO: only if publishing to syndicated host
+        # az acr login --name ${{ parameters.SyndicatedAcrHost }}
+
+  - pwsh: |
+      New-Item -ItemType Directory -Path cli/bin
+      Copy-Item release-staging/azd-linux-amd64 cli/bin/
+    displayName: Move binary to Docker build context
+
+  - task: 1ES.BuildContainerImage@1
+    displayName: Build release container
+    inputs:
+      image: release:latest
+      path: $(Build.SourcesDirectory)
+      dockerfile: cli/Dockerfile
+      enableNetwork: true
+      useBuildKit: true
+
+  - pwsh: |
+      $tags = "${{ parameters.DockerImageTags }}" -split ';'
+      $items = @()
+      foreach ($tag in $tags) {
+        $items += "release:latest ${{ parameters.AcrHost }}/azure-dev:$tag"
+      }
+      $imageNames = $items -join ','
+      Write-Host "Image Names: $imageNames"
+      Write-Host "##vso[task.setvariable variable=ImageNames]$imageNames"
+
+    displayName: Tag release container
+
+  # - ${{ if eq('true', parameters.ReleaseSyndicatedDockerContainer) }}:
+  #   - pwsh: |
+  #       $tags = "${{ parameters.DockerImageTags }}" -split ';'
+  #       foreach ($tag in $tags) {
+  #         Write-Host "docker tag release:latest ${{ parameters.SyndicatedAcrHost }}/public/azure-dev-cli-apps:$tag"
+  #         docker tag release:latest ${{ parameters.SyndicatedAcrHost }}/public/azure-dev-cli-apps:$tag
+  #       }
+  #     displayName: Tag release for syndication
+
+  # - pwsh: |
+  #     docker push ${{ parameters.AcrHost }}/azure-dev --all-tags
+  #   displayName: Push container tags (latest)
+
+  - task: 1ES.PushContainerImage@1
+    displayName: Push container tags
+    inputs:
+      localImage: release:latest
+      remoteImage: $(ImageNames)
+
+  # - ${{ if eq('true', parameters.ReleaseSyndicatedDockerContainer) }}:
+  #   - pwsh: |
+  #       docker push ${{ parameters.SyndicatedAcrHost }}/public/azure-dev-cli-apps --all-tags
+  #     displayName: Push container tags (syndicated release)

--- a/eng/pipelines/templates/steps/publish-cli-container.yml
+++ b/eng/pipelines/templates/steps/publish-cli-container.yml
@@ -9,20 +9,14 @@ parameters:
   - name: DownloadArtifacts
     type: boolean
     default: true
-
-  # TODO: use service connection and az CLI auth
   - name: AcrHost
     type: string
-    default: $(azdev-acr-host-test)
+    default: $(azdev-acr-host)
   - name: SyndicatedAcrHost
     type: string
-    default:  $(azdev-acr-host-test)
-    # TODO: Uncomment before merging
-    # default: $(azdev-acr-syndicated-host)
+    default: $(azdev-acr-syndicated-host)
 
 steps: 
-  # TODO: Docker stuff should be handled as per: https://github.com/Azure/azure-sdk-tools/commit/2623b00fc5b660d48e2301977602ddd8f934ac4a
-
   - ${{ if eq('true', parameters.DownloadArtifacts) }}:
     # Linux binary is not signed today so download from output artifacts
     - task: DownloadPipelineArtifact@2

--- a/eng/pipelines/templates/steps/publish-cli-container.yml
+++ b/eng/pipelines/templates/steps/publish-cli-container.yml
@@ -63,7 +63,7 @@ steps:
       $tags = "${{ parameters.DockerImageTags }}" -split ';'
       $items = @()
       foreach ($tag in $tags) {
-        $items += "release:latest ${{ parameters.AcrHost }}/azure-dev:$tag"
+        $items += "${{ parameters.AcrHost }}/azure-dev:$tag"
       }
       $imageNames = $items -join ','
       Write-Host "Image Names: $imageNames"

--- a/eng/pipelines/templates/steps/publish-cli.yml
+++ b/eng/pipelines/templates/steps/publish-cli.yml
@@ -1,7 +1,5 @@
 parameters:
   CreateGitHubRelease: true
-  ReleaseSyndicatedDockerContainer: false
-  DockerImageTags:
   PublishUploadLocations:
   UploadInstaller: false
   UploadMsi: false
@@ -10,13 +8,6 @@ parameters:
   StorageAccountName: $(azdev-storage-account-name)
   StorageAccountKey: $(azdev-storage-account-key)
   StorageContainerName: azd
-  PublishContainer: true
-  AcrHost: $(azdev-acr-host)
-  AcrUsername: $(azdev-acr-username)
-  AcrPassword: $(azdev-acr-password)
-  SyndicatedAcrHost: $(azdev-acr-syndicated-host)
-  SyndicatedAcrUsername: $(azdev-acr-syndicated-username)
-  SyndicatedAcrPassword: $(azdev-acr-syndicated-password)
   PublishBrewFormula: false
   PublishArm64Binaries: false
   AllowPrerelease: false
@@ -36,19 +27,6 @@ steps:
           -OutputName "GH_RELEASE_TAG"
           -DevOpsOutputFormat
       displayName: Verify and set GitHub Release Tag
-
-  # TODO: Docker stuff should be handled as per: https://github.com/Azure/azure-sdk-tools/commit/2623b00fc5b660d48e2301977602ddd8f934ac4a
-  - ${{ if eq('true', parameters.PublishContainer) }}:
-    - pwsh: |
-        docker login `
-          -u '${{ parameters.AcrUsername }}' `
-          -p '${{ parameters.AcrPassword }}' `
-          ${{ parameters.AcrHost }}
-        docker login `
-          -u '${{ parameters.SyndicatedAcrUsername }}' `
-          -p '${{ parameters.SyndicatedAcrPassword }}' `
-          ${{ parameters.SyndicatedAcrHost }}
-      displayName: Authenticate for publishing
 
   # Download signed artifacts, prepare packaging
   - task: DownloadPipelineArtifact@2
@@ -135,32 +113,6 @@ steps:
         Copy-Item cli/installer/uninstall-azd.ps1 release/
       displayName: Copy install scripts to release (PR only)
 
-  - ${{ if eq('true', parameters.PublishContainer) }}:
-    # Docker build
-    - pwsh: |
-        # Move the binary to a folder where Docker can pick it up
-        New-Item -ItemType Directory -Path cli/bin
-        Copy-Item release-staging/azd-linux-amd64 cli/bin/
-
-        docker build . -f cli/Dockerfile -t release
-
-        $tags = "${{ parameters.DockerImageTags }}" -split ';'
-        foreach ($tag in $tags) {
-          Write-Host "docker tag release ${{ parameters.AcrHost }}/azure-dev:$tag"
-          docker tag release ${{ parameters.AcrHost }}/azure-dev:$tag
-        }
-      displayName: Docker build release container (latest)
-
-    - ${{ if eq('true', parameters.ReleaseSyndicatedDockerContainer) }}:
-      # Syndicated release
-      - pwsh: |
-          $tags = "${{ parameters.DockerImageTags }}" -split ';'
-          foreach ($tag in $tags) {
-            Write-Host "docker tag release ${{ parameters.SyndicatedAcrHost }}/public/azure-dev-cli-apps:$tag"
-            docker tag release ${{ parameters.SyndicatedAcrHost }}/public/azure-dev-cli-apps:$tag
-          }
-        displayName: Build and tag release container (Release)
-
   # Create release
   - ${{ if eq('true', parameters.CreateGitHubRelease ) }}:
     - task: PowerShell@2
@@ -221,16 +173,6 @@ steps:
         StorageContainerName: ${{ parameters.StorageContainerName }}
         PublishDestination: standalone/latest
 
-  - ${{ if eq('true', parameters.PublishContainer) }}:
-    - pwsh: |
-        docker push ${{ parameters.AcrHost }}/azure-dev --all-tags
-      displayName: Push container tags (latest)
-
-    - ${{ if eq('true', parameters.ReleaseSyndicatedDockerContainer) }}:
-      - pwsh: |
-          docker push ${{ parameters.SyndicatedAcrHost }}/public/azure-dev-cli-apps --all-tags
-        displayName: Push container tags (syndicated release)
-
   - ${{ if eq('true', parameters.PublishBrewFormula) }}:
     - pwsh: |
         $submitPackage = eng/scripts/Test-ShouldReleasePackageVersion.ps1 `
@@ -267,7 +209,6 @@ steps:
         CommitMsg: Update formula for azd release $(CLI_VERSION)
         TargetRepoName: homebrew-azd
         WorkingDirectory: homebrew-azd
-
 
   - ${{ if eq('true', parameters.PublishUpdatedDocs) }}:
     - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
Fixes [#7984](https://github.com/Azure/azure-sdk-tools/issues/7984)

* Uses 1ES tasks for building and pushing docker images (authenticates via service connection) 
* Switches `fpm` container to use Mariner 