### PR TITLE
AI/ML Online Endpoint Service Target

### DIFF
--- a/.vscode/cspell.misc.yaml
+++ b/.vscode/cspell.misc.yaml
@@ -39,3 +39,4 @@ overrides:
           - myapp
           - azdev
           - myimage
+          - azureai

--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -21,6 +21,7 @@ armappconfiguration
 armappplatform
 armcognitiveservices
 armcosmos
+armmachinelearning
 armresourcegraph
 armsql
 aspnet
@@ -42,8 +43,10 @@ azdtest
 azfile
 azruntime
 azsdk
+azureai
 AZURECLI
 azureedge
+azureml
 azurestaticapps
 azuretools
 azureutil

--- a/cli/azd/internal/cmd/provision.go
+++ b/cli/azd/internal/cmd/provision.go
@@ -344,30 +344,19 @@ func (p *ProvisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 		}
 	}
 
-	followUpLinks := []string{
-		getResourceGroupFollowUp(
-			ctx,
-			p.formatter,
-			p.portalUrlBase,
-			p.projectConfig,
-			p.resourceManager,
-			p.env,
-			false,
-		),
-	}
-
-	var additionalLinks map[string]*output.Link
-
-	if ok, err := p.env.Config.GetSection("provision.links", &additionalLinks); ok && err == nil {
-		for _, link := range additionalLinks {
-			followUpLinks = append(followUpLinks, fmt.Sprintf("%s\n%s", link.Description, output.WithLinkFormat(link.Url)))
-		}
-	}
-
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header:   fmt.Sprintf("Your application was provisioned in Azure in %s.", ux.DurationAsText(since(startTime))),
-			FollowUp: strings.Join(followUpLinks, "\n\n"),
+			Header: fmt.Sprintf(
+				"Your application was provisioned in Azure in %s.", ux.DurationAsText(since(startTime))),
+			FollowUp: getResourceGroupFollowUp(
+				ctx,
+				p.formatter,
+				p.portalUrlBase,
+				p.projectConfig,
+				p.resourceManager,
+				p.env,
+				false,
+			),
 		},
 	}, nil
 }

--- a/cli/azd/pkg/ai/config.go
+++ b/cli/azd/pkg/ai/config.go
@@ -1,0 +1,86 @@
+package ai
+
+import (
+	"fmt"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"gopkg.in/yaml.v3"
+)
+
+// ComponentConfig is a base configuration structure used by multiple AI components
+type ComponentConfig struct {
+	Name      osutil.ExpandableString            `yaml:"name,omitempty"`
+	Path      string                             `yaml:"path,omitempty"`
+	Overrides map[string]osutil.ExpandableString `yaml:"overrides,omitempty"`
+}
+
+type DeploymentConfig struct {
+	ComponentConfig `yaml:",inline"`
+	// A map of environment variables to set for the deployment
+	Environment map[string]osutil.ExpandableString `yaml:"environment,omitempty"`
+}
+
+// EndpointDeploymentConfig is a configuration structure for an ML online endpoint deployment
+type EndpointDeploymentConfig struct {
+	Workspace   osutil.ExpandableString `yaml:"workspace,omitempty"`
+	Environment *ComponentConfig        `yaml:"environment,omitempty"`
+	Model       *ComponentConfig        `yaml:"model,omitempty"`
+	Flow        *ComponentConfig        `yaml:"flow,omitempty"`
+	Deployment  *DeploymentConfig       `yaml:"deployment,omitempty"`
+}
+
+// Flow is a configuration to defined a Prompt flow component
+type Flow struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Type        string            `json:"type"`
+	Path        string            `json:"path"`
+	DisplayName string            `json:"display_name"`
+	Tags        map[string]string `json:"tags"`
+}
+
+// Scope is a context based structure to define the Azure scope of a AI component
+type Scope struct {
+	subscriptionId string
+	resourceGroup  string
+	workspace      string
+}
+
+// NewScope creates a new Scope instance
+func NewScope(subscriptionId string, resourceGroup string, workspace string) *Scope {
+	return &Scope{
+		subscriptionId: subscriptionId,
+		resourceGroup:  resourceGroup,
+		workspace:      workspace,
+	}
+}
+
+// SubscriptionId returns the subscription ID from the scope
+func (s *Scope) SubscriptionId() string {
+	return s.subscriptionId
+}
+
+// ResourceGroup returns the resource group from the scope
+func (s *Scope) ResourceGroup() string {
+	return s.resourceGroup
+}
+
+// Workspace returns the workspace from the scope
+func (s *Scope) Workspace() string {
+	return s.workspace
+}
+
+// ParseConfig parses a config from a generic interface.
+func ParseConfig[T comparable](config any) (*T, error) {
+	yamlBytes, err := yaml.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed marshalling config: %w", err)
+	}
+
+	var parsedConfig T
+	if err := yaml.Unmarshal(yamlBytes, &parsedConfig); err != nil {
+		return nil, fmt.Errorf("failed unmarshalling config: %w", err)
+	}
+
+	return &parsedConfig, nil
+}

--- a/cli/azd/pkg/ai/config_test.go
+++ b/cli/azd/pkg/ai/config_test.go
@@ -1,0 +1,65 @@
+package ai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ParseConfig(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+
+		config := map[string]any{
+			"workspace": "my-workspace",
+			"flow": map[string]any{
+				"name": "my-flow",
+				"path": "path/to/flow",
+			},
+			"environment": map[string]any{
+				"name": "my-env",
+				"path": "path/to/env.yaml",
+			},
+			"model": map[string]any{
+				"name": "my-model",
+				"path": "path/to/model.yaml",
+			},
+			"deployment": map[string]any{
+				"name": "my-deployment",
+				"path": "path/to/deployment.yaml",
+				"overrides": map[string]any{
+					"key": "value",
+				},
+			},
+		}
+
+		noop := func(value string) string { return "" }
+
+		var endpointConfig *EndpointDeploymentConfig
+		endpointConfig, err := ParseConfig[EndpointDeploymentConfig](config)
+		require.NoError(t, err)
+		require.NotNil(t, endpointConfig)
+
+		require.Equal(t, "my-workspace", endpointConfig.Workspace.MustEnvsubst(noop))
+		require.NotNil(t, endpointConfig.Environment)
+		require.Equal(t, "my-env", endpointConfig.Environment.Name.MustEnvsubst(noop))
+		require.Equal(t, "path/to/env.yaml", endpointConfig.Environment.Path)
+		require.NotNil(t, endpointConfig.Model)
+		require.Equal(t, "my-model", endpointConfig.Model.Name.MustEnvsubst(noop))
+		require.Equal(t, "path/to/model.yaml", endpointConfig.Model.Path)
+		require.NotNil(t, endpointConfig.Flow)
+		require.Equal(t, "my-flow", endpointConfig.Flow.Name.MustEnvsubst(noop))
+		require.Equal(t, "path/to/flow", endpointConfig.Flow.Path)
+		require.NotNil(t, endpointConfig.Deployment)
+		require.Equal(t, "my-deployment", endpointConfig.Deployment.Name.MustEnvsubst(noop))
+		require.Equal(t, "path/to/deployment.yaml", endpointConfig.Deployment.Path)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		config := "invalid structure"
+
+		var endpointConfig *EndpointDeploymentConfig
+		endpointConfig, err := ParseConfig[EndpointDeploymentConfig](config)
+		require.Error(t, err)
+		require.Nil(t, endpointConfig)
+	})
+}

--- a/cli/azd/pkg/ai/python_bridge.go
+++ b/cli/azd/pkg/ai/python_bridge.go
@@ -1,0 +1,131 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/python"
+	"github.com/azure/azure-dev/cli/azd/resources"
+)
+
+// ScriptPath is a type to represent the path of a Python script
+type ScriptPath string
+
+const (
+	// PromptFlowClient is the path to the PromptFlow Client Python script
+	PromptFlowClient ScriptPath = "pf_client.py"
+	// MLClient is the path to the ML Client Python script
+	MLClient ScriptPath = "ml_client.py"
+)
+
+// PythonBridge is an interface to execute python components from the embedded AI resources project
+type PythonBridge interface {
+	Initialize(ctx context.Context) error
+	RequiredExternalTools(ctx context.Context) []tools.ExternalTool
+	Run(ctx context.Context, scriptName ScriptPath, args ...string) (*exec.RunResult, error)
+}
+
+// pythonBridge is a bridge to execute python components from the embedded AI resources project
+type pythonBridge struct {
+	azdCtx      *azdcontext.AzdContext
+	pythonCli   *python.PythonCli
+	workingDir  string
+	initialized bool
+}
+
+// NewPythonBridge creates a new PythonBridge instance
+func NewPythonBridge(
+	azdCtx *azdcontext.AzdContext,
+	pythonCli *python.PythonCli,
+) PythonBridge {
+	return &pythonBridge{
+		azdCtx:    azdCtx,
+		pythonCli: pythonCli,
+	}
+}
+
+// Initialize initializes the PythonBridge
+// Copies embedded AI script files, creates a python virtual environment and installs the required dependencies
+func (b *pythonBridge) Initialize(ctx context.Context) error {
+	if b.initialized {
+		return nil
+	}
+
+	if err := b.initPython(ctx); err != nil {
+		return fmt.Errorf("failed initializing Python: %w", err)
+	}
+
+	b.initialized = true
+
+	return nil
+}
+
+// RequiredExternalTools returns the required external tools for the PythonBridge
+func (b *pythonBridge) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+	return []tools.ExternalTool{b.pythonCli}
+}
+
+// Run executes the specified python script with the given arguments
+func (b *pythonBridge) Run(ctx context.Context, scriptName ScriptPath, args ...string) (*exec.RunResult, error) {
+	allArgs := append([]string{string(scriptName)}, args...)
+	return b.pythonCli.Run(ctx, b.workingDir, ".venv", allArgs...)
+}
+
+// initPython initializes the Python environment
+func (b *pythonBridge) initPython(ctx context.Context) error {
+	configDir, err := config.GetUserConfigDir()
+	if err != nil {
+		return err
+	}
+
+	targetDir := filepath.Join(configDir, "bin", "ai")
+	if _, err := os.Stat(targetDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(targetDir, osutil.PermissionDirectory); err != nil {
+			return err
+		}
+	}
+
+	if err := copyFS(resources.AiPythonApp, "ai-python", targetDir); err != nil {
+		return err
+	}
+
+	if err := b.pythonCli.CreateVirtualEnv(ctx, targetDir, ".venv"); err != nil {
+		return err
+	}
+
+	if err := b.pythonCli.InstallRequirements(ctx, targetDir, ".venv", "requirements.txt"); err != nil {
+		return err
+	}
+
+	b.workingDir = targetDir
+
+	return nil
+}
+
+// copyFS copies the contents of an embedded FS to a target directory
+func copyFS(embedFs fs.FS, root string, target string) error {
+	return fs.WalkDir(embedFs, root, func(name string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		targetPath := filepath.Join(target, name[len(root):])
+
+		if d.IsDir() {
+			return os.MkdirAll(targetPath, osutil.PermissionDirectory)
+		}
+
+		contents, err := fs.ReadFile(embedFs, name)
+		if err != nil {
+			return fmt.Errorf("reading file: %w", err)
+		}
+		return os.WriteFile(targetPath, contents, osutil.PermissionFile)
+	})
+}

--- a/cli/azd/pkg/ai/python_bridge_test.go
+++ b/cli/azd/pkg/ai/python_bridge_test.go
@@ -1,0 +1,79 @@
+package ai
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/python"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_PythonBridge_Init(t *testing.T) {
+	tempDir := t.TempDir()
+	mockContext := mocks.NewMockContext(context.Background())
+	pythonCli := python.NewPythonCli(mockContext.CommandRunner)
+	azdCtx := azdcontext.NewAzdContextWithDirectory(tempDir)
+
+	azdConfigDir := filepath.Join(tempDir, ".azd")
+	os.Setenv("AZD_CONFIG_DIR", azdConfigDir)
+
+	createdVirtualEnv := false
+	installedDependencies := false
+
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "-m venv .venv")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		createdVirtualEnv = true
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "-m pip install -r requirements.txt")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		installedDependencies = true
+		return exec.NewRunResult(0, "", ""), nil
+	})
+
+	userConfigDir, err := config.GetUserConfigDir()
+	require.NoError(t, err)
+
+	aiDir := filepath.Join(userConfigDir, "bin", "ai")
+
+	bridge := NewPythonBridge(azdCtx, pythonCli)
+	err = bridge.Initialize(*mockContext.Context)
+	require.NoError(t, err)
+	require.DirExists(t, aiDir)
+	require.True(t, createdVirtualEnv)
+	require.True(t, installedDependencies)
+}
+
+func Test_PythonBridge_Run(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+	pythonCli := python.NewPythonCli(mockContext.CommandRunner)
+	azdCtx := azdcontext.NewAzdContextWithDirectory(t.TempDir())
+
+	ran := false
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.HasSuffix(command, "script.py arg1 arg2")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		ran = true
+		return exec.NewRunResult(0, "result", ""), nil
+	})
+
+	bridge := NewPythonBridge(azdCtx, pythonCli)
+	result, err := bridge.Run(*mockContext.Context, "script.py", "arg1", "arg2")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, ran)
+
+	require.Equal(t, "result", result.Stdout)
+	require.Equal(t, "", result.Stderr)
+	require.Equal(t, 0, result.ExitCode)
+}

--- a/cli/azd/pkg/ai/util.go
+++ b/cli/azd/pkg/ai/util.go
@@ -1,0 +1,17 @@
+package ai
+
+import (
+	"fmt"
+)
+
+// AzureAiStudioLink returns a link to the Azure AI Studio for the given tenant, subscription, resource group, and workspace
+func AzureAiStudioLink(tenantId string, subscriptionId string, resourceGroup string, workspaceName string) string {
+	return fmt.Sprintf(
+		//nolint:lll
+		"https://ai.azure.com/build/overview?tid=%s&wsid=/subscriptions/%s/resourcegroups/%s/providers/Microsoft.MachineLearningServices/workspaces/%s",
+		tenantId,
+		subscriptionId,
+		resourceGroup,
+		workspaceName,
+	)
+}

