### PR TITLE
vs-server: allow multiple app host projects

### DIFF
--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -199,32 +199,6 @@ func DetectDirectory(ctx context.Context, directory string, options ...DetectDir
 	return detectAny(ctx, config.detectors, directory, entries)
 }
 
-func DetectAspireHosts(ctx context.Context, root string, dotnetCli dotnet.DotNetCli) ([]Project, error) {
-	config := newConfig()
-	config.detectors = []projectDetector{
-		&dotNetAppHostDetector{
-			dotnetCli: dotnetCli,
-		},
-	}
-
-	return detectUnder(ctx, root, config)
-}
-
-func DetectAspireHost(ctx context.Context, directory string, dotnetCli dotnet.DotNetCli) (*Project, error) {
-	config := newConfig()
-	config.detectors = []projectDetector{
-		&dotNetAppHostDetector{
-			dotnetCli: dotnetCli,
-		},
-	}
-	entries, err := os.ReadDir(directory)
-	if err != nil {
-		return nil, fmt.Errorf("reading directory: %w", err)
-	}
-
-	return detectAny(ctx, config.detectors, directory, entries)
-}
-
 func detectUnder(ctx context.Context, root string, config detectConfig) ([]Project, error) {
 	projects := []Project{}
 

--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -210,6 +210,21 @@ func DetectAspireHosts(ctx context.Context, root string, dotnetCli dotnet.DotNet
 	return detectUnder(ctx, root, config)
 }
 
+func DetectAspireHost(ctx context.Context, directory string, dotnetCli dotnet.DotNetCli) (*Project, error) {
+	config := newConfig()
+	config.detectors = []projectDetector{
+		&dotNetAppHostDetector{
+			dotnetCli: dotnetCli,
+		},
+	}
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return nil, fmt.Errorf("reading directory: %w", err)
+	}
+
+	return detectAny(ctx, config.detectors, directory, entries)
+}
+
 func detectUnder(ctx context.Context, root string, config detectConfig) ([]Project, error) {
 	projects := []Project{}
 

--- a/cli/azd/internal/vsrpc/aspire_service.go
+++ b/cli/azd/internal/vsrpc/aspire_service.go
@@ -11,8 +11,6 @@ import (
 	"path/filepath"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/apphost"
-	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
-	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
 )
 
@@ -38,8 +36,7 @@ func (s *aspireService) GetAspireHostAsync(
 	}
 
 	var c struct {
-		azdContext *azdcontext.AzdContext `container:"type"`
-		dotnetCli  dotnet.DotNetCli       `container:"type"`
+		dotnetCli dotnet.DotNetCli `container:"type"`
 	}
 
 	container, err := session.newContainer(rc)
@@ -51,33 +48,18 @@ func (s *aspireService) GetAspireHostAsync(
 		return nil, err
 	}
 
-	var cc struct {
-		projectConfig *project.ProjectConfig `container:"type"`
-	}
-
-	if err := container.Fill(&cc); err != nil {
-		return nil, err
-	}
-
-	appHost, err := appHostForProject(ctx, cc.projectConfig, c.dotnetCli)
-	if err != nil {
-		return nil, err
-	}
-
 	hostInfo := &AspireHost{
-		Name: filepath.Base(filepath.Dir(appHost.Path())),
-		Path: appHost.Path(),
+		Name: filepath.Base(filepath.Dir(rc.HostProjectPath)),
+		Path: rc.HostProjectPath,
 	}
 
-	manifest, err := apphost.ManifestFromAppHost(ctx, appHost.Path(), c.dotnetCli, aspireEnv)
+	manifest, err := apphost.ManifestFromAppHost(ctx, rc.HostProjectPath, c.dotnetCli, aspireEnv)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load app host manifest: %w", err)
 	}
 
 	hostInfo.Services = servicesFromManifest(manifest)
-
 	return hostInfo, nil
-
 }
 
 // RenameAspireHostAsync is the server implementation of:

--- a/cli/azd/internal/vsrpc/debug_service.go
+++ b/cli/azd/internal/vsrpc/debug_service.go
@@ -83,7 +83,9 @@ func (s *debugService) FetchTokenAsync(ctx context.Context, sessionId Session) (
 		credProvider auth.MultiTenantCredentialProvider `container:"type"`
 	}
 
