### PR TITLE
synth: Take `infra` section of `azure.yaml` into account

### DIFF
--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -202,7 +202,7 @@ func ContainerAppManifestTemplateForProject(
 
 // BicepTemplate returns a filesystem containing the generated bicep files for the given manifest. These files represent
 // the shared infrastructure that would normally be under the `infra/` folder for the given manifest.
-func BicepTemplate(manifest *Manifest, options AppHostOptions) (*memfs.FS, error) {
+func BicepTemplate(name string, manifest *Manifest, options AppHostOptions) (*memfs.FS, error) {
 	generator := newInfraGenerator()
 
 	if err := generator.LoadManifest(manifest); err != nil {
@@ -271,7 +271,7 @@ func BicepTemplate(manifest *Manifest, options AppHostOptions) (*memfs.FS, error
 		WithMetadataParameters:  parameters,
 		MainToResourcesParams:   mapToResourceParams,
 	}
-	if err := executeToFS(fs, genTemplates, "main.bicep", "main.bicep", context); err != nil {
+	if err := executeToFS(fs, genTemplates, "main.bicep", name+".bicep", context); err != nil {
 		return nil, fmt.Errorf("generating infra/main.bicep: %w", err)
 	}
 
@@ -280,7 +280,7 @@ func BicepTemplate(manifest *Manifest, options AppHostOptions) (*memfs.FS, error
 	}
 
 	if err := executeToFS(
-		fs, genTemplates, "main.parameters.json", "main.parameters.json", generator.bicepContext); err != nil {
+		fs, genTemplates, "main.parameters.json", name+".parameters.json", generator.bicepContext); err != nil {
 		return nil, fmt.Errorf("generating infra/resources.bicep: %w", err)
 	}
 

--- a/cli/azd/pkg/apphost/generate_test.go
+++ b/cli/azd/pkg/apphost/generate_test.go
@@ -99,7 +99,7 @@ func TestAspireStorageGeneration(t *testing.T) {
 	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli, "")
 	require.NoError(t, err)
 
-	files, err := BicepTemplate(m, AppHostOptions{})
+	files, err := BicepTemplate("main", m, AppHostOptions{})
 	require.NoError(t, err)
 
 	err = fs.WalkDir(files, ".", func(path string, d fs.DirEntry, err error) error {
@@ -141,7 +141,7 @@ func TestAspireBicepGeneration(t *testing.T) {
 	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli, "")
 	require.NoError(t, err)
 
-	files, err := BicepTemplate(m, AppHostOptions{})
+	files, err := BicepTemplate("main", m, AppHostOptions{})
 	require.NoError(t, err)
 
 	err = fs.WalkDir(files, ".", func(path string, d fs.DirEntry, err error) error {
@@ -192,7 +192,7 @@ func TestAspireDockerGeneration(t *testing.T) {
 		})
 	}
 
-	files, err := BicepTemplate(m, AppHostOptions{})
+	files, err := BicepTemplate("main", m, AppHostOptions{})
 	require.NoError(t, err)
 
 	err = fs.WalkDir(files, ".", func(path string, d fs.DirEntry, err error) error {
@@ -227,7 +227,7 @@ func TestAspireDashboardGeneration(t *testing.T) {
 	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli, "")
 	require.NoError(t, err)
 
-	files, err := BicepTemplate(m, AppHostOptions{AspireDashboard: true})
+	files, err := BicepTemplate("main", m, AppHostOptions{AspireDashboard: true})
 	require.NoError(t, err)
 
 	err = fs.WalkDir(files, ".", func(path string, d fs.DirEntry, err error) error {
@@ -281,7 +281,7 @@ func TestAspireContainerGeneration(t *testing.T) {
 	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli, "")
 	require.NoError(t, err)
 
-	files, err := BicepTemplate(m, AppHostOptions{})
+	files, err := BicepTemplate("main", m, AppHostOptions{})
 	require.NoError(t, err)
 
 	err = fs.WalkDir(files, ".", func(path string, d fs.DirEntry, err error) error {


### PR DESCRIPTION
`azd infra synth` was not taking the path to the shared infrastructure folder inor the name of the root module from the `infra` of `azure.yaml` into account, and instead just always generated files into the `infra` folder at the root of the project.

Since these were getting generated to the wrong place, they were ignored during future `azd provision` runs.

We now take these values into account when generating filenames and paths.