### PR TITLE
aspire: Fix invalid bicep when using binding expressions

### DIFF
--- a/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-main.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-main.bicep.snap
@@ -86,7 +86,9 @@ module test 'test/test.bicep' = {
   scope: rg
   params: {
     location: location
+    host: 'frontend.internal.${resources.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}'
     test: parameter
+    url: 'http://frontend.internal.${resources.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}'
     values: ['one','two']
   }
 }

--- a/cli/azd/pkg/apphost/testdata/aspire-bicep.json
+++ b/cli/azd/pkg/apphost/testdata/aspire-bicep.json
@@ -13,6 +13,8 @@
         "path": "test.bicep",
         "params": {
           "test": "{parameter.value}",
+          "url": "{frontend.bindings.http.url}",
+          "host": "{frontend.bindings.http.host}",
           "values": [
             "one",
             "two"


### PR DESCRIPTION
We were not taking the emitType flag into account when generating values for `.host` or `.url` binding expressions and just always emited the yaml format.  This caused invalid bicep generation when a module would have a pramater with a value like
`${project.bindings.https.url}`.

Fixes #3839