### PR TITLE
Remove err wrapping "invoking action"

### DIFF
--- a/cli/azd/pkg/ext/event_dispatcher.go
+++ b/cli/azd/pkg/ext/event_dispatcher.go
@@ -111,7 +111,7 @@ func (ed *EventDispatcher[T]) Invoke(ctx context.Context, name Event, eventArgs 
 	}
 
 	if err := action(); err != nil {
-		return fmt.Errorf("failing invoking action '%s', %w", name, err)
+		return err
 	}
 
 	if err := ed.RaiseEvent(ctx, postEventName, eventArgs); err != nil {


### PR DESCRIPTION
Remove generic error wrapping for "failing invoking action". 