### PR TITLE
Migrate from macos-11

### DIFF
--- a/eng/pipelines/build-notice.yml
+++ b/eng/pipelines/build-notice.yml
@@ -44,7 +44,7 @@ jobs:
           BuildOutputName: azd
         Mac:
           Pool: Azure Pipelines
-          OSVmImage: macOS-11
+          OSVmImage: macOS-latest
           BuildTarget: azd-darwin-amd64
           BuildOutputName: azd
     pool:
@@ -90,7 +90,7 @@ jobs:
           OSVmImage:  MMSUbuntu20.04
         Mac:
           Pool: Azure Pipelines
-          OSVmImage: macOS-11
+          OSVmImage: macOS-latest
 
     pool:
       name: $(Pool)

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -23,7 +23,7 @@ variables:
   - name: WINDOWSARMVMIMAGE
     value: windows-2022-arm64-1espt
   - name: MACVMIMAGE
-    value: macos-11
+    value: macos-latest
   - name: MACVMIMAGE12
     value: macos-12
   - name: MACVMIMAGEM1


### PR DESCRIPTION
MacOS 11 devops images will be deprecated soon. This migration moves away from that process. 