### PR TITLE
keep port when exists

### DIFF
--- a/cli/azd/pkg/apphost/aca_ingress.go
+++ b/cli/azd/pkg/apphost/aca_ingress.go
@@ -251,6 +251,11 @@ func pickIngress(endpointByTargetPortProperties map[string]*acaPort, httpIngress
 		finalIngress.TargetPort = props.port
 		if finalIngress.TargetPort == 0 {
 			finalIngress.TargetPort = defaultPort
+		} else {
+			// negative target port means the target port is defined in the manifest and is not using a default value
+			// azd won't change the value of the target port after building a dotnet project. azd will just use the
+			// value defined in the manifest (will remove the negative).
+			finalIngress.TargetPort *= -1
 		}
 		finalIngress.Transport = acaIngressSchemaHttp
 		if props.hasHttp2 {

--- a/cli/azd/pkg/apphost/aca_ingress.go
+++ b/cli/azd/pkg/apphost/aca_ingress.go
@@ -251,11 +251,7 @@ func pickIngress(endpointByTargetPortProperties map[string]*acaPort, httpIngress
 		finalIngress.TargetPort = props.port
 		if finalIngress.TargetPort == 0 {
 			finalIngress.TargetPort = defaultPort
-		} else {
-			// negative target port means the target port is defined in the manifest and is not using a default value
-			// azd won't change the value of the target port after building a dotnet project. azd will just use the
-			// value defined in the manifest (will remove the negative).
-			finalIngress.TargetPort *= -1
+			finalIngress.UsingDefaultPort = true
 		}
 		finalIngress.Transport = acaIngressSchemaHttp
 		if props.hasHttp2 {

--- a/cli/azd/pkg/apphost/aca_ingress_test.go
+++ b/cli/azd/pkg/apphost/aca_ingress_test.go
@@ -41,6 +41,7 @@ func TestBuildAcaIngress(t *testing.T) {
 			Transport:              acaIngressTransportHttp2,
 			AllowInsecure:          true,
 			AdditionalPortMappings: []genContainerAppIngressAdditionalPortMappings(nil),
+			UsingDefaultPort:       true,
 		}
 		ingress, ingressBinding, err := buildAcaIngress(bindings, 8080)
 		assert.NoError(t, err)
@@ -176,6 +177,7 @@ func TestBuildAcaIngress(t *testing.T) {
 					},
 				},
 			},
+			UsingDefaultPort: true,
 		}
 		ingress, ingressBinding, err := buildAcaIngress(bindings, 8080)
 		assert.NoError(t, err)

--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -178,7 +178,19 @@ func ContainerAppManifestTemplateForProject(
 
 	var buf bytes.Buffer
 
-	tmplCtx := generator.containerAppTemplateContexts[projectName]
+	type yamlTemplateCtx struct {
+		genContainerAppManifestTemplateContext
+		TargetPortExpression string
+	}
+	tCtx := generator.containerAppTemplateContexts[projectName]
+	tmplCtx := yamlTemplateCtx{
+		genContainerAppManifestTemplateContext: tCtx,
+		TargetPortExpression:                   fmt.Sprintf("{{ targetPortOrDefault %d }}", tCtx.Ingress.TargetPort),
+	}
+	if tCtx.Ingress.TargetPort != 0 && !tCtx.Ingress.UsingDefaultPort {
+		// not using default port makes this to be a non-changing value
+		tmplCtx.TargetPortExpression = fmt.Sprintf("%d", tCtx.Ingress.TargetPort)
+	}
 
 	err := genTemplates.ExecuteTemplate(&buf, "containerApp.tmpl.yaml", tmplCtx)
 	if err != nil {

--- a/cli/azd/pkg/apphost/generate_types.go
+++ b/cli/azd/pkg/apphost/generate_types.go
@@ -49,6 +49,7 @@ type genContainerAppIngress struct {
 	genContainerAppIngressPort
 	Transport              string
 	AllowInsecure          bool
+	UsingDefaultPort       bool
 	AdditionalPortMappings []genContainerAppIngressAdditionalPortMappings
 }
 

--- a/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-kafka.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-kafka.snap
@@ -14,7 +14,7 @@ properties:
         autoConfigureDataProtection: true
     ingress:
       external: false
-      targetPort: {{ targetPortOrDefault 9092 }}
+      targetPort: 9092
       exposedPort: 6000
       transport: tcp
       allowInsecure: false

--- a/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-my-sql-abstract.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-my-sql-abstract.snap
@@ -14,7 +14,7 @@ properties:
         autoConfigureDataProtection: true
     ingress:
       external: false
-      targetPort: {{ targetPortOrDefault 3306 }}
+      targetPort: 3306
       transport: tcp
       allowInsecure: false
     registries:

--- a/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-noVolume.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireContainerGeneration-noVolume.snap
@@ -14,7 +14,7 @@ properties:
         autoConfigureDataProtection: true
     ingress:
       external: false
-      targetPort: {{ targetPortOrDefault 3306 }}
+      targetPort: 3306
       transport: tcp
       allowInsecure: false
     registries:

--- a/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-nodeapp.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-nodeapp.snap
@@ -14,7 +14,7 @@ properties:
         autoConfigureDataProtection: true
     ingress:
       external: true
-      targetPort: {{ targetPortOrDefault -3000 }}
+      targetPort: 3000
       transport: http
       allowInsecure: false
     registries:

--- a/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-nodeapp.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireDockerGeneration-nodeapp.snap
@@ -14,7 +14,7 @@ properties:
         autoConfigureDataProtection: true
     ingress:
       external: true
-      targetPort: {{ targetPortOrDefault 3000 }}
+      targetPort: {{ targetPortOrDefault -3000 }}
       transport: http
       allowInsecure: false
     registries:

--- a/cli/azd/pkg/project/service_target_dotnet_containerapp.go
+++ b/cli/azd/pkg/project/service_target_dotnet_containerapp.go
@@ -232,11 +232,6 @@ func (at *dotnetContainerAppTarget) Deploy(
 					"securedParameter": fns.Parameter,
 					"secretOutput":     fns.kvSecret,
 					"targetPortOrDefault": func(targetPortFromManifest int) int {
-						if targetPortFromManifest < 0 {
-							// a negative target port means the target port was defined in the manifest and should not
-							// be changed.
-							return targetPortFromManifest * -1
-						}
 						// portNumber is 0 for dockerfile.v0, so we use the targetPort from the manifest
 						if portNumber == 0 {
 							return targetPortFromManifest

--- a/cli/azd/pkg/project/service_target_dotnet_containerapp.go
+++ b/cli/azd/pkg/project/service_target_dotnet_containerapp.go
@@ -232,6 +232,11 @@ func (at *dotnetContainerAppTarget) Deploy(
 					"securedParameter": fns.Parameter,
 					"secretOutput":     fns.kvSecret,
 					"targetPortOrDefault": func(targetPortFromManifest int) int {
+						if targetPortFromManifest < 0 {
+							// a negative target port means the target port was defined in the manifest and should not
+							// be changed.
+							return targetPortFromManifest * -1
+						}
 						// portNumber is 0 for dockerfile.v0, so we use the targetPort from the manifest
 						if portNumber == 0 {
 							return targetPortFromManifest

--- a/cli/azd/resources/apphost/templates/containerApp.tmpl.yamlt
+++ b/cli/azd/resources/apphost/templates/containerApp.tmpl.yamlt
@@ -46,7 +46,7 @@ properties:
 {{- end}}
 {{- end}}
       external: {{ .Ingress.External }}
-      targetPort: {{ "{{ targetPortOrDefault " }}{{ .Ingress.TargetPort }}{{ " }}" }}
+      targetPort: {{ .TargetPortExpression }}
 {{- if gt .Ingress.ExposedPort 0 }}
       exposedPort: {{ .Ingress.ExposedPort }}
 {{- end}}

--- a/cli/azd/test/functional/testdata/snaps/aspire-full/AspireAzdTests.AppHost/infra/pubsub.tmpl.yaml
+++ b/cli/azd/test/functional/testdata/snaps/aspire-full/AspireAzdTests.AppHost/infra/pubsub.tmpl.yaml
@@ -14,7 +14,7 @@ properties:
         autoConfigureDataProtection: true
     ingress:
       external: false
-      targetPort: {{ targetPortOrDefault 6379 }}
+      targetPort: 6379
       transport: tcp
       allowInsecure: false
     registries:


### PR DESCRIPTION
fix: https://github.com/Azure/azure-dev/issues/4005

Using negative target port when resolving the `target port` as the way to communicate that the port should not be changed. When azd builds a net project and gets a port number from the build result, the port won't be used if the target port in the yaml template is negative. Instead, the negative target port is used (making it positive)

This fix is required for Aspire 8.1. For 8.0, folks need to add `launchProfileName: null` when adding a project so they can use this fix