### PR TITLE
Adds support to filter AZD templates by tags

### DIFF
--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -73,9 +73,10 @@ func (i *initFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOpt
 		"b",
 		"",
 		"The template branch to initialize from. Must be used with a template argument (--template or -t).")
-	local.StringSliceVar(
+	local.StringSliceVarP(
 		&i.templateTags,
-		"tags",
+		"filter",
+		"f",
 		[]string{},
 		"The tag(s) used to filter template results. Supports comma-separated values.",
 	)

--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -53,11 +53,20 @@ func templatesActions(root *actions.ActionDescriptor) *actions.ActionDescriptor 
 
 type templateListFlags struct {
 	source string
+	tags   []string
 }
 
 func newTemplateListFlags(cmd *cobra.Command) *templateListFlags {
 	flags := &templateListFlags{}
 	cmd.Flags().StringVarP(&flags.source, "source", "s", "", "Filters templates by source.")
+
+	cmd.Flags().StringSliceVarP(
+		&flags.tags,
+		"tags",
+		"t",
+		[]string{},
+		"The tag(s) used to filter template results. Supports comma-separated values.",
+	)
 
 	return flags
 }
@@ -92,7 +101,10 @@ func newTemplateListAction(
 }
 
 func (tl *templateListAction) Run(ctx context.Context) (*actions.ActionResult, error) {
-	options := &templates.ListOptions{Source: tl.flags.source}
+	options := &templates.ListOptions{
+		Source: tl.flags.source,
+		Tags:   tl.flags.tags,
+	}
 	listedTemplates, err := tl.templateManager.ListTemplates(ctx, options)
 	if err != nil {
 		return nil, err

--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -62,8 +62,8 @@ func newTemplateListFlags(cmd *cobra.Command) *templateListFlags {
 
 	cmd.Flags().StringSliceVarP(
 		&flags.tags,
-		"tags",
-		"t",
+		"filter",
+		"f",
 		[]string{},
 		"The tag(s) used to filter template results. Supports comma-separated values.",
 	)

--- a/cli/azd/cmd/testdata/TestUsage-azd-init.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-init.snap
@@ -15,6 +15,7 @@ Flags
     -h, --help                	: Gets help for init.
     -l, --location string     	: Azure location for the new environment
     -s, --subscription string 	: Name or ID of an Azure subscription to use for the new environment
+        --tags strings        	: The tag(s) used to filter template results. Supports comma-separated values.
     -t, --template string     	: Initializes a new application from a template. You can use Full URI, <owner>/<repository>, or <repository> if it's part of the azure-samples organization.
 
 Global Flags

--- a/cli/azd/cmd/testdata/TestUsage-azd-init.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-init.snap
@@ -11,11 +11,11 @@ Flags
     -b, --branch string       	: The template branch to initialize from. Must be used with a template argument (--template or -t).
         --docs                	: Opens the documentation for azd init in your web browser.
     -e, --environment string  	: The name of the environment to use.
+    -f, --filter strings      	: The tag(s) used to filter template results. Supports comma-separated values.
         --from-code           	: Initializes a new application from your existing code.
     -h, --help                	: Gets help for init.
     -l, --location string     	: Azure location for the new environment
     -s, --subscription string 	: Name or ID of an Azure subscription to use for the new environment
-        --tags strings        	: The tag(s) used to filter template results. Supports comma-separated values.
     -t, --template string     	: Initializes a new application from a template. You can use Full URI, <owner>/<repository>, or <repository> if it's part of the azure-samples organization.
 
 Global Flags

--- a/cli/azd/cmd/testdata/TestUsage-azd-template-list.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-template-list.snap
@@ -8,6 +8,7 @@ Flags
         --docs          	: Opens the documentation for azd template list in your web browser.
     -h, --help          	: Gets help for list.
     -s, --source string 	: Filters templates by source.
+    -t, --tags strings  	: The tag(s) used to filter template results. Supports comma-separated values.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd-template-list.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-template-list.snap
@@ -5,10 +5,10 @@ Usage
   azd template list [flags]
 
 Flags
-        --docs          	: Opens the documentation for azd template list in your web browser.
-    -h, --help          	: Gets help for list.
-    -s, --source string 	: Filters templates by source.
-    -t, --tags strings  	: The tag(s) used to filter template results. Supports comma-separated values.
+        --docs           	: Opens the documentation for azd template list in your web browser.
+    -f, --filter strings 	: The tag(s) used to filter template results. Supports comma-separated values.
+    -h, --help           	: Gets help for list.
+    -s, --source string  	: Filters templates by source.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/pkg/templates/awesome_source.go
+++ b/cli/azd/pkg/templates/awesome_source.go
@@ -15,9 +15,10 @@ import (
 )
 
 type awesomeAzdTemplate struct {
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Source      string `json:"source"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Source      string   `json:"source"`
+	Tags        []string `json:"tags"`
 }
 
 // NewAwesomeAzdTemplateSource creates a new template source from the awesome-azd templates json file.
@@ -71,6 +72,7 @@ func NewAwesomeAzdTemplateSource(
 			Name:           template.Title,
 			Description:    template.Description,
 			RepositoryPath: repoPath,
+			Tags:           template.Tags,
 		})
 	}
 

--- a/cli/azd/pkg/templates/template.go
+++ b/cli/azd/pkg/templates/template.go
@@ -25,6 +25,9 @@ type Template struct {
 	// or "{repo}" for GitHub repositories under Azure-Samples (default organization).
 	RepositoryPath string `json:"repositoryPath"`
 
+	// A list of tags associated with the template
+	Tags []string `json:"tags"`
+
 	// Additional metadata about the template
 	Metadata Metadata `json:"metadata,omitempty"`
 }
@@ -51,6 +54,7 @@ func (t *Template) Display(writer io.Writer) error {
 		{"Name", ":", t.Name},
 		{"Source", ":", t.Source},
 		{"Description", ":", t.Description},
+		{"Tags", ":", strings.Join(t.Tags, ", ")},
 	}
 
 	for _, line := range text {

--- a/cli/azd/pkg/templates/template_manager.go
+++ b/cli/azd/pkg/templates/template_manager.go
@@ -188,8 +188,9 @@ func PromptTemplate(
 	message string,
 	templateManager *TemplateManager,
 	console input.Console,
+	options *ListOptions,
 ) (*Template, error) {
-	templates, err := templateManager.ListTemplates(ctx, nil)
+	templates, err := templateManager.ListTemplates(ctx, options)
 	if err != nil {
 		return nil, fmt.Errorf("prompting for template: %w", err)
 	}

--- a/cli/azd/pkg/templates/template_manager_test.go
+++ b/cli/azd/pkg/templates/template_manager_test.go
@@ -60,6 +60,38 @@ func Test_Templates_ListTemplates(t *testing.T) {
 	require.NotEmpty(t, storedTemplates)
 }
 
+func Test_Templates_ListTemplates_WithTagFilter(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+	mockAwesomeAzdTemplateSource(mockContext)
+
+	configManager := &mockUserConfigManager{}
+	configManager.On("Load").Return(config.NewConfig(defaultTemplateSourceData), nil)
+
+	templateManager, err := NewTemplateManager(
+		NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.HttpClient),
+		mockContext.Console,
+	)
+	require.NoError(t, err)
+
+	t.Run("WithMatchingTags", func(t *testing.T) {
+		listOptions := &ListOptions{
+			Tags: []string{"nodejs", "mongo"},
+		}
+		templates, err := templateManager.ListTemplates(*mockContext.Context, listOptions)
+		require.Len(t, templates, 5)
+		require.Nil(t, err)
+	})
+
+	t.Run("NoMatchingTags", func(t *testing.T) {
+		listOptions := &ListOptions{
+			Tags: []string{"foo", "bar"},
+		}
+		templates, err := templateManager.ListTemplates(*mockContext.Context, listOptions)
+		require.Len(t, templates, 0)
+		require.Nil(t, err)
+	})
+}
+
 func Test_Templates_ListTemplates_SourceError(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 

--- a/cli/azd/resources/templates.json
+++ b/cli/azd/resources/templates.json
@@ -2,81 +2,165 @@
   {
     "name": "Starter - Bicep",
     "description": "A starter template with Bicep as infrastructure provider",
-    "repositoryPath": "azd-starter-bicep"
+    "repositoryPath": "azd-starter-bicep",
+    "tags": [
+      "bicep"
+    ]
   },
   {
     "name": "Starter - Terraform",
     "description": "A starter template with Terraform as infrastructure provider",
-    "repositoryPath": "azd-starter-terraform"
+    "repositoryPath": "azd-starter-terraform",
+    "tags": [
+      "terraform"
+    ]
   },
   {
     "name": "React Web App with C# API and MongoDB",
     "description": "A blueprint for getting a React web app with a C# API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly.",
-    "repositoryPath": "todo-csharp-cosmos-sql"
+    "repositoryPath": "todo-csharp-cosmos-sql",
+    "tags": [
+      "bicep",
+      "csharp",
+      "cosmos",
+      "sql"
+    ]
   },
   {
     "name": "React Web App with C# API and SQL Database",
     "description": "A blueprint for getting a React web app with a C# API and a SQL database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly.",
-    "repositoryPath": "todo-csharp-sql"
+    "repositoryPath": "todo-csharp-sql",
+    "tags": [
+      "bicep",
+      "csharp",
+      "sql"
+    ]
   },
   {
     "name": "React Web App with Java API and MongoDB",
     "description": "A blueprint for getting a React.js web app with a Java API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
-    "repositoryPath": "todo-java-mongo"
+    "repositoryPath": "todo-java-mongo",
+    "tags": [
+      "bicep",
+      "java",
+      "mongo"
+    ]
   },
   {
     "name": "React Web App with Node.js API and MongoDB",
     "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
-    "repositoryPath": "todo-nodejs-mongo"
+    "repositoryPath": "todo-nodejs-mongo",
+    "tags": [
+      "bicep",
+      "nodejs",
+      "mongo"
+    ]
   },
   {
     "name": "React Web App with Node.js API and MongoDB - Terraform",
     "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Terraform) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
-    "repositoryPath": "todo-nodejs-mongo-terraform"
+    "repositoryPath": "todo-nodejs-mongo-terraform",
+    "tags": [
+      "terraform",
+      "nodejs",
+      "mongo"
+    ]
   },
   {
     "name": "React Web App with Python API and MongoDB",
     "description": "A blueprint for getting a React.js web app with Python (FastAPI) API and a MongoDB API in Cosmos database onto Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
-    "repositoryPath": "todo-python-mongo"
+    "repositoryPath": "todo-python-mongo",
+    "tags": [
+      "bicep",
+      "python",
+      "mongo"
+    ]
   },
   {
     "name": "React Web App with Python API and MongoDB - Terraform",
     "description": "A blueprint for getting a React.js web app with Python (FastAPI) API and a MongoDB API in Cosmos database onto Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Terraform) to get up and running quickly. This architecture is for hosting web apps and APIs without worrying about the infrastructure.",
-    "repositoryPath": "todo-python-mongo-terraform"
+    "repositoryPath": "todo-python-mongo-terraform",
+    "tags": [
+      "terraform",
+      "python",
+      "mongo"
+    ]
   },
   {
     "name": "Containerized React Web App with Java API and MongoDB",
     "description": "A blueprint for getting a React web app with a Java API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for running containerized apps or microservices on a serverless platform.",
-    "repositoryPath": "todo-java-mongo-aca"
+    "repositoryPath": "todo-java-mongo-aca",
+    "tags": [
+      "bicep",
+      "java",
+      "mongo",
+      "containerapp"
+    ]
   },
   {
     "name": "Containerized React Web App with Node.js API and MongoDB",
     "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database onto Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for running containerized apps or microservices on a serverless platform. This architecture is for running containerized microservices without managing the servers.",
-    "repositoryPath": "todo-nodejs-mongo-aca"
+    "repositoryPath": "todo-nodejs-mongo-aca",
+    "tags": [
+      "bicep",
+      "nodejs",
+      "mongo",
+      "containerapp"
+    ]
   },
   {
     "name": "Containerized React Web App with Python API and MongoDB",
     "description": "A blueprint for getting a React.js web app with Python (FastAPI) API and a MongoDB API in Cosmos database onto Azure. The frontend, currently a ToDo application, is designed as a placeholder that can easily be removed and replaced with your own frontend code. This architecture is for running containerized apps or microservices on a serverless platform.",
-    "repositoryPath": "todo-python-mongo-aca"
+    "repositoryPath": "todo-python-mongo-aca",
+    "tags": [
+      "bicep",
+      "python",
+      "mongo",
+      "containerapp"
+    ]
   },
   {
     "name": "Static React Web App + Functions with C# API and SQL Database",
     "description": "A blueprint for getting a React web app with a C# API and a SQL database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting static web apps with serverless logic and functionality.",
-    "repositoryPath": "todo-csharp-sql-swa-func"
+    "repositoryPath": "todo-csharp-sql-swa-func",
+    "tags": [
+      "bicep",
+      "csharp",
+      "sql",
+      "functions"
+    ]
   },
   {
     "name": "Static React Web App + Functions with Node.js API and MongoDB",
     "description": "A blueprint for getting a React web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for hosting static web apps with serverless logic and functionality.",
-    "repositoryPath": "todo-nodejs-mongo-swa-func"
+    "repositoryPath": "todo-nodejs-mongo-swa-func",
+    "tags": [
+      "bicep",
+      "nodejs",
+      "mongo",
+      "functions"
+    ]
   },
   {
     "name": "Static React Web App + Functions with Python API and MongoDB",
     "description": "A blueprint for getting a React.js web app with Python (FastAPI) API and a MongoDB API in Cosmos database onto Azure. The frontend, currently a ToDo application, is designed as a placeholder that can easily be removed and replaced with your own frontend code. This architecture is for hosting static web apps with serverless logic and functionality.",
-    "repositoryPath": "todo-python-mongo-swa-func"
+    "repositoryPath": "todo-python-mongo-swa-func",
+    "tags": [
+      "bicep",
+      "python",
+      "mongo",
+      "functions"
+    ]
   },
   {
     "name": "Kubernetes React Web App with Node.js API and MongoDB",
     "description": "A blueprint for getting a React.js web app with a Node.js API and a MongoDB database on Azure. The blueprint includes sample application code (a ToDo web app) which can be removed and replaced with your own application code. Add your own source code and leverage the Infrastructure as Code assets (written in Bicep) to get up and running quickly. This architecture is for running Kubernetes clusters without setting up the control plane.",
-    "repositoryPath": "todo-nodejs-mongo-aks"
+    "repositoryPath": "todo-nodejs-mongo-aks",
+    "tags": [
+      "bicep",
+      "nodejs",
+      "mongo",
+      "aks"
+    ]
   }
 ]


### PR DESCRIPTION
## Feature Updates

- Adds `tags` to JSON structure for AZD template sources
- Adds (`--filter, -f`) option to `azd template list`
- Adds (`--filter`) options to `azd init`
- Displays tags in `azd template show`

## Filter templates during `azd init`

When specifying `--filter, -f` argument to `azd init` AZD will automatically enter template list mode showing only templates that match the specified tags.

<img width="421" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/445e3038-8d38-450f-b65c-ea3f4b75240f">

## Filter templates during `azd template list`

When specifying `--filter, -f` argument to `azd template list` AZD will filter the template results to show only those templates that have matching tags.

<img width="791" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/dbb5a89e-2037-4fdd-a6b6-2ad094bc769d">

## Display Tags in `azd template show <template>`

Tags will now show along with other template metadata.

<img width="797" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/f386b5ec-97d3-4707-858d-6b3d8a8e9530">