-	container, err := session.newContainer()
+	container, err := session.newContainer(RequestContext{
+		HostProjectPath: session.rootPath,
+	})
 	if err != nil {
 		return azcore.AccessToken{}, err
 	}

--- a/cli/azd/internal/vsrpc/environment_service.go
+++ b/cli/azd/internal/vsrpc/environment_service.go
@@ -42,7 +42,7 @@ func (s *environmentService) GetEnvironmentsAsync(
 		envManager environment.Manager `container:"type"`
 	}
 
-	container, err := session.newContainer()
+	container, err := session.newContainer(rc)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (s *environmentService) SetCurrentEnvironmentAsync(
 		azdCtx *azdcontext.AzdContext `container:"type"`
 	}
 
-	container, err := session.newContainer()
+	container, err := session.newContainer(rc)
 	if err != nil {
 		return false, err
 	}
@@ -135,7 +135,7 @@ func (s *environmentService) DeleteEnvironmentAsync(
 		},
 	}
 
-	container, err := session.newContainer()
+	container, err := session.newContainer(rc)
 	if err != nil {
 		return false, err
 	}

--- a/cli/azd/internal/vsrpc/environment_service_create.go
+++ b/cli/azd/internal/vsrpc/environment_service_create.go
@@ -12,6 +12,8 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/apphost"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
 )
 
@@ -31,20 +33,6 @@ func (s *environmentService) CreateEnvironmentAsync(
 		Location:     newEnv.Properties["Location"],
 	}
 
-	var c struct {
-		azdContext *azdcontext.AzdContext `container:"type"`
-		dotnetCli  dotnet.DotNetCli       `container:"type"`
-		envManager environment.Manager    `container:"type"`
-	}
-
-	container, err := session.newContainer()
-	if err != nil {
-		return false, err
-	}
-	if err := container.Fill(&c); err != nil {
-		return false, err
-	}
-
 	// We had thought at one point that we would introduce `ASPIRE_ENVIRONMENT` as a sibling to `ASPNETCORE_ENVIRONMENT` and
 	// `DOTNET_ENVIRONMENT` and was aspire specific. We no longer intend to do this (because having both DOTNET and
 	// ASPNETCORE versions is already confusing enough). For now, we'll use `ASPIRE_ENVIRONMENT` to seed the initial values of
@@ -57,48 +45,108 @@ func (s *environmentService) CreateEnvironmentAsync(
 		dotnetEnv = v
 	}
 
+	cmdRun := exec.NewCommandRunner(&exec.RunnerOptions{})
+	dotnetCli := dotnet.NewDotNetCli(cmdRun)
+
+	var errMultipleAppHosts = errors.New("multiple app host projects found")
+
 	// If an azure.yaml doesn't already exist, we need to create one. Creating an environment implies initializing the
 	// azd project if it does not already exist.
