### PR TITLE
Update the infra/core modules to AVM modules of "todo-python-mongo-aca"

### DIFF
--- a/templates/todo/api/python/todo/models.py
+++ b/templates/todo/api/python/todo/models.py
@@ -20,11 +20,12 @@ class Settings(BaseSettings):
             credential = DefaultAzureCredential()
             keyvault_client = SecretClient(self.AZURE_KEY_VAULT_ENDPOINT, credential)
             for secret in keyvault_client.list_properties_of_secrets():
-                setattr(
-                    self,
-                    keyvault_name_as_attr(secret.name),
-                    keyvault_client.get_secret(secret.name).value,
-                )
+                if secret.name == "AZURE-COSMOS-CONNECTION-STRING":
+                    setattr(
+                        self,
+                        keyvault_name_as_attr(secret.name),
+                        keyvault_client.get_secret(secret.name).value,
+                    )
 
     AZURE_COSMOS_CONNECTION_STRING: str = ""
     AZURE_COSMOS_DATABASE_NAME: str = "Todo"

--- a/templates/todo/common/infra/bicep/app/apim-api-settings.bicep
+++ b/templates/todo/common/infra/bicep/app/apim-api-settings.bicep
@@ -1,0 +1,99 @@
+@description('Resource name for the existing apim service')
+param name string
+
+@description('Resource name to uniquely identify this API within the API Management service instance')
+@minLength(1)
+param apiName string
+
+@description('Relative URL uniquely identifying this API and all of its resource paths within the API Management service instance. It is appended to the API endpoint base URL specified during the service instance creation to form a public URL for this API.')
+@minLength(1)
+param apiPath string
+
+@description('Resource name for the existing applicationInsights service')
+param applicationInsightsName string
+
+@description('Resource name for backend Web App or Function App')
+param apiAppName string = ''
+
+// Necessary due to https://github.com/Azure/bicep/issues/9594
+// placeholderName is never deployed, it is merely used to make the child name validation pass
+var appNameForBicep = !empty(apiAppName) ? apiAppName : 'placeholderName'
+
+resource apiDiagnostics 'Microsoft.ApiManagement/service/apis/diagnostics@2021-12-01-preview' = {
+  name: 'applicationinsights'
+  parent: apimService::restApi
+  properties: {
+    alwaysLog: 'allErrors'
+    backend: {
+      request: {
+        body: {
+          bytes: 1024
+        }
+      }
+      response: {
+        body: {
+          bytes: 1024
+        }
+      }
+    }
+    frontend: {
+      request: {
+        body: {
+          bytes: 1024
+        }
+      }
+      response: {
+        body: {
+          bytes: 1024
+        }
+      }
+    }
+    httpCorrelationProtocol: 'W3C'
+    logClientIp: true
+    loggerId: apimLogger.id
+    metrics: true
+    sampling: {
+      percentage: 100
+      samplingType: 'fixed'
+    }
+    verbosity: 'verbose'
+  }
+}
+
+resource apiAppProperties 'Microsoft.Web/sites/config@2022-03-01' = if (!empty(apiAppName)) {
+  name: '${appNameForBicep}/web'
+  kind: 'string'
+  properties: {
+      apiManagementConfig: {
+        id: '${apimService.id}/apis/${apiName}'
+      }
+  }
+}
+
+resource apimLogger 'Microsoft.ApiManagement/service/loggers@2021-12-01-preview' = if (!empty(applicationInsightsName)) {
+  name: 'app-insights-logger'
+  parent: apimService
+  properties: {
+    credentials: {
+      instrumentationKey: applicationInsights.properties.InstrumentationKey
+    }
+    description: 'Logger to Azure Application Insights'
+    isBuffered: false
+    loggerType: 'applicationInsights'
+    resourceId: applicationInsights.id
+  }
+}
+
+resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing = if (!empty(applicationInsightsName)) {
+  name: applicationInsightsName
+}
+
+resource apimService 'Microsoft.ApiManagement/service@2021-08-01' existing = {
+  name: name
+
+  resource restApi 'apis@2021-12-01-preview' existing = {
+    name: apiName
+    }
+}
+
+output SERVICE_API_URI string = '${apimService.properties.gatewayUrl}/${apiPath}'

