### PR TITLE
Add option to enable template deployment usage in Key Vault

### DIFF
--- a/templates/common/infra/bicep/core/security/keyvault.bicep
+++ b/templates/common/infra/bicep/core/security/keyvault.bicep
@@ -5,6 +5,9 @@ param tags object = {}
 
 param principalId string = ''
 
+@description('Allow the key vault to be used for template deployment.')
+param enabledForDeployment bool = false
+
 resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
   name: name
   location: location
@@ -19,6 +22,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
         tenantId: subscription().tenantId
       }
     ] : []
+    enabledForDeployment: enabledForDeployment
   }
 }
 


### PR DESCRIPTION
In some scenario, it can be useful to access KV through the `getSecret()` function in Bicep/ARM templates.