### PR TITLE
Avoid re-prompting for Bicep parameters.

### DIFF
--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -11,7 +11,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal/cmd"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
@@ -53,13 +52,12 @@ func newUpCmd() *cobra.Command {
 }
 
 type upAction struct {
-	flags               *upFlags
-	console             input.Console
-	env                 *environment.Environment
-	projectConfig       *project.ProjectConfig
-	provisioningManager *provisioning.Manager
-	importManager       *project.ImportManager
-	workflowRunner      *workflow.Runner
+	flags          *upFlags
+	console        input.Console
+	env            *environment.Environment
+	projectConfig  *project.ProjectConfig
+	importManager  *project.ImportManager
+	workflowRunner *workflow.Runner
 }
 
 var defaultUpWorkflow = &workflow.Workflow{

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -77,18 +77,16 @@ func newUpAction(
 	env *environment.Environment,
 	_ auth.LoggedInGuard,
 	projectConfig *project.ProjectConfig,
-	provisioningManager *provisioning.Manager,
 	importManager *project.ImportManager,
 	workflowRunner *workflow.Runner,
 ) actions.Action {
 	return &upAction{
-		flags:               flags,
-		console:             console,
-		env:                 env,
-		projectConfig:       projectConfig,
-		provisioningManager: provisioningManager,
-		importManager:       importManager,
-		workflowRunner:      workflowRunner,
+		flags:          flags,
+		console:        console,
+		env:            env,
+		projectConfig:  projectConfig,
+		importManager:  importManager,
+		workflowRunner: workflowRunner,
 	}
 }
 
@@ -98,11 +96,6 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		return nil, err
 	}
 	defer func() { _ = infra.Cleanup() }()
-
-	err = u.provisioningManager.Initialize(ctx, u.projectConfig.Path, infra.Options)
-	if err != nil {
-		return nil, err
-	}
 
 	startTime := time.Now()
 

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -98,6 +98,8 @@ func (p *BicepProvider) RequiredExternalTools() []tools.ExternalTool {
 	return []tools.ExternalTool{}
 }
 
