### PR TITLE
Use azd binding to create connections

### DIFF
--- a/templates/common/infra/bicep/core/config/configstore.bicep
+++ b/templates/common/infra/bicep/core/config/configstore.bicep
@@ -45,4 +45,5 @@ module configStoreAccess '../security/configstore-access.bicep' = {
   dependsOn: [configStore]
 }
 
+output name string = configStore.name
 output endpoint string = configStore.properties.endpoint

--- a/templates/common/infra/bicep/core/security/user-assigned-managed-identity.bicep
+++ b/templates/common/infra/bicep/core/security/user-assigned-managed-identity.bicep
@@ -1,0 +1,13 @@
+metadata description = 'Creates a user assigned managed identity.'
+param identityName string
+param location string = resourceGroup().location
+param tags object = {}
+
+resource apiIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: identityName
+  location: location
+  tags: tags
+}
+
+output identityName string = identityName
+output principalId string = apiIdentity.properties.principalId

--- a/templates/cspell-templates.txt
+++ b/templates/cspell-templates.txt
@@ -1,3 +1,4 @@
+APPCONFIGURATION
 APPLICATIONINSIGHTS
 appservice
 asgi
@@ -14,6 +15,7 @@ codepaths
 Codespaces
 configfile
 configurer
+CONNECTIONSTRING
 containerapp
 CUSTOMHANDLER
 databind

--- a/templates/todo/api/js/package-lock.json
+++ b/templates/todo/api/js/package-lock.json
@@ -25,6 +25,7 @@
         "yamljs": "^0.3.0"
       },
       "devDependencies": {
+        "@azure/app-configuration-provider": "1.0.0-preview.4",
         "@babel/preset-env": "^7.18.2",
         "@babel/preset-typescript": "^7.17.12",
         "@types/config": "^0.0.41",
@@ -793,6 +794,37 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@azure/app-configuration": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/app-configuration/-/app-configuration-1.5.0.tgz",
+      "integrity": "sha512-YlXwWc/weDFCk12arPkfskXDGxDaSyAA7JaztSVQ0y/IS7GFYqmIj3RTKbsNUSSuGLrKqcxwJ7y3vY9UmHgsdA==",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-client": "^1.5.0",
+        "@azure/core-http-compat": "^2.0.0",
+        "@azure/core-lro": "^2.5.1",
+        "@azure/core-paging": "^1.4.0",
+        "@azure/core-rest-pipeline": "^1.6.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.1.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/app-configuration-provider": {
+      "version": "1.0.0-preview.4",
+      "resolved": "https://registry.npmjs.org/@azure/app-configuration-provider/-/app-configuration-provider-1.0.0-preview.4.tgz",
+      "integrity": "sha512-yjUqsavcc7y3jrQDnVXnwqokKgPtVmeqCoyvnvs/Ss73PthUtZpN+QAvPzLcV2qLMIvg4PIw455bPUS6Zzsb3g==",
+      "dependencies": {
+        "@azure/app-configuration": "^1.5.0",
+        "@azure/identity": "^4.0.0",
+        "@azure/keyvault-secrets": "^4.7.0"
       }
     },
     "node_modules/@azure/core-auth": {

--- a/templates/todo/api/js/package.json
+++ b/templates/todo/api/js/package.json
@@ -24,6 +24,7 @@
     ]
   },
   "dependencies": {
+    "@azure/app-configuration-provider": "1.0.0-preview.4",
     "@azure/identity": "4.0.1",
     "@azure/keyvault-secrets": "^4.7.0",
     "applicationinsights": "^2.5.1",

--- a/templates/todo/api/js/src/config/index.ts
+++ b/templates/todo/api/js/src/config/index.ts
@@ -100,7 +100,7 @@ const populateEnvironmentFromAppConfig = async () => {
 
         const settings = await load(endpoint, credential, {
             keyVaultOptions: {
-                // Access keyvault using the same idenity, make sure the permission is set correctly.
+                // Access keyvault using the same identity, make sure the permission is set correctly.
                 credential: credential
             }
         });

--- a/templates/todo/common/infra/bicep/app/api-container-app-binding.bicep
+++ b/templates/todo/common/infra/bicep/app/api-container-app-binding.bicep
@@ -1,0 +1,81 @@
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+
+param identityName string
+param appConfigName string
+param containerAppsEnvironmentName string
+param containerRegistryName string
+param containerRegistryHostSuffix string
+param keyVaultName string
+param serviceName string = 'api'
+param corsAcaUrl string
+param exists bool
+
+resource apiIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: identityName
+}
+
+resource appConfiguration 'Microsoft.AppConfiguration/configurationStores@2023-03-01' existing = {
+  name: appConfigName
+}
+
+// Give the API access to KeyVault
+module apiKeyVaultAccess '../../../../../common/infra/bicep/core/security/keyvault-access.bicep' = {
+  name: 'api-keyvault-access'
+  params: {
+    keyVaultName: keyVaultName
+    principalId: apiIdentity.properties.principalId
+  }
+}
+
+// Give the API access to App Configuration. Role assignment after both created otherwise mutual dependency.
+module appConfigurationAccess '../../../../../common/infra/bicep/core/security/configstore-access.bicep' = {
+  name: 'app-configuration-access'
+  params: {
+    configStoreName: appConfigName
+    principalId: apiIdentity.properties.principalId
+  }
+}
+
+module app '../../../../../common/infra/bicep/core/host/container-app-upsert.bicep' = {
+  name: '${serviceName}-container-app'
+  dependsOn: [ apiKeyVaultAccess ]
+  params: {
+    name: name
+    location: location
+    tags: union(tags, { 'azd-service-name': serviceName })
+    identityType: 'UserAssigned'
+    identityName: apiIdentity.name
+    exists: exists
+    containerAppsEnvironmentName: containerAppsEnvironmentName
+    containerRegistryName: containerRegistryName
+    containerRegistryHostSuffix: containerRegistryHostSuffix
+    containerCpuCoreCount: '1.0'
+    containerMemory: '2.0Gi'
+    env: [
+      {
+        name: 'AZURE_CLIENT_ID'
+        value: apiIdentity.properties.clientId
+      }
+      {
+        name: 'AZURE_APPCONFIGURATION_ENDPOINT'
+        value: appConfiguration.properties.endpoint
+      }
+      {
+        name: 'API_ALLOW_ORIGINS'
+        value: corsAcaUrl
+      }
+      {
+        name: 'NODE_ENV'
+        value: 'production'
+      }
+    ]
+    targetPort: 3100
+  }
+}
+
+output SERVICE_API_IDENTITY_PRINCIPAL_ID string = apiIdentity.properties.principalId
+output SERVICE_API_NAME string = app.outputs.name
+output SERVICE_API_URI string = app.outputs.uri
+output SERVICE_API_IMAGE_NAME string = app.outputs.imageName

--- a/templates/todo/common/infra/bicep/app/api-container-app-binding.bicep
+++ b/templates/todo/common/infra/bicep/app/api-container-app-binding.bicep
@@ -63,12 +63,12 @@ module app '../../../../../common/infra/bicep/core/host/container-app-upsert.bic
         value: appConfiguration.properties.endpoint
       }
       {
-        name: 'API_ALLOW_ORIGINS'
-        value: corsAcaUrl
-      }
-      {
         name: 'NODE_ENV'
         value: 'production'
+      }
+      {
+        name: 'API_ALLOW_ORIGINS'
+        value: corsAcaUrl
       }
     ]
     targetPort: 3100

