### PR TITLE
dotnet: Use `dotnet publish` to build and push container images

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -639,15 +639,16 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 
 	// Languages
 	frameworkServiceMap := map[project.ServiceLanguageKind]any{
-		project.ServiceLanguageNone:       project.NewNoOpProject,
-		project.ServiceLanguageDotNet:     project.NewDotNetProject,
-		project.ServiceLanguageCsharp:     project.NewDotNetProject,
-		project.ServiceLanguageFsharp:     project.NewDotNetProject,
-		project.ServiceLanguagePython:     project.NewPythonProject,
-		project.ServiceLanguageJavaScript: project.NewNpmProject,
-		project.ServiceLanguageTypeScript: project.NewNpmProject,
-		project.ServiceLanguageJava:       project.NewMavenProject,
-		project.ServiceLanguageDocker:     project.NewDockerProject,
+		project.ServiceLanguageNone:                   project.NewNoOpProject,
+		project.ServiceLanguageDotNet:                 project.NewDotNetProject,
+		project.ServiceLanguageCsharp:                 project.NewDotNetProject,
+		project.ServiceLanguageFsharp:                 project.NewDotNetProject,
+		project.ServiceLanguagePython:                 project.NewPythonProject,
+		project.ServiceLanguageJavaScript:             project.NewNpmProject,
+		project.ServiceLanguageTypeScript:             project.NewNpmProject,
+		project.ServiceLanguageJava:                   project.NewMavenProject,
+		project.ServiceLanguageDocker:                 project.NewDockerProject,
+		project.ServiceLanguageDotNetContainerPublish: project.NewDotNetContianerPublishProject,
 	}
 
 	for language, constructor := range frameworkServiceMap {

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -648,7 +648,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		project.ServiceLanguageTypeScript:             project.NewNpmProject,
 		project.ServiceLanguageJava:                   project.NewMavenProject,
 		project.ServiceLanguageDocker:                 project.NewDockerProject,
-		project.ServiceLanguageDotNetContainerPublish: project.NewDotNetContianerPublishProject,
+		project.ServiceLanguageDotNetContainerPublish: project.NewDotNetContainerPublishProject,
 	}
 
 	for language, constructor := range frameworkServiceMap {

--- a/cli/azd/pkg/project/container_helper_test.go
+++ b/cli/azd/pkg/project/container_helper_test.go
@@ -58,7 +58,7 @@ func Test_ContainerHelper_LocalImageTag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			env := environment.NewWithValues("dev", map[string]string{})
-			containerHelper := NewContainerHelper(env, nil, clock.NewMock(), nil, nil, cloud.AzurePublic())
+			containerHelper := NewContainerHelper(env, nil, clock.NewMock(), nil, nil, cloud.AzurePublic(), nil)
 			serviceConfig.Docker = tt.dockerConfig
 
 			tag, err := containerHelper.LocalImageTag(*mockContext.Context, serviceConfig)
@@ -107,7 +107,7 @@ func Test_ContainerHelper_RemoteImageTag(t *testing.T) {
 
 	mockContext := mocks.NewMockContext(context.Background())
 	env := environment.NewWithValues("dev", map[string]string{})
-	containerHelper := NewContainerHelper(env, nil, clock.NewMock(), nil, nil, cloud.AzurePublic())
+	containerHelper := NewContainerHelper(env, nil, clock.NewMock(), nil, nil, cloud.AzurePublic(), nil)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -134,7 +134,7 @@ func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {
 			environment.ContainerRegistryEndpointEnvVarName: "contoso.azurecr.io",
 		})
 		envManager := &mockenv.MockEnvManager{}
-		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil, cloud.AzurePublic())
+		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil, cloud.AzurePublic(), nil)
 		serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
 		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig)
 
@@ -146,7 +146,7 @@ func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		env := environment.NewWithValues("dev", map[string]string{})
 		envManager := &mockenv.MockEnvManager{}
-		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil, cloud.AzurePublic())
+		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil, cloud.AzurePublic(), nil)
 		serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
 		serviceConfig.Docker.Registry = osutil.NewExpandableString("contoso.azurecr.io")
 		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig)