-	if _, err := os.Stat(c.azdContext.ProjectPath()); errors.Is(err, fs.ErrNotExist) {
+	initProject := func(dir string) error {
 		_ = observer.OnNext(ctx, newImportantProgressMessage("Analyzing Aspire Application (this might take a moment...)"))
 		// Write an azure.yaml file to the project.
-		hosts, err := appdetect.DetectAspireHosts(ctx, c.azdContext.ProjectDirectory(), c.dotnetCli)
+		hosts, err := appdetect.DetectAspireHosts(ctx, dir, dotnetCli)
 		if err != nil {
-			return false, fmt.Errorf("failed to discover app host project under %s: %w", c.azdContext.ProjectPath(), err)
+			return fmt.Errorf("failed to discover app host project under %s: %w", dir, err)
 		}
 
 		if len(hosts) == 0 {
-			return false, fmt.Errorf("no app host projects found under %s", c.azdContext.ProjectPath())
+			return fmt.Errorf("no app host projects found under %s", dir)
 		}
 
 		if len(hosts) > 1 {
-			return false, fmt.Errorf("multiple app host projects found under %s", c.azdContext.ProjectPath())
+			return fmt.Errorf("%w under %s", errMultipleAppHosts, dir)
 		}
 
-		manifest, err := apphost.ManifestFromAppHost(ctx, hosts[0].Path, c.dotnetCli, dotnetEnv)
+		manifest, err := apphost.ManifestFromAppHost(ctx, hosts[0].Path, dotnetCli, dotnetEnv)
 		if err != nil {
-			return false, fmt.Errorf("reading app host manifest: %w", err)
+			return fmt.Errorf("reading app host manifest: %w", err)
 		}
 
 		files, err := apphost.GenerateProjectArtifacts(
 			ctx,
-			c.azdContext.ProjectDirectory(),
-			filepath.Base(c.azdContext.ProjectDirectory()),
+			dir,
+			filepath.Base(dir),
 			manifest,
 			hosts[0].Path,
 		)
 		if err != nil {
-			return false, fmt.Errorf("generating project artifacts: %w", err)
+			return fmt.Errorf("generating project artifacts: %w", err)
 		}
 
 		file := files["azure.yaml"]
-		projectFilePath := filepath.Join(c.azdContext.ProjectDirectory(), "azure.yaml")
+		projectFilePath := filepath.Join(dir, "azure.yaml")
 
 		if err := os.WriteFile(projectFilePath, []byte(file.Contents), file.Mode); err != nil {
-			return false, fmt.Errorf("writing azure.yaml: %w", err)
+			return fmt.Errorf("writing azure.yaml: %w", err)
 		}
-	} else if err != nil {
+		return nil
+	}
+
+	initializeInAppHostDir := false
+	hostProjectDir := filepath.Dir(rc.HostProjectPath)
+	// Check if local project has azure.yaml file. If it exists, we're done.
+	_, err = os.Stat(filepath.Join(hostProjectDir, "azure.yaml"))
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return false, fmt.Errorf("checking for project: %w", err)
+	} else if errors.Is(err, fs.ErrNotExist) {
+		// Should we create in root, or in app host dir?
+		// Try root, then fall back to app host dir.
+		_, err = os.Stat(filepath.Join(session.rootPath, "azure.yaml"))
+		if err == nil {
+			prjConfig, err := project.Load(ctx, filepath.Join(session.rootPath, "azure.yaml"))
+			if err != nil {
+				return false, err
+			}
+
+			for _, svc := range prjConfig.Services {
+				// check if the current app host project matches the one in root
+				if svc.Language == project.ServiceLanguageDotNet && svc.Host == project.ContainerAppTarget &&
+					filepath.Join(session.rootPath, svc.RelativePath) != rc.HostProjectPath {
+					initializeInAppHostDir = true
+				}
+
+				break
+			}
+		} else if errors.Is(err, fs.ErrNotExist) {
+			if err := initProject(session.rootPath); err != nil && !errors.Is(err, errMultipleAppHosts) {
+				return false, err
+			} else if errors.Is(err, errMultipleAppHosts) {
+				initializeInAppHostDir = true
+			}
+		} else if err != nil {
+			return false, fmt.Errorf("checking for project: %w", err)
+		}
+
+		if initializeInAppHostDir {
+			if err := initProject(hostProjectDir); err != nil {
+				return false, err
+			}
+		}
+	}
+
+	var c struct {
+		azdContext *azdcontext.AzdContext `container:"type"`
+		dotnetCli  dotnet.DotNetCli       `container:"type"`
+		envManager environment.Manager    `container:"type"`
+	}
+
+	container, err := session.newContainer(rc)
+	if err != nil {
+		return false, err
+	}
+	if err := container.Fill(&c); err != nil {
+		return false, err
 	}
 
 	azdEnv, err := c.envManager.Create(ctx, envSpec)

--- a/cli/azd/internal/vsrpc/environment_service_create.go
+++ b/cli/azd/internal/vsrpc/environment_service_create.go
@@ -12,8 +12,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/apphost"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
-	"github.com/azure/azure-dev/cli/azd/pkg/exec"
-	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
 )
 
@@ -33,118 +31,6 @@ func (s *environmentService) CreateEnvironmentAsync(
 		Location:     newEnv.Properties["Location"],
 	}
 
