### PR TITLE
add flaky case for silence build error fail and for run out of time

### DIFF
--- a/cli/azd/pkg/tools/azcli/webapp.go
+++ b/cli/azd/pkg/tools/azcli/webapp.go
@@ -81,14 +81,27 @@ func appServiceRepositoryHost(
 }
 
 func resumeDeployment(err error, progressLog func(msg string)) bool {
-	if strings.Contains(err.Error(), "empty deployment status id") {
+	errorMessage := err.Error()
+	if strings.Contains(errorMessage, "empty deployment status id") {
 		progressLog("Deployment status id is empty. Failed to enable tracking runtime status." +
 			"Resuming deployment without tracking status.")
 		return true
 	}
 
-	if strings.Contains(err.Error(), "response or its properties are empty") {
+	if strings.Contains(errorMessage, "response or its properties are empty") {
 		progressLog("Response or its properties are empty. Failed to enable tracking runtime status." +
+			"Resuming deployment without tracking status.")
+		return true
+	}
+
+	if strings.Contains(errorMessage, "failed to start within the allotted time") {
+		progressLog("Deployment with tracking status failed to start within the allotted time." +
+			"Resuming deployment without tracking status.")
+		return true
+	}
+
+	if strings.Contains(errorMessage, "the build process failed") && !strings.Contains(errorMessage, "logs for more info") {
+		progressLog("Failed to enable tracking runtime status." +
 			"Resuming deployment without tracking status.")
 		return true
 	}


### PR DESCRIPTION
1. Related to https://github.com/Azure/azure-dev/issues/4093, we started to hit this flaky error again in recent daily builds. Adding a temporary solution to fall back to original deployment method while investigating the issue with deployment service team.
2. The API sometimes is unstable. Errors like `ERROR: failed deploying service 'api': deploying service api: Deployment failed because the runtime process failed. In progress instances: 0, Successful instances: 0, Failed Instances: 1 Error: Deployment for site '***' with DeploymentId '********' failed because the worker proccess failed to start within the allotted time. Please check the runtime logs for more info: **********` happened when container crashed on the server side. It can be fixed by re-run. 
3. However, this temporary approach will increase deployment time a lot especially if case 2 happened. 