### PR TITLE
vs-server: Remove http timeout since external prompt requires waiting on server

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -531,9 +530,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		endpoint := os.Getenv("AZD_AUTH_ENDPOINT")
 		key := os.Getenv("AZD_AUTH_KEY")
 
-		client := &http.Client{
-			Timeout: 5 * time.Second,
-		}
+		client := &http.Client{}
 		if len(cert) > 0 {
 			transport, err := httputil.TlsEnabledTransport(cert)
 			if err != nil {

--- a/cli/azd/internal/vsrpc/server_service.go
+++ b/cli/azd/internal/vsrpc/server_service.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"time"
 
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
@@ -64,7 +63,6 @@ func (s *serverService) InitializeAsync(
 			return nil, err
 		}
 		client := &http.Client{
-			Timeout:   5 * time.Second,
 			Transport: transport,
 		}
 


### PR DESCRIPTION
Remove http timeout added recently in #3712 since external prompt requires waiting indefinitely on the server for a response.

This fixes an issue with VS integration where azd errors out after 5-10 seconds on the dialog. 