--- a/cli/azd/pkg/ai/util_test.go
+++ b/cli/azd/pkg/ai/util_test.go
@@ -1,0 +1,20 @@
+package ai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_AzureAiStudioLink(t *testing.T) {
+	tenantId := "tenantId"
+	subscriptionId := "subscriptionId"
+	resourceGroup := "resourceGroup"
+	workspaceName := "workspaceName"
+
+	//nolint:lll
+	expected := "https://ai.azure.com/build/overview?tid=tenantId&wsid=/subscriptions/subscriptionId/resourcegroups/resourceGroup/providers/Microsoft.MachineLearningServices/workspaces/workspaceName"
+	actual := AzureAiStudioLink(tenantId, subscriptionId, resourceGroup, workspaceName)
+
+	require.Equal(t, expected, actual)
+}

--- a/cli/azd/pkg/infra/azure_resource_types.go
+++ b/cli/azd/pkg/infra/azure_resource_types.go
@@ -41,6 +41,10 @@ const (
 	AzurePrivateEndpoint                     AzureResourceType = "Microsoft.Network/privateEndpoints"
 	AzureDevCenter                           AzureResourceType = "Microsoft.DevCenter/devcenters"
 	AzureDevCenterProject                    AzureResourceType = "Microsoft.DevCenter/projects"
+	AzureMachineLearningWorkspace            AzureResourceType = "Microsoft.MachineLearningServices/workspaces"
+	//nolint:lll
+	AzureMachineLearningEndpoint   AzureResourceType = "Microsoft.MachineLearningServices/workspaces/onlineEndpoints"
+	AzureMachineLearningConnection AzureResourceType = "Microsoft.MachineLearningServices/workspaces/connections"
 )
 
 const resourceLevelSeparator = "/"
@@ -114,6 +118,12 @@ func GetResourceTypeDisplayName(resourceType AzureResourceType) string {
 		return "Dev Center"
 	case AzureDevCenterProject:
 		return "Dev Center Project"
+	case AzureMachineLearningWorkspace:
+		return "Machine Learning Workspace"
+	case AzureMachineLearningEndpoint:
+		return "Machine Learning Endpoint"
+	case AzureMachineLearningConnection:
+		return "Machine Learning Connection"
 	}
 
 	return ""

--- a/cli/azd/pkg/output/links.go
+++ b/cli/azd/pkg/output/links.go
@@ -1,0 +1,7 @@
+package output
+
+type Link struct {
+	Name        string `json:"name"`
+	Url         string `json:"url"`
+	Description string `json:"description"`
+}

