### PR TITLE
project: Support Remote Builds

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -29,6 +29,7 @@ aspnetcore
 asyncmy
 asyncpg
 azapi
+azblob
 AZCLI
 azcorelog
 azdcli
@@ -53,6 +54,7 @@ azureutil
 azureyaml
 Backticks
 bicepparam
+blockblob
 BOOLSLICE
 BUILDID
 BUILDNUMBER
@@ -108,6 +110,7 @@ goterm
 gotest
 gotestsum
 hotspot
+ignorefile
 iidfile
 ineffassign
 jaegertracing
@@ -126,6 +129,7 @@ mgmt
 mgutz
 microsoftonline
 missingkey
+moby
 mockarmresources
 mockazcli
 mongojs
@@ -150,6 +154,7 @@ otlptrace
 otlptracehttp
 overriden
 paketobuildpacks
+patternmatcher
 pflag
 posix
 preinit

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -29,6 +29,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/containerapps"
+	"github.com/azure/azure-dev/cli/azd/pkg/containerregistry"
 	"github.com/azure/azure-dev/cli/azd/pkg/devcenter"
 	"github.com/azure/azure-dev/cli/azd/pkg/entraid"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
@@ -570,9 +571,12 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.MustRegisterSingleton(entraid.NewEntraIdService)
 	container.MustRegisterSingleton(azcli.NewContainerRegistryService)
 	container.MustRegisterSingleton(containerapps.NewContainerAppService)
+	container.MustRegisterSingleton(containerregistry.NewRemoteBuildManager)
 	container.MustRegisterSingleton(keyvault.NewKeyVaultService)
 	container.MustRegisterSingleton(storage.NewFileShareService)
+	container.MustRegisterScoped(project.NewImageHelper)
 	container.MustRegisterScoped(project.NewContainerHelper)
