### PR TITLE
Increment VSCode Extension version after release

### DIFF
--- a/ext/vscode/CHANGELOG.md
+++ b/ext/vscode/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 0.9.0-alpha.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 0.8.2 (2024-04-24)
 
 ### Features Added

--- a/ext/vscode/package-lock.json
+++ b/ext/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-dev",
-    "version": "0.8.2",
+    "version": "0.9.0-alpha.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-dev",
-            "version": "0.8.2",
+            "version": "0.9.0-alpha.1",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azext-utils": "~2",

--- a/ext/vscode/package.json
+++ b/ext/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "azure-dev",
     "displayName": "Azure Developer CLI",
     "description": "Makes it easy to run, provision, and deploy Azure applications using the Azure Developer CLI",
-    "version": "0.8.2",
+    "version": "0.9.0-alpha.1",
     "license": "MIT",
     "icon": "resources/icon.png",
     "preview": true,


### PR DESCRIPTION
Did manually due to pipeline issues. Copied from #3501