--- a/cli/azd/pkg/project/ai_helper.go
+++ b/cli/azd/pkg/project/ai_helper.go
@@ -1,0 +1,758 @@
+package project
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
+	"github.com/azure/azure-dev/cli/azd/pkg/account"
+	"github.com/azure/azure-dev/cli/azd/pkg/ai"
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+	"github.com/benbjohnson/clock"
+)
+
+const (
+	// AiHubNameEnvVarName is the environment variable name for the Azure AI Hub name
+	AiHubNameEnvVarName = "AZUREAI_HUB_NAME"
+	// AiProjectNameEnvVarName is the environment variable name for the Azure AI project name
+	AiProjectNameEnvVarName = "AZUREAI_PROJECT_NAME"
+	// AiEnvironmentEnvVarName is the environment variable name for the Azure AI environment name
+	AiEnvironmentEnvVarName = "AZUREAI_ENVIRONMENT_NAME"
+	// AiModelEnvVarName is the environment variable name for the Azure AI model name
+	AiModelEnvVarName = "AZUREAI_MODEL_NAME"
+	// AiEndpointEnvVarName is the environment variable name for the Azure AI endpoint name
+	AiEndpointEnvVarName = "AZUREAI_ENDPOINT_NAME"
+	// AiDeploymentEnvVarName is the environment variable name for the Azure AI deployment name
+	AiDeploymentEnvVarName = "AZUREAI_DEPLOYMENT_NAME"
+	// AiFlowEnvVarName is the environment variable name for the Azure AI flow name
+	AiFlowEnvVarName = "AZUREAI_FLOW_NAME"
+)
+
+type AiHelper interface {
+	// RequiredExternalTools returns the required external tools for the AiHelper
+	RequiredExternalTools(ctx context.Context) []tools.ExternalTool
+	// Initialize initializes the AiHelper
+	Initialize(ctx context.Context) error
+	// ValidateWorkspace ensures that the workspace exists
+	ValidateWorkspace(ctx context.Context, scope *ai.Scope) error
+	// CreateEnvironmentVersion creates a new environment version
+	CreateEnvironmentVersion(
+		ctx context.Context,
+		scope *ai.Scope,
+		serviceConfig *ServiceConfig,
+		config *ai.ComponentConfig,
+	) (*armmachinelearning.EnvironmentVersion, error)
+	// CreateModelVersion creates a new model version
+	CreateModelVersion(
+		ctx context.Context,
+		scope *ai.Scope,
+		serviceConfig *ServiceConfig,
+		config *ai.ComponentConfig,
+	) (*armmachinelearning.ModelVersion, error)
+	// GetEndpoint retrieves an online endpoint
+	GetEndpoint(ctx context.Context, scope *ai.Scope, endpointName string) (*armmachinelearning.OnlineEndpoint, error)
+	// DeployToEndpoint deploys a new online deployment to an online endpoint
+	DeployToEndpoint(
+		ctx context.Context,
+		scope *ai.Scope,
+		serviceConfig *ServiceConfig,
+		endpointName string,
+		config *ai.EndpointDeploymentConfig,
+	) (*armmachinelearning.OnlineDeployment, error)
+	// DeletePreviousDeployments deletes all previous deployments of an online endpoint except the one with 100% traffic
+	DeletePreviousDeployments(ctx context.Context, scope *ai.Scope, endpointName string) error
+	// UpdateTraffic updates the traffic distribution of an online endpoint for the specified deployment
+	UpdateTraffic(
+		ctx context.Context,
+		scope *ai.Scope,
+		endpointName string,
+		deploymentName string,
+	) (*armmachinelearning.OnlineEndpoint, error)
+	// CreateFlow creates a new flow
+	CreateFlow(
+		ctx context.Context,
+		scope *ai.Scope,
+		serviceConfig *ServiceConfig,
+		config *ai.ComponentConfig,
+	) (*ai.Flow, error)
+}
+
+// aiHelper provides helper functions for interacting with Azure Machine Learning resources
+type aiHelper struct {
+	env                   *environment.Environment
+	clock                 clock.Clock
+	pythonBridge          ai.PythonBridge
+	workspacesClient      *armmachinelearning.WorkspacesClient
+	envContainersClient   *armmachinelearning.EnvironmentContainersClient
+	envVersionsClient     *armmachinelearning.EnvironmentVersionsClient
+	modelContainersClient *armmachinelearning.ModelContainersClient
+	modelVersionsClient   *armmachinelearning.ModelVersionsClient
+	endpointsClient       *armmachinelearning.OnlineEndpointsClient
+	deploymentsClient     *armmachinelearning.OnlineDeploymentsClient
+	initialized           bool
+}
+
+// NewAiHelper creates a new instance of AiHelper
+func NewAiHelper(
+	env *environment.Environment,
+	clock clock.Clock,
+	credentialProvider account.SubscriptionCredentialProvider,
+	pythonBridge ai.PythonBridge,
+	workspacesClient *armmachinelearning.WorkspacesClient,
+	envContainersClient *armmachinelearning.EnvironmentContainersClient,
+	envVersionsClient *armmachinelearning.EnvironmentVersionsClient,
+	modelContainersClient *armmachinelearning.ModelContainersClient,
+	modelVersionsClient *armmachinelearning.ModelVersionsClient,
+	endpointsClient *armmachinelearning.OnlineEndpointsClient,
+	deploymentsClient *armmachinelearning.OnlineDeploymentsClient,
+) AiHelper {
+	return &aiHelper{
+		env:                   env,
+		clock:                 clock,
+		pythonBridge:          pythonBridge,
+		workspacesClient:      workspacesClient,
+		envContainersClient:   envContainersClient,
+		envVersionsClient:     envVersionsClient,
+		modelContainersClient: modelContainersClient,
+		modelVersionsClient:   modelVersionsClient,
+		endpointsClient:       endpointsClient,
+		deploymentsClient:     deploymentsClient,
+	}
+}
+
+// RequiredExternalTools returns the required external tools for the AiHelper
+func (a *aiHelper) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+	return a.pythonBridge.RequiredExternalTools(ctx)
+}
+
+// Initialize initializes the AiHelper
+func (a *aiHelper) Initialize(ctx context.Context) error {
+	if a.initialized {
+		return nil
+	}
+
+	if err := a.pythonBridge.Initialize(ctx); err != nil {
+		return err
+	}
+
+	a.initialized = true
+	return nil
+}
+
+// ValidateWorkspace ensures that the workspace exists
+func (a *aiHelper) ValidateWorkspace(
+	ctx context.Context,
+	scope *ai.Scope,
+) error {
+	workspaceName := scope.Workspace()
+
+	_, err := a.workspacesClient.Get(
+		ctx,
+		scope.ResourceGroup(),
+		workspaceName,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateEnvironmentVersion creates a new environment version
+func (a *aiHelper) CreateEnvironmentVersion(
+	ctx context.Context,
+	scope *ai.Scope,
+	serviceConfig *ServiceConfig,
+	config *ai.ComponentConfig,
+) (*armmachinelearning.EnvironmentVersion, error) {
+	yamlFilePath := filepath.Join(serviceConfig.Path(), config.Path)
+	_, err := os.Stat(yamlFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	environmentName, err := config.Name.Envsubst(a.env.Getenv)
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing environment name value: %w", err)
+	}
+
+	if environmentName == "" {
+		environmentName = fmt.Sprintf("%s-environment", serviceConfig.Name)
+	}
+
+	nextVersion := "1"
+	envContainerResponse, err := a.envContainersClient.Get(
+		ctx,
+		scope.ResourceGroup(),
+		scope.Workspace(),
+		environmentName,
+		nil,
+	)
+	if err != nil {
+		// An http 404 error is expected if the environment container does not exist
+		// Therefore we default to version 1
+		var httpErr *azcore.ResponseError
+		isHttpError := errors.As(err, &httpErr)
+		if !isHttpError || (isHttpError && httpErr.StatusCode != http.StatusNotFound) {
+			return nil, fmt.Errorf("failed getting environment container: %w", err)
+		}
+	} else {
+		nextVersion = *envContainerResponse.Properties.NextVersion
+	}
+
+	environmentArgs := []string{
+		"-t", "environment",
+		"-s", scope.SubscriptionId(),
+		"-g", scope.ResourceGroup(),
+		"-w", scope.Workspace(),
+		"-f", yamlFilePath,
+		"--set", fmt.Sprintf("name=%s", environmentName),
+		"--set", fmt.Sprintf("version=%s", nextVersion),
+	}
+
+	environmentArgs, err = a.applyOverrides(environmentArgs, config.Overrides)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := a.pythonBridge.Run(ctx, ai.MLClient, environmentArgs...); err != nil {
+		return nil, err
+	}
+
+	envVersionResponse, err := a.envVersionsClient.Get(
+		ctx,
+		scope.ResourceGroup(),
+		scope.Workspace(),
+		environmentName,
+		nextVersion,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	a.env.DotenvSet(AiEnvironmentEnvVarName, environmentName)
+
+	return &envVersionResponse.EnvironmentVersion, nil
+}
+
+// CreateModelVersion creates a new model version
+func (a *aiHelper) CreateModelVersion(
+	ctx context.Context,
+	scope *ai.Scope,
+	serviceConfig *ServiceConfig,
+	config *ai.ComponentConfig,
+) (*armmachinelearning.ModelVersion, error) {
+	yamlFilePath := filepath.Join(serviceConfig.Path(), config.Path)
+	_, err := os.Stat(yamlFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	modelName, err := config.Name.Envsubst(a.env.Getenv)
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing model name value: %w", err)
+	}
+
+	if modelName == "" {
+		modelName = fmt.Sprintf("%s-model", serviceConfig.Name)
+	}
+
+	nextVersion := "1"
+	modelContainerResponse, err := a.modelContainersClient.Get(
+		ctx,
+		scope.ResourceGroup(),
+		scope.Workspace(),
+		modelName,
+		nil,
+	)
+	if err != nil {
+		// An http 404 error is expected if the environment container does not exist
+		// Therefore we default to version 1
+		var httpErr *azcore.ResponseError
+		isHttpError := errors.As(err, &httpErr)
+		if !isHttpError || (isHttpError && httpErr.StatusCode != http.StatusNotFound) {
+			return nil, fmt.Errorf("failed getting environment container: %w", err)
+		}
+	} else {
+		nextVersion = *modelContainerResponse.Properties.NextVersion
+	}
+
+	modelArgs := []string{
+		"-t", "model",
+		"-s", scope.SubscriptionId(),
+		"-g", scope.ResourceGroup(),
+		"-w", scope.Workspace(),
+		"-f", yamlFilePath,
+		"--set", fmt.Sprintf("name=%s", modelName),
+		"--set", fmt.Sprintf("version=%s", nextVersion),
+	}
+
+	modelArgs, err = a.applyOverrides(modelArgs, config.Overrides)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := a.pythonBridge.Run(ctx, ai.MLClient, modelArgs...); err != nil {
+		return nil, err
+	}
+
+	modelVersionResponse, err := a.modelVersionsClient.Get(
+		ctx,
+		scope.ResourceGroup(),
+		scope.Workspace(),
+		modelName,
+		nextVersion,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	a.env.DotenvSet(AiModelEnvVarName, modelName)
+
+	return &modelVersionResponse.ModelVersion, nil
+}
+
+// GetEndpoint retrieves an online endpoint
+func (a *aiHelper) GetEndpoint(
+	ctx context.Context,
+	scope *ai.Scope,
+	endpointName string,
+) (*armmachinelearning.OnlineEndpoint, error) {
+	endpointResponse, err := a.endpointsClient.Get(
+		ctx,
+		scope.ResourceGroup(),
+		scope.Workspace(),
+		endpointName,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &endpointResponse.OnlineEndpoint, nil
+}
+
+// DeployToEndpoint deploys a new online deployment to an online endpoint
+func (a *aiHelper) DeployToEndpoint(
+	ctx context.Context,
+	scope *ai.Scope,
+	serviceConfig *ServiceConfig,
+	endpointName string,
+	config *ai.EndpointDeploymentConfig,
+) (*armmachinelearning.OnlineDeployment, error) {
+	// Get the custom environment name if configured
+	environmentVersionName, err := a.getEnvironmentVersionName(ctx, scope, serviceConfig, config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the custom model name if configured
+	modelVersionName, err := a.getModelVersionName(ctx, scope, serviceConfig, config)
+	if err != nil {
+		return nil, err
+	}
+
+	deploymentName, err := config.Deployment.Name.Envsubst(a.env.Getenv)
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing deployment name value: %w", err)
+	}
+
+	// Deployment naming rules
+	// Begin with a letter
+	// Be 3-32 characters in length
+	const minDeploymentNameLength = 3
+	const maxDeploymentNameLength = 32
+
+	if deploymentName == "" {
+		deploymentName = fmt.Sprintf("%s-deployment", serviceConfig.Name)
+	}
+
+	timestampSuffix := fmt.Sprintf("-%d", a.clock.Now().Unix())
+	maxDeploymentNameWithTimestamp := maxDeploymentNameLength - len(timestampSuffix)
+
+	// Timestamp is typically 10 digits long so we can use the remaining characters for the deployment name
+	if len(deploymentName) > maxDeploymentNameWithTimestamp {
+		deploymentName = deploymentName[:maxDeploymentNameWithTimestamp]
+	}
+
+	deploymentName = fmt.Sprintf("%s%s", deploymentName, timestampSuffix)
+
+	if len(deploymentName) < minDeploymentNameLength || len(deploymentName) > maxDeploymentNameLength {
+		return nil, fmt.Errorf(
+			"deployment '%s' must be between 3 and 32 characters. Update the deployment name within the azure.yaml.",
+			deploymentName,
+		)
+	}
+
+	yamlFilePath := filepath.Join(serviceConfig.Path(), config.Deployment.Path)
+	_, err = os.Stat(yamlFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	a.env.DotenvSet(AiEndpointEnvVarName, endpointName)
+	a.env.DotenvSet(AiDeploymentEnvVarName, deploymentName)
+
+	deploymentArgs := []string{
+		"-t", "online-deployment",
+		"-s", scope.SubscriptionId(),
+		"-g", scope.ResourceGroup(),
+		"-w", scope.Workspace(),
+		"-f", yamlFilePath,
+		"--set", fmt.Sprintf("name=%s", deploymentName),
+		"--set", fmt.Sprintf("endpoint_name=%s", endpointName),
+	}
+
+	if environmentVersionName != "" {
+		deploymentArgs = append(deploymentArgs, "--set", fmt.Sprintf("environment=%s", environmentVersionName))
+	}
+
+	if modelVersionName != "" {
+		deploymentArgs = append(deploymentArgs, "--set", fmt.Sprintf("model=%s", modelVersionName))
+	}
+
+	if config.Deployment.Overrides == nil {
+		config.Deployment.Overrides = map[string]osutil.ExpandableString{}
+	}
+
+	// Transform any referenced environment variables into override expressions
+	for key, value := range config.Deployment.Environment {
+		envVarOverrideKey := fmt.Sprintf("environment_variables.%s", key)
+		config.Deployment.Overrides[envVarOverrideKey] = value
+	}
+
+	deploymentArgs, err = a.applyOverrides(deploymentArgs, config.Deployment.Overrides)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = a.pythonBridge.Run(ctx, ai.MLClient, deploymentArgs...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Poll for deployment and wait till it reaches a terminal state
+	onlineDeployment, err := a.pollForDeployment(ctx, scope, endpointName, deploymentName)
+	if err != nil {
+		return nil, err
+	}
+
+	return onlineDeployment, nil
+}
+
+// DeletePreviousDeployments deletes all previous deployments of an online endpoint except the one with 100% traffic
+func (a *aiHelper) DeletePreviousDeployments(
+	ctx context.Context,
+	scope *ai.Scope,
+	endpointName string,
+) error {
+	// Get the endpoint
+	getEndpointResponse, err := a.endpointsClient.Get(ctx, scope.ResourceGroup(), scope.Workspace(), endpointName, nil)
+	if err != nil {
+		return err
+	}
+
+	onlineEndpoint := getEndpointResponse.OnlineEndpoint
+	var deploymentName string
+
+	// Detect the deployment with 100% traffic
+	for key, trafficWeight := range onlineEndpoint.Properties.Traffic {
+		if *trafficWeight == 100 {
+			deploymentName = key
+			break
+		}
+	}
+
+	if deploymentName == "" {
+		return errors.New("no deployment found with 100% traffic")
+	}
+
+	// Get existing deployments
+	existingDeployments := []*armmachinelearning.OnlineDeployment{}
+
+	deploymentsPager := a.deploymentsClient.NewListPager(scope.ResourceGroup(), scope.Workspace(), endpointName, nil)
+	for deploymentsPager.More() {
+		page, err := deploymentsPager.NextPage(ctx)
+		if err != nil {
+			return err
+		}
+
+		existingDeployments = append(existingDeployments, page.Value...)
+	}
+
+	// Delete previous deployments
+	for _, existingDeployment := range existingDeployments {
+		// Ignore the new deployment
+		if *existingDeployment.Name == deploymentName {
+			continue
+		}
+
+		// We will start the delete operation but not wait for completion
+		_, err := a.deploymentsClient.BeginDelete(
+			ctx,
+			scope.ResourceGroup(),
+			scope.Workspace(),
+			endpointName,
+			*existingDeployment.Name,
+			nil,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// UpdateTraffic updates the traffic distribution of an online endpoint for the specified deployment
+func (a *aiHelper) UpdateTraffic(
+	ctx context.Context,
+	scope *ai.Scope,
+	endpointName string,
+	deploymentName string,
+) (*armmachinelearning.OnlineEndpoint, error) {
+	// Get the endpoint
+	getEndpointResponse, err := a.endpointsClient.Get(ctx, scope.ResourceGroup(), scope.Workspace(), endpointName, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	onlineEndpoint := getEndpointResponse.OnlineEndpoint
+
+	// Send all traffic to new deployment
+	onlineEndpoint.Properties.Traffic = map[string]*int32{
+		deploymentName: convert.RefOf(int32(100)),
+	}
+
+	poller, err := a.endpointsClient.BeginCreateOrUpdate(
+		ctx,
+		scope.ResourceGroup(),
+		scope.Workspace(),
+		endpointName,
+		onlineEndpoint,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	updateResponse, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updateResponse.OnlineEndpoint, nil
+}
+
+// CreateFlow creates a new prompt flow from the specified configuration
+func (a *aiHelper) CreateFlow(
+	ctx context.Context,
+	scope *ai.Scope,
+	serviceConfig *ServiceConfig,
+	config *ai.ComponentConfig,
+) (*ai.Flow, error) {
+	flowName, err := config.Name.Envsubst(a.env.Getenv)
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing flow name value: %w", err)
+	}
+
+	if flowName == "" {
+		flowName = fmt.Sprintf("%s-flow", serviceConfig.Name)
+	}
+
+	flowName = fmt.Sprintf("%s-%d", flowName, a.clock.Now().Unix())
+
+	flowPath := filepath.Join(serviceConfig.Path(), config.Path)
+	_, err = os.Stat(flowPath)
+	if err != nil {
+		return nil, err
+	}
+
+	createArgs := []string{
+		"create",
+		"-n", flowName,
+		"-f", flowPath,
+		"-s", scope.SubscriptionId(),
+		"-g", scope.ResourceGroup(),
+		"-w", scope.Workspace(),
+	}
+
+	createArgs, err = a.applyOverrides(createArgs, config.Overrides)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := a.pythonBridge.Run(ctx, ai.PromptFlowClient, createArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("flow operation failed: %w", err)
+	}
+
+	var existingFlow *ai.Flow
+	err = json.Unmarshal([]byte(result.Stdout), &existingFlow)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal flow: %w", err)
+	}
+
+	a.env.DotenvSet(AiFlowEnvVarName, flowName)
+
+	return existingFlow, nil
+}
+
+// pollForDeployment polls for the deployment to reach a terminal state
+func (a *aiHelper) pollForDeployment(
+	ctx context.Context,
+	scope *ai.Scope,
+	endpointName string,
+	deploymentName string,
+) (*armmachinelearning.OnlineDeployment, error) {
+	initialDelay := 3 * time.Second
+	regularDelay := 10 * time.Second
+	timer := time.NewTimer(initialDelay)
+
+	terminalStates := []armmachinelearning.DeploymentProvisioningState{
+		armmachinelearning.DeploymentProvisioningStateCanceled,
+		armmachinelearning.DeploymentProvisioningStateFailed,
+		armmachinelearning.DeploymentProvisioningStateSucceeded,
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+			// Get the deployment
+			deploymentResponse, err := a.deploymentsClient.Get(
+				ctx,
+				scope.ResourceGroup(),
+				scope.Workspace(),
+				endpointName,
+				deploymentName,
+				nil,
+			)
+			if err != nil {
+				timer.Stop()
+				return nil, err
+			}
+
+			deploymentProps := deploymentResponse.Properties.GetOnlineDeploymentProperties()
+			if slices.Contains(terminalStates, *deploymentProps.ProvisioningState) {
+				timer.Stop()
+
+				if *deploymentProps.ProvisioningState == armmachinelearning.DeploymentProvisioningStateSucceeded {
+					return &deploymentResponse.OnlineDeployment, nil
+				}
+
+				return nil, fmt.Errorf("deployment completed in unsuccessful state: %s", *deploymentProps.ProvisioningState)
+			}
+
+			timer.Reset(regularDelay)
+		}
+	}
+}
+
+// getEnvironmentVersionName returns the latest environment version name
+func (a *aiHelper) getEnvironmentVersionName(
+	ctx context.Context,
+	scope *ai.Scope,
+	serviceConfig *ServiceConfig,
+	config *ai.EndpointDeploymentConfig,
+) (string, error) {
+	if config.Environment == nil {
+		return "", nil
+	}
+
+	environmentName, err := config.Environment.Name.Envsubst(a.env.Getenv)
+	if err != nil {
+		return "", fmt.Errorf("failed parsing environment name value: %w", err)
+	}
+
+	if environmentName == "" {
+		environmentName = fmt.Sprintf("%s-environment", serviceConfig.Name)
+	}
+
+	envGetResponse, err := a.envContainersClient.Get(
+		ctx,
+		scope.ResourceGroup(),
+		scope.Workspace(),
+		environmentName,
+		nil,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	environmentContainer := envGetResponse.EnvironmentContainer
+	return fmt.Sprintf(
+		"azureml:%s:%s",
+		*environmentContainer.Name,
+		*environmentContainer.Properties.LatestVersion,
+	), nil
+}
+
+// getModelVersionName returns the latest model version name
+func (a *aiHelper) getModelVersionName(
+	ctx context.Context,
+	scope *ai.Scope,
+	serviceConfig *ServiceConfig,
+	config *ai.EndpointDeploymentConfig,
+) (string, error) {
+	if config.Model == nil {
+		return "", nil
+	}
+
+	modelName, err := config.Model.Name.Envsubst(a.env.Getenv)
+	if err != nil {
+		return "", fmt.Errorf("failed parsing model name value: %w", err)
+	}
+
+	if modelName == "" {
+		modelName = fmt.Sprintf("%s-model", serviceConfig.Name)
+	}
+
+	modelGetResponse, err := a.modelContainersClient.Get(
+		ctx,
+		scope.ResourceGroup(),
+		scope.Workspace(),
+		modelName,
+		nil,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	modelContainer := modelGetResponse.ModelContainer
+	return fmt.Sprintf(
+		"azureml:%s:%s",
+		*modelContainer.Name,
+		*modelContainer.Properties.LatestVersion,
+	), nil
+}
+
+// applyOverrides applies the specified overrides to the arguments
+func (a *aiHelper) applyOverrides(args []string, overrides map[string]osutil.ExpandableString) ([]string, error) {
+	for key, value := range overrides {
+		expandedValue, err := value.Envsubst(a.env.Getenv)
+		if err != nil {
+			return nil, fmt.Errorf("failed parsing override %s: %w", key, err)
+		}
+
+		args = append(args, "--set", fmt.Sprintf("%s=%s", key, expandedValue))
+	}
+
+	return args, nil
+}

--- a/cli/azd/pkg/project/ai_helper_test.go
+++ b/cli/azd/pkg/project/ai_helper_test.go
@@ -1,0 +1,493 @@
+package project
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
+	"github.com/azure/azure-dev/cli/azd/pkg/ai"
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockai"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_AiHelper_Init(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+	env := environment.New("test")
+	mockPythonBridge := &mockPythonBridge{}
+	mockPythonBridge.On("Initialize", *mockContext.Context).Return(nil)
+
+	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
+	err := aiHelper.Initialize(*mockContext.Context)
+
+	require.NoError(t, err)
+	mockPythonBridge.AssertCalled(t, "Initialize", *mockContext.Context)
+}
+
+func Test_AiHelper_ValidateWorkspace(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+	env := environment.NewWithValues("test", map[string]string{
+		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
+		environment.ResourceGroupEnvVarName:  "RESOURCE_GROUP",
+	})
+	scope := ai.NewScope(env.GetSubscriptionId(), env.Getenv(environment.ResourceGroupEnvVarName), "AI_WORKSPACE")
+	mockPythonBridge := &mockPythonBridge{}
+	mockai.RegisterGetWorkspaceMock(mockContext, scope.Workspace())
+
+	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
+	err := aiHelper.ValidateWorkspace(*mockContext.Context, scope)
+
+	require.NoError(t, err)
+}
+
+func Test_AiHelper_CreateEnvironmentVersion(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+	testDir := t.TempDir()
+	env := environment.NewWithValues("test", map[string]string{
+		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
+		environment.ResourceGroupEnvVarName:  "RESOURCE_GROUP",
+	})
+	scope := ai.NewScope(env.GetSubscriptionId(), env.Getenv(environment.ResourceGroupEnvVarName), "AI_WORKSPACE")
+	environmentName := "MY-ENVIRONMENT"
+
+	emptyResult := exec.NewRunResult(0, "", "")
+
+	mockPythonBridge := &mockPythonBridge{}
+	mockPythonBridge.
+		On("Run", *mockContext.Context, ai.MLClient, mock.Anything).
+		Return(&emptyResult, nil)
+
+	mockai.RegisterGetEnvironment(mockContext, scope.Workspace(), environmentName, http.StatusNotFound)
+	mockai.RegisterGetEnvironmentVersion(mockContext, scope.Workspace(), environmentName, "1")
+
+	serviceConfig := createTestServiceConfig("./contoso-chat", AiEndpointTarget, ServiceLanguagePython)
+	serviceConfig.Project.Path = testDir
+	environmentConfig := &ai.ComponentConfig{
+		Name: osutil.NewExpandableString(environmentName),
+		Path: "./deployment/environment.yaml",
+	}
+
+	createTestFile(t, testDir, filepath.Join(serviceConfig.RelativePath, environmentConfig.Path))
+
+	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
+	envVersion, err := aiHelper.CreateEnvironmentVersion(*mockContext.Context, scope, serviceConfig, environmentConfig)
+
+	require.NoError(t, err)
+	require.NotNil(t, envVersion)
+	require.Equal(t, "1", *envVersion.Name)
+	require.Equal(t, environmentName, env.Getenv(AiEnvironmentEnvVarName))
+
+	mockPythonBridge.AssertCalled(t, "Run", *mockContext.Context, ai.MLClient, []string{
+		"-t", "environment",
+		"-s", scope.SubscriptionId(),
+		"-g", scope.ResourceGroup(),
+		"-w", scope.Workspace(),
+		"-f", filepath.Join(serviceConfig.Path(), environmentConfig.Path),
+		"--set", fmt.Sprintf("name=%s", environmentName),
+		"--set", fmt.Sprintf("version=%d", 1),
+	})
+}
+
+func Test_AiHelper_CreateModelVersion(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+	testDir := t.TempDir()
+	env := environment.NewWithValues("test", map[string]string{
+		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
+		environment.ResourceGroupEnvVarName:  "RESOURCE_GROUP",
+	})
+	scope := ai.NewScope(env.GetSubscriptionId(), env.Getenv(environment.ResourceGroupEnvVarName), "AI_WORKSPACE")
+	modelName := "MY-MODEL"
+
+	emptyResult := exec.NewRunResult(0, "", "")
+
+	mockPythonBridge := &mockPythonBridge{}
+	mockPythonBridge.
+		On("Run", *mockContext.Context, ai.MLClient, mock.Anything).
+		Return(&emptyResult, nil)
+
+	mockai.RegisterGetModel(mockContext, scope.Workspace(), modelName, http.StatusNotFound)
+	mockai.RegisterGetModelVersion(mockContext, scope.Workspace(), modelName, "1")
+
+	serviceConfig := createTestServiceConfig("./contoso-chat", AiEndpointTarget, ServiceLanguagePython)
+	serviceConfig.Project.Path = testDir
+	modelConfig := &ai.ComponentConfig{
+		Name: osutil.NewExpandableString(modelName),
+		Path: "./deployment/model.yaml",
+	}
+
+	createTestFile(t, testDir, filepath.Join(serviceConfig.RelativePath, modelConfig.Path))
+
+	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
+	modelVersion, err := aiHelper.CreateModelVersion(*mockContext.Context, scope, serviceConfig, modelConfig)
+
+	require.NoError(t, err)
+	require.NotNil(t, modelVersion)
+	require.Equal(t, "1", *modelVersion.Name)
+	require.Equal(t, modelName, env.Getenv(AiModelEnvVarName))
+
+	mockPythonBridge.AssertCalled(t, "Run", *mockContext.Context, ai.MLClient, []string{
+		"-t", "model",
+		"-s", scope.SubscriptionId(),
+		"-g", scope.ResourceGroup(),
+		"-w", scope.Workspace(),
+		"-f", filepath.Join(serviceConfig.Path(), modelConfig.Path),
+		"--set", fmt.Sprintf("name=%s", modelName),
+		"--set", fmt.Sprintf("version=%d", 1),
+	})
+}
+
+func Test_AiHelper_GetEndpoint(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+	env := environment.NewWithValues("test", map[string]string{
+		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
+		environment.ResourceGroupEnvVarName:  "RESOURCE_GROUP",
+	})
+	scope := ai.NewScope(env.GetSubscriptionId(), env.Getenv(environment.ResourceGroupEnvVarName), "AI_WORKSPACE")
+	endpointName := "MY-ENDPOINT"
+
+	mockPythonBridge := &mockPythonBridge{}
+	mockai.RegisterGetOnlineEndpoint(mockContext, scope.Workspace(), endpointName, http.StatusOK, nil)
+
+	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
+	endpoint, err := aiHelper.GetEndpoint(*mockContext.Context, scope, endpointName)
+
+	require.NoError(t, err)
+	require.NotNil(t, endpoint)
+	require.Equal(t, endpointName, *endpoint.Name)
+}
+
+func Test_AiHelper_CreateFlow(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+	testDir := t.TempDir()
+	env := environment.NewWithValues("test", map[string]string{
+		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
+		environment.ResourceGroupEnvVarName:  "RESOURCE_GROUP",
+	})
+	scope := ai.NewScope(env.GetSubscriptionId(), env.Getenv(environment.ResourceGroupEnvVarName), "AI_WORKSPACE")
+	flowName := "MY-FLOW"
+
+	mockContext.Clock.Set(time.Now())
+	expectedFlowName := fmt.Sprintf("%s-%d", flowName, mockContext.Clock.Now().Unix())
+	expectedFlow := ai.Flow{
+		Name:        uuid.New().String(),
+		DisplayName: expectedFlowName,
+		Type:        "chat",
+	}
+
+	jsonBytes, err := json.Marshal(expectedFlow)
+	require.NoError(t, err)
+	expectedFlowJson := string(jsonBytes)
+
+	mockPythonBridge := &mockPythonBridge{}
+	mockPythonBridge.
+		On("Run", *mockContext.Context, ai.PromptFlowClient, mock.Anything).
+		Return(&exec.RunResult{
+			ExitCode: 0,
+			Stdout:   expectedFlowJson,
+			Stderr:   "",
+		}, nil)
+
+	serviceConfig := createTestServiceConfig("./contoso-chat", AiEndpointTarget, ServiceLanguagePython)
+	serviceConfig.Project.Path = testDir
+	flowConfig := &ai.ComponentConfig{
+		Name: osutil.NewExpandableString(flowName),
+		Path: "./my-flow",
+	}
+
+	createTestFile(t, testDir, filepath.Join(serviceConfig.RelativePath, filepath.Join(flowConfig.Path, "flow.dag.yaml")))
+
+	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
+	flow, err := aiHelper.CreateFlow(*mockContext.Context, scope, serviceConfig, flowConfig)
+
+	require.NoError(t, err)
+	require.NotNil(t, flow)
+	require.True(t, strings.HasPrefix(flow.DisplayName, flowName))
+	require.Equal(t, expectedFlowName, flow.DisplayName)
+	require.Equal(t, expectedFlowName, env.Getenv(AiFlowEnvVarName), flowName)
+	mockPythonBridge.AssertCalled(t, "Run", *mockContext.Context, ai.PromptFlowClient, []string{
+		"create",
+		"-n", expectedFlowName,
+		"-f", filepath.Join(serviceConfig.Path(), flowConfig.Path),
+		"-s", scope.SubscriptionId(),
+		"-g", scope.ResourceGroup(),
+		"-w", scope.Workspace(),
+	})
+}
+
+func Test_AiHelper_DeployToEndpoint(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+	testDir := t.TempDir()
+	env := environment.NewWithValues("test", map[string]string{
+		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
+		environment.ResourceGroupEnvVarName:  "RESOURCE_GROUP",
+		"MY_VAR":                             "MY_VALUE",
+	})
+	scope := ai.NewScope(env.GetSubscriptionId(), env.Getenv(environment.ResourceGroupEnvVarName), "AI_WORKSPACE")
+	environmentName := "MY-ENVIRONMENT"
+	environmentVersion := "2"
+	modelName := "MY-MODEL"
+	modelVersion := "2"
+	endpointName := "MY-ENDPOINT"
+	deploymentName := "MY-DEPLOYMENT"
+
+	mockContext.Clock.Set(time.Now())
+	expectedDeploymentName := fmt.Sprintf("%s-%d", deploymentName, mockContext.Clock.Now().Unix())
+
+	mockPythonBridge := &mockPythonBridge{}
+	mockPythonBridge.
+		On("Run", *mockContext.Context, ai.MLClient, mock.Anything).
+		Return(&exec.RunResult{}, nil)
+
+	mockai.RegisterGetEnvironment(mockContext, scope.Workspace(), environmentName, http.StatusOK)
+	mockai.RegisterGetEnvironmentVersion(mockContext, scope.Workspace(), environmentName, environmentVersion)
+	mockai.RegisterGetModel(mockContext, scope.Workspace(), modelName, http.StatusOK)
+	mockai.RegisterGetModelVersion(mockContext, scope.Workspace(), modelName, modelVersion)
+	mockai.RegisterGetOnlineDeployment(
+		mockContext,
+		scope.Workspace(),
+		endpointName,
+		expectedDeploymentName,
+		armmachinelearning.DeploymentProvisioningStateSucceeded,
+	)
+
+	serviceConfig := createTestServiceConfig("./contoso-chat", AiEndpointTarget, ServiceLanguagePython)
+	serviceConfig.Project.Path = testDir
+
+	endpointConfig := &ai.EndpointDeploymentConfig{
+		Workspace: osutil.NewExpandableString(scope.Workspace()),
+		Flow: &ai.ComponentConfig{
+			Path: "./my-flow",
+		},
+		Environment: &ai.ComponentConfig{
+			Name: osutil.NewExpandableString(environmentName),
+			Path: "./deployment/environment.yaml",
+		},
+		Model: &ai.ComponentConfig{
+			Name: osutil.NewExpandableString(modelName),
+			Path: "./deployment/model.yaml",
+		},
+		Deployment: &ai.DeploymentConfig{
+			ComponentConfig: ai.ComponentConfig{
+				Name: osutil.NewExpandableString(deploymentName),
+				Path: "./deployment/deployment.yaml",
+			},
+			Environment: map[string]osutil.ExpandableString{
+				"MY_VAR": osutil.NewExpandableString("${MY_VAR}"),
+			},
+		},
+	}
+
+	createTestFile(t, testDir, filepath.Join(serviceConfig.RelativePath, endpointConfig.Deployment.Path))
+
+	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
+	deployment, err := aiHelper.DeployToEndpoint(*mockContext.Context, scope, serviceConfig, endpointName, endpointConfig)
+
+	require.NoError(t, err)
+	require.NotNil(t, deployment)
+	require.Equal(t, expectedDeploymentName, *deployment.Name)
+	require.Equal(t, expectedDeploymentName, env.Getenv(AiDeploymentEnvVarName), *deployment.Name)
+	require.Equal(t, endpointName, env.Getenv(AiEndpointEnvVarName))
+	require.Equal(t, expectedDeploymentName, env.Getenv(AiDeploymentEnvVarName))
+	mockPythonBridge.AssertCalled(t, "Run", *mockContext.Context, ai.MLClient, []string{
+		"-t", "online-deployment",
+		"-s", scope.SubscriptionId(),
+		"-g", scope.ResourceGroup(),
+		"-w", scope.Workspace(),
+		"-f", filepath.Join(serviceConfig.Path(), endpointConfig.Deployment.Path),
+		"--set", fmt.Sprintf("name=%s", expectedDeploymentName),
+		"--set", fmt.Sprintf("endpoint_name=%s", endpointName),
+		"--set", fmt.Sprintf("environment=azureml:%s:%s", environmentName, environmentVersion),
+		"--set", fmt.Sprintf("model=azureml:%s:%s", modelName, modelVersion),
+		"--set", fmt.Sprintf("environment_variables.MY_VAR=%s", env.Getenv("MY_VAR")),
+	})
+}
+
+func Test_AiHelper_UpdateTraffic(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+	env := environment.NewWithValues("test", map[string]string{
+		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
+		environment.ResourceGroupEnvVarName:  "RESOURCE_GROUP",
+	})
+	scope := ai.NewScope(env.GetSubscriptionId(), env.Getenv(environment.ResourceGroupEnvVarName), "AI_WORKSPACE")
+	endpointName := "MY-ENDPOINT"
+	deploymentName := "MY-DEPLOYMENT"
+
+	mockContext.Clock.Set(time.Now())
+
+	trafficMap := map[string]*int32{
+		deploymentName: convert.RefOf(int32(100)),
+	}
+
+	mockPythonBridge := &mockPythonBridge{}
+	mockai.RegisterGetOnlineEndpoint(mockContext, scope.Workspace(), endpointName, http.StatusOK, nil)
+	updateRequest := mockai.RegisterUpdateOnlineEndpoint(mockContext, scope.Workspace(), endpointName, trafficMap)
+
+	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
+	endpoint, err := aiHelper.UpdateTraffic(*mockContext.Context, scope, endpointName, deploymentName)
+
+	require.NoError(t, err)
+	require.NotNil(t, endpoint)
+	require.NotNil(t, updateRequest)
+	require.Equal(t, endpointName, *endpoint.Name)
+	require.Equal(t, int32(100), *endpoint.Properties.Traffic[deploymentName])
+}
+
+func Test_AiHelper_DeletePreviousDeployments(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+	env := environment.NewWithValues("test", map[string]string{
+		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
+		environment.ResourceGroupEnvVarName:  "RESOURCE_GROUP",
+	})
+	scope := ai.NewScope(env.GetSubscriptionId(), env.Getenv(environment.ResourceGroupEnvVarName), "AI_WORKSPACE")
+	endpointName := "MY-ENDPOINT"
+	deploymentName := "MY-DEPLOYMENT"
+
+	endpoint := &armmachinelearning.OnlineEndpoint{
+		Name: convert.RefOf(endpointName),
+		Properties: &armmachinelearning.OnlineEndpointProperties{
+			Traffic: map[string]*int32{
+				deploymentName: convert.RefOf(int32(100)),
+			},
+		},
+	}
+
+	existingDeploymentNames := []string{
+		"old-deploymen-01",
+		"old-deployment-02",
+	}
+
+	mockPythonBridge := &mockPythonBridge{}
+	mockai.RegisterGetOnlineEndpoint(mockContext, scope.Workspace(), endpointName, http.StatusOK, endpoint)
+	mockai.RegisterListOnlineDeployment(mockContext, scope.Workspace(), endpointName, existingDeploymentNames)
+
+	deleteRequests := []*http.Request{}
+
+	for _, deploymentName := range existingDeploymentNames {
+		deleteRequests = append(deleteRequests, mockai.RegisterDeleteOnlineDeployment(
+			mockContext,
+			scope.Workspace(),
+			endpointName,
+			deploymentName,
+		))
+	}
+
+	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
+	err := aiHelper.DeletePreviousDeployments(*mockContext.Context, scope, endpointName)
+	require.Len(t, deleteRequests, len(existingDeploymentNames))
+
+	require.NoError(t, err)
+}
+
+func createTestFile(t *testing.T, tempDir string, relativePath string) {
+	destPath := filepath.Join(tempDir, relativePath)
+	err := os.MkdirAll(filepath.Dir(destPath), osutil.PermissionDirectory)
+	require.NoError(t, err)
+
+	err = os.WriteFile(destPath, []byte(""), osutil.PermissionFile)
+	require.NoError(t, err)
+}
+
+func newAiHelper(
+	t *testing.T,
+	mockContext *mocks.MockContext,
+	env *environment.Environment,
+	pythonBridge ai.PythonBridge,
+) AiHelper {
+	subscriptionId := env.GetSubscriptionId()
+
+	workspacesClient, err := armmachinelearning.NewWorkspacesClient(
+		subscriptionId,
+		mockContext.Credentials,
+		mockContext.ArmClientOptions,
+	)
+	require.NoError(t, err)
+
+	environmentContainersClient, err := armmachinelearning.NewEnvironmentContainersClient(
+		subscriptionId,
+		mockContext.Credentials,
+		mockContext.ArmClientOptions,
+	)
+	require.NoError(t, err)
+
+	environmentVersionsClient, err := armmachinelearning.NewEnvironmentVersionsClient(
+		subscriptionId,
+		mockContext.Credentials,
+		mockContext.ArmClientOptions,
+	)
+	require.NoError(t, err)
+
+	modelContainersClient, err := armmachinelearning.NewModelContainersClient(
+		subscriptionId,
+		mockContext.Credentials,
+		mockContext.ArmClientOptions,
+	)
+	require.NoError(t, err)
+
+	modelVersionsClient, err := armmachinelearning.NewModelVersionsClient(
+		subscriptionId,
+		mockContext.Credentials,
+		mockContext.ArmClientOptions,
+	)
+	require.NoError(t, err)
+
+	onlineEndpointsClient, err := armmachinelearning.NewOnlineEndpointsClient(
+		subscriptionId,
+		mockContext.Credentials,
+		mockContext.ArmClientOptions,
+	)
+	require.NoError(t, err)
+
+	onlineDeploymentsClient, err := armmachinelearning.NewOnlineDeploymentsClient(
+		subscriptionId,
+		mockContext.Credentials,
+		mockContext.ArmClientOptions,
+	)
+	require.NoError(t, err)
+
+	return NewAiHelper(
+		env,
+		mockContext.Clock,
+		mockContext.SubscriptionCredentialProvider,
+		pythonBridge,
+		workspacesClient,
+		environmentContainersClient,
+		environmentVersionsClient,
+		modelContainersClient,
+		modelVersionsClient,
+		onlineEndpointsClient,
+		onlineDeploymentsClient,
+	)
+}
+
+type mockPythonBridge struct {
+	mock.Mock
+}
+
+func (m *mockPythonBridge) Initialize(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockPythonBridge) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+	args := m.Called(ctx)
+	return args.Get(0).([]tools.ExternalTool)
+}
+
+func (m *mockPythonBridge) Run(ctx context.Context, scriptName ai.ScriptPath, args ...string) (*exec.RunResult, error) {
+	callArgs := m.Called(ctx, scriptName, args)
+	return callArgs.Get(0).(*exec.RunResult), callArgs.Error(1)
+}

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -39,6 +39,8 @@ type ServiceConfig struct {
 	// Options specific to the DotNetContainerApp target. These are set by the importer and
 	// can not be controlled via the project file today.
 	DotNetContainerApp *DotNetContainerAppOptions `yaml:"-,omitempty"`
+	// Custom configuration for the service target
+	Config map[string]any `yaml:"config,omitempty"`
 
 	*ext.EventDispatcher[ServiceLifecycleEventArgs] `yaml:"-"`
 }

--- a/cli/azd/pkg/project/service_models.go
+++ b/cli/azd/pkg/project/service_models.go
@@ -78,7 +78,11 @@ func (spr *ServicePackageResult) ToString(currentIndentation string) string {
 		return uxItem.ToString(currentIndentation)
 	}
 
-	return fmt.Sprintf("%s- Package Output: %s", currentIndentation, output.WithLinkFormat(spr.PackagePath))
+	if spr.PackagePath != "" {
+		return fmt.Sprintf("%s- Package Output: %s", currentIndentation, output.WithLinkFormat(spr.PackagePath))
+	}
+
+	return ""
 }
 
 func (spr *ServicePackageResult) MarshalJSON() ([]byte, error) {

--- a/cli/azd/pkg/project/service_target.go
+++ b/cli/azd/pkg/project/service_target.go
@@ -26,6 +26,7 @@ const (
 	SpringAppTarget          ServiceTargetKind = "springapp"
 	AksTarget                ServiceTargetKind = "aks"
 	DotNetContainerAppTarget ServiceTargetKind = "containerapp-dotnet"
+	AiEndpointTarget         ServiceTargetKind = "ai.endpoint"
 )
 
 // RequiresContainer returns true if the service target runs a container image.
@@ -50,7 +51,8 @@ func parseServiceHost(kind ServiceTargetKind) (ServiceTargetKind, error) {
 		AzureFunctionTarget,
 		StaticWebAppTarget,
 		SpringAppTarget,
-		AksTarget:
+		AksTarget,
+		AiEndpointTarget:
 
 		return kind, nil
 	}

--- a/cli/azd/pkg/project/service_target_ai_endpoint.go
+++ b/cli/azd/pkg/project/service_target_ai_endpoint.go
@@ -1,0 +1,280 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
+	"github.com/azure/azure-dev/cli/azd/pkg/ai"
+	"github.com/azure/azure-dev/cli/azd/pkg/async"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+)
+
+// aiEndpointTarget is a ServiceTarget implementation for deploying to Azure ML online endpoints
+type aiEndpointTarget struct {
+	env        *environment.Environment
+	envManager environment.Manager
+	aiHelper   AiHelper
+}
+
+// NewAiEndpointTarget creates a new aiEndpointTarget instance
+func NewAiEndpointTarget(
+	env *environment.Environment,
+	envManager environment.Manager,
+	aiHelper AiHelper,
+) ServiceTarget {
+	return &aiEndpointTarget{
+		env:        env,
+		envManager: envManager,
+		aiHelper:   aiHelper,
+	}
+}
+
+// AiEndpointDeploymentResult is a struct to hold the result of an online endpoint deployment
+type AiEndpointDeploymentResult struct {
+	Environment *armmachinelearning.EnvironmentVersion
+	Model       *armmachinelearning.ModelVersion
+	Flow        *ai.Flow
+	Deployment  *armmachinelearning.OnlineDeployment
+}
+
+// Initialize initializes the aiEndpointTarget
+func (m *aiEndpointTarget) Initialize(ctx context.Context, serviceConfig *ServiceConfig) error {
+	return serviceConfig.Project.AddHandler(
+		"postprovision",
+		func(ctx context.Context, args ProjectLifecycleEventArgs) error {
+			projectName := m.env.Getenv(AiProjectNameEnvVarName)
+			aiStudioLink := ai.AzureAiStudioLink(
+				m.env.GetTenantId(),
+				m.env.GetSubscriptionId(),
+				m.env.Getenv(environment.ResourceGroupEnvVarName),
+				projectName,
+			)
+
+			err := m.env.Config.Set("provision.links.aiStudio", &output.Link{
+				Name:        "Azure AI Studio",
+				Description: fmt.Sprintf("View the %s project in Azure AI studio:", projectName),
+				Url:         aiStudioLink,
+			})
+			if err != nil {
+				return fmt.Errorf("failed setting aiStudio link: %w", err)
+			}
+
+			if err := m.envManager.Save(ctx, m.env); err != nil {
+				return fmt.Errorf("failed saving environment: %w", err)
+			}
+
+			return nil
+		},
+	)
+}
+
+// RequiredExternalTools returns the required external tools for the machineLearningEndpointTarget
+func (m *aiEndpointTarget) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+	return m.aiHelper.RequiredExternalTools(ctx)
+}
+
+// Package packages the service for deployment to an Azure ML online endpoint
+// This method is a no-op since the actual packaging is handled by the underlying AI/ML Python SDKs
+func (m *aiEndpointTarget) Package(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	frameworkPackageOutput *ServicePackageResult,
+) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress] {
+	return async.RunTaskWithProgress(func(task *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
+		task.SetResult(&ServicePackageResult{})
+	})
+}
+
+// Deploy deploys the service to an Azure ML online endpoint
+func (m *aiEndpointTarget) Deploy(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	servicePackage *ServicePackageResult,
+	targetResource *environment.TargetResource,
+) *async.TaskWithProgress[*ServiceDeployResult, ServiceProgress] {
+	return async.RunTaskWithProgress(func(task *async.TaskContextWithProgress[*ServiceDeployResult, ServiceProgress]) {
+		endpointConfig, err := ai.ParseConfig[ai.EndpointDeploymentConfig](serviceConfig.Config)
+		if err != nil {
+			task.SetError(err)
+			return
+		}
+
+		workspaceScope, err := m.getWorkspaceScope(serviceConfig, targetResource)
+		if err != nil {
+			task.SetError(err)
+			return
+		}
+
+		deployResult := &AiEndpointDeploymentResult{}
+
+		// Initialize the AI project that will be used for the python bridge
+		task.SetProgress(NewServiceProgress("Initializing AI project"))
+		if err := m.aiHelper.Initialize(ctx); err != nil {
+			task.SetError(fmt.Errorf("failed initializing AI project: %w", err))
+			return
+		}
+
+		// Ensure the workspace is valid
+		if err := m.aiHelper.ValidateWorkspace(ctx, workspaceScope); err != nil {
+			task.SetError(
+				fmt.Errorf("workspace '%s' was not found within subscription '%s' and resource group '%s': %w",
+					workspaceScope.Workspace(),
+					workspaceScope.SubscriptionId(),
+					workspaceScope.ResourceGroup(),
+					err,
+				),
+			)
+			return
+		}
+
+		// Deploy flow
+		if endpointConfig.Flow != nil {
+			task.SetProgress(NewServiceProgress("Deploying AI Prompt Flow"))
+			flow, err := m.aiHelper.CreateFlow(ctx, workspaceScope, serviceConfig, endpointConfig.Flow)
+			if err != nil {
+				task.SetError(err)
+				return
+			}
+
+			deployResult.Flow = flow
+		}
+
+		// Deploy environment
+		if endpointConfig.Environment != nil {
+			task.SetProgress(NewServiceProgress("Configuring AI environment"))
+			envVersion, err := m.aiHelper.CreateEnvironmentVersion(
+				ctx,
+				workspaceScope,
+				serviceConfig,
+				endpointConfig.Environment,
+			)
+			if err != nil {
+				task.SetError(err)
+				return
+			}
+
+			deployResult.Environment = envVersion
+		}
+
+		// Deploy model
+		if endpointConfig.Model != nil {
+			task.SetProgress(NewServiceProgress("Configuring AI model"))
+			modelVersion, err := m.aiHelper.CreateModelVersion(ctx, workspaceScope, serviceConfig, endpointConfig.Model)
+			if err != nil {
+				task.SetError(err)
+				return
+			}
+
+			deployResult.Model = modelVersion
+		}
+
+		// Deploy to endpoint
+		if endpointConfig.Deployment != nil {
+			task.SetProgress(NewServiceProgress("Deploying to AI Online Endpoint"))
+			endpointName := filepath.Base(targetResource.ResourceName())
+			onlineDeployment, err := m.aiHelper.DeployToEndpoint(
+				ctx,
+				workspaceScope,
+				serviceConfig,
+				endpointName,
+				endpointConfig,
+			)
+			if err != nil {
+				task.SetError(err)
+				return
+			}
+
+			task.SetProgress(NewServiceProgress("Updating traffic"))
+			_, err = m.aiHelper.UpdateTraffic(ctx, workspaceScope, endpointName, *onlineDeployment.Name)
+			if err != nil {
+				task.SetError(fmt.Errorf("failed updating traffic: %w", err))
+				return
+			}
+
+			task.SetProgress(NewServiceProgress("Removing old deployments"))
+			if err := m.aiHelper.DeletePreviousDeployments(ctx, workspaceScope, endpointName); err != nil {
+				task.SetError(fmt.Errorf("failed deleting previous deployments: %w", err))
+				return
+			}
+
+			deployResult.Deployment = onlineDeployment
+		}
+
+		endpoints, err := m.Endpoints(ctx, serviceConfig, targetResource)
+		if err != nil {
+			task.SetError(err)
+			return
+		}
+
+		if err := m.envManager.Save(ctx, m.env); err != nil {
+			task.SetError(fmt.Errorf("failed saving environment: %w", err))
+			return
+		}
+
+		task.SetResult(&ServiceDeployResult{
+			Details:   deployResult,
+			Package:   servicePackage,
+			Endpoints: endpoints,
+		})
+	})
+}
+
+// Endpoints returns the endpoints for the service
+func (m *aiEndpointTarget) Endpoints(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	targetResource *environment.TargetResource,
+) ([]string, error) {
+	workspaceScope, err := m.getWorkspaceScope(serviceConfig, targetResource)
+	if err != nil {
+		return nil, err
+	}
+
+	endpointName := filepath.Base(targetResource.ResourceName())
+	onlineEndpoint, err := m.aiHelper.GetEndpoint(ctx, workspaceScope, endpointName)
+	if err != nil {
+		return nil, err
+	}
+
+	return []string{
+		fmt.Sprintf("Scoring: %s", *onlineEndpoint.Properties.ScoringURI),
+		fmt.Sprintf("Swagger: %s", *onlineEndpoint.Properties.SwaggerURI),
+	}, nil
+}
+
+// getWorkspaceScope returns the scope for the workspace
+func (m *aiEndpointTarget) getWorkspaceScope(
+	serviceConfig *ServiceConfig,
+	targetResource *environment.TargetResource,
+) (*ai.Scope, error) {
+	endpointConfig, err := ai.ParseConfig[ai.EndpointDeploymentConfig](serviceConfig.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	workspaceName, err := endpointConfig.Workspace.Envsubst(m.env.Getenv)
+	if err != nil {
+		return nil, err
+	}
+
+	// Workspace name can come from the following:
+	// 1. The workspace field in the endpoint service config
+	// 2. The AZUREAI_PROJECT_NAME environment variable
+	if workspaceName == "" {
+		workspaceName = m.env.Getenv(AiProjectNameEnvVarName)
+	}
+
+	if workspaceName == "" {
+		return nil, fmt.Errorf("workspace name is required")
+	}
+
+	return ai.NewScope(
+		m.env.GetSubscriptionId(),
+		targetResource.ResourceGroupName(),
+		workspaceName,
+	), nil
+}

--- a/cli/azd/pkg/project/service_target_ai_endpoint.go
+++ b/cli/azd/pkg/project/service_target_ai_endpoint.go
@@ -9,7 +9,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/ai"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
-	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 )
 
@@ -43,33 +42,7 @@ type AiEndpointDeploymentResult struct {
 
 // Initialize initializes the aiEndpointTarget
 func (m *aiEndpointTarget) Initialize(ctx context.Context, serviceConfig *ServiceConfig) error {
-	return serviceConfig.Project.AddHandler(
-		"postprovision",
-		func(ctx context.Context, args ProjectLifecycleEventArgs) error {
-			projectName := m.env.Getenv(AiProjectNameEnvVarName)
-			aiStudioLink := ai.AzureAiStudioLink(
-				m.env.GetTenantId(),
-				m.env.GetSubscriptionId(),
-				m.env.Getenv(environment.ResourceGroupEnvVarName),
-				projectName,
-			)
-
-			err := m.env.Config.Set("provision.links.aiStudio", &output.Link{
-				Name:        "Azure AI Studio",
-				Description: fmt.Sprintf("View the %s project in Azure AI studio:", projectName),
-				Url:         aiStudioLink,
-			})
-			if err != nil {
-				return fmt.Errorf("failed setting aiStudio link: %w", err)
-			}
-
-			if err := m.envManager.Save(ctx, m.env); err != nil {
-				return fmt.Errorf("failed saving environment: %w", err)
-			}
-
-			return nil
-		},
-	)
+	return nil
 }
 
 // RequiredExternalTools returns the required external tools for the machineLearningEndpointTarget

--- a/cli/azd/pkg/project/service_target_ai_endpoint_test.go
+++ b/cli/azd/pkg/project/service_target_ai_endpoint_test.go
@@ -1,0 +1,237 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
+	"github.com/azure/azure-dev/cli/azd/pkg/ai"
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockenv"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_MlEndpointTarget_Deploy(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+	mockContext.Clock.Set(time.Now())
+	env := environment.NewWithValues("test", map[string]string{
+		AiProjectNameEnvVarName:              "AI_WORKSPACE",
+		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
+		environment.ResourceGroupEnvVarName:  "RESOURCE_GROUP",
+	})
+
+	endpointName := "MY-ONLINE-ENDPOINT"
+	flowName := "MY-FLOW"
+	environmentName := "MY-ENVIRONMENT"
+	modelName := "MY-MODEL"
+	deploymentName := "MY-DEPLOYMENT"
+	expectedDeploymentName := fmt.Sprintf("%s-%d", deploymentName, mockContext.Clock.Now().Unix())
+	expectedFlowName := fmt.Sprintf("%s-%d", flowName, mockContext.Clock.Now().Unix())
+
+	servicePackage := &ServicePackageResult{}
+	targetResource := environment.NewTargetResource(
+		env.GetSubscriptionId(),
+		env.Getenv(environment.ResourceGroupEnvVarName),
+		endpointName,
+		string(infra.AzureMachineLearningEndpoint),
+	)
+	serviceConfig := createTestServiceConfig("./contoso-chat", AiEndpointTarget, ServiceLanguagePython)
+	serviceConfig.Config = map[string]any{
+		"flow": map[string]any{
+			"name": flowName,
+			"path": ".",
+		},
+		"environment": map[string]any{
+			"name": environmentName,
+			"path": "./deployment/environment.yaml",
+		},
+		"model": map[string]any{
+			"name": modelName,
+			"path": "./deployment/model.yaml",
+		},
+		"deployment": map[string]any{
+			"name": deploymentName,
+			"path": "./deployment/deployment.yaml",
+		},
+	}
+
+	flow := &ai.Flow{
+		Name:        uuid.New().String(),
+		DisplayName: expectedFlowName,
+	}
+
+	environmentVersion := &armmachinelearning.EnvironmentVersion{
+		Name: convert.RefOf("1"),
+	}
+
+	modelVersion := &armmachinelearning.ModelVersion{
+		Name: convert.RefOf("1"),
+	}
+
+	onlineDeployment := &armmachinelearning.OnlineDeployment{
+		Name: &expectedDeploymentName,
+	}
+
+	onlineEndpoint := &armmachinelearning.OnlineEndpoint{
+		Name: convert.RefOf(endpointName),
+		Properties: &armmachinelearning.OnlineEndpointProperties{
+			ScoringURI: convert.RefOf("https://SCRORING_URI"),
+			SwaggerURI: convert.RefOf("https://SWAGGER_URI"),
+		},
+	}
+
+	scopeType := mock.AnythingOfType("*ai.Scope")
+	componentConfigType := mock.AnythingOfType("*ai.ComponentConfig")
+	endpointDeploymentConfigType := mock.AnythingOfType("*ai.EndpointDeploymentConfig")
+
+	aiHelper := &mockAiHelper{}
+	aiHelper.
+		On("Initialize", *mockContext.Context).
+		Return(nil)
+	aiHelper.
+		On("ValidateWorkspace", *mockContext.Context, scopeType).
+		Return(nil)
+	aiHelper.
+		On("CreateFlow", *mockContext.Context, scopeType, serviceConfig, componentConfigType).
+		Return(flow, nil)
+	aiHelper.
+		On("CreateEnvironmentVersion", *mockContext.Context, scopeType, serviceConfig, componentConfigType).
+		Return(environmentVersion, nil)
+	aiHelper.
+		On("CreateModelVersion", *mockContext.Context, scopeType, serviceConfig, componentConfigType).
+		Return(modelVersion, nil)
+	aiHelper.
+		On("DeployToEndpoint", *mockContext.Context, scopeType, serviceConfig, endpointName, endpointDeploymentConfigType).
+		Return(onlineDeployment, nil)
+	aiHelper.
+		On("UpdateTraffic", *mockContext.Context, scopeType, endpointName, expectedDeploymentName).
+		Return(onlineEndpoint, nil)
+	aiHelper.
+		On("DeletePreviousDeployments", *mockContext.Context, scopeType, endpointName).
+		Return(nil)
+	aiHelper.
+		On("GetEndpoint", *mockContext.Context, scopeType, endpointName).
+		Return(onlineEndpoint, nil)
+
+	serviceTarget := createMlEndpointTarget(mockContext, env, aiHelper)
+	deployTask := serviceTarget.Deploy(*mockContext.Context, serviceConfig, servicePackage, targetResource)
+	require.NotNil(t, deployTask)
+	logProgress(deployTask)
+
+	deployResult, err := deployTask.Await()
+
+	require.NoError(t, err)
+	require.NotNil(t, deployResult)
+	require.IsType(t, &AiEndpointDeploymentResult{}, deployResult.Details)
+	require.Len(t, deployResult.Endpoints, 2)
+
+	deploymentDetails := deployResult.Details.(*AiEndpointDeploymentResult)
+
+	require.Equal(t, expectedFlowName, deploymentDetails.Flow.DisplayName)
+	require.Equal(t, environmentVersion.Name, deploymentDetails.Environment.Name)
+	require.Equal(t, modelVersion.Name, deploymentDetails.Model.Name)
+	require.Equal(t, expectedDeploymentName, *deploymentDetails.Deployment.Name)
+}
+
+func createMlEndpointTarget(
+	mockContext *mocks.MockContext,
+	env *environment.Environment,
+	aiHelper AiHelper,
+) ServiceTarget {
+	envManager := &mockenv.MockEnvManager{}
+	envManager.On("Save", *mockContext.Context, env).Return(nil)
+
+	return NewAiEndpointTarget(env, envManager, aiHelper)
+}
+
+type mockAiHelper struct {
+	mock.Mock
+}
+
+func (m *mockAiHelper) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+	args := m.Called(ctx)
+	return args.Get(0).([]tools.ExternalTool)
+}
+
+func (m *mockAiHelper) Initialize(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockAiHelper) ValidateWorkspace(ctx context.Context, scope *ai.Scope) error {
+	args := m.Called(ctx, scope)
+	return args.Error(0)
+}
+
+func (m *mockAiHelper) CreateEnvironmentVersion(
+	ctx context.Context,
+	scope *ai.Scope,
+	serviceConfig *ServiceConfig,
+	config *ai.ComponentConfig,
+) (*armmachinelearning.EnvironmentVersion, error) {
+	args := m.Called(ctx, scope, serviceConfig, config)
+	return args.Get(0).(*armmachinelearning.EnvironmentVersion), args.Error(1)
+}
+
+func (m *mockAiHelper) CreateModelVersion(
+	ctx context.Context,
+	scope *ai.Scope,
+	serviceConfig *ServiceConfig,
+	config *ai.ComponentConfig,
+) (*armmachinelearning.ModelVersion, error) {
+	args := m.Called(ctx, scope, serviceConfig, config)
+	return args.Get(0).(*armmachinelearning.ModelVersion), args.Error(1)
+}
+
+func (m *mockAiHelper) GetEndpoint(
+	ctx context.Context,
+	scope *ai.Scope,
+	endpointName string,
+) (*armmachinelearning.OnlineEndpoint, error) {
+	args := m.Called(ctx, scope, endpointName)
+	return args.Get(0).(*armmachinelearning.OnlineEndpoint), args.Error(1)
+}
+
+func (m *mockAiHelper) DeployToEndpoint(
+	ctx context.Context,
+	scope *ai.Scope,
+	serviceConfig *ServiceConfig,
+	endpointName string,
+	config *ai.EndpointDeploymentConfig,
+) (*armmachinelearning.OnlineDeployment, error) {
+	args := m.Called(ctx, scope, serviceConfig, endpointName, config)
+	return args.Get(0).(*armmachinelearning.OnlineDeployment), args.Error(1)
+}
+
+func (m *mockAiHelper) CreateFlow(
+	ctx context.Context,
+	scope *ai.Scope,
+	serviceConfig *ServiceConfig,
+	config *ai.ComponentConfig,
+) (*ai.Flow, error) {
+	args := m.Called(ctx, scope, serviceConfig, config)
+	return args.Get(0).(*ai.Flow), args.Error(1)
+}
+
+func (m *mockAiHelper) DeletePreviousDeployments(ctx context.Context, scope *ai.Scope, endpointName string) error {
+	args := m.Called(ctx, scope, endpointName)
+	return args.Error(0)
+}
+
+func (m *mockAiHelper) UpdateTraffic(
+	ctx context.Context,
+	scope *ai.Scope,
+	endpointName string,
+	deploymentName string,
+) (*armmachinelearning.OnlineEndpoint, error) {
+	args := m.Called(ctx, scope, endpointName, deploymentName)
+	return args.Get(0).(*armmachinelearning.OnlineEndpoint), args.Error(1)
+}

--- a/cli/azd/pkg/tools/python/python.go
+++ b/cli/azd/pkg/tools/python/python.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
@@ -68,43 +69,12 @@ func (cli *PythonCli) Name() string {
 }
 
 func (cli *PythonCli) InstallRequirements(ctx context.Context, workingDir, environment, requirementFile string) error {
-	var err error
-
-	pyString, err := checkPath()
-	if err != nil {
-		return err
-	}
-
-	if runtime.GOOS == "windows" {
-		// Unfortunately neither cmd.exe, nor PowerShell provide a straightforward way to use a script
-		// to modify environment for command(s) in a command list.
-		// So we are going to cheat and replicate the core functionality of Python venv scripts here,
-		// which boils down to setting VIRTUAL_ENV environment variable.
-		absWorkingDir, pathErr := filepath.Abs(workingDir)
-		if pathErr != nil {
-			return pathErr
-		}
-
-		vEnvSetting := fmt.Sprintf("VIRTUAL_ENV=%s", path.Join(absWorkingDir, environment))
-
-		runArgs := exec.
-			NewRunArgs(pyString, "-m", "pip", "install", "-r", requirementFile).
-			WithCwd(workingDir).
-			WithEnv([]string{vEnvSetting})
-
-		_, err = cli.commandRunner.Run(ctx, runArgs)
-	} else {
-		envActivation := ". " + path.Join(environment, "bin", "activate")
-		installCmd := fmt.Sprintf("%s -m pip install -r %s", pyString, requirementFile)
-		commands := []string{envActivation, installCmd}
-
-		runArgs := exec.NewRunArgs(pyString).WithCwd(workingDir)
-		_, err = cli.commandRunner.RunList(ctx, commands, runArgs)
-	}
-
+	args := []string{"-m", "pip", "install", "-r", requirementFile}
+	_, err := cli.Run(ctx, workingDir, environment, args...)
 	if err != nil {
 		return fmt.Errorf("failed to install requirements for project '%s': %w", workingDir, err)
 	}
+
 	return nil
 }
 
@@ -127,6 +97,56 @@ func (cli *PythonCli) CreateVirtualEnv(ctx context.Context, workingDir, name str
 			err)
 	}
 	return nil
+}
+
+func (cli *PythonCli) Run(
+	ctx context.Context,
+	workingDir string,
+	environment string,
+	args ...string,
+) (*exec.RunResult, error) {
+	pyString, err := checkPath()
+	if err != nil {
+		return nil, err
+	}
+
+	var runResult exec.RunResult
+	var runErr error
+
+	if runtime.GOOS == "windows" {
+		// Unfortunately neither cmd.exe, nor PowerShell provide a straightforward way to use a script
+		// to modify environment for command(s) in a command list.
+		// So we are going to cheat and replicate the core functionality of Python venv scripts here,
+		// which boils down to setting VIRTUAL_ENV environment variable.
+		absWorkingDir, pathErr := filepath.Abs(workingDir)
+		if pathErr != nil {
+			return nil, pathErr
+		}
+
+		vEnvSetting := fmt.Sprintf("VIRTUAL_ENV=%s", path.Join(absWorkingDir, environment))
+
+		runArgs := exec.
+			NewRunArgs(pyString, args...).
+			WithCwd(workingDir).
+			WithEnv([]string{vEnvSetting})
+
+		runResult, runErr = cli.commandRunner.Run(ctx, runArgs)
+	} else {
+		// We need to ensure the virtual environment is activated before running the script
+		envActivation := ". " + path.Join(environment, "bin", "activate")
+		allArgs := append([]string{pyString}, args...)
+		runCmd := strings.Join(allArgs, " ")
+		commands := []string{envActivation, runCmd}
+
+		runArgs := exec.NewRunArgs(pyString).WithCwd(workingDir)
+		runResult, runErr = cli.commandRunner.RunList(ctx, commands, runArgs)
+	}
+
+	if runErr != nil {
+		return nil, fmt.Errorf("failed to run Python script: %w", runErr)
+	}
+
+	return &runResult, nil
 }
 
 func checkPath() (pyString string, err error) {

--- a/cli/azd/resources/ai-python/ml_client.py
+++ b/cli/azd/resources/ai-python/ml_client.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import argparse
+from azure.identity import AzureDeveloperCliCredential
+from azure.ai.ml import MLClient, load_environment, load_model, load_online_endpoint, load_online_deployment
+
+def create_or_update_environment(client: MLClient, file_path: str, overrides: list[dict]):
+    environment = load_environment(source=file_path, params_override=overrides)
+    client.environments.create_or_update(environment)
+
+def create_or_update_model(client: MLClient, file_path: str, overrides: list[dict]):
+    model = load_model(source=file_path, params_override=overrides)
+    client.models.create_or_update(model)
+
+def create_or_update_online_endpoint(client: MLClient, file_path: str, overrides: list[dict]):
+    online_endpoint = load_online_endpoint(source=file_path, params_override=overrides)
+    client.online_endpoints.begin_create_or_update(online_endpoint)
+
+def create_or_update_online_deployment(client: MLClient, file_path: str, overrides: list[dict]):
+    deployment = load_online_deployment(source=file_path, params_override=overrides)
+    client.online_deployments.begin_create_or_update(deployment)
+
+def main():
+    parser = argparse.ArgumentParser(description='Create or update machine learning components')
+    parser.add_argument('--type', '-t', type=str, help='Type of the component')
+    parser.add_argument('--subscription-id', '-s', type=str, help='Azure subscription id', )
+    parser.add_argument('--resource-group', '-g', type=str, help='Azure resource group')
+    parser.add_argument('--workspace', '-w', type=str, help='Azure ML workspace name')
+    parser.add_argument('--file', '-f', type=str, help='Path to the component spec file', required=False)
+    parser.add_argument('--set', action='append', type=str, help='Set a value override', required=False)
+
+    args = parser.parse_args()
+
+    subscription_id: str = args.subscription_id
+    resource_group: str = args.resource_group
+    workspace: str = args.workspace
+    overrides = [{k: v} for string in args.set for k, v in [string.split('=', 1)]]
+
+    credential = AzureDeveloperCliCredential()
+    client = MLClient(credential, subscription_id, resource_group, workspace)
+
+    switcher = {
+        'environment': create_or_update_environment,
+        'model': create_or_update_model,
+        'online-endpoint': create_or_update_online_endpoint,
+        'online-deployment': create_or_update_online_deployment,
+    }
+
+    create_or_update_func = switcher.get(args.type)
+    create_or_update_func(client, args.file, overrides)
+
+if __name__ == '__main__':
+    main()

--- a/cli/azd/resources/ai-python/pf_client.py
+++ b/cli/azd/resources/ai-python/pf_client.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import argparse
+import json
+import sys
+from azure.identity import AzureDeveloperCliCredential
+from promptflow.azure import PFClient
+
+orig_stdout = sys.stdout
+
+def create_flow(client: PFClient, file_path: str, overrides: dict = {}):
+    flow = client.flows.create_or_update(file_path, **overrides)
+    print(json.dumps(flow._to_dict()), file=orig_stdout)
+
+def update_flow(client: PFClient, name: str, overrides: dict = {}):
+    flow = _find_flow(client, name)
+    flow = client.flows.create_or_update(flow, **overrides)
+    print(json.dumps(flow._to_dict()), file=orig_stdout)
+
+def get_flow(client: PFClient, flow_name: str):
+    flow = _find_flow(client, flow_name)
+    print(json.dumps(flow._to_dict()), file=orig_stdout)
+
+def list_flows(client: PFClient):
+    output = []
+    flows = client.flows.list()
+    for flow in flows:
+        output.append(flow._to_dict())
+
+    print(json.dumps(output), file=orig_stdout)
+
+def _add_global_args(parser: argparse.ArgumentParser):
+    parser.add_argument('--subscription-id', '-s', type=str, help='Azure subscription id', required=True)
+    parser.add_argument('--resource-group', '-g', type=str, help='Azure resource group', required=True)
+    parser.add_argument('--workspace', '-w', type=str, help='Azure AI workspace name', required=True)
+
+def _find_flow(client: PFClient, flow_name: str):
+    matching_flow = None
+    flows = client.flows.list()
+    for flow in flows:
+        if flow.display_name == flow_name:
+            matching_flow = flow
+            break
+
+    if matching_flow is None:
+        raise ValueError(f'Flow {flow_name} not found')
+
+    return matching_flow
+
+def main():
+    root_parser = argparse.ArgumentParser(description='Prompt flow client')
+
+    subparsers = root_parser.add_subparsers(title='commands', dest='command')
+
+    show_parser = subparsers.add_parser('show', help='Get a flow')
+    show_parser.add_argument('--name', '-n', type=str, help='Name of the flow', required=True)
+
+    list_parser = subparsers.add_parser('list', help='List flows')
+
+    create_parser = subparsers.add_parser('create', help='Creates a flow')
+    create_parser.add_argument('--name', '-n', type=str, help='Name of the flow', required=True)
+    create_parser.add_argument('--file', '-f', type=str, help='Path to the flow file')
+    create_parser.add_argument('--type', '-t', type=str, help='The flow type', default='chat')
+
+    update_parser = subparsers.add_parser('update', help='Updates a flow')
+    update_parser.add_argument('--name', '-n', type=str, help='Name of the flow', required=True)
+    update_parser.add_argument('--type', '-t', type=str, help='The flow type', default='chat')
+
+    for parser in [show_parser, list_parser, create_parser, update_parser]:
+        _add_global_args(parser)
+
+    for parser in [create_parser, update_parser]:
+        parser.add_argument('--set', action='append', type=str, help='Set a value override', required=False)
+
+    args = root_parser.parse_args()
+    overrides = {}
+
+    credential = AzureDeveloperCliCredential()
+    client = PFClient(credential, args.subscription_id, args.resource_group, args.workspace)
+
+    if (args.command == 'create' or args.command == 'update') and args.name is not None:
+        if args.name is not None:
+            overrides['display_name'] = args.name
+
+        if args.type is not None:
+            overrides['type'] = args.type
+
+        if args.set is not None:
+            for pair in args.set:
+                key, value = pair.split('=', 1)
+                overrides[key] = value
+
+    if args.command == 'show':
+        get_flow(client, args.name)
+    elif args.command == 'list':
+        list_flows(client)
+    elif args.command == 'create':
+        create_flow(client, args.file, overrides)
+    elif args.command == 'update':
+        update_flow(client, args.name, overrides)
+
+if __name__ == '__main__':
+    with open('output.txt', 'w') as f:
+        sys.stdout = f
+        main()

--- a/cli/azd/resources/ai-python/requirements.txt
+++ b/cli/azd/resources/ai-python/requirements.txt
@@ -1,0 +1,6 @@
+promptflow
+promptflow-azure
+promptflow-tools
+azure-ai-ml
+azure-ai-resources
+azure-identity

--- a/cli/azd/resources/resources.go
+++ b/cli/azd/resources/resources.go
@@ -24,3 +24,6 @@ var ScaffoldTemplates embed.FS
 
 //go:embed apphost/templates/*
 var AppHostTemplates embed.FS
+
+//go:embed ai-python/*
+var AiPythonApp embed.FS

--- a/cli/azd/test/mocks/mock_context.go
+++ b/cli/azd/test/mocks/mock_context.go
@@ -17,6 +17,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockexec"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockhttp"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
+	"github.com/benbjohnson/clock"
 )
 
 type MockContext struct {
@@ -33,6 +34,7 @@ type MockContext struct {
 	SubscriptionCredentialProvider *MockSubscriptionCredentialProvider
 	MultiTenantCredentialProvider  *MockMultiTenantCredentialProvider
 	Config                         config.Config
+	Clock                          *clock.Mock
 }
 
 func NewMockContext(ctx context.Context) *MockContext {
@@ -60,6 +62,7 @@ func NewMockContext(ctx context.Context) *MockContext {
 		Container:                      ioc.NewNestedContainer(nil),
 		Config:                         config,
 		AlphaFeaturesManager:           alpha.NewFeaturesManagerWithConfig(config),
+		Clock:                          clock.NewMock(),
 	}
 
 	registerCommonMocks(mockContext)

--- a/cli/azd/test/mocks/mockai/deployments.go
+++ b/cli/azd/test/mocks/mockai/deployments.go
@@ -1,0 +1,115 @@
+package mockai
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+)
+
+func RegisterGetOnlineDeployment(
+	mockContext *mocks.MockContext,
+	workspaceName string,
+	endpointName string,
+	deploymentName string,
+	provisioningState armmachinelearning.DeploymentProvisioningState,
+) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && strings.HasSuffix(
+			request.URL.Path,
+			fmt.Sprintf(
+				"providers/Microsoft.MachineLearningServices/workspaces/%s/onlineEndpoints/%s/deployments/%s",
+				workspaceName,
+				endpointName,
+				deploymentName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		response := armmachinelearning.OnlineDeploymentsClientGetResponse{
+			OnlineDeployment: armmachinelearning.OnlineDeployment{
+				Name: &deploymentName,
+				Properties: &armmachinelearning.OnlineDeploymentProperties{
+					ProvisioningState: &provisioningState,
+				},
+			},
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}
+
+func RegisterDeleteOnlineDeployment(
+	mockContext *mocks.MockContext,
+	workspaceName string,
+	endpointName string,
+	deploymentName string,
+) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodDelete && strings.HasSuffix(
+			request.URL.Path,
+			fmt.Sprintf(
+				"providers/Microsoft.MachineLearningServices/workspaces/%s/onlineEndpoints/%s/deployments/%s",
+				workspaceName,
+				endpointName,
+				deploymentName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		response := armmachinelearning.OnlineDeploymentsClientDeleteResponse{}
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}
+
+func RegisterListOnlineDeployment(
+	mockContext *mocks.MockContext,
+	workspaceName string,
+	endpointName string,
+	deploymentNames []string,
+) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && strings.HasSuffix(
+			request.URL.Path,
+			fmt.Sprintf(
+				"providers/Microsoft.MachineLearningServices/workspaces/%s/onlineEndpoints/%s/deployments",
+				workspaceName,
+				endpointName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		deployments := []*armmachinelearning.OnlineDeployment{}
+		for _, deploymentName := range deploymentNames {
+			deployments = append(deployments, &armmachinelearning.OnlineDeployment{
+				Name: convert.RefOf(deploymentName),
+			})
+		}
+
+		response := armmachinelearning.OnlineDeploymentsClientListResponse{
+			OnlineDeploymentTrackedResourceArmPaginatedResult: armmachinelearning.OnlineDeploymentTrackedResourceArmPaginatedResult{
+				Value: deployments,
+			},
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}

--- a/cli/azd/test/mocks/mockai/endpoints.go
+++ b/cli/azd/test/mocks/mockai/endpoints.go
@@ -1,0 +1,91 @@
+package mockai
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+)
+
+func RegisterGetOnlineEndpoint(
+	mockContext *mocks.MockContext,
+	workspaceName string,
+	endpointName string,
+	statusCode int,
+	endpoint *armmachinelearning.OnlineEndpoint,
+) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && strings.HasSuffix(
+			request.URL.Path,
+			fmt.Sprintf(
+				"providers/Microsoft.MachineLearningServices/workspaces/%s/onlineEndpoints/%s",
+				workspaceName,
+				endpointName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		if statusCode == http.StatusNotFound {
+			return mocks.CreateEmptyHttpResponse(request, http.StatusNotFound)
+		}
+
+		if endpoint == nil {
+			endpoint = &armmachinelearning.OnlineEndpoint{
+				Name: &endpointName,
+				Properties: &armmachinelearning.OnlineEndpointProperties{
+					Traffic: map[string]*int32{},
+				},
+			}
+		}
+
+		response := armmachinelearning.OnlineEndpointsClientGetResponse{
+			OnlineEndpoint: *endpoint,
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}
+
+func RegisterUpdateOnlineEndpoint(
+	mockContext *mocks.MockContext,
+	workspaceName string,
+	endpointName string,
+	trafficMap map[string]*int32,
+) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodPut && strings.HasSuffix(
+			request.URL.Path,
+			fmt.Sprintf(
+				"providers/Microsoft.MachineLearningServices/workspaces/%s/onlineEndpoints/%s",
+				workspaceName,
+				endpointName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		response := armmachinelearning.OnlineEndpointsClientCreateOrUpdateResponse{
+			OnlineEndpoint: armmachinelearning.OnlineEndpoint{
+				Name: &endpointName,
+				Properties: &armmachinelearning.OnlineEndpointProperties{
+					Traffic:           trafficMap,
+					ProvisioningState: convert.RefOf(armmachinelearning.EndpointProvisioningStateSucceeded),
+				},
+			},
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}

--- a/cli/azd/test/mocks/mockai/environments.go
+++ b/cli/azd/test/mocks/mockai/environments.go
@@ -1,0 +1,84 @@
+package mockai
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+)
+
+func RegisterGetEnvironment(
+	mockContext *mocks.MockContext,
+	workspaceName string,
+	environmentName string,
+	statusCode int,
+) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && strings.HasSuffix(
+			request.URL.Path,
+			fmt.Sprintf(
+				"providers/Microsoft.MachineLearningServices/workspaces/%s/environments/%s",
+				workspaceName,
+				environmentName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		if statusCode == http.StatusNotFound {
+			return mocks.CreateEmptyHttpResponse(request, http.StatusNotFound)
+		}
+
+		response := armmachinelearning.EnvironmentContainersClientGetResponse{
+			EnvironmentContainer: armmachinelearning.EnvironmentContainer{
+				Name: &environmentName,
+				Properties: &armmachinelearning.EnvironmentContainerProperties{
+					LatestVersion: convert.RefOf("2"),
+					NextVersion:   convert.RefOf("3"),
+				},
+			},
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}
+
+func RegisterGetEnvironmentVersion(
+	mockContext *mocks.MockContext,
+	workspaceName string,
+	environmentName string,
+	version string,
+) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && strings.HasSuffix(
+			request.URL.Path,
+			fmt.Sprintf(
+				"providers/Microsoft.MachineLearningServices/workspaces/%s/environments/%s/versions/%s",
+				workspaceName,
+				environmentName,
+				version,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		response := armmachinelearning.EnvironmentVersionsClientGetResponse{
+			EnvironmentVersion: armmachinelearning.EnvironmentVersion{
+				Name: convert.RefOf(fmt.Sprint(version)),
+			},
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}

--- a/cli/azd/test/mocks/mockai/models.go
+++ b/cli/azd/test/mocks/mockai/models.go
@@ -1,0 +1,79 @@
+package mockai
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+)
+
+func RegisterGetModel(mockContext *mocks.MockContext, workspaceName string, modelName string, statusCode int) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && strings.HasSuffix(
+			request.URL.Path,
+			fmt.Sprintf(
+				"providers/Microsoft.MachineLearningServices/workspaces/%s/models/%s",
+				workspaceName,
+				modelName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		if statusCode == http.StatusNotFound {
+			return mocks.CreateEmptyHttpResponse(request, http.StatusNotFound)
+		}
+
+		response := armmachinelearning.ModelContainersClientGetResponse{
+			ModelContainer: armmachinelearning.ModelContainer{
+				Name: &modelName,
+				Properties: &armmachinelearning.ModelContainerProperties{
+					LatestVersion: convert.RefOf("2"),
+					NextVersion:   convert.RefOf("3"),
+				},
+			},
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}
+
+func RegisterGetModelVersion(
+	mockContext *mocks.MockContext,
+	workspaceName string,
+	modelName string,
+	version string,
+) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && strings.HasSuffix(
+			request.URL.Path,
+			fmt.Sprintf(
+				"providers/Microsoft.MachineLearningServices/workspaces/%s/models/%s/versions/%s",
+				workspaceName,
+				modelName,
+				version,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		response := armmachinelearning.ModelVersionsClientGetResponse{
+			ModelVersion: armmachinelearning.ModelVersion{
+				Name: convert.RefOf(fmt.Sprint(version)),
+			},
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}

--- a/cli/azd/test/mocks/mockai/workspaces.go
+++ b/cli/azd/test/mocks/mockai/workspaces.go
@@ -1,0 +1,39 @@
+package mockai
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+)
+
+func RegisterGetWorkspaceMock(mockContext *mocks.MockContext, workspaceName string) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && strings.Contains(
+			request.URL.Path,
+			fmt.Sprintf(
+				"providers/Microsoft.MachineLearningServices/workspaces/%s",
+				workspaceName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		response := armmachinelearning.WorkspacesClientGetResponse{
+			Workspace: armmachinelearning.Workspace{
+				Name:     &workspaceName,
+				ID:       convert.RefOf("ID"),
+				Location: convert.RefOf("eastus2"),
+			},
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, response)
+	})
+
+	return mockRequest
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v2 v2.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3 v3.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.7.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFG
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.0.0 h1:Jc2KcpCDMu7wJfkrzn7fs/53QMDXH78GuqnH4HOd7zs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.0.0/go.mod h1:PFVgFsclKzPqYRT/BiwpfUN22cab0C7FlgXR3iWpwMo=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3 v3.2.0 h1:m3By8dbZqId80m4AU+sfQOvlISaVV95KoCxQr8235/w=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3 v3.2.0/go.mod h1:p8dwLhouzC7neB2e/5TKZ732Zhu1ydfvOpimPfE9K5w=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.0.0 h1:pPvTJ1dY0sA35JOeFq6TsY2xj6Z85Yo23Pj4wCCvu4o=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.0.0/go.mod h1:mLfWfj8v3jfWKsL9G4eoBoXVcsqcIUTapmdKy7uGOp0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.7.1 h1:eoQrCw9DMThzbJ32fHXZtISnURk6r0TozXiWuTsay5s=

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -93,7 +93,8 @@
                             "function",
                             "springapp",
                             "staticwebapp",
-                            "aks"
+                            "aks",
+                            "ai.endpoint"
                         ]
                     },
                     "language": {
@@ -124,6 +125,10 @@
                     },
                     "k8s": {
                         "$ref": "#/definitions/aksOptions"
+                    },
+                    "config": {
+                        "type": "object",
+                        "additionalProperties": true
                     },
                     "hooks": {
                         "type": "object",
@@ -224,7 +229,8 @@
                                     "host": {
                                         "enum": [
                                             "containerapp",
-                                            "aks"
+                                            "aks",
+                                            "ai.endpoint"
                                         ]
                                     }
                                 }
@@ -237,6 +243,27 @@
                             ],
                             "properties": {
                                 "docker": false
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "host": {
+                                    "const": "ai.endpoint"
+                                }
+                            }
+                        },
+                        "then": {
+                            "required": [
+                                "config"
+                            ],
+                            "properties": {
+                                "config": {
+                                    "$ref": "#/definitions/aiEndpointConfig",
+                                    "title": "The Azure AI endpoint configuration.",
+                                    "description": "Required. Provides additional configuration for Azure AI online endpoint deployment."
+                                }
                             }
                         }
                     },
@@ -905,6 +932,84 @@
                         }
                     }
                 }
+            ]
+        },
+        "aiComponentConfig": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "title": "Name of the AI component.",
+                    "description": "Optional. When omitted AZD will generate a name based on the component type and the service name. Supports environment variable substitution."
+                },
+                "path": {
+                    "type": "string",
+                    "title": "Path to the AI component configuration file or path.",
+                    "description": "Required. The path to the AI component configuration file or path to the AI component source code."
+                },
+                "overrides": {
+                    "type": "object",
+                    "title": "A map of key value pairs used to override the AI component configuration.",
+                    "description": "Optional. Supports environment variable substitution.",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "path"
+            ]
+        },
+        "aiDeploymentConfig": {
+            "allOf": [
+                { "$ref": "#/definitions/aiComponentConfig" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "environment": {
+                            "type": "object",
+                            "title": "A map of key/value pairs to set as environment variables for the deployment.",
+                            "description": "Optional. Values support OS & AZD environment variable substitution.",
+                            "additionalProperties":{
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "aiEndpointConfig": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workspace": {
+                    "type": "string",
+                    "title": "The name of the AI Studio project workspace.",
+                    "description": "Optional. When omitted AZD will use the value specified in the 'AZUREAI_PROJECT_NAME' environment variable. Supports environment variable substitution."
+                },
+                "flow": {
+                    "$ref": "#/definitions/aiComponentConfig",
+                    "title": "The Azure AI Studio Prompt Flow configuration.",
+                    "description": "Optional. When omitted a prompt flow will be not created."
+                },
+                "environment": {
+                    "$ref": "#/definitions/aiComponentConfig",
+                    "title": "The Azure AI Studio custom environment configuration.",
+                    "description": "Optional. When omitted a custom environment will not be created."
+                },
+                "model": {
+                    "$ref": "#/definitions/aiComponentConfig",
+                    "title": "The Azure AI Studio model configuration.",
+                    "description": "Optional. When omitted a model will not be created."
+                },
+                "deployment": {
+                    "$ref": "#/definitions/aiDeploymentConfig",
+                    "title": "The Azure AI Studio online endpoint deployment configuration.",
+                    "description": "Required. A new online endpoint deployment will be created and traffic will automatically to shifted to the new deployment upon successful completion."
+                }
+            },
+            "required": [
+                "deployment"
             ]
         }
     }


### PR DESCRIPTION
Adds ability to quickly and easily deploy to an AI/ML studio online endpoint from `azd`

- When `config.flow` section is defined `azd` will create a new prompt flow from the specified file path
- When `config.environment` section is defined `azd` will create a new  environment version using the referenced yaml file definition
- When `config.model` section is defined `azd` will create a new model version using the referenced yaml file definition

The `config.deployment` section is **required** and will create a new online deployment to the associated online endpoint from the referenced yaml file definition.
  - Associates environment and model will be referenced when available
  - `azd` waits for deployment to enter a terminal provisioning state
  - On successful deployments all traffic is shifted to the new deployment version
  - All previous deployments are deleted to free up compute for future deployments.

> [!TIP]
> Use the custom build of `azd` outlined in the comments below to try out this new feature!

> [!WARNING]
> This feature is a work in progress and is subject to change.  Any and all feedback is welcome and appreciated.

New azd service host type: `ai.endpoint`

> [!IMPORTANT]
> Requires Python installed and available on `PATH`

## What can I deploy to AI online endpoints?

- Custom Environments
  - Environments can be viewed with [Azure ML Studio](https://ml.azure.com) under the `Environments` section
- Custom models
  - Models can be viewed with [Azure ML Studio](https://ml.azure.com) under the `Models` section
- Prompt flows
  - Flows can be viewed in [Azure ML Studio](https://ml.azure.com) under the `Prompt flow` section
  - Flows can be viewed in [Azure AI Studio](https://ai.azure.com) under the `Prompt flow` section
- Online Deployments (within Online-Endpoint)
  - Deployments can be viewed in [Azure ML Studio](https://ml.azure.com) under the `Endpoints` section
  - Deployments can be viewed in [Azure AI Studio](https://ai.azure.com) under the `Deployments` section

## Requirements

The following resources will be expected to be included within your deployed Azure resources.

1. AI Hub Resource  (Azure ML Workspace) & Required dependencies.
    - Key Vault
    - Storage Account
    - Container Registry (optional)
    - App Insights (optional)
    - Azure Open AI Services
    - Azure AI Search (If required by your app)
2. AI Project Resource (Azure ML Workspace)
3. Online Endpoint (ML Online Endpoint)
    - Should be tagged with `azd-service-name` tag
    - This is the target of the azd deployment
5. AI Hub Connections
    - Any required connections that may be referenced in your flow/model

## Example azure.yaml

This example comes from a [fork of the `contoso-chat` application](https://github.com/wbreza/contoso-chat/tree/azd-build).

Reference the [yaml schema](https://[raw.githubusercontent.com/Azure/azure-dev/wabrez/ai-service-targets/schemas/alpha/azure.yaml.json) from this branch for live IntelliSense within the `azure.yaml`

```yaml
name: contoso-chat
metadata:
  template: contoso-chat@0.0.1-beta
hooks:
  # Post provision hooks are still required to seed any data sources or create required search indexes
  postprovision:
    shell: sh
    run: ./infra/hooks/postprovision.sh
services:
  chat:
    # Referenced new ai.endpoint host type
    host: ai.endpoint
    # New config flow for AI project configuration
    config:
      # The name of the AI studio project / workspace
      workspace: ${AZUREAI_PROJECT_NAME}
      # Optional: Path to custom ML environment manifest
      environment:
        path: deployment/docker/environment.yml
      # Optional: Path to your prompt flow folder that contains the flow manifest
      flow:
        path: ./contoso-chat
      # Optional: Path to custom model manifest
      model:
        path: deployment/chat-model.yaml
        overrides:
          "properties.azureml.promptflow.source_flow_id": ${AZUREAI_FLOW_NAME}
      # Required: Path to deployment manifest
      deployment:
        path: deployment/chat-deployment.yaml
        environment:
          PRT_CONFIG_OVERRIDE: deployment.subscription_id=${AZURE_SUBSCRIPTION_ID},deployment.resource_group=${AZURE_RESOURCE_GROUP},deployment.workspace_name=${AZUREAI_PROJECT_NAME},deployment.endpoint_name=${AZUREAI_ENDPOINT_NAME},deployment.deployment_name=${AZUREAI_DEPLOYMENT_NAME}
```

## AI Endpoint Configuration
The configuration spec of the `config` section of services for `ai.endpoint`.

 - **workspace**: The name of the AI studio project / workspace (supports env var substitutions)
 - **flow**: Custom configuration for flows
 - **environment**: Custom configuration for ML environments
 - **model**: Custom configuration for ML models
 - **deployment**: Custom configuration for online endpoint deployments

### Flow (flow)
Optional flow configuration section

 - **name**: Name of flow (defaults to `<service-name>-flow-<timestamp>` if not specified)
 - **path**: Relative path to a flow folder that contains the flow manifest
 - **overrides**: Any custom overrides to apply to the flow
 
> [!NOTE]
> Each call to `azd deploy` will create a new timestamped flow

### Environment (environment)
Optional environment configuration section

 - **name**: Name of custom environment (defaults to `<service-name>-environment` if not specified)
 - **path**: Relative path to a custom [environment yaml manifest](https://learn.microsoft.com/en-us/azure/machine-learning/reference-yaml-environment?view=azureml-api-2)
 - **overrides**: Any custom overrides to apply to the environment

> [!NOTE]
> Each call to `azd deploy` will create a new environment version

### Model (model)
Optional model configuration section

 - **name**: Name of custom model (defaults to `<service-name>-model` if not specified)
 - **path**: Relative path to a custom [model yaml manifest](https://learn.microsoft.com/en-us/azure/machine-learning/reference-yaml-model?view=azureml-api-2)
 - **overrides**: Any custom overrides to apply to the model

> [!NOTE]
> Each call to `azd deploy` will create a new environment version

### Deployment (deployment)
**Required** deployment configuration section.

 - **name**: Name of custom model(defaults to `<service-name>-deployment` if not specified)
 - **path**: Relative path to a custom [deployment yaml manifest](https://learn.microsoft.com/en-us/azure/machine-learning/reference-yaml-deployment-managed-online?view=azureml-api-2)
 - **environment**: A map of key value pairs to set environment variables for the deployment. Supports environment variable substitutions from OS/AZD environment variables using `${VAR_NAME}` syntax.
 - **overrides**: Any custom overrides to apply to the deployment

> [!NOTE]
>Only supports managed online deployments