### PR TITLE
POC: Separate provisioning initialization to other data collection

### DIFF
--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -11,14 +10,10 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/cmd"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
-	"github.com/azure/azure-dev/cli/azd/pkg/environment"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
-	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/bicep"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
-	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
 	"github.com/azure/azure-dev/cli/azd/pkg/workflow"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -56,15 +51,10 @@ func newUpCmd() *cobra.Command {
 }
 
 type upAction struct {
-	flags               *upFlags
-	console             input.Console
-	env                 *environment.Environment
-	projectConfig       *project.ProjectConfig
-	provisioningManager *provisioning.Manager
-	envManager          environment.Manager
-	prompters           prompt.Prompter
-	importManager       *project.ImportManager
-	workflowRunner      *workflow.Runner
+	console        input.Console
+	projectConfig  *project.ProjectConfig
+	importManager  *project.ImportManager
+	workflowRunner *workflow.Runner
 }
 
 var defaultUpWorkflow = &workflow.Workflow{
@@ -77,27 +67,17 @@ var defaultUpWorkflow = &workflow.Workflow{
 }
 
 func newUpAction(
-	flags *upFlags,
 	console input.Console,
-	env *environment.Environment,
 	_ auth.LoggedInGuard,
 	projectConfig *project.ProjectConfig,
-	provisioningManager *provisioning.Manager,
-	envManager environment.Manager,
-	prompters prompt.Prompter,
 	importManager *project.ImportManager,
 	workflowRunner *workflow.Runner,
 ) actions.Action {
 	return &upAction{
-		flags:               flags,
-		console:             console,
-		env:                 env,
-		projectConfig:       projectConfig,
-		provisioningManager: provisioningManager,
-		envManager:          envManager,
-		prompters:           prompters,
-		importManager:       importManager,
-		workflowRunner:      workflowRunner,
+		console:        console,
+		projectConfig:  projectConfig,
+		importManager:  importManager,
+		workflowRunner: workflowRunner,
 	}
 }
 
@@ -107,19 +87,6 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		return nil, err
 	}
 	defer func() { _ = infra.Cleanup() }()
-
-	// TODO(weilim): remove this once we have decided if it's okay to not set AZURE_SUBSCRIPTION_ID and AZURE_LOCATION
-	// early in the up workflow in #3745
-	err = u.provisioningManager.Initialize(ctx, u.projectConfig.Path, infra.Options)
-	if errors.Is(err, bicep.ErrEnsureEnvPreReqBicepCompileFailed) {
-		// If bicep is not available, we continue to prompt for subscription and location unfiltered
-		err = provisioning.EnsureSubscriptionAndLocation(ctx, u.envManager, u.env, u.prompters, nil)
-		if err != nil {
-			return nil, err
-		}
-	} else if err != nil {
-		return nil, err
-	}
 
 	startTime := time.Now()
 

--- a/cli/azd/internal/cmd/provision.go
+++ b/cli/azd/internal/cmd/provision.go
@@ -191,6 +191,10 @@ func (p *ProvisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 		return nil, fmt.Errorf("initializing provisioning manager: %w", err)
 	}
 
+	if err := p.provisionManager.CollectData(ctx); err != nil {
+		return nil, fmt.Errorf("collecting data for provisioning: %w", err)
+	}
+
 	// Get Subscription to Display in Command Title Note
 	// Subscription and Location are ONLY displayed when they are available (found from env), otherwise, this message
 	// is not displayed.

--- a/cli/azd/pkg/devcenter/provision_provider.go
+++ b/cli/azd/pkg/devcenter/provision_provider.go
@@ -80,6 +80,10 @@ func (p *ProvisionProvider) Initialize(ctx context.Context, projectPath string, 
 	return p.EnsureEnv(ctx)
 }
 
+func (p *ProvisionProvider) CollectData(ctx context.Context) error {
+	return nil
+}
+
 // State returns the state of the environment from the most recent ARM deployment
 func (p *ProvisionProvider) State(
 	ctx context.Context,

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -58,6 +58,10 @@ func (m *Manager) Initialize(ctx context.Context, projectPath string, options Op
 	return m.provider.Initialize(ctx, projectPath, options)
 }
 
+func (m *Manager) CollectData(ctx context.Context) error {
+	return m.provider.CollectData(ctx)
+}
+
 // Gets the latest deployment details for the specified scope
 func (m *Manager) State(ctx context.Context, options *StateOptions) (*StateResult, error) {
 	result, err := m.provider.State(ctx, options)

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -53,6 +53,7 @@ type StateResult struct {
 type Provider interface {
 	Name() string
 	Initialize(ctx context.Context, projectPath string, options Options) error
+	CollectData(ctx context.Context) error
 	State(ctx context.Context, options *StateOptions) (*StateResult, error)
 	Deploy(ctx context.Context) (*DeployResult, error)
 	Preview(ctx context.Context) (*DeployPreviewResult, error)

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -115,6 +115,10 @@ func (t *TerraformProvider) Initialize(ctx context.Context, projectPath string, 
 	return nil
 }
 
+func (t *TerraformProvider) CollectData(ctx context.Context) error {
+	return nil
+}
+
 // EnsureEnv ensures that the environment is in a provision-ready state with required values set, prompting the user if
 // values are unset.
 //

--- a/cli/azd/pkg/infra/provisioning/test/test_provider.go
+++ b/cli/azd/pkg/infra/provisioning/test/test_provider.go
@@ -43,6 +43,10 @@ func (p *TestProvider) Initialize(ctx context.Context, projectPath string, optio
 	return p.EnsureEnv(ctx)
 }
 
+func (p *TestProvider) CollectData(ctx context.Context) error {
+	return nil
+}
+
 // EnsureEnv ensures that the environment is in a provision-ready state with required values set, prompting the user if
 // values are unset.
 //


### PR DESCRIPTION
This PR adds a new function `CollectData()` to the provisioning provider interface.

The goal here is to separate the provisioning provider initialization from other aspects of data collection for the provider.

This enables:
1. Initialization can focus on core provider validation and only prompt for core required data
2. Additional data collection for provisioning can happen closer to the actual provisioning process

Output would look like the following

<img width="1111" alt="image" src="https://github.com/Azure/azure-dev/assets/6540159/10cebb8d-ca84-44f6-a385-1f72d58e27fc">
