### PR TITLE
Update cent os - dockerFile in tests with working mirrors

### DIFF
--- a/cli/installer/fpm/test-rpm.Dockerfile
+++ b/cli/installer/fpm/test-rpm.Dockerfile
@@ -1,5 +1,5 @@
 ARG prefix=''
-ARG base='centos:7'
+ARG base='centos:8'
 FROM ${prefix}${base}
 
 WORKDIR /work

--- a/cli/installer/fpm/test-rpm.Dockerfile
+++ b/cli/installer/fpm/test-rpm.Dockerfile
@@ -6,4 +6,8 @@ WORKDIR /work
 COPY test-rpm.sh /work/
 COPY *.rpm /work/
 
+# fix for https://github.com/Azure/azure-dev/issues/4076
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 ENTRYPOINT [ "/bin/bash", "test-rpm.sh" ]

--- a/cli/installer/test/Dockerfile.centos
+++ b/cli/installer/test/Dockerfile.centos
@@ -6,6 +6,10 @@ ARG shell='bash'
 ARG baseUrl='must set baseUrl'
 ARG version='must set version'
 
+# fix for https://github.com/Azure/azure-dev/issues/4076
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum install -y which
 
 COPY ./*.sh ./

--- a/cli/installer/test/Dockerfile.centos
+++ b/cli/installer/test/Dockerfile.centos
@@ -1,5 +1,5 @@
 ARG prefix=''
-ARG base='centos:7'
+ARG base='centos:8'
 FROM ${prefix}${base}
 
 ARG shell='bash'

--- a/cli/installer/test/telemetry/centos.sh.telemetry.csv
+++ b/cli/installer/test/telemetry/centos.sh.telemetry.csv
@@ -1,4 +1,4 @@
 os,centos
-osVersion,7
+osVersion,8
 isWsl,false
 terminal,bash


### PR DESCRIPTION
centos7 is EOL since 6/30
https://www.redhat.com/en/topics/linux/centos-linux-eol

Moving to centos8 in this PR

fix: https://github.com/Azure/azure-dev/issues/4076