### PR TITLE
console: Fix type issues in `PromptDialog` with external prompting

### DIFF
--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -557,7 +557,12 @@ func (c *AskerConsole) PromptDialog(ctx context.Context, dialog PromptDialog) (m
 
 	ret := make(map[string]any, len(*resp.Inputs))
 	for _, v := range *resp.Inputs {
-		ret[v.ID] = v.Value
+		var unmarshalledValue any
+		if err := json.Unmarshal(v.Value, &unmarshalledValue); err != nil {
+			return nil, fmt.Errorf("unmarshalling value %s: %w", v.ID, err)
+		}
+
+		ret[v.ID] = unmarshalledValue
 	}
 
 	return ret, nil


### PR DESCRIPTION
The external prompt client returns us `json.RawMessage` values, per the API, but `PromptDialog` needs to return actual go values, as the rest of the system expects things like `string` or `int`.

Fixes #3902