### PR TITLE
Add `azd script run` command

### DIFF
--- a/cli/azd/.vscode/launch.json
+++ b/cli/azd/.vscode/launch.json
@@ -32,14 +32,14 @@
             "program": "${workspaceFolder}",
             "console": "integratedTerminal",
             "args": [
-                "auth", "login"
+                "script", "run", "start"
                 //"pipeline", "config", "--principal-name", "foo", "--provider", "github"
                 //"package", "api", "--debug"
                 //"provision"
                 //"up"
                 //"env", "new"
             ],
-            //"cwd": "~/workspace/cwd/path",
+            "cwd": "/workspaces/fast-api-test-2",
             // "env": {
             //     "INT_TAG_VALUE":"1989"
             // }

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -125,6 +125,7 @@ func NewRootCmd(
 	templatesActions(root)
 	authActions(root)
 	hooksActions(root)
+	scriptsActions(root)
 
 	root.Add("version", &actions.ActionDescriptorOptions{
 		Command: &cobra.Command{

--- a/cli/azd/cmd/scripts.go
+++ b/cli/azd/cmd/scripts.go
@@ -1,0 +1,229 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/azure/azure-dev/cli/azd/cmd/actions"
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/ext"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func scriptsActions(root *actions.ActionDescriptor) *actions.ActionDescriptor {
+	group := root.Add("script", &actions.ActionDescriptorOptions{
+		Command: &cobra.Command{
+			Use:   "script",
+			Short: fmt.Sprintf("Develop, test and run scripts for an application. %s", output.WithWarningFormat("(Beta)")),
+		},
+		GroupingOptions: actions.CommandGroupOptions{
+			RootLevelHelp: actions.CmdGroupConfig,
+		},
+	})
+
+	group.Add("run", &actions.ActionDescriptorOptions{
+		Command:        newScriptsRunCmd(),
+		FlagsResolver:  newScriptsRunFlags,
+		ActionResolver: newScriptsRunAction,
+	})
+
+	return group
+}
+
+func newScriptsRunFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *scriptsRunFlags {
+	flags := &scriptsRunFlags{}
+	flags.Bind(cmd.Flags(), global)
+
+	return flags
+}
+
+func newScriptsRunCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "run <name>",
+		Short: "Runs the specified script for the project",
+		Args:  cobra.ExactArgs(1),
+	}
+}
+
+type scriptsRunFlags struct {
+	internal.EnvFlag
+	global   *internal.GlobalCommandOptions
+	platform string
+}
+
+func (f *scriptsRunFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
+	f.EnvFlag.Bind(local, global)
+	f.global = global
+
+	local.StringVar(&f.platform, "platform", "", "Forces scripts to run for the specified platform.")
+}
+
+type scriptsRunAction struct {
+	projectConfig *project.ProjectConfig
+	env           *environment.Environment
+	envManager    environment.Manager
+	commandRunner exec.CommandRunner
+	console       input.Console
+	flags         *scriptsRunFlags
+	args          []string
+}
+
+func newScriptsRunAction(
+	projectConfig *project.ProjectConfig,
+	env *environment.Environment,
+	envManager environment.Manager,
+	commandRunner exec.CommandRunner,
+	console input.Console,
+	flags *scriptsRunFlags,
+	args []string,
+) actions.Action {
+	return &scriptsRunAction{
+		projectConfig: projectConfig,
+		env:           env,
+		envManager:    envManager,
+		commandRunner: commandRunner,
+		console:       console,
+		flags:         flags,
+		args:          args,
+	}
+}
+
+const noScriptFoundMessage = " (No script found)"
+
+func (sra *scriptsRunAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	scriptName := sra.args[0]
+
+	// Command title
+	sra.console.MessageUxItem(ctx, &ux.MessageTitle{
+		Title: "Running scripts (azd scripts run)",
+		TitleNote: fmt.Sprintf(
+			"Finding and executing %s scripts for environment %s",
+			output.WithHighLightFormat(scriptName),
+			output.WithHighLightFormat(sra.env.Name()),
+		),
+	})
+
+	// Project level scripts
+	if err := sra.processScripts(
+		ctx,
+		sra.projectConfig.Path,
+		scriptName,
+		fmt.Sprintf("Running %s command script for project", scriptName),
+		fmt.Sprintf("Project: %s Script Output", scriptName),
+		sra.projectConfig.Scripts, // Use projectConfig.Scripts directly
+	); err != nil {
+		return nil, err
+	}
+
+	return &actions.ActionResult{
+		Message: &actions.ResultMessage{
+			Header: "Your scripts have been run successfully",
+		},
+	}, nil
+}
+
+func (sra *scriptsRunAction) processScripts(
+	ctx context.Context,
+	cwd string,
+	scriptName string,
+	spinnerMessage string,
+	previewMessage string,
+	scripts map[string]*ext.HookConfig,
+) error {
+	sra.console.ShowSpinner(ctx, spinnerMessage, input.Step)
+
+	script, ok := scripts[scriptName]
+	if !ok {
+		sra.console.StopSpinner(ctx, spinnerMessage+noScriptFoundMessage, input.StepWarning)
+		return nil
+	}
+
+	if err := sra.prepareScript(scriptName, script); err != nil {
+		return err
+	}
+
+	err := sra.execScript(ctx, previewMessage, cwd, script)
+	if err != nil {
+		sra.console.StopSpinner(ctx, spinnerMessage, input.StepFailed)
+		return fmt.Errorf("failed running script %s, %w", scriptName, err)
+	}
+
+	sra.console.StopSpinner(ctx, spinnerMessage, input.StepDone)
+
+	return nil
+}
+
+func (sra *scriptsRunAction) execScript(
+	ctx context.Context,
+	previewMessage string,
+	cwd string,
+	script *ext.HookConfig,
+) error {
+	scripts := map[string]*ext.HookConfig{
+		script.Name: script,
+	}
+
+	scriptsManager := ext.NewHooksManager(cwd)
+	scriptsRunner := ext.NewHooksRunner(scriptsManager, sra.commandRunner, sra.envManager, sra.console, cwd, scripts, sra.env)
+
+	previewer := sra.console.ShowPreviewer(ctx, &input.ShowPreviewerOptions{
+		Prefix:       "  ",
+		Title:        previewMessage,
+		MaxLineCount: 8,
+	})
+	defer sra.console.StopPreviewer(ctx, false)
+
+	runOptions := &tools.ExecOptions{StdOut: previewer}
+	err := scriptsRunner.RunHooks(ctx, ext.HookTypeNone, runOptions, script.Name)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (sra *scriptsRunAction) prepareScript(name string, script *ext.HookConfig) error {
+	if sra.flags.platform != "" {
+		platformType := ext.HookPlatformType(sra.flags.platform)
+		switch platformType {
+		case ext.HookPlatformWindows:
+			if script.Windows == nil {
+				return fmt.Errorf("script is not configured for Windows")
+			} else {
+				*script = *script.Windows
+			}
+		case ext.HookPlatformPosix:
+			if script.Posix == nil {
+				return fmt.Errorf("script is not configured for Posix")
+			} else {
+				*script = *script.Posix
+			}
+		default:
+			return fmt.Errorf("platform %s is not valid. Supported values are windows & posix", sra.flags.platform)
+		}
+	}
+
+	script.Name = name
+	script.Interactive = true
+
+	sra.configureScriptFlags(script.Windows)
+	sra.configureScriptFlags(script.Posix)
+
+	return nil
+}
+
+func (sra *scriptsRunAction) configureScriptFlags(script *ext.HookConfig) {
+	if script == nil {
+		return
+	}
+
+	script.Interactive = true
+}

--- a/cli/azd/cmd/testdata/TestUsage-azd-script-run.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-script-run.snap
@@ -2,13 +2,17 @@
 Runs the specified script for the project
 
 Usage
-  azd script run <name> [flags]
+  azd script run [name] [flags]
 
 Flags
+        --continueOnError    	: Continue on error.
         --docs               	: Opens the documentation for azd script run in your web browser.
     -e, --environment string 	: The name of the environment to use.
     -h, --help               	: Gets help for run.
+        --interactive        	: Run in interactive mode.
         --platform string    	: Forces scripts to run for the specified platform.
+        --run string         	: Inline script to run.
+        --shell string       	: Shell to use for the script.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd-script-run.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-script-run.snap
@@ -1,0 +1,20 @@
+
+Runs the specified script for the project
+
+Usage
+  azd script run <name> [flags]
+
+Flags
+        --docs               	: Opens the documentation for azd script run in your web browser.
+    -e, --environment string 	: The name of the environment to use.
+    -h, --help               	: Gets help for run.
+        --platform string    	: Forces scripts to run for the specified platform.
+
+Global Flags
+    -C, --cwd string 	: Sets the current working directory.
+        --debug      	: Enables debugging and diagnostics logging.
+        --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
+
+Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.
+
+

--- a/cli/azd/cmd/testdata/TestUsage-azd-script.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-script.snap
@@ -1,0 +1,23 @@
+
+Develop, test and run scripts for an application. (Beta)
+
+Usage
+  azd script [command]
+
+Available Commands
+  run	: Runs the specified script for the project
+
+Flags
+        --docs 	: Opens the documentation for azd script in your web browser.
+    -h, --help 	: Gets help for script.
+
+Global Flags
+    -C, --cwd string 	: Sets the current working directory.
+        --debug      	: Enables debugging and diagnostics logging.
+        --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
+
+Use azd script [command] --help to view examples and more information about a specific command.
+
+Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.
+
+

--- a/cli/azd/cmd/testdata/TestUsage-azd.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd.snap
@@ -11,6 +11,7 @@ Commands
     hooks    	: Develop, test and run hooks for an application. (Beta)
     init     	: Initialize a new application.
     restore  	: Restores the application's dependencies. (Beta)
+    script   	: Develop, test and run scripts for an application. (Beta)
     template 	: Find and view template details. (Beta)
 
   Manage Azure resources and app deployments

--- a/cli/azd/internal/repository/detect_confirm_apphost.go
+++ b/cli/azd/internal/repository/detect_confirm_apphost.go
@@ -80,7 +80,7 @@ func (d *detectConfirmAppHost) render(ctx context.Context) error {
 	d.console.Message(
 		ctx,
 		"azd will generate the files necessary to host your app on Azure using "+color.MagentaString(
-			"Azure Container Apps",
+			"Azure Kubernetes Service",
 		)+".\n",
 	)
 

--- a/cli/azd/internal/repository/detect_confirm_apphost.go
+++ b/cli/azd/internal/repository/detect_confirm_apphost.go
@@ -80,7 +80,7 @@ func (d *detectConfirmAppHost) render(ctx context.Context) error {
 	d.console.Message(
 		ctx,
 		"azd will generate the files necessary to host your app on Azure using "+color.MagentaString(
-			"Azure Kubernetes Service",
+			"Azure Container Apps",
 		)+".\n",
 	)
 

--- a/cli/azd/pkg/project/project_config.go
+++ b/cli/azd/pkg/project/project_config.go
@@ -25,6 +25,7 @@ type ProjectConfig struct {
 	Infra             provisioning.Options       `yaml:"infra,omitempty"`
 	Pipeline          PipelineOptions            `yaml:"pipeline,omitempty"`
 	Hooks             map[string]*ext.HookConfig `yaml:"hooks,omitempty"`
+	Scripts           map[string]*ext.HookConfig `yaml:"scripts,omitempty"`
 	State             *state.Config              `yaml:"state,omitempty"`
 	Platform          *platform.Config           `yaml:"platform,omitempty"`
 	Workflows         workflow.WorkflowMap       `yaml:"workflows,omitempty"`

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -78,7 +78,7 @@
                         "type": "string",
                         "title": "Path to the service source code directory"
                     },
-"image": {
+                    "image": {
                         "type": "string",
                         "title": "Optional. The source image to be used for the container image instead of building from source.",
                         "description": "If omitted, container image will be built from source specified in the 'project' property. Setting both 'project' and 'image' is invalid."
@@ -180,7 +180,7 @@
                     }
                 },
                 "allOf": [
-{
+                    {
                         "if": {
                             "properties": {
                                 "host": {
@@ -353,6 +353,14 @@
                     }
                 }
             }
+        },
+        "scripts": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/hook"
+            },
+            "title": "Scripts for various events",
+            "description": "Users can define multiple hooks for different events. Each key represents a script name, and the value should follow the hook definition."
         },
         "hooks": {
             "type": "object",
@@ -569,7 +577,13 @@
             "description": "Optional. Provides additional configuration for deploying to sovereign clouds such as Azure Government. The default cloud is AzureCloud.",
             "additionalProperties": false,
             "properties": {
-                "name": { "enum": [ "AzureCloud", "AzureChinaCloud", "AzureUSGovernment" ] }
+                "name": {
+                    "enum": [
+                        "AzureCloud",
+                        "AzureChinaCloud",
+                        "AzureUSGovernment"
+                    ]
+                }
             }
         }
     },
@@ -743,7 +757,7 @@
                             "description": "When set will be appended to the root of your ingress resource path."
                         }
                     }
-},
+                },
                 "helm": {
                     "type": "object",
                     "title": "Optional. The helm configuration",
@@ -1002,7 +1016,9 @@
         },
         "aiDeploymentConfig": {
             "allOf": [
-                { "$ref": "#/definitions/aiComponentConfig" },
+                {
+                    "$ref": "#/definitions/aiComponentConfig"
+                },
                 {
                     "type": "object",
                     "properties": {
@@ -1010,7 +1026,7 @@
                             "type": "object",
                             "title": "A map of key/value pairs to set as environment variables for the deployment.",
                             "description": "Optional. Values support OS & AZD environment variable substitution.",
-                            "additionalProperties":{
+                            "additionalProperties": {
                                 "type": "string"
                             }
                         }


### PR DESCRIPTION
Users need to be able to run arbitrary scripts and start applications with azd env vars loaded.  

This PR add a new command `azd script run` that will run any script defined in azure.yaml with azd env vars loaded.

Here's how it works:

1. Define your scripts in `azure.yaml`
```yaml
scripts:
    printenv:
        run: 'printenv'
        shell: sh
        continueOnError: true
        interactive: true
    start:
        run: 'python app.py'
        shell: sh
        continueOnError: true
        interactive: true
```
2. Run with `azd script run printenv` `azd script run start`.

3. These scripts will have all azd env vars loaded.

So you can access the vars as usual:

```python
import os

def print_azure_env_name():
    azure_env_name = os.getenv('AZURE_ENV_NAME')
    if azure_env_name is not None:
        print(f"AZURE_ENV_NAME: {azure_env_name}")
    else:
        print("AZURE_ENV_NAME environment variable is not set.")

if __name__ == "__main__":
    print_azure_env_name()

```

## Docker compose
You can also use this to launch docker compose with azd env vars:

```yaml
scripts:
    docker:
        run: 'docker compose up --build'
        shell: sh
        continueOnError: true
        interactive: true
```

and then

`azd script run docker`

app_server.py
```python
import os
from http.server import BaseHTTPRequestHandler, HTTPServer

class RequestHandler(BaseHTTPRequestHandler):
    def do_GET(self):
        azure_env_name = os.getenv('AZURE_ENV_NAME')
        if azure_env_name is not None:
            response = f"AZURE_ENV_NAME: {azure_env_name}"
        else:
            response = "AZURE_ENV_NAME environment variable is not set."

        self.send_response(200)
        self.send_header('Content-type', 'text/plain')
        self.end_headers()
        self.wfile.write(response.encode('utf-8'))

def run(server_class=HTTPServer, handler_class=RequestHandler, port=80):
    server_address = ('', port)
    httpd = server_class(server_address, handler_class)
    print(f'Starting httpd on port {port}...')
    httpd.serve_forever()

if __name__ == "__main__":
    run()

```
Dockerfile
```
# Use the official Python image from the Docker Hub
FROM python:3.9-slim

# Set the working directory in the container
WORKDIR /app

# Copy the current directory contents into the container at /app
COPY . .

# Install any needed packages specified in requirements.txt
# RUN pip install --no-cache-dir -r requirements.txt

# Make port 80 available to the world outside this container
EXPOSE 80

# Define environment variable
ENV AZURE_ENV_NAME="YourAzureEnvName"

# Run app_server.py when the container launches
CMD ["python", "app_server.py"]

```

docker-compose.yml
```
services:
  app:
    build: .
    ports:
      - "8080:80"
    environment:
      AZURE_ENV_NAME: ${AZURE_ENV_NAME}

```

## Parameters

You can also supply all of the hook parameters via the command line instead of in azure.yaml.

For example:

`azd script run --run 'docker compose up --build'`