### PR TITLE
DO NOT MERGE: Disable TLS Verification for remote credential and prompting

### DIFF
--- a/cli/azd/pkg/auth/remote_credential.go
+++ b/cli/azd/pkg/auth/remote_credential.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -61,7 +62,13 @@ func (rc *RemoteCredential) GetToken(ctx context.Context, options policy.TokenRe
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", rc.key))
 
-	res, err := rc.httpClient.Do(req)
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	res, err := client.Do(req)
 	if err != nil {
 		return azcore.AccessToken{}, fmt.Errorf("making request: %w", err)
 	}

--- a/cli/azd/pkg/input/external_prompt_client.go
+++ b/cli/azd/pkg/input/external_prompt_client.go
@@ -3,6 +3,7 @@ package input
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -115,7 +116,13 @@ func (c *externalPromptClient) PromptDialog(
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.key))
 
-	res, err := c.pipeline.Do(req)
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	res, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("making request: %w", err)
 	}


### PR DESCRIPTION
Just a quick hack to get privates for our friends in VS so they can test their changes that expose these external services over HTTP.

The correct solution on our end will involve validating the certificate that was presented to us when `InitializeServerAsync`, but for now we'll just disable checking the certificate completely, so we can see stuff work over HTTPS.