### PR TITLE
Adds workaround to support ADE Bicep deployments

### DIFF
--- a/cli/azd/pkg/devcenter/manager.go
+++ b/cli/azd/pkg/devcenter/manager.go
@@ -313,7 +313,7 @@ func (m *manager) Outputs(
 	}
 
 	latestDeployment, err := m.LatestArmDeployment(ctx, env, func(d *armresources.DeploymentExtended) bool {
-		return *d.Properties.ProvisioningState == "Succeeded"
+		return *d.Properties.ProvisioningState == armresources.ProvisioningStateSucceeded
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed getting latest deployment: %w", err)

--- a/cli/azd/pkg/devcenter/manager.go
+++ b/cli/azd/pkg/devcenter/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -271,10 +272,10 @@ func (m *manager) LatestArmDeployment(
 		tagEnvName, envOk := d.Tags[DeploymentTagEnvironmentName]
 
 		// ARM runner deployments contain the deployment tags for the specific environment
-		isArmDeployment := devCenterOk && *tagDevCenterName == m.config.Name &&
-			projectOk && *tagProjectName == m.config.Project &&
-			envTypeOk && *tagEnvTypeName == m.config.EnvironmentType &&
-			envOk && *tagEnvName == env.Name
+		isArmDeployment := devCenterOk && strings.EqualFold(*tagDevCenterName, m.config.Name) &&
+			projectOk && strings.EqualFold(*tagProjectName, m.config.Project) &&
+			envTypeOk && strings.EqualFold(*tagEnvTypeName, m.config.EnvironmentType) &&
+			envOk && strings.EqualFold(*tagEnvName, env.Name)
 
 		// Support for untagged Bicep ADE deployments
 		// If the deployment is not tagged but starts with the current date and is running

--- a/cli/azd/pkg/devcenter/provision_provider.go
+++ b/cli/azd/pkg/devcenter/provision_provider.go
@@ -207,7 +207,7 @@ func (p *ProvisionProvider) Deploy(ctx context.Context) (*provisioning.DeployRes
 
 	go p.pollForEnvironment(pollingContext, envName)
 
-	_, err = poller.PollUntilDone(ctx, nil)
+	_, _ = poller.PollUntilDone(ctx, nil)
 	if err != nil {
 		p.console.StopSpinner(ctx, spinnerMessage, input.StepFailed)
 		return nil, fmt.Errorf("failed creating environment: %w", err)
@@ -446,7 +446,7 @@ func (p *ProvisionProvider) pollForEnvironment(ctx context.Context, envName stri
 			// After the resource group has been created
 			// We can start polling for a new deployment that started after we started polling
 			deployment, err := p.manager.Deployment(ctx, environment, func(d *armresources.DeploymentExtended) bool {
-				return d.Properties.Timestamp.After(pollStartTime)
+				return *d.Properties.ProvisioningState == "Running" && d.Properties.Timestamp.After(pollStartTime)
 			})
 
 			if err != nil || deployment == nil {

--- a/cli/azd/pkg/devcenter/provision_provider.go
+++ b/cli/azd/pkg/devcenter/provision_provider.go
@@ -446,7 +446,8 @@ func (p *ProvisionProvider) pollForEnvironment(ctx context.Context, envName stri
 			// After the resource group has been created
 			// We can start polling for a new deployment that started after we started polling
 			deployment, err := p.manager.Deployment(ctx, environment, func(d *armresources.DeploymentExtended) bool {
-				return *d.Properties.ProvisioningState == "Running" && d.Properties.Timestamp.After(pollStartTime)
+				return *d.Properties.ProvisioningState == armresources.ProvisioningStateRunning &&
+					d.Properties.Timestamp.After(pollStartTime)
 			})
 
 			if err != nil || deployment == nil {

--- a/cli/azd/pkg/devcenter/provision_provider.go
+++ b/cli/azd/pkg/devcenter/provision_provider.go
@@ -207,7 +207,7 @@ func (p *ProvisionProvider) Deploy(ctx context.Context) (*provisioning.DeployRes
 
 	go p.pollForEnvironment(pollingContext, envName)
 
-	_, _ = poller.PollUntilDone(ctx, nil)
+	_, err = poller.PollUntilDone(ctx, nil)
 	if err != nil {
 		p.console.StopSpinner(ctx, spinnerMessage, input.StepFailed)
 		return nil, fmt.Errorf("failed creating environment: %w", err)

--- a/cli/azd/pkg/infra/provisioning/provisioning_progress_display.go
+++ b/cli/azd/pkg/infra/provisioning/provisioning_progress_display.go
@@ -18,10 +18,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 )
 
-const succeededProvisioningState string = "Succeeded"
-const runningProvisioningState string = "Running"
-const failedProvisioningState string = "Failed"
-
 // ProvisioningProgressDisplay displays interactive progress for an ongoing Azure provisioning operation.
 type ProvisioningProgressDisplay struct {
 	// Whether the deployment has started
@@ -92,11 +88,11 @@ func (display *ProvisioningProgressDisplay) ReportProgress(
 					infra.AzureResourceType(*operations[i].Properties.TargetResource.ResourceType)) {
 
 				switch *operations[i].Properties.ProvisioningState {
-				case succeededProvisioningState:
+				case string(armresources.ProvisioningStateSucceeded):
 					newlyDeployedResources = append(newlyDeployedResources, operations[i])
-				case runningProvisioningState:
+				case string(armresources.ProvisioningStateRunning):
 					runningDeployments = append(runningDeployments, operations[i])
-				case failedProvisioningState:
+				case string(armresources.ProvisioningStateFailed):
 					newlyFailedResources = append(newlyFailedResources, operations[i])
 				}
 			}

--- a/cli/azd/pkg/infra/provisioning/provisioning_progress_display_test.go
+++ b/cli/azd/pkg/infra/provisioning/provisioning_progress_display_test.go
@@ -76,7 +76,7 @@ func (mock *mockResourceManager) AddInProgressOperation() {
 }
 
 func (mock *mockResourceManager) MarkComplete(i int) {
-	mock.operations[i].Properties.ProvisioningState = to.Ptr(succeededProvisioningState)
+	mock.operations[i].Properties.ProvisioningState = to.Ptr(string(armresources.ProvisioningStateSucceeded))
 	mock.operations[i].Properties.Timestamp = to.Ptr(time.Now().UTC())
 }
 


### PR DESCRIPTION
## Background

> [!NOTE]
> This is only a temporary solution to unblock some //BUILD scenarios. 
> A better future proof solution will be implemented when more dev capacity is available.

Initially ADE only supported ARM based deployments via their v1 runner implementation.
- v1 Runner does not support ADE OUTPUTS Api
- v1 runner tags ARM deployments that `azd` depended to find deployment to be used for incremental progress reporting

ADE v2 runner now supports Bicep, Terraform and any other custom providers but ARM has not been updated to use the newer v2 runner implementation.
- v2 Runner does support ADE OUTPUTS Api
- v2 Runner does NOT support tagged deployments

## Change
This change enables an alternative path to find the correct Azure deployment object if tags are not available.  Since both ARM & Bicep still leverage Azure ARM deployments we can still pull outputs directly from the deployment without having to fully adopt the new OUTPUTS api.