### PR TITLE
Updates devcenter config usage

### DIFF
--- a/cli/azd/pkg/devcenter/devcenter_test.go
+++ b/cli/azd/pkg/devcenter/devcenter_test.go
@@ -123,27 +123,30 @@ func (m *mockDevCenterManager) WritableProjectsWithFilter(
 
 func (m *mockDevCenterManager) Deployment(
 	ctx context.Context,
+	config *Config,
 	env *devcentersdk.Environment,
 	filter DeploymentFilterPredicate,
 ) (infra.Deployment, error) {
-	args := m.Called(ctx, env, filter)
+	args := m.Called(ctx, config, env, filter)
 	return args.Get(0).(infra.Deployment), args.Error(1)
 }
 
 func (m *mockDevCenterManager) LatestArmDeployment(
 	ctx context.Context,
+	config *Config,
 	env *devcentersdk.Environment,
 	filter DeploymentFilterPredicate,
 ) (*armresources.DeploymentExtended, error) {
-	args := m.Called(ctx, env, filter)
+	args := m.Called(ctx, config, env, filter)
 	return args.Get(0).(*armresources.DeploymentExtended), args.Error(1)
 }
 
 func (m *mockDevCenterManager) Outputs(
 	ctx context.Context,
+	config *Config,
 	env *devcentersdk.Environment,
 ) (map[string]provisioning.OutputParameter, error) {
-	args := m.Called(ctx, env)
+	args := m.Called(ctx, config, env)
 
 	outputs, ok := args.Get(0).(map[string]provisioning.OutputParameter)
 	if ok {

--- a/cli/azd/pkg/devcenter/environment_store.go
+++ b/cli/azd/pkg/devcenter/environment_store.go
@@ -18,6 +18,7 @@ const (
 // EnvironmentStore is a remote environment data store for devcenter environments
 type EnvironmentStore struct {
 	config          *Config
+	cachedConfig    *Config
 	devCenterClient devcentersdk.DevCenterClient
 	prompter        *Prompter
 	manager         Manager
@@ -132,7 +133,11 @@ func (s *EnvironmentStore) Reload(ctx context.Context, env *environment.Environm
 		return fmt.Errorf("failed to get devcenter environment: %w", err)
 	}
 
-	outputs, err := s.manager.Outputs(ctx, environment)
+	if err := s.syncEnvironment(env, environment); err != nil {
+		return fmt.Errorf("failed to sync devcenter environment to AZD environment: %w", err)
+	}
+
+	outputs, err := s.manager.Outputs(ctx, s.config, environment)
 	if err != nil {
 		return fmt.Errorf("failed to get environment outputs: %w", err)
 	}
@@ -140,34 +145,6 @@ func (s *EnvironmentStore) Reload(ctx context.Context, env *environment.Environm
 	// Set the environment variables for the environment
 	for key, outputParam := range outputs {
 		env.DotenvSet(key, fmt.Sprintf("%v", outputParam.Value))
-	}
-
-	// Set the devcenter configuration for the environment
-	if err := env.Config.Set(DevCenterNamePath, s.config.Name); err != nil {
-		return err
-	}
-	if err := env.Config.Set(DevCenterProjectPath, s.config.Project); err != nil {
-		return err
-	}
-	if err := env.Config.Set(DevCenterCatalogPath, environment.CatalogName); err != nil {
-		return err
-	}
-	if err := env.Config.Set(DevCenterEnvTypePath, environment.EnvironmentType); err != nil {
-		return err
-	}
-	if err := env.Config.Set(DevCenterEnvDefinitionPath, environment.EnvironmentDefinitionName); err != nil {
-		return err
-	}
-	if err := env.Config.Set(DevCenterUserPath, environment.User); err != nil {
-		return err
-	}
-
-	// Set the environment definition parameters
-	for key, value := range environment.Parameters {
-		path := fmt.Sprintf("%s.%s", ProvisionParametersConfigPath, key)
-		if err := env.Config.Set(path, value); err != nil {
-			return fmt.Errorf("failed setting config value %s: %w", path, err)
-		}
 	}
 
 	return nil
@@ -239,13 +216,94 @@ func (s *EnvironmentStore) ensureDevCenterConfig(ctx context.Context) error {
 	// If we don't have a valid devcenter configuration yet
 	// then prompt the user to initialize the correct configuration then provide the listing
 	if err := s.config.EnsureValid(); err != nil {
-		updatedConfig, err := s.prompter.PromptForConfig(ctx)
+		// Cache the originally loaded config for later comparison when determining if the config has changed.
+		if s.cachedConfig == nil {
+			temp := *s.config
+			s.cachedConfig = &temp
+		}
+
+		err := s.prompter.PromptForConfig(ctx, s.config)
 		if err != nil {
 			return fmt.Errorf("DevCenter configuration is not valid. Confirm your configuration and try again, %w", err)
 		}
-
-		s.config = updatedConfig
 	}
+
+	return nil
+}
+
+// Syncs the devcenter environment to the AZD environment
+func (s *EnvironmentStore) syncEnvironment(env *environment.Environment, environment *devcentersdk.Environment) error {
+	var currentConfig Config
+	if s.cachedConfig == nil {
+		currentConfig = *s.config
+	} else {
+		currentConfig = *s.cachedConfig
+	}
+
+	// Set missing configuration values from the environment
+	if s.config.Catalog == "" {
+		s.config.Catalog = environment.CatalogName
+	}
+
+	if s.config.EnvironmentType == "" {
+		s.config.EnvironmentType = environment.EnvironmentType
+	}
+
+	if s.config.EnvironmentDefinition == "" {
+		s.config.EnvironmentDefinition = environment.EnvironmentDefinitionName
+	}
+
+	if s.config.User == "" {
+		s.config.User = environment.User
+	}
+
+	// Set any missing config values in environment configuration for future use
+	// Some values are set at the global / project level so we only want to set missing values in the environment config
+	if currentConfig.Name == "" {
+		if err := env.Config.Set(DevCenterNamePath, s.config.Name); err != nil {
+			return err
+		}
+	}
+
+	if currentConfig.Project == "" {
+		if err := env.Config.Set(DevCenterProjectPath, s.config.Project); err != nil {
+			return err
+		}
+	}
+
+	if currentConfig.Catalog == "" {
+		if err := env.Config.Set(DevCenterCatalogPath, s.config.Catalog); err != nil {
+			return err
+		}
+	}
+
+	if currentConfig.EnvironmentType == "" {
+		if err := env.Config.Set(DevCenterEnvTypePath, s.config.EnvironmentType); err != nil {
+			return err
+		}
+	}
+
+	if currentConfig.EnvironmentDefinition == "" {
+		if err := env.Config.Set(DevCenterEnvDefinitionPath, s.config.EnvironmentDefinition); err != nil {
+			return err
+		}
+	}
+
+	if currentConfig.User == "" {
+		if err := env.Config.Set(DevCenterUserPath, s.config.User); err != nil {
+			return err
+		}
+	}
+
+	// Set the environment definition parameters
+	for key, value := range environment.Parameters {
+		path := fmt.Sprintf("%s.%s", ProvisionParametersConfigPath, key)
+		if err := env.Config.Set(path, value); err != nil {
+			return fmt.Errorf("failed setting config value %s: %w", path, err)
+		}
+	}
+
+	s.cachedConfig = nil
 
 	return nil
 }

--- a/cli/azd/pkg/devcenter/platform.go
+++ b/cli/azd/pkg/devcenter/platform.go
@@ -161,8 +161,8 @@ func (p *Platform) ConfigureContainer(container *ioc.NestedContainer) error {
 	// Template Sources
 	container.MustRegisterNamedTransient(string(SourceKindDevCenter), NewTemplateSource)
 
-	container.MustRegisterTransient(NewManager)
-	container.MustRegisterTransient(NewPrompter)
+	container.MustRegisterSingleton(NewManager)
+	container.MustRegisterSingleton(NewPrompter)
 
 	// Other devcenter components
 	container.MustRegisterSingleton(func(

--- a/cli/azd/pkg/devcenter/prompter.go
+++ b/cli/azd/pkg/devcenter/prompter.go
@@ -14,7 +14,6 @@ import (
 
 // Prompter provides a common set of methods for prompting the user for devcenter configuration values
 type Prompter struct {
-	config          *Config
 	console         input.Console
 	manager         Manager
 	devCenterClient devcentersdk.DevCenterClient
@@ -22,13 +21,11 @@ type Prompter struct {
 
 // NewPrompter creates a new devcenter prompter
 func NewPrompter(
-	config *Config,
 	console input.Console,
 	manager Manager,
 	devCenterClient devcentersdk.DevCenterClient,
 ) *Prompter {
 	return &Prompter{
-		config:          config,
 		console:         console,
 		manager:         manager,
 		devCenterClient: devCenterClient,
@@ -36,26 +33,26 @@ func NewPrompter(
 }
 
 // PromptForConfig prompts the user for devcenter configuration values that have not been previously set
-func (p *Prompter) PromptForConfig(ctx context.Context) (*Config, error) {
-	if p.config.Project == "" {
-		project, err := p.PromptProject(ctx, p.config.Name)
+func (p *Prompter) PromptForConfig(ctx context.Context, config *Config) error {
+	if config.Project == "" {
+		project, err := p.PromptProject(ctx, config.Name)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		p.config.Name = project.DevCenter.Name
-		p.config.Project = project.Name
+		config.Name = project.DevCenter.Name
+		config.Project = project.Name
 	}
 
-	if p.config.EnvironmentDefinition == "" {
-		envDefinition, err := p.PromptEnvironmentDefinition(ctx, p.config.Name, p.config.Project)
+	if config.EnvironmentDefinition == "" {
+		envDefinition, err := p.PromptEnvironmentDefinition(ctx, config.Name, config.Project)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		p.config.Catalog = envDefinition.CatalogName
-		p.config.EnvironmentDefinition = envDefinition.Name
+		config.Catalog = envDefinition.CatalogName
+		config.EnvironmentDefinition = envDefinition.Name
 	}
 
-	return p.config, nil
+	return nil
 }
 
 // PromptProject prompts the user to select a project for the specified devcenter

--- a/cli/azd/pkg/devcenter/prompter_test.go
+++ b/cli/azd/pkg/devcenter/prompter_test.go
@@ -32,7 +32,7 @@ func Test_Prompt_Project(t *testing.T) {
 			return selectedProjectIndex, nil
 		})
 
-		prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
+		prompter := newPrompterForTest(t, mockContext, manager)
 		selectedProject, err := prompter.PromptProject(*mockContext.Context, selectedDevCenter.Name)
 		require.NoError(t, err)
 		require.NotNil(t, selectedProject)
@@ -47,7 +47,7 @@ func Test_Prompt_Project(t *testing.T) {
 			On("WritableProjects", *mockContext.Context).
 			Return([]*devcentersdk.Project{}, nil)
 
-		prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
+		prompter := newPrompterForTest(t, mockContext, manager)
 		selectedProject, err := prompter.PromptProject(*mockContext.Context, "")
 		require.Error(t, err)
 		require.ErrorContains(t, err, "no dev center projects found")
@@ -77,7 +77,7 @@ func Test_Prompt_EnvironmentType(t *testing.T) {
 			return selectedIndex, nil
 		})
 
-		prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
+		prompter := newPrompterForTest(t, mockContext, manager)
 		selectedEnvironmentType, err := prompter.PromptEnvironmentType(
 			*mockContext.Context,
 			selectedDevCenter.Name,
@@ -109,7 +109,7 @@ func Test_Prompt_EnvironmentType(t *testing.T) {
 			return selectedIndex, nil
 		})
 
-		prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
+		prompter := newPrompterForTest(t, mockContext, manager)
 		selectedEnvironmentType, err := prompter.PromptEnvironmentType(
 			*mockContext.Context,
 			selectedDevCenter.Name,
@@ -143,7 +143,7 @@ func Test_Prompt_EnvironmentDefinitions(t *testing.T) {
 			return selectedIndex, nil
 		})
 
-		prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
+		prompter := newPrompterForTest(t, mockContext, manager)
 		selectedEnvironmentType, err := prompter.PromptEnvironmentDefinition(
 			*mockContext.Context,
 			selectedDevCenter.Name,
@@ -171,7 +171,7 @@ func Test_Prompt_EnvironmentDefinitions(t *testing.T) {
 			On("WritableProjects", *mockContext.Context).
 			Return(mockProjects, nil)
 
-		prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
+		prompter := newPrompterForTest(t, mockContext, manager)
 		selectedEnvironmentType, err := prompter.PromptEnvironmentDefinition(
 			*mockContext.Context,
 			selectedDevCenter.Name,
@@ -197,8 +197,8 @@ func Test_Prompt_Config(t *testing.T) {
 			Catalog:               selectedEnvDefinition.CatalogName,
 		}
 
-		prompter := newPrompterForTest(t, mockContext, config, nil)
-		config, err := prompter.PromptForConfig(*mockContext.Context)
+		prompter := newPrompterForTest(t, mockContext, nil)
+		err := prompter.PromptForConfig(*mockContext.Context, config)
 		require.NoError(t, err)
 		require.NotNil(t, config)
 		require.Equal(t, selectedDevCenter.Name, config.Name)
@@ -233,8 +233,10 @@ func Test_Prompt_Config(t *testing.T) {
 			return 2, nil
 		})
 
-		prompter := newPrompterForTest(t, mockContext, &Config{}, manager)
-		config, err := prompter.PromptForConfig(*mockContext.Context)
+		config := &Config{}
+
+		prompter := newPrompterForTest(t, mockContext, manager)
+		err := prompter.PromptForConfig(*mockContext.Context, config)
 		require.NoError(t, err)
 		require.NotNil(t, config)
 		require.Equal(t, selectedDevCenter.Name, config.Name)
@@ -326,7 +328,7 @@ func Test_Prompt_Parameters(t *testing.T) {
 			},
 		}
 
-		prompter := newPrompterForTest(t, mockContext, &Config{}, nil)
+		prompter := newPrompterForTest(t, mockContext, nil)
 		values, err := prompter.PromptParameters(*mockContext.Context, env, envDefinition)
 		require.NoError(t, err)
 
@@ -337,7 +339,7 @@ func Test_Prompt_Parameters(t *testing.T) {
 
 	t.Run("WithSomeSetValues", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		prompter := newPrompterForTest(t, mockContext, &Config{}, nil)
+		prompter := newPrompterForTest(t, mockContext, nil)
 		promptCalled := false
 
 		// Only mock response for param 3
@@ -382,7 +384,7 @@ func Test_Prompt_Parameters(t *testing.T) {
 
 	t.Run("WithAllSetValues", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		prompter := newPrompterForTest(t, mockContext, &Config{}, nil)
+		prompter := newPrompterForTest(t, mockContext, nil)
 
 		env := environment.New("Test")
 		envDefinition := &devcentersdk.EnvironmentDefinition{
@@ -410,7 +412,7 @@ func Test_Prompt_Parameters(t *testing.T) {
 	})
 }
 
-func newPrompterForTest(t *testing.T, mockContext *mocks.MockContext, config *Config, manager Manager) *Prompter {
+func newPrompterForTest(t *testing.T, mockContext *mocks.MockContext, manager Manager) *Prompter {
 	resourceGraphClient, err := armresourcegraph.NewClient(mockContext.Credentials, mockContext.ArmClientOptions)
 	require.NoError(t, err)
 
@@ -423,5 +425,5 @@ func newPrompterForTest(t *testing.T, mockContext *mocks.MockContext, config *Co
 
 	require.NoError(t, err)
 
-	return NewPrompter(config, mockContext.Console, manager, devCenterClient)
+	return NewPrompter(mockContext.Console, manager, devCenterClient)
 }

--- a/cli/azd/pkg/devcenter/provision_provider.go
+++ b/cli/azd/pkg/devcenter/provision_provider.go
@@ -101,7 +101,7 @@ func (p *ProvisionProvider) State(
 		return nil, fmt.Errorf("failed getting environment: %w", err)
 	}
 
-	outputs, err := p.manager.Outputs(ctx, environment)
+	outputs, err := p.manager.Outputs(ctx, p.config, environment)
 	if err != nil {
 		return nil, fmt.Errorf("failed getting environment outputs: %w", err)
 	}
@@ -227,7 +227,7 @@ func (p *ProvisionProvider) Deploy(ctx context.Context) (*provisioning.DeployRes
 
 	p.console.StopSpinner(ctx, spinnerMessage, input.StepDone)
 
-	outputs, err := p.manager.Outputs(ctx, environment)
+	outputs, err := p.manager.Outputs(ctx, p.config, environment)
 	if err != nil {
 		return nil, fmt.Errorf("failed getting environment outputs: %w", err)
 	}
@@ -306,7 +306,7 @@ func (p *ProvisionProvider) Destroy(
 	}
 
 	// Get environment outputs to invalidate them after destroy
-	outputs, err := p.manager.Outputs(ctx, devCenterEnv)
+	outputs, err := p.manager.Outputs(ctx, p.config, devCenterEnv)
 	if err != nil {
 		return nil, fmt.Errorf("failed getting environment outputs: %w", err)
 	}
@@ -343,58 +343,59 @@ func (p *ProvisionProvider) Destroy(
 // EnsureEnv ensures that the environment is configured for the Dev Center provider.
 // Require selection for devcenter, project, catalog, environment type, and environment definition
 func (p *ProvisionProvider) EnsureEnv(ctx context.Context) error {
-	// Cache config values prior to prompting user
+	// Cache config values prior to prompting user so we can compare what is missing later
 	currentConfig := *p.config
-	updatedConfig, err := p.prompter.PromptForConfig(ctx)
+	err := p.prompter.PromptForConfig(ctx, p.config)
 	if err != nil {
 		return err
 	}
 
-	if updatedConfig.EnvironmentType == "" {
-		envType, err := p.prompter.PromptEnvironmentType(ctx, updatedConfig.Name, updatedConfig.Project)
+	if p.config.EnvironmentType == "" {
+		envType, err := p.prompter.PromptEnvironmentType(ctx, p.config.Name, p.config.Project)
 		if err != nil {
 			return err
 		}
-		updatedConfig.EnvironmentType = envType.Name
+		p.config.EnvironmentType = envType.Name
 	}
 
-	if updatedConfig.User == "" {
-		updatedConfig.User = "me"
+	if p.config.User == "" {
+		p.config.User = "me"
 	}
 
 	// Set any missing config values in environment configuration for future use
+	// Some values are set at the global / project level so we only want to set missing values in the environment config
 	if currentConfig.Name == "" {
-		if err := p.env.Config.Set(DevCenterNamePath, updatedConfig.Name); err != nil {
+		if err := p.env.Config.Set(DevCenterNamePath, p.config.Name); err != nil {
 			return err
 		}
 	}
 
 	if currentConfig.Project == "" {
-		if err := p.env.Config.Set(DevCenterProjectPath, updatedConfig.Project); err != nil {
+		if err := p.env.Config.Set(DevCenterProjectPath, p.config.Project); err != nil {
 			return err
 		}
 	}
 
 	if currentConfig.Catalog == "" {
-		if err := p.env.Config.Set(DevCenterCatalogPath, updatedConfig.Catalog); err != nil {
+		if err := p.env.Config.Set(DevCenterCatalogPath, p.config.Catalog); err != nil {
 			return err
 		}
 	}
 
 	if currentConfig.EnvironmentType == "" {
-		if err := p.env.Config.Set(DevCenterEnvTypePath, updatedConfig.EnvironmentType); err != nil {
+		if err := p.env.Config.Set(DevCenterEnvTypePath, p.config.EnvironmentType); err != nil {
 			return err
 		}
 	}
 
 	if currentConfig.EnvironmentDefinition == "" {
-		if err := p.env.Config.Set(DevCenterEnvDefinitionPath, updatedConfig.EnvironmentDefinition); err != nil {
+		if err := p.env.Config.Set(DevCenterEnvDefinitionPath, p.config.EnvironmentDefinition); err != nil {
 			return err
 		}
 	}
 
 	if currentConfig.User == "" {
-		if err := p.env.Config.Set(DevCenterUserPath, updatedConfig.User); err != nil {
+		if err := p.env.Config.Set(DevCenterUserPath, p.config.User); err != nil {
 			return err
 		}
 	}
@@ -402,8 +403,6 @@ func (p *ProvisionProvider) EnsureEnv(ctx context.Context) error {
 	if err := p.envManager.Save(ctx, p.env); err != nil {
 		return fmt.Errorf("failed saving environment: %w", err)
 	}
-
-	p.config = updatedConfig
 
 	return nil
 }
@@ -445,10 +444,15 @@ func (p *ProvisionProvider) pollForEnvironment(ctx context.Context, envName stri
 
 			// After the resource group has been created
 			// We can start polling for a new deployment that started after we started polling
-			deployment, err := p.manager.Deployment(ctx, environment, func(d *armresources.DeploymentExtended) bool {
-				return *d.Properties.ProvisioningState == armresources.ProvisioningStateRunning &&
-					d.Properties.Timestamp.After(pollStartTime)
-			})
+			deployment, err := p.manager.Deployment(
+				ctx,
+				p.config,
+				environment,
+				func(d *armresources.DeploymentExtended) bool {
+					return *d.Properties.ProvisioningState == armresources.ProvisioningStateRunning &&
+						d.Properties.Timestamp.After(pollStartTime)
+				},
+			)
 
 			if err != nil || deployment == nil {
 				timer.Reset(regularDelay)

--- a/cli/azd/pkg/devcenter/provision_provider_test.go
+++ b/cli/azd/pkg/devcenter/provision_provider_test.go
@@ -100,7 +100,10 @@ func Test_ProvisionProvider_Deploy(t *testing.T) {
 
 		manager := &mockDevCenterManager{}
 		manager.
-			On("Outputs", *mockContext.Context, mock.AnythingOfType("*devcentersdk.Environment")).
+			On("Outputs",
+				*mockContext.Context,
+				mock.AnythingOfType("*devcenter.Config"),
+				mock.AnythingOfType("*devcentersdk.Environment")).
 			Return(outputParams, nil)
 
 		mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
@@ -165,7 +168,10 @@ func Test_ProvisionProvider_Deploy(t *testing.T) {
 
 		manager := &mockDevCenterManager{}
 		manager.
-			On("Outputs", *mockContext.Context, mock.AnythingOfType("*devcentersdk.Environment")).
+			On("Outputs",
+				*mockContext.Context,
+				mock.AnythingOfType("*devcenter.Config"),
+				mock.AnythingOfType("*devcentersdk.Environment")).
 			Return(outputParams, nil)
 
 		mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
@@ -272,7 +278,10 @@ func Test_ProvisionProvider_State(t *testing.T) {
 
 		manager := &mockDevCenterManager{}
 		manager.
-			On("Outputs", *mockContext.Context, mock.AnythingOfType("*devcentersdk.Environment")).
+			On("Outputs",
+				*mockContext.Context,
+				mock.AnythingOfType("*devcenter.Config"),
+				mock.AnythingOfType("*devcentersdk.Environment")).
 			Return(outputParams, nil)
 
 		mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
@@ -320,7 +329,10 @@ func Test_ProvisionProvider_State(t *testing.T) {
 
 		manager := &mockDevCenterManager{}
 		manager.
-			On("Outputs", *mockContext.Context, mock.AnythingOfType("*devcentersdk.Environment")).
+			On("Outputs",
+				*mockContext.Context,
+				mock.AnythingOfType("*devcenter.Config"),
+				mock.AnythingOfType("*devcentersdk.Environment")).
 			Return(nil, errors.New("no outputs"))
 
 		mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
@@ -371,7 +383,10 @@ func Test_ProvisionProvider_Destroy(t *testing.T) {
 
 		manager := &mockDevCenterManager{}
 		manager.
-			On("Outputs", *mockContext.Context, mock.AnythingOfType("*devcentersdk.Environment")).
+			On("Outputs",
+				*mockContext.Context,
+				mock.AnythingOfType("*devcenter.Config"),
+				mock.AnythingOfType("*devcentersdk.Environment")).
 			Return(outputParams, nil)
 
 		provider := newProvisionProviderForTest(t, mockContext, config, env, manager)
@@ -466,7 +481,7 @@ func newProvisionProviderForTest(
 	envManager := &mockenv.MockEnvManager{}
 	envManager.On("Save", *mockContext.Context, env).Return(nil)
 
-	prompter := NewPrompter(config, mockContext.Console, manager, devCenterClient)
+	prompter := NewPrompter(mockContext.Console, manager, devCenterClient)
 
 	return NewProvisionProvider(
 		mockContext.Console,


### PR DESCRIPTION
Resolves #3826 

Devcenter configuration can exist at multiple levels for `azd`

- Environment variables
- Global `azd` configuration
- Project configuration in `azure.yaml`
- `azd` envrionment configuration within `.azure/<env-name>/config.json`

Since the `config` object was being injected as a transient component changes to the config where not getting picked up when changes where made based on user prompts.

This PR removes the config from an injected param of a couple components and into a function param for consumed components.  This allows the correct config to flow through to the required functions.

In addition to this this enables us to now only save updates to the config based on what has changed from the originally loaded value as part of the `azd` environment configuration.