+// Initialize initializes provider state from the options.
+// It also calls EnsureEnv, which ensures the client-side state is ready for provisioning.
 func (p *BicepProvider) Initialize(ctx context.Context, projectPath string, options Options) error {
 	p.projectPath = projectPath
 	p.options = options

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -122,13 +122,15 @@ func (p *BicepProvider) Initialize(ctx context.Context, projectPath string, opti
 	return err
 }
 
+var ErrEnsureEnvPreReqBicepCompileFailed = errors.New("")
+
 // EnsureEnv ensures that the environment is in a provision-ready state with required values set, prompting the user if
 // values are unset. This also requires that the Bicep module can be compiled.
 func (p *BicepProvider) EnsureEnv(ctx context.Context) error {
 	modulePath := p.modulePath()
 	compileResult, compileErr := p.compileBicep(ctx, modulePath)
 	if compileErr != nil {
-		return compileErr
+		return fmt.Errorf("%w%w", ErrEnsureEnvPreReqBicepCompileFailed, compileErr)
 	}
 
 	var filterLocation = func(loc account.Location) bool {

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -121,25 +121,15 @@ func (p *BicepProvider) Initialize(ctx context.Context, projectPath string, opti
 }
 
 // EnsureEnv ensures that the environment is in a provision-ready state with required values set, prompting the user if
-// values are unset.
-//
-// An environment is considered to be in a provision-ready state if it contains both an AZURE_SUBSCRIPTION_ID and
-// AZURE_LOCATION value. Additionally, for resource group scoped deployments, an AZURE_RESOURCE_GROUP value is required.
+// values are unset. This also requires that the Bicep module can be compiled.
 func (p *BicepProvider) EnsureEnv(ctx context.Context) error {
 	modulePath := p.modulePath()
 	compileResult, compileErr := p.compileBicep(ctx, modulePath)
 	if compileErr != nil {
-		log.Printf("Unable to compile bicep module for initializing environment. error: %v", compileErr)
-		log.Printf("Initializing environment w/o arm template info.")
+		return compileErr
 	}
 
-	if err := EnsureSubscriptionAndLocation(ctx, p.envManager, p.env, p.prompters, func(loc account.Location) bool {
-		// compileResult can be nil if the infra folder is missing and azd couldn't get a template information.
-		// A template information can be used to apply filters to the initial values (like location).
-		// But if there's not template, azd will continue with azd env init.
-		if compileResult == nil {
-			return true
-		}
+	var filterLocation = func(loc account.Location) bool {
 		if locationParam, defined := compileResult.Template.Parameters["location"]; defined {
 			if locationParam.AllowedValues != nil {
 				return slices.IndexFunc(*locationParam.AllowedValues, func(allowedValue any) bool {
@@ -149,23 +139,18 @@ func (p *BicepProvider) EnsureEnv(ctx context.Context) error {
 			}
 		}
 		return true
-	}); err != nil {
+	}
+
+	if err := EnsureSubscriptionAndLocation(ctx, p.envManager, p.env, p.prompters, filterLocation); err != nil {
 		return err
 	}
 
-	// If there's not template, just behave as if we are in a subscription scope (and don't ask about
-	// AZURE_RESOURCE_GROUP). Future operations which try to use the infrastructure may fail, but that's ok. These
-	// failures will have reasonable error messages.
-	//
-	// We want to handle the case where the provider can `Initialize` even without a template, because we do this
-	// in a few of our end to end telemetry tests to speed things up.
-	if compileErr != nil {
-		return nil
+	// for .bicep, azd must load a parameters.json file and create the ArmParameters
+	if isBicepFile(modulePath) {
+		if _, err := p.ensureParameters(ctx, compileResult.Template); err != nil {
+			return err
+		}
 	}
-
-	// prompt parameters during initialization and ignore any errors.
-	// This strategy takes advantage of the bicep compilation from initialization and allows prompting for required inputs
-	_, _ = p.ensureParameters(ctx, compileResult.Template)
 
 	scope, err := compileResult.Template.TargetScope()
 	if err != nil {
@@ -567,9 +552,8 @@ func logDS(msg string, v ...any) {
 
 // Provisioning the infrastructure within the specified template
 func (p *BicepProvider) Deploy(ctx context.Context) (*DeployResult, error) {
-
 	if p.ignoreDeploymentState {
-		logDS("Azure Deployment State is disabled by --ignore-ads arg.")
+		logDS("Azure Deployment State is disabled by --no-state arg.")
 	}
 
 	bicepDeploymentData, err := p.plan(ctx)
@@ -1685,6 +1669,8 @@ type compileBicepResult struct {
 	Parameters azure.ArmParameters
 }
 
+// compileBicep compiles the bicep module at the given path and returns the compiled ARM template and parameters.
+// The results of the compilation are cached in memory.
 func (p *BicepProvider) compileBicep(
 	ctx context.Context, modulePath string,
 ) (*compileBicepResult, error) {
@@ -1870,7 +1856,8 @@ func (p *BicepProvider) deployModule(
 	return target.Deploy(ctx, armTemplate, armParameters, tags)
 }
 
-// Gets the folder path to the specified module
+// Returns either the bicep or bicepparam module file located in the infrastructure root.
+// The bicepparam file is preferred over bicep file.
 func (p *BicepProvider) modulePath() string {
 	infraRoot := p.options.Path
 	moduleName := p.options.Module

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -256,8 +256,8 @@ func Test_CLI_Telemetry_NestedCommands(t *testing.T) {
 
 	// We do require that infra folder exist, however, so put it back with a module which will throw during provisioning.
 	require.NoError(t, os.MkdirAll(infraPath, osutil.PermissionDirectoryOwnerOnly))
-	// main.something will allow azd to continue until trying to find and build bicep.
-	file, err := os.Create(filepath.Join(infraPath, "main.something"))
+	// empty main.bicep but with no parameters file.
+	file, err := os.Create(filepath.Join(infraPath, "main.bicep"))
 	require.NoError(t, err)
 	defer file.Close()
 
@@ -295,9 +295,6 @@ func Test_CLI_Telemetry_NestedCommands(t *testing.T) {
 			traceId = span.SpanContext.TraceID
 
 			m := attributesMap(span.Attributes)
-			require.Contains(t, m, fields.SubscriptionIdKey)
-			require.Equal(t, getEnvSubscriptionId(t, dir, envName), m[fields.SubscriptionIdKey])
-
 			require.Contains(t, m, fields.EnvNameKey)
 			require.Equal(t, fields.CaseInsensitiveHash(envName), m[fields.EnvNameKey])
 

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -259,7 +259,8 @@ func Test_CLI_Telemetry_NestedCommands(t *testing.T) {
 	// empty main.bicep but with no parameters file.
 	file, err := os.Create(filepath.Join(infraPath, "main.bicep"))
 	require.NoError(t, err)
-	defer file.Close()
+	err = file.Close()
+	require.NoError(t, err)
 
 	_, err = cli.RunCommandWithStdIn(ctx, stdinForProvision(), "up", "--trace-log-file", traceFilePath)
 	require.Error(t, err)


### PR DESCRIPTION
Avoid re-prompting for Bicep parameters.

azd currently prompts for Bicep parameters during Bicep provider `Initialize`. If an error occurs, such as user cancellation, the error is ignored and the program continues. This leads to azd later re-prompting for the same parameters.

This change makes `bicepProvider.Initialize` assert that all client-state is ready for provisioning.

To avoid any behavioral changes in regards to when prompting occurs during `up`, we have moved that logic into `up` explicitly until we decide directionally where it should go.

Example of the issue currently with reprompting. I cancelled the prompt multiple times:
```bash
~ azd up
? Select an Azure Subscription to use: 25. Azure SDK Developer Playground (faa080af-c1d8-40ad-9cce-e1a450ca5b57)
? Select an Azure location to use: 44. (US) East US 2 (eastus2)
? Enter a value for the 'unfilled' infrastructure parameter:

Packaging services (azd package)


SUCCESS: Your application was packaged for Azure in less than a second.

Provisioning Azure resources (azd provision)
Provisioning Azure resources can take some time.

? Enter a value for the 'unfilled' infrastructure parameter:
Subscription: Azure SDK Developer Playground (faa080af-c1d8-40ad-9cce-e1a450ca5b57)
Location: East US 2

? Enter a value for the 'unfilled' infrastructure parameter:

ERROR: deployment failed: failing invoking action 'provision', error deploying infrastructure: prompting for value: interrupt

ERROR: error executing step command 'provision': deployment failed: failing invoking action 'provision', error deploying infrastructure: prompting for value: interrupt
```
