### PR TITLE
POC: Adds supports for saving environment variable secrets in config vault

### DIFF
--- a/cli/azd/cmd/testdata/TestUsage-azd-env-set.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env-set.snap
@@ -8,6 +8,7 @@ Flags
         --docs               	: Opens the documentation for azd env set in your web browser.
     -e, --environment string 	: The name of the environment to use.
     -h, --help               	: Gets help for set.
+        --secret             	: Marks the value as a secret when set.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -2110,7 +2110,7 @@ func mustSetParamAsConfig(key string, value any, config config.Config, isSecured
 	if !castOk {
 		log.Panic("tried to set a non-string as secret. This is not supported.")
 	}
-	if err := config.SetSecret(configKey, secretString); err != nil {
+	if _, err := config.SetSecret(configKey, secretString); err != nil {
 		log.Panicf("failed setting a secret in config: %v", err)
 	}
 }


### PR DESCRIPTION
Adds the ability to store azd environment variable secrets in azd config vault.

- Adds `--secret` param to `azd env set`
- Stores env var secrets in config vaults
- Unset cleans vaults & secrets