### PR TITLE
Enable DataProtection Runtime feature in ACA

### DIFF
--- a/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-frontend.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-frontend.snap
@@ -1,3 +1,4 @@
+api-version: 2024-02-02-preview
 location: {{ .Env.AZURE_LOCATION }}
 identity:
   type: UserAssigned
@@ -8,6 +9,9 @@ properties:
   environmentId: {{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_ID }}
   configuration:
     activeRevisionsMode: single
+    runtime:
+      dotnet:
+        autoConfigureDataProtection: true
     ingress:
       external: false
       targetPort: {{ targetPortOrDefault 8080 }}

--- a/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-nodeapp.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-nodeapp.snap
@@ -1,3 +1,4 @@
+api-version: 2024-02-02-preview
 location: {{ .Env.AZURE_LOCATION }}
 identity:
   type: UserAssigned
@@ -8,6 +9,9 @@ properties:
   environmentId: {{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_ID }}
   configuration:
     activeRevisionsMode: single
+    runtime:
+      dotnet:
+        autoConfigureDataProtection: true
     ingress:
       external: true
       targetPort: {{ targetPortOrDefault 3000 }}

--- a/cli/azd/pkg/apphost/testdata/TestAspireEscaping-api.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireEscaping-api.snap
@@ -1,3 +1,4 @@
+api-version: 2024-02-02-preview
 location: {{ .Env.AZURE_LOCATION }}
 identity:
   type: UserAssigned
@@ -8,6 +9,9 @@ properties:
   environmentId: {{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_ID }}
   configuration:
     activeRevisionsMode: single
+    runtime:
+      dotnet:
+        autoConfigureDataProtection: true
     ingress:
       external: false
       targetPort: {{ targetPortOrDefault 8080 }}

--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -1,11 +1,18 @@
 package containerapps
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
+	"net/http"
+	"slices"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3"
 	azdinternal "github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
@@ -101,6 +108,10 @@ func (cas *containerAppService) GetIngressConfiguration(
 	}, nil
 }
 
