### PR TITLE
Sync container app revision KeyVault secrets 

### DIFF
--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -303,8 +303,10 @@ func (cas *containerAppService) syncSecrets(
 	secrets := []*armappcontainers.Secret{}
 	for _, secret := range secretsResponse.SecretsCollection.Value {
 		secrets = append(secrets, &armappcontainers.Secret{
-			Name:  secret.Name,
-			Value: secret.Value,
+			Name:        secret.Name,
+			Value:       secret.Value,
+			Identity:    secret.Identity,
+			KeyVaultURL: secret.KeyVaultURL,
 		})
 	}
 


### PR DESCRIPTION
This change fixes KeyVault secrets not being preserved for container app deployments.

We currently do a client-side fetch and patch operation on container app revisions for traditional (non-manifest) container app deployments. This involves fetching and setting the secrets since it's not returned in the initial container app GET request. As such, we need to roundtrip all available information, which includes the KeyVault related properties.

Fixes #3871