### PR TITLE
Upgrade Todo python apps to B3 sku

### DIFF
--- a/templates/todo/projects/python-mongo/.repo/terraform/infra/main.tf
+++ b/templates/todo/projects/python-mongo/.repo/terraform/infra/main.tf
@@ -85,6 +85,7 @@ module "appserviceplan" {
   rg_name        = azurerm_resource_group.rg.name
   tags           = azurerm_resource_group.rg.tags
   resource_token = local.resource_token
+  sku_name       = "B3"
 }
 
 # ------------------------------------------------------------------------------------------------------
@@ -101,7 +102,7 @@ module "web" {
   appservice_plan_id = module.appserviceplan.APPSERVICE_PLAN_ID
 
   app_settings = {
-    "SCM_DO_BUILD_DURING_DEPLOYMENT"                  = "false"
+    "SCM_DO_BUILD_DURING_DEPLOYMENT" = "false"
   }
 
   app_command_line = "pm2 serve /home/site/wwwroot --no-daemon --spa"


### PR DESCRIPTION
B1 SKU seems to be too slow to run multiple Python apps.  
Upgrading this to B3 to match recent changes on the Bicep Todo versions.

Resolves #3893