-	// We had thought at one point that we would introduce `ASPIRE_ENVIRONMENT` as a sibling to `ASPNETCORE_ENVIRONMENT` and
-	// `DOTNET_ENVIRONMENT` and was aspire specific. We no longer intend to do this (because having both DOTNET and
-	// ASPNETCORE versions is already confusing enough). For now, we'll use `ASPIRE_ENVIRONMENT` to seed the initial values of
-	// `DOTNET_ENVIRONMENT`, but allow them to be overriden at environment construction time.
-	//
-	// We only retain `DOTNET_ENVIRONMENT` in the .env file.
-	dotnetEnv := newEnv.Properties["ASPIRE_ENVIRONMENT"]
-
-	if v, has := newEnv.Values["DOTNET_ENVIRONMENT"]; has {
-		dotnetEnv = v
-	}
-
-	cmdRun := exec.NewCommandRunner(&exec.RunnerOptions{})
-	dotnetCli := dotnet.NewDotNetCli(cmdRun)
-
-	var errMultipleAppHosts = errors.New("multiple app host projects found")
-
-	// If an azure.yaml doesn't already exist, we need to create one. Creating an environment implies initializing the
-	// azd project if it does not already exist.
-	initProject := func(dir string) error {
-		_ = observer.OnNext(ctx, newImportantProgressMessage("Analyzing Aspire Application (this might take a moment...)"))
-		// Write an azure.yaml file to the project.
-		hosts, err := appdetect.DetectAspireHosts(ctx, dir, dotnetCli)
-		if err != nil {
-			return fmt.Errorf("failed to discover app host project under %s: %w", dir, err)
-		}
-
-		if len(hosts) == 0 {
-			return fmt.Errorf("no app host projects found under %s", dir)
-		}
-
-		if len(hosts) > 1 {
-			return fmt.Errorf("%w under %s", errMultipleAppHosts, dir)
-		}
-
-		manifest, err := apphost.ManifestFromAppHost(ctx, hosts[0].Path, dotnetCli, dotnetEnv)
-		if err != nil {
-			return fmt.Errorf("reading app host manifest: %w", err)
-		}
-
-		files, err := apphost.GenerateProjectArtifacts(
-			ctx,
-			dir,
-			filepath.Base(dir),
-			manifest,
-			hosts[0].Path,
-		)
-		if err != nil {
-			return fmt.Errorf("generating project artifacts: %w", err)
-		}
-
-		file := files["azure.yaml"]
-		projectFilePath := filepath.Join(dir, "azure.yaml")
-
-		if err := os.WriteFile(projectFilePath, []byte(file.Contents), file.Mode); err != nil {
-			return fmt.Errorf("writing azure.yaml: %w", err)
-		}
-		return nil
-	}
-
-	initializeInAppHostDir := false
-	hostProjectDir := filepath.Dir(rc.HostProjectPath)
-	hostProjectDir, err = filepath.EvalSymlinks(hostProjectDir)
-	if err != nil {
-		return false, fmt.Errorf("normalizing path '%s': %w", hostProjectDir, err)
-	}
-
-	// Check if local project has azure.yaml file. If it exists, we're done.
-	_, err = os.Stat(filepath.Join(hostProjectDir, "azure.yaml"))
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return false, fmt.Errorf("checking for project: %w", err)
-	} else if errors.Is(err, fs.ErrNotExist) {
-		// Should we create in root, or in app host dir?
-		// Try root, then fall back to app host dir.
-		_, err = os.Stat(filepath.Join(session.rootPath, "azure.yaml"))
-		if err == nil {
-			prjConfig, err := project.Load(ctx, filepath.Join(session.rootPath, "azure.yaml"))
-			if err != nil {
-				return false, err
-			}
-
-			for _, svc := range prjConfig.Services {
-				// check if the current app host project matches the one in root
-				if svc.Language == project.ServiceLanguageDotNet && svc.Host == project.ContainerAppTarget {
-					serviceDir, err := filepath.EvalSymlinks(filepath.Join(session.rootPath, svc.RelativePath))
-					if err != nil {
-						return false, fmt.Errorf("normalizing path '%s': %w", serviceDir, err)
-					}
-					if serviceDir != rc.HostProjectPath {
-						initializeInAppHostDir = true
-					}
-				}
-
-				break
-			}
-		} else if errors.Is(err, fs.ErrNotExist) {
-			if err := initProject(session.rootPath); err != nil && !errors.Is(err, errMultipleAppHosts) {
-				return false, err
-			} else if errors.Is(err, errMultipleAppHosts) {
-				initializeInAppHostDir = true
-			}
-		} else if err != nil {
-			return false, fmt.Errorf("checking for project: %w", err)
-		}
-
-		if initializeInAppHostDir {
-			if err := initProject(hostProjectDir); err != nil {
-				return false, err
-			}
-		}
-	}
-
 	var c struct {
 		azdContext *azdcontext.AzdContext `container:"type"`
 		dotnetCli  dotnet.DotNetCli       `container:"type"`
@@ -157,6 +43,71 @@ func (s *environmentService) CreateEnvironmentAsync(
 	}
 	if err := container.Fill(&c); err != nil {
 		return false, err
+	}
+
+	// We had thought at one point that we would introduce `ASPIRE_ENVIRONMENT` as a sibling to `ASPNETCORE_ENVIRONMENT` and
+	// `DOTNET_ENVIRONMENT` and was aspire specific. We no longer intend to do this (because having both DOTNET and
+	// ASPNETCORE versions is already confusing enough). For now, we'll use `ASPIRE_ENVIRONMENT` to seed the initial values of
+	// `DOTNET_ENVIRONMENT`, but allow them to be overriden at environment construction time.
+	//
+	// We only retain `DOTNET_ENVIRONMENT` in the .env file.
+	dotnetEnv := newEnv.Properties["ASPIRE_ENVIRONMENT"]
+
+	if v, has := newEnv.Values["DOTNET_ENVIRONMENT"]; has {
+		dotnetEnv = v
+	}
+
+	// If an azure.yaml doesn't already exist, we need to create one. Creating an environment implies initializing the
+	// azd project if it does not already exist.
+	if _, err := os.Stat(c.azdContext.ProjectPath()); errors.Is(err, fs.ErrNotExist) {
+		_ = observer.OnNext(ctx, newImportantProgressMessage("Analyzing Aspire Application (this might take a moment...)"))
+		hosts, err := appdetect.DetectAspireHosts(ctx, c.azdContext.ProjectDirectory(), c.dotnetCli)
+		if err != nil {
+			return false, fmt.Errorf("failed to discover app host project under %s: %w", c.azdContext.ProjectDirectory(), err)
+		}
+
+		if len(hosts) == 0 {
+			return false, fmt.Errorf("no app host projects found under %s", c.azdContext.ProjectDirectory())
+		}
+
+		// multiple app hosts detected, create azure.yaml in the host project directory instead
+		if len(hosts) > 1 {
+			hostProjectDir := filepath.Dir(rc.HostProjectPath)
+			host, err := appdetect.DetectAspireHost(ctx, hostProjectDir, c.dotnetCli)
+			if err != nil {
+				return false, fmt.Errorf("failed to discover app host project in %s: %w", hostProjectDir, err)
+			} else if host == nil {
+				return false, fmt.Errorf("no app host project found in %s", hostProjectDir)
+			}
+
+			hosts = []appdetect.Project{*host}
+		}
+
+		manifest, err := apphost.ManifestFromAppHost(ctx, hosts[0].Path, c.dotnetCli, dotnetEnv)
+		if err != nil {
+			return false, fmt.Errorf("reading app host manifest: %w", err)
+		}
+
+		// Write an azure.yaml file to the project.
+		files, err := apphost.GenerateProjectArtifacts(
+			ctx,
+			c.azdContext.ProjectDirectory(),
+			filepath.Base(c.azdContext.ProjectDirectory()),
+			manifest,
+			hosts[0].Path,
+		)
+		if err != nil {
+			return false, fmt.Errorf("generating project artifacts: %w", err)
+		}
+
+		file := files["azure.yaml"]
+		projectFilePath := filepath.Join(c.azdContext.ProjectDirectory(), "azure.yaml")
+
+		if err := os.WriteFile(projectFilePath, []byte(file.Contents), file.Mode); err != nil {
+			return false, fmt.Errorf("writing azure.yaml: %w", err)
+		}
+	} else if err != nil {
+		return false, fmt.Errorf("checking for project: %w", err)
 	}
 
 	azdEnv, err := c.envManager.Create(ctx, envSpec)

--- a/cli/azd/internal/vsrpc/environment_service_deploy.go
+++ b/cli/azd/internal/vsrpc/environment_service_deploy.go
@@ -47,7 +47,7 @@ func (s *environmentService) DeployAsync(
 		},
 	}
 
