### PR TITLE
fix exposedPort for Ingress

### DIFF
--- a/cli/azd/pkg/apphost/aca_ingress.go
+++ b/cli/azd/pkg/apphost/aca_ingress.go
@@ -278,9 +278,7 @@ func pickIngress(endpointByTargetPortProperties map[string]*acaPort, httpIngress
 		port := selectedIngress.port
 		finalIngress.Transport = acaIngressSchemaTcp
 		finalIngress.TargetPort = port
-		if selectedIngress.exposedPort != 0 {
-			finalIngress.ExposedPort = selectedIngress.exposedPort
-		}
+		finalIngress.ExposedPort = selectedIngress.exposedPort
 	}
 
 	for groupKey, props := range endpointByTargetPortProperties {
@@ -290,7 +288,8 @@ func pickIngress(endpointByTargetPortProperties map[string]*acaPort, httpIngress
 		finalIngress.AdditionalPortMappings = append(finalIngress.AdditionalPortMappings,
 			genContainerAppIngressAdditionalPortMappings{
 				genContainerAppIngressPort: genContainerAppIngressPort{
-					TargetPort: props.port,
+					TargetPort:  props.port,
+					ExposedPort: props.exposedPort,
 				},
 			})
 	}

--- a/cli/azd/pkg/apphost/aca_ingress.go
+++ b/cli/azd/pkg/apphost/aca_ingress.go
@@ -38,10 +38,11 @@ func buildAcaIngress(
 }
 
 type endpointGroupProperties struct {
-	port     int
-	external bool
-	httpOnly bool
-	hasHttp2 bool
+	port        int
+	external    bool
+	httpOnly    bool
+	hasHttp2    bool
+	exposedPort int
 }
 
 const (
@@ -126,6 +127,9 @@ func groupProperties(endpointByTargetPort map[string][]*bindingWithOrder) map[st
 			}
 			if binding.Transport == acaIngressTransportHttp2 {
 				props.hasHttp2 = true
+			}
+			if binding.Port != nil {
+				props.exposedPort = *binding.Port
 			}
 		}
 		endpointByTargetPortProperties[containerPort] = props
@@ -274,6 +278,9 @@ func pickIngress(endpointByTargetPortProperties map[string]*acaPort, httpIngress
 		port := selectedIngress.port
 		finalIngress.Transport = acaIngressSchemaTcp
 		finalIngress.TargetPort = port
+		if selectedIngress.exposedPort != 0 {
+			finalIngress.ExposedPort = selectedIngress.exposedPort
+		}
 	}
 
 	for groupKey, props := range endpointByTargetPortProperties {

--- a/cli/azd/pkg/apphost/generate_test.go
+++ b/cli/azd/pkg/apphost/generate_test.go
@@ -281,7 +281,7 @@ func TestAspireContainerGeneration(t *testing.T) {
 	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli, "")
 	require.NoError(t, err)
 
-	for _, name := range []string{"mysqlabstract", "my-sql-abstract", "noVolume"} {
+	for _, name := range []string{"mysqlabstract", "my-sql-abstract", "noVolume", "kafka"} {
 		t.Run(name, func(t *testing.T) {
 			tmpl, err := ContainerAppManifestTemplateForProject(m, name, AppHostOptions{})
 			require.NoError(t, err)

--- a/cli/azd/pkg/apphost/generate_types.go
+++ b/cli/azd/pkg/apphost/generate_types.go
@@ -35,8 +35,9 @@ type genContainerApp struct {
 }
 
 type genContainerAppIngressPort struct {
-	External   bool
-	TargetPort int
+	External    bool
+	TargetPort  int
+	ExposedPort int
 }
 
 type genContainerAppIngressAdditionalPortMappings struct {

--- a/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-kafka.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-kafka.snap
@@ -1,0 +1,38 @@
+api-version: 2024-02-02-preview
+location: {{ .Env.AZURE_LOCATION }}
+identity:
+  type: UserAssigned
+  userAssignedIdentities:
+    ? "{{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}"
+    : {}
+properties:
+  environmentId: {{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_ID }}
+  configuration:
+    activeRevisionsMode: single
+    runtime:
+      dotnet:
+        autoConfigureDataProtection: true
+    ingress:
+      external: false
+      targetPort: {{ targetPortOrDefault 9092 }}
+      exposedPort: 6000
+      transport: tcp
+      allowInsecure: false
+    registries:
+      - server: {{ .Env.AZURE_CONTAINER_REGISTRY_ENDPOINT }}
+        identity: {{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}
+  template:
+    containers:
+      - image: {{ .Image }}
+        name: kafka
+        env:
+          - name: AZURE_CLIENT_ID
+            value: {{ .Env.MANAGED_IDENTITY_CLIENT_ID }}
+          - name: KAFKA_ADVERTISED_LISTENERS
+            value: PLAINTEXT://localhost:29092,PLAINTEXT_HOST://localhost:9092
+    scale:
+      minReplicas: 1
+tags:
+  azd-service-name: kafka
+  aspire-resource-name: kafka
+

--- a/cli/azd/pkg/apphost/testdata/aspire-container.json
+++ b/cli/azd/pkg/apphost/testdata/aspire-container.json
@@ -167,6 +167,23 @@
         }
       },
       "connectionString": "Server={noVolume.bindings.tcp.host};Port={noVolume.bindings.tcp.port};User ID=root;Password={noVolume-password.value}"
+    },
+    "kafka": {
+      "type": "container.v0",
+      "connectionString": "{kafka.bindings.tcp.host}:{kafka.bindings.tcp.port}",
+      "image": "docker.io/confluentinc/confluent-local:7.6.1",
+      "env": {
+        "KAFKA_ADVERTISED_LISTENERS": "PLAINTEXT://localhost:29092,PLAINTEXT_HOST://localhost:9092"
+      },
+      "bindings": {
+        "tcp": {
+          "scheme": "tcp",
+          "protocol": "tcp",
+          "transport": "tcp",
+          "port": 6000,
+          "targetPort": 9092
+        }
+      }
     }
   }
 }

--- a/cli/azd/resources/apphost/templates/containerApp.tmpl.yamlt
+++ b/cli/azd/resources/apphost/templates/containerApp.tmpl.yamlt
@@ -47,6 +47,9 @@ properties:
 {{- end}}
       external: {{ .Ingress.External }}
       targetPort: {{ "{{ targetPortOrDefault " }}{{ .Ingress.TargetPort }}{{ " }}" }}
+{{- if gt .Ingress.ExposedPort 0 }}
+      exposedPort: {{ .Ingress.ExposedPort }}
+{{- end}}
       transport: {{ .Ingress.Transport }}
       allowInsecure: {{ .Ingress.AllowInsecure }}
 {{- end }}


### PR DESCRIPTION
Fix issue: 
  - Port was ignored when building the ingress for a non-http endpoint. Leaving the exposedPort as 0.


fix: https://github.com/dotnet/aspire/issues/4232
