### PR TITLE
Add an optional parameter to the key vault resource to send audit logs to the log analytics workspace

### DIFF
--- a/cli/azd/resources/scaffold/templates/main.bicept
+++ b/cli/azd/resources/scaffold/templates/main.bicept
@@ -76,6 +76,7 @@ module keyVault './shared/keyvault.bicep' = {
     tags: tags
     name: '${abbrs.keyVaultVaults}${resourceToken}'
     principalId: principalId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
   }
   scope: rg
 }

--- a/templates/common/infra/bicep/core/security/keyvault.bicep
+++ b/templates/common/infra/bicep/core/security/keyvault.bicep
@@ -3,7 +3,11 @@ param name string
 param location string = resourceGroup().location
 param tags object = {}
 
+@description('The ID of the principal to grant access to the key vault.')
 param principalId string = ''
+
+@description('The ID of the Log Analytics workspace to send audit logs to.')
+param logAnalyticsWorkspaceId string = ''
 
 resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
   name: name
@@ -19,6 +23,21 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
         tenantId: subscription().tenantId
       }
     ] : []
+  }
+}
+
+// Keyvault audit logs
+resource logs 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (!empty(logAnalyticsWorkspaceId)) {
+  name: '${name}-auditlogs'
+  scope: keyVault
+  properties: {
+    workspaceId: logAnalyticsWorkspaceId
+    logs: [
+      {
+        category: 'AuditEvent'
+        enabled: true
+      }
+    ]
   }
 }
 

--- a/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/csharp-cosmos-sql/.repo/bicep/infra/main.bicep
@@ -147,6 +147,7 @@ module keyVault '../../../../../../common/infra/bicep/core/security/keyvault.bic
     location: location
     tags: tags
     principalId: principalId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
   }
 }
 

--- a/templates/todo/projects/csharp-sql-swa-func/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/csharp-sql-swa-func/.repo/bicep/infra/main.bicep
@@ -144,6 +144,7 @@ module keyVault '../../../../../../common/infra/bicep/core/security/keyvault.bic
     location: location
     tags: tags
     principalId: principalId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
   }
 }
 

--- a/templates/todo/projects/csharp-sql/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/csharp-sql/.repo/bicep/infra/main.bicep
@@ -132,6 +132,7 @@ module keyVault '../../../../../../common/infra/bicep/core/security/keyvault.bic
     location: location
     tags: tags
     principalId: principalId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
   }
 }
 

--- a/templates/todo/projects/java-mongo-aca/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/java-mongo-aca/.repo/bicep/infra/main.bicep
@@ -135,6 +135,7 @@ module keyVault '../../../../../../common/infra/bicep/core/security/keyvault.bic
     location: location
     tags: tags
     principalId: principalId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
   }
 }
 

--- a/templates/todo/projects/java-mongo/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/java-mongo/.repo/bicep/infra/main.bicep
@@ -125,6 +125,7 @@ module keyVault '../../../../../../common/infra/bicep/core/security/keyvault.bic
     location: location
     tags: tags
     principalId: principalId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
   }
 }
 

--- a/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo-aca/.repo/bicep/infra/main.bicep
@@ -135,6 +135,7 @@ module keyVault '../../../../../../common/infra/bicep/core/security/keyvault.bic
     location: location
     tags: tags
     principalId: principalId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
   }
 }
 

--- a/templates/todo/projects/nodejs-mongo-aks/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo-aks/.repo/bicep/infra/main.bicep
@@ -76,6 +76,7 @@ module keyVault '../../../../../../common/infra/bicep/core/security/keyvault.bic
     location: location
     tags: tags
     principalId: principalId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
   }
 }
 

--- a/templates/todo/projects/nodejs-mongo-swa-func/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo-swa-func/.repo/bicep/infra/main.bicep
@@ -137,6 +137,7 @@ module keyVault '../../../../../../common/infra/bicep/core/security/keyvault.bic
     location: location
     tags: tags
     principalId: principalId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
   }
 }
 

--- a/templates/todo/projects/nodejs-mongo/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo/.repo/bicep/infra/main.bicep
@@ -125,6 +125,7 @@ module keyVault '../../../../../../common/infra/bicep/core/security/keyvault.bic
     location: location
     tags: tags
     principalId: principalId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
   }
 }
 

--- a/templates/todo/projects/python-mongo-aca/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/python-mongo-aca/.repo/bicep/infra/main.bicep
@@ -136,6 +136,7 @@ module keyVault '../../../../../../common/infra/bicep/core/security/keyvault.bic
     location: location
     tags: tags
     principalId: principalId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
   }
 }
 

--- a/templates/todo/projects/python-mongo-swa-func/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/python-mongo-swa-func/.repo/bicep/infra/main.bicep
@@ -137,6 +137,7 @@ module keyVault '../../../../../../common/infra/bicep/core/security/keyvault.bic
     location: location
     tags: tags
     principalId: principalId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
   }
 }
 

--- a/templates/todo/projects/python-mongo/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/python-mongo/.repo/bicep/infra/main.bicep
@@ -125,6 +125,7 @@ module keyVault '../../../../../../common/infra/bicep/core/security/keyvault.bic
     location: location
     tags: tags
     principalId: principalId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
   }
 }
 


### PR DESCRIPTION
Our Well Architected Framework specifies that key vault resources should send audit logs to a log analytics workspace.

This change adds the parameter and if specified configures the audit logs to a log analytics workspace ID.

I've updated the existing templates in this repository to use it, since they're already provisioning a log analytics workspace.

See https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.Logs/