### PR TITLE
fix: Resolve `azd` crash when using the `ai.endpoint` service host with Python 3.8

### DIFF
--- a/cli/azd/resources/ai-python/ml_client.py
+++ b/cli/azd/resources/ai-python/ml_client.py
@@ -2,22 +2,23 @@
 # coding: utf-8
 
 import argparse
+from typing import List
 from azure.identity import AzureDeveloperCliCredential
 from azure.ai.ml import MLClient, load_environment, load_model, load_online_endpoint, load_online_deployment
 
-def create_or_update_environment(client: MLClient, file_path: str, overrides: list[dict]):
+def create_or_update_environment(client: MLClient, file_path: str, overrides: List[dict]):
     environment = load_environment(source=file_path, params_override=overrides)
     client.environments.create_or_update(environment)
 
-def create_or_update_model(client: MLClient, file_path: str, overrides: list[dict]):
+def create_or_update_model(client: MLClient, file_path: str, overrides: List[dict]):
     model = load_model(source=file_path, params_override=overrides)
     client.models.create_or_update(model)
 
-def create_or_update_online_endpoint(client: MLClient, file_path: str, overrides: list[dict]):
+def create_or_update_online_endpoint(client: MLClient, file_path: str, overrides: List[dict]):
     online_endpoint = load_online_endpoint(source=file_path, params_override=overrides)
     client.online_endpoints.begin_create_or_update(online_endpoint)
 
-def create_or_update_online_deployment(client: MLClient, file_path: str, overrides: list[dict]):
+def create_or_update_online_deployment(client: MLClient, file_path: str, overrides: List[dict]):
     deployment = load_online_deployment(source=file_path, params_override=overrides)
     client.online_deployments.begin_create_or_update(deployment)
 

--- a/cli/azd/resources/ai-python/ml_client.py
+++ b/cli/azd/resources/ai-python/ml_client.py
@@ -3,8 +3,10 @@
 
 import argparse
 from typing import List
+
+from azure.ai.ml import MLClient, load_environment, load_model, load_online_deployment, load_online_endpoint
 from azure.identity import AzureDeveloperCliCredential
-from azure.ai.ml import MLClient, load_environment, load_model, load_online_endpoint, load_online_deployment
+
 
 def create_or_update_environment(client: MLClient, file_path: str, overrides: List[dict]):
     environment = load_environment(source=file_path, params_override=overrides)


### PR DESCRIPTION
# Description

This pull request is a bugfix for a crash that occurs when using the `ai.endpoint` service host on a machine that has Python3.8 in $PATH.

# Background

#3718 introduces a new service host `ai.endpoint`, which works by leveraging the `azure-ai-ml` SDK in the [ml_client.py](https://github.com/Azure/azure-dev/blob/5bf8568b1566723be8bc2259c578df4f931cf430/cli/azd/resources/ai-python/ml_client.py) script. `azd` runs that script using whichever version of python is available in a user's $PATH.



The `ml_client.py` script type hints a function parameter by subscripting the builtin type `list`:

https://github.com/Azure/azure-dev/blob/5bf8568b1566723be8bc2259c578df4f931cf430/cli/azd/resources/ai-python/ml_client.py#L8

Support for subscripting the builtin "generic" types was only added to the language in Python 3.9 (See [PEP 585](https://peps.python.org/pep-0585/))

Attempting to use `ai.endpoint` service host on a system with Python3.8 in $PATH will cause `azd` to crash with the following error:

```
--- ✅ | 3. Post-provisioning - populated data ---

Deploying services (azd deploy)

  (x) Failed: Deploying service chat

ERROR: error executing step command 'deploy': failed deploying service 'chat': failed to run Python script: exit code: 1, stdout: , stderr: Traceback (most recent call last):
  File "ml_client.py", line 8, in <module>
    def create_or_update_environment(client: MLClient, file_path: str, overrides: list[dict]):
TypeError: 'type' object is not subscriptable
```

Prior to Python3.9, the conventional way to write `list[dict]` would be to subscript [`typing.List`](https://docs.python.org/3.8/library/typing.html#typing.List) (i.e. `List[dict]`). That form works for all currently supported versions of Python (Python3.8-3.12)
