### PR TITLE
pipeline: Allow configuration of client secret lifetime

### DIFF
--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
@@ -62,6 +63,14 @@ func (pc *pipelineConfigFlags) Bind(local *pflag.FlagSet, global *internal.Globa
 		pipeline.DefaultRoleNames,
 		"The roles to assign to the service principal. By default the service principal will be granted the Contributor and User Access Administrator roles.",
 	)
+
+	local.DurationVar(
+		&pc.PipelineClientSecretDuration,
+		"client-secret-duration",
+		time.Duration(180*time.Hour*24),
+		"The duration for which the client secret should be valid. The default is 180 days.",
+	)
+
 	// default provider is empty because it can be set from azure.yaml. By letting default here be empty, we know that
 	// there no customer input using --provider
 	local.StringVar(&pc.PipelineProvider, "provider", "",

--- a/cli/azd/cmd/testdata/TestUsage-azd-pipeline-config.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-pipeline-config.snap
@@ -9,15 +9,16 @@ Usage
   azd pipeline config [flags]
 
 Flags
-        --auth-type string           	: The authentication type used between the pipeline provider and Azure for deployment (Only valid for GitHub provider). Valid values: federated, client-credentials.
-        --docs                       	: Opens the documentation for azd pipeline config in your web browser.
-    -e, --environment string         	: The name of the environment to use.
-    -h, --help                       	: Gets help for config.
-        --principal-id string        	: The client id of the service principal to use to grant access to Azure resources as part of the pipeline.
-        --principal-name string      	: The name of the service principal to use to grant access to Azure resources as part of the pipeline.
-        --principal-role stringArray 	: The roles to assign to the service principal. By default the service principal will be granted the Contributor and User Access Administrator roles.
-        --provider string            	: The pipeline provider to use (github for Github Actions and azdo for Azure Pipelines).
-        --remote-name string         	: The name of the git remote to configure the pipeline to run on.
+        --auth-type string                	: The authentication type used between the pipeline provider and Azure for deployment (Only valid for GitHub provider). Valid values: federated, client-credentials.
+        --client-secret-duration duration 	: The duration for which the client secret should be valid. The default is 180 days.
+        --docs                            	: Opens the documentation for azd pipeline config in your web browser.
+    -e, --environment string              	: The name of the environment to use.
+    -h, --help                            	: Gets help for config.
+        --principal-id string             	: The client id of the service principal to use to grant access to Azure resources as part of the pipeline.
+        --principal-name string           	: The name of the service principal to use to grant access to Azure resources as part of the pipeline.
+        --principal-role stringArray      	: The roles to assign to the service principal. By default the service principal will be granted the Contributor and User Access Administrator roles.
+        --provider string                 	: The pipeline provider to use (github for Github Actions and azdo for Azure Pipelines).
+        --remote-name string              	: The name of the git remote to configure the pipeline to run on.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/pkg/graphsdk/application_request_builders.go
+++ b/cli/azd/pkg/graphsdk/application_request_builders.go
@@ -172,13 +172,15 @@ func (c *ApplicationItemRequestBuilder) RemovePassword(ctx context.Context, keyI
 	return nil
 }
 
-func (c *ApplicationItemRequestBuilder) AddPassword(ctx context.Context) (*ApplicationPasswordCredential, error) {
+func (c *ApplicationItemRequestBuilder) AddPassword(
+	ctx context.Context, lifetime time.Duration,
+) (*ApplicationPasswordCredential, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPost, fmt.Sprintf("%s/applications/%s/addPassword", c.client.host, c.id))
 	if err != nil {
 		return nil, fmt.Errorf("failed creating request: %w", err)
 	}
 
-	endDateTime := time.Now().Add(time.Hour * 24 * 180)
+	endDateTime := time.Now().Add(lifetime)
 	addPasswordRequest := ApplicationAddPasswordRequest{
 		PasswordCredential: ApplicationPasswordCredential{
 			DisplayName: convert.RefOf("Azure Developer CLI"),

--- a/cli/azd/pkg/graphsdk/application_request_builders_test.go
+++ b/cli/azd/pkg/graphsdk/application_request_builders_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
@@ -188,7 +189,7 @@ func TestApplicationAddPassword(t *testing.T) {
 
 		actual, err := client.
 			ApplicationById(*application.Id).
-			AddPassword(*mockContext.Context)
+			AddPassword(*mockContext.Context, 180*234*time.Hour)
 
 		require.NoError(t, err)
 		require.NotNil(t, actual)
@@ -206,7 +207,7 @@ func TestApplicationAddPassword(t *testing.T) {
 
 		actual, err := client.
 			ApplicationById("bad-app-id").
-			AddPassword(*mockContext.Context)
+			AddPassword(*mockContext.Context, 180*24*time.Hour)
 
 		require.Error(t, err)
 		require.Nil(t, actual)

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -56,6 +56,7 @@ type PipelineManagerArgs struct {
 	PipelineRoleNames            []string
 	PipelineProvider             string
 	PipelineAuthTypeName         string
+	PipelineClientSecretDuration time.Duration
 }
 
 // CredentialOptions represents the options for configuring credentials for a pipeline.
@@ -309,7 +310,8 @@ func (pm *PipelineManager) Configure(ctx context.Context) (result *PipelineConfi
 		spinnerMessage := "Configuring client credentials for service principal"
 		pm.console.ShowSpinner(ctx, spinnerMessage, input.Step)
 
-		creds, err := pm.adService.ResetPasswordCredentials(ctx, subscriptionId, servicePrincipal.AppId)
+		creds, err := pm.adService.ResetPasswordCredentials(
+			ctx, subscriptionId, servicePrincipal.AppId, pm.args.PipelineClientSecretDuration)
 		pm.console.StopSpinner(ctx, spinnerMessage, input.GetStepResultFormat(err))
 		if err != nil {
 			return result, fmt.Errorf("failed to reset password credentials: %w", err)

--- a/cli/azd/pkg/tools/azcli/ad.go
+++ b/cli/azd/pkg/tools/azcli/ad.go
@@ -62,6 +62,7 @@ type AdService interface {
 		ctx context.Context,
 		subscriptionId string,
 		appId string,
+		duration time.Duration,
 	) (*AzureCredentials, error)
 	ApplyFederatedCredentials(
 		ctx context.Context,
@@ -148,6 +149,7 @@ func (ad *adService) ResetPasswordCredentials(
 	ctx context.Context,
 	subscriptionId string,
 	appId string,
+	duration time.Duration,
 ) (*AzureCredentials, error) {
 	graphClient, err := ad.getOrCreateGraphClient(ctx, subscriptionId)
 	if err != nil {
@@ -176,7 +178,7 @@ func (ad *adService) ResetPasswordCredentials(
 
 	credential, err := graphClient.
 		ApplicationById(*application.Id).
-		AddPassword(ctx)
+		AddPassword(ctx, duration)
 
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/cli/azd/pkg/tools/azcli/ad_test.go
+++ b/cli/azd/pkg/tools/azcli/ad_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
@@ -483,6 +484,7 @@ func Test_ResetPasswordCredentials(t *testing.T) {
 			*mockContext.Context,
 			"SUBSCRIPTION_ID",
 			*mockApplication.AppId,
+			180*24*time.Hour,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, credentials)
@@ -505,6 +507,7 @@ func Test_ResetPasswordCredentials(t *testing.T) {
 			*mockContext.Context,
 			"SUBSCRIPTION_ID",
 			*mockApplication.AppId,
+			180*24*time.Hour,
 		)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "failed finding matching application")
@@ -531,6 +534,7 @@ func Test_ResetPasswordCredentials(t *testing.T) {
 			*mockContext.Context,
 			"SUBSCRIPTION_ID",
 			*mockApplication.AppId,
+			180*24*time.Hour,
 		)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "failed removing credentials")
@@ -558,6 +562,7 @@ func Test_ResetPasswordCredentials(t *testing.T) {
 			*mockContext.Context,
 			"SUBSCRIPTION_ID",
 			*mockApplication.AppId,
+			180*24*time.Hour,
 		)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "failed adding new password credential")


### PR DESCRIPTION
With this change, `azd pipeline config` gains a new flag, `--client-secret-duration` which allows control over how long the client secret we create when using a shared secret instead of federated credentails is valid for. This defaults to 180 days, the previously unconfigurable default.

The value should be a string as recognized by `time.ParseDuration`.