### PR TITLE
Adding support for overriding the location in AppHost for a bicep module.

### DIFF
--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -719,6 +719,10 @@ func (b *infraGenerator) addBicep(name string, comp *Resource) error {
 	if _, keyVaultInjected := autoInjectedParams[knownParameterKeyVault]; keyVaultInjected {
 		b.addKeyVault("kv"+uniqueFnvNumber(name), true, true)
 	}
+	if _, hasLocation := stringParams["location"]; !hasLocation {
+		// if location is not provided, add it as a link to location parameter
+		stringParams["location"] = "location"
+	}
 
 	b.bicepContext.BicepModules[name] = genBicepModules{Path: *comp.Path, Params: stringParams}
 	return nil

--- a/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-main.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-main.bicep.snap
@@ -41,8 +41,8 @@ module ai 'ai/aspire.hosting.azure.bicep.appinsights.bicep' = {
   name: 'ai'
   scope: rg
   params: {
-    location: location
     appInsightsName: 'ai'
+    location: location
     logAnalyticsWorkspaceId: resources.outputs.AZURE_LOG_ANALYTICS_WORKSPACE_ID
   }
 }
@@ -50,11 +50,11 @@ module postgres_2 'postgres-2/aspire.hosting.azure.bicep.postgres.bicep' = {
   name: 'postgres-2'
   scope: rg
   params: {
-    location: location
     administratorLogin: administrator_login
     administratorLoginPassword: administratorLoginPassword
     databases: ['db2']
     keyVaultName: resources.outputs.SERVICE_BINDING_KV854251F1_NAME
+    location: location
     serverName: 'postgres-2'
   }
 }
@@ -74,8 +74,8 @@ module sql 'sql/aspire.hosting.azure.bicep.sql.bicep' = {
   name: 'sql'
   scope: rg
   params: {
-    location: location
     databases: ['db']
+    location: location
     principalId: resources.outputs.MANAGED_IDENTITY_PRINCIPAL_ID
     principalName: resources.outputs.MANAGED_IDENTITY_NAME
     serverName: 'sql'
@@ -85,8 +85,8 @@ module test 'test/test.bicep' = {
   name: 'test'
   scope: rg
   params: {
-    location: location
     host: 'frontend.internal.${resources.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}'
+    location: location
     test: parameter
     url: 'http://frontend.internal.${resources.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}'
     values: ['one','two']

--- a/cli/azd/resources/apphost/templates/main.bicept
+++ b/cli/azd/resources/apphost/templates/main.bicept
@@ -56,7 +56,6 @@ module {{bicepParameterName $name}} '{{ fixBackSlash $module.Path }}' = {
   name: '{{$name}}'
   scope: rg
   params: {
-    location: location
 {{- range $param, $value := $module.Params}}
     {{$param}}: {{$value}}
 {{- end}}

--- a/cli/azd/test/functional/testdata/snaps/aspire-full/infra/main.bicep
+++ b/cli/azd/test/functional/testdata/snaps/aspire-full/infra/main.bicep
@@ -37,8 +37,8 @@ module cosmos 'cosmos/cosmos.module.bicep' = {
   name: 'cosmos'
   scope: rg
   params: {
-    location: location
     keyVaultName: resources.outputs.SERVICE_BINDING_KVF2EDECB5_NAME
+    location: location
   }
 }
 module storage 'storage/storage.module.bicep' = {


### PR DESCRIPTION
If a bicep module is defined including the location parameter, azd will use that value instead of linking the `location` parameter from the main.bicep

fix: https://github.com/Azure/azure-dev/issues/3857
