### PR TITLE
Adds pre/post build hooks to service hooks definitions schema

### DIFF
--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -161,6 +161,16 @@
                                 "description": "Runs after the service dependencies are restored",
                                 "$ref": "#/definitions/hook"
                             },
+                            "prebuild": {
+                                "title": "pre build hook",
+                                "description": "Runs before the service is built",
+                                "$ref": "#/definitions/hook"
+                            },
+                            "postbuild": {
+                                "title": "post build hook",
+                                "description": "Runs after the service is built",
+                                "$ref": "#/definitions/hook"
+                            },
                             "prepackage": {
                                 "title": "pre package hook",
                                 "description": "Runs before the service is deployment package is created",

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -156,6 +156,16 @@
                                 "description": "Runs after the service dependencies are restored",
                                 "$ref": "#/definitions/hook"
                             },
+                            "prebuild": {
+                                "title": "pre build hook",
+                                "description": "Runs before the service is built",
+                                "$ref": "#/definitions/hook"
+                            },
+                            "postbuild": {
+                                "title": "post build hook",
+                                "description": "Runs after the service is built",
+                                "$ref": "#/definitions/hook"
+                            },
                             "prepackage": {
                                 "title": "pre package hook",
                                 "description": "Runs before the service is deployment package is created",


### PR DESCRIPTION
Pre/Post build hooks already exist but are missing from schema definition.  This enables more discoverability for scenarios where users need to perform an action after restoring but before package.

One scenario is for the VITE integration for front-end web apps.  Docker builds happen at the `build` state of the `azd` pipeline so users can hook into `prebuild` to set any `VITE_` environment variables needed for building container images.

Adds missing docs for `prebuild` and `postbuild` service lifecycle hook.
https://github.com/MicrosoftDocs/azure-dev-docs/pull/1399