### PR TITLE
Update the infra/core modules to AVM modules of "todo-nodejs-mongo-aks"

### DIFF
--- a/templates/todo/common/infra/bicep/app/applicationinsights-dashboard.bicep
+++ b/templates/todo/common/infra/bicep/app/applicationinsights-dashboard.bicep
@@ -1,0 +1,1236 @@
+metadata description = 'Creates a dashboard for an Application Insights instance.'
+param name string
+param applicationInsightsName string
+param location string = resourceGroup().location
+param tags object = {}
+
+// 2020-09-01-preview because that is the latest valid version
+resource applicationInsightsDashboard 'Microsoft.Portal/dashboards@2020-09-01-preview' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    lenses: [
+      {
+        order: 0
+        parts: [
+          {
+            position: {
+              x: 0
+              y: 0
+              colSpan: 2
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'id'
+                  value: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                }
+                {
+                  name: 'Version'
+                  value: '1.0'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/AspNetOverviewPinnedPart'
+              asset: {
+                idInputName: 'id'
+                type: 'ApplicationInsights'
+              }
+              defaultMenuItemId: 'overview'
+            }
+          }
+          {
+            position: {
+              x: 2
+              y: 0
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'Version'
+                  value: '1.0'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/ProactiveDetectionAsyncPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+              defaultMenuItemId: 'ProactiveDetection'
+            }
+          }
+          {
+            position: {
+              x: 3
+              y: 0
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'ResourceId'
+                  value: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/QuickPulseButtonSmallPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+            }
+          }
+          {
+            position: {
+              x: 4
+              y: 0
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'TimeContext'
+                  value: {
+                    durationMs: 86400000
+                    endTime: null
+                    createdTime: '2018-05-04T01:20:33.345Z'
+                    isInitialTime: true
+                    grain: 1
+                    useDashboardTimeRange: false
+                  }
+                }
+                {
+                  name: 'Version'
+                  value: '1.0'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/AvailabilityNavButtonPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+            }
+          }
+          {
+            position: {
+              x: 5
+              y: 0
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'TimeContext'
+                  value: {
+                    durationMs: 86400000
+                    endTime: null
+                    createdTime: '2018-05-08T18:47:35.237Z'
+                    isInitialTime: true
+                    grain: 1
+                    useDashboardTimeRange: false
+                  }
+                }
+                {
+                  name: 'ConfigurationId'
+                  value: '78ce933e-e864-4b05-a27b-71fd55a6afad'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/AppMapButtonPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+            }
+          }
+          {
+            position: {
+              x: 0
+              y: 1
+              colSpan: 3
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: []
+              type: 'Extension/HubsExtension/PartType/MarkdownPart'
+              settings: {
+                content: {
+                  settings: {
+                    content: '# Usage'
+                    title: ''
+                    subtitle: ''
+                  }
+                }
+              }
+            }
+          }
+          {
+            position: {
+              x: 3
+              y: 1
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'TimeContext'
+                  value: {
+                    durationMs: 86400000
+                    endTime: null
+                    createdTime: '2018-05-04T01:22:35.782Z'
+                    isInitialTime: true
+                    grain: 1
+                    useDashboardTimeRange: false
+                  }
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/UsageUsersOverviewPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+            }
+          }
+          {
+            position: {
+              x: 4
+              y: 1
+              colSpan: 3
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: []
+              type: 'Extension/HubsExtension/PartType/MarkdownPart'
+              settings: {
+                content: {
+                  settings: {
+                    content: '# Reliability'
+                    title: ''
+                    subtitle: ''
+                  }
+                }
+              }
+            }
+          }
+          {
+            position: {
+              x: 7
+              y: 1
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ResourceId'
+                  value: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                }
+                {
+                  name: 'DataModel'
+                  value: {
+                    version: '1.0.0'
+                    timeContext: {
+                      durationMs: 86400000
+                      createdTime: '2018-05-04T23:42:40.072Z'
+                      isInitialTime: false
+                      grain: 1
+                      useDashboardTimeRange: false
+                    }
+                  }
+                  isOptional: true
+                }
+                {
+                  name: 'ConfigurationId'
+                  value: '8a02f7bf-ac0f-40e1-afe9-f0e72cfee77f'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/CuratedBladeFailuresPinnedPart'
+              isAdapter: true
+              asset: {
+                idInputName: 'ResourceId'
+                type: 'ApplicationInsights'
+              }
+              defaultMenuItemId: 'failures'
+            }
+          }
+          {
+            position: {
+              x: 8
+              y: 1
+              colSpan: 3
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: []
+              type: 'Extension/HubsExtension/PartType/MarkdownPart'
+              settings: {
+                content: {
+                  settings: {
+                    content: '# Responsiveness\r\n'
+                    title: ''
+                    subtitle: ''
+                  }
+                }
+              }
+            }
+          }
+          {
+            position: {
+              x: 11
+              y: 1
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ResourceId'
+                  value: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                }
+                {
+                  name: 'DataModel'
+                  value: {
+                    version: '1.0.0'
+                    timeContext: {
+                      durationMs: 86400000
+                      createdTime: '2018-05-04T23:43:37.804Z'
+                      isInitialTime: false
+                      grain: 1
+                      useDashboardTimeRange: false
+                    }
+                  }
+                  isOptional: true
+                }
+                {
+                  name: 'ConfigurationId'
+                  value: '2a8ede4f-2bee-4b9c-aed9-2db0e8a01865'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/CuratedBladePerformancePinnedPart'
+              isAdapter: true
+              asset: {
+                idInputName: 'ResourceId'
+                type: 'ApplicationInsights'
+              }
+              defaultMenuItemId: 'performance'
+            }
+          }
+          {
+            position: {
+              x: 12
+              y: 1
+              colSpan: 3
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: []
+              type: 'Extension/HubsExtension/PartType/MarkdownPart'
+              settings: {
+                content: {
+                  settings: {
+                    content: '# Browser'
+                    title: ''
+                    subtitle: ''
+                  }
+                }
+              }
+            }
+          }
+          {
+            position: {
+              x: 15
+              y: 1
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'MetricsExplorerJsonDefinitionId'
+                  value: 'BrowserPerformanceTimelineMetrics'
+                }
+                {
+                  name: 'TimeContext'
+                  value: {
+                    durationMs: 86400000
+                    createdTime: '2018-05-08T12:16:27.534Z'
+                    isInitialTime: false
+                    grain: 1
+                    useDashboardTimeRange: false
+                  }
+                }
+                {
+                  name: 'CurrentFilter'
+                  value: {
+                    eventTypes: [
+                      4
+                      1
+                      3
+                      5
+                      2
+                      6
+                      13
+                    ]
+                    typeFacets: {}
+                    isPermissive: false
+                  }
+                }
+                {
+                  name: 'id'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'Version'
+                  value: '1.0'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/MetricsExplorerBladePinnedPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+              defaultMenuItemId: 'browser'
+            }
+          }
+          {
+            position: {
+              x: 0
+              y: 2
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'sessions/count'
+                          aggregationType: 5
+                          namespace: 'microsoft.insights/components/kusto'
+                          metricVisualization: {
+                            displayName: 'Sessions'
+                            color: '#47BDF5'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'users/count'
+                          aggregationType: 5
+                          namespace: 'microsoft.insights/components/kusto'
+                          metricVisualization: {
+                            displayName: 'Users'
+                            color: '#7E58FF'
+                          }
+                        }
+                      ]
+                      title: 'Unique sessions and users'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                      openBladeOnClick: {
+                        openBlade: true
+                        destinationBlade: {
+                          extensionName: 'HubsExtension'
+                          bladeName: 'ResourceMenuBlade'
+                          parameters: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                            menuid: 'segmentationUsers'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 4
+              y: 2
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'requests/failed'
+                          aggregationType: 7
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Failed requests'
+                            color: '#EC008C'
+                          }
+                        }
+                      ]
+                      title: 'Failed requests'
+                      visualization: {
+                        chartType: 3
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                      openBladeOnClick: {
+                        openBlade: true
+                        destinationBlade: {
+                          extensionName: 'HubsExtension'
+                          bladeName: 'ResourceMenuBlade'
+                          parameters: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                            menuid: 'failures'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 8
+              y: 2
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'requests/duration'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Server response time'
+                            color: '#00BCF2'
+                          }
+                        }
+                      ]
+                      title: 'Server response time'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                      openBladeOnClick: {
+                        openBlade: true
+                        destinationBlade: {
+                          extensionName: 'HubsExtension'
+                          bladeName: 'ResourceMenuBlade'
+                          parameters: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                            menuid: 'performance'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 12
+              y: 2
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'browserTimings/networkDuration'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Page load network connect time'
+                            color: '#7E58FF'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'browserTimings/processingDuration'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Client processing time'
+                            color: '#44F1C8'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'browserTimings/sendDuration'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Send request time'
+                            color: '#EB9371'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'browserTimings/receiveDuration'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Receiving response time'
+                            color: '#0672F1'
+                          }
+                        }
+                      ]
+                      title: 'Average page load time breakdown'
+                      visualization: {
+                        chartType: 3
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 0
+              y: 5
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'availabilityResults/availabilityPercentage'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Availability'
+                            color: '#47BDF5'
+                          }
+                        }
+                      ]
+                      title: 'Average availability'
+                      visualization: {
+                        chartType: 3
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                      openBladeOnClick: {
+                        openBlade: true
+                        destinationBlade: {
+                          extensionName: 'HubsExtension'
+                          bladeName: 'ResourceMenuBlade'
+                          parameters: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                            menuid: 'availability'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 4
+              y: 5
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'exceptions/server'
+                          aggregationType: 7
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Server exceptions'
+                            color: '#47BDF5'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'dependencies/failed'
+                          aggregationType: 7
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Dependency failures'
+                            color: '#7E58FF'
+                          }
+                        }
+                      ]
+                      title: 'Server exceptions and Dependency failures'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 8
+              y: 5
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'performanceCounters/processorCpuPercentage'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Processor time'
+                            color: '#47BDF5'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'performanceCounters/processCpuPercentage'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Process CPU'
+                            color: '#7E58FF'
+                          }
+                        }
+                      ]
+                      title: 'Average processor and process CPU utilization'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 12
+              y: 5
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'exceptions/browser'
+                          aggregationType: 7
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Browser exceptions'
+                            color: '#47BDF5'
+                          }
+                        }
+                      ]
+                      title: 'Browser exceptions'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 0
+              y: 8
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'availabilityResults/count'
+                          aggregationType: 7
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Availability test results count'
+                            color: '#47BDF5'
+                          }
+                        }
+                      ]
+                      title: 'Availability test results count'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 4
+              y: 8
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'performanceCounters/processIOBytesPerSecond'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Process IO rate'
+                            color: '#47BDF5'
+                          }
+                        }
+                      ]
+                      title: 'Average process I/O rate'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 8
+              y: 8
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'performanceCounters/memoryAvailableBytes'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Available memory'
+                            color: '#47BDF5'
+                          }
+                        }
+                      ]
+                      title: 'Average available memory'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+
+resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing = {
+  name: applicationInsightsName
+}

