### PR TITLE
List all regions when a debug flag is set

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -55,6 +55,7 @@ BUILDID
 BUILDNUMBER
 buildpacks
 byoi
+centralusstage
 cflags
 circleci
 cmdrecord
@@ -88,6 +89,7 @@ envname
 errcheck
 errorinfo
 errorlint
+EUAP
 executil
 Frontends
 funcapp


### PR DESCRIPTION
By default, `azd` only lists a subset of the locations that a user has access to. Our filtering huristics exclude both EUAP and the "stage" regions which some customers may have access to but in practice don't always support all of the infrastructure that users of `azd` may try to provison.

However, when testing new features, it's often useful to be able to select these regions from the picker, instead of forcing folks to run something like `azd env set AZURE_LOCATION <short-name-of-region>`

This change adds support for setting `AZD_DEBUG_INCLUDE_ALL_LOCATIONS` to a true value (as recognized by `strconv.ParseBool`) to prevent us from filtering out these other locations.