### PR TITLE
Adds missing `namespace` property to Helm configuration schema

### DIFF
--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -773,6 +773,11 @@
                                         "title": "The version of the helm chart",
                                         "description": "The version of the helm chart to install."
                                     },
+                                    "namespace": {
+                                        "type": "string",
+                                        "title": "Optional. The k8s namespace to install the helm chart",
+                                        "description": "When set will install the helm chart to the specified namespace. Defaults to the service namespace."
+                                    },
                                     "values": {
                                         "type": "string",
                                         "title": "Optional. Relative path from service to a values.yaml to pass to the helm chart",

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -793,6 +793,11 @@
                                         "title": "The version of the helm chart",
                                         "description": "The version of the helm chart to install."
                                     },
+                                    "namespace": {
+                                        "type": "string",
+                                        "title": "Optional. The k8s namespace to install the helm chart",
+                                        "description": "When set will install the helm chart to the specified namespace. Defaults to the service namespace."
+                                    },
                                     "values": {
                                         "type": "string",
                                         "title": "Optional. Relative path from service to a values.yaml to pass to the helm chart",


### PR DESCRIPTION
When using Helm with `azd` users can specify the `namespace` of where a helm release will be deployed to.  The Helm integration already supports this but the `namespace` property was unintentionally omitted in the schema.