### PR TITLE
easyinit: handle vite and Java

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -203,6 +203,7 @@ unsetenvs
 unsets
 upgrader
 utsname
+vite
 vsrpc
 vuejs
 webfrontend

--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -52,7 +52,6 @@ type Dependency string
 const (
 	JsReact   Dependency = "react"
 	JsAngular Dependency = "angular"
-	JsVue     Dependency = "vuejs"
 	JsJQuery  Dependency = "jquery"
 	JsVite    Dependency = "vite"
 
@@ -70,7 +69,7 @@ var WebUIFrameworks = map[Dependency]struct{}{
 
 func (f Dependency) Language() Language {
 	switch f {
-	case JsReact, JsAngular, JsVue, JsJQuery:
+	case JsReact, JsAngular, JsJQuery, JsVite:
 		return JavaScript
 	}
 

--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -54,6 +54,7 @@ const (
 	JsAngular Dependency = "angular"
 	JsVue     Dependency = "vuejs"
 	JsJQuery  Dependency = "jquery"
+	JsVite    Dependency = "vite"
 
 	PyFlask   Dependency = "flask"
 	PyDjango  Dependency = "django"
@@ -63,8 +64,8 @@ const (
 var WebUIFrameworks = map[Dependency]struct{}{
 	JsReact:   {},
 	JsAngular: {},
-	JsVue:     {},
 	JsJQuery:  {},
+	JsVite:    {},
 }
 
 func (f Dependency) Language() Language {
@@ -82,10 +83,10 @@ func (f Dependency) Display() string {
 		return "React"
 	case JsAngular:
 		return "Angular"
-	case JsVue:
-		return "Vue.js"
 	case JsJQuery:
 		return "JQuery"
+	case JsVite:
+		return "Vite"
 	}
 
 	return ""

--- a/cli/azd/internal/appdetect/appdetect_test.go
+++ b/cli/azd/internal/appdetect/appdetect_test.go
@@ -54,7 +54,7 @@ func TestDetect(t *testing.T) {
 						JsAngular,
 						JsJQuery,
 						JsReact,
-						JsVue,
+						JsVite,
 					},
 					DatabaseDeps: []DatabaseDep{
 						DbMongo,

--- a/cli/azd/internal/appdetect/javascript.go
+++ b/cli/azd/internal/appdetect/javascript.go
@@ -13,7 +13,8 @@ import (
 )
 
 type PackagesJson struct {
-	Dependencies map[string]string `json:"dependencies"`
+	Dependencies    map[string]string `json:"dependencies"`
+	DevDependencies map[string]string `json:"devDependencies"`
 }
 
 type javaScriptDetector struct {
@@ -44,6 +45,7 @@ func (nd *javaScriptDetector) DetectProject(ctx context.Context, path string, en
 			}
 
 			angularAdded := false
+			viteAdded := false
 			databaseDepMap := map[DatabaseDep]struct{}{}
 
 			for dep := range packagesJson.Dependencies {
@@ -52,8 +54,9 @@ func (nd *javaScriptDetector) DetectProject(ctx context.Context, path string, en
 					project.Dependencies = append(project.Dependencies, JsReact)
 				case "jquery":
 					project.Dependencies = append(project.Dependencies, JsJQuery)
-				case "vue":
-					project.Dependencies = append(project.Dependencies, JsVue)
+				case "vite":
+					project.Dependencies = append(project.Dependencies, JsVite)
+					viteAdded = true
 				default:
 					if strings.HasPrefix(dep, "@angular") && !angularAdded {
 						project.Dependencies = append(project.Dependencies, JsAngular)
@@ -72,6 +75,15 @@ func (nd *javaScriptDetector) DetectProject(ctx context.Context, path string, en
 					databaseDepMap[DbSqlServer] = struct{}{}
 				case "redis", "redis-om":
 					databaseDepMap[DbRedis] = struct{}{}
+				}
+			}
+
+			for dep := range packagesJson.DevDependencies {
+				switch dep {
+				case "vite":
+					if !viteAdded {
+						project.Dependencies = append(project.Dependencies, JsVite)
+					}
 				}
 			}
 

--- a/cli/azd/internal/appdetect/testdata/javascript-full/package.json
+++ b/cli/azd/internal/appdetect/testdata/javascript-full/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "chalk": "^5.0.1",
     "react": ">=18.2.0",
-    "vue": ">=3.3.4",
     "jquery": ">=3.7.0",
     "@angular/core": ">=16.1.2",
 
@@ -17,5 +16,8 @@
     "pg-promise": "^11.5.3",
     "tedious": "^16.4.0",
     "redis": "^4.6.10"
+  },
+  "devDependencies": {
+    "vite": ">=5.2.0"
   }
 }

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -388,7 +388,7 @@ func prjConfigFromDetect(
 		if prj.HasWebUIFramework() {
 			// By default, use 'dist'. This is common for frameworks such as:
 			// - TypeScript
-			// - Vue.js
+			// - Vite
 			svc.OutputPath = "dist"
 
 		loop:

--- a/cli/azd/internal/repository/infra_confirm.go
+++ b/cli/azd/internal/repository/infra_confirm.go
@@ -103,6 +103,10 @@ func (i *Initializer) infraSpecFromDetect(
 		if svc.Docker == nil || svc.Docker.Path == "" {
 			// default builder always specifies port 80
 			serviceSpec.Port = 80
+
+			if svc.Language == appdetect.Java {
+				serviceSpec.Port = 8080
+			}
 		}
 
 		for _, framework := range svc.Dependencies {

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -371,6 +371,10 @@ func (p *dockerProject) packBuild(
 		// Always default to port 80 for consistency across languages
 		environ = append(environ, "ORYX_RUNTIME_PORT=80")
 
+		if svc.Language == ServiceLanguageJava {
+			environ = append(environ, "ORYX_RUNTIME_PORT=8080")
+		}
+
 		if svc.OutputPath != "" && (svc.Language == ServiceLanguageTypeScript || svc.Language == ServiceLanguageJavaScript) {
 			inDockerOutputPath := path.Join("/workspace", svc.OutputPath)
 			// A dist folder has been set.


### PR DESCRIPTION
Add detection for vite as a static-front end. Remove Vue.js which uses Vite.

Update Java default port to 8080. Otherwise, Spring Boot fails to bind to port 80 in recent container images.