### PR TITLE
[core/bicep] Fix missing daprEnabled param in container apps template

### DIFF
--- a/templates/common/infra/bicep/core/host/container-apps.bicep
+++ b/templates/common/infra/bicep/core/host/container-apps.bicep
@@ -9,6 +9,7 @@ param containerRegistryResourceGroupName string = ''
 param containerRegistryAdminUserEnabled bool = false
 param logAnalyticsWorkspaceName string
 param applicationInsightsName string = ''
+param daprEnabled bool = false
 
 module containerAppsEnvironment 'container-apps-environment.bicep' = {
   name: '${name}-container-apps-environment'
@@ -18,6 +19,7 @@ module containerAppsEnvironment 'container-apps-environment.bicep' = {
     tags: tags
     logAnalyticsWorkspaceName: logAnalyticsWorkspaceName
     applicationInsightsName: applicationInsightsName
+    daprEnabled: daprEnabled
   }
 }
 


### PR DESCRIPTION
The template previously had this parameter exposed, to be passed on to the CA environment. It's used by multiple samples currently.

This fix restores the missing parameter.