### PR TITLE
Adds support to get/set secret values in AZD configuration

### DIFF
--- a/cli/azd/pkg/config/file_config_manager.go
+++ b/cli/azd/pkg/config/file_config_manager.go
@@ -42,6 +42,7 @@ func (m *fileConfigManager) Load(filePath string) (Config, error) {
 		return nil, err
 	}
 
+	// If the configuration contains a vault, then also load the vault configuration
 	vaultId, ok := azdConfig.GetString("vault")
 	if ok {
 		configPath, err := GetUserConfigDir()
@@ -89,6 +90,8 @@ func (m *fileConfigManager) Save(c Config, filePath string) error {
 		return fmt.Errorf("failed casting azd configuration to config")
 	}
 
+	// If the configuration contains a vault, then also save the vault configuration
+	// Vault configuration always gets saved in a separate file in the users HOME directory.
 	if baseConfig.vaultId != "" {
 		configPath, err := GetUserConfigDir()
 		if err != nil {

--- a/cli/azd/pkg/config/file_config_manager_test.go
+++ b/cli/azd/pkg/config/file_config_manager_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -60,6 +61,10 @@ func Test_Secrets_GetSet(t *testing.T) {
 	updatedConfig, err := configManager.Load(configFilePath)
 	require.NoError(t, err)
 	require.NotNil(t, updatedConfig)
+
+	userPasswordConfigValue, ok := updatedConfig.GetString("secrets.password")
+	require.True(t, ok)
+	require.True(t, strings.HasPrefix(userPasswordConfigValue, "vault://"))
 
 	userPassword, ok := updatedConfig.GetSecret("secrets.password")
 	require.True(t, ok)

--- a/cli/azd/pkg/config/file_config_manager_test.go
+++ b/cli/azd/pkg/config/file_config_manager_test.go
@@ -114,10 +114,10 @@ func Test_FileConfigManager_GetSetSecretsInSection(t *testing.T) {
 	err = azdConfig.SetSecret("infra.provisioning.secret1", "secrect1Value")
 	require.NoError(t, err)
 
-	azdConfig.SetSecret("infra.provisioning.secret2", "secrect2Value")
+	err = azdConfig.SetSecret("infra.provisioning.secret2", "secrect2Value")
 	require.NoError(t, err)
 
-	azdConfig.Set("infra.provisioning.normalValue", "normalValue")
+	err = azdConfig.Set("infra.provisioning.normalValue", "normalValue")
 	require.NoError(t, err)
 
 	err = configManager.Save(azdConfig, configFilePath)

--- a/cli/azd/pkg/config/file_config_manager_test.go
+++ b/cli/azd/pkg/config/file_config_manager_test.go
@@ -41,3 +41,24 @@ func Test_FileConfigManager_SaveAndLoadEmptyConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, existingConfig)
 }
+
+func Test_Secrets_GetSet(t *testing.T) {
+	configFilePath := filepath.Join(t.TempDir(), "config.json")
+	configManager := NewFileConfigManager(NewManager())
+	azdConfig := NewConfig(nil)
+
+	expectedPassword := "P@55w0rd!"
+	err := azdConfig.SetSecret("secrets.password", expectedPassword)
+	require.NoError(t, err)
+
+	err = configManager.Save(azdConfig, configFilePath)
+	require.NoError(t, err)
+
+	updatedConfig, err := configManager.Load(configFilePath)
+	require.NoError(t, err)
+	require.NotNil(t, updatedConfig)
+
+	value, ok := updatedConfig.GetSecret("secrets.password")
+	require.True(t, ok)
+	require.Equal(t, expectedPassword, value)
+}

--- a/cli/azd/pkg/config/file_config_manager_test.go
+++ b/cli/azd/pkg/config/file_config_manager_test.go
@@ -51,6 +51,9 @@ func Test_Secrets_GetSet(t *testing.T) {
 	err := azdConfig.SetSecret("secrets.password", expectedPassword)
 	require.NoError(t, err)
 
+	err = azdConfig.SetSecret("infra.provisioning.sqlPassword", expectedPassword)
+	require.NoError(t, err)
+
 	err = configManager.Save(azdConfig, configFilePath)
 	require.NoError(t, err)
 
@@ -58,7 +61,11 @@ func Test_Secrets_GetSet(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, updatedConfig)
 
-	value, ok := updatedConfig.GetSecret("secrets.password")
+	userPassword, ok := updatedConfig.GetSecret("secrets.password")
 	require.True(t, ok)
-	require.Equal(t, expectedPassword, value)
+	require.Equal(t, expectedPassword, userPassword)
+
+	sqlPassword, ok := updatedConfig.GetSecret("infra.provisioning.sqlPassword")
+	require.True(t, ok)
+	require.Equal(t, expectedPassword, sqlPassword)
 }


### PR DESCRIPTION
Adds the following functions to the `Config` interface:
- `SetSecret`

The following functions have been updated:
- `Get/GetString` - If the config entry contains a vault reference, the secret value will automatically be retrieved from the vault and returned to the caller.

When secrets are stored a new config vault is created @ `${AZD_CONFIG_DIR}/vaults/${VAULT_ID}.json`

> [!IMPORTANT]
> Secrets stored in `azd` should only be used for development purposes.
> In production scenarios [managed identities](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview) should be leveraged as much as possible.
> If [managed identities](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview) are not supported a secure solution like [Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/general/overview) should be used.