--- a/templates/todo/projects/nodejs-mongo-aks/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo-aks/.repo/bicep/infra/main.bicep
@@ -159,7 +159,6 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.1.7
       {
         principalId: principalId
         roleDefinitionIdOrName: aksClusterAdminRole
-        principalType: principalType
       }
     ]
     monitoringWorkspaceId: loganalytics.outputs.resourceId

--- a/templates/todo/projects/nodejs-mongo-aks/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo-aks/.repo/bicep/infra/main.bicep
@@ -65,6 +65,10 @@ param collections array = [
 @description('Id of the user or app to assign application roles')
 param principalId string = ''
 
+@description('The type of principal to assign application roles')
+@allowed(['Device', 'ForeignGroup', 'Group', 'ServicePrincipal', 'User'])
+param principalType string = 'User'
+
 @allowed([
   'CostOptimised'
   'Standard'
@@ -155,7 +159,7 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.1.7
       {
         principalId: principalId
         roleDefinitionIdOrName: aksClusterAdminRole
-        principalType: 'User'
+        principalType: principalType
       }
     ]
     monitoringWorkspaceId: loganalytics.outputs.resourceId

--- a/templates/todo/projects/nodejs-mongo-aks/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo-aks/.repo/bicep/infra/main.bicep
@@ -26,17 +26,102 @@ param cosmosDatabaseName string = ''
 param keyVaultName string = ''
 param logAnalyticsName string = ''
 param resourceGroupName string = ''
+param connectionStringKey string = 'AZURE-COSMOS-CONNECTION-STRING'
+param collections array = [
+  {
+    name: 'TodoList'
+    id: 'TodoList'
+    shardKey: {keys: [
+      'Hash'
+    ]}
+    indexes: [
+      {
+        key: {
+          keys: [
+            '_id'
+          ]
+        }
+      }
+    ]
+  }
+  {
+    name: 'TodoItem'
+    id: 'TodoItem'
+    shardKey: {keys: [
+      'Hash'
+    ]}
+    indexes: [
+      {
+        key: {
+          keys: [
+            '_id'
+          ]
+        }
+      }
+    ]
+  }
+]
 
 @description('Id of the user or app to assign application roles')
 param principalId string = ''
 
-@description('The type of principal to assign application roles')
-@allowed(['Device', 'ForeignGroup', 'Group', 'ServicePrincipal', 'User'])
-param principalType string = 'User'
+@allowed([
+  'CostOptimised'
+  'Standard'
+  'HighSpec'
+  'Custom'
+])
+@description('The System Pool Preset sizing')
+param systemPoolType string = 'CostOptimised'
 
 var abbrs = loadJsonContent('../../../../../../common/infra/bicep/abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
 var tags = { 'azd-env-name': environmentName }
+var acrPullRole = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+var aksClusterAdminRole = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b')
+var systemPoolSpec = nodePoolPresets[systemPoolType]
+var nodePoolBase = {
+  osType: 'Linux'
+  maxPods: 30
+  type: 'VirtualMachineScaleSets'
+  upgradeSettings: {
+    maxSurge: '33%'
+  }
+}
+var nodePoolPresets = {
+  CostOptimised: {
+    vmSize: 'Standard_B4ms'
+    count: 1
+    minCount: 1
+    maxCount: 3
+    enableAutoScaling: true
+    availabilityZones: []
+  }
+  Standard: {
+    vmSize: 'Standard_DS2_v2'
+    count: 3
+    minCount: 3
+    maxCount: 5
+    enableAutoScaling: true
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+  HighSpec: {
+    vmSize: 'Standard_D4s_v3'
+    count: 3
+    minCount: 3
+    maxCount: 5
+    enableAutoScaling: true
+    availabilityZones: [
+      '1'
+      '2'
+      '3'
+    ]
+  }
+}
 
 // Organize resources in a resource group
 resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
@@ -46,72 +131,216 @@ resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
 }
 
 // The AKS cluster to host applications
-module aks '../../../../../../common/infra/bicep/core/host/aks.bicep' = {
-  name: 'aks'
+module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.1.7' = {
+  name: 'managed-cluster'
   scope: rg
   params: {
-    location: location
     name: !empty(clusterName) ? clusterName : '${abbrs.containerServiceManagedClusters}${resourceToken}'
-    containerRegistryName: !empty(containerRegistryName) ? containerRegistryName : '${abbrs.containerRegistryRegistries}${resourceToken}'
-    logAnalyticsName: monitoring.outputs.logAnalyticsWorkspaceName
-    keyVaultName: keyVault.outputs.name
-    principalId: principalId
-    principalType: principalType
-    // Set enableAzureRbac & disableLocalAccounts to use Azure AD for authentication and authorization
-    enableAzureRbac: false
-    disableLocalAccounts: false
+    primaryAgentPoolProfile: [
+      union(
+        { name: 'npsystem', mode: 'System' },
+        nodePoolBase,
+        systemPoolSpec
+      )
+    ]
+    skuTier: 'Free'
+    kubernetesVersion: '1.27.7'
+    location: location
+    networkPlugin: 'azure'
+    networkPolicy: 'azure'
+    publicNetworkAccess: 'Enabled'
+    webApplicationRoutingEnabled: true
+    enableKeyvaultSecretsProvider: true
+    roleAssignments: [
+      {
+        principalId: principalId
+        roleDefinitionIdOrName: aksClusterAdminRole
+        principalType: 'User'
+      }
+    ]
+    monitoringWorkspaceId: loganalytics.outputs.resourceId
+    diagnosticSettings: [
+      {
+        workspaceResourceId: loganalytics.outputs.resourceId
+        logCategoriesAndGroups: [
+          {
+            category: 'cluster-autoscaler'
+            enabled: true
+          }
+          {
+            category: 'kube-controller-manager'
+            enabled: true
+          }
+          {
+            category: 'kube-audit-admin'
+            enabled: true
+          }
+          {
+            category: 'guard'
+            enabled: true
+          }
+        ]
+        metricCategories: [
+          {
+            category: 'AllMetrics'
+          }
+        ]
+      }
+    ]
+    agentPools: [
+      {
+        name: 'npuserpool'
+        mode: 'User'
+        osType: 'Linux'
+        maxPods: 30
+        type: 'VirtualMachineScaleSets'
+        maxSurge: '33%'
+        vmSize: 'standard_a2'
+      }
+    ]
+    managedIdentities: {
+      systemAssigned: true
+    }
+  }
+}
+
+//Azure Container Registries (ACR)
+module containerRegistry 'br/public:avm/res/container-registry/registry:0.1.1' = {
+  name: 'container-registry'
+  scope: rg
+  params: {
+    name: !empty(containerRegistryName) ? containerRegistryName : '${abbrs.containerRegistryRegistries}${resourceToken}'
+    acrSku: 'Basic'
+    publicNetworkAccess: 'Enabled'
+    location: location
+    diagnosticSettings: [
+      {
+        workspaceResourceId: loganalytics.outputs.resourceId
+        logCategoriesAndGroups: [
+          {
+            category: 'ContainerRegistryRepositoryEvents'
+            enabled: true
+          }
+          {
+            category: 'ContainerRegistryLoginEvents'
+            enabled: true
+          }
+        ]
+        metricCategories: [
+          {
+            category: 'AllMetrics'
+            enabled: true
+          }
+        ]
+      }
+    ]
+    roleAssignments: [
+      {
+        principalId: managedCluster.outputs.kubeletIdentityObjectId
+        roleDefinitionIdOrName: acrPullRole
+        principalType: 'ServicePrincipal'
+      }
+    ]
   }
 }
 
 // The application database
-module cosmos '../../../../../common/infra/bicep/app/cosmos-mongo-db.bicep' = {
+module cosmos 'br/public:avm/res/document-db/database-account:0.5.1' = {
   name: 'cosmos'
   scope: rg
   params: {
-    accountName: !empty(cosmosAccountName) ? cosmosAccountName : '${abbrs.documentDBDatabaseAccounts}${resourceToken}'
-    databaseName: cosmosDatabaseName
+    locations: [
+      {
+        failoverPriority: 0
+        isZoneRedundant: false
+        locationName: location
+      }
+    ]
+    name: !empty(cosmosAccountName) ? cosmosAccountName : '${abbrs.documentDBDatabaseAccounts}${resourceToken}'
     location: location
-    tags: tags
-    keyVaultName: keyVault.outputs.name
+    mongodbDatabases: [
+      {
+        name: 'Todo'
+        tags: tags
+        collections: collections
+      }
+    ]
+    secretsKeyVault: {
+      keyVaultName: keyVault.outputs.name
+      primaryWriteConnectionStringSecretName: connectionStringKey
+    }
   }
 }
 
 // Store secrets in a keyvault
-module keyVault '../../../../../../common/infra/bicep/core/security/keyvault.bicep' = {
+module keyVault 'br/public:avm/res/key-vault/vault:0.3.5' = {
   name: 'keyvault'
   scope: rg
   params: {
     name: !empty(keyVaultName) ? keyVaultName : '${abbrs.keyVaultVaults}${resourceToken}'
     location: location
     tags: tags
-    principalId: principalId
+    enableRbacAuthorization: false
+    accessPolicies: [
+      {
+        objectId: managedCluster.outputs.kubeletIdentityObjectId
+        permissions: {
+          secrets: [ 'get', 'list' ]
+        }
+      }
+      {
+        objectId: principalId
+        permissions: {
+          secrets: [ 'get', 'list' ]
+        }
+      }
+    ]
   }
 }
 
-// Monitor application with Azure Monitor
-module monitoring '../../../../../../common/infra/bicep/core/monitor/monitoring.bicep' = {
-  name: 'monitoring'
+// Monitor application with Azure loganalytics
+module loganalytics 'br/public:avm/res/operational-insights/workspace:0.3.4' = {
+  name: 'loganalytics'
   scope: rg
   params: {
+    name: !empty(logAnalyticsName) ? logAnalyticsName : '${abbrs.operationalInsightsWorkspaces}${resourceToken}'
     location: location
-    tags: tags
-    logAnalyticsName: !empty(logAnalyticsName) ? logAnalyticsName : '${abbrs.operationalInsightsWorkspaces}${resourceToken}'
-    applicationInsightsName: !empty(applicationInsightsName) ? applicationInsightsName : '${abbrs.insightsComponents}${resourceToken}'
-    applicationInsightsDashboardName: !empty(applicationInsightsDashboardName) ? applicationInsightsDashboardName : '${abbrs.portalDashboards}${resourceToken}'
+  }
+}
+
+// Monitor application with Azure applicationInsights
+module applicationInsights 'br/public:avm/res/insights/component:0.3.0' = {
+  name: 'applicationInsights'
+  scope: rg
+  params: {
+    name: !empty(applicationInsightsName) ? applicationInsightsName : '${abbrs.insightsComponents}${resourceToken}'
+    workspaceResourceId: loganalytics.outputs.resourceId
+    location: location
+  }
+}
+
+// Monitor application with Azure applicationInsightsDashboard
+module applicationInsightsDashboard '../../../../../common/infra/bicep/app/applicationinsights-dashboard.bicep' = {
+  name: 'application-insights-dashboard'
+  scope: rg
+  params: {
+    name: !empty(applicationInsightsDashboardName) ? applicationInsightsDashboardName : '${abbrs.portalDashboards}${resourceToken}'
+    location: location
+    applicationInsightsName: applicationInsights.outputs.name
   }
 }
 
 // Data outputs
-output AZURE_COSMOS_CONNECTION_STRING_KEY string = cosmos.outputs.connectionStringKey
-output AZURE_COSMOS_DATABASE_NAME string = cosmos.outputs.databaseName
+output AZURE_COSMOS_CONNECTION_STRING_KEY string = connectionStringKey
+output AZURE_COSMOS_DATABASE_NAME string = !empty(cosmosDatabaseName) ? cosmosDatabaseName: 'Todo'
 
 // App outputs
-output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.applicationInsightsConnectionString
-output AZURE_KEY_VAULT_ENDPOINT string = keyVault.outputs.endpoint
+output APPLICATIONINSIGHTS_CONNECTION_STRING string = applicationInsights.outputs.connectionString
+output AZURE_KEY_VAULT_ENDPOINT string = keyVault.outputs.uri
 output AZURE_KEY_VAULT_NAME string = keyVault.outputs.name
 output AZURE_LOCATION string = location
 output AZURE_TENANT_ID string = tenant().tenantId
-output AZURE_AKS_CLUSTER_NAME string = aks.outputs.clusterName
-output AZURE_AKS_IDENTITY_CLIENT_ID string = aks.outputs.clusterIdentity.clientId
-output AZURE_CONTAINER_REGISTRY_ENDPOINT string = aks.outputs.containerRegistryLoginServer
-output AZURE_CONTAINER_REGISTRY_NAME string = aks.outputs.containerRegistryName
+output AZURE_AKS_CLUSTER_NAME string = managedCluster.outputs.name
+output AZURE_AKS_IDENTITY_CLIENT_ID string = managedCluster.outputs.kubeletIdentityClientId
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.outputs.loginServer
+output AZURE_CONTAINER_REGISTRY_NAME string = containerRegistry.outputs.name

--- a/templates/todo/projects/nodejs-mongo-aks/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/nodejs-mongo-aks/.repo/bicep/repo.yaml
@@ -85,6 +85,9 @@ repo:
     - from: ../../../../common/infra/bicep/app/cosmos-mongo-db.bicep
       to: ./infra/app/db.bicep
 
+    - from: ../../../../common/infra/bicep/app/applicationinsights-dashboard.bicep
+      to: ./infra/app/applicationinsights-dashboard.bicep
+
     - from: ./../../
       to: ./
       ignore:


### PR DESCRIPTION
Update the infra/core modules to AVM modules for `todo-nodejs-mongo-aks`.

**1. Modules not replaced by AVM**
- **Monitoring (applicationinsights-dashboard)** : Missing the feature `Microsoft.Portal/dashboards`.
AVM issue link: https://github.com/Azure/bicep-registry-modules/issues/1130

**2. Modules replaced by AVM**

- **Managed Cluster**
- **Container Registry**
- **Key Vault**
- **Cosmos mongo**
- **Azure loganalytics**
- **Azure applicationInsights**

@jongio for notification.
