### PR TITLE
WIP: Adds support for multiple containers within container based hosts

### DIFF
--- a/cli/azd/cmd/middleware/hooks_test.go
+++ b/cli/azd/cmd/middleware/hooks_test.go
@@ -226,11 +226,12 @@ func Test_ServiceHooks_Registered(t *testing.T) {
 	}
 
 	serviceConfig := &project.ServiceConfig{
-		ComponentConfig: &project.ComponentConfig{
-
-			Language:     "ts",
-			RelativePath: "./src/api",
-			Host:         "appservice",
+		Host: "appservice",
+		Components: map[string]*project.ComponentConfig{
+			project.DefaultComponentName: {
+				Language:     "ts",
+				RelativePath: "./src/api",
+			},
 		},
 		EventDispatcher: ext.NewEventDispatcher[project.ServiceLifecycleEventArgs](project.ServiceEvents...),
 		Hooks: map[string]*ext.HookConfig{

--- a/cli/azd/cmd/middleware/hooks_test.go
+++ b/cli/azd/cmd/middleware/hooks_test.go
@@ -226,10 +226,13 @@ func Test_ServiceHooks_Registered(t *testing.T) {
 	}
 
 	serviceConfig := &project.ServiceConfig{
+		ComponentConfig: &project.ComponentConfig{
+
+			Language:     "ts",
+			RelativePath: "./src/api",
+			Host:         "appservice",
+		},
 		EventDispatcher: ext.NewEventDispatcher[project.ServiceLifecycleEventArgs](project.ServiceEvents...),
-		Language:        "ts",
-		RelativePath:    "./src/api",
-		Host:            "appservice",
 		Hooks: map[string]*ext.HookConfig{
 			"predeploy": {
 				Shell: ext.ShellTypeBash,

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -365,7 +365,15 @@ func prjConfigFromDetect(
 		if !supported {
 			continue
 		}
-		svc.Language = language
+
+		mainComponent := &project.ComponentConfig{
+			Service: &svc,
+		}
+		svc.Components = map[string]*project.ComponentConfig{
+			project.DefaultComponentName: mainComponent,
+		}
+
+		mainComponent.Language = language
 
 		if prj.Docker != nil {
 			relDocker, err := filepath.Rel(prj.Path, prj.Docker.Path)
@@ -373,7 +381,7 @@ func prjConfigFromDetect(
 				return project.ProjectConfig{}, err
 			}
 
-			svc.Docker = project.DockerProjectOptions{
+			mainComponent.Docker = project.DockerProjectOptions{
 				Path: relDocker,
 			}
 		}
@@ -382,25 +390,25 @@ func prjConfigFromDetect(
 			// By default, use 'dist'. This is common for frameworks such as:
 			// - TypeScript
 			// - Vite
-			svc.OutputPath = "dist"
+			mainComponent.OutputPath = "dist"
 
 		loop:
 			for _, dep := range prj.Dependencies {
 				switch dep {
 				case appdetect.JsNext:
 					// next.js works as SSR with default node configuration without static build output
-					svc.OutputPath = ""
+					mainComponent.OutputPath = ""
 					break loop
 				case appdetect.JsVite:
-					svc.OutputPath = "dist"
+					mainComponent.OutputPath = "dist"
 					break loop
 				case appdetect.JsReact:
 					// react from create-react-app uses 'build' when used, but this can be overridden
 					// by choice of build tool, such as when using Vite.
-					svc.OutputPath = "build"
+					mainComponent.OutputPath = "build"
 				case appdetect.JsAngular:
 					// angular uses dist/<project name>
-					svc.OutputPath = "dist/" + filepath.Base(rel)
+					mainComponent.OutputPath = "dist/" + filepath.Base(rel)
 					break loop
 				}
 			}

--- a/cli/azd/internal/vsrpc/utils_test.go
+++ b/cli/azd/internal/vsrpc/utils_test.go
@@ -67,10 +67,12 @@ func createProject(prjDir string, appHostPath string) error {
 		Name: "app",
 		Services: map[string]*project.ServiceConfig{
 			"app": {
-				ComponentConfig: &project.ComponentConfig{
-					Host:         project.ContainerAppTarget,
-					Language:     project.ServiceLanguageDotNet,
-					RelativePath: appHostPath,
+				Host: project.ContainerAppTarget,
+				Components: map[string]*project.ComponentConfig{
+					project.DefaultComponentName: {
+						Language:     project.ServiceLanguageDotNet,
+						RelativePath: appHostPath,
+					},
 				},
 			},
 		},

--- a/cli/azd/internal/vsrpc/utils_test.go
+++ b/cli/azd/internal/vsrpc/utils_test.go
@@ -67,9 +67,11 @@ func createProject(prjDir string, appHostPath string) error {
 		Name: "app",
 		Services: map[string]*project.ServiceConfig{
 			"app": {
-				Host:         project.ContainerAppTarget,
-				Language:     project.ServiceLanguageDotNet,
-				RelativePath: appHostPath,
+				ComponentConfig: &project.ComponentConfig{
+					Host:         project.ContainerAppTarget,
+					Language:     project.ServiceLanguageDotNet,
+					RelativePath: appHostPath,
+				},
 			},
 		},
 	}

--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -167,7 +167,7 @@ func (cas *containerAppService) DeployYaml(
 	}
 
 	if shouldPersist := cas.alphaFeatureManager.IsEnabled(persistCustomDomainsFeature); shouldPersist {
-		aca, err := cas.getContainerApp(ctx, subscriptionId, resourceGroupName, appName)
+		aca, err := cas.Get(ctx, subscriptionId, resourceGroupName, appName)
 		if err == nil {
 			acaAsConfig := config.NewConfig(obj)
 			err := acaAsConfig.Set(

--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -26,6 +26,13 @@ import (
 
 // ContainerAppService exposes operations for managing Azure Container Apps
 type ContainerAppService interface {
+	// Gets the container app configuration
+	Get(
+		ctx context.Context,
+		subscriptionId string,
+		resourceGroupName string,
+		appName string,
+	) (*armappcontainers.ContainerApp, error)
 	// Gets the ingress configuration for the specified container app
 	GetIngressConfiguration(
 		ctx context.Context,
@@ -33,6 +40,14 @@ type ContainerAppService interface {
 		resourceGroup,
 		appName string,
 	) (*ContainerAppIngressConfiguration, error)
+	// Gets the container app revision with the specified name
+	GetRevision(
+		ctx context.Context,
+		subscriptionId string,
+		resourceGroupName string,
+		appName string,
+		revisionName string,
+	) (*armappcontainers.Revision, error)
 	DeployYaml(
 		ctx context.Context,
 		subscriptionId string,
@@ -46,7 +61,8 @@ type ContainerAppService interface {
 		subscriptionId string,
 		resourceGroupName string,
 		appName string,
-		imageName string,
+		containerApp *armappcontainers.ContainerApp,
+		revision *armappcontainers.Revision,
 	) error
 	ListSecrets(ctx context.Context,
 		subscriptionId string,
@@ -86,6 +102,25 @@ type ContainerAppIngressConfiguration struct {
 	HostNames []string
 }
 
+func (cas *containerAppService) Get(
+	ctx context.Context,
+	subscriptionId string,
+	resourceGroupName string,
+	appName string,
+) (*armappcontainers.ContainerApp, error) {
+	appClient, err := cas.createContainerAppsClient(ctx, subscriptionId)
+	if err != nil {
+		return nil, err
+	}
+
+	containerAppResponse, err := appClient.Get(ctx, resourceGroupName, appName, nil)
+	if err != nil {
+		return nil, fmt.Errorf("getting container app: %w", err)
+	}
+
+	return &containerAppResponse.ContainerApp, nil
+}
+
 // Gets the ingress configuration for the specified container app
 func (cas *containerAppService) GetIngressConfiguration(
 	ctx context.Context,
@@ -93,7 +128,7 @@ func (cas *containerAppService) GetIngressConfiguration(
 	resourceGroup string,
 	appName string,
 ) (*ContainerAppIngressConfiguration, error) {
-	containerApp, err := cas.getContainerApp(ctx, subscriptionId, resourceGroup, appName)
+	containerApp, err := cas.Get(ctx, subscriptionId, resourceGroup, appName)
 	if err != nil {
 		return nil, fmt.Errorf("failed retrieving container app properties: %w", err)
 	}
@@ -223,45 +258,43 @@ func (cas *containerAppService) DeployYaml(
 	return nil
 }
 
+func (cas *containerAppService) GetRevision(
+	ctx context.Context,
+	subscriptionId string,
+	resourceGroupName string,
+	appName string,
+	revisionName string,
+) (*armappcontainers.Revision, error) {
+	revisionsClient, err := cas.createRevisionsClient(ctx, subscriptionId)
+	if err != nil {
+		return nil, err
+	}
+
+	revisionResponse, err := revisionsClient.GetRevision(ctx, resourceGroupName, appName, revisionName, nil)
+	if err != nil {
+		return nil, fmt.Errorf("getting revision '%s': %w", revisionName, err)
+	}
+
+	return &revisionResponse.Revision, nil
+}
+
 // Adds and activates a new revision to the specified container app
 func (cas *containerAppService) AddRevision(
 	ctx context.Context,
 	subscriptionId string,
 	resourceGroupName string,
 	appName string,
-	imageName string,
+	containerApp *armappcontainers.ContainerApp,
+	revision *armappcontainers.Revision,
 ) error {
-	containerApp, err := cas.getContainerApp(ctx, subscriptionId, resourceGroupName, appName)
-	if err != nil {
-		return fmt.Errorf("getting container app: %w", err)
-	}
-
-	// Get the latest revision name
-	currentRevisionName := *containerApp.Properties.LatestRevisionName
-	revisionsClient, err := cas.createRevisionsClient(ctx, subscriptionId)
-	if err != nil {
-		return err
-	}
-
-	revisionResponse, err := revisionsClient.GetRevision(ctx, resourceGroupName, appName, currentRevisionName, nil)
-	if err != nil {
-		return fmt.Errorf("getting revision '%s': %w", currentRevisionName, err)
-	}
-
 	// Update the revision with the new image name and suffix
-	revision := revisionResponse.Revision
 	revision.Properties.Template.RevisionSuffix = convert.RefOf(fmt.Sprintf("azd-%d", cas.clock.Now().Unix()))
-	revision.Properties.Template.Containers[0].Image = convert.RefOf(imageName)
 
 	// Update the container app with the new revision
 	containerApp.Properties.Template = revision.Properties.Template
-	containerApp, err = cas.syncSecrets(ctx, subscriptionId, resourceGroupName, appName, containerApp)
-	if err != nil {
-		return fmt.Errorf("syncing secrets: %w", err)
-	}
 
 	// Update the container app
-	err = cas.updateContainerApp(ctx, subscriptionId, resourceGroupName, appName, containerApp)
+	err := cas.update(ctx, subscriptionId, resourceGroupName, appName, containerApp)
 	if err != nil {
 		return fmt.Errorf("updating container app revision: %w", err)
 	}
@@ -269,7 +302,7 @@ func (cas *containerAppService) AddRevision(
 	// If the container app is in multiple revision mode, update the traffic to point to the new revision
 	if *containerApp.Properties.Configuration.ActiveRevisionsMode == armappcontainers.ActiveRevisionsModeMultiple {
 		newRevisionName := fmt.Sprintf("%s--%s", appName, *revision.Properties.Template.RevisionSuffix)
-		err = cas.setTrafficWeights(ctx, subscriptionId, resourceGroupName, appName, containerApp, newRevisionName)
+		err := cas.setTrafficWeights(ctx, subscriptionId, resourceGroupName, appName, containerApp, newRevisionName)
 		if err != nil {
 			return fmt.Errorf("setting traffic weights: %w", err)
 		}
@@ -295,6 +328,37 @@ func (cas *containerAppService) ListSecrets(
 	}
 
 	return secretsResponse.Value, nil
+}
+
+func (cas *containerAppService) update(
+	ctx context.Context,
+	subscriptionId string,
+	resourceGroupName string,
+	appName string,
+	containerApp *armappcontainers.ContainerApp,
+) error {
+	appClient, err := cas.createContainerAppsClient(ctx, subscriptionId)
+	if err != nil {
+		return err
+	}
+
+	// Sync the secrets from the current container app
+	containerApp, err = cas.syncSecrets(ctx, subscriptionId, resourceGroupName, appName, containerApp)
+	if err != nil {
+		return fmt.Errorf("syncing secrets: %w", err)
+	}
+
+	poller, err := appClient.BeginUpdate(ctx, resourceGroupName, appName, *containerApp, nil)
+	if err != nil {
+		return fmt.Errorf("begin updating ingress traffic: %w", err)
+	}
+
+	_, err = poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("polling for container app update completion: %w", err)
+	}
+
+	return nil
 }
 
 func (cas *containerAppService) syncSecrets(
@@ -352,53 +416,9 @@ func (cas *containerAppService) setTrafficWeights(
 		},
 	}
 
-	err := cas.updateContainerApp(ctx, subscriptionId, resourceGroupName, appName, containerApp)
+	err := cas.update(ctx, subscriptionId, resourceGroupName, appName, containerApp)
 	if err != nil {
 		return fmt.Errorf("updating traffic weights: %w", err)
-	}
-
-	return nil
-}
-
-func (cas *containerAppService) getContainerApp(
-	ctx context.Context,
-	subscriptionId string,
-	resourceGroupName string,
-	appName string,
-) (*armappcontainers.ContainerApp, error) {
-	appClient, err := cas.createContainerAppsClient(ctx, subscriptionId)
-	if err != nil {
-		return nil, err
-	}
-
-	containerAppResponse, err := appClient.Get(ctx, resourceGroupName, appName, nil)
-	if err != nil {
-		return nil, fmt.Errorf("getting container app: %w", err)
-	}
-
-	return &containerAppResponse.ContainerApp, nil
-}
-
-func (cas *containerAppService) updateContainerApp(
-	ctx context.Context,
-	subscriptionId string,
-	resourceGroupName string,
-	appName string,
-	containerApp *armappcontainers.ContainerApp,
-) error {
-	appClient, err := cas.createContainerAppsClient(ctx, subscriptionId)
-	if err != nil {
-		return err
-	}
-
-	poller, err := appClient.BeginUpdate(ctx, resourceGroupName, appName, *containerApp, nil)
-	if err != nil {
-		return fmt.Errorf("begin updating ingress traffic: %w", err)
-	}
-
-	_, err = poller.PollUntilDone(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("polling for container app update completion: %w", err)
 	}
 
 	return nil

--- a/cli/azd/pkg/containerapps/container_app_test.go
+++ b/cli/azd/pkg/containerapps/container_app_test.go
@@ -140,7 +140,31 @@ func Test_ContainerApp_AddRevision(t *testing.T) {
 		mockContext.ArmClientOptions,
 		mockContext.AlphaFeaturesManager,
 	)
-	err := cas.AddRevision(*mockContext.Context, subscriptionId, resourceGroup, appName, updatedImageName)
+
+	myApp, err := cas.Get(*mockContext.Context, subscriptionId, resourceGroup, appName)
+	require.NoError(t, err)
+	require.NotNil(t, myApp)
+
+	latestRevision, err := cas.GetRevision(
+		*mockContext.Context,
+		subscriptionId,
+		resourceGroup,
+		appName,
+		*myApp.Properties.LatestRevisionName,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, latestRevision)
+
+	latestRevision.Properties.Template.Containers[0].Image = &updatedImageName
+
+	err = cas.AddRevision(
+		*mockContext.Context,
+		subscriptionId,
+		resourceGroup,
+		appName,
+		containerApp,
+		latestRevision,
+	)
 	require.NoError(t, err)
 
 	// Verify lastest revision is read

--- a/cli/azd/pkg/helm/cli_test.go
+++ b/cli/azd/pkg/helm/cli_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,8 @@ func Test_Cli_AddRepo(t *testing.T) {
 				return exec.NewRunResult(0, "", ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.AddRepo(*mockContext.Context, repo)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -59,7 +61,8 @@ func Test_Cli_AddRepo(t *testing.T) {
 				return exec.NewRunResult(1, "", ""), errors.New("failed to add repo")
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.AddRepo(*mockContext.Context, repo)
 
 		require.True(t, ran)
@@ -84,7 +87,8 @@ func Test_Cli_UpdateRepo(t *testing.T) {
 				return exec.NewRunResult(0, "", ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.UpdateRepo(*mockContext.Context, "test")
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -110,7 +114,8 @@ func Test_Cli_UpdateRepo(t *testing.T) {
 				return exec.NewRunResult(1, "", ""), errors.New("failed to update repo")
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.UpdateRepo(*mockContext.Context, "test")
 
 		require.True(t, ran)
@@ -141,7 +146,8 @@ func Test_Cli_Install(t *testing.T) {
 				return exec.NewRunResult(0, "", ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.Install(*mockContext.Context, release)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -172,7 +178,8 @@ func Test_Cli_Install(t *testing.T) {
 				return exec.NewRunResult(0, "", ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.Install(*mockContext.Context, &releaseWithValues)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -200,7 +207,8 @@ func Test_Cli_Install(t *testing.T) {
 				return exec.NewRunResult(1, "", ""), errors.New("failed to install release")
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.Install(*mockContext.Context, release)
 
 		require.True(t, ran)
@@ -230,7 +238,8 @@ func Test_Cli_Upgrade(t *testing.T) {
 				return exec.NewRunResult(0, "", ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.Upgrade(*mockContext.Context, release)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -263,7 +272,8 @@ func Test_Cli_Upgrade(t *testing.T) {
 				return exec.NewRunResult(0, "", ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.Upgrade(*mockContext.Context, &releaseWithValues)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -298,7 +308,8 @@ func Test_Cli_Upgrade(t *testing.T) {
 				return exec.NewRunResult(0, "", ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.Upgrade(*mockContext.Context, &releaseWithVersion)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -333,7 +344,8 @@ func Test_Cli_Upgrade(t *testing.T) {
 				return exec.NewRunResult(0, "", ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.Upgrade(*mockContext.Context, &releaseWithNamespace)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -364,7 +376,8 @@ func Test_Cli_Upgrade(t *testing.T) {
 				return exec.NewRunResult(1, "", ""), errors.New("failed to upgrade release")
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		err := cli.Upgrade(*mockContext.Context, release)
 
 		require.True(t, ran)
@@ -397,7 +410,8 @@ func Test_Cli_Status(t *testing.T) {
 				}`, ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		status, err := cli.Status(*mockContext.Context, release)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -434,7 +448,8 @@ func Test_Cli_Status(t *testing.T) {
 				}`, ""), nil
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		status, err := cli.Status(*mockContext.Context, &releaseWithNamespace)
 		require.True(t, ran)
 		require.NoError(t, err)
@@ -464,7 +479,8 @@ func Test_Cli_Status(t *testing.T) {
 				return exec.NewRunResult(1, "", ""), errors.New("failed to get status")
 			})
 
-		cli := NewCli(mockContext.CommandRunner)
+		env := environment.NewWithValues("test", nil)
+		cli := NewCli(mockContext.CommandRunner, env)
 		_, err := cli.Status(*mockContext.Context, release)
 
 		require.True(t, ran)

--- a/cli/azd/pkg/helm/config.go
+++ b/cli/azd/pkg/helm/config.go
@@ -1,5 +1,7 @@
 package helm
 
+import "github.com/azure/azure-dev/cli/azd/pkg/osutil"
+
 type Config struct {
 	Repositories []*Repository `yaml:"repositories"`
 	Releases     []*Release    `yaml:"releases"`
@@ -11,9 +13,10 @@ type Repository struct {
 }
 
 type Release struct {
-	Name      string `yaml:"name"`
-	Chart     string `yaml:"chart"`
-	Version   string `yaml:"version"`
-	Namespace string `yaml:"namespace"`
-	Values    string `yaml:"values"`
+	Name      string                             `yaml:"name"`
+	Chart     string                             `yaml:"chart"`
+	Version   string                             `yaml:"version"`
+	Namespace string                             `yaml:"namespace"`
+	Values    string                             `yaml:"values"`
+	Overrides map[string]osutil.ExpandableString `yaml:"overrides"`
 }

--- a/cli/azd/pkg/osutil/expandable_string.go
+++ b/cli/azd/pkg/osutil/expandable_string.go
@@ -7,48 +7,53 @@ import (
 	"fmt"
 
 	"github.com/drone/envsubst"
+	"gopkg.in/yaml.v3"
 )
 
 func NewExpandableString(template string) ExpandableString {
 	return ExpandableString{
-		template: template,
+		Template: template,
 	}
 }
 
 // ExpandableString is a string that has ${foo} style references inside which can be evaluated.
 type ExpandableString struct {
-	template string
+	Template string `yaml:",inline"`
 }
 
 // Empty returns true if the template is empty.
 func (e ExpandableString) Empty() bool {
-	return e.template == ""
+	return e.Template == ""
 }
 
 // Envsubst evaluates the template, substituting values as [envsubst.Eval] would.
-func (e ExpandableString) Envsubst(mapping func(string) string) (string, error) {
-	return envsubst.Eval(e.template, mapping)
+func (e *ExpandableString) Envsubst(mapping func(string) string) (string, error) {
+	return envsubst.Eval(e.Template, mapping)
 }
 
 // MustEnvsubst evaluates the template, substituting values as [envsubst.Eval] would and panics if there
 // is an error (for example, the string is malformed).
-func (e ExpandableString) MustEnvsubst(mapping func(string) string) string {
-	if v, err := envsubst.Eval(e.template, mapping); err != nil {
+func (e *ExpandableString) MustEnvsubst(mapping func(string) string) string {
+	if v, err := envsubst.Eval(e.Template, mapping); err != nil {
 		panic(fmt.Sprintf("MustEnvsubst: %v", err))
 	} else {
 		return v
 	}
 }
 
-func (e ExpandableString) MarshalYAML() (interface{}, error) {
-	return e.template, nil
+func (e ExpandableString) MarshalText() ([]byte, error) {
+	return []byte(e.Template), nil
 }
 
-func (e *ExpandableString) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var s string
-	if err := unmarshal(&s); err != nil {
+func (e *ExpandableString) UnmarshalYAML(node *yaml.Node) error {
+	var value any
+	if err := node.Decode(&value); err != nil {
 		return err
 	}
-	e.template = s
+
+	if str, ok := value.(string); ok {
+		e.Template = str
+	}
+
 	return nil
 }

--- a/cli/azd/pkg/osutil/expandable_string_test.go
+++ b/cli/azd/pkg/osutil/expandable_string_test.go
@@ -11,17 +11,52 @@ import (
 )
 
 func TestExpandableStringYaml(t *testing.T) {
-	var e ExpandableString
+	var e *ExpandableString
 
 	err := yaml.Unmarshal([]byte(`"${foo}"`), &e)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "${foo}", e.template)
+	assert.Equal(t, "${foo}", e.Template)
 
 	marshalled, err := yaml.Marshal(e)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "${foo}\n", string(marshalled))
+}
+
+func TestNestedObjectYaml(t *testing.T) {
+	expected := "a: ${foo}\nb: ${bar}\n"
+
+	var custom *Custom
+	err := yaml.Unmarshal([]byte(expected), &custom)
+	assert.NoError(t, err)
+	assert.Equal(t, "${foo}", custom.A.Template)
+	assert.Equal(t, "${bar}", custom.B.Template)
+
+	marshalled, err := yaml.Marshal(custom)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expected, string(marshalled))
+}
+
+func TestNestedObjectWithEmpty(t *testing.T) {
+	expected := "{}\n"
+
+	var custom *Custom
+	err := yaml.Unmarshal([]byte(expected), &custom)
+	assert.NoError(t, err)
+	assert.NotNil(t, custom.A)
+	assert.NotNil(t, custom.B)
+
+	marshalled, err := yaml.Marshal(custom)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expected, string(marshalled))
+}
+
+type Custom struct {
+	A ExpandableString `yaml:"a,omitempty"`
+	B ExpandableString `yaml:"b,omitempty"`
 }
 
 func TestExpandableString_Empty(t *testing.T) {

--- a/cli/azd/pkg/project/ai_helper_test.go
+++ b/cli/azd/pkg/project/ai_helper_test.go
@@ -81,7 +81,7 @@ func Test_AiHelper_CreateEnvironmentVersion(t *testing.T) {
 		Path: "./deployment/environment.yaml",
 	}
 
-	createTestFile(t, testDir, filepath.Join(serviceConfig.RelativePath, environmentConfig.Path))
+	createTestFile(t, testDir, filepath.Join(serviceConfig.Components[DefaultComponentName].RelativePath, environmentConfig.Path))
 
 	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
 	envVersion, err := aiHelper.CreateEnvironmentVersion(*mockContext.Context, scope, serviceConfig, environmentConfig)
@@ -129,7 +129,7 @@ func Test_AiHelper_CreateModelVersion(t *testing.T) {
 		Path: "./deployment/model.yaml",
 	}
 
-	createTestFile(t, testDir, filepath.Join(serviceConfig.RelativePath, modelConfig.Path))
+	createTestFile(t, testDir, filepath.Join(serviceConfig.Components[DefaultComponentName].RelativePath, modelConfig.Path))
 
 	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
 	modelVersion, err := aiHelper.CreateModelVersion(*mockContext.Context, scope, serviceConfig, modelConfig)
@@ -208,7 +208,7 @@ func Test_AiHelper_CreateFlow(t *testing.T) {
 		Path: "./my-flow",
 	}
 
-	createTestFile(t, testDir, filepath.Join(serviceConfig.RelativePath, filepath.Join(flowConfig.Path, "flow.dag.yaml")))
+	createTestFile(t, testDir, filepath.Join(serviceConfig.Components[DefaultComponentName].RelativePath, filepath.Join(flowConfig.Path, "flow.dag.yaml")))
 
 	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
 	flow, err := aiHelper.CreateFlow(*mockContext.Context, scope, serviceConfig, flowConfig)
@@ -291,7 +291,7 @@ func Test_AiHelper_DeployToEndpoint(t *testing.T) {
 		},
 	}
 
-	createTestFile(t, testDir, filepath.Join(serviceConfig.RelativePath, endpointConfig.Deployment.Path))
+	createTestFile(t, testDir, filepath.Join(serviceConfig.Components[DefaultComponentName].RelativePath, endpointConfig.Deployment.Path))
 
 	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
 	deployment, err := aiHelper.DeployToEndpoint(*mockContext.Context, scope, serviceConfig, endpointName, endpointConfig)

--- a/cli/azd/pkg/project/ai_helper_test.go
+++ b/cli/azd/pkg/project/ai_helper_test.go
@@ -74,17 +74,17 @@ func Test_AiHelper_CreateEnvironmentVersion(t *testing.T) {
 	mockai.RegisterGetEnvironment(mockContext, scope.Workspace(), environmentName, http.StatusNotFound)
 	mockai.RegisterGetEnvironmentVersion(mockContext, scope.Workspace(), environmentName, "1")
 
-	serviceConfig := createTestServiceConfig("./contoso-chat", AiEndpointTarget, ServiceLanguagePython)
-	serviceConfig.Project.Path = testDir
+	component := createTestComponentConfig("./contoso-chat", AiEndpointTarget, ServiceLanguagePython)
+	component.Service.Project.Path = testDir
 	environmentConfig := &ai.ComponentConfig{
 		Name: osutil.NewExpandableString(environmentName),
 		Path: "./deployment/environment.yaml",
 	}
 
-	createTestFile(t, testDir, filepath.Join(serviceConfig.Components[DefaultComponentName].RelativePath, environmentConfig.Path))
+	createTestFile(t, testDir, filepath.Join(component.RelativePath, environmentConfig.Path))
 
 	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
-	envVersion, err := aiHelper.CreateEnvironmentVersion(*mockContext.Context, scope, serviceConfig, environmentConfig)
+	envVersion, err := aiHelper.CreateEnvironmentVersion(*mockContext.Context, scope, component, environmentConfig)
 
 	require.NoError(t, err)
 	require.NotNil(t, envVersion)
@@ -96,7 +96,7 @@ func Test_AiHelper_CreateEnvironmentVersion(t *testing.T) {
 		"-s", scope.SubscriptionId(),
 		"-g", scope.ResourceGroup(),
 		"-w", scope.Workspace(),
-		"-f", filepath.Join(serviceConfig.Path(), environmentConfig.Path),
+		"-f", filepath.Join(component.Path(), environmentConfig.Path),
 		"--set", fmt.Sprintf("name=%s", environmentName),
 		"--set", fmt.Sprintf("version=%d", 1),
 	})
@@ -122,17 +122,17 @@ func Test_AiHelper_CreateModelVersion(t *testing.T) {
 	mockai.RegisterGetModel(mockContext, scope.Workspace(), modelName, http.StatusNotFound)
 	mockai.RegisterGetModelVersion(mockContext, scope.Workspace(), modelName, "1")
 
-	serviceConfig := createTestServiceConfig("./contoso-chat", AiEndpointTarget, ServiceLanguagePython)
-	serviceConfig.Project.Path = testDir
+	component := createTestComponentConfig("./contoso-chat", AiEndpointTarget, ServiceLanguagePython)
+	component.Service.Project.Path = testDir
 	modelConfig := &ai.ComponentConfig{
 		Name: osutil.NewExpandableString(modelName),
 		Path: "./deployment/model.yaml",
 	}
 
-	createTestFile(t, testDir, filepath.Join(serviceConfig.Components[DefaultComponentName].RelativePath, modelConfig.Path))
+	createTestFile(t, testDir, filepath.Join(component.RelativePath, modelConfig.Path))
 
 	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
-	modelVersion, err := aiHelper.CreateModelVersion(*mockContext.Context, scope, serviceConfig, modelConfig)
+	modelVersion, err := aiHelper.CreateModelVersion(*mockContext.Context, scope, component, modelConfig)
 
 	require.NoError(t, err)
 	require.NotNil(t, modelVersion)
@@ -144,7 +144,7 @@ func Test_AiHelper_CreateModelVersion(t *testing.T) {
 		"-s", scope.SubscriptionId(),
 		"-g", scope.ResourceGroup(),
 		"-w", scope.Workspace(),
-		"-f", filepath.Join(serviceConfig.Path(), modelConfig.Path),
+		"-f", filepath.Join(component.Path(), modelConfig.Path),
 		"--set", fmt.Sprintf("name=%s", modelName),
 		"--set", fmt.Sprintf("version=%d", 1),
 	})
@@ -201,17 +201,17 @@ func Test_AiHelper_CreateFlow(t *testing.T) {
 			Stderr:   "",
 		}, nil)
 
-	serviceConfig := createTestServiceConfig("./contoso-chat", AiEndpointTarget, ServiceLanguagePython)
-	serviceConfig.Project.Path = testDir
+	component := createTestComponentConfig("./contoso-chat", AiEndpointTarget, ServiceLanguagePython)
+	component.Service.Project.Path = testDir
 	flowConfig := &ai.ComponentConfig{
 		Name: osutil.NewExpandableString(flowName),
 		Path: "./my-flow",
 	}
 
-	createTestFile(t, testDir, filepath.Join(serviceConfig.Components[DefaultComponentName].RelativePath, filepath.Join(flowConfig.Path, "flow.dag.yaml")))
+	createTestFile(t, testDir, filepath.Join(component.RelativePath, filepath.Join(flowConfig.Path, "flow.dag.yaml")))
 
 	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
-	flow, err := aiHelper.CreateFlow(*mockContext.Context, scope, serviceConfig, flowConfig)
+	flow, err := aiHelper.CreateFlow(*mockContext.Context, scope, component, flowConfig)
 
 	require.NoError(t, err)
 	require.NotNil(t, flow)
@@ -221,7 +221,7 @@ func Test_AiHelper_CreateFlow(t *testing.T) {
 	mockPythonBridge.AssertCalled(t, "Run", *mockContext.Context, ai.PromptFlowClient, []string{
 		"create",
 		"-n", expectedFlowName,
-		"-f", filepath.Join(serviceConfig.Path(), flowConfig.Path),
+		"-f", filepath.Join(component.Path(), flowConfig.Path),
 		"-s", scope.SubscriptionId(),
 		"-g", scope.ResourceGroup(),
 		"-w", scope.Workspace(),
@@ -264,8 +264,8 @@ func Test_AiHelper_DeployToEndpoint(t *testing.T) {
 		armmachinelearning.DeploymentProvisioningStateSucceeded,
 	)
 
-	serviceConfig := createTestServiceConfig("./contoso-chat", AiEndpointTarget, ServiceLanguagePython)
-	serviceConfig.Project.Path = testDir
+	component := createTestComponentConfig("./contoso-chat", AiEndpointTarget, ServiceLanguagePython)
+	component.Service.Project.Path = testDir
 
 	endpointConfig := &ai.EndpointDeploymentConfig{
 		Workspace: osutil.NewExpandableString(scope.Workspace()),
@@ -291,10 +291,10 @@ func Test_AiHelper_DeployToEndpoint(t *testing.T) {
 		},
 	}
 
-	createTestFile(t, testDir, filepath.Join(serviceConfig.Components[DefaultComponentName].RelativePath, endpointConfig.Deployment.Path))
+	createTestFile(t, testDir, filepath.Join(component.RelativePath, endpointConfig.Deployment.Path))
 
 	aiHelper := newAiHelper(t, mockContext, env, mockPythonBridge)
-	deployment, err := aiHelper.DeployToEndpoint(*mockContext.Context, scope, serviceConfig, endpointName, endpointConfig)
+	deployment, err := aiHelper.DeployToEndpoint(*mockContext.Context, scope, component, endpointName, endpointConfig)
 
 	require.NoError(t, err)
 	require.NotNil(t, deployment)
@@ -307,7 +307,7 @@ func Test_AiHelper_DeployToEndpoint(t *testing.T) {
 		"-s", scope.SubscriptionId(),
 		"-g", scope.ResourceGroup(),
 		"-w", scope.Workspace(),
-		"-f", filepath.Join(serviceConfig.Path(), endpointConfig.Deployment.Path),
+		"-f", filepath.Join(component.Path(), endpointConfig.Deployment.Path),
 		"--set", fmt.Sprintf("name=%s", expectedDeploymentName),
 		"--set", fmt.Sprintf("endpoint_name=%s", endpointName),
 		"--set", fmt.Sprintf("environment=azureml:%s:%s", environmentName, environmentVersion),

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -331,7 +331,11 @@ func (ch *ContainerHelper) Deploy(
 			if writeImageToEnv {
 				// Save the name of the image we pushed into the environment with a well known key.
 				log.Printf("writing image name to environment")
-				ch.env.SetServiceProperty(component.Name, "IMAGE_NAME", remoteImage)
+				ch.env.SetServiceProperty(
+					fmt.Sprintf("%s_%s", strings.ToUpper(component.Service.Name), strings.ToUpper(component.Name)),
+					"IMAGE_NAME",
+					remoteImage,
+				)
 
 				if err := ch.envManager.Save(ctx, ch.env); err != nil {
 					task.SetError(fmt.Errorf("saving image name to environment: %w", err))

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -278,7 +278,7 @@ func (ch *ContainerHelper) Deploy(
 					// When the project does not contain source and we are using an external image we first need to pull the image
 					// before we're able to push it to a remote registry
 					// In most cases this pull will have already been part of the package step
-					if packageDetails != nil && component.RelativePath == "" {
+					if packageDetails != nil && component.RelativePath == "" && sourceImage != "" {
 						task.SetProgress(NewServiceProgress("Pulling container image"))
 						err = ch.docker.Pull(ctx, sourceImage)
 						if err != nil {
@@ -332,7 +332,7 @@ func (ch *ContainerHelper) Deploy(
 				// Save the name of the image we pushed into the environment with a well known key.
 				log.Printf("writing image name to environment")
 				ch.env.SetServiceProperty(
-					fmt.Sprintf("%s_%s", strings.ToUpper(component.Service.Name), strings.ToUpper(component.Name)),
+					fmt.Sprintf("%s_%s", component.Service.Name, component.Name),
 					"IMAGE_NAME",
 					remoteImage,
 				)

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -50,7 +50,7 @@ func NewContainerHelper(
 // RegistryName returns the name of the destination container registry to use for the current environment from the following:
 // 1. AZURE_CONTAINER_REGISTRY_ENDPOINT environment variable
 // 2. docker.registry from the service configuration
-func (ch *ContainerHelper) RegistryName(ctx context.Context, serviceConfig *ServiceConfig) (string, error) {
+func (ch *ContainerHelper) RegistryName(ctx context.Context, component *ComponentConfig) (string, error) {
 	registryName, found := ch.env.LookupEnv(environment.ContainerRegistryEndpointEnvVarName)
 	if !found {
 		log.Printf(
@@ -60,7 +60,7 @@ func (ch *ContainerHelper) RegistryName(ctx context.Context, serviceConfig *Serv
 	}
 
 	if registryName == "" {
-		yamlRegistryName, err := serviceConfig.Docker.Registry.Envsubst(ch.env.Getenv)
+		yamlRegistryName, err := component.Docker.Registry.Envsubst(ch.env.Getenv)
 		if err != nil {
 			log.Println("Failed expanding 'docker.registry'")
 		}
@@ -72,7 +72,7 @@ func (ch *ContainerHelper) RegistryName(ctx context.Context, serviceConfig *Serv
 	// pushed to a container registry.
 	// If the service does not provide its own code artifacts then the expectation is a registry is optional and
 	// an image can be referenced independently.
-	if serviceConfig.RelativePath != "" && registryName == "" {
+	if component.RelativePath != "" && registryName == "" {
 		return "", fmt.Errorf(
 			//nolint:lll
 			"could not determine container registry endpoint, ensure 'registry' has been set in the docker options or '%s' environment variable has been set",
@@ -87,10 +87,10 @@ func (ch *ContainerHelper) RegistryName(ctx context.Context, serviceConfig *Serv
 // or a default image name generated from the service name and environment name.
 func (ch *ContainerHelper) GeneratedImage(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 ) (*docker.ContainerImage, error) {
 	// Parse the image from azure.yaml configuration when available
-	configuredImage, err := serviceConfig.Docker.Image.Envsubst(ch.env.Getenv)
+	configuredImage, err := component.Docker.Image.Envsubst(ch.env.Getenv)
 	if err != nil {
 		return nil, fmt.Errorf("failed parsing 'image' from docker configuration, %w", err)
 	}
@@ -98,8 +98,8 @@ func (ch *ContainerHelper) GeneratedImage(
 	// Set default image name if not configured
 	if configuredImage == "" {
 		configuredImage = fmt.Sprintf("%s/%s-%s",
-			strings.ToLower(serviceConfig.Project.Name),
-			strings.ToLower(serviceConfig.Name),
+			strings.ToLower(component.Project.Name),
+			strings.ToLower(component.Name),
 			strings.ToLower(ch.env.Name()),
 		)
 	}
@@ -110,7 +110,7 @@ func (ch *ContainerHelper) GeneratedImage(
 	}
 
 	if parsedImage.Tag == "" {
-		configuredTag, err := serviceConfig.Docker.Tag.Envsubst(ch.env.Getenv)
+		configuredTag, err := component.Docker.Tag.Envsubst(ch.env.Getenv)
 		if err != nil {
 			return nil, fmt.Errorf("failed parsing 'tag' from docker configuration, %w", err)
 		}
@@ -128,7 +128,7 @@ func (ch *ContainerHelper) GeneratedImage(
 	// Set default registry if not configured
 	if parsedImage.Registry == "" {
 		// This can fail if called before provisioning the registry
-		configuredRegistry, err := ch.RegistryName(ctx, serviceConfig)
+		configuredRegistry, err := ch.RegistryName(ctx, component)
 		if err == nil {
 			parsedImage.Registry = configuredRegistry
 		}
@@ -140,10 +140,10 @@ func (ch *ContainerHelper) GeneratedImage(
 // RemoteImageTag returns the remote image tag for the service configuration.
 func (ch *ContainerHelper) RemoteImageTag(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	localImageTag string,
 ) (string, error) {
-	registryName, err := ch.RegistryName(ctx, serviceConfig)
+	registryName, err := ch.RegistryName(ctx, component)
 	if err != nil {
 		return "", err
 	}
@@ -161,8 +161,8 @@ func (ch *ContainerHelper) RemoteImageTag(
 }
 
 // LocalImageTag returns the local image tag for the service configuration.
-func (ch *ContainerHelper) LocalImageTag(ctx context.Context, serviceConfig *ServiceConfig) (string, error) {
-	configuredImage, err := ch.GeneratedImage(ctx, serviceConfig)
+func (ch *ContainerHelper) LocalImageTag(ctx context.Context, component *ComponentConfig) (string, error) {
+	configuredImage, err := ch.GeneratedImage(ctx, component)
 	if err != nil {
 		return "", err
 	}
@@ -178,9 +178,9 @@ func (ch *ContainerHelper) RequiredExternalTools(context.Context) []tools.Extern
 // it returns the name of the container registry that was logged into.
 func (ch *ContainerHelper) Login(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 ) (string, error) {
-	registryName, err := ch.RegistryName(ctx, serviceConfig)
+	registryName, err := ch.RegistryName(ctx, component)
 	if err != nil {
 		return "", err
 	}
@@ -199,10 +199,10 @@ var defaultCredentialsRetryDelay = 20 * time.Second
 
 func (ch *ContainerHelper) Credentials(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	targetResource *environment.TargetResource,
 ) (*azcli.DockerCredentials, error) {
-	loginServer, err := ch.RegistryName(ctx, serviceConfig)
+	loginServer, err := ch.RegistryName(ctx, component)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +236,7 @@ func (ch *ContainerHelper) Credentials(
 // environment on success.
 func (ch *ContainerHelper) Deploy(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	packageOutput *ServicePackageResult,
 	targetResource *environment.TargetResource,
 	writeImageToEnv bool,
@@ -244,7 +244,7 @@ func (ch *ContainerHelper) Deploy(
 	return async.RunTaskWithProgress(
 		func(task *async.TaskContextWithProgress[*ServiceDeployResult, ServiceProgress]) {
 			// Get ACR Login Server
-			registryName, err := ch.RegistryName(ctx, serviceConfig)
+			registryName, err := ch.RegistryName(ctx, component)
 			if err != nil {
 				task.SetError(err)
 				return
@@ -264,7 +264,7 @@ func (ch *ContainerHelper) Deploy(
 
 			// If we don't have a registry specified and the service does not reference a project path
 			// then we are referencing a public/pre-existing image and don't have anything to tag or push
-			if registryName == "" && serviceConfig.RelativePath == "" && sourceImage != "" {
+			if registryName == "" && component.RelativePath == "" && sourceImage != "" {
 				remoteImage = sourceImage
 			} else {
 				if targetImage == "" {
@@ -277,7 +277,7 @@ func (ch *ContainerHelper) Deploy(
 					// When the project does not contain source and we are using an external image we first need to pull the image
 					// before we're able to push it to a remote registry
 					// In most cases this pull will have already been part of the package step
-					if packageDetails != nil && serviceConfig.RelativePath == "" {
+					if packageDetails != nil && component.RelativePath == "" {
 						task.SetProgress(NewServiceProgress("Pulling container image"))
 						err = ch.docker.Pull(ctx, sourceImage)
 						if err != nil {
@@ -288,7 +288,7 @@ func (ch *ContainerHelper) Deploy(
 
 					// Tag image
 					// Get remote remoteImageWithTag from the container helper then call docker cli remoteImageWithTag command
-					remoteImageWithTag, err := ch.RemoteImageTag(ctx, serviceConfig, targetImage)
+					remoteImageWithTag, err := ch.RemoteImageTag(ctx, component, targetImage)
 					if err != nil {
 						task.SetError(fmt.Errorf("getting remote image tag: %w", err))
 						return
@@ -297,7 +297,7 @@ func (ch *ContainerHelper) Deploy(
 					remoteImage = remoteImageWithTag
 
 					task.SetProgress(NewServiceProgress("Tagging container image"))
-					if err := ch.docker.Tag(ctx, serviceConfig.Path(), targetImage, remoteImage); err != nil {
+					if err := ch.docker.Tag(ctx, component.Path(), targetImage, remoteImage); err != nil {
 						task.SetError(err)
 						return
 					}
@@ -305,7 +305,7 @@ func (ch *ContainerHelper) Deploy(
 					log.Printf("logging into container registry '%s'\n", registryName)
 					task.SetProgress(NewServiceProgress("Logging into container registry"))
 
-					_, err = ch.Login(ctx, serviceConfig)
+					_, err = ch.Login(ctx, component)
 					if err != nil {
 						task.SetError(err)
 						return
@@ -314,7 +314,7 @@ func (ch *ContainerHelper) Deploy(
 					// Push image.
 					log.Printf("pushing %s to registry", remoteImage)
 					task.SetProgress(NewServiceProgress("Pushing container image"))
-					if err := ch.docker.Push(ctx, serviceConfig.Path(), remoteImage); err != nil {
+					if err := ch.docker.Push(ctx, component.Path(), remoteImage); err != nil {
 						errSuggestion := &internal.ErrorWithSuggestion{
 							Err: err,
 							//nolint:lll
@@ -330,7 +330,7 @@ func (ch *ContainerHelper) Deploy(
 			if writeImageToEnv {
 				// Save the name of the image we pushed into the environment with a well known key.
 				log.Printf("writing image name to environment")
-				ch.env.SetServiceProperty(serviceConfig.Name, "IMAGE_NAME", remoteImage)
+				ch.env.SetServiceProperty(component.Name, "IMAGE_NAME", remoteImage)
 
 				if err := ch.envManager.Save(ctx, ch.env); err != nil {
 					task.SetError(fmt.Errorf("saving image name to environment: %w", err))

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -97,8 +97,9 @@ func (ch *ContainerHelper) GeneratedImage(
 
 	// Set default image name if not configured
 	if configuredImage == "" {
-		configuredImage = fmt.Sprintf("%s/%s-%s",
-			strings.ToLower(component.Project.Name),
+		configuredImage = fmt.Sprintf("%s/%s/%s-%s",
+			strings.ToLower(component.Service.Project.Name),
+			strings.ToLower(component.Service.Name),
 			strings.ToLower(component.Name),
 			strings.ToLower(ch.env.Name()),
 		)

--- a/cli/azd/pkg/project/container_helper_test.go
+++ b/cli/azd/pkg/project/container_helper_test.go
@@ -32,10 +32,12 @@ func Test_ContainerHelper_LocalImageTag(t *testing.T) {
 	projectName := "my-app"
 	serviceName := "web"
 	serviceConfig := &ServiceConfig{
-		Name: serviceName,
-		Host: "containerapp",
-		Project: &ProjectConfig{
-			Name: projectName,
+		ComponentConfig: &ComponentConfig{
+			Name: serviceName,
+			Host: "containerapp",
+			Project: &ProjectConfig{
+				Name: projectName,
+			},
 		},
 	}
 	defaultImageName := fmt.Sprintf("%s/%s-%s", projectName, serviceName, envName)
@@ -64,7 +66,7 @@ func Test_ContainerHelper_LocalImageTag(t *testing.T) {
 			containerHelper := NewContainerHelper(env, nil, clock.NewMock(), nil, nil, cloud.AzurePublic())
 			serviceConfig.Docker = tt.dockerConfig
 
-			tag, err := containerHelper.LocalImageTag(*mockContext.Context, serviceConfig)
+			tag, err := containerHelper.LocalImageTag(*mockContext.Context, serviceConfig.ComponentConfig)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, tag)
 		})
@@ -117,7 +119,11 @@ func Test_ContainerHelper_RemoteImageTag(t *testing.T) {
 			serviceConfig := createTestServiceConfig(tt.project, ContainerAppTarget, ServiceLanguageTypeScript)
 			serviceConfig.Docker.Registry = tt.registry
 
-			remoteTag, err := containerHelper.RemoteImageTag(*mockContext.Context, serviceConfig, tt.localImageTag)
+			remoteTag, err := containerHelper.RemoteImageTag(
+				*mockContext.Context,
+				serviceConfig.ComponentConfig,
+				tt.localImageTag,
+			)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -139,7 +145,7 @@ func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {
 		envManager := &mockenv.MockEnvManager{}
 		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil, cloud.AzurePublic())
 		serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
-		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig)
+		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig.ComponentConfig)
 
 		require.NoError(t, err)
 		require.Equal(t, "contoso.azurecr.io", registryName)
@@ -152,7 +158,7 @@ func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {
 		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil, cloud.AzurePublic())
 		serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
 		serviceConfig.Docker.Registry = osutil.NewExpandableString("contoso.azurecr.io")
-		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig)
+		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig.ComponentConfig)
 
 		require.NoError(t, err)
 		require.Equal(t, "contoso.azurecr.io", registryName)
@@ -166,7 +172,7 @@ func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {
 		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil, cloud.AzurePublic())
 		serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
 		serviceConfig.Docker.Registry = osutil.NewExpandableString("${MY_CUSTOM_REGISTRY}")
-		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig)
+		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig.ComponentConfig)
 
 		require.NoError(t, err)
 		require.Equal(t, "custom.azurecr.io", registryName)
@@ -178,7 +184,7 @@ func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {
 		envManager := &mockenv.MockEnvManager{}
 		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil, cloud.AzurePublic())
 		serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
-		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig)
+		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig.ComponentConfig)
 
 		require.Error(t, err)
 		require.Empty(t, registryName)
@@ -358,7 +364,13 @@ func Test_ContainerHelper_Deploy(t *testing.T) {
 				PackagePath: tt.packagePath,
 			}
 
-			deployTask := containerHelper.Deploy(*mockContext.Context, serviceConfig, packageOutput, targetResource, true)
+			deployTask := containerHelper.Deploy(
+				*mockContext.Context,
+				serviceConfig.ComponentConfig,
+				packageOutput,
+				targetResource,
+				true,
+			)
 			logProgress(deployTask)
 			deployResult, err := deployTask.Await()
 
@@ -524,7 +536,7 @@ func Test_ContainerHelper_ConfiguredImage(t *testing.T) {
 				env.DotenvSet(k, v)
 			}
 
-			image, err := containerHelper.GeneratedImage(*mockContext.Context, serviceConfig)
+			image, err := containerHelper.GeneratedImage(*mockContext.Context, serviceConfig.ComponentConfig)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/cli/azd/pkg/project/container_helper_test.go
+++ b/cli/azd/pkg/project/container_helper_test.go
@@ -32,9 +32,9 @@ func Test_ContainerHelper_LocalImageTag(t *testing.T) {
 	projectName := "my-app"
 	serviceName := "web"
 	serviceConfig := &ServiceConfig{
+		Host: "containerapp",
 		ComponentConfig: &ComponentConfig{
 			Name: serviceName,
-			Host: "containerapp",
 			Project: &ProjectConfig{
 				Name: projectName,
 			},

--- a/cli/azd/pkg/project/dotnet_importer.go
+++ b/cli/azd/pkg/project/dotnet_importer.go
@@ -415,7 +415,12 @@ func (ai *DotNetImporter) ReadManifest(ctx context.Context, svcConfig *ServiceCo
 	}
 
 	ai.console.ShowSpinner(ctx, "Analyzing Aspire Application (this might take a moment...)", input.Step)
-	manifest, err := apphost.ManifestFromAppHost(ctx, svcConfig.Components[DefaultComponentName].Path(), ai.dotnetCli, dotnetEnv)
+	manifest, err := apphost.ManifestFromAppHost(
+		ctx,
+		svcConfig.Components[DefaultComponentName].Path(),
+		ai.dotnetCli,
+		dotnetEnv,
+	)
 	ai.console.StopSpinner(ctx, "", input.Step)
 	if err != nil {
 		return nil, err

--- a/cli/azd/pkg/project/dotnet_importer.go
+++ b/cli/azd/pkg/project/dotnet_importer.go
@@ -185,16 +185,18 @@ func (ai *DotNetImporter) Services(
 
 		// TODO(ellismg): Some of this code is duplicated from project.Parse, we should centralize this logic long term.
 		svc := &ServiceConfig{
-			RelativePath: relPath,
-			Language:     ServiceLanguageDotNet,
-			Host:         DotNetContainerAppTarget,
+			ComponentConfig: &ComponentConfig{
+				RelativePath: relPath,
+				Language:     ServiceLanguageDotNet,
+				Host:         DotNetContainerAppTarget,
+			},
 		}
 
 		svc.Name = name
 		svc.Project = p
 		svc.EventDispatcher = ext.NewEventDispatcher[ServiceLifecycleEventArgs]()
 
-		svc.Infra.Provider, err = provisioning.ParseProvider(svc.Infra.Provider)
+		svc.Project.Infra.Provider, err = provisioning.ParseProvider(svc.Project.Infra.Provider)
 		if err != nil {
 			return nil, fmt.Errorf("parsing service %s: %w", svc.Name, err)
 		}
@@ -217,13 +219,15 @@ func (ai *DotNetImporter) Services(
 
 		// TODO(ellismg): Some of this code is duplicated from project.Parse, we should centralize this logic long term.
 		svc := &ServiceConfig{
-			RelativePath: relPath,
-			Language:     ServiceLanguageDocker,
-			Host:         DotNetContainerAppTarget,
-			Docker: DockerProjectOptions{
-				Path:      dockerfile.Path,
-				Context:   dockerfile.Context,
-				BuildArgs: mapToStringSlice(dockerfile.BuildArgs, "="),
+			ComponentConfig: &ComponentConfig{
+				RelativePath: relPath,
+				Language:     ServiceLanguageDocker,
+				Host:         DotNetContainerAppTarget,
+				Docker: DockerProjectOptions{
+					Path:      dockerfile.Path,
+					Context:   dockerfile.Context,
+					BuildArgs: mapToStringSlice(dockerfile.BuildArgs, "="),
+				},
 			},
 		}
 
@@ -231,7 +235,7 @@ func (ai *DotNetImporter) Services(
 		svc.Project = p
 		svc.EventDispatcher = ext.NewEventDispatcher[ServiceLifecycleEventArgs]()
 
-		svc.Infra.Provider, err = provisioning.ParseProvider(svc.Infra.Provider)
+		svc.Project.Infra.Provider, err = provisioning.ParseProvider(svc.Project.Infra.Provider)
 		if err != nil {
 			return nil, fmt.Errorf("parsing service %s: %w", svc.Name, err)
 		}
@@ -249,16 +253,18 @@ func (ai *DotNetImporter) Services(
 	for name, container := range containers {
 		// TODO(ellismg): Some of this code is duplicated from project.Parse, we should centralize this logic long term.
 		svc := &ServiceConfig{
-			RelativePath: svcConfig.RelativePath,
-			Language:     ServiceLanguageDotNet,
-			Host:         DotNetContainerAppTarget,
+			ComponentConfig: &ComponentConfig{
+				RelativePath: svcConfig.RelativePath,
+				Language:     ServiceLanguageDotNet,
+				Host:         DotNetContainerAppTarget,
+			},
 		}
 
 		svc.Name = name
 		svc.Project = p
 		svc.EventDispatcher = ext.NewEventDispatcher[ServiceLifecycleEventArgs]()
 
-		svc.Infra.Provider, err = provisioning.ParseProvider(svc.Infra.Provider)
+		svc.Project.Infra.Provider, err = provisioning.ParseProvider(svc.Project.Infra.Provider)
 		if err != nil {
 			return nil, fmt.Errorf("parsing service %s: %w", svc.Name, err)
 		}

--- a/cli/azd/pkg/project/framework_service.go
+++ b/cli/azd/pkg/project/framework_service.go
@@ -68,7 +68,7 @@ type FrameworkService interface {
 
 	// Initializes the framework service for the specified service configuration
 	// This is useful if the framework needs to subscribe to any service events
-	Initialize(ctx context.Context, serviceConfig *ServiceConfig) error
+	Initialize(ctx context.Context, component *ComponentConfig) error
 
 	// Gets the requirements for the language or framework service.
 	// This enables more fine grain control on whether the language / framework
@@ -78,13 +78,13 @@ type FrameworkService interface {
 	// Restores dependencies for the framework service
 	Restore(
 		ctx context.Context,
-		serviceConfig *ServiceConfig,
+		component *ComponentConfig,
 	) *async.TaskWithProgress[*ServiceRestoreResult, ServiceProgress]
 
 	// Builds the source for the framework service
 	Build(
 		ctx context.Context,
-		serviceConfig *ServiceConfig,
+		component *ComponentConfig,
 		restoreOutput *ServiceRestoreResult,
 	) *async.TaskWithProgress[*ServiceBuildResult, ServiceProgress]
 
@@ -92,7 +92,7 @@ type FrameworkService interface {
 	// This may optionally perform a rebuild internally depending on the language/framework requirements
 	Package(
 		ctx context.Context,
-		serviceConfig *ServiceConfig,
+		component *ComponentConfig,
 		buildOutput *ServiceBuildResult,
 	) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress]
 }

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -214,8 +214,9 @@ func (p *dockerProject) Build(
 			)
 
 			imageName := fmt.Sprintf(
-				"%s-%s",
-				strings.ToLower(component.Project.Name),
+				"%s-%s-%s",
+				strings.ToLower(component.Service.Project.Name),
+				strings.ToLower(component.Service.Name),
 				strings.ToLower(component.Name),
 			)
 

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -370,7 +370,7 @@ func (p *dockerProject) packBuild(
 		// Always default to port 80 for consistency across languages
 		environ = append(environ, "ORYX_RUNTIME_PORT=80")
 
-		if component.Language  == ServiceLanguageJava {
+		if component.Language == ServiceLanguageJava {
 			environ = append(environ, "ORYX_RUNTIME_PORT=8080")
 		}
 

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -49,12 +49,11 @@ type dockerBuildResult struct {
 }
 
 func (dbr *dockerBuildResult) ToString(currentIndentation string) string {
-	lines := []string{
-		fmt.Sprintf("%s- Image ID: %s", currentIndentation, output.WithLinkFormat(dbr.ImageId)),
-		fmt.Sprintf("%s- Image Name: %s", currentIndentation, output.WithLinkFormat(dbr.ImageName)),
-	}
+	builder := strings.Builder{}
+	builder.WriteString(fmt.Sprintf("%s- Image Hash: %s\n", currentIndentation, output.WithLinkFormat(dbr.ImageId)))
+	builder.WriteString(fmt.Sprintf("%s- Image Name: %s\n", currentIndentation, output.WithLinkFormat(dbr.ImageName)))
 
-	return strings.Join(lines, "\n")
+	return builder.String()
 }
 
 func (dbr *dockerBuildResult) MarshalJSON() ([]byte, error) {
@@ -162,8 +161,8 @@ func (p *dockerProject) RequiredExternalTools(context.Context) []tools.ExternalT
 }
 
 // Initializes the docker project
-func (p *dockerProject) Initialize(ctx context.Context, serviceConfig *ServiceConfig) error {
-	return p.framework.Initialize(ctx, serviceConfig)
+func (p *dockerProject) Initialize(ctx context.Context, component *ComponentConfig) error {
+	return p.framework.Initialize(ctx, component)
 }
 
 // Sets the inner framework service used for restore and build command
@@ -174,28 +173,28 @@ func (p *dockerProject) SetSource(inner FrameworkService) {
 // Restores the dependencies for the docker project
 func (p *dockerProject) Restore(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 ) *async.TaskWithProgress[*ServiceRestoreResult, ServiceProgress] {
 	// When the program runs the restore actions for the underlying project (containerapp),
 	// the dependencies are installed locally
-	return p.framework.Restore(ctx, serviceConfig)
+	return p.framework.Restore(ctx, component)
 }
 
 // Builds the docker project based on the docker options specified within the Service configuration
 func (p *dockerProject) Build(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	restoreOutput *ServiceRestoreResult,
 ) *async.TaskWithProgress[*ServiceBuildResult, ServiceProgress] {
 	return async.RunTaskWithProgress(
 		func(task *async.TaskContextWithProgress[*ServiceBuildResult, ServiceProgress]) {
-			dockerOptions := getDockerOptionsWithDefaults(serviceConfig.Docker)
+			dockerOptions := getDockerOptionsWithDefaults(component.Docker)
 
 			// For services that do not specify a project path and have not specified a language then
 			// there is nothing to build and we can return an empty build result
 			// Ex) A container app project that uses an external image path
-			if serviceConfig.RelativePath == "" &&
-				(serviceConfig.Language == ServiceLanguageNone || serviceConfig.Language == ServiceLanguageDocker) {
+			if component.RelativePath == "" &&
+				(component.Language == ServiceLanguageNone || component.Language == ServiceLanguageDocker) {
 				task.SetResult(&ServiceBuildResult{})
 				return
 			}
@@ -207,8 +206,8 @@ func (p *dockerProject) Build(
 
 			log.Printf(
 				"building image for service %s, cwd: %s, path: %s, context: %s, buildArgs: %s)",
-				serviceConfig.Name,
-				serviceConfig.Path(),
+				component.Name,
+				component.Path(),
 				dockerOptions.Path,
 				dockerOptions.Context,
 				buildArgs,
@@ -216,13 +215,13 @@ func (p *dockerProject) Build(
 
 			imageName := fmt.Sprintf(
 				"%s-%s",
-				strings.ToLower(serviceConfig.Project.Name),
-				strings.ToLower(serviceConfig.Name),
+				strings.ToLower(component.Project.Name),
+				strings.ToLower(component.Name),
 			)
 
 			path := dockerOptions.Path
 			if !filepath.IsAbs(path) {
-				path = filepath.Join(serviceConfig.Path(), path)
+				path = filepath.Join(component.Path(), path)
 			}
 
 			_, err := os.Stat(path)
@@ -234,7 +233,7 @@ func (p *dockerProject) Build(
 			if errors.Is(err, os.ErrNotExist) {
 				// Build the container from source
 				task.SetProgress(NewServiceProgress("Building Docker image from source"))
-				res, err := p.packBuild(ctx, serviceConfig, dockerOptions, imageName)
+				res, err := p.packBuild(ctx, component, dockerOptions, imageName)
 				if err != nil {
 					task.SetError(err)
 					return
@@ -255,7 +254,7 @@ func (p *dockerProject) Build(
 				})
 			imageId, err := p.docker.Build(
 				ctx,
-				serviceConfig.Path(),
+				component.Path(),
 				dockerOptions.Path,
 				dockerOptions.Platform,
 				dockerOptions.Target,
@@ -266,11 +265,11 @@ func (p *dockerProject) Build(
 			)
 			p.console.StopPreviewer(ctx, false)
 			if err != nil {
-				task.SetError(fmt.Errorf("building container: %s at %s: %w", serviceConfig.Name, dockerOptions.Context, err))
+				task.SetError(fmt.Errorf("building container: %s at %s: %w", component.Name, dockerOptions.Context, err))
 				return
 			}
 
-			log.Printf("built image %s for %s", imageId, serviceConfig.Name)
+			log.Printf("built image %s for %s", imageId, component.Name)
 			task.SetResult(&ServiceBuildResult{
 				Restore:         restoreOutput,
 				BuildOutputPath: imageId,
@@ -285,7 +284,7 @@ func (p *dockerProject) Build(
 
 func (p *dockerProject) Package(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	buildOutput *ServiceBuildResult,
 ) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress] {
 	return async.RunTaskWithProgress(
@@ -302,7 +301,7 @@ func (p *dockerProject) Package(
 
 			// If we don't have an image ID from a docker build then an external source image is being used
 			if imageId == "" {
-				sourceImage, err := docker.ParseContainerImage(serviceConfig.Image)
+				sourceImage, err := docker.ParseContainerImage(component.Image)
 				if err != nil {
 					task.SetError(fmt.Errorf("parsing source container image: %w", err))
 					return
@@ -321,7 +320,7 @@ func (p *dockerProject) Package(
 			}
 
 			// Generate a local tag from the 'docker' configuration section of the service
-			imageWithTag, err := p.containerHelper.LocalImageTag(ctx, serviceConfig)
+			imageWithTag, err := p.containerHelper.LocalImageTag(ctx, component)
 			if err != nil {
 				task.SetError(fmt.Errorf("generating local image tag: %w", err))
 				return
@@ -330,7 +329,7 @@ func (p *dockerProject) Package(
 			// Tag image.
 			log.Printf("tagging image %s as %s", imageId, imageWithTag)
 			task.SetProgress(NewServiceProgress("Tagging container image"))
-			if err := p.docker.Tag(ctx, serviceConfig.Path(), imageId, imageWithTag); err != nil {
+			if err := p.docker.Tag(ctx, component.Path(), imageId, imageWithTag); err != nil {
 				task.SetError(fmt.Errorf("tagging image: %w", err))
 				return
 			}
@@ -351,7 +350,7 @@ const DefaultBuilderImage = "mcr.microsoft.com/oryx/builder:debian-bullseye-2023
 
 func (p *dockerProject) packBuild(
 	ctx context.Context,
-	svc *ServiceConfig,
+	component *ComponentConfig,
 	dockerOptions DockerProjectOptions,
 	imageName string) (*ServiceBuildResult, error) {
 	packCli, err := pack.NewPackCli(ctx, p.console, p.commandRunner)
@@ -371,12 +370,14 @@ func (p *dockerProject) packBuild(
 		// Always default to port 80 for consistency across languages
 		environ = append(environ, "ORYX_RUNTIME_PORT=80")
 
-		if svc.Language == ServiceLanguageJava {
+		if component.Language  == ServiceLanguageJava {
 			environ = append(environ, "ORYX_RUNTIME_PORT=8080")
 		}
 
-		if svc.OutputPath != "" && (svc.Language == ServiceLanguageTypeScript || svc.Language == ServiceLanguageJavaScript) {
-			inDockerOutputPath := path.Join("/workspace", svc.OutputPath)
+		if component.OutputPath != "" &&
+			(component.Language == ServiceLanguageTypeScript || component.Language == ServiceLanguageJavaScript) {
+			inDockerOutputPath := path.Join("/workspace", component.OutputPath)
+
 			// A dist folder has been set.
 			// We assume that the service is a front-end service, configuring a nginx web server to serve the static content
 			// produced.
@@ -388,13 +389,13 @@ func (p *dockerProject) packBuild(
 						"rm -rf /usr/share/nginx/html && ln -sT %s /usr/share/nginx/html && "+
 						"nginx -g 'daemon off;'",
 					inDockerOutputPath,
-					svc.OutputPath,
+					component.OutputPath,
 					inDockerOutputPath,
 				))
 		}
 
-		if svc.Language == ServiceLanguagePython {
-			pyEnviron, err := getEnvironForPython(ctx, svc)
+		if component.Language == ServiceLanguagePython {
+			pyEnviron, err := getEnvironForPython(ctx, component)
 			if err != nil {
 				return nil, err
 			}
@@ -414,7 +415,7 @@ func (p *dockerProject) packBuild(
 	ctx, span := tracing.Start(
 		ctx,
 		events.PackBuildEvent,
-		trace.WithAttributes(fields.ProjectServiceLanguageKey.String(string(svc.Language))))
+		trace.WithAttributes(fields.ProjectServiceLanguageKey.String(string(component.Language))))
 
 	img, tag := docker.SplitDockerImage(builder)
 	if userDefinedImage {
@@ -431,7 +432,7 @@ func (p *dockerProject) packBuild(
 
 	err = packCli.Build(
 		ctx,
-		svc.Path(),
+		component.Path(),
 		builder,
 		imageName,
 		environ,
@@ -447,7 +448,7 @@ func (p *dockerProject) packBuild(
 				Suggestion: "No Dockerfile was found, and image could not be automatically built from source. " +
 					fmt.Sprintf(
 						"\nSuggested action: Author a Dockerfile and save it as %s",
-						filepath.Join(svc.Path(), dockerOptions.Path)),
+						filepath.Join(component.Path(), dockerOptions.Path)),
 			}
 		}
 
@@ -471,8 +472,8 @@ func (p *dockerProject) packBuild(
 	}, nil
 }
 
-func getEnvironForPython(ctx context.Context, svc *ServiceConfig) ([]string, error) {
-	prj, err := appdetect.DetectDirectory(ctx, svc.Path())
+func getEnvironForPython(ctx context.Context, component *ComponentConfig) ([]string, error) {
+	prj, err := appdetect.DetectDirectory(ctx, component.Path())
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -114,7 +114,7 @@ services:
 		mockContext.CommandRunner)
 	framework.SetSource(internalFramework)
 
-	buildTask := framework.Build(*mockContext.Context, service, nil)
+	buildTask := framework.Build(*mockContext.Context, service.ComponentConfig, nil)
 	go func() {
 		for value := range buildTask.Progress() {
 			progressMessages = append(progressMessages, value.Message)
@@ -222,7 +222,7 @@ services:
 		mockContext.CommandRunner)
 	framework.SetSource(internalFramework)
 
-	buildTask := framework.Build(*mockContext.Context, service, nil)
+	buildTask := framework.Build(*mockContext.Context, service.ComponentConfig, nil)
 	go func() {
 		for value := range buildTask.Progress() {
 			status = value.Message
@@ -428,7 +428,7 @@ func Test_DockerProject_Build(t *testing.T) {
 				dockerProject.SetSource(npmProject)
 			}
 
-			buildTask := dockerProject.Build(*mockContext.Context, serviceConfig, nil)
+			buildTask := dockerProject.Build(*mockContext.Context, serviceConfig.ComponentConfig, nil)
 			logProgress(buildTask)
 			result, err := buildTask.Await()
 
@@ -554,7 +554,7 @@ func Test_DockerProject_Package(t *testing.T) {
 
 			packageTask := dockerProject.Package(
 				*mockContext.Context,
-				serviceConfig,
+				serviceConfig.ComponentConfig,
 				&ServiceBuildResult{
 					BuildOutputPath: buildOutputPath,
 				},

--- a/cli/azd/pkg/project/framework_service_dotnet.go
+++ b/cli/azd/pkg/project/framework_service_dotnet.go
@@ -61,7 +61,7 @@ func (dp *dotnetProject) Initialize(ctx context.Context, component *ComponentCon
 	//
 	// We'd like to stop doing this at some point for all .NET projects, but we can make sure that we don't inherit the
 	// bad behavior for containerized projects, without being concerned about it being considered a breaking change.
-	if component.Host != DotNetContainerAppTarget {
+	if component.Service.Host != DotNetContainerAppTarget {
 		projFile, err := findProjectFile(component.Name, component.Path())
 		if err != nil {
 			return err
@@ -156,7 +156,7 @@ func (dp *dotnetProject) Package(
 ) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress] {
 	return async.RunTaskWithProgress(
 		func(task *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
-			if component.Host == DotNetContainerAppTarget {
+			if component.Service.Host == DotNetContainerAppTarget {
 				// TODO(weilim): For containerized projects, we publish the produced container image in a single call
 				// via `dotnet publish /p:PublishProfile=DefaultContainer`, thus the default `dotnet publish` command
 				// executed here is not useful.

--- a/cli/azd/pkg/project/framework_service_dotnet_test.go
+++ b/cli/azd/pkg/project/framework_service_dotnet_test.go
@@ -41,16 +41,18 @@ func TestBicepOutputsWithDoubleUnderscoresAreConverted(t *testing.T) {
 	})
 
 	serviceConfig := &ServiceConfig{
-		Project: &ProjectConfig{
-			Path: "/sample/path/for/test",
+		ComponentConfig: &ComponentConfig{
+			Project: &ProjectConfig{
+				Path: "/sample/path/for/test",
+			},
+			RelativePath: "",
 		},
-		RelativePath: "",
 	}
 
 	dotNetCli := dotnet.NewDotNetCli(mockContext.CommandRunner)
 	dp := NewDotNetProject(dotNetCli, environment.New("test")).(*dotnetProject)
 
-	err := dp.setUserSecretsFromOutputs(*mockContext.Context, serviceConfig, ServiceLifecycleEventArgs{
+	err := dp.setUserSecretsFromOutputs(*mockContext.Context, serviceConfig.ComponentConfig, ServiceLifecycleEventArgs{
 		Args: map[string]any{
 			"bicepOutput": map[string]provisioning.OutputParameter{
 				"EXAMPLE_OUTPUT":          {Type: "string", Value: "foo"},
@@ -98,7 +100,7 @@ func Test_DotNetProject_Init(t *testing.T) {
 
 	dotnetProject := NewDotNetProject(dotNetCli, env)
 
-	err = dotnetProject.Initialize(*mockContext.Context, serviceConfig)
+	err = dotnetProject.Initialize(*mockContext.Context, serviceConfig.ComponentConfig)
 	require.NoError(t, err)
 
 	eventArgs := ServiceLifecycleEventArgs{
@@ -149,7 +151,7 @@ func Test_DotNetProject_Restore(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api/test.csproj", AppServiceTarget, ServiceLanguageCsharp)
 
 	dotnetProject := NewDotNetProject(dotNetCli, env)
-	restoreTask := dotnetProject.Restore(*mockContext.Context, serviceConfig)
+	restoreTask := dotnetProject.Restore(*mockContext.Context, serviceConfig.ComponentConfig)
 	logProgress(restoreTask)
 
 	result, err := restoreTask.Await()
@@ -193,7 +195,7 @@ func Test_DotNetProject_Build(t *testing.T) {
 	require.NoError(t, err)
 
 	dotnetProject := NewDotNetProject(dotNetCli, env)
-	buildTask := dotnetProject.Build(*mockContext.Context, serviceConfig, nil)
+	buildTask := dotnetProject.Build(*mockContext.Context, serviceConfig.ComponentConfig, nil)
 	logProgress(buildTask)
 
 	result, err := buildTask.Await()
@@ -249,7 +251,7 @@ func Test_DotNetProject_Package(t *testing.T) {
 	dotnetProject := NewDotNetProject(dotNetCli, env)
 	packageTask := dotnetProject.Package(
 		*mockContext.Context,
-		serviceConfig,
+		serviceConfig.ComponentConfig,
 		&ServiceBuildResult{
 			BuildOutputPath: serviceConfig.Path(),
 		},

--- a/cli/azd/pkg/project/framework_service_maven.go
+++ b/cli/azd/pkg/project/framework_service_maven.go
@@ -53,7 +53,7 @@ func (m *mavenProject) RequiredExternalTools(context.Context) []tools.ExternalTo
 
 // Initializes the maven project
 func (m *mavenProject) Initialize(ctx context.Context, component *ComponentConfig) error {
-	m.mavenCli.SetPath(component.Path(), component.Project.Path)
+	m.mavenCli.SetPath(component.Path(), component.Service.Project.Path)
 	return nil
 }
 

--- a/cli/azd/pkg/project/framework_service_maven_test.go
+++ b/cli/azd/pkg/project/framework_service_maven_test.go
@@ -165,11 +165,11 @@ func Test_MavenProject_Package(t *testing.T) {
 			"Default",
 			args{
 				&ServiceConfig{
+					Host: AppServiceTarget,
 					ComponentConfig: &ComponentConfig{
 						Project:      &ProjectConfig{},
 						Name:         "api",
 						RelativePath: "src/api",
-						Host:         AppServiceTarget,
 						Language:     ServiceLanguageJava,
 					},
 					EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
@@ -181,12 +181,12 @@ func Test_MavenProject_Package(t *testing.T) {
 		{
 			"SpecifyOutputDir",
 			args{&ServiceConfig{
+				Host: AppServiceTarget,
 				ComponentConfig: &ComponentConfig{
 					Project:      &ProjectConfig{},
 					Name:         "api",
 					RelativePath: "src/api",
 					OutputPath:   "mydir",
-					Host:         AppServiceTarget,
 					Language:     ServiceLanguageJava,
 				},
 				EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
@@ -198,12 +198,12 @@ func Test_MavenProject_Package(t *testing.T) {
 		{
 			"SpecifyOutputFile",
 			args{&ServiceConfig{
+				Host: AppServiceTarget,
 				ComponentConfig: &ComponentConfig{
 					Project:      &ProjectConfig{},
 					Name:         "api",
 					RelativePath: "src/api",
 					OutputPath:   "mydir/ear.ear",
-					Host:         AppServiceTarget,
 					Language:     ServiceLanguageJava,
 				},
 				EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
@@ -215,11 +215,11 @@ func Test_MavenProject_Package(t *testing.T) {
 		{
 			"ErrNoArchive",
 			args{&ServiceConfig{
+				Host: AppServiceTarget,
 				ComponentConfig: &ComponentConfig{
 					Project:      &ProjectConfig{},
 					Name:         "api",
 					RelativePath: "src/api",
-					Host:         AppServiceTarget,
 					Language:     ServiceLanguageJava,
 				},
 				EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
@@ -231,12 +231,12 @@ func Test_MavenProject_Package(t *testing.T) {
 		{
 			"ErrMultipleArchives",
 			args{&ServiceConfig{
+				Host: AppServiceTarget,
 				ComponentConfig: &ComponentConfig{
 					Project:      &ProjectConfig{},
 					Name:         "api",
 					RelativePath: "src/api",
 					OutputPath:   "mydir",
-					Host:         AppServiceTarget,
 					Language:     ServiceLanguageJava,
 				},
 				EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),

--- a/cli/azd/pkg/project/framework_service_maven_test.go
+++ b/cli/azd/pkg/project/framework_service_maven_test.go
@@ -199,7 +199,8 @@ func Test_MavenProject_Package(t *testing.T) {
 			"SpecifyOutputFile",
 			args{&ServiceConfig{
 				Host: AppServiceTarget,
-				ComponentConfig: &ComponentConfig{
+				Components: map[string]*ComponentConfig{
+					DefaultComponentName: {
 					Project:      &ProjectConfig{},
 					Name:         "api",
 					RelativePath: "src/api",
@@ -216,11 +217,12 @@ func Test_MavenProject_Package(t *testing.T) {
 			"ErrNoArchive",
 			args{&ServiceConfig{
 				Host: AppServiceTarget,
-				ComponentConfig: &ComponentConfig{
-					Project:      &ProjectConfig{},
-					Name:         "api",
-					RelativePath: "src/api",
-					Language:     ServiceLanguageJava,
+				Components: map[string]*ComponentConfig{
+					DefaultComponentName: {
+						Name:         "api",
+						RelativePath: "src/api",
+						Language:     ServiceLanguageJava,
+					},
 				},
 				EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
 			},

--- a/cli/azd/pkg/project/framework_service_maven_test.go
+++ b/cli/azd/pkg/project/framework_service_maven_test.go
@@ -46,10 +46,10 @@ func Test_MavenProject(t *testing.T) {
 		javaCli := javac.NewCli(mockContext.CommandRunner)
 
 		mavenProject := NewMavenProject(env, mavenCli, javaCli)
-		err = mavenProject.Initialize(*mockContext.Context, serviceConfig)
+		err = mavenProject.Initialize(*mockContext.Context, serviceConfig.ComponentConfig)
 		require.NoError(t, err)
 
-		restoreTask := mavenProject.Restore(*mockContext.Context, serviceConfig)
+		restoreTask := mavenProject.Restore(*mockContext.Context, serviceConfig.ComponentConfig)
 		logProgress(restoreTask)
 
 		result, err := restoreTask.Await()
@@ -82,10 +82,10 @@ func Test_MavenProject(t *testing.T) {
 		javaCli := javac.NewCli(mockContext.CommandRunner)
 
 		mavenProject := NewMavenProject(env, mavenCli, javaCli)
-		err = mavenProject.Initialize(*mockContext.Context, serviceConfig)
+		err = mavenProject.Initialize(*mockContext.Context, serviceConfig.ComponentConfig)
 		require.NoError(t, err)
 
-		buildTask := mavenProject.Build(*mockContext.Context, serviceConfig, nil)
+		buildTask := mavenProject.Build(*mockContext.Context, serviceConfig.ComponentConfig, nil)
 		logProgress(buildTask)
 
 		result, err := buildTask.Await()
@@ -124,12 +124,12 @@ func Test_MavenProject(t *testing.T) {
 		require.NoError(t, err)
 
 		mavenProject := NewMavenProject(env, mavenCli, javaCli)
-		err = mavenProject.Initialize(*mockContext.Context, serviceConfig)
+		err = mavenProject.Initialize(*mockContext.Context, serviceConfig.ComponentConfig)
 		require.NoError(t, err)
 
 		packageTask := mavenProject.Package(
 			*mockContext.Context,
-			serviceConfig,
+			serviceConfig.ComponentConfig,
 			&ServiceBuildResult{
 				BuildOutputPath: serviceConfig.Path(),
 			},
@@ -165,11 +165,13 @@ func Test_MavenProject_Package(t *testing.T) {
 			"Default",
 			args{
 				&ServiceConfig{
-					Project:         &ProjectConfig{},
-					Name:            "api",
-					RelativePath:    "src/api",
-					Host:            AppServiceTarget,
-					Language:        ServiceLanguageJava,
+					ComponentConfig: &ComponentConfig{
+						Project:      &ProjectConfig{},
+						Name:         "api",
+						RelativePath: "src/api",
+						Host:         AppServiceTarget,
+						Language:     ServiceLanguageJava,
+					},
 					EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
 				},
 				[]string{".jar"},
@@ -179,12 +181,14 @@ func Test_MavenProject_Package(t *testing.T) {
 		{
 			"SpecifyOutputDir",
 			args{&ServiceConfig{
-				Project:         &ProjectConfig{},
-				Name:            "api",
-				RelativePath:    "src/api",
-				OutputPath:      "mydir",
-				Host:            AppServiceTarget,
-				Language:        ServiceLanguageJava,
+				ComponentConfig: &ComponentConfig{
+					Project:      &ProjectConfig{},
+					Name:         "api",
+					RelativePath: "src/api",
+					OutputPath:   "mydir",
+					Host:         AppServiceTarget,
+					Language:     ServiceLanguageJava,
+				},
 				EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
 			},
 				[]string{".war"},
@@ -194,12 +198,14 @@ func Test_MavenProject_Package(t *testing.T) {
 		{
 			"SpecifyOutputFile",
 			args{&ServiceConfig{
-				Project:         &ProjectConfig{},
-				Name:            "api",
-				RelativePath:    "src/api",
-				OutputPath:      "mydir/ear.ear",
-				Host:            AppServiceTarget,
-				Language:        ServiceLanguageJava,
+				ComponentConfig: &ComponentConfig{
+					Project:      &ProjectConfig{},
+					Name:         "api",
+					RelativePath: "src/api",
+					OutputPath:   "mydir/ear.ear",
+					Host:         AppServiceTarget,
+					Language:     ServiceLanguageJava,
+				},
 				EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
 			},
 				[]string{".ear"},
@@ -209,11 +215,13 @@ func Test_MavenProject_Package(t *testing.T) {
 		{
 			"ErrNoArchive",
 			args{&ServiceConfig{
-				Project:         &ProjectConfig{},
-				Name:            "api",
-				RelativePath:    "src/api",
-				Host:            AppServiceTarget,
-				Language:        ServiceLanguageJava,
+				ComponentConfig: &ComponentConfig{
+					Project:      &ProjectConfig{},
+					Name:         "api",
+					RelativePath: "src/api",
+					Host:         AppServiceTarget,
+					Language:     ServiceLanguageJava,
+				},
 				EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
 			},
 				[]string{},
@@ -223,12 +231,14 @@ func Test_MavenProject_Package(t *testing.T) {
 		{
 			"ErrMultipleArchives",
 			args{&ServiceConfig{
-				Project:         &ProjectConfig{},
-				Name:            "api",
-				RelativePath:    "src/api",
-				OutputPath:      "mydir",
-				Host:            AppServiceTarget,
-				Language:        ServiceLanguageJava,
+				ComponentConfig: &ComponentConfig{
+					Project:      &ProjectConfig{},
+					Name:         "api",
+					RelativePath: "src/api",
+					OutputPath:   "mydir",
+					Host:         AppServiceTarget,
+					Language:     ServiceLanguageJava,
+				},
 				EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
 			},
 				[]string{".jar", ".war", ".ear"},
@@ -285,12 +295,13 @@ func Test_MavenProject_Package(t *testing.T) {
 			mavenCli := maven.NewMavenCli(mockContext.CommandRunner)
 			javaCli := javac.NewCli(mockContext.CommandRunner)
 			mavenProject := NewMavenProject(env, mavenCli, javaCli)
-			err = mavenProject.Initialize(*mockContext.Context, tt.args.svc)
+			svc := tt.args.svc
+			err = mavenProject.Initialize(*mockContext.Context, svc.ComponentConfig)
 			require.NoError(t, err)
 
 			packageTask := mavenProject.Package(
 				*mockContext.Context,
-				tt.args.svc,
+				svc.ComponentConfig,
 				&ServiceBuildResult{},
 			)
 			logProgress(packageTask)

--- a/cli/azd/pkg/project/framework_service_noop.go
+++ b/cli/azd/pkg/project/framework_service_noop.go
@@ -27,13 +27,13 @@ func (n *noOpProject) Requirements() FrameworkRequirements {
 	}
 }
 
-func (n *noOpProject) Initialize(ctx context.Context, serviceConfig *ServiceConfig) error {
+func (n *noOpProject) Initialize(ctx context.Context, component *ComponentConfig) error {
 	return nil
 }
 
 func (n *noOpProject) Restore(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 ) *async.TaskWithProgress[*ServiceRestoreResult, ServiceProgress] {
 	return async.RunTaskWithProgress(
 		func(task *async.TaskContextWithProgress[*ServiceRestoreResult, ServiceProgress]) {
@@ -44,7 +44,7 @@ func (n *noOpProject) Restore(
 
 func (n *noOpProject) Build(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	restoreOutput *ServiceRestoreResult,
 ) *async.TaskWithProgress[*ServiceBuildResult, ServiceProgress] {
 	return async.RunTaskWithProgress(
@@ -56,7 +56,7 @@ func (n *noOpProject) Build(
 
 func (n *noOpProject) Package(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	buildOutput *ServiceBuildResult,
 ) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress] {
 	return async.RunTaskWithProgress(

--- a/cli/azd/pkg/project/framework_service_npm_test.go
+++ b/cli/azd/pkg/project/framework_service_npm_test.go
@@ -34,7 +34,7 @@ func Test_NpmProject_Restore(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageTypeScript)
 
 	npmProject := NewNpmProject(npmCli, env)
-	restoreTask := npmProject.Restore(*mockContext.Context, serviceConfig)
+	restoreTask := npmProject.Restore(*mockContext.Context, serviceConfig.ComponentConfig)
 	logProgress(restoreTask)
 
 	result, err := restoreTask.Await()
@@ -66,7 +66,7 @@ func Test_NpmProject_Build(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageTypeScript)
 
 	npmProject := NewNpmProject(npmCli, env)
-	buildTask := npmProject.Build(*mockContext.Context, serviceConfig, nil)
+	buildTask := npmProject.Build(*mockContext.Context, serviceConfig.ComponentConfig, nil)
 	logProgress(buildTask)
 
 	result, err := buildTask.Await()
@@ -106,7 +106,7 @@ func Test_NpmProject_Package(t *testing.T) {
 	npmProject := NewNpmProject(npmCli, env)
 	packageTask := npmProject.Package(
 		*mockContext.Context,
-		serviceConfig,
+		serviceConfig.ComponentConfig,
 		&ServiceBuildResult{
 			BuildOutputPath: serviceConfig.Path(),
 		},

--- a/cli/azd/pkg/project/framework_service_npm_test.go
+++ b/cli/azd/pkg/project/framework_service_npm_test.go
@@ -31,17 +31,17 @@ func Test_NpmProject_Restore(t *testing.T) {
 
 	env := environment.New("test")
 	npmCli := npm.NewNpmCli(mockContext.CommandRunner)
-	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageTypeScript)
+	component := createTestComponentConfig("./src/api", AppServiceTarget, ServiceLanguageTypeScript)
 
 	npmProject := NewNpmProject(npmCli, env)
-	restoreTask := npmProject.Restore(*mockContext.Context, serviceConfig.ComponentConfig)
+	restoreTask := npmProject.Restore(*mockContext.Context, component)
 	logProgress(restoreTask)
 
 	result, err := restoreTask.Await()
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, "npm", runArgs.Cmd)
-	require.Equal(t, serviceConfig.Path(), runArgs.Cwd)
+	require.Equal(t, component.Path(), runArgs.Cwd)
 	require.Equal(t,
 		[]string{"install"},
 		runArgs.Args,
@@ -63,10 +63,10 @@ func Test_NpmProject_Build(t *testing.T) {
 
 	env := environment.New("test")
 	npmCli := npm.NewNpmCli(mockContext.CommandRunner)
-	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageTypeScript)
+	component := createTestComponentConfig("./src/api", AppServiceTarget, ServiceLanguageTypeScript)
 
 	npmProject := NewNpmProject(npmCli, env)
-	buildTask := npmProject.Build(*mockContext.Context, serviceConfig.ComponentConfig, nil)
+	buildTask := npmProject.Build(*mockContext.Context, component, nil)
 	logProgress(buildTask)
 
 	result, err := buildTask.Await()
@@ -97,18 +97,18 @@ func Test_NpmProject_Package(t *testing.T) {
 
 	env := environment.New("test")
 	npmCli := npm.NewNpmCli(mockContext.CommandRunner)
-	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageTypeScript)
-	err := os.MkdirAll(serviceConfig.Path(), osutil.PermissionDirectory)
+	component := createTestComponentConfig("./src/api", AppServiceTarget, ServiceLanguageTypeScript)
+	err := os.MkdirAll(component.Path(), osutil.PermissionDirectory)
 	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(serviceConfig.Path(), "package.json"), nil, osutil.PermissionFile)
+	err = os.WriteFile(filepath.Join(component.Path(), "package.json"), nil, osutil.PermissionFile)
 	require.NoError(t, err)
 
 	npmProject := NewNpmProject(npmCli, env)
 	packageTask := npmProject.Package(
 		*mockContext.Context,
-		serviceConfig.ComponentConfig,
+		component,
 		&ServiceBuildResult{
-			BuildOutputPath: serviceConfig.Path(),
+			BuildOutputPath: component.Path(),
 		},
 	)
 	logProgress(packageTask)

--- a/cli/azd/pkg/project/framework_service_python_test.go
+++ b/cli/azd/pkg/project/framework_service_python_test.go
@@ -45,10 +45,10 @@ func Test_PythonProject_Restore(t *testing.T) {
 
 	env := environment.New("test")
 	pythonCli := python.NewPythonCli(mockContext.CommandRunner)
-	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguagePython)
+	component := createTestComponentConfig("./src/api", AppServiceTarget, ServiceLanguagePython)
 
 	pythonProject := NewPythonProject(pythonCli, env)
-	restoreTask := pythonProject.Restore(*mockContext.Context, serviceConfig.ComponentConfig)
+	restoreTask := pythonProject.Restore(*mockContext.Context, component)
 	logProgress(restoreTask)
 
 	result, err := restoreTask.Await()
@@ -77,10 +77,10 @@ func Test_PythonProject_Build(t *testing.T) {
 
 	env := environment.New("test")
 	pythonCli := python.NewPythonCli(mockContext.CommandRunner)
-	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguagePython)
+	component := createTestComponentConfig("./src/api", AppServiceTarget, ServiceLanguagePython)
 
 	pythonProject := NewPythonProject(pythonCli, env)
-	buildTask := pythonProject.Build(*mockContext.Context, serviceConfig.ComponentConfig, nil)
+	buildTask := pythonProject.Build(*mockContext.Context, component, nil)
 	logProgress(buildTask)
 
 	result, err := buildTask.Await()
@@ -95,18 +95,18 @@ func Test_PythonProject_Package(t *testing.T) {
 
 	env := environment.New("test")
 	pythonCli := python.NewPythonCli(mockContext.CommandRunner)
-	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguagePython)
-	err := os.MkdirAll(serviceConfig.Path(), osutil.PermissionDirectory)
+	component := createTestComponentConfig("./src/api", AppServiceTarget, ServiceLanguagePython)
+	err := os.MkdirAll(component.Path(), osutil.PermissionDirectory)
 	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(serviceConfig.Path(), "requirements.txt"), nil, osutil.PermissionFile)
+	err = os.WriteFile(filepath.Join(component.Path(), "requirements.txt"), nil, osutil.PermissionFile)
 	require.NoError(t, err)
 
 	pythonProject := NewPythonProject(pythonCli, env)
 	packageTask := pythonProject.Package(
 		*mockContext.Context,
-		serviceConfig.ComponentConfig,
+		component,
 		&ServiceBuildResult{
-			BuildOutputPath: serviceConfig.Path(),
+			BuildOutputPath: component.Path(),
 		},
 	)
 	logProgress(packageTask)

--- a/cli/azd/pkg/project/framework_service_python_test.go
+++ b/cli/azd/pkg/project/framework_service_python_test.go
@@ -48,7 +48,7 @@ func Test_PythonProject_Restore(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguagePython)
 
 	pythonProject := NewPythonProject(pythonCli, env)
-	restoreTask := pythonProject.Restore(*mockContext.Context, serviceConfig)
+	restoreTask := pythonProject.Restore(*mockContext.Context, serviceConfig.ComponentConfig)
 	logProgress(restoreTask)
 
 	result, err := restoreTask.Await()
@@ -80,7 +80,7 @@ func Test_PythonProject_Build(t *testing.T) {
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguagePython)
 
 	pythonProject := NewPythonProject(pythonCli, env)
-	buildTask := pythonProject.Build(*mockContext.Context, serviceConfig, nil)
+	buildTask := pythonProject.Build(*mockContext.Context, serviceConfig.ComponentConfig, nil)
 	logProgress(buildTask)
 
 	result, err := buildTask.Await()
@@ -104,7 +104,7 @@ func Test_PythonProject_Package(t *testing.T) {
 	pythonProject := NewPythonProject(pythonCli, env)
 	packageTask := pythonProject.Package(
 		*mockContext.Context,
-		serviceConfig,
+		serviceConfig.ComponentConfig,
 		&ServiceBuildResult{
 			BuildOutputPath: serviceConfig.Path(),
 		},

--- a/cli/azd/pkg/project/framework_service_swa.go
+++ b/cli/azd/pkg/project/framework_service_swa.go
@@ -68,8 +68,8 @@ func (p *swaProject) RequiredExternalTools(context.Context) []tools.ExternalTool
 }
 
 // Initializes the swa project
-func (p *swaProject) Initialize(ctx context.Context, serviceConfig *ServiceConfig) error {
-	return p.framework.Initialize(ctx, serviceConfig)
+func (p *swaProject) Initialize(ctx context.Context, component *ComponentConfig) error {
+	return p.framework.Initialize(ctx, component)
 }
 
 // Sets the inner framework service used for restore and build command
@@ -80,17 +80,17 @@ func (p *swaProject) SetSource(inner FrameworkService) {
 // Restores the dependencies for the swa project
 func (p *swaProject) Restore(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 ) *async.TaskWithProgress[*ServiceRestoreResult, ServiceProgress] {
 	// When the program runs the restore actions for the underlying project (containerapp),
 	// the dependencies are installed locally
-	return p.framework.Restore(ctx, serviceConfig)
+	return p.framework.Restore(ctx, component)
 }
 
 // Builds the swa project based on the swa-cli.config.json options specified within the Service path
 func (p *swaProject) Build(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	restoreOutput *ServiceRestoreResult,
 ) *async.TaskWithProgress[*ServiceBuildResult, ServiceProgress] {
 	return async.RunTaskWithProgress(
@@ -104,7 +104,7 @@ func (p *swaProject) Build(
 				})
 			err := p.swa.Build(
 				ctx,
-				serviceConfig.Path(),
+				component.Path(),
 				previewerWriter,
 			)
 			p.console.StopPreviewer(ctx, false)
@@ -123,7 +123,7 @@ func (p *swaProject) Build(
 
 func (p *swaProject) Package(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	buildOutput *ServiceBuildResult,
 ) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress] {
 	return async.RunTaskWithProgress(

--- a/cli/azd/pkg/project/importer.go
+++ b/cli/azd/pkg/project/importer.go
@@ -54,8 +54,13 @@ func (im *ImportManager) ServiceStable(ctx context.Context, projectConfig *Proje
 	allServices := make(map[string]*ServiceConfig)
 
 	for name, svcConfig := range projectConfig.Services {
-		if svcConfig.Language == ServiceLanguageDotNet {
-			if canImport, err := im.dotNetImporter.CanImport(ctx, svcConfig.Path()); canImport {
+		main, err := svcConfig.Main()
+		if err != nil {
+			return nil, err
+		}
+
+		if main.Language == ServiceLanguageDotNet {
+			if canImport, err := im.dotNetImporter.CanImport(ctx, main.Path()); canImport {
 				if len(projectConfig.Services) != 1 {
 					return nil, errNoMultipleServicesWithAppHost
 				}
@@ -79,7 +84,7 @@ func (im *ImportManager) ServiceStable(ctx context.Context, projectConfig *Proje
 
 				continue
 			} else if err != nil {
-				log.Printf("error checking if %s is an app host project: %v", svcConfig.Path(), err)
+				log.Printf("error checking if %s is an app host project: %v", main.Path(), err)
 			}
 		}
 
@@ -131,8 +136,13 @@ func (im *ImportManager) ProjectInfrastructure(ctx context.Context, projectConfi
 	}
 
 	for _, svcConfig := range projectConfig.Services {
-		if svcConfig.Language == ServiceLanguageDotNet {
-			if canImport, err := im.dotNetImporter.CanImport(ctx, svcConfig.Path()); canImport {
+		main, err := svcConfig.Main()
+		if err != nil {
+			return nil, err
+		}
+
+		if main.Language == ServiceLanguageDotNet {
+			if canImport, err := im.dotNetImporter.CanImport(ctx, main.Path()); canImport {
 				if len(projectConfig.Services) != 1 {
 					return nil, errNoMultipleServicesWithAppHost
 				}
@@ -143,7 +153,7 @@ func (im *ImportManager) ProjectInfrastructure(ctx context.Context, projectConfi
 
 				return im.dotNetImporter.ProjectInfrastructure(ctx, svcConfig)
 			} else if err != nil {
-				log.Printf("error checking if %s is an app host project: %v", svcConfig.Path(), err)
+				log.Printf("error checking if %s is an app host project: %v", main.Path(), err)
 			}
 		}
 	}
@@ -168,7 +178,12 @@ func pathHasModule(path, module string) (bool, error) {
 
 func (im *ImportManager) SynthAllInfrastructure(ctx context.Context, projectConfig *ProjectConfig) (fs.FS, error) {
 	for _, svcConfig := range projectConfig.Services {
-		if svcConfig.Language == ServiceLanguageDotNet {
+		main, err := svcConfig.Main()
+		if err != nil {
+			return nil, err
+		}
+
+		if main.Language == ServiceLanguageDotNet {
 			if len(projectConfig.Services) != 1 {
 				return nil, errNoMultipleServicesWithAppHost
 			}

--- a/cli/azd/pkg/project/importer.go
+++ b/cli/azd/pkg/project/importer.go
@@ -54,7 +54,7 @@ func (im *ImportManager) ServiceStable(ctx context.Context, projectConfig *Proje
 	allServices := make(map[string]*ServiceConfig)
 
 	for name, svcConfig := range projectConfig.Services {
-		if len(svcConfig.Components) == 0 {
+		if len(svcConfig.Components) == 1 {
 			mainComponent, err := svcConfig.Main()
 			if err != nil {
 				return nil, err

--- a/cli/azd/pkg/project/importer_test.go
+++ b/cli/azd/pkg/project/importer_test.go
@@ -43,21 +43,22 @@ func TestImportManagerHasService(t *testing.T) {
 		}),
 	})
 
-	// has service
-	r, e := manager.HasService(*mockContext.Context, &ProjectConfig{
+	testServiceConfig := createTestServiceConfig("path", ContainerAppTarget, ServiceLanguageJava)
+	testServiceConfig.Name = "test"
+
+	projectConfig := &ProjectConfig{
 		Services: map[string]*ServiceConfig{
-			"test": createTestServiceConfig("path", ContainerAppTarget, ServiceLanguageJava),
+			"test": testServiceConfig,
 		},
-	}, "test")
+	}
+
+	// has service
+	r, e := manager.HasService(*mockContext.Context, projectConfig, "test")
 	require.NoError(t, e)
 	require.True(t, r)
 
 	// has not
-	r, e = manager.HasService(*mockContext.Context, &ProjectConfig{
-		Services: map[string]*ServiceConfig{
-			"test": createTestServiceConfig("path", ContainerAppTarget, ServiceLanguageJava),
-		},
-	}, "other")
+	r, e = manager.HasService(*mockContext.Context, projectConfig, "other")
 	require.NoError(t, e)
 	require.False(t, r)
 }

--- a/cli/azd/pkg/project/importer_test.go
+++ b/cli/azd/pkg/project/importer_test.go
@@ -161,10 +161,10 @@ func TestImportManagerHasServiceErrorAppHostMustTargetContainerApp(t *testing.T)
 		Path: "path",
 		Services: map[string]*ServiceConfig{
 			"test": {
+				Host: StaticWebAppTarget,
 				ComponentConfig: &ComponentConfig{
 					Name:         "test",
 					Language:     ServiceLanguageDotNet,
-					Host:         StaticWebAppTarget,
 					RelativePath: "path",
 					Project: &ProjectConfig{
 						Path: "path",
@@ -340,10 +340,10 @@ func TestImportManagerProjectInfrastructureAspire(t *testing.T) {
 	r, e := manager.ProjectInfrastructure(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
 			"test": {
+				Host: ContainerAppTarget,
 				ComponentConfig: &ComponentConfig{
 					Name:         "test",
 					Language:     ServiceLanguageDotNet,
-					Host:         ContainerAppTarget,
 					RelativePath: "path",
 					Project: &ProjectConfig{
 						Path: "path",
@@ -369,10 +369,10 @@ func TestImportManagerProjectInfrastructureAspire(t *testing.T) {
 	_, e = manager.ProjectInfrastructure(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
 			"test": {
+				Host: ContainerAppTarget,
 				ComponentConfig: &ComponentConfig{
 					Name:         "test",
 					Language:     ServiceLanguageDotNet,
-					Host:         ContainerAppTarget,
 					RelativePath: "path",
 					Project: &ProjectConfig{
 						Path: "path",

--- a/cli/azd/pkg/project/importer_test.go
+++ b/cli/azd/pkg/project/importer_test.go
@@ -46,12 +46,7 @@ func TestImportManagerHasService(t *testing.T) {
 	// has service
 	r, e := manager.HasService(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
-			"test": {
-				ComponentConfig: &ComponentConfig{
-					Name:     "test",
-					Language: ServiceLanguageJava,
-				},
-			},
+			"test": createTestServiceConfig("path", ContainerAppTarget, ServiceLanguageJava),
 		},
 	}, "test")
 	require.NoError(t, e)
@@ -60,12 +55,7 @@ func TestImportManagerHasService(t *testing.T) {
 	// has not
 	r, e = manager.HasService(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
-			"test": {
-				ComponentConfig: &ComponentConfig{
-					Name:     "test",
-					Language: ServiceLanguageJava,
-				},
-			},
+			"test": createTestServiceConfig("path", ContainerAppTarget, ServiceLanguageJava),
 		},
 	}, "other")
 	require.NoError(t, e)
@@ -103,26 +93,8 @@ func TestImportManagerHasServiceErrorNoMultipleServicesWithAppHost(t *testing.T)
 	r, e := manager.HasService(*mockContext.Context, &ProjectConfig{
 		Path: "path",
 		Services: map[string]*ServiceConfig{
-			"test": {
-				ComponentConfig: &ComponentConfig{
-					Name:         "test",
-					Language:     ServiceLanguageDotNet,
-					RelativePath: "path",
-					Project: &ProjectConfig{
-						Path: "path",
-					},
-				},
-			},
-			"foo": {
-				ComponentConfig: &ComponentConfig{
-					Name:         "foo",
-					Language:     ServiceLanguageDotNet,
-					RelativePath: "path2",
-					Project: &ProjectConfig{
-						Path: "path",
-					},
-				},
-			},
+			"test": createTestServiceConfig("path", ContainerAppTarget, ServiceLanguageDotNet),
+			"foo":  createTestServiceConfig("path2", ContainerAppTarget, ServiceLanguageDotNet),
 		},
 	}, "other")
 	require.Error(t, e, errNoMultipleServicesWithAppHost)
@@ -160,17 +132,7 @@ func TestImportManagerHasServiceErrorAppHostMustTargetContainerApp(t *testing.T)
 	r, e := manager.HasService(*mockContext.Context, &ProjectConfig{
 		Path: "path",
 		Services: map[string]*ServiceConfig{
-			"test": {
-				Host: StaticWebAppTarget,
-				ComponentConfig: &ComponentConfig{
-					Name:         "test",
-					Language:     ServiceLanguageDotNet,
-					RelativePath: "path",
-					Project: &ProjectConfig{
-						Path: "path",
-					},
-				},
-			},
+			"test": createTestServiceConfig("path", StaticWebAppTarget, ServiceLanguageDotNet),
 		},
 	}, "other")
 	require.Error(t, e, errAppHostMustTargetContainerApp)
@@ -339,17 +301,7 @@ func TestImportManagerProjectInfrastructureAspire(t *testing.T) {
 	// Use an a dotnet project and use the mock to simulate an Aspire project
 	r, e := manager.ProjectInfrastructure(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
-			"test": {
-				Host: ContainerAppTarget,
-				ComponentConfig: &ComponentConfig{
-					Name:         "test",
-					Language:     ServiceLanguageDotNet,
-					RelativePath: "path",
-					Project: &ProjectConfig{
-						Path: "path",
-					},
-				},
-			},
+			"test": createTestServiceConfig("path", ContainerAppTarget, ServiceLanguageDotNet),
 		},
 	})
 
@@ -368,17 +320,7 @@ func TestImportManagerProjectInfrastructureAspire(t *testing.T) {
 	// Use an a dotnet project and use the mock to simulate an Aspire project
 	_, e = manager.ProjectInfrastructure(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
-			"test": {
-				Host: ContainerAppTarget,
-				ComponentConfig: &ComponentConfig{
-					Name:         "test",
-					Language:     ServiceLanguageDotNet,
-					RelativePath: "path",
-					Project: &ProjectConfig{
-						Path: "path",
-					},
-				},
-			},
+			"test": createTestServiceConfig("path", ContainerAppTarget, ServiceLanguageDotNet),
 		},
 	})
 

--- a/cli/azd/pkg/project/importer_test.go
+++ b/cli/azd/pkg/project/importer_test.go
@@ -47,8 +47,10 @@ func TestImportManagerHasService(t *testing.T) {
 	r, e := manager.HasService(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
 			"test": {
-				Name:     "test",
-				Language: ServiceLanguageJava,
+				ComponentConfig: &ComponentConfig{
+					Name:     "test",
+					Language: ServiceLanguageJava,
+				},
 			},
 		},
 	}, "test")
@@ -59,8 +61,10 @@ func TestImportManagerHasService(t *testing.T) {
 	r, e = manager.HasService(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
 			"test": {
-				Name:     "test",
-				Language: ServiceLanguageJava,
+				ComponentConfig: &ComponentConfig{
+					Name:     "test",
+					Language: ServiceLanguageJava,
+				},
 			},
 		},
 	}, "other")
@@ -100,19 +104,23 @@ func TestImportManagerHasServiceErrorNoMultipleServicesWithAppHost(t *testing.T)
 		Path: "path",
 		Services: map[string]*ServiceConfig{
 			"test": {
-				Name:         "test",
-				Language:     ServiceLanguageDotNet,
-				RelativePath: "path",
-				Project: &ProjectConfig{
-					Path: "path",
+				ComponentConfig: &ComponentConfig{
+					Name:         "test",
+					Language:     ServiceLanguageDotNet,
+					RelativePath: "path",
+					Project: &ProjectConfig{
+						Path: "path",
+					},
 				},
 			},
 			"foo": {
-				Name:         "foo",
-				Language:     ServiceLanguageDotNet,
-				RelativePath: "path2",
-				Project: &ProjectConfig{
-					Path: "path",
+				ComponentConfig: &ComponentConfig{
+					Name:         "foo",
+					Language:     ServiceLanguageDotNet,
+					RelativePath: "path2",
+					Project: &ProjectConfig{
+						Path: "path",
+					},
 				},
 			},
 		},
@@ -153,12 +161,14 @@ func TestImportManagerHasServiceErrorAppHostMustTargetContainerApp(t *testing.T)
 		Path: "path",
 		Services: map[string]*ServiceConfig{
 			"test": {
-				Name:         "test",
-				Language:     ServiceLanguageDotNet,
-				Host:         StaticWebAppTarget,
-				RelativePath: "path",
-				Project: &ProjectConfig{
-					Path: "path",
+				ComponentConfig: &ComponentConfig{
+					Name:         "test",
+					Language:     ServiceLanguageDotNet,
+					Host:         StaticWebAppTarget,
+					RelativePath: "path",
+					Project: &ProjectConfig{
+						Path: "path",
+					},
 				},
 			},
 		},
@@ -330,12 +340,14 @@ func TestImportManagerProjectInfrastructureAspire(t *testing.T) {
 	r, e := manager.ProjectInfrastructure(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
 			"test": {
-				Name:         "test",
-				Language:     ServiceLanguageDotNet,
-				Host:         ContainerAppTarget,
-				RelativePath: "path",
-				Project: &ProjectConfig{
-					Path: "path",
+				ComponentConfig: &ComponentConfig{
+					Name:         "test",
+					Language:     ServiceLanguageDotNet,
+					Host:         ContainerAppTarget,
+					RelativePath: "path",
+					Project: &ProjectConfig{
+						Path: "path",
+					},
 				},
 			},
 		},
@@ -357,12 +369,14 @@ func TestImportManagerProjectInfrastructureAspire(t *testing.T) {
 	_, e = manager.ProjectInfrastructure(*mockContext.Context, &ProjectConfig{
 		Services: map[string]*ServiceConfig{
 			"test": {
-				Name:         "test",
-				Language:     ServiceLanguageDotNet,
-				Host:         ContainerAppTarget,
-				RelativePath: "path",
-				Project: &ProjectConfig{
-					Path: "path",
+				ComponentConfig: &ComponentConfig{
+					Name:         "test",
+					Language:     ServiceLanguageDotNet,
+					Host:         ContainerAppTarget,
+					RelativePath: "path",
+					Project: &ProjectConfig{
+						Path: "path",
+					},
 				},
 			},
 		},

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -98,15 +98,30 @@ func Parse(ctx context.Context, yamlContent string) (*ProjectConfig, error) {
 			return nil, fmt.Errorf("parsing service %s: %w", svc.Name, err)
 		}
 
-		svc.Infra.Provider, err = provisioning.ParseProvider(svc.Infra.Provider)
-		if err != nil {
-			return nil, fmt.Errorf("parsing service %s: %w", svc.Name, err)
+		if len(svc.Components) == 0 {
+			svc.Components = map[string]*ComponentConfig{}
+			svc.Components[defaultComponentName] = &ComponentConfig{
+				Name:         defaultComponentName,
+				Host:         svc.Host,
+				RelativePath: svc.RelativePath,
+				Language:     svc.Language,
+				OutputPath:   svc.OutputPath,
+				Image:        svc.Image,
+				Docker:       svc.Docker,
+			}
+		}
+
+		for _, comp := range svc.Components {
+			comp.Service = svc
+			comp.Project = &projectConfig
 		}
 
 		// TODO: Move parsing/validation requirements for service targets into their respective components.
 		// When working within container based applications users may be using external/pre-built images instead of source
 		// In this case it is valid to have not specified a language but would be required to specify a source image
-		if svc.Host == ContainerAppTarget && svc.Language == ServiceLanguageNone && svc.Image == "" {
+		if svc.Host == ContainerAppTarget &&
+			svc.Language == ServiceLanguageNone &&
+			svc.Image == "" && len(svc.Components) == 1 {
 			return nil, fmt.Errorf("parsing service %s: must specify language or image", svc.Name)
 		}
 	}

--- a/cli/azd/pkg/project/project_config_test.go
+++ b/cli/azd/pkg/project/project_config_test.go
@@ -120,10 +120,11 @@ services:
 	require.Nil(t, err)
 
 	service := projectConfig.Services["web"]
+	main := mustMainComponent(service)
 
-	require.Equal(t, "./Dockerfile.dev", service.Docker.Path)
-	require.Equal(t, "../", service.Docker.Context)
-	require.Equal(t, []string{"foo", "bar"}, service.Docker.BuildArgs)
+	require.Equal(t, "./Dockerfile.dev", main.Docker.Path)
+	require.Equal(t, "../", main.Docker.Context)
+	require.Equal(t, []string{"foo", "bar"}, main.Docker.BuildArgs)
 }
 
 func TestProjectConfigAddHandler(t *testing.T) {

--- a/cli/azd/pkg/project/project_manager.go
+++ b/cli/azd/pkg/project/project_manager.go
@@ -195,17 +195,19 @@ func (pm *projectManager) EnsureFrameworkTools(
 			continue
 		}
 
-		frameworkService, err := pm.serviceManager.GetFrameworkService(ctx, svc)
-		if err != nil {
-			return fmt.Errorf("getting framework service: %w", err)
-		}
+		for _, component := range svc.Components {
+			frameworkService, err := pm.serviceManager.GetFrameworkService(ctx, component)
+			if err != nil {
+				return fmt.Errorf("getting framework service: %w", err)
+			}
 
-		frameworkTools := frameworkService.RequiredExternalTools(ctx)
-		if err != nil {
-			return fmt.Errorf("getting service required tools: %w", err)
-		}
+			frameworkTools := frameworkService.RequiredExternalTools(ctx)
+			if err != nil {
+				return fmt.Errorf("getting service required tools: %w", err)
+			}
 
-		requiredTools = append(requiredTools, frameworkTools...)
+			requiredTools = append(requiredTools, frameworkTools...)
+		}
 	}
 
 	if err := tools.EnsureInstalled(ctx, tools.Unique(requiredTools)...); err != nil {

--- a/cli/azd/pkg/project/project_manager.go
+++ b/cli/azd/pkg/project/project_manager.go
@@ -138,7 +138,12 @@ func (pm *projectManager) DefaultServiceFromWd(
 	}
 
 	for _, svcConfig := range servicesStable {
-		if wd == svcConfig.Path() {
+		main, err := svcConfig.Main()
+		if err != nil {
+			return nil, err
+		}
+
+		if wd == main.Path() {
 			return svcConfig, nil
 		}
 	}

--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -279,10 +279,10 @@ func TestMinimalYaml(t *testing.T) {
 		{
 			"minimal-service",
 			ServiceConfig{
+				Host: AppServiceTarget,
 				ComponentConfig: &ComponentConfig{
 					Name:         "ignored",
 					Language:     ServiceLanguagePython,
-					Host:         AppServiceTarget,
 					RelativePath: "./src",
 				},
 			},
@@ -290,10 +290,10 @@ func TestMinimalYaml(t *testing.T) {
 		{
 			"minimal-docker",
 			ServiceConfig{
+				Host: ContainerAppTarget,
 				ComponentConfig: &ComponentConfig{
 					Name:     "ignored",
 					Language: ServiceLanguageDotNet,
-					Host:     ContainerAppTarget,
 					Docker: DockerProjectOptions{
 						Path: "./Dockerfile",
 					},

--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -280,10 +280,12 @@ func TestMinimalYaml(t *testing.T) {
 			"minimal-service",
 			ServiceConfig{
 				Host: AppServiceTarget,
-				ComponentConfig: &ComponentConfig{
-					Name:         "ignored",
-					Language:     ServiceLanguagePython,
-					RelativePath: "./src",
+				Components: map[string]*ComponentConfig{
+					DefaultComponentName: {
+						Name:         "ignored",
+						Language:     ServiceLanguagePython,
+						RelativePath: "./src",
+					},
 				},
 			},
 		},
@@ -291,13 +293,15 @@ func TestMinimalYaml(t *testing.T) {
 			"minimal-docker",
 			ServiceConfig{
 				Host: ContainerAppTarget,
-				ComponentConfig: &ComponentConfig{
-					Name:     "ignored",
-					Language: ServiceLanguageDotNet,
-					Docker: DockerProjectOptions{
-						Path: "./Dockerfile",
+				Components: map[string]*ComponentConfig{
+					DefaultComponentName: {
+						Name:     "ignored",
+						Language: ServiceLanguageDotNet,
+						Docker: DockerProjectOptions{
+							Path: "./Dockerfile",
+						},
+						RelativePath: "./src",
 					},
-					RelativePath: "./src",
 				},
 			},
 		},

--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -279,22 +279,26 @@ func TestMinimalYaml(t *testing.T) {
 		{
 			"minimal-service",
 			ServiceConfig{
-				Name:         "ignored",
-				Language:     ServiceLanguagePython,
-				Host:         AppServiceTarget,
-				RelativePath: "./src",
+				ComponentConfig: &ComponentConfig{
+					Name:         "ignored",
+					Language:     ServiceLanguagePython,
+					Host:         AppServiceTarget,
+					RelativePath: "./src",
+				},
 			},
 		},
 		{
 			"minimal-docker",
 			ServiceConfig{
-				Name:     "ignored",
-				Language: ServiceLanguageDotNet,
-				Host:     ContainerAppTarget,
-				Docker: DockerProjectOptions{
-					Path: "./Dockerfile",
+				ComponentConfig: &ComponentConfig{
+					Name:     "ignored",
+					Language: ServiceLanguageDotNet,
+					Host:     ContainerAppTarget,
+					Docker: DockerProjectOptions{
+						Path: "./Dockerfile",
+					},
+					RelativePath: "./src",
 				},
-				RelativePath: "./src",
 			},
 		},
 	}

--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -279,10 +279,10 @@ func TestMinimalYaml(t *testing.T) {
 		{
 			"minimal-service",
 			ServiceConfig{
+				Name: "minimal-service",
 				Host: AppServiceTarget,
 				Components: map[string]*ComponentConfig{
 					DefaultComponentName: {
-						Name:         "ignored",
 						Language:     ServiceLanguagePython,
 						RelativePath: "./src",
 					},
@@ -292,10 +292,10 @@ func TestMinimalYaml(t *testing.T) {
 		{
 			"minimal-docker",
 			ServiceConfig{
+				Name: "minimal-docker",
 				Host: ContainerAppTarget,
 				Components: map[string]*ComponentConfig{
 					DefaultComponentName: {
-						Name:     "ignored",
 						Language: ServiceLanguageDotNet,
 						Docker: DockerProjectOptions{
 							Path: "./Dockerfile",

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -5,37 +5,22 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/apphost"
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 )
 
+const defaultComponentName = "main"
+
 type ServiceConfig struct {
-	// Reference to the parent project configuration
-	Project *ProjectConfig `yaml:"-"`
-	// The friendly name/key of the project from the azure.yaml file
-	Name string `yaml:"-"`
+	*ComponentConfig `yaml:",inline"`
+
 	// The azure resource group to deploy the service to
 	ResourceGroupName osutil.ExpandableString `yaml:"resourceGroup,omitempty"`
 	// The name used to override the default azure resource name
 	ResourceName osutil.ExpandableString `yaml:"resourceName,omitempty"`
-	// The relative path to the project folder from the project root
-	RelativePath string `yaml:"project"`
-	// The azure hosting model to use, ex) appservice, function, containerapp
-	Host ServiceTargetKind `yaml:"host"`
-	// The programming language of the project
-	Language ServiceLanguageKind `yaml:"language"`
-	// The output path for build artifacts
-	OutputPath string `yaml:"dist,omitempty"`
-	// The source image to use for container based applications
-	Image string `yaml:"image,omitempty"`
-	// The optional docker options for configuring the output image
-	Docker DockerProjectOptions `yaml:"docker,omitempty"`
 	// The optional K8S / AKS options
 	K8s AksOptions `yaml:"k8s,omitempty"`
 	// The optional Azure Spring Apps options
 	Spring SpringOptions `yaml:"spring,omitempty"`
-	// The infrastructure provisioning configuration
-	Infra provisioning.Options `yaml:"infra,omitempty"`
 	// Hook configuration for service
 	Hooks map[string]*ext.HookConfig `yaml:"hooks,omitempty"`
 	// Options specific to the DotNetContainerApp target. These are set by the importer and
@@ -43,8 +28,39 @@ type ServiceConfig struct {
 	DotNetContainerApp *DotNetContainerAppOptions `yaml:"-,omitempty"`
 	// Custom configuration for the service target
 	Config map[string]any `yaml:"config,omitempty"`
+	// The optional container configuration for container based applications
+	Components map[string]*ComponentConfig `yaml:"containers,omitempty"`
 
 	*ext.EventDispatcher[ServiceLifecycleEventArgs] `yaml:"-"`
+}
+
+// ComponentConfig is the configuration for a container based projects
+type ComponentConfig struct {
+	// Reference to the parent project configuration
+	Project *ProjectConfig `yaml:"-"`
+	// Reference to the parent project configuration
+	Service *ServiceConfig `yaml:"-"`
+	// The azure hosting model to use, ex) appservice, function, containerapp
+	Host ServiceTargetKind `yaml:"host,omitempty"`
+	// The friendly name/key of the project from the azure.yaml file
+	Name string `yaml:"-"`
+	// The relative path to the project folder from the project root
+	RelativePath string `yaml:"project,omitempty"`
+	// The programming language of the project
+	Language ServiceLanguageKind `yaml:"language,omitempty"`
+	// The output path for build artifacts
+	OutputPath string `yaml:"dist,omitempty"`
+	// The source image to use for container based applications
+	Image string `yaml:"image,omitempty"`
+	// The optional docker options for configuring the output image
+	Docker DockerProjectOptions `yaml:"docker,omitempty"`
+}
+
+func (cc *ComponentConfig) Path() string {
+	if filepath.IsAbs(cc.RelativePath) {
+		return cc.RelativePath
+	}
+	return filepath.Join(cc.Project.Path, cc.RelativePath)
 }
 
 type DotNetContainerAppOptions struct {
@@ -61,4 +77,48 @@ func (sc *ServiceConfig) Path() string {
 		return sc.RelativePath
 	}
 	return filepath.Join(sc.Project.Path, sc.RelativePath)
+}
+
+func (sc *ServiceConfig) MarshalYAML() (interface{}, error) {
+	type serviceConfig ServiceConfig
+
+	svc := serviceConfig(*sc)
+
+	// If there is only a single container and it maps to our "default" convention,
+	// then we can promote the container to the service level
+	if _, has := svc.Components[defaultComponentName]; has && len(svc.Components) == 1 {
+		svc.ComponentConfig = svc.Components[defaultComponentName]
+		svc.Components = nil
+	} else {
+		// Host can be ignored
+		for _, value := range svc.Components {
+			value.Host = ""
+		}
+	}
+
+	return svc, nil
+}
+
+func (sc *ServiceConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// Leverage the built-in unmarshaler to hydrate the service configuration
+	type serviceConfig ServiceConfig
+	var svc serviceConfig
+	if err := unmarshal(&svc); err != nil {
+		return err
+	}
+
+	if len(svc.Components) == 0 {
+		svc.Components = map[string]*ComponentConfig{
+			defaultComponentName: svc.ComponentConfig,
+		}
+	}
+
+	for key, value := range svc.Components {
+		value.Name = key
+		value.Host = svc.Host
+	}
+
+	*sc = ServiceConfig(svc)
+
+	return nil
 }

--- a/cli/azd/pkg/project/service_config_test.go
+++ b/cli/azd/pkg/project/service_config_test.go
@@ -238,9 +238,9 @@ func Test_ServiceConfig_Unmarshall(t *testing.T) {
 				require.Equal(t, "./src/api", proj.Services["api"].RelativePath)
 
 				// Expect the same values to be available in the container configuration
-				require.Equal(t, AksTarget, proj.Services["api"].Components[defaultComponentName].Host)
-				require.Equal(t, ServiceLanguageJavaScript, proj.Services["api"].Components[defaultComponentName].Language)
-				require.Equal(t, "./src/api", proj.Services["api"].Components[defaultComponentName].RelativePath)
+				require.Equal(t, AksTarget, proj.Services["api"].Components[DefaultComponentName].Service.Host)
+				require.Equal(t, ServiceLanguageJavaScript, proj.Services["api"].Components[DefaultComponentName].Language)
+				require.Equal(t, "./src/api", proj.Services["api"].Components[DefaultComponentName].RelativePath)
 			},
 		},
 		{
@@ -294,9 +294,9 @@ func Test_ServiceConfig_Marshall(t *testing.T) {
 				Name: "test-proj",
 				Services: map[string]*ServiceConfig{
 					"api": {
+						Host: AksTarget,
 						Components: map[string]*ComponentConfig{
-							defaultComponentName: {
-								Host:         AksTarget,
+							DefaultComponentName: {
 								Language:     ServiceLanguageJavaScript,
 								RelativePath: "./src/api",
 							},
@@ -311,9 +311,8 @@ func Test_ServiceConfig_Marshall(t *testing.T) {
 				Name: "test-proj",
 				Services: map[string]*ServiceConfig{
 					"todo": {
-						ComponentConfig: &ComponentConfig{
-							Host: AksTarget,
-						},
+						Host:            AksTarget,
+						ComponentConfig: &ComponentConfig{},
 						Components: map[string]*ComponentConfig{
 							"api": {
 								Language:     ServiceLanguageJavaScript,
@@ -334,9 +333,8 @@ func Test_ServiceConfig_Marshall(t *testing.T) {
 				Name: "test-proj",
 				Services: map[string]*ServiceConfig{
 					"todo": {
-						ComponentConfig: &ComponentConfig{
-							Host: AksTarget,
-						},
+						Host:            AksTarget,
+						ComponentConfig: &ComponentConfig{},
 						Components: map[string]*ComponentConfig{
 							"api": {
 								Language:     ServiceLanguageJavaScript,
@@ -353,9 +351,8 @@ func Test_ServiceConfig_Marshall(t *testing.T) {
 				Name: "test-proj",
 				Services: map[string]*ServiceConfig{
 					"todo": {
-						ComponentConfig: &ComponentConfig{
-							Host: ContainerAppTarget,
-						},
+						Host:            ContainerAppTarget,
+						ComponentConfig: &ComponentConfig{},
 						Components: map[string]*ComponentConfig{
 							"main": {
 								Language:     ServiceLanguageJavaScript,
@@ -396,19 +393,18 @@ func createTestServiceConfig(path string, host ServiceTargetKind, language Servi
 
 	componentConfig := &ComponentConfig{
 		Name:         "api",
-		Host:         host,
 		Language:     language,
 		RelativePath: filepath.Join(path),
-		Project:      projectConfig,
 	}
 
 	serviceConfig := &ServiceConfig{
-		ComponentConfig: componentConfig,
+		Project:         projectConfig,
+		Host:            host,
 		EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
-		Components:      map[string]*ComponentConfig{defaultComponentName: componentConfig},
+		Components:      map[string]*ComponentConfig{DefaultComponentName: componentConfig},
 	}
 
-	serviceConfig.ComponentConfig.Service = serviceConfig
+	componentConfig.Service = serviceConfig
 
 	return serviceConfig
 }

--- a/cli/azd/pkg/project/service_config_test.go
+++ b/cli/azd/pkg/project/service_config_test.go
@@ -4,11 +4,16 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/azure/azure-dev/cli/azd/test/snapshot"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestServiceConfigAddHandler(t *testing.T) {
@@ -210,17 +215,238 @@ func TestServiceConfigRaiseEventWithArgs(t *testing.T) {
 	require.True(t, handlerCalled)
 }
 
+func Test_ServiceConfig_Unmarshall(t *testing.T) {
+	tests := []struct {
+		name       string
+		yaml       string
+		validateFn func(t *testing.T, proj *ProjectConfig)
+	}{
+		{
+			name: "Standard Project",
+			yaml: heredoc.Doc(`
+				name: test-proj
+				services:
+					api:
+						host: aks
+						language: js
+						project: ./src/api
+			`),
+			validateFn: func(t *testing.T, proj *ProjectConfig) {
+				require.Equal(t, "api", proj.Services["api"].Name)
+				require.Equal(t, AksTarget, proj.Services["api"].Host)
+				require.Equal(t, ServiceLanguageJavaScript, proj.Services["api"].Language)
+				require.Equal(t, "./src/api", proj.Services["api"].RelativePath)
+
+				// Expect the same values to be available in the container configuration
+				require.Equal(t, AksTarget, proj.Services["api"].Components[defaultComponentName].Host)
+				require.Equal(t, ServiceLanguageJavaScript, proj.Services["api"].Components[defaultComponentName].Language)
+				require.Equal(t, "./src/api", proj.Services["api"].Components[defaultComponentName].RelativePath)
+			},
+		},
+		{
+			name: "Multiple Containers",
+			yaml: heredoc.Doc(`
+				name: test-proj
+				services:
+					todo:
+						host: aks
+						containers:
+							api:
+								language: js
+								project: ./src/api
+							web:
+								language: js
+								project: ./src/web
+			`),
+			validateFn: func(t *testing.T, proj *ProjectConfig) {
+				require.Equal(t, "todo", proj.Services["todo"].Name)
+				require.Equal(t, AksTarget, proj.Services["todo"].Host)
+				require.Equal(t, 2, len(proj.Services["todo"].Components))
+				require.Equal(t, ServiceLanguageJavaScript, proj.Services["todo"].Components["api"].Language)
+				require.Equal(t, ServiceLanguageJavaScript, proj.Services["todo"].Components["web"].Language)
+				require.Equal(t, "./src/api", proj.Services["todo"].Components["api"].RelativePath)
+				require.Equal(t, "./src/web", proj.Services["todo"].Components["web"].RelativePath)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockContext := mocks.NewMockContext(context.Background())
+			testYaml := strings.ReplaceAll(test.yaml, "\t", "  ")
+			azdProj, err := Parse(*mockContext.Context, testYaml)
+			require.NoError(t, err)
+			require.NotNil(t, azdProj)
+
+			test.validateFn(t, azdProj)
+		})
+	}
+}
+
+func Test_ServiceConfig_Marshall(t *testing.T) {
+	tests := []struct {
+		name   string
+		config ProjectConfig
+	}{
+		{
+			name: "Standard Project",
+			config: ProjectConfig{
+				Name: "test-proj",
+				Services: map[string]*ServiceConfig{
+					"api": {
+						Components: map[string]*ComponentConfig{
+							defaultComponentName: {
+								Host:         AksTarget,
+								Language:     ServiceLanguageJavaScript,
+								RelativePath: "./src/api",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple Containers",
+			config: ProjectConfig{
+				Name: "test-proj",
+				Services: map[string]*ServiceConfig{
+					"todo": {
+						ComponentConfig: &ComponentConfig{
+							Host: AksTarget,
+						},
+						Components: map[string]*ComponentConfig{
+							"api": {
+								Language:     ServiceLanguageJavaScript,
+								RelativePath: "./src/api",
+							},
+							"web": {
+								Language:     ServiceLanguageJavaScript,
+								RelativePath: "./src/web",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Single container with non-default name",
+			config: ProjectConfig{
+				Name: "test-proj",
+				Services: map[string]*ServiceConfig{
+					"todo": {
+						ComponentConfig: &ComponentConfig{
+							Host: AksTarget,
+						},
+						Components: map[string]*ComponentConfig{
+							"api": {
+								Language:     ServiceLanguageJavaScript,
+								RelativePath: "./src/api",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple containers with other configuration",
+			config: ProjectConfig{
+				Name: "test-proj",
+				Services: map[string]*ServiceConfig{
+					"todo": {
+						ComponentConfig: &ComponentConfig{
+							Host: ContainerAppTarget,
+						},
+						Components: map[string]*ComponentConfig{
+							"main": {
+								Language:     ServiceLanguageJavaScript,
+								RelativePath: "./src/api",
+								Docker: DockerProjectOptions{
+									Path:     "./Dockerfile",
+									Registry: osutil.NewExpandableString("docker.io"),
+									Image:    osutil.NewExpandableString("test-image"),
+									Tag:      osutil.NewExpandableString("latest"),
+								},
+							},
+							"sidecar": {
+								Image: "docker.io/sidecar:latest",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			outputYaml, err := yaml.Marshal(test.config)
+			require.NoError(t, err)
+			require.NotEmpty(t, string(outputYaml))
+			snapshot.SnapshotT(t, string(outputYaml))
+		})
+	}
+}
+
 func createTestServiceConfig(path string, host ServiceTargetKind, language ServiceLanguageKind) *ServiceConfig {
-	return &ServiceConfig{
+	projectConfig := &ProjectConfig{
+		Name:            "Test-App",
+		Path:            ".",
+		EventDispatcher: ext.NewEventDispatcher[ProjectLifecycleEventArgs](),
+	}
+
+	componentConfig := &ComponentConfig{
 		Name:         "api",
 		Host:         host,
 		Language:     language,
 		RelativePath: filepath.Join(path),
-		Project: &ProjectConfig{
-			Name:            "Test-App",
-			Path:            ".",
-			EventDispatcher: ext.NewEventDispatcher[ProjectLifecycleEventArgs](),
-		},
-		EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
+		Project:      projectConfig,
 	}
+
+	serviceConfig := &ServiceConfig{
+		ComponentConfig: componentConfig,
+		EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
+		Components:      map[string]*ComponentConfig{defaultComponentName: componentConfig},
+	}
+
+	serviceConfig.ComponentConfig.Service = serviceConfig
+
+	return serviceConfig
+}
+
+func Test_Parent_Child(t *testing.T) {
+	parent := &Parent{
+		Name: "John",
+		Age:  40,
+		Children: map[string]*Child{
+			"child1": {
+				Name: "Alice",
+				Age:  10,
+			},
+		},
+	}
+
+	yamlBytes, err := yaml.Marshal(parent)
+	require.NoError(t, err)
+
+	yamlStr := string(yamlBytes)
+	require.NotEmpty(t, yamlStr)
+}
+
+type Parent struct {
+	Name     string
+	Age      int
+	Children map[string]*Child
+}
+
+type Child struct {
+	Name   string
+	Age    int
+	Gender string
+}
+
+func (c *Child) MarshalYAML() (interface{}, error) {
+	type child Child
+	cc := child(*c)
+
+	return cc, nil
 }

--- a/cli/azd/pkg/project/service_config_test.go
+++ b/cli/azd/pkg/project/service_config_test.go
@@ -234,13 +234,12 @@ func Test_ServiceConfig_Unmarshall(t *testing.T) {
 			validateFn: func(t *testing.T, proj *ProjectConfig) {
 				require.Equal(t, "api", proj.Services["api"].Name)
 				require.Equal(t, AksTarget, proj.Services["api"].Host)
-				require.Equal(t, ServiceLanguageJavaScript, proj.Services["api"].Language)
+				// require.Equal(t, ServiceLanguageJavaScript, proj.Services["api"].Language)
 				require.Equal(t, "./src/api", proj.Services["api"].RelativePath)
 
 				// Expect the same values to be available in the container configuration
-				require.Equal(t, AksTarget, proj.Services["api"].Components[DefaultComponentName].Service.Host)
 				require.Equal(t, ServiceLanguageJavaScript, proj.Services["api"].Components[DefaultComponentName].Language)
-				require.Equal(t, "./src/api", proj.Services["api"].Components[DefaultComponentName].RelativePath)
+				require.Equal(t, "", proj.Services["api"].Components[DefaultComponentName].RelativePath)
 			},
 		},
 		{
@@ -311,8 +310,7 @@ func Test_ServiceConfig_Marshall(t *testing.T) {
 				Name: "test-proj",
 				Services: map[string]*ServiceConfig{
 					"todo": {
-						Host:            AksTarget,
-						ComponentConfig: &ComponentConfig{},
+						Host: AksTarget,
 						Components: map[string]*ComponentConfig{
 							"api": {
 								Language:     ServiceLanguageJavaScript,
@@ -333,8 +331,7 @@ func Test_ServiceConfig_Marshall(t *testing.T) {
 				Name: "test-proj",
 				Services: map[string]*ServiceConfig{
 					"todo": {
-						Host:            AksTarget,
-						ComponentConfig: &ComponentConfig{},
+						Host: AksTarget,
 						Components: map[string]*ComponentConfig{
 							"api": {
 								Language:     ServiceLanguageJavaScript,
@@ -351,8 +348,7 @@ func Test_ServiceConfig_Marshall(t *testing.T) {
 				Name: "test-proj",
 				Services: map[string]*ServiceConfig{
 					"todo": {
-						Host:            ContainerAppTarget,
-						ComponentConfig: &ComponentConfig{},
+						Host: ContainerAppTarget,
 						Components: map[string]*ComponentConfig{
 							"main": {
 								Language:     ServiceLanguageJavaScript,
@@ -392,12 +388,13 @@ func createTestServiceConfig(path string, host ServiceTargetKind, language Servi
 	}
 
 	componentConfig := &ComponentConfig{
-		Name:         "api",
+		Name:         DefaultComponentName,
 		Language:     language,
 		RelativePath: filepath.Join(path),
 	}
 
 	serviceConfig := &ServiceConfig{
+		Name:            "api",
 		Project:         projectConfig,
 		Host:            host,
 		EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
@@ -426,13 +423,15 @@ func createTestComponentConfig(path string, host ServiceTargetKind, language Ser
 	}
 
 	serviceConfig := &ServiceConfig{
-		Host:       host,
-		Components: map[string]*ComponentConfig{},
-		Project:    projectgConfig,
+		Name:            "api",
+		Host:            host,
+		Components:      map[string]*ComponentConfig{},
+		Project:         projectgConfig,
+		EventDispatcher: ext.NewEventDispatcher[ServiceLifecycleEventArgs](),
 	}
 
 	componentConfig := &ComponentConfig{
-		Name:         "api",
+		Name:         DefaultComponentName,
 		Language:     language,
 		RelativePath: filepath.Join(path),
 		Service:      serviceConfig,

--- a/cli/azd/pkg/project/service_config_test.go
+++ b/cli/azd/pkg/project/service_config_test.go
@@ -409,6 +409,40 @@ func createTestServiceConfig(path string, host ServiceTargetKind, language Servi
 	return serviceConfig
 }
 
+func mustMainComponent(serviceConfig *ServiceConfig) *ComponentConfig {
+	mainComponent, err := serviceConfig.Main()
+	if err != nil {
+		panic(err)
+	}
+
+	return mainComponent
+}
+
+func createTestComponentConfig(path string, host ServiceTargetKind, language ServiceLanguageKind) *ComponentConfig {
+	projectgConfig := &ProjectConfig{
+		Name:            "Test-App",
+		Path:            ".",
+		EventDispatcher: ext.NewEventDispatcher[ProjectLifecycleEventArgs](),
+	}
+
+	serviceConfig := &ServiceConfig{
+		Host:       host,
+		Components: map[string]*ComponentConfig{},
+		Project:    projectgConfig,
+	}
+
+	componentConfig := &ComponentConfig{
+		Name:         "api",
+		Language:     language,
+		RelativePath: filepath.Join(path),
+		Service:      serviceConfig,
+	}
+
+	serviceConfig.Components[DefaultComponentName] = componentConfig
+
+	return componentConfig
+}
+
 func Test_Parent_Child(t *testing.T) {
 	parent := &Parent{
 		Name: "John",

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -645,8 +645,8 @@ func (sm *serviceManager) GetFrameworkService(ctx context.Context, component *Co
 				err,
 			)
 		}
-	} else if serviceConfig.Host == StaticWebAppTarget {
-		withSwaConfig, err := swa.ContainsSwaConfig(serviceConfig.Path())
+	} else if component.Service.Host == StaticWebAppTarget {
+		withSwaConfig, err := swa.ContainsSwaConfig(component.Path())
 		if err != nil {
 			return nil, fmt.Errorf("checking for swa-cli.config.json: %w", err)
 		}
@@ -654,8 +654,8 @@ func (sm *serviceManager) GetFrameworkService(ctx context.Context, component *Co
 			if err := sm.serviceLocator.ResolveNamed(string(ServiceLanguageSwa), &compositeFramework); err != nil {
 				return nil, fmt.Errorf(
 					"failed resolving composite framework service for '%s', language '%s': %w",
-					serviceConfig.Name,
-					serviceConfig.Language,
+					component.Name,
+					component.Language,
 					err,
 				)
 			}

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -636,7 +636,7 @@ func (sm *serviceManager) GetFrameworkService(ctx context.Context, component *Co
 	// For hosts which run in containers, if the source project is not already a container, we need to wrap it in a docker
 	// project that handles the containerization.
 	requiresLanguage := component.Language != ServiceLanguageDocker && component.Language != ServiceLanguageNone
-	if component.Host.RequiresContainer() && requiresLanguage {
+	if component.Service.Host.RequiresContainer() && requiresLanguage {
 		if err := sm.serviceLocator.ResolveNamed(string(ServiceLanguageDocker), &compositeFramework); err != nil {
 			return nil, fmt.Errorf(
 				"failed resolving composite framework service for '%s', language '%s': %w",

--- a/cli/azd/pkg/project/service_manager_test.go
+++ b/cli/azd/pkg/project/service_manager_test.go
@@ -3,7 +3,6 @@ package project
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -13,27 +12,20 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
-	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockarmresources"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazcli"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-type contextKey string
 
 const (
 	ServiceLanguageFake ServiceLanguageKind = "fake-framework"
 	ServiceTargetFake   ServiceTargetKind   = "fake-service-target"
-
-	frameworkRestoreCalled     contextKey = "frameworkRestoreCalled"
-	frameworkBuildCalled       contextKey = "frameworkBuildCalled"
-	frameworkPackageCalled     contextKey = "frameworkPackageCalled"
-	serviceTargetPackageCalled contextKey = "serviceTargetPackageCalled"
-	serviceTargetDeployCalled  contextKey = "serviceTargetDeployCalled"
 )
 
 func createServiceManager(
@@ -57,36 +49,62 @@ func createServiceManager(
 
 func Test_ServiceManager_GetRequiredTools(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
-	setupMocksForServiceManager(mockContext)
+
+	fakeServiceTarget := &fakeServiceTarget{}
+	fakeServiceTarget.
+		On("RequiredExternalTools", *mockContext.Context).
+		Return([]tools.ExternalTool{&fakeTool{}})
+
+	fakeFramework := &fakeFramework{}
+	fakeFramework.
+		On("RequiredExternalTools", *mockContext.Context).
+		Return([]tools.ExternalTool{&fakeTool{}})
+
+	setupMocksForServiceManager(mockContext, fakeServiceTarget, fakeFramework)
 	env := environment.New("test")
-	sm := createServiceManager(mockContext, env, ServiceOperationCache{})
+	serviceManager := createServiceManager(mockContext, env, ServiceOperationCache{})
 	serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
-	tools, err := sm.GetRequiredTools(*mockContext.Context, serviceConfig)
+	tools, err := serviceManager.GetRequiredTools(*mockContext.Context, serviceConfig)
 	require.NoError(t, err)
 	// Both require a tool, but only 1 unique tool
 	require.Len(t, tools, 1)
+
+	fakeServiceTarget.AssertCalled(t, "RequiredExternalTools", *mockContext.Context)
+	fakeFramework.AssertCalled(t, "RequiredExternalTools", *mockContext.Context)
 }
 
 func Test_ServiceManager_Initialize(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
-	setupMocksForServiceManager(mockContext)
+
 	env := environment.New("test")
-	sm := createServiceManager(mockContext, env, ServiceOperationCache{})
+	serviceManager := createServiceManager(mockContext, env, ServiceOperationCache{})
 	serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
-	err := sm.Initialize(*mockContext.Context, serviceConfig)
+	fakeServiceTarget := &fakeServiceTarget{}
+	fakeServiceTarget.On("Initialize", *mockContext.Context, serviceConfig).Return(nil)
+
+	fakeFramework := &fakeFramework{}
+	fakeFramework.
+		On("Initialize", *mockContext.Context, serviceConfig.ComponentConfig).
+		Return(nil)
+
+	setupMocksForServiceManager(mockContext, fakeServiceTarget, fakeFramework)
+
+	err := serviceManager.Initialize(*mockContext.Context, serviceConfig)
 	require.NoError(t, err)
+
+	fakeServiceTarget.AssertCalled(t, "Initialize", *mockContext.Context, serviceConfig)
+	fakeFramework.AssertCalled(t, "Initialize", *mockContext.Context, serviceConfig.ComponentConfig)
 }
 
 func Test_ServiceManager_Restore(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
-	setupMocksForServiceManager(mockContext)
+
 	env := environment.New("test")
-	sm := createServiceManager(mockContext, env, ServiceOperationCache{})
-	serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
 	raisedPreRestoreEvent := false
 	raisedPostRestoreEvent := false
+	serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
 	_ = serviceConfig.AddHandler("prerestore", func(ctx context.Context, args ServiceLifecycleEventArgs) error {
 		raisedPreRestoreEvent = true
@@ -98,29 +116,42 @@ func Test_ServiceManager_Restore(t *testing.T) {
 		return nil
 	})
 
-	restoreCalled := convert.RefOf(false)
-	ctx := context.WithValue(*mockContext.Context, frameworkRestoreCalled, restoreCalled)
+	fakeServiceTarget := newFakeServiceTarget()
 
-	restoreTask := sm.Restore(ctx, serviceConfig)
+	fakeFramework := &fakeFramework{}
+	frameworkRestoreTask := async.RunTaskWithProgress(
+		func(task *async.TaskContextWithProgress[*ServiceRestoreResult, ServiceProgress]) {
+			task.SetProgress(NewServiceProgress("Restoring"))
+			task.SetResult(&ServiceRestoreResult{})
+		},
+	)
+
+	fakeFramework.
+		On("Restore", *mockContext.Context, serviceConfig.ComponentConfig).
+		Return(frameworkRestoreTask)
+
+	setupMocksForServiceManager(mockContext, fakeServiceTarget, fakeFramework)
+
+	serviceManager := createServiceManager(mockContext, env, ServiceOperationCache{})
+	restoreTask := serviceManager.Restore(*mockContext.Context, serviceConfig)
 	logProgress(restoreTask)
 
 	result, err := restoreTask.Await()
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.True(t, *restoreCalled)
 	require.True(t, raisedPreRestoreEvent)
 	require.True(t, raisedPostRestoreEvent)
+
+	fakeFramework.AssertCalled(t, "Restore", *mockContext.Context, serviceConfig.ComponentConfig)
 }
 
 func Test_ServiceManager_Build(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
-	setupMocksForServiceManager(mockContext)
 	env := environment.New("test")
-	sm := createServiceManager(mockContext, env, ServiceOperationCache{})
-	serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
 	raisedPreBuildEvent := false
 	raisedPostBuildEvent := false
+	serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
 	_ = serviceConfig.AddHandler("prebuild", func(ctx context.Context, args ServiceLifecycleEventArgs) error {
 		raisedPreBuildEvent = true
@@ -132,25 +163,40 @@ func Test_ServiceManager_Build(t *testing.T) {
 		return nil
 	})
 
-	buildCalled := convert.RefOf(false)
-	ctx := context.WithValue(*mockContext.Context, frameworkBuildCalled, buildCalled)
+	fakeServiceTarget := &fakeServiceTarget{}
 
-	buildTask := sm.Build(ctx, serviceConfig, nil)
+	frameworkBuildTask := async.RunTaskWithProgress(
+		func(task *async.TaskContextWithProgress[*ServiceBuildResult, ServiceProgress]) {
+			task.SetProgress(NewServiceProgress("Building"))
+			task.SetResult(&ServiceBuildResult{})
+		},
+	)
+
+	var restoreResult *ServiceRestoreResult
+	fakeFramework := &fakeFramework{}
+	fakeFramework.
+		On("Build", *mockContext.Context, serviceConfig.ComponentConfig, restoreResult).
+		Return(frameworkBuildTask)
+
+	setupMocksForServiceManager(mockContext, fakeServiceTarget, fakeFramework)
+
+	serviceManager := createServiceManager(mockContext, env, ServiceOperationCache{})
+	buildTask := serviceManager.Build(*mockContext.Context, serviceConfig, restoreResult)
 	logProgress(buildTask)
 
 	result, err := buildTask.Await()
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.True(t, *buildCalled)
 	require.True(t, raisedPreBuildEvent)
 	require.True(t, raisedPostBuildEvent)
+
+	fakeFramework.AssertCalled(t, "Build", *mockContext.Context, serviceConfig.ComponentConfig, restoreResult)
 }
 
 func Test_ServiceManager_Package(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
-	setupMocksForServiceManager(mockContext)
 	env := environment.New("test")
-	sm := createServiceManager(mockContext, env, ServiceOperationCache{})
+
 	serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
 	raisedPrePackageEvent := false
@@ -166,30 +212,57 @@ func Test_ServiceManager_Package(t *testing.T) {
 		return nil
 	})
 
-	fakeFrameworkPackageCalled := convert.RefOf(false)
-	fakeServiceTargetPackageCalled := convert.RefOf(false)
-	ctx := context.WithValue(*mockContext.Context, frameworkPackageCalled, fakeFrameworkPackageCalled)
-	ctx = context.WithValue(ctx, serviceTargetPackageCalled, fakeServiceTargetPackageCalled)
+	serviceTargetPackageTask := async.RunTaskWithProgress(
+		func(task *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
+			task.SetProgress(NewServiceProgress("Packaging"))
+			task.SetResult(&ServicePackageResult{})
+		},
+	)
 
-	packageTask := sm.Package(ctx, serviceConfig, nil, nil)
+	fakeServiceTarget := &fakeServiceTarget{}
+	fakeServiceTarget.
+		On("Package", *mockContext.Context, serviceConfig, mock.Anything).
+		Return(serviceTargetPackageTask)
+
+	frameworkPackageTask := async.RunTaskWithProgress(
+		func(ctx *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
+			ctx.SetProgress(NewServiceProgress("Packaging"))
+			ctx.SetResult(&ServicePackageResult{})
+		},
+	)
+
+	fakeFramework := &fakeFramework{}
+	fakeFramework.On("Requirements").Return(FrameworkRequirements{
+		Package: FrameworkPackageRequirements{
+			RequireRestore: false,
+			RequireBuild:   false,
+		},
+	})
+
+	fakeFramework.
+		On("Package", *mockContext.Context, serviceConfig.ComponentConfig, mock.Anything).
+		Return(frameworkPackageTask)
+
+	setupMocksForServiceManager(mockContext, fakeServiceTarget, fakeFramework)
+	serviceManager := createServiceManager(mockContext, env, ServiceOperationCache{})
+	packageTask := serviceManager.Package(*mockContext.Context, serviceConfig, nil, nil)
 	logProgress(packageTask)
 
 	result, err := packageTask.Await()
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.True(t, *fakeFrameworkPackageCalled)
-	require.True(t, *fakeServiceTargetPackageCalled)
 	require.True(t, raisedPrePackageEvent)
 	require.True(t, raisedPostPackageEvent)
+
+	fakeServiceTarget.AssertCalled(t, "Package", *mockContext.Context, serviceConfig, mock.Anything)
+	fakeFramework.AssertCalled(t, "Package", *mockContext.Context, serviceConfig.ComponentConfig, mock.Anything)
 }
 
 func Test_ServiceManager_Deploy(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
-	setupMocksForServiceManager(mockContext)
 	env := environment.NewWithValues("test", map[string]string{
 		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
 	})
-	sm := createServiceManager(mockContext, env, ServiceOperationCache{})
 	serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
 	raisedPreDeployEvent := false
@@ -205,29 +278,44 @@ func Test_ServiceManager_Deploy(t *testing.T) {
 		return nil
 	})
 
-	deployCalled := convert.RefOf(false)
-	ctx := context.WithValue(*mockContext.Context, serviceTargetDeployCalled, deployCalled)
+	serviceTargetDeployTask := async.RunTaskWithProgress(
+		func(ctx *async.TaskContextWithProgress[*ServiceDeployResult, ServiceProgress]) {
+			ctx.SetProgress(NewServiceProgress("Deploying"))
+			ctx.SetResult(&ServiceDeployResult{})
+		},
+	)
 
-	deployTask := sm.Deploy(ctx, serviceConfig, nil)
+	fakeServiceTarget := &fakeServiceTarget{}
+	fakeServiceTarget.
+		On("Deploy", *mockContext.Context, serviceConfig, mock.Anything, mock.Anything).
+		Return(serviceTargetDeployTask)
+
+	fakeFramework := &fakeFramework{}
+
+	setupMocksForServiceManager(mockContext, fakeServiceTarget, fakeFramework)
+
+	serviceManager := createServiceManager(mockContext, env, ServiceOperationCache{})
+	deployTask := serviceManager.Deploy(*mockContext.Context, serviceConfig, nil)
 	logProgress(deployTask)
 
 	result, err := deployTask.Await()
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.True(t, *deployCalled)
 	require.True(t, raisedPreDeployEvent)
 	require.True(t, raisedPostDeployEvent)
+
+	fakeServiceTarget.AssertCalled(t, "Deploy", *mockContext.Context, serviceConfig, mock.Anything, mock.Anything)
 }
 
 func Test_ServiceManager_GetFrameworkService(t *testing.T) {
 	t.Run("Standard", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		setupMocksForServiceManager(mockContext)
+		setupMocksForServiceManager(mockContext, newFakeServiceTarget(), newFakeFramework())
 		env := environment.New("test")
 		sm := createServiceManager(mockContext, env, ServiceOperationCache{})
 		serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
-		framework, err := sm.GetFrameworkService(*mockContext.Context, serviceConfig)
+		framework, err := sm.GetFrameworkService(*mockContext.Context, serviceConfig.ComponentConfig)
 		require.NoError(t, err)
 		require.NotNil(t, framework)
 		require.IsType(t, new(fakeFramework), framework)
@@ -237,13 +325,13 @@ func Test_ServiceManager_GetFrameworkService(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		mockContext.Container.MustRegisterNamedTransient("docker", newFakeFramework)
 
-		setupMocksForServiceManager(mockContext)
+		setupMocksForServiceManager(mockContext, newFakeServiceTarget(), newFakeFramework())
 		env := environment.New("test")
-		sm := createServiceManager(mockContext, env, ServiceOperationCache{})
+		serviceManager := createServiceManager(mockContext, env, ServiceOperationCache{})
 		serviceConfig := createTestServiceConfig("", ServiceTargetFake, ServiceLanguageNone)
 		serviceConfig.Image = "nginx"
 
-		framework, err := sm.GetFrameworkService(*mockContext.Context, serviceConfig)
+		framework, err := serviceManager.GetFrameworkService(*mockContext.Context, serviceConfig.ComponentConfig)
 		require.NoError(t, err)
 		require.NotNil(t, framework)
 		require.IsType(t, new(fakeFramework), framework)
@@ -253,24 +341,24 @@ func Test_ServiceManager_GetFrameworkService(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		mockContext.Container.MustRegisterNamedTransient("docker", newFakeFramework)
 
-		setupMocksForServiceManager(mockContext)
+		setupMocksForServiceManager(mockContext, newFakeServiceTarget(), newFakeFramework())
 		env := environment.New("test")
-		sm := createServiceManager(mockContext, env, ServiceOperationCache{})
+		serviceManager := createServiceManager(mockContext, env, ServiceOperationCache{})
 		serviceConfig := createTestServiceConfig("", ServiceTargetFake, ServiceLanguageNone)
 
-		_, err := sm.GetFrameworkService(*mockContext.Context, serviceConfig)
+		_, _ = serviceManager.GetFrameworkService(*mockContext.Context, serviceConfig.ComponentConfig)
 		require.Error(t, err)
 	})
 }
 
 func Test_ServiceManager_GetServiceTarget(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
-	setupMocksForServiceManager(mockContext)
+	setupMocksForServiceManager(mockContext, newFakeServiceTarget(), newFakeFramework())
 	env := environment.New("test")
-	sm := createServiceManager(mockContext, env, ServiceOperationCache{})
+	serviceManager := createServiceManager(mockContext, env, ServiceOperationCache{})
 	serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
-	serviceTarget, err := sm.GetServiceTarget(*mockContext.Context, serviceConfig)
+	serviceTarget, err := serviceManager.GetServiceTarget(*mockContext.Context, serviceConfig)
 	require.NoError(t, err)
 	require.NotNil(t, serviceTarget)
 	require.IsType(t, new(fakeServiceTarget), serviceTarget)
@@ -278,60 +366,98 @@ func Test_ServiceManager_GetServiceTarget(t *testing.T) {
 
 func Test_ServiceManager_CacheResults(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
-	setupMocksForServiceManager(mockContext)
+
 	env := environment.New("test")
-	sm := createServiceManager(mockContext, env, ServiceOperationCache{})
 	serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
-	buildCalled := convert.RefOf(false)
-	ctx := context.WithValue(*mockContext.Context, frameworkBuildCalled, buildCalled)
+	fakeServiceTarget := &fakeServiceTarget{}
 
-	buildTask1 := sm.Build(ctx, serviceConfig, nil)
+	frameworkBuildTask := async.RunTaskWithProgress(
+		func(task *async.TaskContextWithProgress[*ServiceBuildResult, ServiceProgress]) {
+			task.SetProgress(NewServiceProgress("Building"))
+			task.SetResult(&ServiceBuildResult{})
+		},
+	)
+
+	fakeFramework := &fakeFramework{}
+	fakeFramework.
+		On("Build", *mockContext.Context, serviceConfig.ComponentConfig, mock.Anything).
+		Return(frameworkBuildTask)
+
+	setupMocksForServiceManager(mockContext, fakeServiceTarget, fakeFramework)
+
+	serviceManager := createServiceManager(mockContext, env, ServiceOperationCache{})
+	buildTask1 := serviceManager.Build(*mockContext.Context, serviceConfig, nil)
 	logProgress(buildTask1)
 
 	buildResult1, _ := buildTask1.Await()
 
-	require.True(t, *buildCalled)
-	*buildCalled = false
-
-	buildTask2 := sm.Build(ctx, serviceConfig, nil)
+	buildTask2 := serviceManager.Build(*mockContext.Context, serviceConfig, nil)
 	logProgress(buildTask1)
 
 	buildResult2, _ := buildTask2.Await()
 
-	require.False(t, *buildCalled)
 	require.Same(t, buildResult1, buildResult2)
+	fakeFramework.AssertNumberOfCalls(t, "Build", 1)
 }
 
 func Test_ServiceManager_CacheResults_Across_Instances(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
-	setupMocksForServiceManager(mockContext)
 	env := environment.New("test")
+	serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
+
+	serviceTargetPackageTask := async.RunTaskWithProgress(
+		func(ctx *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
+			ctx.SetProgress(NewServiceProgress("Packaging"))
+			ctx.SetResult(&ServicePackageResult{})
+		},
+	)
+
+	fakeServiceTarget := &fakeServiceTarget{}
+	fakeServiceTarget.
+		On("Package", *mockContext.Context, serviceConfig, mock.Anything).
+		Return(serviceTargetPackageTask)
+
+	frameworkPackageTask := async.RunTaskWithProgress(
+		func(ctx *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
+			ctx.SetProgress(NewServiceProgress("Packaging"))
+			ctx.SetResult(&ServicePackageResult{})
+		},
+	)
+
+	fakeFramework := &fakeFramework{}
+	fakeFramework.On("Requirements").Return(FrameworkRequirements{
+		Package: FrameworkPackageRequirements{
+			RequireRestore: false,
+			RequireBuild:   false,
+		},
+	})
+
+	fakeFramework.
+		On("Package", *mockContext.Context, serviceConfig.ComponentConfig, mock.Anything).
+		Return(frameworkPackageTask)
+
+	setupMocksForServiceManager(mockContext, fakeServiceTarget, fakeFramework)
 
 	operationCache := ServiceOperationCache{}
 
 	sm1 := createServiceManager(mockContext, env, operationCache)
-	serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
-	packageCalled := convert.RefOf(false)
-	ctx := context.WithValue(*mockContext.Context, serviceTargetPackageCalled, packageCalled)
-
-	packageTask1 := sm1.Package(ctx, serviceConfig, nil, nil)
+	packageTask1 := sm1.Package(*mockContext.Context, serviceConfig, nil, nil)
 	logProgress(packageTask1)
 
 	packageResult1, _ := packageTask1.Await()
 
-	require.True(t, *packageCalled)
-	*packageCalled = false
-
 	sm2 := createServiceManager(mockContext, env, operationCache)
-	packageTask2 := sm2.Package(ctx, serviceConfig, nil, nil)
+	packageTask2 := sm2.Package(*mockContext.Context, serviceConfig, nil, nil)
 	logProgress(packageTask2)
 
 	packageResult2, _ := packageTask2.Await()
 
-	require.False(t, *packageCalled)
 	require.Same(t, packageResult1, packageResult2)
+
+	fakeFramework.AssertNumberOfCalls(t, "Package", 1)
+	fakeServiceTarget.AssertNumberOfCalls(t, "Package", 1)
 }
 
 func Test_ServiceManager_Events_With_Errors(t *testing.T) {
@@ -377,11 +503,11 @@ func Test_ServiceManager_Events_With_Errors(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			mockContext := mocks.NewMockContext(context.Background())
-			setupMocksForServiceManager(mockContext)
+			setupMocksForServiceManager(mockContext, nil, nil)
 			env := environment.NewWithValues("test", map[string]string{
 				environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
 			})
-			sm := createServiceManager(mockContext, env, ServiceOperationCache{})
+			serviceManager := createServiceManager(mockContext, env, ServiceOperationCache{})
 			serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
 			eventTypes := []string{"pre", "post"}
@@ -395,7 +521,7 @@ func Test_ServiceManager_Events_With_Errors(t *testing.T) {
 						},
 					)
 
-					result, err := test.run(*mockContext.Context, sm, serviceConfig)
+					result, err := test.run(*mockContext.Context, serviceManager, serviceConfig)
 					require.Error(t, err)
 					require.Nil(t, result)
 				})
@@ -404,39 +530,13 @@ func Test_ServiceManager_Events_With_Errors(t *testing.T) {
 	}
 }
 
-func setupMocksForServiceManager(mockContext *mocks.MockContext) {
-	mockContext.Container.MustRegisterNamedSingleton(string(ServiceLanguageFake), newFakeFramework)
-	mockContext.Container.MustRegisterNamedSingleton(string(ServiceTargetFake), newFakeServiceTarget)
-
-	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.Contains(command, "fake-framework restore")
-	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-		return exec.NewRunResult(0, "", ""), nil
-	})
-
-	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.Contains(command, "fake-framework build")
-	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-		return exec.NewRunResult(0, "", ""), nil
-	})
-
-	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.Contains(command, "fake-framework package")
-	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-		return exec.NewRunResult(0, "", ""), nil
-	})
-
-	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.Contains(command, "fake-service-target package")
-	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-		return exec.NewRunResult(0, "", ""), nil
-	})
-
-	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
-		return strings.Contains(command, "fake-service-target deploy")
-	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-		return exec.NewRunResult(0, "", ""), nil
-	})
+func setupMocksForServiceManager(
+	mockContext *mocks.MockContext,
+	serviceTarget ServiceTarget,
+	frameworkService FrameworkService,
+) {
+	ioc.RegisterNamedInstance(mockContext.Container, string(ServiceLanguageFake), frameworkService)
+	ioc.RegisterNamedInstance(mockContext.Container, string(ServiceTargetFake), serviceTarget)
 
 	mockarmresources.AddResourceGroupListMock(mockContext.HttpClient, "SUBSCRIPTION_ID", []*armresources.ResourceGroup{
 		{
@@ -466,122 +566,71 @@ func setupMocksForServiceManager(mockContext *mocks.MockContext) {
 
 // Fake implementation of framework service
 type fakeFramework struct {
-	commandRunner exec.CommandRunner
+	mock.Mock
 }
 
-func newFakeFramework(commandRunner exec.CommandRunner) FrameworkService {
-	return &fakeFramework{
-		commandRunner: commandRunner,
-	}
+func newFakeFramework() FrameworkService {
+	return &fakeFramework{}
 }
 
 func (f *fakeFramework) Requirements() FrameworkRequirements {
-	return FrameworkRequirements{
-		Package: FrameworkPackageRequirements{
-			RequireRestore: false,
-			RequireBuild:   false,
-		},
-	}
+	args := f.Called()
+	return args.Get(0).(FrameworkRequirements)
 }
 
 func (f *fakeFramework) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
-	return []tools.ExternalTool{&fakeTool{}}
+	args := f.Called(ctx)
+	return args.Get(0).([]tools.ExternalTool)
 }
 
-func (f *fakeFramework) Initialize(ctx context.Context, serviceConfig *ServiceConfig) error {
-	return nil
+func (f *fakeFramework) Initialize(ctx context.Context, component *ComponentConfig) error {
+	args := f.Called(ctx, component)
+	return args.Error(0)
 }
 
 func (f *fakeFramework) Restore(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 ) *async.TaskWithProgress[*ServiceRestoreResult, ServiceProgress] {
-	restoreCalled, ok := ctx.Value(frameworkRestoreCalled).(*bool)
-	if ok {
-		*restoreCalled = true
-	}
-
-	return async.RunTaskWithProgress(func(task *async.TaskContextWithProgress[*ServiceRestoreResult, ServiceProgress]) {
-		runArgs := exec.NewRunArgs("fake-framework", "restore")
-		result, err := f.commandRunner.Run(ctx, runArgs)
-		if err != nil {
-			task.SetError(err)
-			return
-		}
-
-		task.SetResult(&ServiceRestoreResult{
-			Details: result,
-		})
-	})
+	args := f.Called(ctx, component)
+	return args.Get(0).(*async.TaskWithProgress[*ServiceRestoreResult, ServiceProgress])
 }
 
 func (f *fakeFramework) Build(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	restoreOutput *ServiceRestoreResult,
 ) *async.TaskWithProgress[*ServiceBuildResult, ServiceProgress] {
-	buildCalled, ok := ctx.Value(frameworkBuildCalled).(*bool)
-	if ok {
-		*buildCalled = true
-	}
-
-	return async.RunTaskWithProgress(func(task *async.TaskContextWithProgress[*ServiceBuildResult, ServiceProgress]) {
-		runArgs := exec.NewRunArgs("fake-framework", "build")
-		result, err := f.commandRunner.Run(ctx, runArgs)
-		if err != nil {
-			task.SetError(err)
-			return
-		}
-
-		task.SetResult(&ServiceBuildResult{
-			Restore: restoreOutput,
-			Details: result,
-		})
-	})
+	args := f.Called(ctx, component, restoreOutput)
+	return args.Get(0).(*async.TaskWithProgress[*ServiceBuildResult, ServiceProgress])
 }
 
 func (f *fakeFramework) Package(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	buildOutput *ServiceBuildResult,
 ) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress] {
-	packageCalled, ok := ctx.Value(frameworkPackageCalled).(*bool)
-	if ok {
-		*packageCalled = true
-	}
-
-	return async.RunTaskWithProgress(func(task *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
-		runArgs := exec.NewRunArgs("fake-framework", "package")
-		result, err := f.commandRunner.Run(ctx, runArgs)
-		if err != nil {
-			task.SetError(err)
-			return
-		}
-
-		task.SetResult(&ServicePackageResult{
-			Build:   buildOutput,
-			Details: result,
-		})
-	})
+	args := f.Called(ctx, component, buildOutput)
+	return args.Get(0).(*async.TaskWithProgress[*ServicePackageResult, ServiceProgress])
 }
 
 // Fake implementation of a service target
 type fakeServiceTarget struct {
-	commandRunner exec.CommandRunner
+	mock.Mock
 }
 
-func newFakeServiceTarget(commandRunner exec.CommandRunner) ServiceTarget {
-	return &fakeServiceTarget{
-		commandRunner: commandRunner,
-	}
+func newFakeServiceTarget() ServiceTarget {
+	return &fakeServiceTarget{}
 }
 
 func (st *fakeServiceTarget) Initialize(ctx context.Context, serviceConfig *ServiceConfig) error {
-	return nil
+	args := st.Called(ctx, serviceConfig)
+	return args.Error(0)
 }
 
 func (st *fakeServiceTarget) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
-	return []tools.ExternalTool{&fakeTool{}}
+	args := st.Called(ctx)
+	return args.Get(0).([]tools.ExternalTool)
 }
 
 func (st *fakeServiceTarget) Package(
@@ -589,24 +638,8 @@ func (st *fakeServiceTarget) Package(
 	serviceConfig *ServiceConfig,
 	packageOutput *ServicePackageResult,
 ) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress] {
-	packageCalled, ok := ctx.Value(serviceTargetPackageCalled).(*bool)
-	if ok {
-		*packageCalled = true
-	}
-
-	return async.RunTaskWithProgress(func(task *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
-		runArgs := exec.NewRunArgs("fake-service-target", "package")
-		result, err := st.commandRunner.Run(ctx, runArgs)
-		if err != nil {
-			task.SetError(err)
-			return
-		}
-
-		task.SetResult(&ServicePackageResult{
-			Build:   packageOutput.Build,
-			Details: result,
-		})
-	})
+	args := st.Called(ctx, serviceConfig, packageOutput)
+	return args.Get(0).(*async.TaskWithProgress[*ServicePackageResult, ServiceProgress])
 }
 
 func (st *fakeServiceTarget) Deploy(
@@ -615,24 +648,8 @@ func (st *fakeServiceTarget) Deploy(
 	packageOutput *ServicePackageResult,
 	targetResource *environment.TargetResource,
 ) *async.TaskWithProgress[*ServiceDeployResult, ServiceProgress] {
-	deployCalled, ok := ctx.Value(serviceTargetDeployCalled).(*bool)
-	if ok {
-		*deployCalled = true
-	}
-
-	return async.RunTaskWithProgress(func(task *async.TaskContextWithProgress[*ServiceDeployResult, ServiceProgress]) {
-		runArgs := exec.NewRunArgs("fake-service-target", "deploy")
-		result, err := st.commandRunner.Run(ctx, runArgs)
-		if err != nil {
-			task.SetError(err)
-			return
-		}
-
-		task.SetResult(&ServiceDeployResult{
-			Package: packageOutput,
-			Details: result,
-		})
-	})
+	args := st.Called(ctx, serviceConfig, packageOutput, targetResource)
+	return args.Get(0).(*async.TaskWithProgress[*ServiceDeployResult, ServiceProgress])
 }
 
 func (st *fakeServiceTarget) Endpoints(
@@ -640,7 +657,8 @@ func (st *fakeServiceTarget) Endpoints(
 	serviceConfig *ServiceConfig,
 	targetResource *environment.TargetResource,
 ) ([]string, error) {
-	return []string{"https://test.azurewebsites.net"}, nil
+	args := st.Called(ctx, serviceConfig, targetResource)
+	return args.Get(0).([]string), args.Error(1)
 }
 
 type fakeTool struct {

--- a/cli/azd/pkg/project/service_manager_test.go
+++ b/cli/azd/pkg/project/service_manager_test.go
@@ -81,7 +81,7 @@ func Test_ServiceManager_Initialize(t *testing.T) {
 	component := createTestComponentConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
 	fakeServiceTarget := &fakeServiceTarget{}
-	fakeServiceTarget.On("Initialize", *mockContext.Context, component).Return(nil)
+	fakeServiceTarget.On("Initialize", *mockContext.Context, component.Service).Return(nil)
 
 	fakeFramework := &fakeFramework{}
 	fakeFramework.
@@ -94,7 +94,7 @@ func Test_ServiceManager_Initialize(t *testing.T) {
 	require.NoError(t, err)
 
 	fakeServiceTarget.AssertCalled(t, "Initialize", *mockContext.Context, component.Service)
-	fakeFramework.AssertCalled(t, "Initialize", *mockContext.Context, component.Service)
+	fakeFramework.AssertCalled(t, "Initialize", *mockContext.Context, component)
 }
 
 func Test_ServiceManager_Restore(t *testing.T) {
@@ -221,7 +221,7 @@ func Test_ServiceManager_Package(t *testing.T) {
 
 	fakeServiceTarget := &fakeServiceTarget{}
 	fakeServiceTarget.
-		On("Package", *mockContext.Context, component, mock.Anything).
+		On("Package", *mockContext.Context, component.Service, mock.Anything).
 		Return(serviceTargetPackageTask)
 
 	frameworkPackageTask := async.RunTaskWithProgress(
@@ -254,7 +254,7 @@ func Test_ServiceManager_Package(t *testing.T) {
 	require.True(t, raisedPrePackageEvent)
 	require.True(t, raisedPostPackageEvent)
 
-	fakeServiceTarget.AssertCalled(t, "Package", *mockContext.Context, component, mock.Anything)
+	fakeServiceTarget.AssertCalled(t, "Package", *mockContext.Context, component.Service, mock.Anything)
 	fakeFramework.AssertCalled(t, "Package", *mockContext.Context, component, mock.Anything)
 }
 
@@ -415,7 +415,7 @@ func Test_ServiceManager_CacheResults_Across_Instances(t *testing.T) {
 
 	fakeServiceTarget := &fakeServiceTarget{}
 	fakeServiceTarget.
-		On("Package", *mockContext.Context, component, mock.Anything).
+		On("Package", *mockContext.Context, component.Service, mock.Anything).
 		Return(serviceTargetPackageTask)
 
 	frameworkPackageTask := async.RunTaskWithProgress(

--- a/cli/azd/pkg/project/service_manager_test.go
+++ b/cli/azd/pkg/project/service_manager_test.go
@@ -346,7 +346,7 @@ func Test_ServiceManager_GetFrameworkService(t *testing.T) {
 		serviceManager := createServiceManager(mockContext, env, ServiceOperationCache{})
 		serviceConfig := createTestServiceConfig("", ServiceTargetFake, ServiceLanguageNone)
 
-		_, _ = serviceManager.GetFrameworkService(*mockContext.Context, serviceConfig.ComponentConfig)
+		_, err := serviceManager.GetFrameworkService(*mockContext.Context, serviceConfig.ComponentConfig)
 		require.Error(t, err)
 	})
 }

--- a/cli/azd/pkg/project/service_models.go
+++ b/cli/azd/pkg/project/service_models.go
@@ -52,6 +52,24 @@ type ServiceBuildResult struct {
 
 // Supports rendering messages for UX items
 func (sbr *ServiceBuildResult) ToString(currentIndentation string) string {
+	compositeResult, ok := sbr.Details.(map[string]*ServiceBuildResult)
+	if ok {
+		builder := strings.Builder{}
+		componentIndentation := currentIndentation
+		for name, componentResult := range compositeResult {
+			builder.WriteString(
+				fmt.Sprintf(
+					"%s%s:\n%s",
+					componentIndentation,
+					output.WithBold(name),
+					componentResult.ToString(componentIndentation+"  "),
+				),
+			)
+		}
+
+		return builder.String()
+	}
+
 	uxItem, ok := sbr.Details.(ux.UxItem)
 	if ok {
 		return uxItem.ToString(currentIndentation)
@@ -77,6 +95,24 @@ type ServicePackageResult struct {
 
 // Supports rendering messages for UX items
 func (spr *ServicePackageResult) ToString(currentIndentation string) string {
+	compositeResult, ok := spr.Details.(map[string]*ServicePackageResult)
+	if ok {
+		builder := strings.Builder{}
+		componentIndentation := currentIndentation
+		for name, componentResult := range compositeResult {
+			builder.WriteString(
+				fmt.Sprintf(
+					"%s%s:\n%s",
+					componentIndentation,
+					output.WithBold(name),
+					componentResult.ToString(componentIndentation+"  "),
+				),
+			)
+		}
+
+		return builder.String()
+	}
+
 	uxItem, ok := spr.Details.(ux.UxItem)
 	if ok {
 		return uxItem.ToString(currentIndentation)

--- a/cli/azd/pkg/project/service_target_ai_endpoint.go
+++ b/cli/azd/pkg/project/service_target_ai_endpoint.go
@@ -84,6 +84,12 @@ func (m *aiEndpointTarget) Deploy(
 
 		deployResult := &AiEndpointDeploymentResult{}
 
+		mainComponent, err := serviceConfig.Main()
+		if err != nil {
+			task.SetError(err)
+			return
+		}
+
 		// Initialize the AI project that will be used for the python bridge
 		task.SetProgress(NewServiceProgress("Initializing AI project"))
 		if err := m.aiHelper.Initialize(ctx); err != nil {
@@ -107,7 +113,7 @@ func (m *aiEndpointTarget) Deploy(
 		// Deploy flow
 		if endpointConfig.Flow != nil {
 			task.SetProgress(NewServiceProgress("Deploying AI Prompt Flow"))
-			flow, err := m.aiHelper.CreateFlow(ctx, workspaceScope, serviceConfig, endpointConfig.Flow)
+			flow, err := m.aiHelper.CreateFlow(ctx, workspaceScope, mainComponent, endpointConfig.Flow)
 			if err != nil {
 				task.SetError(err)
 				return
@@ -122,7 +128,7 @@ func (m *aiEndpointTarget) Deploy(
 			envVersion, err := m.aiHelper.CreateEnvironmentVersion(
 				ctx,
 				workspaceScope,
-				serviceConfig,
+				mainComponent,
 				endpointConfig.Environment,
 			)
 			if err != nil {
@@ -136,7 +142,7 @@ func (m *aiEndpointTarget) Deploy(
 		// Deploy model
 		if endpointConfig.Model != nil {
 			task.SetProgress(NewServiceProgress("Configuring AI model"))
-			modelVersion, err := m.aiHelper.CreateModelVersion(ctx, workspaceScope, serviceConfig, endpointConfig.Model)
+			modelVersion, err := m.aiHelper.CreateModelVersion(ctx, workspaceScope, mainComponent, endpointConfig.Model)
 			if err != nil {
 				task.SetError(err)
 				return
@@ -152,7 +158,7 @@ func (m *aiEndpointTarget) Deploy(
 			onlineDeployment, err := m.aiHelper.DeployToEndpoint(
 				ctx,
 				workspaceScope,
-				serviceConfig,
+				mainComponent,
 				endpointName,
 				endpointConfig,
 			)

--- a/cli/azd/pkg/project/service_target_ai_endpoint_test.go
+++ b/cli/azd/pkg/project/service_target_ai_endpoint_test.go
@@ -44,8 +44,8 @@ func Test_MlEndpointTarget_Deploy(t *testing.T) {
 		endpointName,
 		string(infra.AzureMachineLearningEndpoint),
 	)
-	serviceConfig := createTestServiceConfig("./contoso-chat", AiEndpointTarget, ServiceLanguagePython)
-	serviceConfig.Config = map[string]any{
+	component := createTestComponentConfig("./contoso-chat", AiEndpointTarget, ServiceLanguagePython)
+	component.Service.Config = map[string]any{
 		"flow": map[string]any{
 			"name": flowName,
 			"path": ".",
@@ -104,16 +104,16 @@ func Test_MlEndpointTarget_Deploy(t *testing.T) {
 		On("ValidateWorkspace", *mockContext.Context, scopeType).
 		Return(nil)
 	aiHelper.
-		On("CreateFlow", *mockContext.Context, scopeType, serviceConfig, componentConfigType).
+		On("CreateFlow", *mockContext.Context, scopeType, component, componentConfigType).
 		Return(flow, nil)
 	aiHelper.
-		On("CreateEnvironmentVersion", *mockContext.Context, scopeType, serviceConfig, componentConfigType).
+		On("CreateEnvironmentVersion", *mockContext.Context, scopeType, component, componentConfigType).
 		Return(environmentVersion, nil)
 	aiHelper.
-		On("CreateModelVersion", *mockContext.Context, scopeType, serviceConfig, componentConfigType).
+		On("CreateModelVersion", *mockContext.Context, scopeType, component, componentConfigType).
 		Return(modelVersion, nil)
 	aiHelper.
-		On("DeployToEndpoint", *mockContext.Context, scopeType, serviceConfig, endpointName, endpointDeploymentConfigType).
+		On("DeployToEndpoint", *mockContext.Context, scopeType, component, endpointName, endpointDeploymentConfigType).
 		Return(onlineDeployment, nil)
 	aiHelper.
 		On("UpdateTraffic", *mockContext.Context, scopeType, endpointName, expectedDeploymentName).
@@ -126,7 +126,7 @@ func Test_MlEndpointTarget_Deploy(t *testing.T) {
 		Return(onlineEndpoint, nil)
 
 	serviceTarget := createMlEndpointTarget(mockContext, env, aiHelper)
-	deployTask := serviceTarget.Deploy(*mockContext.Context, serviceConfig, servicePackage, targetResource)
+	deployTask := serviceTarget.Deploy(*mockContext.Context, component.Service, servicePackage, targetResource)
 	require.NotNil(t, deployTask)
 	logProgress(deployTask)
 

--- a/cli/azd/pkg/project/service_target_ai_endpoint_test.go
+++ b/cli/azd/pkg/project/service_target_ai_endpoint_test.go
@@ -178,20 +178,20 @@ func (m *mockAiHelper) ValidateWorkspace(ctx context.Context, scope *ai.Scope) e
 func (m *mockAiHelper) CreateEnvironmentVersion(
 	ctx context.Context,
 	scope *ai.Scope,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	config *ai.ComponentConfig,
 ) (*armmachinelearning.EnvironmentVersion, error) {
-	args := m.Called(ctx, scope, serviceConfig, config)
+	args := m.Called(ctx, scope, component, config)
 	return args.Get(0).(*armmachinelearning.EnvironmentVersion), args.Error(1)
 }
 
 func (m *mockAiHelper) CreateModelVersion(
 	ctx context.Context,
 	scope *ai.Scope,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	config *ai.ComponentConfig,
 ) (*armmachinelearning.ModelVersion, error) {
-	args := m.Called(ctx, scope, serviceConfig, config)
+	args := m.Called(ctx, scope, component, config)
 	return args.Get(0).(*armmachinelearning.ModelVersion), args.Error(1)
 }
 
@@ -207,21 +207,21 @@ func (m *mockAiHelper) GetEndpoint(
 func (m *mockAiHelper) DeployToEndpoint(
 	ctx context.Context,
 	scope *ai.Scope,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	endpointName string,
 	config *ai.EndpointDeploymentConfig,
 ) (*armmachinelearning.OnlineDeployment, error) {
-	args := m.Called(ctx, scope, serviceConfig, endpointName, config)
+	args := m.Called(ctx, scope, component, endpointName, config)
 	return args.Get(0).(*armmachinelearning.OnlineDeployment), args.Error(1)
 }
 
 func (m *mockAiHelper) CreateFlow(
 	ctx context.Context,
 	scope *ai.Scope,
-	serviceConfig *ServiceConfig,
+	component *ComponentConfig,
 	config *ai.ComponentConfig,
 ) (*ai.Flow, error) {
-	args := m.Called(ctx, scope, serviceConfig, config)
+	args := m.Called(ctx, scope, component, config)
 	return args.Get(0).(*ai.Flow), args.Error(1)
 }
 

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -262,7 +262,7 @@ func (t *aksTarget) Deploy(
 
 			// Vanilla k8s manifests with minimal templating support
 			deployments, err := t.deployManifests(ctx, serviceConfig, rootTask)
-			if err != nil && !os.IsNotExist(err) {
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
 				rootTask.SetError(err)
 				return
 			}

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -270,7 +270,7 @@ func (t *aksTarget) Deploy(
 			deployed = deployed || len(deployments) > 0
 
 			if !deployed {
-				rootTask.SetError(errors.New("no deployment manifests found"))
+				rootTask.SetError(err)
 				return
 			}
 
@@ -324,7 +324,7 @@ func (t *aksTarget) deployManifests(
 
 	// Manifests are optional so we will continue if the directory does not exist
 	if _, err := os.Stat(deploymentPath); os.IsNotExist(err) {
-		return nil, err
+		return nil, fmt.Errorf("no deployment manifests found at '%s', %w", deploymentPath, err)
 	}
 
 	task.SetProgress(NewServiceProgress("Applying k8s manifests"))

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -149,7 +149,7 @@ func Test_Package_Deploy_HappyPath(t *testing.T) {
 	require.IsType(t, []*kubectl.Deployment{}, deployResult.Details)
 	require.Greater(t, len(deployResult.Endpoints), 0)
 	// New env variable is created
-	require.Equal(t, "REGISTRY.azurecr.io/test-app/api-test:azd-deploy-0", env.Dotenv()["SERVICE_API_IMAGE_NAME"])
+	require.Equal(t, "REGISTRY.azurecr.io/test-app/api-test:azd-deploy-0", env.Dotenv()["SERVICE_API_MAIN_IMAGE_NAME"])
 }
 
 func Test_Resolve_Cluster_Name(t *testing.T) {

--- a/cli/azd/pkg/project/service_target_appservice.go
+++ b/cli/azd/pkg/project/service_target_appservice.go
@@ -51,11 +51,29 @@ func (st *appServiceTarget) Package(
 ) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress] {
 	return async.RunTaskWithProgress(
 		func(task *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
+			mainComponent, err := serviceConfig.Main()
+			if err != nil {
+				task.SetError(err)
+				return
+			}
+
+			componentPackageResults, ok := packageOutput.Details.(map[string]*ServicePackageResult)
+			if !ok {
+				task.SetError(fmt.Errorf("invalid package details"))
+				return
+			}
+
+			mainPackageOutput, has := componentPackageResults[mainComponent.Name]
+			if !has {
+				task.SetError(fmt.Errorf("missing main component package output"))
+				return
+			}
+
 			task.SetProgress(NewServiceProgress("Compressing deployment artifacts"))
 			zipFilePath, err := createDeployableZip(
 				serviceConfig.Project.Name,
 				serviceConfig.Name,
-				packageOutput.PackagePath,
+				mainPackageOutput.PackagePath,
 			)
 			if err != nil {
 				task.SetError(err)
@@ -63,7 +81,7 @@ func (st *appServiceTarget) Package(
 			}
 
 			task.SetResult(&ServicePackageResult{
-				Build:       packageOutput.Build,
+				Build:       mainPackageOutput.Build,
 				PackagePath: zipFilePath,
 			})
 		},

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -135,7 +135,9 @@ func (at *containerAppTarget) Deploy(
 					return
 				}
 
-				imageName := at.env.GetServiceProperty(component.Name, "IMAGE_NAME")
+				imageName := at.env.GetServiceProperty(
+					fmt.Sprintf("%s_%s", component.Service.Name, component.Name), "IMAGE_NAME",
+				)
 				rootTask.SetProgress(NewServiceProgress("Updating container app revision"))
 
 				var matchingContainer *armappcontainers.Container

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -208,7 +208,7 @@ func setupMocksForContainerApps(mockContext *mocks.MockContext) {
 			Template: &armappcontainers.Template{
 				Containers: []*armappcontainers.Container{
 					{
-						Name:  convert.RefOf(defaultComponentName),
+						Name:  convert.RefOf(DefaultComponentName),
 						Image: &originalImageName,
 					},
 				},
@@ -221,7 +221,7 @@ func setupMocksForContainerApps(mockContext *mocks.MockContext) {
 			Template: &armappcontainers.Template{
 				Containers: []*armappcontainers.Container{
 					{
-						Name:  convert.RefOf(defaultComponentName),
+						Name:  convert.RefOf(DefaultComponentName),
 						Image: &updatedRevisionName,
 					},
 				},

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -89,9 +89,13 @@ func Test_ContainerApp_Deploy(t *testing.T) {
 		serviceConfig,
 		&ServicePackageResult{
 			PackagePath: "test-app/api-test:azd-deploy-0",
-			Details: &dockerPackageResult{
-				ImageHash:   "IMAGE_HASH",
-				TargetImage: "test-app/api-test:azd-deploy-0",
+			Details: map[string]*ServicePackageResult{
+				"main": {
+					Details: &dockerPackageResult{
+						ImageHash:   "IMAGE_HASH",
+						TargetImage: "test-app/api-test:azd-deploy-0",
+					},
+				},
 			},
 		},
 	)
@@ -100,7 +104,7 @@ func Test_ContainerApp_Deploy(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, packageResult)
-	require.IsType(t, new(dockerPackageResult), packageResult.Details)
+	require.IsType(t, map[string]*ServicePackageResult{}, packageResult.Details)
 
 	scope := environment.NewTargetResource(
 		"SUBSCRIPTION_ID",
@@ -204,6 +208,7 @@ func setupMocksForContainerApps(mockContext *mocks.MockContext) {
 			Template: &armappcontainers.Template{
 				Containers: []*armappcontainers.Container{
 					{
+						Name:  convert.RefOf(defaultComponentName),
 						Image: &originalImageName,
 					},
 				},
@@ -216,6 +221,7 @@ func setupMocksForContainerApps(mockContext *mocks.MockContext) {
 			Template: &armappcontainers.Template{
 				Containers: []*armappcontainers.Container{
 					{
+						Name:  convert.RefOf(defaultComponentName),
 						Image: &updatedRevisionName,
 					},
 				},

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -88,12 +88,12 @@ func Test_ContainerApp_Deploy(t *testing.T) {
 		*mockContext.Context,
 		serviceConfig,
 		&ServicePackageResult{
-			PackagePath: "test-app/api-test:azd-deploy-0",
+			PackagePath: "test-app/api/main-test:azd-deploy-0",
 			Details: map[string]*ServicePackageResult{
-				"main": {
+				DefaultComponentName: {
 					Details: &dockerPackageResult{
 						ImageHash:   "IMAGE_HASH",
-						TargetImage: "test-app/api-test:azd-deploy-0",
+						TargetImage: "test-app/api/main-test:azd-deploy-0",
 					},
 				},
 			},
@@ -121,7 +121,7 @@ func Test_ContainerApp_Deploy(t *testing.T) {
 	require.Equal(t, ContainerAppTarget, deployResult.Kind)
 	require.Greater(t, len(deployResult.Endpoints), 0)
 	// New env variable is created
-	require.Equal(t, "REGISTRY.azurecr.io/test-app/api-test:azd-deploy-0", env.Dotenv()["SERVICE_API_IMAGE_NAME"])
+	require.Equal(t, "REGISTRY.azurecr.io/test-app/api/main-test:azd-deploy-0", env.Dotenv()["SERVICE_API_MAIN_IMAGE_NAME"])
 }
 
 func createContainerAppServiceTarget(

--- a/cli/azd/pkg/project/service_target_dotnet_containerapp.go
+++ b/cli/azd/pkg/project/service_target_dotnet_containerapp.go
@@ -140,7 +140,13 @@ func (at *dotnetContainerAppTarget) Deploy(
 			// The name of the image that should be referenced in the manifest is stored in `remoteImageName` and presented
 			// to the deployment template as a parameter named `Image`.
 			if serviceConfig.Language == ServiceLanguageDocker {
-				containerDeployTask := at.containerHelper.Deploy(ctx, serviceConfig.ComponentConfig, packageOutput, targetResource, false)
+				containerDeployTask := at.containerHelper.Deploy(
+					ctx,
+					serviceConfig.ComponentConfig,
+					packageOutput,
+					targetResource,
+					false,
+				)
 				syncProgress(task, containerDeployTask.Progress())
 
 				res, err := containerDeployTask.Await()

--- a/cli/azd/pkg/project/service_target_dotnet_containerapp.go
+++ b/cli/azd/pkg/project/service_target_dotnet_containerapp.go
@@ -113,7 +113,7 @@ func (at *dotnetContainerAppTarget) Deploy(
 			task.SetProgress(NewServiceProgress("Logging in to registry"))
 
 			// Login, tag & push container image to ACR
-			dockerCreds, err := at.containerHelper.Credentials(ctx, serviceConfig, targetResource)
+			dockerCreds, err := at.containerHelper.Credentials(ctx, serviceConfig.ComponentConfig, targetResource)
 			if err != nil {
 				task.SetError(fmt.Errorf("logging in to registry: %w", err))
 				return
@@ -140,7 +140,7 @@ func (at *dotnetContainerAppTarget) Deploy(
 			// The name of the image that should be referenced in the manifest is stored in `remoteImageName` and presented
 			// to the deployment template as a parameter named `Image`.
 			if serviceConfig.Language == ServiceLanguageDocker {
-				containerDeployTask := at.containerHelper.Deploy(ctx, serviceConfig, packageOutput, targetResource, false)
+				containerDeployTask := at.containerHelper.Deploy(ctx, serviceConfig.ComponentConfig, packageOutput, targetResource, false)
 				syncProgress(task, containerDeployTask.Progress())
 
 				res, err := containerDeployTask.Await()

--- a/cli/azd/pkg/project/service_target_functionapp.go
+++ b/cli/azd/pkg/project/service_target_functionapp.go
@@ -95,10 +95,17 @@ func (f *functionAppTarget) Deploy(
 			defer os.Remove(packageOutput.PackagePath)
 			defer zipFile.Close()
 
+			mainComponent, err := serviceConfig.Main()
+			if err != nil {
+				task.SetError(err)
+				return
+			}
+
 			task.SetProgress(NewServiceProgress("Uploading deployment package"))
-			remoteBuild := serviceConfig.Language == ServiceLanguageJavaScript ||
-				serviceConfig.Language == ServiceLanguageTypeScript ||
-				serviceConfig.Language == ServiceLanguagePython
+			remoteBuild := mainComponent.Language == ServiceLanguageJavaScript ||
+				mainComponent.Language == ServiceLanguageTypeScript ||
+				mainComponent.Language == ServiceLanguagePython
+
 			res, err := f.cli.DeployFunctionAppUsingZipFile(
 				ctx,
 				targetResource.SubscriptionId(),

--- a/cli/azd/pkg/project/service_target_staticwebapp.go
+++ b/cli/azd/pkg/project/service_target_staticwebapp.go
@@ -67,6 +67,13 @@ func (at *staticWebAppTarget) Package(
 				return
 			}
 
+			mainComponent, err := serviceConfig.Main()
+			if err != nil {
+				task.SetError(err)
+				return
+			}
+
+			packagePath := mainComponent.OutputPath
 			// packageOutput.PackagePath != "" -> This means swa framework service is not used to build/deploy and there
 			// is no a swa-cli.config.json file to govern the output.
 			// In this case, the serviceConfig.OutputPath (azure.yaml -> service -> dist) defines where is the output from
@@ -74,7 +81,6 @@ func (at *staticWebAppTarget) Package(
 			// If serviceConfig.OutputPath is not defined, azd should use the package path defined by the language framework
 			// service.
 
-			packagePath := serviceConfig.OutputPath
 			if strings.TrimSpace(packagePath) == "" {
 				packagePath = packageOutput.PackagePath
 			}
@@ -107,6 +113,12 @@ func (at *staticWebAppTarget) Deploy(
 				return
 			}
 
+			mainComponent, err := serviceConfig.Main()
+			if err != nil {
+				task.SetError(err)
+				return
+			}
+
 			// Get the static webapp deployment token
 			task.SetProgress(NewServiceProgress("Retrieving deployment token"))
 			deploymentToken, err := at.cli.GetStaticWebAppApiKey(
@@ -135,6 +147,7 @@ func (at *staticWebAppTarget) Deploy(
 				targetResource.SubscriptionId(),
 				targetResource.ResourceGroupName(),
 				targetResource.ResourceName(),
+				mainComponent.RelativePath,
 				DefaultStaticWebAppEnvironmentName,
 				*deploymentToken,
 				dOptions)

--- a/cli/azd/pkg/project/service_target_staticwebapp.go
+++ b/cli/azd/pkg/project/service_target_staticwebapp.go
@@ -113,12 +113,6 @@ func (at *staticWebAppTarget) Deploy(
 				return
 			}
 
-			mainComponent, err := serviceConfig.Main()
-			if err != nil {
-				task.SetError(err)
-				return
-			}
-
 			// Get the static webapp deployment token
 			task.SetProgress(NewServiceProgress("Retrieving deployment token"))
 			deploymentToken, err := at.cli.GetStaticWebAppApiKey(
@@ -147,7 +141,6 @@ func (at *staticWebAppTarget) Deploy(
 				targetResource.SubscriptionId(),
 				targetResource.ResourceGroupName(),
 				targetResource.ResourceName(),
-				mainComponent.RelativePath,
 				DefaultStaticWebAppEnvironmentName,
 				*deploymentToken,
 				dOptions)

--- a/cli/azd/pkg/project/testdata/TestMinimalYaml-minimal-docker.snap
+++ b/cli/azd/pkg/project/testdata/TestMinimalYaml-minimal-docker.snap
@@ -1,8 +1,8 @@
 name: minimal
 services:
     minimal-docker:
-        project: ./src
         host: containerapp
+        project: ./src
         language: dotnet
         docker:
             path: ./Dockerfile

--- a/cli/azd/pkg/project/testdata/TestMinimalYaml-minimal-service.snap
+++ b/cli/azd/pkg/project/testdata/TestMinimalYaml-minimal-service.snap
@@ -1,7 +1,7 @@
 name: minimal
 services:
     minimal-service:
-        project: ./src
         host: appservice
+        project: ./src
         language: python
 

--- a/cli/azd/pkg/project/testdata/Test_ServiceConfig_Marshall-Multiple_Containers.snap
+++ b/cli/azd/pkg/project/testdata/Test_ServiceConfig_Marshall-Multiple_Containers.snap
@@ -1,0 +1,12 @@
+name: test-proj
+services:
+    todo:
+        host: aks
+        containers:
+            api:
+                project: ./src/api
+                language: js
+            web:
+                project: ./src/web
+                language: js
+

--- a/cli/azd/pkg/project/testdata/Test_ServiceConfig_Marshall-Multiple_containers_with_other_configuration.snap
+++ b/cli/azd/pkg/project/testdata/Test_ServiceConfig_Marshall-Multiple_containers_with_other_configuration.snap
@@ -1,0 +1,16 @@
+name: test-proj
+services:
+    todo:
+        host: containerapp
+        containers:
+            main:
+                project: ./src/api
+                language: js
+                docker:
+                    path: ./Dockerfile
+                    registry: docker.io
+                    image: test-image
+                    tag: latest
+            sidecar:
+                image: docker.io/sidecar:latest
+

--- a/cli/azd/pkg/project/testdata/Test_ServiceConfig_Marshall-Single_container_with_non-default_name.snap
+++ b/cli/azd/pkg/project/testdata/Test_ServiceConfig_Marshall-Single_container_with_non-default_name.snap
@@ -1,0 +1,9 @@
+name: test-proj
+services:
+    todo:
+        host: aks
+        containers:
+            api:
+                project: ./src/api
+                language: js
+

--- a/cli/azd/pkg/project/testdata/Test_ServiceConfig_Marshall-Standard_Project.snap
+++ b/cli/azd/pkg/project/testdata/Test_ServiceConfig_Marshall-Standard_Project.snap
@@ -1,0 +1,7 @@
+name: test-proj
+services:
+    api:
+        host: aks
+        project: ./src/api
+        language: js
+

--- a/cli/azd/pkg/tools/azcli/azcli_functions_test.go
+++ b/cli/azd/pkg/tools/azcli/azcli_functions_test.go
@@ -159,7 +159,9 @@ func registerInfoMocks(mockContext *mocks.MockContext, ran *bool) {
 							},
 						},
 						//nolint:lll
-						ServerFarmID: convert.RefOf("/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_ID/providers/Microsoft.Web/serverfarms/FUNC_APP_PLAN_NAME"),
+						ServerFarmID: convert.RefOf(
+							"/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_ID/providers/Microsoft.Web/serverfarms/FUNC_APP_PLAN_NAME",
+						),
 					},
 				},
 			},

--- a/cli/azd/pkg/tools/azcli/azcli_linuxwebapp_test.go
+++ b/cli/azd/pkg/tools/azcli/azcli_linuxwebapp_test.go
@@ -72,8 +72,10 @@ func Test_DeployTrackLinuxWebAppStatus(t *testing.T) {
 func registerIsLinuxWebAppMocks(mockContext *mocks.MockContext, ran *bool) {
 	mockContext.HttpClient.When(func(request *http.Request) bool {
 		return request.Method == http.MethodGet &&
-			strings.Contains(request.URL.Path,
-				"/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_ID/providers/Microsoft.Web/sites/LINUX_WEB_APP_NAME")
+			strings.Contains(
+				request.URL.Path,
+				"/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_ID/providers/Microsoft.Web/sites/LINUX_WEB_APP_NAME",
+			)
 	}).RespondFn(func(request *http.Request) (*http.Response, error) {
 		*ran = true
 		response := armappservice.WebAppsClientGetResponse{

--- a/cli/azd/test/functional/show_test.go
+++ b/cli/azd/test/functional/show_test.go
@@ -59,8 +59,8 @@ func Test_CLI_ShowWorksWithoutEnvironment(t *testing.T) {
 
 	require.Equal(t, "webapp", showRes.Name)
 	require.Equal(t, 1, len(showRes.Services))
-	require.NotNil(t, showRes.Services["web"])
-	require.Nil(t, showRes.Services["web"].Target)
+	require.NotNil(t, showRes.Services["web/main"])
+	require.Nil(t, showRes.Services["web/main"].Target)
 
 	// Repeat the process but passing an explicit environment name for an environment that doesn't exist and ensure
 	// that we get an error, as the selected env does not exists.

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -203,7 +203,9 @@ func Test_CLI_Telemetry_UsageData_EnvProjectLoad(t *testing.T) {
 			languages := []string{}
 			for _, svc := range projConfig.Services {
 				hosts = append(hosts, string(svc.Host))
-				languages = append(languages, string(svc.Language))
+				for _, component := range svc.Components {
+					languages = append(languages, string(component.Language))
+				}
 			}
 			require.Contains(t, m, fields.ProjectServiceHostsKey)
 			require.ElementsMatch(t, m[fields.ProjectServiceHostsKey], hosts)


### PR DESCRIPTION
Resolves #3236, #3239

Adds support to configure multiple containers within either ACA/AKS service targets and deploy them as an atomic unit.

Implementation is based on [this gist](https://gist.github.com/wbreza/67fdc3054025311fdf147f303f04dc4e)

## Use Case: Develop a Helm chart that references multiple containers

Custom variation of Todo AKS template is available @ https://github.com/wbreza/todo-nodejs-mongo-aks/tree/helm

The following will deploy a single service named `todo` that contains multiple containers that are built from source.
The `web` and `api` containers will be built, pushed to the container registry then referenced in a local helm chart.

> [!NOTE]
> This example uses helm but will work in any AKS configuration

```yaml
# azure.yaml

name: todo-nodejs-mongo-aks
metadata:
  template: todo-nodejs-mongo-aks@0.0.1-beta
services:
  todo:
    host: aks
    # Specify the multiple containers that will be deployed when this `todo` service is deployed.
    containers:
      web:
        project: ./src/web
        dist: build
        language: js
      api:
        project: ./src/api
        language: js
    k8s:
      helm:
        releases:
          - name: todo
            # Reference the local helm chart and values.yaml
            chart: ./charts/todo
            values: ./charts/todo/values.yaml
            namespace: todo-helm
            # Override/set additional values in addition to values.yaml
            overrides:
              cluster.clientId: ${AZURE_AKS_IDENTITY_CLIENT_ID}
              keyvault.endpoint: ${AZURE_KEY_VAULT_ENDPOINT}
              appInsights.connectionString: ${APPLICATIONINSIGHTS_CONNECTION_STRING}
              api.image: ${SERVICE_API_IMAGE_NAME}
              web.image: ${SERVICE_WEB_IMAGE_NAME}
```
### Helm Configuration

The helm chart organization of multiple resource components.

<img width="250" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/4d830b70-51a7-42e4-bdcd-db1b776614e6">

Helm chart `values.yaml` contains the baseline configuration for the chart

```yaml
# values.yaml

api:
  port: 3100
web:
  port: 3000
```

## Use Case: Deploy multiple sidecar containers to a single Azure Container App

Custom variation of Todo ACA template is available @ https://github.com/wbreza/todo-nodejs-mongo-aca/tree/multi-container-poc

In the following example a Todo application with 2 container apps is deployed.

- `web` container app contains a single container with standard configuration
- `api` container app contains multiple containers leveraging the new `containers` configuration section
  - Includes a `main` container as well as a `sidecar`

> [!IMPORTANT] 
> During the deployment a single revision is added referencing both containers

```yaml
# azure.yaml

name: todo-nodejs-mongo-aca
metadata:
  template: todo-nodejs-mongo-aca@0.0.1-beta
services:
  web:
    project: ./src/web
    language: js
    host: containerapp
  api:
    host: containerapp
    # Configure multiple containers that will be build, tagged and pushed as part of deployment
    containers: 
      main: 
        project: ./src/api
        language: js
      sidecar:
        project: ./src/sidecar
        language: js
```

**Azure Portal after deployment**
 
<img width="677" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/df001c00-0bc9-48dd-87b1-85f473a5d723">