--- a/templates/todo/common/infra/bicep/app/applicationinsights-dashboard.bicep
+++ b/templates/todo/common/infra/bicep/app/applicationinsights-dashboard.bicep
@@ -1,0 +1,1236 @@
+metadata description = 'Creates a dashboard for an Application Insights instance.'
+param name string
+param applicationInsightsName string
+param location string = resourceGroup().location
+param tags object = {}
+
+// 2020-09-01-preview because that is the latest valid version
+resource applicationInsightsDashboard 'Microsoft.Portal/dashboards@2020-09-01-preview' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    lenses: [
+      {
+        order: 0
+        parts: [
+          {
+            position: {
+              x: 0
+              y: 0
+              colSpan: 2
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'id'
+                  value: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                }
+                {
+                  name: 'Version'
+                  value: '1.0'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/AspNetOverviewPinnedPart'
+              asset: {
+                idInputName: 'id'
+                type: 'ApplicationInsights'
+              }
+              defaultMenuItemId: 'overview'
+            }
+          }
+          {
+            position: {
+              x: 2
+              y: 0
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'Version'
+                  value: '1.0'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/ProactiveDetectionAsyncPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+              defaultMenuItemId: 'ProactiveDetection'
+            }
+          }
+          {
+            position: {
+              x: 3
+              y: 0
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'ResourceId'
+                  value: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/QuickPulseButtonSmallPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+            }
+          }
+          {
+            position: {
+              x: 4
+              y: 0
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'TimeContext'
+                  value: {
+                    durationMs: 86400000
+                    endTime: null
+                    createdTime: '2018-05-04T01:20:33.345Z'
+                    isInitialTime: true
+                    grain: 1
+                    useDashboardTimeRange: false
+                  }
+                }
+                {
+                  name: 'Version'
+                  value: '1.0'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/AvailabilityNavButtonPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+            }
+          }
+          {
+            position: {
+              x: 5
+              y: 0
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'TimeContext'
+                  value: {
+                    durationMs: 86400000
+                    endTime: null
+                    createdTime: '2018-05-08T18:47:35.237Z'
+                    isInitialTime: true
+                    grain: 1
+                    useDashboardTimeRange: false
+                  }
+                }
+                {
+                  name: 'ConfigurationId'
+                  value: '78ce933e-e864-4b05-a27b-71fd55a6afad'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/AppMapButtonPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+            }
+          }
+          {
+            position: {
+              x: 0
+              y: 1
+              colSpan: 3
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: []
+              type: 'Extension/HubsExtension/PartType/MarkdownPart'
+              settings: {
+                content: {
+                  settings: {
+                    content: '# Usage'
+                    title: ''
+                    subtitle: ''
+                  }
+                }
+              }
+            }
+          }
+          {
+            position: {
+              x: 3
+              y: 1
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'TimeContext'
+                  value: {
+                    durationMs: 86400000
+                    endTime: null
+                    createdTime: '2018-05-04T01:22:35.782Z'
+                    isInitialTime: true
+                    grain: 1
+                    useDashboardTimeRange: false
+                  }
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/UsageUsersOverviewPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+            }
+          }
+          {
+            position: {
+              x: 4
+              y: 1
+              colSpan: 3
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: []
+              type: 'Extension/HubsExtension/PartType/MarkdownPart'
+              settings: {
+                content: {
+                  settings: {
+                    content: '# Reliability'
+                    title: ''
+                    subtitle: ''
+                  }
+                }
+              }
+            }
+          }
+          {
+            position: {
+              x: 7
+              y: 1
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ResourceId'
+                  value: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                }
+                {
+                  name: 'DataModel'
+                  value: {
+                    version: '1.0.0'
+                    timeContext: {
+                      durationMs: 86400000
+                      createdTime: '2018-05-04T23:42:40.072Z'
+                      isInitialTime: false
+                      grain: 1
+                      useDashboardTimeRange: false
+                    }
+                  }
+                  isOptional: true
+                }
+                {
+                  name: 'ConfigurationId'
+                  value: '8a02f7bf-ac0f-40e1-afe9-f0e72cfee77f'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/CuratedBladeFailuresPinnedPart'
+              isAdapter: true
+              asset: {
+                idInputName: 'ResourceId'
+                type: 'ApplicationInsights'
+              }
+              defaultMenuItemId: 'failures'
+            }
+          }
+          {
+            position: {
+              x: 8
+              y: 1
+              colSpan: 3
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: []
+              type: 'Extension/HubsExtension/PartType/MarkdownPart'
+              settings: {
+                content: {
+                  settings: {
+                    content: '# Responsiveness\r\n'
+                    title: ''
+                    subtitle: ''
+                  }
+                }
+              }
+            }
+          }
+          {
+            position: {
+              x: 11
+              y: 1
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ResourceId'
+                  value: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                }
+                {
+                  name: 'DataModel'
+                  value: {
+                    version: '1.0.0'
+                    timeContext: {
+                      durationMs: 86400000
+                      createdTime: '2018-05-04T23:43:37.804Z'
+                      isInitialTime: false
+                      grain: 1
+                      useDashboardTimeRange: false
+                    }
+                  }
+                  isOptional: true
+                }
+                {
+                  name: 'ConfigurationId'
+                  value: '2a8ede4f-2bee-4b9c-aed9-2db0e8a01865'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/CuratedBladePerformancePinnedPart'
+              isAdapter: true
+              asset: {
+                idInputName: 'ResourceId'
+                type: 'ApplicationInsights'
+              }
+              defaultMenuItemId: 'performance'
+            }
+          }
+          {
+            position: {
+              x: 12
+              y: 1
+              colSpan: 3
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: []
+              type: 'Extension/HubsExtension/PartType/MarkdownPart'
+              settings: {
+                content: {
+                  settings: {
+                    content: '# Browser'
+                    title: ''
+                    subtitle: ''
+                  }
+                }
+              }
+            }
+          }
+          {
+            position: {
+              x: 15
+              y: 1
+              colSpan: 1
+              rowSpan: 1
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'ComponentId'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'MetricsExplorerJsonDefinitionId'
+                  value: 'BrowserPerformanceTimelineMetrics'
+                }
+                {
+                  name: 'TimeContext'
+                  value: {
+                    durationMs: 86400000
+                    createdTime: '2018-05-08T12:16:27.534Z'
+                    isInitialTime: false
+                    grain: 1
+                    useDashboardTimeRange: false
+                  }
+                }
+                {
+                  name: 'CurrentFilter'
+                  value: {
+                    eventTypes: [
+                      4
+                      1
+                      3
+                      5
+                      2
+                      6
+                      13
+                    ]
+                    typeFacets: {}
+                    isPermissive: false
+                  }
+                }
+                {
+                  name: 'id'
+                  value: {
+                    Name: applicationInsights.name
+                    SubscriptionId: subscription().subscriptionId
+                    ResourceGroup: resourceGroup().name
+                  }
+                }
+                {
+                  name: 'Version'
+                  value: '1.0'
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/AppInsightsExtension/PartType/MetricsExplorerBladePinnedPart'
+              asset: {
+                idInputName: 'ComponentId'
+                type: 'ApplicationInsights'
+              }
+              defaultMenuItemId: 'browser'
+            }
+          }
+          {
+            position: {
+              x: 0
+              y: 2
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'sessions/count'
+                          aggregationType: 5
+                          namespace: 'microsoft.insights/components/kusto'
+                          metricVisualization: {
+                            displayName: 'Sessions'
+                            color: '#47BDF5'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'users/count'
+                          aggregationType: 5
+                          namespace: 'microsoft.insights/components/kusto'
+                          metricVisualization: {
+                            displayName: 'Users'
+                            color: '#7E58FF'
+                          }
+                        }
+                      ]
+                      title: 'Unique sessions and users'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                      openBladeOnClick: {
+                        openBlade: true
+                        destinationBlade: {
+                          extensionName: 'HubsExtension'
+                          bladeName: 'ResourceMenuBlade'
+                          parameters: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                            menuid: 'segmentationUsers'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 4
+              y: 2
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'requests/failed'
+                          aggregationType: 7
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Failed requests'
+                            color: '#EC008C'
+                          }
+                        }
+                      ]
+                      title: 'Failed requests'
+                      visualization: {
+                        chartType: 3
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                      openBladeOnClick: {
+                        openBlade: true
+                        destinationBlade: {
+                          extensionName: 'HubsExtension'
+                          bladeName: 'ResourceMenuBlade'
+                          parameters: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                            menuid: 'failures'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 8
+              y: 2
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'requests/duration'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Server response time'
+                            color: '#00BCF2'
+                          }
+                        }
+                      ]
+                      title: 'Server response time'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                      openBladeOnClick: {
+                        openBlade: true
+                        destinationBlade: {
+                          extensionName: 'HubsExtension'
+                          bladeName: 'ResourceMenuBlade'
+                          parameters: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                            menuid: 'performance'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 12
+              y: 2
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'browserTimings/networkDuration'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Page load network connect time'
+                            color: '#7E58FF'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'browserTimings/processingDuration'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Client processing time'
+                            color: '#44F1C8'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'browserTimings/sendDuration'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Send request time'
+                            color: '#EB9371'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'browserTimings/receiveDuration'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Receiving response time'
+                            color: '#0672F1'
+                          }
+                        }
+                      ]
+                      title: 'Average page load time breakdown'
+                      visualization: {
+                        chartType: 3
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 0
+              y: 5
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'availabilityResults/availabilityPercentage'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Availability'
+                            color: '#47BDF5'
+                          }
+                        }
+                      ]
+                      title: 'Average availability'
+                      visualization: {
+                        chartType: 3
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                      openBladeOnClick: {
+                        openBlade: true
+                        destinationBlade: {
+                          extensionName: 'HubsExtension'
+                          bladeName: 'ResourceMenuBlade'
+                          parameters: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                            menuid: 'availability'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 4
+              y: 5
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'exceptions/server'
+                          aggregationType: 7
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Server exceptions'
+                            color: '#47BDF5'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'dependencies/failed'
+                          aggregationType: 7
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Dependency failures'
+                            color: '#7E58FF'
+                          }
+                        }
+                      ]
+                      title: 'Server exceptions and Dependency failures'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 8
+              y: 5
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'performanceCounters/processorCpuPercentage'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Processor time'
+                            color: '#47BDF5'
+                          }
+                        }
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'performanceCounters/processCpuPercentage'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Process CPU'
+                            color: '#7E58FF'
+                          }
+                        }
+                      ]
+                      title: 'Average processor and process CPU utilization'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 12
+              y: 5
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'exceptions/browser'
+                          aggregationType: 7
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Browser exceptions'
+                            color: '#47BDF5'
+                          }
+                        }
+                      ]
+                      title: 'Browser exceptions'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 0
+              y: 8
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'availabilityResults/count'
+                          aggregationType: 7
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Availability test results count'
+                            color: '#47BDF5'
+                          }
+                        }
+                      ]
+                      title: 'Availability test results count'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 4
+              y: 8
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'performanceCounters/processIOBytesPerSecond'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Process IO rate'
+                            color: '#47BDF5'
+                          }
+                        }
+                      ]
+                      title: 'Average process I/O rate'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+          {
+            position: {
+              x: 8
+              y: 8
+              colSpan: 4
+              rowSpan: 3
+            }
+            metadata: {
+              inputs: [
+                {
+                  name: 'options'
+                  value: {
+                    chart: {
+                      metrics: [
+                        {
+                          resourceMetadata: {
+                            id: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Insights/components/${applicationInsights.name}'
+                          }
+                          name: 'performanceCounters/memoryAvailableBytes'
+                          aggregationType: 4
+                          namespace: 'microsoft.insights/components'
+                          metricVisualization: {
+                            displayName: 'Available memory'
+                            color: '#47BDF5'
+                          }
+                        }
+                      ]
+                      title: 'Average available memory'
+                      visualization: {
+                        chartType: 2
+                        legendVisualization: {
+                          isVisible: true
+                          position: 2
+                          hideSubtitle: false
+                        }
+                        axisVisualization: {
+                          x: {
+                            isVisible: true
+                            axisType: 2
+                          }
+                          y: {
+                            isVisible: true
+                            axisType: 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                {
+                  name: 'sharedTimeRange'
+                  isOptional: true
+                }
+              ]
+              #disable-next-line BCP036
+              type: 'Extension/HubsExtension/PartType/MonitorChartPart'
+              settings: {}
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+
+resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing = {
+  name: applicationInsightsName
+}

--- a/templates/todo/projects/python-mongo-aca/.repo/bicep/repo.yaml
+++ b/templates/todo/projects/python-mongo-aca/.repo/bicep/repo.yaml
@@ -87,6 +87,16 @@ repo:
         patterns:
           - "apim-api.bicep"
 
+      - from: ../../../api/common/openapi.yaml
+        to: ../src/api/openapi.yaml
+        patterns:
+          - "**/main.bicep"
+
+      - from: ../../../common/infra/shared/gateway/apim/apim-api-policy.xml
+        to: ./app/apim-api-policy.xml
+        patterns:
+          - "**/main.bicep"
+
   assets:
     # # Common assets
 
@@ -111,6 +121,12 @@ repo:
 
     - from: ../../../../common/infra/bicep/app/cosmos-mongo-db.bicep
       to: ./infra/app/db.bicep
+    
+    - from: ../../../../common/infra/bicep/app/applicationinsights-dashboard.bicep
+      to: ./infra/app/applicationinsights-dashboard.bicep
+
+    - from: ../../../../common/infra/bicep/app/apim-api-settings.bicep
+      to: ./infra/app/apim-api-settings.bicep
 
     - from: ./../../
       to: ./


### PR DESCRIPTION
Update the infra/core modules to AVM modules for `todo-python-mongo-aca`.

1. **Modules not replaced by AVM.**


- **Monitoring** (`applicationinsights-dashboard`) : Missing the feature `Microsoft.Portal/dashboards`.
   AVM issue link: https://github.com/Azure/bicep-registry-modules/issues/1130
- **APIM**: Missing features `Microsoft.ApiManagement/service/loggers` and 
  `Microsoft.ApiManagement/service/apis/diagnostics`.
  AVM issue link: https://github.com/Azure/bicep-registry-modules/issues/1124

2. **Modules replaced by AVM.**

- **Container app**
- **Container environment**
- **Container registry**
- **Key Vault**
- **Cosmos mongo**
- **Azure loganalytics**
- **Azure applicationInsights**

@jongio for notification.
