### PR TITLE
Remove unused interfaces from the tools

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -609,7 +609,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.MustRegisterSingleton(helm.NewCli)
 	container.MustRegisterSingleton(kustomize.NewCli)
 	container.MustRegisterSingleton(npm.NewCli)
-	container.MustRegisterSingleton(python.NewPythonCli)
+	container.MustRegisterSingleton(python.NewCli)
 	container.MustRegisterSingleton(swa.NewSwaCli)
 	container.MustRegisterScoped(ai.NewPythonBridge)
 	container.MustRegisterScoped(project.NewAiHelper)

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -598,7 +598,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	})
 	container.MustRegisterSingleton(azapi.NewDeployments)
 	container.MustRegisterSingleton(azapi.NewDeploymentOperations)
-	container.MustRegisterSingleton(docker.NewDocker)
+	container.MustRegisterSingleton(docker.NewCli)
 	container.MustRegisterSingleton(dotnet.NewDotNetCli)
 	container.MustRegisterSingleton(git.NewGitCli)
 	container.MustRegisterSingleton(github.NewGitHubCli)

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -603,7 +603,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.MustRegisterSingleton(git.NewCli)
 	container.MustRegisterSingleton(github.NewGitHubCli)
 	container.MustRegisterSingleton(javac.NewCli)
-	container.MustRegisterSingleton(kubectl.NewKubectl)
+	container.MustRegisterSingleton(kubectl.NewCli)
 	container.MustRegisterSingleton(maven.NewMavenCli)
 	container.MustRegisterSingleton(kubelogin.NewCli)
 	container.MustRegisterSingleton(helm.NewCli)

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -600,7 +600,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.MustRegisterSingleton(azapi.NewDeploymentOperations)
 	container.MustRegisterSingleton(docker.NewCli)
 	container.MustRegisterSingleton(dotnet.NewCli)
-	container.MustRegisterSingleton(git.NewGitCli)
+	container.MustRegisterSingleton(git.NewCli)
 	container.MustRegisterSingleton(github.NewGitHubCli)
 	container.MustRegisterSingleton(javac.NewCli)
 	container.MustRegisterSingleton(kubectl.NewKubectl)

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -610,7 +610,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.MustRegisterSingleton(kustomize.NewCli)
 	container.MustRegisterSingleton(npm.NewCli)
 	container.MustRegisterSingleton(python.NewCli)
-	container.MustRegisterSingleton(swa.NewSwaCli)
+	container.MustRegisterSingleton(swa.NewCli)
 	container.MustRegisterScoped(ai.NewPythonBridge)
 	container.MustRegisterScoped(project.NewAiHelper)
 

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -608,7 +608,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.MustRegisterSingleton(kubelogin.NewCli)
 	container.MustRegisterSingleton(helm.NewCli)
 	container.MustRegisterSingleton(kustomize.NewCli)
-	container.MustRegisterSingleton(npm.NewNpmCli)
+	container.MustRegisterSingleton(npm.NewCli)
 	container.MustRegisterSingleton(python.NewPythonCli)
 	container.MustRegisterSingleton(swa.NewSwaCli)
 	container.MustRegisterScoped(ai.NewPythonBridge)

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -599,7 +599,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.MustRegisterSingleton(azapi.NewDeployments)
 	container.MustRegisterSingleton(azapi.NewDeploymentOperations)
 	container.MustRegisterSingleton(docker.NewCli)
-	container.MustRegisterSingleton(dotnet.NewDotNetCli)
+	container.MustRegisterSingleton(dotnet.NewCli)
 	container.MustRegisterSingleton(git.NewGitCli)
 	container.MustRegisterSingleton(github.NewGitHubCli)
 	container.MustRegisterSingleton(javac.NewCli)

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -604,7 +604,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.MustRegisterSingleton(github.NewGitHubCli)
 	container.MustRegisterSingleton(javac.NewCli)
 	container.MustRegisterSingleton(kubectl.NewCli)
