### PR TITLE
vs-server: https enabled with VS when AuthenticationCertificate is provided.

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -533,7 +534,9 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		endpoint := os.Getenv("AZD_AUTH_ENDPOINT")
 		key := os.Getenv("AZD_AUTH_KEY")
 
-		client := &http.Client{}
+		client := &http.Client{
+			Timeout: 5 * time.Second,
+		}
 		if len(cert) > 0 {
 			certBytes, decodeErr := base64.StdEncoding.DecodeString(cert)
 			if decodeErr != nil {

--- a/cli/azd/internal/vsrpc/models.go
+++ b/cli/azd/internal/vsrpc/models.go
@@ -68,6 +68,9 @@ type InitializeServerOptions struct {
 	// expected by the AZD_AUTH_KEY environment variable. Note that both AuthenticationEndpoint and AuthenticationKey
 	// need to be set for external authentication to be used.
 	AuthenticationKey *string `json:",omitempty"`
+	// When non nil, AuthenticationCertificate is a base64-encoded x509 certificate used to trust and
+	// secure the communications to the server. It is in the same form as the AZD_AUTH_CERT environment variable.
+	AuthenticationCertificate *string `json:",omitempty"`
 }
 
 func newInfoProgressMessage(message string) ProgressMessage {

--- a/cli/azd/internal/vsrpc/server_service.go
+++ b/cli/azd/internal/vsrpc/server_service.go
@@ -73,13 +73,14 @@ func (s *serverService) InitializeAsync(
 		caCertPool := x509.NewCertPool()
 		caCertPool.AddCert(cert)
 		tlsConfig := &tls.Config{
-			RootCAs: caCertPool,
+			RootCAs:    caCertPool,
+			MinVersion: tls.VersionTLS12,
 		}
 
-		client := http.DefaultClient
-		client.Transport = &http.Transport{
-			TLSClientConfig: tlsConfig,
-		}
+		client := &http.Client{}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = tlsConfig
+		client.Transport = transport
 
 		endpointUrl, err := url.Parse(session.externalServicesEndpoint)
 		if err != nil {

--- a/cli/azd/internal/vsrpc/server_service.go
+++ b/cli/azd/internal/vsrpc/server_service.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
 )
@@ -77,7 +78,9 @@ func (s *serverService) InitializeAsync(
 			MinVersion: tls.VersionTLS12,
 		}
 
-		client := &http.Client{}
+		client := &http.Client{
+			Timeout: 5 * time.Second,
+		}
 		transport := http.DefaultTransport.(*http.Transport).Clone()
 		transport.TLSClientConfig = tlsConfig
 		client.Transport = transport
@@ -94,6 +97,8 @@ func (s *serverService) InitializeAsync(
 		}
 
 		session.externalServicesClient = client
+	} else {
+		session.externalServicesClient = http.DefaultClient
 	}
 
 	return &Session{

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -93,6 +93,7 @@ type Manager struct {
 type ExternalAuthConfiguration struct {
 	Endpoint string
 	Key      string
+	Client   httputil.HttpClient
 }
 
 func NewManager(
@@ -199,7 +200,11 @@ func (m *Manager) CredentialForCurrentUser(
 
 	if m.UseExternalAuth() {
 		log.Printf("delegating auth to external process")
-		return newRemoteCredential(m.externalAuthCfg.Endpoint, m.externalAuthCfg.Key, options.TenantID, m.httpClient), nil
+		return newRemoteCredential(
+			m.externalAuthCfg.Endpoint,
+			m.externalAuthCfg.Key,
+			options.TenantID,
+			m.externalAuthCfg.Client), nil
 	}
 
 	userConfig, err := m.userConfigManager.Load()


### PR DESCRIPTION
Enable https connecting to vs when AuthenticationCertificate is provided in vs-server.

Also, allow AZD_AUTH_CERT to inherit the same behavior when interacting with azd CLI.