### PR TITLE
Fix publishing for vscode extension

### DIFF
--- a/eng/pipelines/templates/jobs/vscode-build.yml
+++ b/eng/pipelines/templates/jobs/vscode-build.yml
@@ -82,7 +82,7 @@ jobs:
           filePath: eng/scripts/Set-ShieldInfo.ps1
           arguments: >-
             -TemplatePath eng/shields/vscode.json
-            -OutputPath $(Build.ArtifactStagingDirectory)/shield/standalone.json
+            -OutputPath $(Build.ArtifactStagingDirectory)/shield/vscode.json
             -Version "$(VSIX_VERSION)"
         displayName: Set shield info
 


### PR DESCRIPTION
Output path was incorrectly specified. This was a copy/paste error from the 1ES migration.