### PR TITLE
Resolve secrets in pipeline config outside of the environment.

### DIFF
--- a/cli/azd/pkg/config/file_config_manager_test.go
+++ b/cli/azd/pkg/config/file_config_manager_test.go
@@ -97,6 +97,11 @@ func Test_FileConfigManager_GetSetSecrets(t *testing.T) {
 	missingPassword, ok := updatedConfig.GetString("secrets.misingVaultRef")
 	require.False(t, ok)
 	require.Empty(t, missingPassword)
+
+	require.NotEqual(t, updatedConfig.Raw(), updatedConfig.ResolvedRaw())
+	require.Equal(t, azdConfig.Raw(), updatedConfig.Raw())
+	require.Equal(t, azdConfig.ResolvedRaw(), updatedConfig.ResolvedRaw())
+
 }
 
 func Test_FileConfigManager_GetSetSecretsInSection(t *testing.T) {

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -366,8 +366,11 @@ func (pm *PipelineManager) Configure(ctx context.Context) (result *PipelineConfi
 	// the secrets would be resolved during save XD.
 	// This is a patch for pipeline config to do secrets-resolving outside of the environment.
 	for _, path := range configPaths {
+		// get will always return true (no need to check) because the path was gotten from the raw config
 		value, _ := pm.env.Config.Get(path)
-		resolvedConfig.Set(path, value)
+		if err := resolvedConfig.Set(path, value); err != nil {
+			return result, fmt.Errorf("failed setting initial azd config for CI: %w", err)
+		}
 	}
 	localEnvConfig, err := json.Marshal(resolvedConfig.Raw())
 	if err != nil {

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
@@ -358,21 +357,7 @@ func (pm *PipelineManager) Configure(ctx context.Context) (result *PipelineConfi
 	// Adding environment.AzdInitialEnvironmentConfigName as a secret to the pipeline as the base configuration for
 	// whenever a new environment is created. This means loading the local environment config into a pipeline secret which
 	// azd will use to restore the the config on CI
-	rawConfig := pm.env.Config.Raw()
-	configPaths := paths(rawConfig)
-	resolvedConfig := config.NewEmptyConfig()
-	// pm.env.Config.Raw does not resolve secrets refs to values like .Get() does
-	// The `Config.Raw()` api is used by the EnvManager-> Save(), so it can't resolve secrets b/c
-	// the secrets would be resolved during save XD.
-	// This is a patch for pipeline config to do secrets-resolving outside of the environment.
-	for _, path := range configPaths {
-		// get will always return true (no need to check) because the path was gotten from the raw config
-		value, _ := pm.env.Config.Get(path)
-		if err := resolvedConfig.Set(path, value); err != nil {
-			return result, fmt.Errorf("failed setting initial azd config for CI: %w", err)
-		}
-	}
-	localEnvConfig, err := json.Marshal(resolvedConfig.Raw())
+	localEnvConfig, err := json.Marshal(pm.env.Config.ResolvedRaw())
 	if err != nil {
 		return result, fmt.Errorf("failed to marshal environment config: %w", err)
 	}
@@ -453,23 +438,6 @@ func (pm *PipelineManager) Configure(ctx context.Context) (result *PipelineConfi
 		RepositoryLink: gitRepoInfo.url,
 		PipelineLink:   ciPipeline.url(),
 	}, nil
-}
-
-// paths recursively traverses a map and returns a list of all the paths to the leaf nodes.
-// The start parameter is the initial map to start traversing from.
-// It returns a slice of strings representing the paths to the leaf nodes.
-func paths(start map[string]any) []string {
-	var all []string
-	for path, value := range start {
-		if node, isNode := value.(map[string]any); isNode {
-			for _, child := range paths(node) {
-				all = append(all, fmt.Sprintf("%s.%s", path, child))
-			}
-		} else {
-			all = append(all, path)
-		}
-	}
-	return all
 }
 
 // requiredTools get all the provider's required tools.


### PR DESCRIPTION
Adding `ResolvedRaw()` to config for pulling all the config with any secret resolved