--- a/templates/todo/common/infra/bicep/app/cosmos-mongo-db.bicep
+++ b/templates/todo/common/infra/bicep/app/cosmos-mongo-db.bicep
@@ -36,5 +36,6 @@ module cosmos '../../../../../common/infra/bicep/core/database/cosmos/mongo/cosm
 }
 
 output connectionStringKey string = cosmos.outputs.connectionStringKey
+output accountName string = accountName
 output databaseName string = cosmos.outputs.databaseName
 output endpoint string = cosmos.outputs.endpoint

--- a/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/azure.yaml
+++ b/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/azure.yaml
@@ -1,5 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
-
+# yaml-language-server: $schema=https://raw.githubusercontent.com/houk-ms/azure-dev/bindings/schemas/alpha/azure.yaml.json
 name: todo-nodejs-mongo-aca
 metadata:
   template: todo-nodejs-mongo-aca@0.0.1-beta
@@ -7,6 +6,7 @@ workflows:
   up: 
     steps:
       - azd: provision
+      - azd: binding
       - azd: deploy --all
 services:
   web:
@@ -17,6 +17,15 @@ services:
     project: ./src/api
     language: js
     host: containerapp
+    bindings:
+    - name: api2cosmos
+      targetType: cosmos
+      targetResource: cosmosaccount
+      keyvault: keyvault
+    - name: api2appinsight
+      targetType: appinsights
+      targetResource: appinsight
+      keyvault: keyvault
 # using predeploy hook for web until
 # https://github.com/Azure/azure-dev/issues/3546 is fixed
 hooks:
@@ -28,7 +37,7 @@ hooks:
   predeploy:
     windows:
       shell: pwsh
-      run: 'echo "VITE_API_BASE_URL=\"$env:API_BASE_URL\"" > ./src/web/.env.local ; echo "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$env:APPLICATIONINSIGHTS_CONNECTION_STRING\"" >> ./src/web/.env.local'
+      run: 'echo "VITE_API_BASE_URL=$env:API_BASE_URL" > ./src/web/.env.local ; echo "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=$env:APPLICATIONINSIGHTS_CONNECTION_STRING" >> ./src/web/.env.local'
     posix:
       shell: sh
       run: 'echo VITE_API_BASE_URL=\"$API_BASE_URL\" > ./src/web/.env.local && echo VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" >> ./src/web/.env.local'    

--- a/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/azure.yaml
+++ b/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/azure.yaml
@@ -39,7 +39,7 @@ hooks:
   predeploy:
     windows:
       shell: pwsh
