### PR TITLE
Add bicepparam handling for prompting

### DIFF
--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -10,7 +10,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/cmd"
-	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
@@ -114,8 +113,7 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	err = u.provisioningManager.Initialize(ctx, u.projectConfig.Path, infra.Options)
 	if errors.Is(err, bicep.ErrEnsureEnvPreReqBicepCompileFailed) {
 		// If bicep is not available, we continue to prompt for subscription and location unfiltered
-		err = provisioning.EnsureSubscriptionAndLocation(ctx, u.envManager, u.env, u.prompters,
-			func(_ account.Location) bool { return true })
+		err = provisioning.EnsureSubscriptionAndLocation(ctx, u.envManager, u.env, u.prompters, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/cli/azd/pkg/azureutil/location.go
+++ b/cli/azd/pkg/azureutil/location.go
@@ -16,16 +16,7 @@ import (
 )
 
 // PromptLocation asks the user to select a location from a list of supported azure locations for a given subscription.
-func PromptLocation(
-	ctx context.Context, subscriptionId string, message string, help string, console input.Console,
-	accountManager account.Manager,
-) (string, error) {
-	return PromptLocationWithFilter(ctx, subscriptionId, message, help, console, accountManager,
-		func(_ account.Location) bool {
-			return true
-		})
-}
-
+// shouldDisplay, when non-nil, filters the location being displayed.
 func PromptLocationWithFilter(
 	ctx context.Context,
 	subscriptionId string,
@@ -43,7 +34,7 @@ func PromptLocationWithFilter(
 	locations := make([]account.Location, 0, len(allLocations))
 
 	for _, location := range allLocations {
-		if shouldDisplay(location) {
+		if shouldDisplay != nil && shouldDisplay(location) {
 			locations = append(locations, location)
 		}
 	}

--- a/cli/azd/pkg/azureutil/location.go
+++ b/cli/azd/pkg/azureutil/location.go
@@ -34,7 +34,7 @@ func PromptLocationWithFilter(
 	locations := make([]account.Location, 0, len(allLocations))
 
 	for _, location := range allLocations {
-		if shouldDisplay != nil && shouldDisplay(location) {
+		if shouldDisplay == nil || shouldDisplay(location) {
 			locations = append(locations, location)
 		}
 	}

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -132,7 +132,7 @@ func (p *BicepProvider) EnsureEnv(ctx context.Context) error {
 	// for .bicepparam, we first prompt for environment values before calling compiling bicepparam file
 	// which can reference these values
 	if isBicepParamFile(modulePath) {
-		if err := EnsureSubscriptionAndLocation(ctx, p.envManager, p.env, p.prompters, func(loc account.Location) bool {
+		if err := EnsureSubscriptionAndLocation(ctx, p.envManager, p.env, p.prompters, func(_ account.Location) bool {
 			return true
 		}); err != nil {
 			return err

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -132,9 +132,7 @@ func (p *BicepProvider) EnsureEnv(ctx context.Context) error {
 	// for .bicepparam, we first prompt for environment values before calling compiling bicepparam file
 	// which can reference these values
 	if isBicepParamFile(modulePath) {
-		if err := EnsureSubscriptionAndLocation(ctx, p.envManager, p.env, p.prompters, func(_ account.Location) bool {
-			return true
-		}); err != nil {
+		if err := EnsureSubscriptionAndLocation(ctx, p.envManager, p.env, p.prompters, nil); err != nil {
 			return err
 		}
 	}

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -129,7 +129,7 @@ var ErrEnsureEnvPreReqBicepCompileFailed = errors.New("")
 func (p *BicepProvider) EnsureEnv(ctx context.Context) error {
 	modulePath := p.modulePath()
 
-	// for .bicepparam, we first prompt for environment values before calling compiling bicepparams file
+	// for .bicepparam, we first prompt for environment values before calling compiling bicepparam file
 	// which can reference these values
 	if isBicepParamFile(modulePath) {
 		if err := EnsureSubscriptionAndLocation(ctx, p.envManager, p.env, p.prompters, nil); err != nil {

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -132,7 +132,9 @@ func (p *BicepProvider) EnsureEnv(ctx context.Context) error {
 	// for .bicepparam, we first prompt for environment values before calling compiling bicepparam file
 	// which can reference these values
 	if isBicepParamFile(modulePath) {
-		if err := EnsureSubscriptionAndLocation(ctx, p.envManager, p.env, p.prompters, nil); err != nil {
+		if err := EnsureSubscriptionAndLocation(ctx, p.envManager, p.env, p.prompters, func(loc account.Location) bool {
+			return true
+		}); err != nil {
 			return err
 		}
 	}

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -175,6 +175,7 @@ func (m *Manager) UpdateEnvironment(
 
 // EnsureSubscriptionAndLocation ensures that that that subscription (AZURE_SUBSCRIPTION_ID) and location (AZURE_LOCATION)
 // variables are set in the environment, prompting the user for the values if they do not exist.
+// locationFilter, when non-nil, filters the locations being displayed.
 func EnsureSubscriptionAndLocation(
 	ctx context.Context,
 	envManager environment.Manager,

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
-	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	. "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -127,7 +126,7 @@ func (t *TerraformProvider) EnsureEnv(ctx context.Context) error {
 		t.envManager,
 		t.env,
 		t.prompters,
-		func(_ account.Location) bool { return true },
+		nil,
 	)
 }
 


### PR DESCRIPTION
Move prompting for subscription and location before compiling bicepparam. This avoids bicepparam from failing outright.

Failing test `Test_CLI_InfraBicepParam` (fails locally in record mode) passes after this change. Unsure yet why live tests on CI do not fail in the same manner.