### PR TITLE
remove azdo git remote constraint for dev.azure.com only

### DIFF
--- a/cli/azd/pkg/pipeline/azdo_provider_test.go
+++ b/cli/azd/pkg/pipeline/azdo_provider_test.go
@@ -38,22 +38,11 @@ func Test_azdo_provider_getRepoDetails(t *testing.T) {
 		require.EqualValues(t, false, details.pushStatus)
 	})
 
-	t.Run("ssh not supported", func(t *testing.T) {
-		// arrange
-		provider := getAzdoScmProviderTestHarness(mockinput.NewMockConsole())
-		ctx := context.Background()
-
-		// act
-		details, e := provider.gitRepoDetails(ctx, "git@ssh.dev.azure.com:v3/fake_org/repo1/repo1")
-
-		// assert
-		require.Error(t, e, ErrSSHNotSupported)
-		require.EqualValues(t, (*gitRepositoryDetails)(nil), details)
-	})
-
 	t.Run("non azure devops https remote", func(t *testing.T) {
 		//arrange
-		provider := &AzdoScmProvider{}
+		provider := &AzdoScmProvider{
+			env: environment.New("test"),
+		}
 		ctx := context.Background()
 
 		//act
@@ -66,7 +55,9 @@ func Test_azdo_provider_getRepoDetails(t *testing.T) {
 
 	t.Run("non azure devops git remote", func(t *testing.T) {
 		//arrange
-		provider := &AzdoScmProvider{}
+		provider := &AzdoScmProvider{
+			env: environment.New("test"),
+		}
 		ctx := context.Background()
 
 		//act

--- a/cli/azd/pkg/pipeline/azdo_provider_test.go
+++ b/cli/azd/pkg/pipeline/azdo_provider_test.go
@@ -221,3 +221,116 @@ func getAzdoCiProviderTestHarness(console input.Console) *AzdoCiProvider {
 		console: console,
 	}
 }
+
+func Test_parseAzDoRemote(t *testing.T) {
+
+	// the url can be in the form of:
+	//   - https://dev.azure.com/[org|user]/[project]/_git/[repo]
+	t.Run("valid HTTPS remote", func(t *testing.T) {
+		remoteUrl := "https://dev.azure.com/org/project/_git/repo"
+		expected := &azdoRemote{
+			Project:        "project",
+			RepositoryName: "repo",
+		}
+
+		result, err := parseAzDoRemote(remoteUrl)
+
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+	})
+
+	// the url can be in the form of:
+	//   - https://[user]@dev.azure.com/[org|user]/[project]/_git/[repo]
+	t.Run("valid user HTTPS remote", func(t *testing.T) {
+		remoteUrl := "https://user@visualstudio.com/org/project/_git/repo"
+		expected := &azdoRemote{
+			Project:        "project",
+			RepositoryName: "repo",
+		}
+
+		result, err := parseAzDoRemote(remoteUrl)
+
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+	})
+
+	// the url can be in the form of:
+	//   - https://[org].visualstudio.com/[project]/_git/[repo]
+	t.Run("valid legacy HTTPS remote", func(t *testing.T) {
+		remoteUrl := "https://visualstudio.com/org/project/_git/repo"
+		expected := &azdoRemote{
+			Project:        "project",
+			RepositoryName: "repo",
+		}
+
+		result, err := parseAzDoRemote(remoteUrl)
+
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("valid legacy HTTPS remote with org", func(t *testing.T) {
+		remoteUrl := "https://org.visualstudio.com/org/project/_git/repo"
+		expected := &azdoRemote{
+			Project:        "project",
+			RepositoryName: "repo",
+		}
+
+		result, err := parseAzDoRemote(remoteUrl)
+
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+	})
+
+	// the url can be in the form of:
+	//   - git@ssh.dev.azure.com:v[1-3]/[user|org]/[project]/[repo]
+	//   - git@vs-ssh.visualstudio.com:v[1-3]/[user|org]/[project]/[repo]
+	//   - git@ssh.visualstudio.com:v[1-3]/[user|org]/[project]/[repo]
+	t.Run("valid SSH remote", func(t *testing.T) {
+		remoteUrl := "git@ssh.dev.azure.com:v3/org/project/repo"
+		expected := &azdoRemote{
+			Project:        "project",
+			RepositoryName: "repo",
+		}
+
+		result, err := parseAzDoRemote(remoteUrl)
+
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("valid legacy SSH remote", func(t *testing.T) {
+		remoteUrl := "git@vs-ssh.visualstudio.com:v3/org/project/repo"
+		expected := &azdoRemote{
+			Project:        "project",
+			RepositoryName: "repo",
+		}
+
+		result, err := parseAzDoRemote(remoteUrl)
+
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("valid legacy SSH remote", func(t *testing.T) {
+		remoteUrl := "git@ssh.visualstudio.com:v3/org/project/repo"
+		expected := &azdoRemote{
+			Project:        "project",
+			RepositoryName: "repo",
+		}
+
+		result, err := parseAzDoRemote(remoteUrl)
+
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("invalid remote", func(t *testing.T) {
+		remoteUrl := "https://github.com/user/repo"
+
+		result, err := parseAzDoRemote(remoteUrl)
+
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+}


### PR DESCRIPTION
fix: https://github.com/Azure/azure-dev/issues/1072

This PR updates the logic for validating Azure devops git remotes and how to extract the project and repo name from it

fix: https://github.com/Azure/azure-dev/issues/1896