@@ -160,7 +160,7 @@ func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {
 		env := environment.NewWithValues("dev", map[string]string{})
 		env.DotenvSet("MY_CUSTOM_REGISTRY", "custom.azurecr.io")
 		envManager := &mockenv.MockEnvManager{}
-		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil, cloud.AzurePublic())
+		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil, cloud.AzurePublic(), nil)
 		serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
 		serviceConfig.Docker.Registry = osutil.NewExpandableString("${MY_CUSTOM_REGISTRY}")
 		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig)
@@ -173,7 +173,7 @@ func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		env := environment.NewWithValues("dev", map[string]string{})
 		envManager := &mockenv.MockEnvManager{}
-		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil, cloud.AzurePublic())
+		containerHelper := NewContainerHelper(env, envManager, clock.NewMock(), nil, nil, cloud.AzurePublic(), nil)
 		serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
 		registryName, err := containerHelper.RegistryName(*mockContext.Context, serviceConfig)
 
@@ -343,6 +343,7 @@ func Test_ContainerHelper_Deploy(t *testing.T) {
 				mockContainerRegistryService,
 				dockerCli,
 				cloud.AzurePublic(),
+				nil,
 			)
 			serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
 
@@ -402,7 +403,7 @@ func Test_ContainerHelper_Deploy(t *testing.T) {
 func Test_ContainerHelper_ConfiguredImage(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	env := environment.NewWithValues("dev", map[string]string{})
-	containerHelper := NewContainerHelper(env, nil, clock.NewMock(), nil, nil, cloud.AzurePublic())
+	containerHelper := NewContainerHelper(env, nil, clock.NewMock(), nil, nil, cloud.AzurePublic(), nil)
 
 	tests := []struct {
 		name                 string

--- a/cli/azd/pkg/project/framework_service.go
+++ b/cli/azd/pkg/project/framework_service.go
@@ -15,15 +15,16 @@ import (
 type ServiceLanguageKind string
 
 const (
-	ServiceLanguageNone       ServiceLanguageKind = ""
-	ServiceLanguageDotNet     ServiceLanguageKind = "dotnet"
-	ServiceLanguageCsharp     ServiceLanguageKind = "csharp"
-	ServiceLanguageFsharp     ServiceLanguageKind = "fsharp"
-	ServiceLanguageJavaScript ServiceLanguageKind = "js"
-	ServiceLanguageTypeScript ServiceLanguageKind = "ts"
-	ServiceLanguagePython     ServiceLanguageKind = "python"
-	ServiceLanguageJava       ServiceLanguageKind = "java"
-	ServiceLanguageDocker     ServiceLanguageKind = "docker"
+	ServiceLanguageNone                   ServiceLanguageKind = ""
+	ServiceLanguageDotNet                 ServiceLanguageKind = "dotnet"
+	ServiceLanguageCsharp                 ServiceLanguageKind = "csharp"
+	ServiceLanguageFsharp                 ServiceLanguageKind = "fsharp"
+	ServiceLanguageJavaScript             ServiceLanguageKind = "js"
+	ServiceLanguageTypeScript             ServiceLanguageKind = "ts"
+	ServiceLanguagePython                 ServiceLanguageKind = "python"
+	ServiceLanguageJava                   ServiceLanguageKind = "java"
+	ServiceLanguageDocker                 ServiceLanguageKind = "docker"
+	ServiceLanguageDotNetContainerPublish ServiceLanguageKind = "dotnet-container-publish"
 )
 
 func parseServiceLanguage(kind ServiceLanguageKind) (ServiceLanguageKind, error) {
@@ -41,7 +42,8 @@ func parseServiceLanguage(kind ServiceLanguageKind) (ServiceLanguageKind, error)
 		ServiceLanguageTypeScript,
 		ServiceLanguagePython,
 		ServiceLanguageJava:
-		// Excluding ServiceLanguageDocker since it is implicitly derived currently, and not an actual language
+		// Excluding ServiceLanguageDocker and ServiceLanguageDotNetContainerPublish since they are implicitly derived
+		// currently, and not an actual language.
 		return kind, nil
 	}
 

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -108,7 +108,7 @@ services:
 	framework := NewDockerProject(
 		env,
 		docker,
-		NewContainerHelper(env, envManager, clock.NewMock(), nil, docker, cloud.AzurePublic()),
+		NewContainerHelper(env, envManager, clock.NewMock(), nil, docker, cloud.AzurePublic(), nil),
 		mockinput.NewMockConsole(),
 		mockContext.AlphaFeaturesManager,
 		mockContext.CommandRunner)
@@ -216,7 +216,7 @@ services:
 	framework := NewDockerProject(
 		env,
 		docker,
-		NewContainerHelper(env, envManager, clock.NewMock(), nil, docker, cloud.AzurePublic()),
+		NewContainerHelper(env, envManager, clock.NewMock(), nil, docker, cloud.AzurePublic(), nil),
 		mockinput.NewMockConsole(),
 		mockContext.AlphaFeaturesManager,
 		mockContext.CommandRunner)
@@ -418,7 +418,7 @@ func Test_DockerProject_Build(t *testing.T) {
 			dockerProject := NewDockerProject(
 				env,
 				dockerCli,
-				NewContainerHelper(env, envManager, clock.NewMock(), nil, dockerCli, cloud.AzurePublic()),
+				NewContainerHelper(env, envManager, clock.NewMock(), nil, dockerCli, cloud.AzurePublic(), nil),
 				mockinput.NewMockConsole(),
 				mockContext.AlphaFeaturesManager,
 				mockContext.CommandRunner)
@@ -532,7 +532,7 @@ func Test_DockerProject_Package(t *testing.T) {
 			dockerProject := NewDockerProject(
 				env,
 				dockerCli,
-				NewContainerHelper(env, envManager, clock.NewMock(), nil, dockerCli, cloud.AzurePublic()),
+				NewContainerHelper(env, envManager, clock.NewMock(), nil, dockerCli, cloud.AzurePublic(), nil),
 				mockinput.NewMockConsole(),
 				mockContext.AlphaFeaturesManager,
 				mockContext.CommandRunner)

--- a/cli/azd/pkg/project/framework_service_dotnet_container_publish.go
+++ b/cli/azd/pkg/project/framework_service_dotnet_container_publish.go
@@ -1,0 +1,83 @@
+package project
+
+import (
+	"context"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/async"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+)
+
+type dotNetContainerPublishProject struct {
+	inner FrameworkService
+}
+
+func NewDotNetContianerPublishProject() CompositeFrameworkService {
+	return &dotNetContainerPublishProject{}
+}
+
+// Gets a list of the required external tools for the framework service
+func (dp *dotNetContainerPublishProject) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+	return dp.inner.RequiredExternalTools(ctx)
+}
+
+// Initializes the framework service for the specified service configuration
+// This is useful if the framework needs to subscribe to any service events
+func (dp *dotNetContainerPublishProject) Initialize(ctx context.Context, serviceConfig *ServiceConfig) error {
+	return dp.inner.Initialize(ctx, serviceConfig)
+}
+
+// Gets the requirements for the language or framework service.
+// This enables more fine grain control on whether the language / framework
+// supports or requires lifecycle commands such as restore, build, and package
+func (dp *dotNetContainerPublishProject) Requirements() FrameworkRequirements {
+	return FrameworkRequirements{
+		Package: FrameworkPackageRequirements{
+			RequireRestore: false,
+			RequireBuild:   false,
+		},
+	}
+}
+
+// Restores dependencies for the framework service
+func (dp *dotNetContainerPublishProject) Restore(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+) *async.TaskWithProgress[*ServiceRestoreResult, ServiceProgress] {
+	return dp.inner.Restore(ctx, serviceConfig)
+}
+
+// Builds the source for the framework service
+func (dp *dotNetContainerPublishProject) Build(
+	ctx context.Context, serviceConfig *ServiceConfig,
+	restoreOutput *ServiceRestoreResult,
+) *async.TaskWithProgress[*ServiceBuildResult, ServiceProgress] {
+	return dp.inner.Build(ctx, serviceConfig, restoreOutput)
+}
+
+// Packages the source suitable for deployment
+// This may optionally perform a rebuild internally depending on the language/framework requirements
+func (dp *dotNetContainerPublishProject) Package(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	buildOutput *ServiceBuildResult,
+) *async.TaskWithProgress[*ServicePackageResult, ServiceProgress] {
+	return async.RunTaskWithProgress(func(task *async.TaskContextWithProgress[*ServicePackageResult, ServiceProgress]) {
+		task.SetResult(&ServicePackageResult{
+			Build:       buildOutput,
+			PackagePath: "",
+			Details: &dotNetSdkPublishConfiguration{
+				ProjectPath: serviceConfig.Path(),
+			},
+		})
+
+		return
+	})
+}
+
+func (dp *dotNetContainerPublishProject) SetSource(inner FrameworkService) {
+	dp.inner = inner
+}
+
+type dotNetSdkPublishConfiguration struct {
+	ProjectPath string
+}

--- a/cli/azd/pkg/project/framework_service_dotnet_container_publish.go
+++ b/cli/azd/pkg/project/framework_service_dotnet_container_publish.go
@@ -11,7 +11,7 @@ type dotNetContainerPublishProject struct {
 	inner FrameworkService
 }
 
-func NewDotNetContianerPublishProject() CompositeFrameworkService {
+func NewDotNetContainerPublishProject() CompositeFrameworkService {
 	return &dotNetContainerPublishProject{}
 }
 
@@ -69,8 +69,6 @@ func (dp *dotNetContainerPublishProject) Package(
 				ProjectPath: serviceConfig.Path(),
 			},
 		})
-
-		return
 	})
 }
 

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -583,8 +583,14 @@ func (sm *serviceManager) GetFrameworkService(ctx context.Context, serviceConfig
 	// project that handles the containerization.
 	requiresLanguage := serviceConfig.Language != ServiceLanguageDocker && serviceConfig.Language != ServiceLanguageNone
 	if serviceConfig.Host.RequiresContainer() && requiresLanguage {
+		var serviceTargetType = string(ServiceLanguageDocker)
+
+		if serviceConfig.Language == ServiceLanguageDotNet {
+			serviceTargetType = string(ServiceLanguageDotNetContainerPublish)
+		}
+
 		var compositeFramework CompositeFrameworkService
-		if err := sm.serviceLocator.ResolveNamed(string(ServiceLanguageDocker), &compositeFramework); err != nil {
+		if err := sm.serviceLocator.ResolveNamed(serviceTargetType, &compositeFramework); err != nil {
 			return nil, fmt.Errorf(
 				"failed resolving composite framework service for '%s', language '%s': %w",
 				serviceConfig.Name,

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -838,6 +838,7 @@ func createAksServiceTarget(
 		containerRegistryService,
 		dockerCli,
 		cloud.AzurePublic(),
+		nil,
 	)
 
 	if userConfig == nil {

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -153,6 +153,7 @@ func createContainerAppServiceTarget(
 		containerRegistryService,
 		dockerCli,
 		cloud.AzurePublic(),
+		nil,
 	)
 	azCli := mockazcli.NewAzCliFromMockContext(mockContext)
 	depOpService := mockazcli.NewDeploymentOperationsServiceFromMockContext(mockContext)


### PR DESCRIPTION
When deploying to a host that requires a container image, if the `language` of a project was `dotnet` we required the use of Docker to both build and push the container image. If the user had not authored a Dockerfile, we would try to use Oryx to build the container image "from source".

With .NET 8, the SDK itself now has good support for both building a container image for an app and pushing it to a remote registry. We leveraged this for our Aspire work but non Aspire dotnet projects couldn't leverage this.

This change fixes the situation. If your language is `dotnet` and your host requires a container, we'll now use `dotnet publish /t:PublishContainer` to build and push the container image.

This does mean that the typical "Build" and "Package" steps behave differently for these apps now.  Since our "Publish" step now both builds and pushes the container image, we defer the the work we would have done in "Build" and "Package" into the "Publish" step. Doing this allows us to eschew the need for a local Docker daemon to be installed and running.

The .NET tooling does support creating a `.tgz` which could later be `docker load`'ed, and you could imagine that "Build" or "Package" produces such a thing, but doesn't allow us to use this as the input to a publish, so for now we don't spend time producing this artifact which would be unused by the downstream publish step.

Fixes #2632