### PR TITLE
Fixes issue selected environment with different environment type

### DIFF
--- a/cli/azd/.vscode/settings.json
+++ b/cli/azd/.vscode/settings.json
@@ -7,7 +7,7 @@
     "go.lintFlags": ["--fast"],
     "go.lintOnSave": "package",
     "go.lintTool": "golangci-lint",
-    "go.testTimeout": "30m",
+    "go.testTimeout": "10m",
     "files.associations": {
         "*.bicept": "go-template"
       }

--- a/cli/azd/.vscode/settings.json
+++ b/cli/azd/.vscode/settings.json
@@ -7,7 +7,7 @@
     "go.lintFlags": ["--fast"],
     "go.lintOnSave": "package",
     "go.lintTool": "golangci-lint",
-    "go.testTimeout": "10m",
+    "go.testTimeout": "30m",
     "files.associations": {
         "*.bicept": "go-template"
       }

--- a/cli/azd/pkg/devcenter/environment_store_test.go
+++ b/cli/azd/pkg/devcenter/environment_store_test.go
@@ -220,11 +220,16 @@ func Test_EnvironmentStore_Save(t *testing.T) {
 		name     string
 		env      *environment.Environment
 		config   *Config
+		isNew    bool
 		validate func(t *testing.T, env *environment.Environment)
 	}{
 		{
-			name: "BeforeProvision",
-			env:  environment.NewWithValues(mockEnvironments[0].Name, nil),
+			name: "NewEnvironment",
+			env: environment.NewWithValues(mockEnvironments[0].Name, map[string]string{
+				environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
+				environment.ResourceGroupEnvVarName:  "RESOURCE_GROUP_NAME",
+			}),
+			isNew: true,
 			config: &Config{
 				Name:                  "DEV_CENTER_01",
 				Project:               "Project1",
@@ -244,11 +249,12 @@ func Test_EnvironmentStore_Save(t *testing.T) {
 			},
 		},
 		{
-			name: "AfterProvision",
+			name: "ExistingEnvironment",
 			env: environment.NewWithValues(mockEnvironments[0].Name, map[string]string{
 				environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
 				environment.ResourceGroupEnvVarName:  "RESOURCE_GROUP_NAME",
 			}),
+			isNew: false,
 			config: &Config{
 				Name:                  "DEV_CENTER_01",
 				Project:               "Project1",
@@ -275,7 +281,7 @@ func Test_EnvironmentStore_Save(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			mockContext := mocks.NewMockContext(context.Background())
 			store := newEnvironmentStoreForTest(t, mockContext, test.config, nil)
-			err := store.Save(*mockContext.Context, test.env)
+			err := store.Save(*mockContext.Context, test.env, &environment.SaveOptions{IsNew: test.isNew})
 			require.NoError(t, err)
 			test.validate(t, test.env)
 		})

--- a/cli/azd/pkg/devcenter/manager.go
+++ b/cli/azd/pkg/devcenter/manager.go
@@ -276,7 +276,7 @@ func (m *manager) LatestArmDeployment(
 		// ARM runner deployments contain the deployment tags for the specific environment
 		isArmDeployment := devCenterOk && strings.EqualFold(*tagDevCenterName, config.Name) &&
 			projectOk && strings.EqualFold(*tagProjectName, config.Project) &&
-			envTypeOk && strings.EqualFold(*tagEnvTypeName, config.EnvironmentType) &&
+			envTypeOk && strings.EqualFold(*tagEnvTypeName, env.EnvironmentType) &&
 			envOk && strings.EqualFold(*tagEnvName, env.Name)
 
 		// Support for untagged Bicep ADE deployments

--- a/cli/azd/pkg/environment/data_store.go
+++ b/cli/azd/pkg/environment/data_store.go
@@ -18,6 +18,12 @@ var ValidRemoteKinds = []string{
 	string(RemoteKindAzureBlobStorage),
 }
 
+// SaveOptions provide additional metadata for the save operation
+type SaveOptions struct {
+	// Whether or not the environment is new
+	IsNew bool
+}
+
 type DataStore interface {
 	// Gets the path to the environment .env file
 	EnvPath(env *Environment) string
@@ -35,7 +41,7 @@ type DataStore interface {
 	Reload(ctx context.Context, env *Environment) error
 
 	// Saves the environment to the persistent data store
-	Save(ctx context.Context, env *Environment) error
+	Save(ctx context.Context, env *Environment, options *SaveOptions) error
 
 	// Deletes the environment from the persistent data store
 	Delete(ctx context.Context, name string) error

--- a/cli/azd/pkg/environment/local_file_data_store.go
+++ b/cli/azd/pkg/environment/local_file_data_store.go
@@ -132,7 +132,7 @@ func (fs *LocalFileDataStore) Reload(ctx context.Context, env *Environment) erro
 }
 
 // Save saves the environment to the persistent data store
-func (fs *LocalFileDataStore) Save(ctx context.Context, env *Environment) error {
+func (fs *LocalFileDataStore) Save(ctx context.Context, env *Environment, options *SaveOptions) error {
 	// Update configuration
 	if err := fs.configManager.Save(env.Config, fs.ConfigPath(env)); err != nil {
 		return fmt.Errorf("saving config: %w", err)

--- a/cli/azd/pkg/environment/local_file_data_store_test.go
+++ b/cli/azd/pkg/environment/local_file_data_store_test.go
@@ -19,11 +19,11 @@ func Test_LocalFileDataStore_List(t *testing.T) {
 
 	t.Run("List", func(t *testing.T) {
 		env1 := New("env1")
-		err := dataStore.Save(*mockContext.Context, env1)
+		err := dataStore.Save(*mockContext.Context, env1, nil)
 		require.NoError(t, err)
 
 		env2 := New("env2")
-		err = dataStore.Save(*mockContext.Context, env2)
+		err = dataStore.Save(*mockContext.Context, env2, nil)
 		require.NoError(t, err)
 
 		envList, err := dataStore.List(*mockContext.Context)
@@ -48,7 +48,7 @@ func Test_LocalFileDataStore_SaveAndGet(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		env1 := New("env1")
 		env1.DotenvSet("key1", "value1")
-		err := dataStore.Save(*mockContext.Context, env1)
+		err := dataStore.Save(*mockContext.Context, env1, nil)
 		require.NoError(t, err)
 
 		env, err := dataStore.Get(*mockContext.Context, "env1")

--- a/cli/azd/pkg/environment/manager_test.go
+++ b/cli/azd/pkg/environment/manager_test.go
@@ -227,7 +227,7 @@ func Test_EnvManager_Get(t *testing.T) {
 
 		localDataStore.On("Get", *mockContext.Context, "env1").Return(nil, ErrNotFound)
 		remoteDataStore.On("Get", *mockContext.Context, "env1").Return(getEnv, nil)
-		localDataStore.On("Save", *mockContext.Context, getEnv).Return(nil)
+		localDataStore.On("Save", *mockContext.Context, getEnv, mock.Anything).Return(nil)
 
 		manager := newManagerForTest(azdContext, mockContext.Console, localDataStore, remoteDataStore)
 		env, err := manager.Get(*mockContext.Context, "env1")
@@ -259,7 +259,7 @@ func Test_EnvManager_Get(t *testing.T) {
 		})
 
 		localDataStore.On("Get", *mockContext.Context, "env1").Return(foundEnv, nil)
-		localDataStore.On("Save", *mockContext.Context, foundEnv).Return(nil)
+		localDataStore.On("Save", *mockContext.Context, foundEnv, mock.Anything).Return(nil)
 
 		manager := newManagerForTest(azdContext, mockContext.Console, localDataStore, nil)
 		env, err := manager.Get(*mockContext.Context, "env1")
@@ -269,7 +269,7 @@ func Test_EnvManager_Get(t *testing.T) {
 		require.Equal(t, "env1", env.Name())
 		require.Equal(t, "env1", env.Getenv(EnvNameEnvVarName))
 
-		localDataStore.AssertCalled(t, "Save", *mockContext.Context, foundEnv)
+		localDataStore.AssertCalled(t, "Save", *mockContext.Context, foundEnv, mock.Anything)
 	})
 }
 
@@ -285,15 +285,15 @@ func Test_EnvManager_Save(t *testing.T) {
 			"key1": "value1",
 		})
 
-		localDataStore.On("Save", *mockContext.Context, env).Return(nil)
-		remoteDataStore.On("Save", *mockContext.Context, env).Return(nil)
+		localDataStore.On("Save", *mockContext.Context, env, mock.Anything).Return(nil)
+		remoteDataStore.On("Save", *mockContext.Context, env, mock.Anything).Return(nil)
 
 		manager := newManagerForTest(azdContext, mockContext.Console, localDataStore, remoteDataStore)
 		err := manager.Save(*mockContext.Context, env)
 		require.NoError(t, err)
 
-		localDataStore.AssertCalled(t, "Save", *mockContext.Context, env)
-		remoteDataStore.AssertCalled(t, "Save", *mockContext.Context, env)
+		localDataStore.AssertCalled(t, "Save", *mockContext.Context, env, mock.Anything)
+		remoteDataStore.AssertCalled(t, "Save", *mockContext.Context, env, mock.Anything)
 	})
 
 	t.Run("Error", func(t *testing.T) {
@@ -304,14 +304,14 @@ func Test_EnvManager_Save(t *testing.T) {
 			"key1": "value1",
 		})
 
-		localDataStore.On("Save", *mockContext.Context, env).Return(errors.New("error"))
+		localDataStore.On("Save", *mockContext.Context, env, mock.Anything).Return(errors.New("error"))
 
 		manager := newManagerForTest(azdContext, mockContext.Console, localDataStore, remoteDataStore)
 		err := manager.Save(*mockContext.Context, env)
 		require.Error(t, err)
 
-		localDataStore.AssertCalled(t, "Save", *mockContext.Context, env)
-		remoteDataStore.AssertNotCalled(t, "Save", *mockContext.Context, env)
+		localDataStore.AssertCalled(t, "Save", *mockContext.Context, env, mock.Anything)
+		remoteDataStore.AssertNotCalled(t, "Save", *mockContext.Context, env, mock.Anything)
 	})
 }
 
@@ -433,8 +433,8 @@ func (m *MockDataStore) Reload(ctx context.Context, env *Environment) error {
 	return args.Error(0)
 }
 
-func (m *MockDataStore) Save(ctx context.Context, env *Environment) error {
-	args := m.Called(ctx, env)
+func (m *MockDataStore) Save(ctx context.Context, env *Environment, options *SaveOptions) error {
+	args := m.Called(ctx, env, options)
 	return args.Error(0)
 }
 

--- a/cli/azd/pkg/environment/storage_blob_data_store.go
+++ b/cli/azd/pkg/environment/storage_blob_data_store.go
@@ -116,7 +116,7 @@ func (sbd *StorageBlobDataStore) Get(ctx context.Context, name string) (*Environ
 	return env, nil
 }
 
-func (sbd *StorageBlobDataStore) Save(ctx context.Context, env *Environment) error {
+func (sbd *StorageBlobDataStore) Save(ctx context.Context, env *Environment, options *SaveOptions) error {
 	// Update configuration
 	cfgWriter := new(bytes.Buffer)
 

--- a/cli/azd/pkg/environment/storage_blob_data_store_test.go
+++ b/cli/azd/pkg/environment/storage_blob_data_store_test.go
@@ -78,7 +78,7 @@ func Test_StorageBlobDataStore_SaveAndGet(t *testing.T) {
 
 		env1 := New("env1")
 		env1.DotenvSet("key1", "value1")
-		err := dataStore.Save(*mockContext.Context, env1)
+		err := dataStore.Save(*mockContext.Context, env1, nil)
 		require.NoError(t, err)
 
 		env, err := dataStore.Get(*mockContext.Context, "env1")

--- a/cli/azd/test/functional/initialize_test.go
+++ b/cli/azd/test/functional/initialize_test.go
@@ -63,7 +63,7 @@ func Test_CommandsAndActions_Initialize(t *testing.T) {
 	env := environment.New(envName)
 	env.SetSubscriptionId(cfg.SubscriptionID)
 	env.SetLocation(cfg.Location)
-	err = localDataStore.Save(ctx, env)
+	err = localDataStore.Save(ctx, env, nil)
 	require.NoError(t, err)
 
 	// Also requires that the user is logged in. This is automatically done in CI. Locally, `azd auth login` is required.

--- a/cli/azd/test/mocks/mockenv/mock_manager.go
+++ b/cli/azd/test/mocks/mockenv/mock_manager.go
@@ -36,6 +36,15 @@ func (m *MockEnvManager) Save(ctx context.Context, env *environment.Environment)
 	return args.Error(0)
 }
 
+func (m *MockEnvManager) SaveWithOptions(
+	ctx context.Context,
+	env *environment.Environment,
+	options *environment.SaveOptions,
+) error {
+	args := m.Called(ctx, env, options)
+	return args.Error(0)
+}
+
 func (m *MockEnvManager) Reload(ctx context.Context, env *environment.Environment) error {
 	args := m.Called(ctx, env)
 	return args.Error(0)


### PR DESCRIPTION
Fixes #3861

- [x] Fixes comparison check against the specified ADE environment instead of the currently loaded devcenter configuration
- [x] Fixes an issue when creating new environment it automatically copies the project/environment type of the currently loaded environment instead of allowing the user to select new values on next provision. 

What was happening in the linked issue is that the ARM deployment object was comparing the deployment object tags against the currently loaded devcenter environment instead of the found matching devcenter environment.