### PR TITLE
Update golangci-lint local installation install link

### DIFF
--- a/cli/azd/CONTRIBUTING.md
+++ b/cli/azd/CONTRIBUTING.md
@@ -16,7 +16,7 @@ and logged in.
 
 We have some additional linting tools that we run in CI, and you will want to be able to run locally:
 
-- [golangci-lint](https://golangci-lint.run/usage/install/#local-installation)
+- [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation)
 
 In order to run end-to-end tests and develop templates, you'll need the following dependencies:
 
@@ -53,7 +53,7 @@ behalf.
 
 ## Debugging
 
-In VS Code you can add a configuration to launch.json that runs the tool with a specified set of arguments and in a specific 
+In VS Code you can add a configuration to launch.json that runs the tool with a specified set of arguments and in a specific
 folder, for example:
 
 ```json


### PR DESCRIPTION
Updates the local installation link of `golangci-lint`  in the CONTRIBUTING guide to the new location of the installation. The previous link returns a 404: Not found error