### PR TITLE
persistIngressSessionAffinity

### DIFF
--- a/cli/azd/resources/alpha_features.yaml
+++ b/cli/azd/resources/alpha_features.yaml
@@ -10,3 +10,5 @@
   description: "Do not change custom domains when deploying Azure Container Apps."
 - id: azd.operations
   description: "Extends provisioning providers with azd operations."
+- id: aca.persistIngressSessionAffinity
+  description: "Do not change Ingress Session Affinity when deploying Azure Container Apps."


### PR DESCRIPTION
Adding alpha feature `aca.persistIngressSessionAffinity`

Enable with `azd config set alpha.aca.persistIngressSessionAffinity on`

When enabled, Session Affinity is persisted (if manually turned on before) during deployment

![image](https://github.com/user-attachments/assets/6e2df93f-b97e-4938-a636-849db5f9a090)


fix: https://github.com/Azure/azure-dev/issues/3993

