### PR TITLE
Update provider.tf files with skip_provider_registration = "true"

### DIFF
--- a/cli/azd/test/functional/testdata/samples/resourcegroupterraform/infra/provider.tf
+++ b/cli/azd/test/functional/testdata/samples/resourcegroupterraform/infra/provider.tf
@@ -16,5 +16,6 @@ terraform {
 }
 
 provider "azurerm" {
+  skip_provider_registration = "true"
   features {}
 }

--- a/cli/azd/test/functional/testdata/samples/resourcegroupterraformremote/infra/provider.tf
+++ b/cli/azd/test/functional/testdata/samples/resourcegroupterraformremote/infra/provider.tf
@@ -18,5 +18,6 @@ terraform {
 }
 
 provider "azurerm" {
+  skip_provider_registration = "true"
   features {}
 }

--- a/cli/azd/test/functional/testdata/samples/springapp/infra-terraform/provider.tf
+++ b/cli/azd/test/functional/testdata/samples/springapp/infra-terraform/provider.tf
@@ -20,6 +20,7 @@ terraform {
 }
 
 provider "azurerm" {
+  skip_provider_registration = "true"
   features {
     key_vault {
       purge_soft_delete_on_destroy = false

--- a/templates/starter/terraform/infra/provider.tf
+++ b/templates/starter/terraform/infra/provider.tf
@@ -15,6 +15,7 @@ terraform {
 
 # Enable features for azurerm
 provider "azurerm" {
+  skip_provider_registration = "true"
   features {
     key_vault {
       purge_soft_delete_on_destroy = false

--- a/templates/todo/projects/java-postgresql/.repo/terraform/infra/provider.tf
+++ b/templates/todo/projects/java-postgresql/.repo/terraform/infra/provider.tf
@@ -16,6 +16,7 @@ terraform {
 }
 
 provider "azurerm" {
+  skip_provider_registration = "true"
   features {
     key_vault {
       purge_soft_delete_on_destroy = false

--- a/templates/todo/projects/nodejs-mongo/.repo/terraform/infra/provider.tf
+++ b/templates/todo/projects/nodejs-mongo/.repo/terraform/infra/provider.tf
@@ -16,6 +16,7 @@ terraform {
 }
 
 provider "azurerm" {
+  skip_provider_registration = "true"
   features {
     key_vault {
       purge_soft_delete_on_destroy = false

--- a/templates/todo/projects/python-mongo/.repo/terraform/infra/provider.tf
+++ b/templates/todo/projects/python-mongo/.repo/terraform/infra/provider.tf
@@ -16,6 +16,7 @@ terraform {
 }
 
 provider "azurerm" {
+  skip_provider_registration = "true"
   features {
     key_vault {
       purge_soft_delete_on_destroy = false


### PR DESCRIPTION
This PR updates all provider.tf files where this could be a problem but the issue was originally uncovered in sovereign environments in the `todo` app. 


Fixes #3797 