### PR TITLE
chore: Pin cspell version

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - run: npm install -g cspell
+      - run: npm install -g cspell@8.12.1
       - name: Spell check for CLI source code
         run: cspell lint '**/*.{go,md}' --config ./cli/azd/.vscode/cspell.yaml --root ./cli/azd --no-progress
 

--- a/.github/workflows/cspell-misc.yml
+++ b/.github/workflows/cspell-misc.yml
@@ -20,6 +20,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - run: npm install -g cspell
+      - run: npm install -g cspell@8.12.1
       - name: Spell check for general files
         run: cspell lint '**/*' --config ./.vscode/cspell.misc.yaml --relative --no-progress

--- a/.github/workflows/templates-ci.yml
+++ b/.github/workflows/templates-ci.yml
@@ -24,6 +24,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - run: npm install -g cspell
+      - run: npm install -g cspell@8.12.1
       - name: Spell check for templates
         run: cspell lint '**/*' --config ./templates/cspell.yaml --root ./templates --no-progress

--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - run: npm install -g cspell
+      - run: npm install -g cspell@8.12.1
       - name: Spell check for vscode extension
         run: cspell lint '**/*.ts' --config ./ext/vscode/.vscode/cspell.yaml --root ./ext/vscode --no-progress
 


### PR DESCRIPTION
The latest version of cspell (8.13.0) has issues where it ignores parts of our config. Pin to an ealier version while we wait for the upstream issue to be fixed.