### PR TITLE
Updating service plan to B3.

### DIFF
--- a/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/infra/main.bicep
@@ -133,7 +133,7 @@ module appServicePlan '../../../../../../common/infra/bicep/core/host/appservice
     location: location
     tags: tags
     sku: {
-      name: 'B1'
+      name: 'B3'
     }
   }
 }

--- a/templates/todo/projects/csharp-sql/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/csharp-sql/.repo/bicep/infra/main.bicep
@@ -118,7 +118,7 @@ module appServicePlan '../../../../../../common/infra/bicep/core/host/appservice
     location: location
     tags: tags
     sku: {
-      name: 'B1'
+      name: 'B3'
     }
   }
 }

--- a/templates/todo/projects/java-mongo/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/java-mongo/.repo/bicep/infra/main.bicep
@@ -111,7 +111,7 @@ module appServicePlan '../../../../../../common/infra/bicep/core/host/appservice
     location: location
     tags: tags
     sku: {
-      name: 'B1'
+      name: 'B3'
     }
   }
 }

--- a/templates/todo/projects/nodejs-mongo/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo/.repo/bicep/infra/main.bicep
@@ -111,7 +111,7 @@ module appServicePlan '../../../../../../common/infra/bicep/core/host/appservice
     location: location
     tags: tags
     sku: {
-      name: 'B1'
+      name: 'B3'
     }
   }
 }

--- a/templates/todo/projects/python-mongo/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/python-mongo/.repo/bicep/infra/main.bicep
@@ -111,7 +111,7 @@ module appServicePlan '../../../../../../common/infra/bicep/core/host/appservice
     location: location
     tags: tags
     sku: {
-      name: 'B1'
+      name: 'B3'
     }
   }
 }


### PR DESCRIPTION
Templates were using B1 which takes a long time to boot and be ready to deploy.
Also, when using Oryx, it takes more than 3 minutes to build a node app.

The experience from azd deploy is very bad for webApp using B1 and the cost benefit is not that much compared to B3 (.017 v/s .067 p/h).

The fact that B1 runs with only 1 vCPU drastically reduces its performance compared to B3 running with 4 vCPUs
