### PR TITLE
easyinit: Improve handling for empty state 

### DIFF
--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -54,6 +54,7 @@ const (
 	JsAngular Dependency = "angular"
 	JsJQuery  Dependency = "jquery"
 	JsVite    Dependency = "vite"
+	JsNext    Dependency = "next"
 
 	PyFlask   Dependency = "flask"
 	PyDjango  Dependency = "django"
@@ -86,6 +87,8 @@ func (f Dependency) Display() string {
 		return "JQuery"
 	case JsVite:
 		return "Vite"
+	case JsNext:
+		return "Next.js"
 	}
 
 	return ""

--- a/cli/azd/internal/appdetect/javascript.go
+++ b/cli/azd/internal/appdetect/javascript.go
@@ -57,6 +57,8 @@ func (nd *javaScriptDetector) DetectProject(ctx context.Context, path string, en
 				case "vite":
 					project.Dependencies = append(project.Dependencies, JsVite)
 					viteAdded = true
+				case "next":
+					project.Dependencies = append(project.Dependencies, JsNext)
 				default:
 					if strings.HasPrefix(dep, "@angular") && !angularAdded {
 						project.Dependencies = append(project.Dependencies, JsAngular)

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -233,10 +233,6 @@ func (i *Initializer) InitFromApp(
 
 	detect := detectConfirm{console: i.console}
 	detect.Init(projects, wd)
-	if len(detect.Services) == 0 {
-		return ErrNoServicesDetected
-	}
-
 	tracing.SetUsageAttributes(fields.AppInitLastStep.String("modify"))
 
 	// Confirm selection of services and databases

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -37,8 +36,6 @@ var dbMap = map[appdetect.DatabaseDep]struct{}{
 	appdetect.DbPostgres: {},
 	appdetect.DbRedis:    {},
 }
-
-var ErrNoServicesDetected = errors.New("no services detected in the current directory")
 
 // InitFromApp initializes the infra directory and project file from the current existing app.
 func (i *Initializer) InitFromApp(

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -387,6 +387,10 @@ func prjConfigFromDetect(
 		loop:
 			for _, dep := range prj.Dependencies {
 				switch dep {
+				case appdetect.JsNext:
+					// next.js works as SSR with default node configuration without static build output
+					svc.OutputPath = ""
+					break loop
 				case appdetect.JsVite:
 					svc.OutputPath = "dist"
 					break loop

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -387,10 +387,13 @@ func prjConfigFromDetect(
 		loop:
 			for _, dep := range prj.Dependencies {
 				switch dep {
-				case appdetect.JsReact:
-					// react uses 'build'
-					svc.OutputPath = "build"
+				case appdetect.JsVite:
+					svc.OutputPath = "dist"
 					break loop
+				case appdetect.JsReact:
+					// react from create-react-app uses 'build' when used, but this can be overridden
+					// by choice of build tool, such as when using Vite.
+					svc.OutputPath = "build"
 				case appdetect.JsAngular:
 					// angular uses dist/<project name>
 					svc.OutputPath = "dist/" + filepath.Base(rel)

--- a/cli/azd/internal/repository/detect_confirm.go
+++ b/cli/azd/internal/repository/detect_confirm.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -428,6 +429,27 @@ func (d *detectConfirm) add(ctx context.Context) error {
 			}
 
 			return nil
+		}
+	}
+
+	// Provide additional validation for project selection
+	if s.Language == appdetect.Python {
+		if _, err := os.Stat(filepath.Join(path, "requirements.txt")); errors.Is(err, os.ErrNotExist) {
+			d.console.Message(
+				ctx,
+				fmt.Sprintf("No '%s' file found in %s.",
+					output.WithBold("requirements.txt"),
+					output.WithHighLightFormat(path)))
+			confirm, err := d.console.Confirm(ctx, input.ConsoleOptions{
+				Message: "This file may be required when deploying to Azure. Continue?",
+			})
+			if err != nil {
+				return err
+			}
+
+			if !confirm {
+				return fmt.Errorf("cancelled")
+			}
 		}
 	}
 

--- a/cli/azd/internal/repository/detect_confirm.go
+++ b/cli/azd/internal/repository/detect_confirm.go
@@ -105,9 +105,8 @@ func (d *detectConfirm) Confirm(ctx context.Context) error {
 		if err := d.render(ctx); err != nil {
 			return err
 		}
-		d.modified = false
 
-		if len(d.Services) == 0 {
+		if len(d.Services) == 0 && !d.modified {
 			confirmAdd, err := d.console.Confirm(ctx, input.ConsoleOptions{
 				Message:      "Add an undetected service?",
 				DefaultValue: true,
@@ -127,6 +126,8 @@ func (d *detectConfirm) Confirm(ctx context.Context) error {
 			tracing.IncrementUsageAttribute(fields.AppInitModifyAddCount.Int(1))
 			continue
 		}
+
+		d.modified = false
 
 		continueOption, err := d.console.Select(ctx, input.ConsoleOptions{
 			Message: "Select an option",

--- a/cli/azd/internal/repository/detect_confirm_test.go
+++ b/cli/azd/internal/repository/detect_confirm_test.go
@@ -41,6 +41,23 @@ func Test_detectConfirm_confirm(t *testing.T) {
 		want         []appdetect.Project
 	}{
 		{
+			name:      "add from empty",
+			detection: []appdetect.Project{},
+			interactions: []string{
+				"y",
+				fmt.Sprintf("%s\t%s", appdetect.Java.Display(), "[Language]"),
+				"java-dir",
+				"Confirm and continue initializing my app",
+			},
+			want: []appdetect.Project{
+				{
+					Language:      appdetect.Java,
+					Path:          javaDir,
+					DetectionRule: string(EntryKindManual),
+				},
+			},
+		},
+		{
 			name: "confirm single",
 			detection: []appdetect.Project{
 				{

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -1084,6 +1084,10 @@ func GetStepResultFormat(result error) SpinnerUxType {
 // dirSuggestions provides suggestion completions for directories given the current input directory.
 func dirSuggestions(input string) []string {
 	completions := []string{}
+	if input == "" {
+		completions = append(completions, ".")
+	}
+
 	matches, _ := filepath.Glob(input + "*")
 	for _, match := range matches {
 		if fs, err := os.Stat(match); err == nil && fs.IsDir() {


### PR DESCRIPTION
When no services are detected, we now allow the user manually add undetected services instead of erroring out. This allows the user to progressively discover languages supported.

We also provide a slight disclosure when adding a Python project without 'requirements.txt'.

Screenshot example:
<img width="1433" alt="image" src="https://github.com/Azure/azure-dev/assets/2322434/18c0fe3c-f5d0-4ea1-b4c8-7b9a7b926d90">