-      run: 'echo "VITE_API_BASE_URL=\"$env:API_BASE_URL\"" > ./src/web/.env.local ; echo "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$env:APPLICATIONINSIGHTS_CONNECTION_STRING\"" >> ./src/web/.env.local'
+      run: 'echo "VITE_API_BASE_URL=$env:API_BASE_URL" > ./src/web/.env.local ; echo "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=$env:APPLICATIONINSIGHTS_CONNECTION_STRING" >> ./src/web/.env.local'
     posix:
       shell: sh
       run: 'echo VITE_API_BASE_URL=\"$API_BASE_URL\" > ./src/web/.env.local && echo VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" >> ./src/web/.env.local'    

--- a/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/azure.yaml
+++ b/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/azure.yaml
@@ -43,11 +43,11 @@ hooks:
     posix:
       shell: sh
       run: 'echo VITE_API_BASE_URL=\"$API_BASE_URL\" > ./src/web/.env.local && echo VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" >> ./src/web/.env.local'    
-  # postdeploy:
-  #   windows:
-  #     shell: pwsh
-  #     run: 'rm ./src/web/.env.local'
-  #   posix:
-  #     shell: sh
-  #     run: 'rm ./src/web/.env.local'
+  postdeploy:
+    windows:
+      shell: pwsh
+      run: 'rm ./src/web/.env.local'
+    posix:
+      shell: sh
+      run: 'rm ./src/web/.env.local'
 

--- a/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/azure.yaml
+++ b/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/azure.yaml
@@ -22,6 +22,8 @@ services:
       targetType: cosmos
       targetResource: cosmosaccount
       keyvault: keyvault
+      customKeys:
+        AZURE_COSMOS_CONNECTIONSTRING: AZURE_COSMOS_CONNECTION_STRING
     - name: api2appinsight
       targetType: appinsights
       targetResource: appinsight
@@ -37,15 +39,15 @@ hooks:
   predeploy:
     windows:
       shell: pwsh
-      run: 'echo "VITE_API_BASE_URL=$env:API_BASE_URL" > ./src/web/.env.local ; echo "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=$env:APPLICATIONINSIGHTS_CONNECTION_STRING" >> ./src/web/.env.local'
+      run: 'echo "VITE_API_BASE_URL=\"$env:API_BASE_URL\"" > ./src/web/.env.local ; echo "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$env:APPLICATIONINSIGHTS_CONNECTION_STRING\"" >> ./src/web/.env.local'
     posix:
       shell: sh
       run: 'echo VITE_API_BASE_URL=\"$API_BASE_URL\" > ./src/web/.env.local && echo VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" >> ./src/web/.env.local'    
-  postdeploy:
-    windows:
-      shell: pwsh
-      run: 'rm ./src/web/.env.local'
-    posix:
-      shell: sh
-      run: 'rm ./src/web/.env.local'
+  # postdeploy:
+  #   windows:
+  #     shell: pwsh
+  #     run: 'rm ./src/web/.env.local'
+  #   posix:
+  #     shell: sh
+  #     run: 'rm ./src/web/.env.local'
 

--- a/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/infra/main.bicep
@@ -211,6 +211,7 @@ output AZURE_COSMOS_DATABASE_NAME string = cosmos.outputs.databaseName
 output API_CORS_ACA_URL string = corsAcaUrl
 output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.applicationInsightsConnectionString
 output APPLICATIONINSIGHTS_NAME string = monitoring.outputs.applicationInsightsName
+output AZURE_APPCONFIGURATION_ENDPOINT string = appConfig.outputs.endpoint
 output AZURE_CONTAINER_ENVIRONMENT_NAME string = containerApps.outputs.environmentName
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerApps.outputs.registryLoginServer
 output AZURE_CONTAINER_REGISTRY_NAME string = containerApps.outputs.registryName

--- a/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/repo.yaml
@@ -72,7 +72,7 @@ repo:
         patterns:
           - "**/main.bicep"
 
-      - from: api-container-app.bicep
+      - from: api-container-app-binding.bicep
         to: api.bicep
         patterns:
           - "**/main.bicep"
@@ -100,7 +100,7 @@ repo:
     - from: ../../../../common/infra/bicep/app/web-container-app.bicep
       to: ./infra/app/web.bicep
 
-    - from: ../../../../common/infra/bicep/app/api-container-app.bicep
+    - from: ../../../../common/infra/bicep/app/api-container-app-binding.bicep
       to: ./infra/app/api.bicep
 
     - from: ../../../../common/infra/bicep/app/apim-api.bicep


### PR DESCRIPTION
This is a demo sample based on the nodejs-mongo-aca project, using new azd binding feature to create connections from host to service. 
The changed items are::
- Specify bindings in azure.yaml, this will store connection strings in app config, which further reference to keyvault.
- Project specific main.bicep is modified:
  - App config and keyvault will be uses MI + endpoint authentication specified in bicep
  - CosmosDB and App Insights will be connected via binding feature that writes the connection string into above app config and further reference to the keyvault
- Api server init config will read the configurations from app config (instead of host env or keyvault directly).