### PR TITLE
Allow to disable local auth on cosmosdb accounts

### DIFF
--- a/templates/common/infra/bicep/core/database/cosmos/cosmos-account.bicep
+++ b/templates/common/infra/bicep/core/database/cosmos/cosmos-account.bicep
@@ -9,6 +9,8 @@ param keyVaultName string
 @allowed([ 'GlobalDocumentDB', 'MongoDB', 'Parse' ])
 param kind string
 
+param disableLocalAuth bool = false
+
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' = {
   name: name
   kind: kind
@@ -29,6 +31,7 @@ resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' = {
     apiProperties: (kind == 'MongoDB') ? { serverVersion: '4.2' } : {}
     capabilities: [ { name: 'EnableServerless' } ]
     minimalTlsVersion: 'Tls12'
+    disableLocalAuth: disableLocalAuth
   }
 }
 

--- a/templates/common/infra/bicep/core/database/cosmos/mongo/cosmos-mongo-account.bicep
+++ b/templates/common/infra/bicep/core/database/cosmos/mongo/cosmos-mongo-account.bicep
@@ -5,6 +5,7 @@ param tags object = {}
 
 param keyVaultName string
 param connectionStringKey string = 'AZURE-COSMOS-CONNECTION-STRING'
+param disableLocalAuth bool = false
 
 module cosmos '../../cosmos/cosmos-account.bicep' = {
   name: 'cosmos-account'
@@ -15,6 +16,7 @@ module cosmos '../../cosmos/cosmos-account.bicep' = {
     keyVaultName: keyVaultName
     kind: 'MongoDB'
     tags: tags
+    disableLocalAuth: disableLocalAuth
   }
 }
 

--- a/templates/common/infra/bicep/core/database/cosmos/mongo/cosmos-mongo-db.bicep
+++ b/templates/common/infra/bicep/core/database/cosmos/mongo/cosmos-mongo-db.bicep
@@ -7,6 +7,7 @@ param tags object = {}
 param collections array = []
 param connectionStringKey string = 'AZURE-COSMOS-CONNECTION-STRING'
 param keyVaultName string
+param disableLocalAuth bool = false
 
 module cosmos 'cosmos-mongo-account.bicep' = {
   name: 'cosmos-mongo-account'
@@ -16,6 +17,7 @@ module cosmos 'cosmos-mongo-account.bicep' = {
     keyVaultName: keyVaultName
     tags: tags
     connectionStringKey: connectionStringKey
+    disableLocalAuth: disableLocalAuth
   }
 }
 

--- a/templates/common/infra/bicep/core/database/cosmos/sql/cosmos-sql-account.bicep
+++ b/templates/common/infra/bicep/core/database/cosmos/sql/cosmos-sql-account.bicep
@@ -4,6 +4,7 @@ param location string = resourceGroup().location
 param tags object = {}
 
 param keyVaultName string
+param disableLocalAuth bool = false
 
 module cosmos '../../cosmos/cosmos-account.bicep' = {
   name: 'cosmos-account'
@@ -13,6 +14,7 @@ module cosmos '../../cosmos/cosmos-account.bicep' = {
     tags: tags
     keyVaultName: keyVaultName
     kind: 'GlobalDocumentDB'
+    disableLocalAuth: disableLocalAuth
   }
 }
 

--- a/templates/common/infra/bicep/core/database/cosmos/sql/cosmos-sql-db.bicep
+++ b/templates/common/infra/bicep/core/database/cosmos/sql/cosmos-sql-db.bicep
@@ -7,6 +7,7 @@ param tags object = {}
 param containers array = []
 param keyVaultName string
 param principalIds array = []
+param disableLocalAuth bool = false
 
 module cosmos 'cosmos-sql-account.bicep' = {
   name: 'cosmos-sql-account'
@@ -15,6 +16,7 @@ module cosmos 'cosmos-sql-account.bicep' = {
     location: location
     tags: tags
     keyVaultName: keyVaultName
+    disableLocalAuth: disableLocalAuth
   }
 }
 


### PR DESCRIPTION
This PR allows to restrict CosmosDB account to use managed identity only.