### PR TITLE
Update bicep to 0.28.1.

### DIFF
--- a/cli/azd/pkg/tools/bicep/bicep.go
+++ b/cli/azd/pkg/tools/bicep/bicep.go
@@ -27,7 +27,7 @@ import (
 
 // BicepVersion is the minimum version of bicep that we require (and the one we fetch when we fetch bicep on behalf of a
 // user).
-var BicepVersion semver.Version = semver.MustParse("0.26.170")
+var BicepVersion semver.Version = semver.MustParse("0.28.1")
 
 type BicepCli interface {
 	Build(ctx context.Context, file string) (BuildResult, error)


### PR DESCRIPTION
0.28.1 released 3 weeks ago. Support for MSGraph extension is in public preview.  

https://github.com/Azure/bicep/releases/tag/v0.28.1