### PR TITLE
Update functions/app service templates

### DIFF
--- a/templates/common/infra/bicep/core/host/appservice.bicep
+++ b/templates/common/infra/bicep/core/host/appservice.bicep
@@ -36,6 +36,7 @@ param scmDoBuildDuringDeployment bool = false
 param use32BitWorkerProcess bool = false
 param ftpsState string = 'FtpsOnly'
 param healthCheckPath string = ''
+param virtualNetworkSubnetId string = ''
 
 resource appService 'Microsoft.Web/sites@2022-03-01' = {
   name: name
@@ -61,6 +62,7 @@ resource appService 'Microsoft.Web/sites@2022-03-01' = {
     }
     clientAffinityEnabled: clientAffinityEnabled
     httpsOnly: true
+    virtualNetworkSubnetId: !empty(virtualNetworkSubnetId) ? virtualNetworkSubnetId : null
   }
 
   identity: { type: managedIdentity ? 'SystemAssigned' : 'None' }

--- a/templates/common/infra/bicep/core/host/functions.bicep
+++ b/templates/common/infra/bicep/core/host/functions.bicep
@@ -9,6 +9,7 @@ param appServicePlanId string
 param keyVaultName string = ''
 param managedIdentity bool = !empty(keyVaultName)
 param storageAccountName string
+param virtualNetworkSubnetId string = ''
 
 // Runtime Properties
 @allowed([
@@ -74,6 +75,7 @@ module functions 'appservice.bicep' = {
     runtimeNameAndVersion: runtimeNameAndVersion
     scmDoBuildDuringDeployment: scmDoBuildDuringDeployment
     use32BitWorkerProcess: use32BitWorkerProcess
+    virtualNetworkSubnetId: virtualNetworkSubnetId
   }
 }
 

--- a/templates/common/infra/bicep/core/host/functions.bicep
+++ b/templates/common/infra/bicep/core/host/functions.bicep
@@ -7,8 +7,9 @@ param tags object = {}
 param applicationInsightsName string = ''
 param appServicePlanId string
 param keyVaultName string = ''
-param managedIdentity bool = !empty(keyVaultName)
+param managedIdentity bool = !empty(keyVaultName) || storageManagedIdentity
 param storageAccountName string
+param storageManagedIdentity bool = false
 param virtualNetworkSubnetId string = ''
 
 // Runtime Properties
@@ -56,7 +57,8 @@ module functions 'appservice.bicep' = {
     applicationInsightsName: applicationInsightsName
     appServicePlanId: appServicePlanId
     appSettings: union(appSettings, {
-        AzureWebJobsStorage: 'DefaultEndpointsProtocol=https;AccountName=${storage.name};AccountKey=${storage.listKeys().keys[0].value};EndpointSuffix=${environment().suffixes.storage}'
+        AzureWebJobsStorage__accountName: storageManagedIdentity ? storage.name : null
+        AzureWebJobsStorage: storageManagedIdentity ? null : 'DefaultEndpointsProtocol=https;AccountName=${storage.name};AccountKey=${storage.listKeys().keys[0].value};EndpointSuffix=${environment().suffixes.storage}'
         FUNCTIONS_EXTENSION_VERSION: extensionVersion
         FUNCTIONS_WORKER_RUNTIME: runtimeName
       })
@@ -76,6 +78,16 @@ module functions 'appservice.bicep' = {
     scmDoBuildDuringDeployment: scmDoBuildDuringDeployment
     use32BitWorkerProcess: use32BitWorkerProcess
     virtualNetworkSubnetId: virtualNetworkSubnetId
+  }
+}
+
+module storageOwnerRole '../../core/security/role.bicep' = if (storageManagedIdentity) {
+  name: 'search-index-contrib-role-api'
+  params: {
+    principalId: functions.outputs.identityPrincipalId
+    // Search Index Data Contributor
+    roleDefinitionId: '8ebe5a00-799e-43f5-93ac-243d3dce84a7'
+    principalType: 'ServicePrincipal'
   }
 }
 


### PR DESCRIPTION
- add vnet option
- add option to enable managed identity on Functions backing storage (note: currently AZD isn't able to deploy Node/Python functions in that case, see https://github.com/Azure/azure-dev/issues/4025)