### PR TITLE
Add managed identity template

### DIFF
--- a/templates/common/infra/bicep/core/security/managed-identity.bicep
+++ b/templates/common/infra/bicep/core/security/managed-identity.bicep
@@ -1,0 +1,12 @@
+metadata description = 'Creates an user-assigned managed identity.'
+param name string
+param location string = resourceGroup().location
+
+resource apiIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: name
+  location: location
+}
+
+output tenantId string = apiIdentity.properties.tenantId
+output principalId string = apiIdentity.properties.principalId
+output clientId string = apiIdentity.properties.clientId


### PR DESCRIPTION
Adds a new template for user-assigned managed identity.

This template is useful when used alongside Azure Container Apps for assigning roles for example, and is already used in multiple Azure samples repos.