### PR TITLE
[ACA] Persist current custom domain

### DIFF
--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -135,9 +135,14 @@ func (cas *containerAppService) DeployYaml(
 		aca, err := cas.getContainerApp(ctx, subscriptionId, resourceGroupName, appName)
 		if err == nil {
 			acaAsConfig := config.NewConfig(obj)
-			acaAsConfig.Set(
+			err := acaAsConfig.Set(
 				"properties.configuration.ingress.customDomains", aca.Properties.Configuration.Ingress.CustomDomains)
-			obj = acaAsConfig.Raw()
+
+			if err == nil {
+				obj = acaAsConfig.Raw()
+			} else {
+				log.Printf("failed to set custom domains: %v. Domains will be ignored.", err)
+			}
 		}
 	}
 

--- a/cli/azd/pkg/containerapps/container_app_test.go
+++ b/cli/azd/pkg/containerapps/container_app_test.go
@@ -42,6 +42,7 @@ func Test_ContainerApp_GetIngressConfiguration(t *testing.T) {
 		mockContext.HttpClient,
 		clock.NewMock(),
 		mockContext.ArmClientOptions,
+		mockContext.AlphaFeaturesManager,
 	)
 	ingressConfig, err := cas.GetIngressConfiguration(*mockContext.Context, subscriptionId, resourceGroup, appName)
 	require.NoError(t, err)
@@ -137,6 +138,7 @@ func Test_ContainerApp_AddRevision(t *testing.T) {
 		mockContext.HttpClient,
 		clock.NewMock(),
 		mockContext.ArmClientOptions,
+		mockContext.AlphaFeaturesManager,
 	)
 	err := cas.AddRevision(*mockContext.Context, subscriptionId, resourceGroup, appName, updatedImageName)
 	require.NoError(t, err)

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -139,6 +139,7 @@ func createContainerAppServiceTarget(
 		mockContext.HttpClient,
 		clock.NewMock(),
 		mockContext.ArmClientOptions,
+		mockContext.AlphaFeaturesManager,
 	)
 	containerRegistryService := azcli.NewContainerRegistryService(
 		credentialProvider,

--- a/cli/azd/resources/alpha_features.yaml
+++ b/cli/azd/resources/alpha_features.yaml
@@ -6,3 +6,5 @@
   description: "Enable Helm support for AKS deployments."
 - id: aks.kustomize
   description: "Enable Kustomize support for AKS deployments."
+- id: aca.persistDomains
+  description: "Do not change custom domains when deploying Azure Container Apps."


### PR DESCRIPTION
Adding feature flag: `aca.persistDomains`

When turned on: `azd config set alpha.aca.persistDomains on` , azd will use any existing customDomains from a ACA before deploying  an update for it, preventing the deletion of any manually-configured custom domain from the Portal.