-	container, err := session.newContainer()
+	container, err := session.newContainer(rc)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/internal/vsrpc/environment_service_load.go
+++ b/cli/azd/internal/vsrpc/environment_service_load.go
@@ -28,7 +28,7 @@ func (s *environmentService) OpenEnvironmentAsync(
 		return nil, err
 	}
 
-	container, err := session.newContainer()
+	container, err := session.newContainer(rc)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (s *environmentService) LoadEnvironmentAsync(
 		return nil, err
 	}
 
-	container, err := session.newContainer()
+	container, err := session.newContainer(rc)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/internal/vsrpc/environment_service_refresh.go
+++ b/cli/azd/internal/vsrpc/environment_service_refresh.go
@@ -33,7 +33,7 @@ func (s *environmentService) RefreshEnvironmentAsync(
 		return nil, err
 	}
 
-	container, err := session.newContainer()
+	container, err := session.newContainer(rc)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/internal/vsrpc/server_session.go
+++ b/cli/azd/internal/vsrpc/server_session.go
@@ -95,7 +95,7 @@ func (s *serverSession) newContainer(rc RequestContext) (*container, error) {
 	}
 
 	id := s.id
-	azdCtx, err := azdContext(rc.HostProjectPath, s.rootPath)
+	azdCtx, err := azdContext(rc.HostProjectPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/internal/vsrpc/server_session.go
+++ b/cli/azd/internal/vsrpc/server_session.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
@@ -96,8 +95,7 @@ func (s *serverSession) newContainer(rc RequestContext) (*container, error) {
 	}
 
 	id := s.id
-	projectDir := filepath.Dir(rc.HostProjectPath)
-	azdCtx, err := azdcontext.NewAzdContextFromWd(projectDir)
+	azdCtx, err := azdContext(rc.HostProjectPath, s.rootPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/internal/vsrpc/server_session.go
+++ b/cli/azd/internal/vsrpc/server_session.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
@@ -88,14 +89,18 @@ type container struct {
 }
 
 // newContainer creates a new container for the session.
-func (s *serverSession) newContainer() (*container, error) {
+func (s *serverSession) newContainer(rc RequestContext) (*container, error) {
 	c, err := s.rootContainer.NewScopeRegistrationsOnly()
 	if err != nil {
 		return nil, err
 	}
 
 	id := s.id
-	azdCtx := azdcontext.NewAzdContextWithDirectory(s.rootPath)
+	projectDir := filepath.Dir(rc.HostProjectPath)
+	azdCtx, err := azdcontext.NewAzdContextFromWd(projectDir)
+	if err != nil {
+		return nil, err
+	}
 
 	outWriter := newWriter(fmt.Sprintf("[%s stdout] ", id))
 	errWriter := newWriter(fmt.Sprintf("[%s stderr] ", id))

--- a/cli/azd/internal/vsrpc/utils.go
+++ b/cli/azd/internal/vsrpc/utils.go
@@ -2,11 +2,15 @@ package vsrpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/apphost"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
 )
@@ -43,4 +47,60 @@ func servicesFromManifest(manifest *apphost.Manifest) []*Service {
 	}
 
 	return services
+}
+
+// azdContext resolves the azd context directory to use.
+//
+//   - If the host project directory contains azure.yaml, the host project directory is used.
+//   - If the nearest project directory contains azure.yaml, and the azure.yaml has services matching the given host project,
+//     the nearest project directory is used.
+//   - Otherwise, the root directory is used by default.
+//
+// The desired effect is that in Visual Studio, we prefer using the solution directory as the context directory by default.
+// When the solution directory has an existing azure.yaml referencing a different app host project, we then
+// prefer using the app host project directory. This allows publishing multiple app host projects within a solution without
+// additional configuration.
+func azdContext(hostProjectPath string, root string) (*azdcontext.AzdContext, error) {
+	hostProjectDir := filepath.Dir(hostProjectPath)
+	azdCtx, err := azdcontext.NewAzdContextFromWd(hostProjectDir)
+	if errors.Is(err, azdcontext.ErrNoProject) {
+		// no project exists, use root directory as the default
+		azdCtx = azdcontext.NewAzdContextWithDirectory(root)
+
+		if _, err := os.Stat(azdCtx.ProjectPath()); errors.Is(err, os.ErrNotExist) {
+			return azdCtx, nil
+		} else if err != nil {
+			return nil, err
+		}
+		// If we got here, it means the "solution root" is a sibling rather than the root of the project directory
+		// If so, we want to continue validating whether the azure.yaml targets the current app host project
+	} else if err != nil {
+		return nil, err
+	}
+
+	// nearest project is in host project directory, use it
+	if azdCtx.ProjectDirectory() == hostProjectDir {
+		return azdCtx, nil
+	}
+
+	// nearest project is not in host project directory, check if it targets the current app host project
+	prjConfig, err := project.Load(context.Background(), azdCtx.ProjectPath())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, svc := range prjConfig.Services {
+		if svc.Language == project.ServiceLanguageDotNet && svc.Host == project.ContainerAppTarget {
+			if svc.Path() != hostProjectPath {
+				log.Printf("use app host directory: %s", hostProjectDir)
+				return azdcontext.NewAzdContextWithDirectory(hostProjectDir), nil
+			}
+		}
+
+		// there can only be one app host project
+		break
+	}
+
+	log.Printf("use nearest directory: %s", azdCtx.ProjectDirectory())
+	return azdCtx, nil
 }

--- a/cli/azd/internal/vsrpc/utils_test.go
+++ b/cli/azd/internal/vsrpc/utils_test.go
@@ -23,35 +23,35 @@ func Test_azdContext(t *testing.T) {
 	require.NoError(t, createAppHost(inAppHost))
 	require.NoError(t, createAppHost(nearestUnmatched))
 
-	// By default, no azure.yaml is present. All projects would choose 'root' as the context directory.
-	ctxDir, err := azdContext(nearest, root)
+	// By default, no azure.yaml is present. All projects would choose their app host directory as the context directory.
+	ctxDir, err := azdContext(nearest)
 	require.NoError(t, err)
-	require.Equal(t, root, ctxDir.ProjectDirectory())
+	require.Equal(t, filepath.Dir(nearest), ctxDir.ProjectDirectory())
 
-	ctxDir, err = azdContext(inAppHost, root)
+	ctxDir, err = azdContext(inAppHost)
 	require.NoError(t, err)
-	require.Equal(t, root, ctxDir.ProjectDirectory())
+	require.Equal(t, filepath.Dir(inAppHost), ctxDir.ProjectDirectory())
 
-	ctxDir, err = azdContext(nearestUnmatched, root)
+	ctxDir, err = azdContext(nearestUnmatched)
 	require.NoError(t, err)
-	require.Equal(t, root, ctxDir.ProjectDirectory())
+	require.Equal(t, filepath.Dir(nearestUnmatched), ctxDir.ProjectDirectory())
 
 	// Create azure.yaml files.
 	require.NoError(t, createProject(root, nearestRel))
 	require.NoError(t, createProject(filepath.Dir(inAppHost), "apphost.csproj"))
 
 	// nearest uses 'root'
-	ctxDir, err = azdContext(nearest, root)
+	ctxDir, err = azdContext(nearest)
 	require.NoError(t, err)
 	require.Equal(t, root, ctxDir.ProjectDirectory())
 
 	// inAppHost uses 'in-apphost'
-	ctxDir, err = azdContext(inAppHost, root)
+	ctxDir, err = azdContext(inAppHost)
 	require.NoError(t, err)
 	require.Equal(t, filepath.Dir(inAppHost), ctxDir.ProjectDirectory())
 
 	// nearestUnmatched uses its own directory
-	ctxDir, err = azdContext(nearestUnmatched, root)
+	ctxDir, err = azdContext(nearestUnmatched)
 	require.NoError(t, err)
 	require.Equal(t, filepath.Dir(nearestUnmatched), ctxDir.ProjectDirectory())
 }

--- a/cli/azd/internal/vsrpc/utils_test.go
+++ b/cli/azd/internal/vsrpc/utils_test.go
@@ -1,0 +1,92 @@
+package vsrpc
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_azdContext(t *testing.T) {
+	root := t.TempDir()
+	nearestRel := filepath.Join("nearest", "apphost.csproj")
+	nearest := filepath.Join(root, nearestRel)
+	inAppHost := filepath.Join(root, filepath.Join("in-apphost", "apphost.csproj"))
+	nearestUnmatched := filepath.Join(root, filepath.Join("nearest-unmatched", "apphost.csproj"))
+
+	// Create app host directories and files
+	require.NoError(t, createAppHost(nearest))
+	require.NoError(t, createAppHost(inAppHost))
+	require.NoError(t, createAppHost(nearestUnmatched))
+
+	// By default, no azure.yaml is present. All projects would choose 'root' as the context directory.
+	ctxDir, err := azdContext(nearest, root)
+	require.NoError(t, err)
+	require.Equal(t, root, ctxDir.ProjectDirectory())
+
+	ctxDir, err = azdContext(inAppHost, root)
+	require.NoError(t, err)
+	require.Equal(t, root, ctxDir.ProjectDirectory())
+
+	ctxDir, err = azdContext(nearestUnmatched, root)
+	require.NoError(t, err)
+	require.Equal(t, root, ctxDir.ProjectDirectory())
+
+	// Create azure.yaml files.
+	require.NoError(t, createProject(root, nearestRel))
+	require.NoError(t, createProject(filepath.Dir(inAppHost), "apphost.csproj"))
+
+	// nearest uses 'root'
+	ctxDir, err = azdContext(nearest, root)
+	require.NoError(t, err)
+	require.Equal(t, root, ctxDir.ProjectDirectory())
+
+	// inAppHost uses 'in-apphost'
+	ctxDir, err = azdContext(inAppHost, root)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Dir(inAppHost), ctxDir.ProjectDirectory())
+
+	// nearestUnmatched uses its own directory
+	ctxDir, err = azdContext(nearestUnmatched, root)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Dir(nearestUnmatched), ctxDir.ProjectDirectory())
+}
+
+func createProject(prjDir string, appHostPath string) error {
+	err := os.MkdirAll(prjDir, 0755)
+	if err != nil {
+		return err
+	}
+	prjPath := filepath.Join(prjDir, azdcontext.ProjectFileName)
+
+	prjConfig := &project.ProjectConfig{
+		Name: "app",
+		Services: map[string]*project.ServiceConfig{
+			"app": {
+				Host:         project.ContainerAppTarget,
+				Language:     project.ServiceLanguageDotNet,
+				RelativePath: appHostPath,
+			},
+		},
+	}
+
+	return project.Save(context.Background(), prjConfig, prjPath)
+}
+
+func createAppHost(path string) error {
+	dir := filepath.Dir(path)
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}

