### PR TITLE
fix webapp vite for aks template

### DIFF
--- a/templates/todo/projects/nodejs-mongo-aks/.repo/bicep/azure.yaml
+++ b/templates/todo/projects/nodejs-mongo-aks/.repo/bicep/azure.yaml
@@ -32,3 +32,23 @@ services:
         posix:
           shell: sh
           run: azd env set REACT_APP_API_BASE_URL ${SERVICE_API_ENDPOINT_URL}
+hooks:
+  # Creates a temporary `.env.local` file for the build command. Vite will automatically use it during build.
+  # The expected/required values are mapped to the infrastructure outputs.
+  # .env.local is ignored by git, so it will not be committed if, for any reason, if deployment fails.
+  # see: https://vitejs.dev/guide/env-and-mode
+  # Note: Notice that dotenv must be a project dependency for this to work. See package.json.
+  predeploy:
+    windows:
+      shell: pwsh
+      run: 'echo "VITE_API_BASE_URL=""$env:SERVICE_API_ENDPOINT_URL""" > ./src/web/.env.local ; echo "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=""$env:APPLICATIONINSIGHTS_CONNECTION_STRING""" >> ./src/web/.env.local'
+    posix:
+      shell: sh
+      run: 'echo VITE_API_BASE_URL=\"$SERVICE_API_ENDPOINT_URL\" > ./src/web/.env.local && echo VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" >> ./src/web/.env.local'    
+  postdeploy:
+    windows:
+      shell: pwsh
+      run: 'rm ./src/web/.env.local'
+    posix:
+      shell: sh
+      run: 'rm ./src/web/.env.local'


### PR DESCRIPTION
fix for: https://github.com/Azure/azure-dev/issues/4108#issuecomment-2226282647

The todo ask template was missing the hook which sets the api env vars for building the web application to be deployed.