### PR TITLE
Add `--managed-identity` to `azd auth login`

### DIFF
--- a/cli/azd/cmd/testdata/TestUsage-azd-auth-login.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-auth-login.snap
@@ -12,6 +12,7 @@ Flags
         --docs                                 	: Opens the documentation for azd auth login in your web browser.
         --federated-credential-provider string 	: The provider to use to acquire a federated token to authenticate with.
     -h, --help                                 	: Gets help for login.
+        --managed-identity                     	: Use a managed identity to authenticate.
         --redirect-port int                    	: Choose the port to be used as part of the redirect URI during interactive login.
         --tenant-id string                     	: The tenant id or domain name to authenticate with.
         --use-device-code                      	: When true, log in by using a device code instead of a browser.


### PR DESCRIPTION
We had seen requests for this in the past, e.g., #2568. It would be useful to have for cases where you are running `azd` inside Azure (say as part of some deployment system you've put together) and want to use managed identity instead of having to have a long lived service princiapl.

By default `--managed-identity` uses the system assigned managed identity, but `--client-id` can be passed to use a user assigned one.