### PR TITLE
re-enable tests with fix location

### DIFF
--- a/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-resources.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-resources.bicep.snap
@@ -95,7 +95,6 @@ resource kv854251f1UserReadRoleAssignment 'Microsoft.Authorization/roleAssignmen
   scope: kv854251f1
   properties: {
     principalId: principalId
-    principalType: 'User'
     roleDefinitionId:  subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')
   }
 }

--- a/cli/azd/resources/apphost/templates/resources.bicept
+++ b/cli/azd/resources/apphost/templates/resources.bicept
@@ -340,7 +340,6 @@ resource {{bicepName $name}}UserReadRoleAssignment 'Microsoft.Authorization/role
   scope: {{bicepName $name}}
   properties: {
     principalId: principalId
-    principalType: 'User'
     roleDefinitionId:  subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')
   }
 }

--- a/cli/azd/test/functional/aspire_test.go
+++ b/cli/azd/test/functional/aspire_test.go
@@ -68,7 +68,7 @@ func restoreDotnetWorkload(t *testing.T) {
 
 // Test_CLI_Aspire_DetectGen tests the detection and generation of an Aspire project.
 func Test_CLI_Aspire_DetectGen(t *testing.T) {
-	restoreDotnetWorkload(t)
+	//restoreDotnetWorkload(t)
 
 	sn := snapshot.NewDefaultConfig().WithOptions(cupaloy.SnapshotFileExtension(""))
 	snRoot := filepath.Join("testdata", "snaps", "aspire-full")

--- a/cli/azd/test/functional/aspire_test.go
+++ b/cli/azd/test/functional/aspire_test.go
@@ -68,7 +68,7 @@ func restoreDotnetWorkload(t *testing.T) {
 
 // Test_CLI_Aspire_DetectGen tests the detection and generation of an Aspire project.
 func Test_CLI_Aspire_DetectGen(t *testing.T) {
-	//restoreDotnetWorkload(t)
+	restoreDotnetWorkload(t)
 
 	sn := snapshot.NewDefaultConfig().WithOptions(cupaloy.SnapshotFileExtension(""))
 	snRoot := filepath.Join("testdata", "snaps", "aspire-full")

--- a/cli/azd/test/functional/testdata/snaps/aspire-full/infra/resources.bicep
+++ b/cli/azd/test/functional/testdata/snaps/aspire-full/infra/resources.bicep
@@ -95,7 +95,6 @@ resource kvf2edecb5UserReadRoleAssignment 'Microsoft.Authorization/roleAssignmen
   scope: kvf2edecb5
   properties: {
     principalId: principalId
-    principalType: 'User'
     roleDefinitionId:  subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')
   }
 }

--- a/cli/azd/test/functional/vs_server_test.go
+++ b/cli/azd/test/functional/vs_server_test.go
@@ -248,8 +248,7 @@ func Test_CLI_VsServer(t *testing.T) {
 			cmd.Dir = testDir
 			cmd.Env = append(cmd.Env, os.Environ()...)
 			cmd.Env = append(cmd.Env, "AZURE_SUBSCRIPTION_ID="+subscriptionId)
-			// forcing location to centralus to avoid overloading whatever is in cfg.Location
-			cmd.Env = append(cmd.Env, "AZURE_LOCATION=centralus")
+			cmd.Env = append(cmd.Env, "AZURE_LOCATION="+cfg.Location)
 			cmd.Env = append(cmd.Env, fmt.Sprintf("PORT=%d", svr.Port))
 			cmd.Env = append(cmd.Env, "CERTIFICATE_BYTES="+*svr.CertificateBytes)
 			cmd.Env = append(cmd.Env, "ROOT_DIR="+dir)

--- a/cli/azd/test/functional/vs_server_test.go
+++ b/cli/azd/test/functional/vs_server_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 func Test_CLI_VsServerExternalAuth(t *testing.T) {
-	t.Skip("skiping to unblock daily build. Test needs maintenance")
 	ctx, cancel := newTestContext(t)
 	defer cancel()
 
@@ -140,7 +139,6 @@ func Test_CLI_VsServerExternalAuth(t *testing.T) {
 }
 
 func Test_CLI_VsServer(t *testing.T) {
-	t.Skip("skiping to unblock daily build. Test needs maintenance")
 	testDir := filepath.Join("testdata", "vs-server", "tests")
 	// List all tests
 	var stdout, stderr bytes.Buffer
@@ -250,7 +248,8 @@ func Test_CLI_VsServer(t *testing.T) {
 			cmd.Dir = testDir
 			cmd.Env = append(cmd.Env, os.Environ()...)
 			cmd.Env = append(cmd.Env, "AZURE_SUBSCRIPTION_ID="+subscriptionId)
-			cmd.Env = append(cmd.Env, "AZURE_LOCATION="+cfg.Location)
+			// forcing location to centralus to avoid overloading whatever is in cfg.Location
+			cmd.Env = append(cmd.Env, "AZURE_LOCATION=centralus")
 			cmd.Env = append(cmd.Env, fmt.Sprintf("PORT=%d", svr.Port))
 			cmd.Env = append(cmd.Env, "CERTIFICATE_BYTES="+*svr.CertificateBytes)
 			cmd.Env = append(cmd.Env, "ROOT_DIR="+dir)


### PR DESCRIPTION
re-enabling tests skipped during: https://github.com/Azure/azure-dev/pull/3835

Using a fixed location to prevent over-utilization of location defined in tests during live tests.