### PR TITLE
chore: Skip dev center configuration in test environment

### DIFF
--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -122,6 +122,7 @@ func TestMain(m *testing.M) {
 
 func Test_CLI_DevCenter_Init_Up_Down(t *testing.T) {
 	// running this test in parallel is ok as it uses a t.TempDir()
+	t.Skip("missing dev center configuration in test environment")
 	t.Parallel()
 	ctx, cancel := newTestContext(t)
 	defer cancel()


### PR DESCRIPTION
daily build is broken by devcenter tests not finding some resources (key vault). 

Disabling test to unblock daily build as this is test infrastructure issue