+	container.MustRegisterScoped(project.NewRemoteBuildHelper)
 	container.MustRegisterSingleton(azcli.NewSpringService)
 
 	container.MustRegisterSingleton(func(subManager *account.SubscriptionsManager) account.SubscriptionTenantResolver {

--- a/cli/azd/pkg/containerregistry/pack_source.go
+++ b/cli/azd/pkg/containerregistry/pack_source.go
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package containerregistry
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	"github.com/moby/patternmatcher"
+	"github.com/moby/patternmatcher/ignorefile"
+)
+
+// PackRemoteBuildSource creates a tarball of the specified context directory into a temporary file and returns the path to
+// it. It ensures that the dockerfile is present in the tarball and returns the relative path of it in the archive. If the
+// dockerfile is located outside of the context, it is added to the root of the archive with a unique prefix.
+//
+// This tarball may be used as source input for the ACR Remote Build feature.
+//
+// On error, if the archive had been created, the path is returned. The caller should ensure it is removed.
+//
+// A `.dockerignore` file may be used to control what is included in the build context. If a file with the same path as
+// `dockerfile` exists but with an additional `.dockerignore` suffix, it is used as the ignore file. Otherwise, if a
+// `.dockerignore` file exists in the root of the context, it is used.
+//
+// Any folders named `.git` is excluded from the produced archive.
+func PackRemoteBuildSource(ctx context.Context, root string, dockerfile string) (string, string, error) {
+	var ignores []string
+
+	// Like docker, we allow the use of a .dockerignore file to control what is included in the build context.
+	candidates := []string{dockerfile + ".dockerignore", filepath.Join(root, ".dockerignore")}
+
+	for _, candidate := range candidates {
+		f, err := os.Open(candidate)
+		if err == nil {
+			defer f.Close()
+			i, err := ignorefile.ReadAll(f)
+			if err != nil {
+				return "", "", err
+			}
+			ignores = i
+			break
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", "", err
+		}
+	}
+
+	contextArchive, err := os.CreateTemp("", "azd-docker-context*.tar.gz")
+	if err != nil {
+		return "", "", err
+	}
+	defer contextArchive.Close()
+
+	gw := gzip.NewWriter(contextArchive)
+	defer gw.Close()
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	var dockerfileArchivePath string
+
+	err = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if filepath.Base(path) == ".git" {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		archivePath := filepath.ToSlash(path[len(root)+1:])
+
+		ignore, err := patternmatcher.MatchesOrParentMatches(archivePath, ignores)
+		if err != nil {
+			return err
+		}
+
+		if !ignore {
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+
+			hdr, err := tar.FileInfoHeader(info, info.Name())
+			if err != nil {
+				return err
+			}
+
+			hdr.Name = archivePath
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+
+			err = func() error {
+				f, err := os.Open(path)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+
+				_, err = io.Copy(tw, f)
+				if err != nil {
+					return err
+				}
+
+				return nil
+			}()
+			if err != nil {
+				return err
+			}
+
+			if path == dockerfile {
+				dockerfileArchivePath = archivePath
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return contextArchive.Name(), dockerfileArchivePath, err
+	}
+
+	// If we didn't see the dockerfile in the context, add it to the archive at the root with a unique name.
+	if dockerfileArchivePath == "" {
+		f, err := os.Open(dockerfile)
+		if err != nil {
+			return contextArchive.Name(), dockerfileArchivePath, err
+		}
+		defer f.Close()
+		info, err := f.Stat()
+		if err != nil {
+			return contextArchive.Name(), dockerfileArchivePath, err
+		}
+
+		hdr, err := tar.FileInfoHeader(info, info.Name())
+		if err != nil {
+			return contextArchive.Name(), dockerfileArchivePath, err
+		}
+
+		uniqueName := uuid.NewString() + "_" + filepath.Base(dockerfile)
+
+		hdr.Name = uniqueName
+		if err := tw.WriteHeader(hdr); err != nil {
+			return contextArchive.Name(), dockerfileArchivePath, err
+		}
+
+		_, err = io.Copy(tw, f)
+		if err != nil {
+			return contextArchive.Name(), dockerfileArchivePath, err
+		}
+
+		dockerfileArchivePath = uniqueName
+	}
+
+	return contextArchive.Name(), dockerfileArchivePath, err
+}

--- a/cli/azd/pkg/containerregistry/remote_build.go
+++ b/cli/azd/pkg/containerregistry/remote_build.go
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package containerregistry
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/azure/azure-dev/cli/azd/pkg/account"
+	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
+)
+
+// RemoteBuildManager provides functionality to interact with the Azure Container Registry Remote Build feature.
+type RemoteBuildManager struct {
+	credentialProvider account.SubscriptionCredentialProvider
+	httpClient         httputil.HttpClient
+	armClientOptions   *arm.ClientOptions
+}
+
+// UploadBuildSource uploads the build source to the specified registry. The returned SourceUploadDefinition may be used
+// when scheduling a build to reference the uploaded source.
+func (r *RemoteBuildManager) UploadBuildSource(
+	ctx context.Context,
+	subscriptionID string,
+	resourceGroupName string,
+	registryName string,
+	buildSourcePath string,
+) (armcontainerregistry.SourceUploadDefinition, error) {
+	cred, err := r.credentialProvider.CredentialForSubscription(ctx, subscriptionID)
+	if err != nil {
+		return armcontainerregistry.SourceUploadDefinition{}, err
+	}
+
+	regClient, err := armcontainerregistry.NewRegistriesClient(subscriptionID, cred, r.armClientOptions)
+	if err != nil {
+		return armcontainerregistry.SourceUploadDefinition{}, err
+	}
+
+	sourceUploadRes, err := regClient.GetBuildSourceUploadURL(ctx, resourceGroupName, registryName, nil)
+	if err != nil {
+		return armcontainerregistry.SourceUploadDefinition{}, err
+	}
+
+	blobClient, err := blockblob.NewClientWithNoCredential(*sourceUploadRes.UploadURL, nil)
+	if err != nil {
+		return armcontainerregistry.SourceUploadDefinition{}, err
+	}
+
+	dockerContext, err := os.Open(buildSourcePath)
+	if err != nil {
+		return armcontainerregistry.SourceUploadDefinition{}, err
+	}
+	defer dockerContext.Close()
+
+	_, err = blobClient.UploadFile(context.Background(), dockerContext, nil)
+	if err != nil {
+		return armcontainerregistry.SourceUploadDefinition{}, err
+	}
+
+	return sourceUploadRes.SourceUploadDefinition, nil
+}
+
+// RunDockerBuildRequestWithLogs initiates a remote build on the specified registry and streams the logs to the provided
+// writer.
+func (r *RemoteBuildManager) RunDockerBuildRequestWithLogs(
+	ctx context.Context,
+	subscriptionID, resourceGroupName, registryName string,
+	buildRequest *armcontainerregistry.DockerBuildRequest,
+	writer io.Writer,
+) error {
+	cred, err := r.credentialProvider.CredentialForSubscription(ctx, subscriptionID)
+	if err != nil {
+		return err
+	}
+
+	regClient, err := armcontainerregistry.NewRegistriesClient(subscriptionID, cred, r.armClientOptions)
+	if err != nil {
+		return err
+	}
+
+	runPoller, err := regClient.BeginScheduleRun(ctx, resourceGroupName, registryName, buildRequest, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := runPoller.Poll(ctx)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var runResp armcontainerregistry.RegistriesClientScheduleRunResponse
+	if err := json.NewDecoder(resp.Body).Decode(&runResp); err != nil {
+		return err
+	}
+
+	runClient, err := armcontainerregistry.NewRunsClient(subscriptionID, cred, r.armClientOptions)
+	if err != nil {
+		return err
+	}
+
+	logRes, err := runClient.GetLogSasURL(ctx, resourceGroupName, registryName, *runResp.Properties.RunID, nil)
+	if err != nil {
+		return err
+	}
+
+	logBlobClient, err := blockblob.NewClientWithNoCredential(*logRes.LogLink, &blockblob.ClientOptions{
+		ClientOptions: r.armClientOptions.ClientOptions,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = streamLogs(ctx, logBlobClient, writer)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// streamLogs streams the logs from the specified blob client to the provided writer, until the log is marked as complete
+// or an error occurs.
+func streamLogs(ctx context.Context, blobClient *blockblob.Client, writer io.Writer) error {
+	var written int64 = 0
+	for {
+		props, err := blobClient.GetProperties(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+		length := *props.ContentLength
+		if (length - written) == 0 {
+			if props.Metadata != nil {
+				if _, has := props.Metadata["Complete"]; has {
+					return nil
+				}
+			}
+
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		err = func() error {
+			res, err := blobClient.DownloadStream(ctx, &blob.DownloadStreamOptions{
+				Range: azblob.HTTPRange{
+					Offset: written,
+					Count:  length - written,
+				},
+			})
+			if err != nil {
+				return err
+			}
+			defer res.Body.Close()
+			copied, err := io.Copy(writer, res.Body)
+			if err != nil {
+				return err
+			}
+			written += copied
+			return nil
+		}()
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func NewRemoteBuildManager(
+	credentialProvider account.SubscriptionCredentialProvider,
+	httpClient httputil.HttpClient,
+	armClientOptions *arm.ClientOptions,
+) *RemoteBuildManager {
+	return &RemoteBuildManager{
+		credentialProvider: credentialProvider,
+		httpClient:         httpClient,
+		armClientOptions:   armClientOptions,
+	}
+}

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -16,23 +16,22 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
-	"github.com/benbjohnson/clock"
 	"github.com/sethvargo/go-retry"
 )
 
 type ContainerHelper struct {
 	env                      *environment.Environment
 	envManager               environment.Manager
+	imageHelper              *ImageHelper
 	containerRegistryService azcli.ContainerRegistryService
 	docker                   docker.Docker
-	clock                    clock.Clock
 	cloud                    *cloud.Cloud
 }
 
 func NewContainerHelper(
 	env *environment.Environment,
 	envManager environment.Manager,
-	clock clock.Clock,
+	imageHelper *ImageHelper,
 	containerRegistryService azcli.ContainerRegistryService,
 	docker docker.Docker,
 	cloud *cloud.Cloud,
@@ -40,141 +39,11 @@ func NewContainerHelper(
 	return &ContainerHelper{
 		env:                      env,
 		envManager:               envManager,
+		imageHelper:              imageHelper,
 		containerRegistryService: containerRegistryService,
 		docker:                   docker,
-		clock:                    clock,
 		cloud:                    cloud,
 	}
-}
-
-// DefaultImageName returns a default image name generated from the service name and environment name.
-func (ch *ContainerHelper) DefaultImageName(serviceConfig *ServiceConfig) string {
-	return fmt.Sprintf("%s/%s-%s",
-		strings.ToLower(serviceConfig.Project.Name),
-		strings.ToLower(serviceConfig.Name),
-		strings.ToLower(ch.env.Name()))
-}
-
-// DefaultImageTag returns a default image tag generated from the current time.
-func (ch *ContainerHelper) DefaultImageTag() string {
-	return fmt.Sprintf("azd-deploy-%d", ch.clock.Now().Unix())
-}
-
-// RegistryName returns the name of the destination container registry to use for the current environment from the following:
-// 1. AZURE_CONTAINER_REGISTRY_ENDPOINT environment variable
-// 2. docker.registry from the service configuration
-func (ch *ContainerHelper) RegistryName(ctx context.Context, serviceConfig *ServiceConfig) (string, error) {
-	registryName, found := ch.env.LookupEnv(environment.ContainerRegistryEndpointEnvVarName)
-	if !found {
-		log.Printf(
-			"Container registry not found in '%s' environment variable\n",
-			environment.ContainerRegistryEndpointEnvVarName,
-		)
-	}
-
-	if registryName == "" {
-		yamlRegistryName, err := serviceConfig.Docker.Registry.Envsubst(ch.env.Getenv)
-		if err != nil {
-			log.Println("Failed expanding 'docker.registry'")
-		}
-
-		registryName = yamlRegistryName
-	}
-
-	// If the service provides its own code artifacts then the expectation is that an images needs to be built and
-	// pushed to a container registry.
-	// If the service does not provide its own code artifacts then the expectation is a registry is optional and
-	// an image can be referenced independently.
-	if serviceConfig.RelativePath != "" && registryName == "" {
-		return "", fmt.Errorf(
-			//nolint:lll
-			"could not determine container registry endpoint, ensure 'registry' has been set in the docker options or '%s' environment variable has been set",
-			environment.ContainerRegistryEndpointEnvVarName,
-		)
-	}
-
-	return registryName, nil
-}
-
-// GeneratedImage returns the configured image from the service configuration
-// or a default image name generated from the service name and environment name.
-func (ch *ContainerHelper) GeneratedImage(
-	ctx context.Context,
-	serviceConfig *ServiceConfig,
-) (*docker.ContainerImage, error) {
-	// Parse the image from azure.yaml configuration when available
-	configuredImage, err := serviceConfig.Docker.Image.Envsubst(ch.env.Getenv)
-	if err != nil {
-		return nil, fmt.Errorf("failed parsing 'image' from docker configuration, %w", err)
-	}
-
-	// Set default image name if not configured
-	if configuredImage == "" {
-		configuredImage = ch.DefaultImageName(serviceConfig)
-	}
-
-	parsedImage, err := docker.ParseContainerImage(configuredImage)
-	if err != nil {
-		return nil, fmt.Errorf("failed parsing configured image, %w", err)
-	}
-
-	if parsedImage.Tag == "" {
-		configuredTag, err := serviceConfig.Docker.Tag.Envsubst(ch.env.Getenv)
-		if err != nil {
-			return nil, fmt.Errorf("failed parsing 'tag' from docker configuration, %w", err)
-		}
-
-		// Set default tag if not configured
-		if configuredTag == "" {
-			configuredTag = ch.DefaultImageTag()
-		}
-
-		parsedImage.Tag = configuredTag
-	}
-
-	// Set default registry if not configured
-	if parsedImage.Registry == "" {
-		// This can fail if called before provisioning the registry
-		configuredRegistry, err := ch.RegistryName(ctx, serviceConfig)
-		if err == nil {
-			parsedImage.Registry = configuredRegistry
-		}
-	}
-
-	return parsedImage, nil
-}
-
-// RemoteImageTag returns the remote image tag for the service configuration.
-func (ch *ContainerHelper) RemoteImageTag(
-	ctx context.Context,
-	serviceConfig *ServiceConfig,
-	localImageTag string,
-) (string, error) {
-	registryName, err := ch.RegistryName(ctx, serviceConfig)
-	if err != nil {
-		return "", err
-	}
-
-	containerImage, err := docker.ParseContainerImage(localImageTag)
-	if err != nil {
-		return "", err
-	}
-
-	if registryName != "" {
-		containerImage.Registry = registryName
-	}
-
-	return containerImage.Remote(), nil
-}
-
-// LocalImageTag returns the local image tag for the service configuration.
-func (ch *ContainerHelper) LocalImageTag(ctx context.Context, serviceConfig *ServiceConfig) (string, error) {
-	configuredImage, err := ch.GeneratedImage(ctx, serviceConfig)
-	if err != nil {
-		return "", err
-	}
-
-	return configuredImage.Local(), nil
 }
 
 func (ch *ContainerHelper) RequiredExternalTools(context.Context) []tools.ExternalTool {
@@ -187,7 +56,7 @@ func (ch *ContainerHelper) Login(
 	ctx context.Context,
 	serviceConfig *ServiceConfig,
 ) (string, error) {
-	registryName, err := ch.RegistryName(ctx, serviceConfig)
+	registryName, err := ch.imageHelper.RegistryName(ctx, serviceConfig)
 	if err != nil {
 		return "", err
 	}
@@ -209,7 +78,7 @@ func (ch *ContainerHelper) Credentials(
 	serviceConfig *ServiceConfig,
 	targetResource *environment.TargetResource,
 ) (*azcli.DockerCredentials, error) {
-	loginServer, err := ch.RegistryName(ctx, serviceConfig)
+	loginServer, err := ch.imageHelper.RegistryName(ctx, serviceConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +119,7 @@ func (ch *ContainerHelper) Deploy(
 	progress *async.Progress[ServiceProgress],
 ) (*ServiceDeployResult, error) {
 	// Get ACR Login Server
-	registryName, err := ch.RegistryName(ctx, serviceConfig)
+	registryName, err := ch.imageHelper.RegistryName(ctx, serviceConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +160,7 @@ func (ch *ContainerHelper) Deploy(
 
 			// Tag image
 			// Get remote remoteImageWithTag from the container helper then call docker cli remoteImageWithTag command
-			remoteImageWithTag, err := ch.RemoteImageTag(ctx, serviceConfig, targetImage)
+			remoteImageWithTag, err := ch.imageHelper.RemoteImageTag(ctx, serviceConfig, targetImage)
 			if err != nil {
 				return nil, fmt.Errorf("getting remote image tag: %w", err)
 			}

--- a/cli/azd/pkg/project/framework_service.go
+++ b/cli/azd/pkg/project/framework_service.go
@@ -64,7 +64,7 @@ type FrameworkPackageRequirements struct {
 // restore and build commands
 type FrameworkService interface {
 	// Gets a list of the required external tools for the framework service
-	RequiredExternalTools(ctx context.Context) []tools.ExternalTool
+	RequiredExternalTools(ctx context.Context, serviceConfig *ServiceConfig) []tools.ExternalTool
 
 	// Initializes the framework service for the specified service configuration
 	// This is useful if the framework needs to subscribe to any service events

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -34,14 +34,15 @@ import (
 )
 
 type DockerProjectOptions struct {
-	Path      string                  `yaml:"path,omitempty"      json:"path,omitempty"`
-	Context   string                  `yaml:"context,omitempty"   json:"context,omitempty"`
-	Platform  string                  `yaml:"platform,omitempty"  json:"platform,omitempty"`
-	Target    string                  `yaml:"target,omitempty"    json:"target,omitempty"`
-	Registry  osutil.ExpandableString `yaml:"registry,omitempty"  json:"registry,omitempty"`
-	Image     osutil.ExpandableString `yaml:"image,omitempty"     json:"image,omitempty"`
-	Tag       osutil.ExpandableString `yaml:"tag,omitempty"       json:"tag,omitempty"`
-	BuildArgs []string                `yaml:"buildArgs,omitempty" json:"buildArgs,omitempty"`
+	Path        string                  `yaml:"path,omitempty"      json:"path,omitempty"`
+	Context     string                  `yaml:"context,omitempty"   json:"context,omitempty"`
+	Platform    string                  `yaml:"platform,omitempty"  json:"platform,omitempty"`
+	Target      string                  `yaml:"target,omitempty"    json:"target,omitempty"`
+	Registry    osutil.ExpandableString `yaml:"registry,omitempty"  json:"registry,omitempty"`
+	Image       osutil.ExpandableString `yaml:"image,omitempty"     json:"image,omitempty"`
+	Tag         osutil.ExpandableString `yaml:"tag,omitempty"       json:"tag,omitempty"`
+	RemoteBuild bool                    `yaml:"remoteBuild,omitempty" json:"remoteBuild,omitempty"`
+	BuildArgs   []string                `yaml:"buildArgs,omitempty" json:"buildArgs,omitempty"`
 	// not supported from azure.yaml directly yet. Adding it for Aspire to use it, initially.
 	// Aspire would pass the secret keys, which are env vars that azd will set just to run docker build.
 	BuildSecrets []string `yaml:"-" json:"-"`
@@ -111,6 +112,7 @@ type dockerProject struct {
 	docker              docker.Docker
 	framework           FrameworkService
 	containerHelper     *ContainerHelper
+	imageHelper         *ImageHelper
 	console             input.Console
 	alphaFeatureManager *alpha.FeatureManager
 	commandRunner       exec.CommandRunner
@@ -122,6 +124,7 @@ func NewDockerProject(
 	env *environment.Environment,
 	docker docker.Docker,
 	containerHelper *ContainerHelper,
+	imageHelper *ImageHelper,
 	console input.Console,
 	alphaFeatureManager *alpha.FeatureManager,
 	commandRunner exec.CommandRunner,
@@ -130,6 +133,7 @@ func NewDockerProject(
 		env:                 env,
 		docker:              docker,
 		containerHelper:     containerHelper,
+		imageHelper:         imageHelper,
 		console:             console,
 		alphaFeatureManager: alphaFeatureManager,
 		commandRunner:       commandRunner,
@@ -144,11 +148,12 @@ func NewDockerProjectAsFrameworkService(
 	env *environment.Environment,
 	docker docker.Docker,
 	containerHelper *ContainerHelper,
+	imageHelper *ImageHelper,
 	console input.Console,
 	alphaFeatureManager *alpha.FeatureManager,
 	commandRunner exec.CommandRunner,
 ) FrameworkService {
-	return NewDockerProject(env, docker, containerHelper, console, alphaFeatureManager, commandRunner)
+	return NewDockerProject(env, docker, containerHelper, imageHelper, console, alphaFeatureManager, commandRunner)
 }
 
 func (p *dockerProject) Requirements() FrameworkRequirements {
@@ -162,7 +167,11 @@ func (p *dockerProject) Requirements() FrameworkRequirements {
 }
 
 // Gets the required external tools for the project
-func (p *dockerProject) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
+func (p *dockerProject) RequiredExternalTools(_ context.Context, sc *ServiceConfig) []tools.ExternalTool {
+	if sc.Docker.RemoteBuild {
+		return []tools.ExternalTool{}
+	}
+
 	return []tools.ExternalTool{p.docker}
 }
 
@@ -194,6 +203,10 @@ func (p *dockerProject) Build(
 	restoreOutput *ServiceRestoreResult,
 	progress *async.Progress[ServiceProgress],
 ) (*ServiceBuildResult, error) {
+	if serviceConfig.Docker.RemoteBuild {
+		return &ServiceBuildResult{Restore: restoreOutput}, nil
+	}
+
 	dockerOptions := getDockerOptionsWithDefaults(serviceConfig.Docker)
 
 	resolveParameters := func(source []string) ([]string, error) {
@@ -320,6 +333,10 @@ func (p *dockerProject) Package(
 	buildOutput *ServiceBuildResult,
 	progress *async.Progress[ServiceProgress],
 ) (*ServicePackageResult, error) {
+	if serviceConfig.Docker.RemoteBuild {
+		return &ServicePackageResult{Build: buildOutput}, nil
+	}
+
 	var imageId string
 
 	if buildOutput != nil {
@@ -349,7 +366,7 @@ func (p *dockerProject) Package(
 	}
 
 	// Generate a local tag from the 'docker' configuration section of the service
-	imageWithTag, err := p.containerHelper.LocalImageTag(ctx, serviceConfig)
+	imageWithTag, err := p.imageHelper.LocalImageTag(ctx, serviceConfig)
 	if err != nil {
 		return nil, fmt.Errorf("generating local image tag: %w", err)
 	}

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -162,7 +162,7 @@ func (p *dockerProject) Requirements() FrameworkRequirements {
 }
 
 // Gets the required external tools for the project
-func (p *dockerProject) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (p *dockerProject) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{p.docker}
 }
 

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -104,10 +104,13 @@ services:
 	internalFramework := NewNpmProject(npmCli, env)
 	progressMessages := []string{}
 
+	imageHelper := NewImageHelper(env, clock.NewMock())
+
 	framework := NewDockerProject(
 		env,
 		docker,
-		NewContainerHelper(env, envManager, clock.NewMock(), nil, docker, cloud.AzurePublic()),
+		NewContainerHelper(env, envManager, imageHelper, nil, docker, cloud.AzurePublic()),
+		imageHelper,
 		mockinput.NewMockConsole(),
 		mockContext.AlphaFeaturesManager,
 		mockContext.CommandRunner)
@@ -208,10 +211,13 @@ services:
 	internalFramework := NewNpmProject(npmCli, env)
 	status := ""
 
+	imageHelper := NewImageHelper(env, clock.NewMock())
+
 	framework := NewDockerProject(
 		env,
 		docker,
-		NewContainerHelper(env, envManager, clock.NewMock(), nil, docker, cloud.AzurePublic()),
+		NewContainerHelper(env, envManager, imageHelper, nil, docker, cloud.AzurePublic()),
+		imageHelper,
 		mockinput.NewMockConsole(),
 		mockContext.AlphaFeaturesManager,
 		mockContext.CommandRunner)
@@ -407,10 +413,13 @@ func Test_DockerProject_Build(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			imageHelper := NewImageHelper(env, clock.NewMock())
+
 			dockerProject := NewDockerProject(
 				env,
 				dockerCli,
-				NewContainerHelper(env, envManager, clock.NewMock(), nil, dockerCli, cloud.AzurePublic()),
+				NewContainerHelper(env, envManager, imageHelper, nil, dockerCli, cloud.AzurePublic()),
+				imageHelper,
 				mockinput.NewMockConsole(),
 				mockContext.AlphaFeaturesManager,
 				mockContext.CommandRunner)
@@ -523,10 +532,13 @@ func Test_DockerProject_Package(t *testing.T) {
 			dockerCli := docker.NewDocker(mockContext.CommandRunner)
 			serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
 
+			imageHelper := NewImageHelper(env, clock.NewMock())
+
 			dockerProject := NewDockerProject(
 				env,
 				dockerCli,
-				NewContainerHelper(env, envManager, clock.NewMock(), nil, dockerCli, cloud.AzurePublic()),
+				NewContainerHelper(env, envManager, imageHelper, nil, dockerCli, cloud.AzurePublic()),
+				imageHelper,
 				mockinput.NewMockConsole(),
 				mockContext.AlphaFeaturesManager,
 				mockContext.CommandRunner)

--- a/cli/azd/pkg/project/framework_service_dotnet.go
+++ b/cli/azd/pkg/project/framework_service_dotnet.go
@@ -49,7 +49,7 @@ func (dp *dotnetProject) Requirements() FrameworkRequirements {
 }
 
 // Gets the required external tools for the project
-func (dp *dotnetProject) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (dp *dotnetProject) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{dp.dotnetCli}
 }
 

--- a/cli/azd/pkg/project/framework_service_maven.go
+++ b/cli/azd/pkg/project/framework_service_maven.go
@@ -44,7 +44,7 @@ func (m *mavenProject) Requirements() FrameworkRequirements {
 }
 
 // Gets the required external tools for the project
-func (m *mavenProject) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (m *mavenProject) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{
 		m.mavenCli,
 		m.javacCli,

--- a/cli/azd/pkg/project/framework_service_noop.go
+++ b/cli/azd/pkg/project/framework_service_noop.go
@@ -14,7 +14,7 @@ func NewNoOpProject(env *environment.Environment) FrameworkService {
 	return &noOpProject{}
 }
 
-func (n *noOpProject) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+func (n *noOpProject) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{}
 }
 

--- a/cli/azd/pkg/project/framework_service_npm.go
+++ b/cli/azd/pkg/project/framework_service_npm.go
@@ -39,7 +39,7 @@ func (np *npmProject) Requirements() FrameworkRequirements {
 }
 
 // Gets the required external tools for the project
-func (np *npmProject) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (np *npmProject) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{np.cli}
 }
 

--- a/cli/azd/pkg/project/framework_service_python.go
+++ b/cli/azd/pkg/project/framework_service_python.go
@@ -41,7 +41,7 @@ func (pp *pythonProject) Requirements() FrameworkRequirements {
 }
 
 // Gets the required external tools for the project
-func (pp *pythonProject) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (pp *pythonProject) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{pp.cli}
 }
 

--- a/cli/azd/pkg/project/framework_service_swa.go
+++ b/cli/azd/pkg/project/framework_service_swa.go
@@ -63,7 +63,7 @@ func (p *swaProject) Requirements() FrameworkRequirements {
 }
 
 // Gets the required external tools for the project
-func (p *swaProject) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (p *swaProject) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{p.swa}
 }
 

--- a/cli/azd/pkg/project/image_helper.go
+++ b/cli/azd/pkg/project/image_helper.go
@@ -1,0 +1,157 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
+	"github.com/benbjohnson/clock"
+)
+
+type ImageHelper struct {
+	env   *environment.Environment
+	clock clock.Clock
+}
+
+func NewImageHelper(
+	env *environment.Environment,
+	clock clock.Clock,
+) *ImageHelper {
+	return &ImageHelper{
+		env:   env,
+		clock: clock,
+	}
+}
+
+// DefaultImageName returns a default image name generated from the service name and environment name.
+func (ih *ImageHelper) DefaultImageName(serviceConfig *ServiceConfig) string {
+	return fmt.Sprintf("%s/%s-%s",
+		strings.ToLower(serviceConfig.Project.Name),
+		strings.ToLower(serviceConfig.Name),
+		strings.ToLower(ih.env.Name()))
+}
+
+// DefaultImageTag returns a default image tag generated from the current time.
+func (ih *ImageHelper) DefaultImageTag() string {
+	return fmt.Sprintf("azd-deploy-%d", ih.clock.Now().Unix())
+}
+
+// RegistryName returns the name of the destination container registry to use for the current environment from the following:
+// 1. AZURE_CONTAINER_REGISTRY_ENDPOINT environment variable
+// 2. docker.registry from the service configuration
+func (ih *ImageHelper) RegistryName(ctx context.Context, serviceConfig *ServiceConfig) (string, error) {
+	registryName, found := ih.env.LookupEnv(environment.ContainerRegistryEndpointEnvVarName)
+	if !found {
+		log.Printf(
+			"Container registry not found in '%s' environment variable\n",
+			environment.ContainerRegistryEndpointEnvVarName,
+		)
+	}
+
+	if registryName == "" {
+		yamlRegistryName, err := serviceConfig.Docker.Registry.Envsubst(ih.env.Getenv)
+		if err != nil {
+			log.Println("Failed expanding 'docker.registry'")
+		}
+
+		registryName = yamlRegistryName
+	}
+
+	// If the service provides its own code artifacts then the expectation is that an images needs to be built and
+	// pushed to a container registry.
+	// If the service does not provide its own code artifacts then the expectation is a registry is optional and
+	// an image can be referenced independently.
+	if serviceConfig.RelativePath != "" && registryName == "" {
+		return "", fmt.Errorf(
+			//nolint:lll
+			"could not determine container registry endpoint, ensure 'registry' has been set in the docker options or '%s' environment variable has been set",
+			environment.ContainerRegistryEndpointEnvVarName,
+		)
+	}
+
+	return registryName, nil
+}
+
+// GeneratedImage returns the configured image from the service configuration
+// or a default image name generated from the service name and environment name.
+func (ih *ImageHelper) GeneratedImage(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+) (*docker.ContainerImage, error) {
+	// Parse the image from azure.yaml configuration when available
+	configuredImage, err := serviceConfig.Docker.Image.Envsubst(ih.env.Getenv)
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing 'image' from docker configuration, %w", err)
+	}
+
+	// Set default image name if not configured
+	if configuredImage == "" {
+		configuredImage = ih.DefaultImageName(serviceConfig)
+	}
+
+	parsedImage, err := docker.ParseContainerImage(configuredImage)
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing configured image, %w", err)
+	}
+
+	if parsedImage.Tag == "" {
+		configuredTag, err := serviceConfig.Docker.Tag.Envsubst(ih.env.Getenv)
+		if err != nil {
+			return nil, fmt.Errorf("failed parsing 'tag' from docker configuration, %w", err)
+		}
+
+		// Set default tag if not configured
+		if configuredTag == "" {
+			configuredTag = ih.DefaultImageTag()
+		}
+
+		parsedImage.Tag = configuredTag
+	}
+
+	// Set default registry if not configured
+	if parsedImage.Registry == "" {
+		// This can fail if called before provisioning the registry
+		configuredRegistry, err := ih.RegistryName(ctx, serviceConfig)
+		if err == nil {
+			parsedImage.Registry = configuredRegistry
+		}
+	}
+
+	return parsedImage, nil
+}
+
+// RemoteImageTag returns the remote image tag for the service configuration.
+func (ih *ImageHelper) RemoteImageTag(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	localImageTag string,
+) (string, error) {
+	registryName, err := ih.RegistryName(ctx, serviceConfig)
+	if err != nil {
+		return "", err
+	}
+
+	containerImage, err := docker.ParseContainerImage(localImageTag)
+	if err != nil {
+		return "", err
+	}
+
+	if registryName != "" {
+		containerImage.Registry = registryName
+	}
+
+	return containerImage.Remote(), nil
+}
+
+// LocalImageTag returns the local image tag for the service configuration.
+func (ih *ImageHelper) LocalImageTag(ctx context.Context, serviceConfig *ServiceConfig) (string, error) {
+	configuredImage, err := ih.GeneratedImage(ctx, serviceConfig)
+	if err != nil {
+		return "", err
+	}
+
+	return configuredImage.Local(), nil
+}

--- a/cli/azd/pkg/project/project_manager.go
+++ b/cli/azd/pkg/project/project_manager.go
@@ -200,7 +200,7 @@ func (pm *projectManager) EnsureFrameworkTools(
 			return fmt.Errorf("getting framework service: %w", err)
 		}
 
-		frameworkTools := frameworkService.RequiredExternalTools(ctx)
+		frameworkTools := frameworkService.RequiredExternalTools(ctx, svc)
 		if err != nil {
 			return fmt.Errorf("getting service required tools: %w", err)
 		}

--- a/cli/azd/pkg/project/remote_build_helper.go
+++ b/cli/azd/pkg/project/remote_build_helper.go
@@ -1,0 +1,126 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
+	"github.com/azure/azure-dev/cli/azd/pkg/async"
+	"github.com/azure/azure-dev/cli/azd/pkg/containerregistry"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/benbjohnson/clock"
+)
+
+type RemoteBuildHelper struct {
+	env                *environment.Environment
+	imageHelper        *ImageHelper
+	remoteBuildManager *containerregistry.RemoteBuildManager
+	console            input.Console
+	clock              clock.Clock
+}
+
+func NewRemoteBuildHelper(
+	env *environment.Environment,
+	imageHelper *ImageHelper,
+	remoteBuildManager *containerregistry.RemoteBuildManager,
+	console input.Console,
+	clock clock.Clock,
+) *RemoteBuildHelper {
+	return &RemoteBuildHelper{
+		env:                env,
+		imageHelper:        imageHelper,
+		remoteBuildManager: remoteBuildManager,
+		console:            console,
+		clock:              clock,
+	}
+}
+
+func (rh *RemoteBuildHelper) RunRemoteBuild(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	target *environment.TargetResource,
+	progress *async.Progress[ServiceProgress],
+) error {
+	dockerOptions := getDockerOptionsWithDefaults(serviceConfig.Docker)
+
+	if !filepath.IsAbs(dockerOptions.Path) {
+		dockerOptions.Path = filepath.Join(serviceConfig.Path(), dockerOptions.Path)
+	}
+
+	if !filepath.IsAbs(dockerOptions.Context) {
+		dockerOptions.Context = filepath.Join(serviceConfig.Path(), dockerOptions.Context)
+	}
+
+	if dockerOptions.Platform != "linux/amd64" {
+		return fmt.Errorf("remote build only supports the linux/amd64 platform")
+	}
+
+	progress.SetProgress(NewServiceProgress("Packing remote build context"))
+
+	contextPath, dockerPath, err := containerregistry.PackRemoteBuildSource(ctx, dockerOptions.Context, dockerOptions.Path)
+	if contextPath != "" {
+		defer os.Remove(contextPath)
+	}
+	if err != nil {
+		return err
+	}
+
+	progress.SetProgress(NewServiceProgress("Uploading remote build context"))
+
+	registryName, err := rh.imageHelper.RegistryName(ctx, serviceConfig)
+	if err != nil {
+		return err
+	}
+
+	registryResourceName := strings.Split(registryName, ".")[0]
+
+	source, err := rh.remoteBuildManager.UploadBuildSource(
+		ctx, target.SubscriptionId(), target.ResourceGroupName(), registryResourceName, contextPath)
+	if err != nil {
+		return err
+	}
+
+	localImageTag, err := rh.imageHelper.LocalImageTag(ctx, serviceConfig)
+	if err != nil {
+		return err
+	}
+
+	imageName, err := rh.imageHelper.RemoteImageTag(ctx, serviceConfig, localImageTag)
+	if err != nil {
+		return err
+	}
+
+	progress.SetProgress(NewServiceProgress("Running remote build"))
+
+	buildRequest := &armcontainerregistry.DockerBuildRequest{
+		SourceLocation: source.RelativePath,
+		DockerFilePath: to.Ptr(dockerPath),
+		IsPushEnabled:  to.Ptr(true),
+		ImageNames:     []*string{to.Ptr(imageName)},
+		Platform: &armcontainerregistry.PlatformProperties{
+			OS:           to.Ptr(armcontainerregistry.OSLinux),
+			Architecture: to.Ptr(armcontainerregistry.ArchitectureAmd64),
+		},
+	}
+
+	previewerWriter := rh.console.ShowPreviewer(ctx,
+		&input.ShowPreviewerOptions{
+			Prefix:       "  ",
+			MaxLineCount: 8,
+			Title:        "Docker Output",
+		})
+	err = rh.remoteBuildManager.RunDockerBuildRequestWithLogs(
+		ctx, target.SubscriptionId(), target.ResourceGroupName(), registryResourceName, buildRequest, previewerWriter)
+	rh.console.StopPreviewer(ctx, false)
+	if err != nil {
+		return err
+	}
+
+	rh.env.SetServiceProperty(serviceConfig.Name, "IMAGE_NAME", fmt.Sprintf("%s/%s", registryName, imageName))
+	return nil
+}

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -148,7 +148,7 @@ func (sm *serviceManager) GetRequiredTools(ctx context.Context, serviceConfig *S
 	}
 
 	requiredTools := []tools.ExternalTool{}
-	requiredTools = append(requiredTools, frameworkService.RequiredExternalTools(ctx)...)
+	requiredTools = append(requiredTools, frameworkService.RequiredExternalTools(ctx, serviceConfig)...)
 	requiredTools = append(requiredTools, serviceTarget.RequiredExternalTools(ctx)...)
 
 	return tools.Unique(requiredTools), nil

--- a/cli/azd/pkg/project/service_manager_test.go
+++ b/cli/azd/pkg/project/service_manager_test.go
@@ -491,7 +491,7 @@ func (f *fakeFramework) Requirements() FrameworkRequirements {
 	}
 }
 
-func (f *fakeFramework) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+func (f *fakeFramework) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{&fakeTool{}}
 }
 

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -840,7 +840,7 @@ func createAksServiceTarget(
 	containerHelper := NewContainerHelper(
 		env,
 		envManager,
-		clock.NewMock(),
+		NewImageHelper(env, clock.NewMock()),
 		containerRegistryService,
 		dockerCli,
 		cloud.AzurePublic(),

--- a/cli/azd/pkg/project/service_target_dotnet_containerapp.go
+++ b/cli/azd/pkg/project/service_target_dotnet_containerapp.go
@@ -29,6 +29,7 @@ import (
 
 type dotnetContainerAppTarget struct {
 	env                 *environment.Environment
+	imageHelper         *ImageHelper
 	containerHelper     *ContainerHelper
 	containerAppService containerapps.ContainerAppService
 	resourceManager     ResourceManager
@@ -50,6 +51,7 @@ type dotnetContainerAppTarget struct {
 func NewDotNetContainerAppTarget(
 	env *environment.Environment,
 	containerHelper *ContainerHelper,
+	imageHelper *ImageHelper,
 	containerAppService containerapps.ContainerAppService,
 	resourceManager ResourceManager,
 	dotNetCli dotnet.DotNetCli,
@@ -61,6 +63,7 @@ func NewDotNetContainerAppTarget(
 	return &dotnetContainerAppTarget{
 		env:                 env,
 		containerHelper:     containerHelper,
+		imageHelper:         imageHelper,
 		containerAppService: containerAppService,
 		resourceManager:     resourceManager,
 		dotNetCli:           dotNetCli,
@@ -144,8 +147,8 @@ func (at *dotnetContainerAppTarget) Deploy(
 		remoteImageName = serviceConfig.DotNetContainerApp.ContainerImage
 	} else {
 		imageName := fmt.Sprintf("%s:%s",
-			at.containerHelper.DefaultImageName(serviceConfig),
-			at.containerHelper.DefaultImageTag())
+			at.imageHelper.DefaultImageName(serviceConfig),
+			at.imageHelper.DefaultImageTag())
 
 		portNumber, err = at.dotNetCli.PublishContainer(
 			ctx,

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/mattn/go-isatty v0.0.14
 	github.com/microsoft/ApplicationInsights-Go v0.4.4
 	github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0
+	github.com/moby/patternmatcher v0.6.0
 	github.com/nathan-fiscaletti/consolesize-go v0.0.0-20220204101620-317176b6684d
 	github.com/otiai10/copy v1.9.0
 	github.com/psanford/memfs v0.0.0-20230130182539-4dbf7e3e865e

--- a/go.sum
+++ b/go.sum
@@ -410,6 +410,8 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
+github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=


### PR DESCRIPTION
This change sketches out support for using the ACR remote build feature and uses it the the `containerapp` service target.

To use it, add `remoteBuild: true` to the `docker` member of a `service` in `azure.yaml`

Fixes #509