### PR TITLE
Require success to upload artifact (on cross-build)

### DIFF
--- a/eng/pipelines/templates/jobs/cross-build-cli.yml
+++ b/eng/pipelines/templates/jobs/cross-build-cli.yml
@@ -84,7 +84,7 @@ jobs:
         - output: pipelineArtifact
           path: $(Build.ArtifactStagingDirectory)/build-output
           artifact: $(BuildTarget)
-          condition: always()
+          condition: succeeded()
           displayName: Upload azd binary to artifact store
 
         - output: pipelineArtifact


### PR DESCRIPTION
Fix failure seen in https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3738125&view=logs&jobId=f45fc40e-fed6-5690-00a4-8f5cef8e7f59&j=94ca385e-9655-5fbd-de13-6f931a1114dd&t=e5107889-11db-5ae5-3e13-abdcda2bed09&s=2b1cf740-7e83-5b38-9f56-89c750cf5d77