### PR TITLE
Add support in ACA for keyvault identities

### DIFF
--- a/templates/common/infra/bicep/core/host/container-app-upsert.bicep
+++ b/templates/common/infra/bicep/core/host/container-app-upsert.bicep
@@ -59,6 +59,10 @@ param imageName string = ''
 @secure()
 param secrets object = {}
 
+@description('The keyvault identities required for the container')
+@secure()
+param keyvaultIdentities object = {}
+
 @description('The environment variables for the container')
 param env array = []
 
@@ -96,6 +100,7 @@ module app 'container-app.bicep' = {
     daprAppId: daprAppId
     daprAppProtocol: daprAppProtocol
     secrets: secrets
+    keyvaultIdentities: keyvaultIdentities
     external: external
     env: env
     imageName: !empty(imageName) ? imageName : exists ? existingApp.properties.template.containers[0].image : ''


### PR DESCRIPTION
Extends a change @pamelafox made to make the ACA secrets a `secure()` value, but that only works with name:value secrets and not identity secrets. This adds another parameter and merges them together.