--- a/cli/azd/pkg/environment/azdcontext/azdcontext.go
+++ b/cli/azd/pkg/environment/azdcontext/azdcontext.go
@@ -101,16 +101,22 @@ var (
 	ErrNoProject = errors.New("no project exists; to create a new project, run `azd init`")
 )
 
-// Creates context with project directory set to the nearest project file found.
-//
-// The project file is first searched for in the current directory, if not found, the parent directory is searched
-// recursively up to root. If no project file is found, errNoProject is returned.
+// Creates context with project directory set to the nearest project file found by calling NewAzdContextFromWd
+// on the current working directory.
 func NewAzdContext() (*AzdContext, error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the current directory: %w", err)
 	}
 
+	return NewAzdContextFromWd(wd)
+}
+
+// Creates context with project directory set to the nearest project file found.
+//
+// The project file is first searched for in the working directory, if not found, the parent directory is searched
+// recursively up to root. If no project file is found, errNoProject is returned.
+func NewAzdContextFromWd(wd string) (*AzdContext, error) {
 	// Walk up from the CWD to the root, looking for a project file. If we find one, that's
 	// the root project directory.
 	searchDir, err := filepath.Abs(wd)

--- a/cli/azd/pkg/environment/azdcontext/azdcontext.go
+++ b/cli/azd/pkg/environment/azdcontext/azdcontext.go
@@ -117,7 +117,7 @@ func NewAzdContext() (*AzdContext, error) {
 // The project file is first searched for in the working directory, if not found, the parent directory is searched
 // recursively up to root. If no project file is found, errNoProject is returned.
 func NewAzdContextFromWd(wd string) (*AzdContext, error) {
-	// Walk up from the CWD to the root, looking for a project file. If we find one, that's
+	// Walk up from the wd to the root, looking for a project file. If we find one, that's
 	// the root project directory.
 	searchDir, err := filepath.Abs(wd)
 	if err != nil {


### PR DESCRIPTION
Use the newly available information of the app host project to decide how the azd project context should be created an initialized from.

By default, use the app host project directory when none exists. Otherwise, find the nearest azd project that matches the current app host project.

fixes #3563 