-	container.MustRegisterSingleton(maven.NewMavenCli)
+	container.MustRegisterSingleton(maven.NewCli)
 	container.MustRegisterSingleton(kubelogin.NewCli)
 	container.MustRegisterSingleton(helm.NewCli)
 	container.MustRegisterSingleton(kustomize.NewCli)

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -104,7 +104,7 @@ type initAction struct {
 	lazyEnvManager  *lazy.Lazy[environment.Manager]
 	console         input.Console
 	cmdRun          exec.CommandRunner
-	gitCli          git.GitCli
+	gitCli          *git.Cli
 	flags           *initFlags
 	repoInitializer *repository.Initializer
 	templateManager *templates.TemplateManager
@@ -116,7 +116,7 @@ func newInitAction(
 	lazyEnvManager *lazy.Lazy[environment.Manager],
 	cmdRun exec.CommandRunner,
 	console input.Console,
-	gitCli git.GitCli,
+	gitCli *git.Cli,
 	flags *initFlags,
 	repoInitializer *repository.Initializer,
 	templateManager *templates.TemplateManager,

--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -176,10 +176,10 @@ var allDetectors = []projectDetector{
 	&javaDetector{},
 	&dotNetAppHostDetector{
 		// TODO(ellismg): Remove ambient authority.
-		dotnetCli: dotnet.NewDotNetCli(exec.NewCommandRunner(nil)),
+		dotnetCli: dotnet.NewCli(exec.NewCommandRunner(nil)),
 	},
 	&dotNetDetector{
-		dotnetCli: dotnet.NewDotNetCli(exec.NewCommandRunner(nil)),
+		dotnetCli: dotnet.NewCli(exec.NewCommandRunner(nil)),
 	},
 	&pythonDetector{},
 	&javaScriptDetector{},

--- a/cli/azd/internal/appdetect/dotnet.go
+++ b/cli/azd/internal/appdetect/dotnet.go
@@ -12,7 +12,7 @@ import (
 )
 
 type dotNetDetector struct {
-	dotnetCli dotnet.DotNetCli
+	dotnetCli *dotnet.Cli
 }
 
 func (dd *dotNetDetector) Language() Language {

--- a/cli/azd/internal/appdetect/dotnet_apphost.go
+++ b/cli/azd/internal/appdetect/dotnet_apphost.go
@@ -11,7 +11,7 @@ import (
 )
 
 type dotNetAppHostDetector struct {
-	dotnetCli dotnet.DotNetCli
+	dotnetCli *dotnet.Cli
 }
 
 func (ad *dotNetAppHostDetector) Language() Language {

--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -30,14 +30,14 @@ import (
 // Initializer handles the initialization of a local repository.
 type Initializer struct {
 	console        input.Console
-	gitCli         git.GitCli
+	gitCli         *git.Cli
 	dotnetCli      *dotnet.Cli
 	lazyEnvManager *lazy.Lazy[environment.Manager]
 }
 
 func NewInitializer(
 	console input.Console,
-	gitCli git.GitCli,
+	gitCli *git.Cli,
 	dotnetCli *dotnet.Cli,
 	lazyEnvManager *lazy.Lazy[environment.Manager],
 ) *Initializer {

--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -31,14 +31,14 @@ import (
 type Initializer struct {
 	console        input.Console
 	gitCli         git.GitCli
-	dotnetCli      dotnet.DotNetCli
+	dotnetCli      *dotnet.Cli
 	lazyEnvManager *lazy.Lazy[environment.Manager]
 }
 
 func NewInitializer(
 	console input.Console,
 	gitCli git.GitCli,
-	dotnetCli dotnet.DotNetCli,
+	dotnetCli *dotnet.Cli,
 	lazyEnvManager *lazy.Lazy[environment.Manager],
 ) *Initializer {
 	return &Initializer{

--- a/cli/azd/internal/repository/initializer_test.go
+++ b/cli/azd/internal/repository/initializer_test.go
@@ -57,7 +57,7 @@ func Test_Initializer_Initialize(t *testing.T) {
 
 			i := NewInitializer(
 				mockContext.Console,
-				git.NewGitCli(mockContext.CommandRunner),
+				git.NewCli(mockContext.CommandRunner),
 				dotnet.NewCli(mockContext.CommandRunner),
 				lazy.From[environment.Manager](mockEnv),
 			)
@@ -101,7 +101,7 @@ func Test_Initializer_DevCenter(t *testing.T) {
 
 	i := NewInitializer(
 		mockContext.Console,
-		git.NewGitCli(mockContext.CommandRunner),
+		git.NewCli(mockContext.CommandRunner),
 		dotnet.NewCli(mockContext.CommandRunner),
 		lazy.From[environment.Manager](mockEnv),
 	)
@@ -171,7 +171,7 @@ func Test_Initializer_InitializeWithOverwritePrompt(t *testing.T) {
 
 			i := NewInitializer(
 				console,
-				git.NewGitCli(mockRunner),
+				git.NewCli(mockRunner),
 				dotnet.NewCli(mockRunner),
 				lazy.From[environment.Manager](mockEnv),
 			)
@@ -291,7 +291,7 @@ func verifyTemplateCopied(
 
 func verifyExecutableFilePermissions(t *testing.T,
 	ctx context.Context,
-	git git.GitCli,
+	git *git.Cli,
 	repoPath string,
 	expectedFiles []string) {
 	output, err := git.ListStagedFiles(ctx, repoPath)
@@ -376,7 +376,7 @@ func Test_Initializer_WriteCoreAssets(t *testing.T) {
 			envManager.On("Save", mock.Anything, mock.Anything).Return(nil)
 
 			i := NewInitializer(
-				console, git.NewGitCli(realRunner), nil, lazy.From[environment.Manager](envManager))
+				console, git.NewCli(realRunner), nil, lazy.From[environment.Manager](envManager))
 			err := i.writeCoreAssets(context.Background(), azdCtx)
 			require.NoError(t, err)
 
@@ -605,7 +605,7 @@ func TestInitializer_PromptIfNonEmpty(t *testing.T) {
 			dir := t.TempDir()
 			console := mockinput.NewMockConsole()
 			cmdRun := mockexec.NewMockCommandRunner()
-			gitCli := git.NewGitCli(cmdRun)
+			gitCli := git.NewCli(cmdRun)
 
 			// create files
 			for _, file := range tt.dir.files {

--- a/cli/azd/internal/repository/initializer_test.go
+++ b/cli/azd/internal/repository/initializer_test.go
@@ -58,7 +58,7 @@ func Test_Initializer_Initialize(t *testing.T) {
 			i := NewInitializer(
 				mockContext.Console,
 				git.NewGitCli(mockContext.CommandRunner),
-				dotnet.NewDotNetCli(mockContext.CommandRunner),
+				dotnet.NewCli(mockContext.CommandRunner),
 				lazy.From[environment.Manager](mockEnv),
 			)
 			err := i.Initialize(*mockContext.Context, azdCtx, &templates.Template{RepositoryPath: "local"}, "")
@@ -102,7 +102,7 @@ func Test_Initializer_DevCenter(t *testing.T) {
 	i := NewInitializer(
 		mockContext.Console,
 		git.NewGitCli(mockContext.CommandRunner),
-		dotnet.NewDotNetCli(mockContext.CommandRunner),
+		dotnet.NewCli(mockContext.CommandRunner),
 		lazy.From[environment.Manager](mockEnv),
 	)
 	err := i.Initialize(*mockContext.Context, azdCtx, template, "")
@@ -172,7 +172,7 @@ func Test_Initializer_InitializeWithOverwritePrompt(t *testing.T) {
 			i := NewInitializer(
 				console,
 				git.NewGitCli(mockRunner),
-				dotnet.NewDotNetCli(mockRunner),
+				dotnet.NewCli(mockRunner),
 				lazy.From[environment.Manager](mockEnv),
 			)
 			err = i.Initialize(context.Background(), azdCtx, &templates.Template{RepositoryPath: "local"}, "")

--- a/cli/azd/internal/vsrpc/aspire_service.go
+++ b/cli/azd/internal/vsrpc/aspire_service.go
@@ -36,7 +36,7 @@ func (s *aspireService) GetAspireHostAsync(
 	}
 
 	var c struct {
-		dotnetCli dotnet.DotNetCli `container:"type"`
+		dotnetCli *dotnet.Cli `container:"type"`
 	}
 
 	container, err := session.newContainer(rc)

--- a/cli/azd/internal/vsrpc/environment_service_create.go
+++ b/cli/azd/internal/vsrpc/environment_service_create.go
@@ -33,7 +33,7 @@ func (s *environmentService) CreateEnvironmentAsync(
 
 	var c struct {
 		azdContext *azdcontext.AzdContext `container:"type"`
-		dotnetCli  dotnet.DotNetCli       `container:"type"`
+		dotnetCli  *dotnet.Cli            `container:"type"`
 		envManager environment.Manager    `container:"type"`
 	}
 

--- a/cli/azd/internal/vsrpc/environment_service_load.go
+++ b/cli/azd/internal/vsrpc/environment_service_load.go
@@ -65,7 +65,7 @@ func (s *environmentService) loadEnvironmentAsync(
 		azdCtx         *azdcontext.AzdContext  `container:"type"`
 		envManager     environment.Manager     `container:"type"`
 		projectConfig  *project.ProjectConfig  `container:"type"`
-		dotnetCli      dotnet.DotNetCli        `container:"type"`
+		dotnetCli      *dotnet.Cli             `container:"type"`
 		dotnetImporter *project.DotNetImporter `container:"type"`
 	}
 

--- a/cli/azd/internal/vsrpc/utils.go
+++ b/cli/azd/internal/vsrpc/utils.go
@@ -16,7 +16,7 @@ import (
 
 // appHostServiceForProject returns the ServiceConfig of the service for the AppHost project for the given azd project.
 func appHostForProject(
-	ctx context.Context, pc *project.ProjectConfig, dotnetCli dotnet.DotNetCli,
+	ctx context.Context, pc *project.ProjectConfig, dotnetCli *dotnet.Cli,
 ) (*project.ServiceConfig, error) {
 	for _, service := range pc.Services {
 		if service.Language == project.ServiceLanguageDotNet {

--- a/cli/azd/pkg/ai/python_bridge.go
+++ b/cli/azd/pkg/ai/python_bridge.go
@@ -36,7 +36,7 @@ type PythonBridge interface {
 // pythonBridge is a bridge to execute python components from the embedded AI resources project
 type pythonBridge struct {
 	azdCtx      *azdcontext.AzdContext
-	pythonCli   *python.PythonCli
+	pythonCli   *python.Cli
 	workingDir  string
 	initialized bool
 }
@@ -44,7 +44,7 @@ type pythonBridge struct {
 // NewPythonBridge creates a new PythonBridge instance
 func NewPythonBridge(
 	azdCtx *azdcontext.AzdContext,
-	pythonCli *python.PythonCli,
+	pythonCli *python.Cli,
 ) PythonBridge {
 	return &pythonBridge{
 		azdCtx:    azdCtx,

--- a/cli/azd/pkg/ai/python_bridge_test.go
+++ b/cli/azd/pkg/ai/python_bridge_test.go
@@ -18,7 +18,7 @@ import (
 func Test_PythonBridge_Init(t *testing.T) {
 	tempDir := t.TempDir()
 	mockContext := mocks.NewMockContext(context.Background())
-	pythonCli := python.NewPythonCli(mockContext.CommandRunner)
+	pythonCli := python.NewCli(mockContext.CommandRunner)
 	azdCtx := azdcontext.NewAzdContextWithDirectory(tempDir)
 
 	azdConfigDir := filepath.Join(tempDir, ".azd")
@@ -56,7 +56,7 @@ func Test_PythonBridge_Init(t *testing.T) {
 
 func Test_PythonBridge_Run(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
-	pythonCli := python.NewPythonCli(mockContext.CommandRunner)
+	pythonCli := python.NewCli(mockContext.CommandRunner)
 	azdCtx := azdcontext.NewAzdContextWithDirectory(t.TempDir())
 
 	ran := false

--- a/cli/azd/pkg/apphost/generate_test.go
+++ b/cli/azd/pkg/apphost/generate_test.go
@@ -74,7 +74,7 @@ func TestAspireBicepGeneration(t *testing.T) {
 	filesFromManifest["aspire.hosting.azure.bicep.appinsights.bicep"] = ignoredBicepContent
 	filesFromManifest["aspire.hosting.azure.bicep.sql.bicep"] = ignoredBicepContent
 	mockPublishManifest(mockCtx, aspireBicepManifest, filesFromManifest)
-	mockCli := dotnet.NewDotNetCli(mockCtx.CommandRunner)
+	mockCli := dotnet.NewCli(mockCtx.CommandRunner)
 
 	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli, "")
 	require.NoError(t, err)
@@ -117,7 +117,7 @@ func TestAspireDockerGeneration(t *testing.T) {
 	ctx := context.Background()
 	mockCtx := mocks.NewMockContext(ctx)
 	mockPublishManifest(mockCtx, aspireDockerManifest, nil)
-	mockCli := dotnet.NewDotNetCli(mockCtx.CommandRunner)
+	mockCli := dotnet.NewCli(mockCtx.CommandRunner)
 
 	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli, "")
 	require.NoError(t, err)
@@ -160,7 +160,7 @@ func TestAspireDashboardGeneration(t *testing.T) {
 	ctx := context.Background()
 	mockCtx := mocks.NewMockContext(ctx)
 	mockPublishManifest(mockCtx, aspireDockerManifest, nil)
-	mockCli := dotnet.NewDotNetCli(mockCtx.CommandRunner)
+	mockCli := dotnet.NewCli(mockCtx.CommandRunner)
 
 	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli, "")
 	require.NoError(t, err)
@@ -195,7 +195,7 @@ func TestAspireArgsGeneration(t *testing.T) {
 	ctx := context.Background()
 	mockCtx := mocks.NewMockContext(ctx)
 	mockPublishManifest(mockCtx, aspireArgsManifest, nil)
-	mockCli := dotnet.NewDotNetCli(mockCtx.CommandRunner)
+	mockCli := dotnet.NewCli(mockCtx.CommandRunner)
 
 	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireArgs.AppHost.csproj"), mockCli, "")
 	require.NoError(t, err)
@@ -214,7 +214,7 @@ func TestAspireContainerGeneration(t *testing.T) {
 	ctx := context.Background()
 	mockCtx := mocks.NewMockContext(ctx)
 	mockPublishManifest(mockCtx, aspireContainerManifest, nil)
-	mockCli := dotnet.NewDotNetCli(mockCtx.CommandRunner)
+	mockCli := dotnet.NewCli(mockCtx.CommandRunner)
 
 	m, err := ManifestFromAppHost(ctx, filepath.Join("testdata", "AspireDocker.AppHost.csproj"), mockCli, "")
 	require.NoError(t, err)

--- a/cli/azd/pkg/apphost/manifest.go
+++ b/cli/azd/pkg/apphost/manifest.go
@@ -185,7 +185,7 @@ type InputDefault struct {
 
 // ManifestFromAppHost returns the Manifest from the given app host.
 func ManifestFromAppHost(
-	ctx context.Context, appHostProject string, dotnetCli dotnet.DotNetCli, dotnetEnv string,
+	ctx context.Context, appHostProject string, dotnetCli *dotnet.Cli, dotnetEnv string,
 ) (*Manifest, error) {
 	tempDir, err := os.MkdirTemp("", "azd-provision")
 	if err != nil {

--- a/cli/azd/pkg/azd/default.go
+++ b/cli/azd/pkg/azd/default.go
@@ -45,7 +45,7 @@ func (p *DefaultPlatform) IsEnabled() bool {
 // ConfigureContainer configures the IoC container for the default platform components
 func (p *DefaultPlatform) ConfigureContainer(container *ioc.NestedContainer) error {
 	// Tools
-	container.MustRegisterSingleton(terraform.NewTerraformCli)
+	container.MustRegisterSingleton(terraform.NewCli)
 	container.MustRegisterSingleton(bicep.NewCli)
 
 	// Provisioning Providers

--- a/cli/azd/pkg/github/remote.go
+++ b/cli/azd/pkg/github/remote.go
@@ -18,7 +18,7 @@ var gitHubRemoteHttpsUrlRegex = regexp.MustCompile(`^https://(?:www\.)?github\.c
 // `repositoryPath` has a remote and it is configured with a
 // URL for a repository hosted on GitHub.
 // It returns the repository slug `(<organization>/<repo>)`.
-func EnsureRemote(ctx context.Context, repositoryPath string, remoteName string, gitCli git.GitCli) (string, error) {
+func EnsureRemote(ctx context.Context, repositoryPath string, remoteName string, gitCli *git.Cli) (string, error) {
 	remoteUrl, err := gitCli.GetRemoteUrl(ctx, repositoryPath, remoteName)
 	if err != nil {
 		return "", fmt.Errorf("failed to get remote url: %w", err)

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -33,7 +33,7 @@ type TerraformProvider struct {
 	env          *environment.Environment
 	prompters    prompt.Prompter
 	console      input.Console
-	cli          terraform.TerraformCli
+	cli          *terraform.Cli
 	curPrincipal CurrentPrincipalIdProvider
 	projectPath  string
 	options      Options
@@ -56,7 +56,7 @@ func (t *TerraformProvider) RequiredExternalTools() []tools.ExternalTool {
 
 // NewTerraformProvider creates a new instance of a Terraform Infra provider
 func NewTerraformProvider(
-	cli terraform.TerraformCli,
+	cli *terraform.Cli,
 	envManager environment.Manager,
 	env *environment.Environment,
 	console input.Console,

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
@@ -129,7 +129,7 @@ func createTerraformProvider(t *testing.T, mockContext *mocks.MockContext) *Terr
 	envManager.On("Save", mock.Anything, mock.Anything).Return(nil)
 
 	provider := NewTerraformProvider(
-		terraformTools.NewTerraformCli(mockContext.CommandRunner),
+		terraformTools.NewCli(mockContext.CommandRunner),
 		envManager,
 		env,
 		mockContext.Console,

--- a/cli/azd/pkg/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/pipeline/azdo_provider.go
@@ -38,7 +38,7 @@ type AzdoScmProvider struct {
 	azdoConnection *azuredevops.Connection
 	commandRunner  exec.CommandRunner
 	console        input.Console
-	gitCli         git.GitCli
+	gitCli         *git.Cli
 }
 
 func NewAzdoScmProvider(
@@ -47,7 +47,7 @@ func NewAzdoScmProvider(
 	azdContext *azdcontext.AzdContext,
 	commandRunner exec.CommandRunner,
 	console input.Console,
-	gitCli git.GitCli,
+	gitCli *git.Cli,
 ) ScmProvider {
 	return &AzdoScmProvider{
 		envManager:    envManager,

--- a/cli/azd/pkg/pipeline/github_provider.go
+++ b/cli/azd/pkg/pipeline/github_provider.go
@@ -36,13 +36,13 @@ import (
 type GitHubScmProvider struct {
 	newGitHubRepoCreated bool
 	console              input.Console
-	ghCli                github.GitHubCli
+	ghCli                *github.Cli
 	gitCli               *git.Cli
 }
 
 func NewGitHubScmProvider(
 	console input.Console,
-	ghCli github.GitHubCli,
+	ghCli *github.Cli,
 	gitCli *git.Cli,
 ) ScmProvider {
 	return &GitHubScmProvider{
@@ -315,7 +315,7 @@ type GitHubCiProvider struct {
 	env                *environment.Environment
 	credentialProvider account.SubscriptionCredentialProvider
 	entraIdService     entraid.EntraIdService
-	ghCli              github.GitHubCli
+	ghCli              *github.Cli
 	gitCli             *git.Cli
 	console            input.Console
 	httpClient         httputil.HttpClient
@@ -325,7 +325,7 @@ func NewGitHubCiProvider(
 	env *environment.Environment,
 	credentialProvider account.SubscriptionCredentialProvider,
 	entraIdService entraid.EntraIdService,
-	ghCli github.GitHubCli,
+	ghCli *github.Cli,
 	gitCli *git.Cli,
 	console input.Console,
 	httpClient httputil.HttpClient) CiProvider {
@@ -736,7 +736,7 @@ func (w *workflow) url() string {
 func ensureGitHubLogin(
 	ctx context.Context,
 	projectPath string,
-	ghCli github.GitHubCli,
+	ghCli *github.Cli,
 	gitCli *git.Cli,
 	hostname string,
 	console input.Console) (bool, error) {
@@ -787,7 +787,7 @@ func ensureGitHubLogin(
 
 // getRemoteUrlFromExisting let user to select an existing repository from his/her account and
 // returns the remote url for that repository.
-func getRemoteUrlFromExisting(ctx context.Context, ghCli github.GitHubCli, console input.Console) (string, error) {
+func getRemoteUrlFromExisting(ctx context.Context, ghCli *github.Cli, console input.Console) (string, error) {
 	repos, err := ghCli.ListRepositories(ctx)
 	if err != nil {
 		return "", fmt.Errorf("listing existing repositories: %w", err)
@@ -816,7 +816,7 @@ func getRemoteUrlFromExisting(ctx context.Context, ghCli github.GitHubCli, conso
 
 // selectRemoteUrl let user to type and enter the url from an existing GitHub repo.
 // If the url is valid, the remote url is returned. Otherwise an error is returned.
-func selectRemoteUrl(ctx context.Context, ghCli github.GitHubCli, repo github.GhCliRepository) (string, error) {
+func selectRemoteUrl(ctx context.Context, ghCli *github.Cli, repo github.GhCliRepository) (string, error) {
 	protocolType, err := ghCli.GetGitProtocolType(ctx)
 	if err != nil {
 		return "", fmt.Errorf("detecting default protocol: %w", err)
@@ -835,7 +835,7 @@ func selectRemoteUrl(ctx context.Context, ghCli github.GitHubCli, repo github.Gh
 // getRemoteUrlFromNewRepository creates a new repository on GitHub and returns its remote url
 func getRemoteUrlFromNewRepository(
 	ctx context.Context,
-	ghCli github.GitHubCli,
+	ghCli *github.Cli,
 	currentPathName string,
 	console input.Console,
 ) (string, error) {

--- a/cli/azd/pkg/pipeline/github_provider.go
+++ b/cli/azd/pkg/pipeline/github_provider.go
@@ -37,13 +37,13 @@ type GitHubScmProvider struct {
 	newGitHubRepoCreated bool
 	console              input.Console
 	ghCli                github.GitHubCli
-	gitCli               git.GitCli
+	gitCli               *git.Cli
 }
 
 func NewGitHubScmProvider(
 	console input.Console,
 	ghCli github.GitHubCli,
-	gitCli git.GitCli,
+	gitCli *git.Cli,
 ) ScmProvider {
 	return &GitHubScmProvider{
 		console: console,
@@ -316,7 +316,7 @@ type GitHubCiProvider struct {
 	credentialProvider account.SubscriptionCredentialProvider
 	entraIdService     entraid.EntraIdService
 	ghCli              github.GitHubCli
-	gitCli             git.GitCli
+	gitCli             *git.Cli
 	console            input.Console
 	httpClient         httputil.HttpClient
 }
@@ -326,7 +326,7 @@ func NewGitHubCiProvider(
 	credentialProvider account.SubscriptionCredentialProvider,
 	entraIdService entraid.EntraIdService,
 	ghCli github.GitHubCli,
-	gitCli git.GitCli,
+	gitCli *git.Cli,
 	console input.Console,
 	httpClient httputil.HttpClient) CiProvider {
 	return &GitHubCiProvider{
@@ -737,7 +737,7 @@ func ensureGitHubLogin(
 	ctx context.Context,
 	projectPath string,
 	ghCli github.GitHubCli,
-	gitCli git.GitCli,
+	gitCli *git.Cli,
 	hostname string,
 	console input.Console) (bool, error) {
 	authResult, err := ghCli.GetAuthStatus(ctx, hostname)

--- a/cli/azd/pkg/pipeline/github_provider_test.go
+++ b/cli/azd/pkg/pipeline/github_provider_test.go
@@ -127,7 +127,7 @@ func createGitHubCiProvider(t *testing.T, mockContext *mocks.MockContext) CiProv
 			mockContext.CoreClientOptions,
 		),
 		ghCli,
-		git.NewGitCli(mockContext.CommandRunner),
+		git.NewCli(mockContext.CommandRunner),
 		mockContext.Console,
 		mockContext.HttpClient,
 	)

--- a/cli/azd/pkg/pipeline/github_provider_test.go
+++ b/cli/azd/pkg/pipeline/github_provider_test.go
@@ -143,6 +143,6 @@ func setupGithubCliMocks(mockContext *mocks.MockContext) {
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 		return strings.Contains(command, "--version")
 	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-		return exec.NewRunResult(0, fmt.Sprintf("gh version %s", github.GitHubCliVersion), ""), nil
+		return exec.NewRunResult(0, fmt.Sprintf("gh version %s", github.Version), ""), nil
 	})
 }

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -86,7 +86,7 @@ type PipelineManager struct {
 	azdCtx            *azdcontext.AzdContext
 	env               *environment.Environment
 	entraIdService    entraid.EntraIdService
-	gitCli            git.GitCli
+	gitCli            *git.Cli
 	console           input.Console
 	serviceLocator    ioc.ServiceLocator
 	importManager     *project.ImportManager
@@ -99,7 +99,7 @@ func NewPipelineManager(
 	ctx context.Context,
 	envManager environment.Manager,
 	entraIdService entraid.EntraIdService,
-	gitCli git.GitCli,
+	gitCli *git.Cli,
 	azdCtx *azdcontext.AzdContext,
 	env *environment.Environment,
 	console input.Console,

--- a/cli/azd/pkg/pipeline/pipeline_manager_test.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager_test.go
@@ -445,7 +445,7 @@ func createPipelineManager(
 		mockContext.SubscriptionCredentialProvider,
 	)
 	mockContext.Container.MustRegisterSingleton(github.NewGitHubCli)
-	mockContext.Container.MustRegisterSingleton(git.NewGitCli)
+	mockContext.Container.MustRegisterSingleton(git.NewCli)
 
 	// Pipeline providers
 	pipelineProviderMap := map[string]any{
@@ -463,7 +463,7 @@ func createPipelineManager(
 		*mockContext.Context,
 		envManager,
 		entraIdService,
-		git.NewGitCli(mockContext.CommandRunner),
+		git.NewCli(mockContext.CommandRunner),
 		azdContext,
 		env,
 		mockContext.Console,

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -24,7 +24,7 @@ type ContainerHelper struct {
 	env                      *environment.Environment
 	envManager               environment.Manager
 	containerRegistryService azcli.ContainerRegistryService
-	docker                   docker.Docker
+	docker                   *docker.Cli
 	clock                    clock.Clock
 	cloud                    *cloud.Cloud
 }
@@ -34,7 +34,7 @@ func NewContainerHelper(
 	envManager environment.Manager,
 	clock clock.Clock,
 	containerRegistryService azcli.ContainerRegistryService,
-	docker docker.Docker,
+	docker *docker.Cli,
 	cloud *cloud.Cloud,
 ) *ContainerHelper {
 	return &ContainerHelper{

--- a/cli/azd/pkg/project/container_helper_test.go
+++ b/cli/azd/pkg/project/container_helper_test.go
@@ -333,7 +333,7 @@ func Test_ContainerHelper_Deploy(t *testing.T) {
 			mockContext := mocks.NewMockContext(context.Background())
 			mockResults := setupDockerMocks(mockContext)
 			env := environment.NewWithValues("dev", map[string]string{})
-			dockerCli := docker.NewDocker(mockContext.CommandRunner)
+			dockerCli := docker.NewCli(mockContext.CommandRunner)
 			envManager := &mockenv.MockEnvManager{}
 			envManager.On("Save", *mockContext.Context, env).Return(nil)
 

--- a/cli/azd/pkg/project/dotnet_importer.go
+++ b/cli/azd/pkg/project/dotnet_importer.go
@@ -31,7 +31,7 @@ type hostCheckResult struct {
 
 // DotNetImporter is an importer that is able to import projects and infrastructure from a manifest produced by a .NET App.
 type DotNetImporter struct {
-	dotnetCli           dotnet.DotNetCli
+	dotnetCli           *dotnet.Cli
 	console             input.Console
 	lazyEnv             *lazy.Lazy[*environment.Environment]
 	lazyEnvManager      *lazy.Lazy[environment.Manager]
@@ -56,7 +56,7 @@ type manifestCacheKey struct {
 }
 
 func NewDotNetImporter(
-	dotnetCli dotnet.DotNetCli,
+	dotnetCli *dotnet.Cli,
 	console input.Console,
 	lazyEnv *lazy.Lazy[*environment.Environment],
 	lazyEnvManager *lazy.Lazy[environment.Manager],

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -108,7 +108,7 @@ func (dpr *dockerPackageResult) MarshalJSON() ([]byte, error) {
 
 type dockerProject struct {
 	env                 *environment.Environment
-	docker              docker.Docker
+	docker              *docker.Cli
 	framework           FrameworkService
 	containerHelper     *ContainerHelper
 	console             input.Console
@@ -120,7 +120,7 @@ type dockerProject struct {
 // leverages docker for building
 func NewDockerProject(
 	env *environment.Environment,
-	docker docker.Docker,
+	docker *docker.Cli,
 	containerHelper *ContainerHelper,
 	console input.Console,
 	alphaFeatureManager *alpha.FeatureManager,
@@ -142,7 +142,7 @@ func NewDockerProject(
 // of a CompositeFrameworkService as [NewDockerProject] does.
 func NewDockerProjectAsFrameworkService(
 	env *environment.Environment,
-	docker docker.Docker,
+	docker *docker.Cli,
 	containerHelper *ContainerHelper,
 	console input.Console,
 	alphaFeatureManager *alpha.FeatureManager,

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -378,7 +378,7 @@ func (p *dockerProject) packBuild(
 	svc *ServiceConfig,
 	dockerOptions DockerProjectOptions,
 	imageName string) (*ServiceBuildResult, error) {
-	packCli, err := pack.NewPackCli(ctx, p.console, p.commandRunner)
+	packCli, err := pack.NewCli(ctx, p.console, p.commandRunner)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -98,7 +98,7 @@ services:
 	err = os.WriteFile(filepath.Join(temp, "Dockerfile"), []byte("FROM node:14"), 0600)
 	require.NoError(t, err)
 
-	npmCli := npm.NewNpmCli(mockContext.CommandRunner)
+	npmCli := npm.NewCli(mockContext.CommandRunner)
 	docker := docker.NewCli(mockContext.CommandRunner)
 
 	internalFramework := NewNpmProject(npmCli, env)
@@ -192,7 +192,7 @@ services:
 		}, nil
 	})
 
-	npmCli := npm.NewNpmCli(mockContext.CommandRunner)
+	npmCli := npm.NewCli(mockContext.CommandRunner)
 	docker := docker.NewCli(mockContext.CommandRunner)
 
 	projectConfig, err := Parse(*mockContext.Context, testProj)
@@ -416,7 +416,7 @@ func Test_DockerProject_Build(t *testing.T) {
 				mockContext.CommandRunner)
 
 			if tt.language == ServiceLanguageTypeScript || tt.language == ServiceLanguageJavaScript {
-				npmProject := NewNpmProject(npm.NewNpmCli(mockContext.CommandRunner), env)
+				npmProject := NewNpmProject(npm.NewCli(mockContext.CommandRunner), env)
 				dockerProject.SetSource(npmProject)
 			}
 
@@ -537,7 +537,7 @@ func Test_DockerProject_Package(t *testing.T) {
 			serviceConfig.Image = tt.image
 
 			if serviceConfig.RelativePath != "" {
-				npmProject := NewNpmProject(npm.NewNpmCli(mockContext.CommandRunner), env)
+				npmProject := NewNpmProject(npm.NewCli(mockContext.CommandRunner), env)
 				dockerProject.SetSource(npmProject)
 			}
 

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -99,7 +99,7 @@ services:
 	require.NoError(t, err)
 
 	npmCli := npm.NewNpmCli(mockContext.CommandRunner)
-	docker := docker.NewDocker(mockContext.CommandRunner)
+	docker := docker.NewCli(mockContext.CommandRunner)
 
 	internalFramework := NewNpmProject(npmCli, env)
 	progressMessages := []string{}
@@ -193,7 +193,7 @@ services:
 	})
 
 	npmCli := npm.NewNpmCli(mockContext.CommandRunner)
-	docker := docker.NewDocker(mockContext.CommandRunner)
+	docker := docker.NewCli(mockContext.CommandRunner)
 
 	projectConfig, err := Parse(*mockContext.Context, testProj)
 	require.NoError(t, err)
@@ -388,7 +388,7 @@ func Test_DockerProject_Build(t *testing.T) {
 			temp := t.TempDir()
 
 			env := environment.New("test")
-			dockerCli := docker.NewDocker(mockContext.CommandRunner)
+			dockerCli := docker.NewCli(mockContext.CommandRunner)
 			serviceConfig := createTestServiceConfig(tt.project, ContainerAppTarget, tt.language)
 			serviceConfig.Project.Path = temp
 			serviceConfig.Docker = tt.dockerOptions
@@ -520,7 +520,7 @@ func Test_DockerProject_Package(t *testing.T) {
 			envManager := &mockenv.MockEnvManager{}
 
 			env := environment.NewWithValues("test", map[string]string{})
-			dockerCli := docker.NewDocker(mockContext.CommandRunner)
+			dockerCli := docker.NewCli(mockContext.CommandRunner)
 			serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
 
 			dockerProject := NewDockerProject(

--- a/cli/azd/pkg/project/framework_service_dotnet.go
+++ b/cli/azd/pkg/project/framework_service_dotnet.go
@@ -24,12 +24,12 @@ const (
 
 type dotnetProject struct {
 	env       *environment.Environment
-	dotnetCli dotnet.DotNetCli
+	dotnetCli *dotnet.Cli
 }
 
 // NewDotNetProject creates a new instance of a dotnet project
 func NewDotNetProject(
-	dotNetCli dotnet.DotNetCli,
+	dotNetCli *dotnet.Cli,
 	env *environment.Environment,
 ) FrameworkService {
 	return &dotnetProject{

--- a/cli/azd/pkg/project/framework_service_dotnet_test.go
+++ b/cli/azd/pkg/project/framework_service_dotnet_test.go
@@ -48,7 +48,7 @@ func TestBicepOutputsWithDoubleUnderscoresAreConverted(t *testing.T) {
 		RelativePath: "",
 	}
 
-	dotNetCli := dotnet.NewDotNetCli(mockContext.CommandRunner)
+	dotNetCli := dotnet.NewCli(mockContext.CommandRunner)
 	dp := NewDotNetProject(dotNetCli, environment.New("test")).(*dotnetProject)
 
 	err := dp.setUserSecretsFromOutputs(*mockContext.Context, serviceConfig, ServiceLifecycleEventArgs{
@@ -94,7 +94,7 @@ func Test_DotNetProject_Init(t *testing.T) {
 	})
 
 	env := environment.New("test")
-	dotNetCli := dotnet.NewDotNetCli(mockContext.CommandRunner)
+	dotNetCli := dotnet.NewCli(mockContext.CommandRunner)
 	serviceConfig := createTestServiceConfig("./src/api/test.csproj", AppServiceTarget, ServiceLanguageDotNet)
 
 	dotnetProject := NewDotNetProject(dotNetCli, env)
@@ -146,7 +146,7 @@ func Test_DotNetProject_Restore(t *testing.T) {
 		})
 
 	env := environment.New("test")
-	dotNetCli := dotnet.NewDotNetCli(mockContext.CommandRunner)
+	dotNetCli := dotnet.NewCli(mockContext.CommandRunner)
 	serviceConfig := createTestServiceConfig("./src/api/test.csproj", AppServiceTarget, ServiceLanguageCsharp)
 
 	dotnetProject := NewDotNetProject(dotNetCli, env)
@@ -186,7 +186,7 @@ func Test_DotNetProject_Build(t *testing.T) {
 		})
 
 	env := environment.New("test")
-	dotNetCli := dotnet.NewDotNetCli(mockContext.CommandRunner)
+	dotNetCli := dotnet.NewCli(mockContext.CommandRunner)
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageCsharp)
 
 	buildOutputDir := filepath.Join(serviceConfig.Path(), "bin", "Release", "net8.0")
@@ -246,7 +246,7 @@ func Test_DotNetProject_Package(t *testing.T) {
 		})
 
 	env := environment.New("test")
-	dotNetCli := dotnet.NewDotNetCli(mockContext.CommandRunner)
+	dotNetCli := dotnet.NewCli(mockContext.CommandRunner)
 	serviceConfig := createTestServiceConfig("./src/api/test3.csproj", AppServiceTarget, ServiceLanguageCsharp)
 
 	dotnetProject := NewDotNetProject(dotNetCli, env)

--- a/cli/azd/pkg/project/framework_service_maven.go
+++ b/cli/azd/pkg/project/framework_service_maven.go
@@ -21,11 +21,11 @@ const AppServiceJavaPackageName = "app"
 type mavenProject struct {
 	env      *environment.Environment
 	mavenCli maven.MavenCli
-	javacCli javac.JavacCli
+	javacCli *javac.Cli
 }
 
 // NewMavenProject creates a new instance of a maven project
-func NewMavenProject(env *environment.Environment, mavenCli maven.MavenCli, javaCli javac.JavacCli) FrameworkService {
+func NewMavenProject(env *environment.Environment, mavenCli maven.MavenCli, javaCli *javac.Cli) FrameworkService {
 	return &mavenProject{
 		env:      env,
 		mavenCli: mavenCli,

--- a/cli/azd/pkg/project/framework_service_maven.go
+++ b/cli/azd/pkg/project/framework_service_maven.go
@@ -20,12 +20,12 @@ const AppServiceJavaPackageName = "app"
 
 type mavenProject struct {
 	env      *environment.Environment
-	mavenCli maven.MavenCli
+	mavenCli *maven.Cli
 	javacCli *javac.Cli
 }
 
 // NewMavenProject creates a new instance of a maven project
-func NewMavenProject(env *environment.Environment, mavenCli maven.MavenCli, javaCli *javac.Cli) FrameworkService {
+func NewMavenProject(env *environment.Environment, mavenCli *maven.Cli, javaCli *javac.Cli) FrameworkService {
 	return &mavenProject{
 		env:      env,
 		mavenCli: mavenCli,

--- a/cli/azd/pkg/project/framework_service_maven_test.go
+++ b/cli/azd/pkg/project/framework_service_maven_test.go
@@ -43,7 +43,7 @@ func Test_MavenProject(t *testing.T) {
 
 		env := environment.New("test")
 		serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageJava)
-		mavenCli := maven.NewMavenCli(mockContext.CommandRunner)
+		mavenCli := maven.NewCli(mockContext.CommandRunner)
 		javaCli := javac.NewCli(mockContext.CommandRunner)
 
 		mavenProject := NewMavenProject(env, mavenCli, javaCli)
@@ -79,7 +79,7 @@ func Test_MavenProject(t *testing.T) {
 
 		env := environment.New("test")
 		serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageJava)
-		mavenCli := maven.NewMavenCli(mockContext.CommandRunner)
+		mavenCli := maven.NewCli(mockContext.CommandRunner)
 		javaCli := javac.NewCli(mockContext.CommandRunner)
 
 		mavenProject := NewMavenProject(env, mavenCli, javaCli)
@@ -116,7 +116,7 @@ func Test_MavenProject(t *testing.T) {
 
 		env := environment.New("test")
 		serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageJava)
-		mavenCli := maven.NewMavenCli(mockContext.CommandRunner)
+		mavenCli := maven.NewCli(mockContext.CommandRunner)
 		javaCli := javac.NewCli(mockContext.CommandRunner)
 
 		// Simulate a build output with a jar file
@@ -286,7 +286,7 @@ func Test_MavenProject_Package(t *testing.T) {
 				})
 
 			env := environment.New("test")
-			mavenCli := maven.NewMavenCli(mockContext.CommandRunner)
+			mavenCli := maven.NewCli(mockContext.CommandRunner)
 			javaCli := javac.NewCli(mockContext.CommandRunner)
 			mavenProject := NewMavenProject(env, mavenCli, javaCli)
 			err = mavenProject.Initialize(*mockContext.Context, tt.args.svc)

--- a/cli/azd/pkg/project/framework_service_npm.go
+++ b/cli/azd/pkg/project/framework_service_npm.go
@@ -17,11 +17,11 @@ import (
 
 type npmProject struct {
 	env *environment.Environment
-	cli npm.NpmCli
+	cli *npm.Cli
 }
 
 // NewNpmProject creates a new instance of a NPM project
-func NewNpmProject(cli npm.NpmCli, env *environment.Environment) FrameworkService {
+func NewNpmProject(cli *npm.Cli, env *environment.Environment) FrameworkService {
 	return &npmProject{
 		env: env,
 		cli: cli,

--- a/cli/azd/pkg/project/framework_service_npm_test.go
+++ b/cli/azd/pkg/project/framework_service_npm_test.go
@@ -31,7 +31,7 @@ func Test_NpmProject_Restore(t *testing.T) {
 		})
 
 	env := environment.New("test")
-	npmCli := npm.NewNpmCli(mockContext.CommandRunner)
+	npmCli := npm.NewCli(mockContext.CommandRunner)
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageTypeScript)
 
 	npmProject := NewNpmProject(npmCli, env)
@@ -63,7 +63,7 @@ func Test_NpmProject_Build(t *testing.T) {
 		})
 
 	env := environment.New("test")
-	npmCli := npm.NewNpmCli(mockContext.CommandRunner)
+	npmCli := npm.NewCli(mockContext.CommandRunner)
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageTypeScript)
 
 	npmProject := NewNpmProject(npmCli, env)
@@ -99,7 +99,7 @@ func Test_NpmProject_Package(t *testing.T) {
 		})
 
 	env := environment.New("test")
-	npmCli := npm.NewNpmCli(mockContext.CommandRunner)
+	npmCli := npm.NewCli(mockContext.CommandRunner)
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguageTypeScript)
 	err := os.MkdirAll(serviceConfig.Path(), osutil.PermissionDirectory)
 	require.NoError(t, err)

--- a/cli/azd/pkg/project/framework_service_python.go
+++ b/cli/azd/pkg/project/framework_service_python.go
@@ -19,11 +19,11 @@ import (
 
 type pythonProject struct {
 	env *environment.Environment
-	cli *python.PythonCli
+	cli *python.Cli
 }
 
 // NewPythonProject creates a new instance of the Python project
-func NewPythonProject(cli *python.PythonCli, env *environment.Environment) FrameworkService {
+func NewPythonProject(cli *python.Cli, env *environment.Environment) FrameworkService {
 	return &pythonProject{
 		env: env,
 		cli: cli,

--- a/cli/azd/pkg/project/framework_service_python_test.go
+++ b/cli/azd/pkg/project/framework_service_python_test.go
@@ -45,7 +45,7 @@ func Test_PythonProject_Restore(t *testing.T) {
 		})
 
 	env := environment.New("test")
-	pythonCli := python.NewPythonCli(mockContext.CommandRunner)
+	pythonCli := python.NewCli(mockContext.CommandRunner)
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguagePython)
 
 	pythonProject := NewPythonProject(pythonCli, env)
@@ -77,7 +77,7 @@ func Test_PythonProject_Build(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 
 	env := environment.New("test")
-	pythonCli := python.NewPythonCli(mockContext.CommandRunner)
+	pythonCli := python.NewCli(mockContext.CommandRunner)
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguagePython)
 
 	pythonProject := NewPythonProject(pythonCli, env)
@@ -97,7 +97,7 @@ func Test_PythonProject_Package(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 
 	env := environment.New("test")
-	pythonCli := python.NewPythonCli(mockContext.CommandRunner)
+	pythonCli := python.NewCli(mockContext.CommandRunner)
 	serviceConfig := createTestServiceConfig("./src/api", AppServiceTarget, ServiceLanguagePython)
 	err := os.MkdirAll(serviceConfig.Path(), osutil.PermissionDirectory)
 	require.NoError(t, err)

--- a/cli/azd/pkg/project/framework_service_swa.go
+++ b/cli/azd/pkg/project/framework_service_swa.go
@@ -18,7 +18,7 @@ type swaProject struct {
 	env           *environment.Environment
 	console       input.Console
 	commandRunner exec.CommandRunner
-	swa           swa.SwaCli
+	swa           *swa.Cli
 	framework     FrameworkService
 }
 
@@ -28,7 +28,7 @@ func NewSwaProject(
 	env *environment.Environment,
 	console input.Console,
 	commandRunner exec.CommandRunner,
-	swa swa.SwaCli,
+	swa *swa.Cli,
 	framework FrameworkService,
 ) CompositeFrameworkService {
 	return &swaProject{
@@ -47,7 +47,7 @@ func NewSwaProjectAsFrameworkService(
 	env *environment.Environment,
 	console input.Console,
 	commandRunner exec.CommandRunner,
-	swa swa.SwaCli,
+	swa *swa.Cli,
 	framework FrameworkService,
 ) FrameworkService {
 	return NewSwaProject(env, console, commandRunner, swa, framework)

--- a/cli/azd/pkg/project/importer_test.go
+++ b/cli/azd/pkg/project/importer_test.go
@@ -33,7 +33,7 @@ func TestImportManagerHasService(t *testing.T) {
 	mockEnv.On("Save", mock.Anything, mock.Anything).Return(nil)
 
 	manager := NewImportManager(&DotNetImporter{
-		dotnetCli: dotnet.NewDotNetCli(mockContext.CommandRunner),
+		dotnetCli: dotnet.NewCli(mockContext.CommandRunner),
 		console:   mockContext.Console,
 		lazyEnv: lazy.NewLazy(func() (*environment.Environment, error) {
 			return environment.NewWithValues("env", map[string]string{}), nil
@@ -74,7 +74,7 @@ func TestImportManagerHasServiceErrorNoMultipleServicesWithAppHost(t *testing.T)
 	mockEnv.On("Save", mock.Anything, mock.Anything).Return(nil)
 
 	manager := NewImportManager(&DotNetImporter{
-		dotnetCli: dotnet.NewDotNetCli(mockContext.CommandRunner),
+		dotnetCli: dotnet.NewCli(mockContext.CommandRunner),
 		console:   mockContext.Console,
 		lazyEnv: lazy.NewLazy(func() (*environment.Environment, error) {
 			return environment.NewWithValues("env", map[string]string{}), nil
@@ -127,7 +127,7 @@ func TestImportManagerHasServiceErrorAppHostMustTargetContainerApp(t *testing.T)
 	mockEnv.On("Save", mock.Anything, mock.Anything).Return(nil)
 
 	manager := NewImportManager(&DotNetImporter{
-		dotnetCli: dotnet.NewDotNetCli(mockContext.CommandRunner),
+		dotnetCli: dotnet.NewCli(mockContext.CommandRunner),
 		console:   mockContext.Console,
 		lazyEnv: lazy.NewLazy(func() (*environment.Environment, error) {
 			return environment.NewWithValues("env", map[string]string{}), nil
@@ -173,7 +173,7 @@ func TestImportManagerProjectInfrastructureDefaults(t *testing.T) {
 	mockEnv.On("Save", mock.Anything, mock.Anything).Return(nil)
 
 	manager := NewImportManager(&DotNetImporter{
-		dotnetCli: dotnet.NewDotNetCli(mockContext.CommandRunner),
+		dotnetCli: dotnet.NewCli(mockContext.CommandRunner),
 		console:   mockContext.Console,
 		lazyEnv: lazy.NewLazy(func() (*environment.Environment, error) {
 			return environment.NewWithValues("env", map[string]string{}), nil
@@ -222,7 +222,7 @@ func TestImportManagerProjectInfrastructure(t *testing.T) {
 	mockEnv.On("Save", mock.Anything, mock.Anything).Return(nil)
 
 	manager := NewImportManager(&DotNetImporter{
-		dotnetCli: dotnet.NewDotNetCli(mockContext.CommandRunner),
+		dotnetCli: dotnet.NewCli(mockContext.CommandRunner),
 		console:   mockContext.Console,
 		lazyEnv: lazy.NewLazy(func() (*environment.Environment, error) {
 			return environment.NewWithValues("env", map[string]string{}), nil
@@ -300,7 +300,7 @@ func TestImportManagerProjectInfrastructureAspire(t *testing.T) {
 	})
 
 	manager := NewImportManager(&DotNetImporter{
-		dotnetCli: dotnet.NewDotNetCli(mockContext.CommandRunner),
+		dotnetCli: dotnet.NewCli(mockContext.CommandRunner),
 		console:   mockContext.Console,
 		lazyEnv: lazy.NewLazy(func() (*environment.Environment, error) {
 			return environment.NewWithValues("env", map[string]string{

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -83,7 +83,7 @@ type aksTarget struct {
 	console                input.Console
 	managedClustersService azcli.ManagedClustersService
 	resourceManager        ResourceManager
-	kubectl                kubectl.KubectlCli
+	kubectl                *kubectl.Cli
 	kubeLoginCli           *kubelogin.Cli
 	helmCli                *helm.Cli
 	kustomizeCli           *kustomize.Cli
@@ -98,7 +98,7 @@ func NewAksTarget(
 	console input.Console,
 	managedClustersService azcli.ManagedClustersService,
 	resourceManager ResourceManager,
-	kubectlCli kubectl.KubectlCli,
+	kubectlCli *kubectl.Cli,
 	kubeLoginCli *kubelogin.Cli,
 	helmCli *helm.Cli,
 	kustomizeCli *kustomize.Cli,

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -70,7 +70,7 @@ func Test_Required_Tools(t *testing.T) {
 	requiredTools := serviceTarget.RequiredExternalTools(*mockContext.Context)
 	require.Len(t, requiredTools, 2)
 	require.IsType(t, &docker.Cli{}, requiredTools[0])
-	require.Implements(t, new(kubectl.KubectlCli), requiredTools[1])
+	require.IsType(t, &kubectl.Cli{}, requiredTools[1])
 }
 
 func Test_Required_Tools_WithAlpha(t *testing.T) {
@@ -92,7 +92,7 @@ func Test_Required_Tools_WithAlpha(t *testing.T) {
 	requiredTools := serviceTarget.RequiredExternalTools(*mockContext.Context)
 	require.Len(t, requiredTools, 4)
 	require.IsType(t, &docker.Cli{}, requiredTools[0])
-	require.Implements(t, new(kubectl.KubectlCli), requiredTools[1])
+	require.IsType(t, &kubectl.Cli{}, requiredTools[1])
 	require.IsType(t, &helm.Cli{}, requiredTools[2])
 	require.IsType(t, &kustomize.Cli{}, requiredTools[3])
 }
@@ -806,7 +806,7 @@ func createAksServiceTarget(
 	env *environment.Environment,
 	userConfig config.Config,
 ) ServiceTarget {
-	kubeCtl := kubectl.NewKubectl(mockContext.CommandRunner)
+	kubeCtl := kubectl.NewCli(mockContext.CommandRunner)
 	helmCli := helm.NewCli(mockContext.CommandRunner)
 	kustomizeCli := kustomize.NewCli(mockContext.CommandRunner)
 	dockerCli := docker.NewCli(mockContext.CommandRunner)

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -69,7 +69,7 @@ func Test_Required_Tools(t *testing.T) {
 
 	requiredTools := serviceTarget.RequiredExternalTools(*mockContext.Context)
 	require.Len(t, requiredTools, 2)
-	require.Implements(t, new(docker.Docker), requiredTools[0])
+	require.IsType(t, &docker.Cli{}, requiredTools[0])
 	require.Implements(t, new(kubectl.KubectlCli), requiredTools[1])
 }
 
@@ -91,7 +91,7 @@ func Test_Required_Tools_WithAlpha(t *testing.T) {
 
 	requiredTools := serviceTarget.RequiredExternalTools(*mockContext.Context)
 	require.Len(t, requiredTools, 4)
-	require.Implements(t, new(docker.Docker), requiredTools[0])
+	require.IsType(t, &docker.Cli{}, requiredTools[0])
 	require.Implements(t, new(kubectl.KubectlCli), requiredTools[1])
 	require.IsType(t, &helm.Cli{}, requiredTools[2])
 	require.IsType(t, &kustomize.Cli{}, requiredTools[3])
@@ -809,7 +809,7 @@ func createAksServiceTarget(
 	kubeCtl := kubectl.NewKubectl(mockContext.CommandRunner)
 	helmCli := helm.NewCli(mockContext.CommandRunner)
 	kustomizeCli := kustomize.NewCli(mockContext.CommandRunner)
-	dockerCli := docker.NewDocker(mockContext.CommandRunner)
+	dockerCli := docker.NewCli(mockContext.CommandRunner)
 	kubeLoginCli := kubelogin.NewCli(mockContext.CommandRunner)
 	credentialProvider := mockaccount.SubscriptionCredentialProviderFunc(
 		func(_ context.Context, _ string) (azcore.TokenCredential, error) {

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -132,7 +132,7 @@ func createContainerAppServiceTarget(
 	serviceConfig *ServiceConfig,
 	env *environment.Environment,
 ) ServiceTarget {
-	dockerCli := docker.NewDocker(mockContext.CommandRunner)
+	dockerCli := docker.NewCli(mockContext.CommandRunner)
 	credentialProvider := mockaccount.SubscriptionCredentialProviderFunc(
 		func(_ context.Context, _ string) (azcore.TokenCredential, error) {
 			return mockContext.Credentials, nil

--- a/cli/azd/pkg/project/service_target_dotnet_containerapp.go
+++ b/cli/azd/pkg/project/service_target_dotnet_containerapp.go
@@ -32,7 +32,7 @@ type dotnetContainerAppTarget struct {
 	containerHelper     *ContainerHelper
 	containerAppService containerapps.ContainerAppService
 	resourceManager     ResourceManager
-	dotNetCli           dotnet.DotNetCli
+	dotNetCli           *dotnet.Cli
 	cosmosDbService     cosmosdb.CosmosDbService
 	sqlDbService        sqldb.SqlDbService
 	keyvaultService     keyvault.KeyVaultService
@@ -52,7 +52,7 @@ func NewDotNetContainerAppTarget(
 	containerHelper *ContainerHelper,
 	containerAppService containerapps.ContainerAppService,
 	resourceManager ResourceManager,
-	dotNetCli dotnet.DotNetCli,
+	dotNetCli *dotnet.Cli,
 	cosmosDbService cosmosdb.CosmosDbService,
 	sqlDbService sqldb.SqlDbService,
 	keyvaultService keyvault.KeyVaultService,

--- a/cli/azd/pkg/project/service_target_staticwebapp.go
+++ b/cli/azd/pkg/project/service_target_staticwebapp.go
@@ -26,14 +26,14 @@ const DefaultStaticWebAppEnvironmentName = "default"
 type staticWebAppTarget struct {
 	env *environment.Environment
 	cli azcli.AzCli
-	swa swa.SwaCli
+	swa *swa.Cli
 }
 
 // NewStaticWebAppTarget creates a new instance of the Static Web App target
 func NewStaticWebAppTarget(
 	env *environment.Environment,
 	azCli azcli.AzCli,
-	swaCli swa.SwaCli,
+	swaCli *swa.Cli,
 ) ServiceTarget {
 	return &staticWebAppTarget{
 		env: env,

--- a/cli/azd/pkg/tools/azcli/container_registry.go
+++ b/cli/azd/pkg/tools/azcli/container_registry.go
@@ -51,7 +51,7 @@ type ContainerRegistryService interface {
 
 type containerRegistryService struct {
 	credentialProvider account.SubscriptionCredentialProvider
-	docker             docker.Docker
+	docker             *docker.Cli
 	armClientOptions   *arm.ClientOptions
 	coreClientOptions  *azcore.ClientOptions
 }
@@ -59,7 +59,7 @@ type containerRegistryService struct {
 // Creates a new instance of the ContainerRegistryService
 func NewContainerRegistryService(
 	credentialProvider account.SubscriptionCredentialProvider,
-	docker docker.Docker,
+	docker *docker.Cli,
 	armClientOptions *arm.ClientOptions,
 	coreClientOptions *azcore.ClientOptions,
 ) ContainerRegistryService {

--- a/cli/azd/pkg/tools/docker/docker.go
+++ b/cli/azd/pkg/tools/docker/docker.go
@@ -18,39 +18,19 @@ import (
 
 const DefaultPlatform string = "linux/amd64"
 
-type Docker interface {
-	tools.ExternalTool
-	Login(ctx context.Context, loginServer string, username string, password string) error
-	Build(
-		ctx context.Context,
-		cwd string,
-		dockerFilePath string,
-		platform string,
-		target string,
-		buildContext string,
-		name string,
-		buildArgs []string,
-		buildSecrets []string,
-		buildEnv []string,
-		buildProgress io.Writer,
-	) (string, error)
-	Tag(ctx context.Context, cwd string, imageName string, tag string) error
-	Push(ctx context.Context, cwd string, tag string) error
-	Pull(ctx context.Context, imageName string) error
-	Inspect(ctx context.Context, imageName string, format string) (string, error)
-}
+var _ tools.ExternalTool = (*Cli)(nil)
 
-func NewDocker(commandRunner exec.CommandRunner) Docker {
-	return &docker{
+func NewCli(commandRunner exec.CommandRunner) *Cli {
+	return &Cli{
 		commandRunner: commandRunner,
 	}
 }
 
-type docker struct {
+type Cli struct {
 	commandRunner exec.CommandRunner
 }
 
-func (d *docker) Login(ctx context.Context, loginServer string, username string, password string) error {
+func (d *Cli) Login(ctx context.Context, loginServer string, username string, password string) error {
 	runArgs := exec.NewRunArgs(
 		"docker", "login",
 		"--username", username,
@@ -69,7 +49,7 @@ func (d *docker) Login(ctx context.Context, loginServer string, username string,
 // Runs a Docker build for a given Dockerfile, writing the output of docker build to [stdOut] when it is
 // not nil. If the platform is not specified (empty) it defaults to amd64. If the build is successful,
 // the function returns the image id of the built image.
-func (d *docker) Build(
+func (d *Cli) Build(
 	ctx context.Context,
 	cwd string,
 	dockerFilePath string,
@@ -145,7 +125,7 @@ func (d *docker) Build(
 	return strings.TrimSpace(string(imgId)), nil
 }
 
-func (d *docker) Tag(ctx context.Context, cwd string, imageName string, tag string) error {
+func (d *Cli) Tag(ctx context.Context, cwd string, imageName string, tag string) error {
 	_, err := d.executeCommand(ctx, cwd, "tag", imageName, tag)
 	if err != nil {
 		return fmt.Errorf("tagging image: %w", err)
@@ -154,7 +134,7 @@ func (d *docker) Tag(ctx context.Context, cwd string, imageName string, tag stri
 	return nil
 }
 
-func (d *docker) Push(ctx context.Context, cwd string, tag string) error {
+func (d *Cli) Push(ctx context.Context, cwd string, tag string) error {
 	_, err := d.executeCommand(ctx, cwd, "push", tag)
 	if err != nil {
 		return fmt.Errorf("pushing image: %w", err)
@@ -163,7 +143,7 @@ func (d *docker) Push(ctx context.Context, cwd string, tag string) error {
 	return nil
 }
 
-func (d *docker) Pull(ctx context.Context, imageName string) error {
+func (d *Cli) Pull(ctx context.Context, imageName string) error {
 	_, err := d.executeCommand(ctx, "", "pull", imageName)
 	if err != nil {
 		return fmt.Errorf("pulling image: %w", err)
@@ -172,7 +152,7 @@ func (d *docker) Pull(ctx context.Context, imageName string) error {
 	return nil
 }
 
-func (d *docker) Inspect(ctx context.Context, imageName string, format string) (string, error) {
+func (d *Cli) Inspect(ctx context.Context, imageName string, format string) (string, error) {
 	out, err := d.executeCommand(ctx, "", "image", "inspect", "--format", format, imageName)
 	if err != nil {
 		return "", fmt.Errorf("inspecting image: %w", err)
@@ -181,7 +161,7 @@ func (d *docker) Inspect(ctx context.Context, imageName string, format string) (
 	return out.Stdout, nil
 }
 
-func (d *docker) versionInfo() tools.VersionInfo {
+func (d *Cli) versionInfo() tools.VersionInfo {
 	return tools.VersionInfo{
 		MinimumVersion: semver.Version{
 			Major: 17,
@@ -266,7 +246,7 @@ func isSupportedDockerVersion(cliOutput string) (bool, error) {
 	// If we reach this point, we don't understand how to validate the version based on its scheme.
 	return false, fmt.Errorf("could not determine version from docker version string: %s", version)
 }
-func (d *docker) CheckInstalled(ctx context.Context) error {
+func (d *Cli) CheckInstalled(ctx context.Context) error {
 	err := tools.ToolInPath("docker")
 	if err != nil {
 		return err
@@ -286,15 +266,15 @@ func (d *docker) CheckInstalled(ctx context.Context) error {
 	return nil
 }
 
-func (d *docker) InstallUrl() string {
+func (d *Cli) InstallUrl() string {
 	return "https://aka.ms/azure-dev/docker-install"
 }
 
-func (d *docker) Name() string {
+func (d *Cli) Name() string {
 	return "Docker"
 }
 
-func (d *docker) executeCommand(ctx context.Context, cwd string, args ...string) (exec.RunResult, error) {
+func (d *Cli) executeCommand(ctx context.Context, cwd string, args ...string) (exec.RunResult, error) {
 	runArgs := exec.NewRunArgs("docker", args...).
 		WithCwd(cwd)
 

--- a/cli/azd/pkg/tools/docker/docker_test.go
+++ b/cli/azd/pkg/tools/docker/docker_test.go
@@ -27,7 +27,7 @@ func Test_DockerBuild(t *testing.T) {
 		ran := false
 
 		mockContext := mocks.NewMockContext(context.Background())
-		docker := NewDocker(mockContext.CommandRunner)
+		docker := NewCli(mockContext.CommandRunner)
 		mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 			return strings.Contains(command, "docker build")
 		}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
@@ -85,7 +85,7 @@ func Test_DockerBuild(t *testing.T) {
 		buildArgs := []string{"foo=bar"}
 
 		mockContext := mocks.NewMockContext(context.Background())
-		docker := NewDocker(mockContext.CommandRunner)
+		docker := NewCli(mockContext.CommandRunner)
 
 		mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 			return strings.Contains(command, "docker build")
@@ -152,7 +152,7 @@ func Test_DockerBuildEmptyPlatform(t *testing.T) {
 	buildArgs := []string{"foo=bar"}
 
 	mockContext := mocks.NewMockContext(context.Background())
-	docker := NewDocker(mockContext.CommandRunner)
+	docker := NewCli(mockContext.CommandRunner)
 
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 		return strings.Contains(command, "docker build")
@@ -202,7 +202,7 @@ func Test_DockerBuildArgsEmpty(t *testing.T) {
 	buildArgs := []string{}
 
 	mockContext := mocks.NewMockContext(context.Background())
-	docker := NewDocker(mockContext.CommandRunner)
+	docker := NewCli(mockContext.CommandRunner)
 
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 		return strings.Contains(command, "docker build")
@@ -251,7 +251,7 @@ func Test_DockerBuildArgsMultiple(t *testing.T) {
 	buildArgs := []string{"foo=bar", "bar=baz"}
 
 	mockContext := mocks.NewMockContext(context.Background())
-	docker := NewDocker(mockContext.CommandRunner)
+	docker := NewCli(mockContext.CommandRunner)
 
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 		return strings.Contains(command, "docker build")
@@ -301,7 +301,7 @@ func Test_DockerTag(t *testing.T) {
 		ran := false
 
 		mockContext := mocks.NewMockContext(context.Background())
-		docker := NewDocker(mockContext.CommandRunner)
+		docker := NewCli(mockContext.CommandRunner)
 
 		mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 			return strings.Contains(command, "docker tag")
@@ -335,7 +335,7 @@ func Test_DockerTag(t *testing.T) {
 		customErrorMessage := "example error message"
 
 		mockContext := mocks.NewMockContext(context.Background())
-		docker := NewDocker(mockContext.CommandRunner)
+		docker := NewCli(mockContext.CommandRunner)
 
 		mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 			return strings.Contains(command, "docker tag")
@@ -377,7 +377,7 @@ func Test_DockerPush(t *testing.T) {
 		ran := false
 
 		mockContext := mocks.NewMockContext(context.Background())
-		docker := NewDocker(mockContext.CommandRunner)
+		docker := NewCli(mockContext.CommandRunner)
 
 		mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 			return strings.Contains(command, "docker push")
@@ -410,7 +410,7 @@ func Test_DockerPush(t *testing.T) {
 		customErrorMessage := "example error message"
 
 		mockContext := mocks.NewMockContext(context.Background())
-		docker := NewDocker(mockContext.CommandRunner)
+		docker := NewCli(mockContext.CommandRunner)
 
 		mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 			return strings.Contains(command, "docker push")
@@ -448,7 +448,7 @@ func Test_DockerLogin(t *testing.T) {
 		ran := false
 
 		mockContext := mocks.NewMockContext(context.Background())
-		docker := NewDocker(mockContext.CommandRunner)
+		docker := NewCli(mockContext.CommandRunner)
 
 		mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 			return strings.Contains(command, "docker login")
@@ -482,7 +482,7 @@ func Test_DockerLogin(t *testing.T) {
 		customErrorMessage := "example error message"
 
 		mockContext := mocks.NewMockContext(context.Background())
-		docker := NewDocker(mockContext.CommandRunner)
+		docker := NewCli(mockContext.CommandRunner)
 
 		mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 			return strings.Contains(command, "docker login")

--- a/cli/azd/pkg/tools/dotnet/dotnet_test.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet_test.go
@@ -15,7 +15,7 @@ var publishWithWorkloadUpdate string
 func Test_getTargetPort(t *testing.T) {
 	mockCtx := mocks.NewMockContext(context.Background())
 
-	cli := &dotNetCli{
+	cli := &Cli{
 		commandRunner: mockCtx.CommandRunner,
 	}
 

--- a/cli/azd/pkg/tools/github/github_test.go
+++ b/cli/azd/pkg/tools/github/github_test.go
@@ -100,7 +100,7 @@ func TestNewGitHubCli(t *testing.T) {
 		return strings.Contains(args.Cmd, "gh") && len(args.Args) == 1 && args.Args[0] == "--version"
 	}).Respond(exec.NewRunResult(
 		0,
-		fmt.Sprintf("gh version %s (abcdef0123)", GitHubCliVersion.String()),
+		fmt.Sprintf("gh version %s (abcdef0123)", Version.String()),
 		"",
 	))
 
@@ -137,9 +137,9 @@ func TestNewGitHubCli(t *testing.T) {
 
 	require.Equal(t, []byte("this is github cli"), contents)
 
-	ver, err := cli.(*ghCli).extractVersion(context.Background())
+	ver, err := cli.extractVersion(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, GitHubCliVersion.String(), ver)
+	require.Equal(t, Version.String(), ver)
 }
 
 func TestNewGitHubCliUpdate(t *testing.T) {

--- a/cli/azd/pkg/tools/javac/javac.go
+++ b/cli/azd/pkg/tools/javac/javac.go
@@ -16,21 +16,19 @@ import (
 
 const javac = "javac"
 
-type JavacCli interface {
-	tools.ExternalTool
-}
+var _ tools.ExternalTool = (*Cli)(nil)
 
-type javacCli struct {
+type Cli struct {
 	cmdRun exec.CommandRunner
 }
 
-func NewCli(cmdRun exec.CommandRunner) JavacCli {
-	return &javacCli{
+func NewCli(cmdRun exec.CommandRunner) *Cli {
+	return &Cli{
 		cmdRun: cmdRun,
 	}
 }
 
-func (j *javacCli) VersionInfo() tools.VersionInfo {
+func (j *Cli) VersionInfo() tools.VersionInfo {
 	return tools.VersionInfo{
 		MinimumVersion: semver.Version{
 			Major: 17,
@@ -40,7 +38,7 @@ func (j *javacCli) VersionInfo() tools.VersionInfo {
 	}
 }
 
-func (j *javacCli) CheckInstalled(ctx context.Context) error {
+func (j *Cli) CheckInstalled(ctx context.Context) error {
 	path, err := getInstalledPath()
 	if err != nil {
 		return err
@@ -81,11 +79,11 @@ func (j *javacCli) CheckInstalled(ctx context.Context) error {
 	return nil
 }
 
-func (j *javacCli) InstallUrl() string {
+func (j *Cli) InstallUrl() string {
 	return "https://www.microsoft.com/openjdk"
 }
 
-func (j *javacCli) Name() string {
+func (j *Cli) Name() string {
 	return "Java JDK"
 }
 

--- a/cli/azd/pkg/tools/kubectl/kube_config.go
+++ b/cli/azd/pkg/tools/kubectl/kube_config.go
@@ -13,12 +13,12 @@ import (
 
 // Manages k8s configurations available to the k8s CLI
 type KubeConfigManager struct {
-	cli        KubectlCli
+	cli        *Cli
 	configPath string
 }
 
 // Creates a new instance of the KubeConfigManager
-func NewKubeConfigManager(cli KubectlCli) (*KubeConfigManager, error) {
+func NewKubeConfigManager(cli *Cli) (*KubeConfigManager, error) {
 	kubeConfigDir, err := getKubeConfigDir()
 	if err != nil {
 		return nil, err

--- a/cli/azd/pkg/tools/kubectl/kube_config_test.go
+++ b/cli/azd/pkg/tools/kubectl/kube_config_test.go
@@ -14,7 +14,7 @@ import (
 func Test_MergeKubeConfig(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	commandRunner := exec.NewCommandRunner(nil)
-	cli := NewKubectl(commandRunner)
+	cli := NewCli(commandRunner)
 	kubeConfigManager, err := NewKubeConfigManager(cli)
 	require.NoError(t, err)
 

--- a/cli/azd/pkg/tools/kubectl/kubectl_test.go
+++ b/cli/azd/pkg/tools/kubectl/kubectl_test.go
@@ -32,7 +32,7 @@ func Test_ApplyFiles(t *testing.T) {
 		return exec.NewRunResult(0, "", ""), nil
 	})
 
-	cli := NewKubectl(mockContext.CommandRunner)
+	cli := NewCli(mockContext.CommandRunner)
 
 	err := os.WriteFile("test.yaml", []byte("yaml"), osutil.PermissionFile)
 	require.NoError(t, err)
@@ -53,7 +53,7 @@ func Test_Command_Args(t *testing.T) {
 	ostest.Chdir(t, tempDir)
 
 	mockContext := mocks.NewMockContext(context.Background())
-	cli := NewKubectl(mockContext.CommandRunner)
+	cli := NewCli(mockContext.CommandRunner)
 
 	tests := map[string]*kubeCliTestConfig{
 		"apply-with-stdin": {
@@ -191,9 +191,9 @@ func TestGetClientVersion(t *testing.T) {
 		  }`, ""), nil
 	})
 
-	cli := NewKubectl(mockContext.CommandRunner)
+	cli := NewCli(mockContext.CommandRunner)
 
-	ver, err := (cli.(*kubectlCli)).getClientVersion(context.Background())
+	ver, err := cli.getClientVersion(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "v1.25.4", ver)
 }
@@ -210,7 +210,7 @@ func Test_Apply_Template(t *testing.T) {
 	})
 
 	t.Run("RawYaml", func(t *testing.T) {
-		cli := NewKubectl(mockContext.CommandRunner)
+		cli := NewCli(mockContext.CommandRunner)
 		flags := &KubeCliFlags{
 			Namespace: "test",
 		}
@@ -225,7 +225,7 @@ func Test_Apply_Template(t *testing.T) {
 	})
 
 	t.Run("TemplateYaml", func(t *testing.T) {
-		cli := NewKubectl(mockContext.CommandRunner)
+		cli := NewCli(mockContext.CommandRunner)
 		env := map[string]string{
 			"SERVICE_API_IMAGE_NAME":       "test.azureacr.io/repo/service:latest",
 			"AZURE_AKS_IDENTITY_CLIENT_ID": "EXAMPLE_CLIENT_ID",

--- a/cli/azd/pkg/tools/kubectl/util.go
+++ b/cli/azd/pkg/tools/kubectl/util.go
@@ -18,7 +18,7 @@ var (
 
 func GetResource[T any](
 	ctx context.Context,
-	cli KubectlCli,
+	cli *Cli,
 	resourceType ResourceType,
 	resourceName string,
 	flags *KubeCliFlags,
@@ -58,7 +58,7 @@ func GetResource[T any](
 
 func GetResources[T any](
 	ctx context.Context,
-	cli KubectlCli,
+	cli *Cli,
 	resourceType ResourceType,
 	flags *KubeCliFlags,
 ) (*List[T], error) {
@@ -99,7 +99,7 @@ type ResourceFilterFn[T comparable] func(resource T) bool
 
 func WaitForResource[T comparable](
 	ctx context.Context,
-	cli KubectlCli,
+	cli *Cli,
 	resourceType ResourceType,
 	resourceFilter ResourceFilterFn[T],
 	readyStatusFilter ResourceFilterFn[T],

--- a/cli/azd/pkg/tools/maven/maven.go
+++ b/cli/azd/pkg/tools/maven/maven.go
@@ -16,15 +16,9 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 )
 
-type MavenCli interface {
-	tools.ExternalTool
-	SetPath(projectPath string, rootProjectPath string)
-	ResolveDependencies(ctx context.Context, projectPath string) error
-	Compile(ctx context.Context, projectPath string) error
-	Package(ctx context.Context, projectPath string) error
-}
+var _ tools.ExternalTool = (*Cli)(nil)
 
-type mavenCli struct {
+type Cli struct {
 	commandRunner   exec.CommandRunner
 	projectPath     string
 	rootProjectPath string
@@ -35,15 +29,15 @@ type mavenCli struct {
 	mvnCmdErr  error
 }
 
-func (m *mavenCli) Name() string {
+func (m *Cli) Name() string {
 	return "Maven"
 }
 
-func (m *mavenCli) InstallUrl() string {
+func (m *Cli) InstallUrl() string {
 	return "https://maven.apache.org"
 }
 
-func (m *mavenCli) CheckInstalled(ctx context.Context) error {
+func (m *Cli) CheckInstalled(ctx context.Context) error {
 	_, err := m.mvnCmd()
 	if err != nil {
 		return err
@@ -56,12 +50,12 @@ func (m *mavenCli) CheckInstalled(ctx context.Context) error {
 	return nil
 }
 
-func (m *mavenCli) SetPath(projectPath string, rootProjectPath string) {
+func (m *Cli) SetPath(projectPath string, rootProjectPath string) {
 	m.projectPath = projectPath
 	m.rootProjectPath = rootProjectPath
 }
 
-func (m *mavenCli) mvnCmd() (string, error) {
+func (m *Cli) mvnCmd() (string, error) {
 	m.mvnCmdOnce.Do(func() {
 		mvnCmd, err := getMavenPath(m.projectPath, m.rootProjectPath)
 		if err != nil {
@@ -153,7 +147,7 @@ func getMavenWrapperPath(projectPath string, rootProjectPath string) (string, er
 // OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"
 var cMavenVersionRegexp = regexp.MustCompile(`Apache Maven (.*) \(`)
 
-func (cli *mavenCli) extractVersion(ctx context.Context) (string, error) {
+func (cli *Cli) extractVersion(ctx context.Context) (string, error) {
 	mvnCmd, err := cli.mvnCmd()
 	if err != nil {
 		return "", err
@@ -173,7 +167,7 @@ func (cli *mavenCli) extractVersion(ctx context.Context) (string, error) {
 	return parts[1], nil
 }
 
-func (cli *mavenCli) Compile(ctx context.Context, projectPath string) error {
+func (cli *Cli) Compile(ctx context.Context, projectPath string) error {
 	mvnCmd, err := cli.mvnCmd()
 	if err != nil {
 		return err
@@ -188,7 +182,7 @@ func (cli *mavenCli) Compile(ctx context.Context, projectPath string) error {
 	return nil
 }
 
-func (cli *mavenCli) Package(ctx context.Context, projectPath string) error {
+func (cli *Cli) Package(ctx context.Context, projectPath string) error {
 	mvnCmd, err := cli.mvnCmd()
 	if err != nil {
 		return err
@@ -204,7 +198,7 @@ func (cli *mavenCli) Package(ctx context.Context, projectPath string) error {
 	return nil
 }
 
-func (cli *mavenCli) ResolveDependencies(ctx context.Context, projectPath string) error {
+func (cli *Cli) ResolveDependencies(ctx context.Context, projectPath string) error {
 	mvnCmd, err := cli.mvnCmd()
 	if err != nil {
 		return err
@@ -218,8 +212,8 @@ func (cli *mavenCli) ResolveDependencies(ctx context.Context, projectPath string
 	return nil
 }
 
-func NewMavenCli(commandRunner exec.CommandRunner) MavenCli {
-	return &mavenCli{
+func NewCli(commandRunner exec.CommandRunner) *Cli {
+	return &Cli{
 		commandRunner: commandRunner,
 	}
 }

--- a/cli/azd/pkg/tools/maven/maven_test.go
+++ b/cli/azd/pkg/tools/maven/maven_test.go
@@ -121,7 +121,7 @@ func Test_extractVersion(t *testing.T) {
 			`), ""), nil
 		})
 
-	mvn := NewMavenCli(execMock).(*mavenCli)
+	mvn := NewCli(execMock)
 	placeExecutable(t, mvnwWithExt(), mvn.projectPath)
 	ver, err := mvn.extractVersion(context.Background())
 	require.NoError(t, err)

--- a/cli/azd/pkg/tools/npm/npm.go
+++ b/cli/azd/pkg/tools/npm/npm.go
@@ -12,28 +12,19 @@ import (
 	"github.com/blang/semver/v4"
 )
 
-type NpmCli interface {
-	tools.ExternalTool
-	Install(ctx context.Context, project string) error
+var _ tools.ExternalTool = (*Cli)(nil)
 
-	// RunScript runs the given npm script (if it exists) in the project.
-	//
-	// Returns an error only if the script execution fails. If the script doesn't exist, no error is returned.
-	RunScript(ctx context.Context, projectPath string, scriptName string) error
-	Prune(ctx context.Context, projectPath string, production bool) error
-}
-
-type npmCli struct {
+type Cli struct {
 	commandRunner exec.CommandRunner
 }
 
-func NewNpmCli(commandRunner exec.CommandRunner) NpmCli {
-	return &npmCli{
+func NewCli(commandRunner exec.CommandRunner) *Cli {
+	return &Cli{
 		commandRunner: commandRunner,
 	}
 }
 
-func (cli *npmCli) versionInfoNode() tools.VersionInfo {
+func (cli *Cli) versionInfoNode() tools.VersionInfo {
 	return tools.VersionInfo{
 		MinimumVersion: semver.Version{
 			Major: 18,
@@ -43,7 +34,7 @@ func (cli *npmCli) versionInfoNode() tools.VersionInfo {
 	}
 }
 
-func (cli *npmCli) CheckInstalled(ctx context.Context) error {
+func (cli *Cli) CheckInstalled(ctx context.Context) error {
 	err := tools.ToolInPath("npm")
 	if err != nil {
 		return err
@@ -66,15 +57,15 @@ func (cli *npmCli) CheckInstalled(ctx context.Context) error {
 	return nil
 }
 
-func (cli *npmCli) InstallUrl() string {
+func (cli *Cli) InstallUrl() string {
 	return "https://nodejs.org/"
 }
 
-func (cli *npmCli) Name() string {
+func (cli *Cli) Name() string {
 	return "npm CLI"
 }
 
-func (cli *npmCli) Install(ctx context.Context, project string) error {
+func (cli *Cli) Install(ctx context.Context, project string) error {
 	runArgs := exec.
 		NewRunArgs("npm", "install").
 		WithCwd(project)
@@ -87,7 +78,7 @@ func (cli *npmCli) Install(ctx context.Context, project string) error {
 	return nil
 }
 
-func (cli *npmCli) RunScript(ctx context.Context, projectPath string, scriptName string) error {
+func (cli *Cli) RunScript(ctx context.Context, projectPath string, scriptName string) error {
 	runArgs := exec.
 		NewRunArgs("npm", "run", scriptName, "--if-present").
 		WithCwd(projectPath)
@@ -101,7 +92,7 @@ func (cli *npmCli) RunScript(ctx context.Context, projectPath string, scriptName
 	return nil
 }
 
-func (cli *npmCli) Prune(ctx context.Context, projectPath string, production bool) error {
+func (cli *Cli) Prune(ctx context.Context, projectPath string, production bool) error {
 	runArgs := exec.
 		NewRunArgs("npm", "prune").
 		WithCwd(projectPath)

--- a/cli/azd/pkg/tools/pack/pack_test.go
+++ b/cli/azd/pkg/tools/pack/pack_test.go
@@ -161,7 +161,7 @@ func TestNewPackCliInstall(t *testing.T) {
 		return strings.HasSuffix(args.Cmd, packName()) && args.Args[0] == "--version" && len(args.Args) == 1
 	}).Respond(exec.NewRunResult(
 		0,
-		fmt.Sprintf("%s+git-c38f7da.build-4952", PackVersion.String()),
+		fmt.Sprintf("%s+git-c38f7da.build-4952", Version.String()),
 		"",
 	))
 

--- a/cli/azd/pkg/tools/python/python.go
+++ b/cli/azd/pkg/tools/python/python.go
@@ -16,17 +16,17 @@ import (
 	"github.com/blang/semver/v4"
 )
 
-type PythonCli struct {
+type Cli struct {
 	commandRunner exec.CommandRunner
 }
 
-func NewPythonCli(commandRunner exec.CommandRunner) *PythonCli {
-	return &PythonCli{
+func NewCli(commandRunner exec.CommandRunner) *Cli {
+	return &Cli{
 		commandRunner: commandRunner,
 	}
 }
 
-func (cli *PythonCli) versionInfo() tools.VersionInfo {
+func (cli *Cli) versionInfo() tools.VersionInfo {
 	return tools.VersionInfo{
 		MinimumVersion: semver.Version{
 			Major: 3,
@@ -36,7 +36,7 @@ func (cli *PythonCli) versionInfo() tools.VersionInfo {
 	}
 }
 
-func (cli *PythonCli) CheckInstalled(ctx context.Context) error {
+func (cli *Cli) CheckInstalled(ctx context.Context) error {
 	pyString, err := checkPath()
 	if err != nil {
 		return err
@@ -59,15 +59,15 @@ func (cli *PythonCli) CheckInstalled(ctx context.Context) error {
 	return nil
 }
 
-func (cli *PythonCli) InstallUrl() string {
+func (cli *Cli) InstallUrl() string {
 	return "https://wiki.python.org/moin/BeginnersGuide/Download"
 }
 
-func (cli *PythonCli) Name() string {
+func (cli *Cli) Name() string {
 	return "Python CLI"
 }
 
-func (cli *PythonCli) InstallRequirements(ctx context.Context, workingDir, environment, requirementFile string) error {
+func (cli *Cli) InstallRequirements(ctx context.Context, workingDir, environment, requirementFile string) error {
 	args := []string{"-m", "pip", "install", "-r", requirementFile}
 	_, err := cli.Run(ctx, workingDir, environment, args...)
 	if err != nil {
@@ -77,7 +77,7 @@ func (cli *PythonCli) InstallRequirements(ctx context.Context, workingDir, envir
 	return nil
 }
 
-func (cli *PythonCli) CreateVirtualEnv(ctx context.Context, workingDir, name string) error {
+func (cli *Cli) CreateVirtualEnv(ctx context.Context, workingDir, name string) error {
 	pyString, err := checkPath()
 	if err != nil {
 		return err
@@ -98,7 +98,7 @@ func (cli *PythonCli) CreateVirtualEnv(ctx context.Context, workingDir, name str
 	return nil
 }
 
-func (cli *PythonCli) Run(
+func (cli *Cli) Run(
 	ctx context.Context,
 	workingDir string,
 	environment string,

--- a/cli/azd/pkg/tools/python/python_test.go
+++ b/cli/azd/pkg/tools/python/python_test.go
@@ -26,7 +26,7 @@ func Test_Python_Run(t *testing.T) {
 		return strings.Contains(command, pyString)
 	}).Respond(exec.NewRunResult(0, "", ""))
 
-	cli := NewPythonCli(mockContext.CommandRunner)
+	cli := NewCli(mockContext.CommandRunner)
 
 	runResult, err := cli.Run(*mockContext.Context, tempDir, ".venv", "pf_client.py", "arg1", "arg2", "arg3")
 	require.NoError(t, err)
@@ -54,7 +54,7 @@ func Test_Python_InstallRequirements(t *testing.T) {
 		return strings.Contains(command, "requirements.txt")
 	}).Respond(exec.NewRunResult(0, "", ""))
 
-	cli := NewPythonCli(mockContext.CommandRunner)
+	cli := NewCli(mockContext.CommandRunner)
 
 	err = cli.InstallRequirements(*mockContext.Context, tempDir, ".venv", "requirements.txt")
 	require.NoError(t, err)
@@ -80,7 +80,7 @@ func Test_Python_CreateVirtualEnv(t *testing.T) {
 		return strings.Contains(command, "-m venv .venv")
 	}).Respond(exec.NewRunResult(0, "", ""))
 
-	cli := NewPythonCli(mockContext.CommandRunner)
+	cli := NewCli(mockContext.CommandRunner)
 
 	err = cli.CreateVirtualEnv(*mockContext.Context, tempDir, ".venv")
 	require.NoError(t, err)

--- a/cli/azd/pkg/tools/swa/swa_test.go
+++ b/cli/azd/pkg/tools/swa/swa_test.go
@@ -22,7 +22,7 @@ func Test_SwaBuild(t *testing.T) {
 
 	t.Run("NoErrors", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		swacli := NewSwaCli(mockContext.CommandRunner)
+		swacli := NewCli(mockContext.CommandRunner)
 
 		mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 			return strings.Contains(command, "npx")
@@ -52,7 +52,7 @@ func Test_SwaBuild(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		swacli := NewSwaCli(mockContext.CommandRunner)
+		swacli := NewCli(mockContext.CommandRunner)
 
 		mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 			return strings.Contains(command, "npx")
@@ -87,7 +87,7 @@ func Test_SwaDeploy(t *testing.T) {
 
 	t.Run("NoErrors", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		swacli := NewSwaCli(mockContext.CommandRunner)
+		swacli := NewCli(mockContext.CommandRunner)
 
 		mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 			return strings.Contains(command, "npx")
@@ -134,7 +134,7 @@ func Test_SwaDeploy(t *testing.T) {
 
 	t.Run("NoErrorsNoConfig", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		swacli := NewSwaCli(mockContext.CommandRunner)
+		swacli := NewCli(mockContext.CommandRunner)
 
 		mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 			return strings.Contains(command, "npx")
@@ -186,7 +186,7 @@ func Test_SwaDeploy(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
-		swacli := NewSwaCli(mockContext.CommandRunner)
+		swacli := NewCli(mockContext.CommandRunner)
 
 		mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
 			return strings.Contains(command, "npx")

--- a/cli/azd/pkg/tools/terraform/terraform_test.go
+++ b/cli/azd/pkg/tools/terraform/terraform_test.go
@@ -24,7 +24,7 @@ func Test_WithEnv(t *testing.T) {
 		return exec.NewRunResult(0, "", ""), nil
 	})
 
-	cli := NewTerraformCli(mockContext.CommandRunner)
+	cli := NewCli(mockContext.CommandRunner)
 	cli.SetEnv(expectedEnvVars)
 
 	_, err := cli.Init(*mockContext.Context, "path/to/module")

--- a/cli/azd/test/functional/aspire_test.go
+++ b/cli/azd/test/functional/aspire_test.go
@@ -95,7 +95,7 @@ func Test_CLI_Aspire_DetectGen(t *testing.T) {
 		err = copySample(dir, "aspire-full")
 		require.NoError(t, err, "failed expanding sample")
 
-		dotnetCli := dotnet.NewDotNetCli(exec.NewCommandRunner(nil))
+		dotnetCli := dotnet.NewCli(exec.NewCommandRunner(nil))
 		appHostProject := filepath.Join(dir, "AspireAzdTests.AppHost")
 		manifestPath := filepath.Join(appHostProject, "manifest.json")
 


### PR DESCRIPTION
This is a continuation of #4116, removing the interfaces we were not using from our tool wrappers, simplifying the codebase.