+// apiVersionKey is the key that can be set in the root of a deployment yaml to control the API version used when creating
+// or updating the container app. When unset, we use the default API version of the armappcontainers.ContainerAppsClient.
+const apiVersionKey = "api-version"
+
 func (cas *containerAppService) DeployYaml(
 	ctx context.Context,
 	subscriptionId string,
@@ -108,32 +119,81 @@ func (cas *containerAppService) DeployYaml(
 	appName string,
 	containerAppYaml []byte,
 ) error {
-	appClient, err := cas.createContainerAppsClient(ctx, subscriptionId)
-	if err != nil {
-		return err
-	}
-
 	var obj map[string]any
 	if err := yaml.Unmarshal(containerAppYaml, &obj); err != nil {
 		return fmt.Errorf("decoding yaml: %w", err)
 	}
 
-	containerAppJson, err := json.Marshal(obj)
-	if err != nil {
-		panic("should not have failed")
+	var poller *runtime.Poller[armappcontainers.ContainerAppsClientCreateOrUpdateResponse]
+
+	// The way we make the initial request depends on whether the apiVersion is specified in the YAML.
+	if apiVersion, ok := obj[apiVersionKey].(string); ok {
+		// When the apiVersion is specified, we need to use a custom policy to inject the apiVersion and body into the
+		// request. This is because the ContainerAppsClient is built for a specific api version and does not allow us to
+		// change it.  The custom policy allows us to use the parts of the SDK around building the request URL and using
+		// the standard pipeline - but we have to use a policy to change the api-version header and inject the body since
+		// the armappcontainers.ContainerApp{} is also built for a specific api version.
+		customPolicy := &containerAppCustomApiVersionAndBodyPolicy{
+			apiVersion: apiVersion,
+		}
+
+		appClient, err := cas.createContainerAppsClientWithPerCallPolicy(ctx, subscriptionId, customPolicy)
+		if err != nil {
+			return err
+		}
+
+		// Remove the apiVersion field from the object so it doesn't get injected into the request body. On the wire this
+		// is in a query parameter, not the body.
+		delete(obj, apiVersionKey)
+
+		containerAppJson, err := json.Marshal(obj)
+		if err != nil {
+			panic("should not have failed")
+		}
+
+		// Set the body injected by the policy to be the full container app JSON from the YAML.
+		customPolicy.body = (*json.RawMessage)(&containerAppJson)
+
+		// It doesn't matter what we configure here - the value is going to be overwritten by the custom policy. But we need
+		// to pass in a value, so use the zero value.
+		emptyApp := armappcontainers.ContainerApp{}
+
+		p, err := appClient.BeginCreateOrUpdate(ctx, resourceGroupName, appName, emptyApp, nil)
+		if err != nil {
+			return fmt.Errorf("applying manifest: %w", err)
+		}
+		poller = p
+
+		// Now that we've sent the request, clear the body so it is not injected on any subsequent requests (e.g. ones made
+		// by the poller when we poll).
+		customPolicy.body = nil
+	} else {
+		// When the apiVersion field is unset in the YAML, we can use the standard SDK to build the request and send it
+		// like normal.
+		appClient, err := cas.createContainerAppsClient(ctx, subscriptionId)
+		if err != nil {
+			return err
+		}
+
+		containerAppJson, err := json.Marshal(obj)
+		if err != nil {
+			panic("should not have failed")
+		}
+
+		var containerApp armappcontainers.ContainerApp
+		if err := json.Unmarshal(containerAppJson, &containerApp); err != nil {
+			return fmt.Errorf("converting to container app type: %w", err)
+		}
+
+		p, err := appClient.BeginCreateOrUpdate(ctx, resourceGroupName, appName, containerApp, nil)
+		if err != nil {
+			return fmt.Errorf("applying manifest: %w", err)
+		}
+
+		poller = p
 	}
 
-	var containerApp armappcontainers.ContainerApp
-	if err := json.Unmarshal(containerAppJson, &containerApp); err != nil {
-		return fmt.Errorf("converting to container app type: %w", err)
-	}
-
-	poller, err := appClient.BeginCreateOrUpdate(ctx, resourceGroupName, appName, containerApp, nil)
-	if err != nil {
-		return fmt.Errorf("applying manifest: %w", err)
-	}
-
-	_, err = poller.PollUntilDone(ctx, nil)
+	_, err := poller.PollUntilDone(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("polling for container app update completion: %w", err)
 	}
@@ -337,6 +397,28 @@ func (cas *containerAppService) createContainerAppsClient(
 	return client, nil
 }
 
+func (cas *containerAppService) createContainerAppsClientWithPerCallPolicy(
+	ctx context.Context,
+	subscriptionId string,
+	policy policy.Policy,
+) (*armappcontainers.ContainerAppsClient, error) {
+	credential, err := cas.credentialProvider.CredentialForSubscription(ctx, subscriptionId)
+	if err != nil {
+		return nil, err
+	}
+
+	// Clone the options so we don't modify the original - we don't want to inject this custom policy into every request.
+	options := *cas.armClientOptions
+	options.PerCallPolicies = append(slices.Clone(options.PerCallPolicies), policy)
+
+	client, err := armappcontainers.NewContainerAppsClient(subscriptionId, credential, &options)
+	if err != nil {
+		return nil, fmt.Errorf("creating ContainerApps client: %w", err)
+	}
+
+	return client, nil
+}
+
 func (cas *containerAppService) createRevisionsClient(
 	ctx context.Context,
 	subscriptionId string,
@@ -352,4 +434,25 @@ func (cas *containerAppService) createRevisionsClient(
 	}
 
 	return client, nil
+}
+
+type containerAppCustomApiVersionAndBodyPolicy struct {
+	apiVersion string
+	body       *json.RawMessage
+}
+
+func (p *containerAppCustomApiVersionAndBodyPolicy) Do(req *policy.Request) (*http.Response, error) {
+	if p.body != nil {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", p.apiVersion)
+		req.Raw().URL.RawQuery = reqQP.Encode()
+
+		log.Printf("setting body to %s", string(*p.body))
+
+		if err := req.SetBody(streaming.NopCloser(bytes.NewReader(*p.body)), "application/json"); err != nil {
+			return nil, fmt.Errorf("updating request body: %w", err)
+		}
+	}
+
+	return req.Next()
 }

--- a/cli/azd/resources/apphost/templates/containerApp.tmpl.yamlt
+++ b/cli/azd/resources/apphost/templates/containerApp.tmpl.yamlt
@@ -1,4 +1,5 @@
 {{define "containerApp.tmpl.yaml" -}}
+api-version: 2024-02-02-preview
 location: {{ "{{ .Env.AZURE_LOCATION }}" }}
 identity:
   type: UserAssigned
@@ -9,6 +10,9 @@ properties:
   environmentId: {{ "{{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_ID }}" }}
   configuration:
     activeRevisionsMode: single
+    runtime:
+      dotnet:
+        autoConfigureDataProtection: true
 {{- if .Dapr}}
     dapr:
       appId: {{ .Dapr.AppId }}

--- a/cli/azd/test/functional/testdata/snaps/aspire-full/AspireAzdTests.ApiService/manifests/containerApp.tmpl.yaml
+++ b/cli/azd/test/functional/testdata/snaps/aspire-full/AspireAzdTests.ApiService/manifests/containerApp.tmpl.yaml
@@ -1,3 +1,4 @@
+api-version: 2024-02-02-preview
 location: {{ .Env.AZURE_LOCATION }}
 identity:
   type: UserAssigned
@@ -8,6 +9,9 @@ properties:
   environmentId: {{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_ID }}
   configuration:
     activeRevisionsMode: single
+    runtime:
+      dotnet:
+        autoConfigureDataProtection: true
     ingress:
       external: false
       targetPort: {{ .TargetPort }}

--- a/cli/azd/test/functional/testdata/snaps/aspire-full/AspireAzdTests.Web/manifests/containerApp.tmpl.yaml
+++ b/cli/azd/test/functional/testdata/snaps/aspire-full/AspireAzdTests.Web/manifests/containerApp.tmpl.yaml
@@ -1,3 +1,4 @@
+api-version: 2024-02-02-preview
 location: {{ .Env.AZURE_LOCATION }}
 identity:
   type: UserAssigned
@@ -8,6 +9,9 @@ properties:
   environmentId: {{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_ID }}
   configuration:
     activeRevisionsMode: single
+    runtime:
+      dotnet:
+        autoConfigureDataProtection: true
     ingress:
       external: false
       targetPort: {{ .TargetPort }}


### PR DESCRIPTION
This change does two things:

- Supports using a custom api-version of the ACA CreateOrUpdate request by allowing the yaml deployment template to have an `api-version` property at top level. When set, this value is used as the `api-version` of the request. The request body is the object, rendered as JSON, with the `api-version` key removed.

- Uses the above new feature to opt into the `2024-02-02-preview` in Aspire and sets the
`configuration.runtime.dotnet.autoConfigureDataProtection` property to `true`.

Fixes #3538