### PR TITLE
Address `gopls check` issues

### DIFF
--- a/cli/azd/.golangci.yaml
+++ b/cli/azd/.golangci.yaml
@@ -4,7 +4,6 @@ linters:
     - gofmt
     - lll
     - gosec
-    - revive
 linters-settings:
   errorlint:
     errorf: true
@@ -14,7 +13,3 @@ linters-settings:
     # GitHub recommended for code review
     line-length: 125
     tab-width: 4
-  revive:
-    rules:
-      - name: unused-parameter
-      

--- a/cli/azd/.golangci.yaml
+++ b/cli/azd/.golangci.yaml
@@ -4,6 +4,7 @@ linters:
     - gofmt
     - lll
     - gosec
+    - revive
 linters-settings:
   errorlint:
     errorf: true
@@ -13,3 +14,7 @@ linters-settings:
     # GitHub recommended for code review
     line-length: 125
     tab-width: 4
+  revive:
+    rules:
+      - name: unused-parameter
+      

--- a/cli/azd/cmd/middleware/hooks.go
+++ b/cli/azd/cmd/middleware/hooks.go
@@ -164,7 +164,7 @@ func (m *HooksMiddleware) registerServiceHooks(
 
 			if err := service.AddHandler(
 				ext.Event(hookName),
-				m.createServiceEventHandler(ctx, hookType, eventName, serviceHooksRunner),
+				m.createServiceEventHandler(hookType, eventName, serviceHooksRunner),
 			); err != nil {
 				return fmt.Errorf(
 					"failed registering event handler for service '%s' and event '%s', %w",
@@ -181,7 +181,6 @@ func (m *HooksMiddleware) registerServiceHooks(
 
 // Creates an event handler for the specified service config and event name
 func (m *HooksMiddleware) createServiceEventHandler(
-	ctx context.Context,
 	hookType ext.HookType,
 	hookName string,
 	hooksRunner *ext.HooksRunner,

--- a/cli/azd/cmd/middleware/hooks_test.go
+++ b/cli/azd/cmd/middleware/hooks_test.go
@@ -42,7 +42,7 @@ func Test_CommandHooks_Middleware_WithValidProjectAndMatchingCommand(t *testing.
 
 	nextFn, actionRan := createNextFn()
 	hookRan := setupHookMock(mockContext, 0)
-	result, err := runMiddleware(mockContext, azdContext, envName, &projectConfig, &runOptions, nextFn)
+	result, err := runMiddleware(mockContext, envName, &projectConfig, &runOptions, nextFn)
 
 	require.NotNil(t, result)
 	require.NoError(t, err)
@@ -74,7 +74,7 @@ func Test_CommandHooks_Middleware_ValidProjectWithDifferentCommand(t *testing.T)
 
 	nextFn, actionRan := createNextFn()
 	hookRan := setupHookMock(mockContext, 0)
-	result, err := runMiddleware(mockContext, azdContext, envName, &projectConfig, &runOptions, nextFn)
+	result, err := runMiddleware(mockContext, envName, &projectConfig, &runOptions, nextFn)
 
 	require.NotNil(t, result)
 	require.NoError(t, err)
@@ -100,7 +100,7 @@ func Test_CommandHooks_Middleware_ValidProjectWithNoHooks(t *testing.T) {
 
 	nextFn, actionRan := createNextFn()
 	hookRan := setupHookMock(mockContext, 0)
-	result, err := runMiddleware(mockContext, azdContext, envName, &projectConfig, &runOptions, nextFn)
+	result, err := runMiddleware(mockContext, envName, &projectConfig, &runOptions, nextFn)
 
 	require.NotNil(t, result)
 	require.NoError(t, err)
@@ -133,7 +133,7 @@ func Test_CommandHooks_Middleware_PreHookWithError(t *testing.T) {
 	nextFn, actionRan := createNextFn()
 	// Set a non-zero exit code to simulate failure
 	hookRan := setupHookMock(mockContext, 1)
-	result, err := runMiddleware(mockContext, azdContext, envName, &projectConfig, &runOptions, nextFn)
+	result, err := runMiddleware(mockContext, envName, &projectConfig, &runOptions, nextFn)
 
 	require.Nil(t, result)
 	require.Error(t, err)
@@ -169,7 +169,7 @@ func Test_CommandHooks_Middleware_PreHookWithErrorAndContinue(t *testing.T) {
 	nextFn, actionRan := createNextFn()
 	// Set a non-zero exit code to simulate failure
 	hookRan := setupHookMock(mockContext, 1)
-	result, err := runMiddleware(mockContext, azdContext, envName, &projectConfig, &runOptions, nextFn)
+	result, err := runMiddleware(mockContext, envName, &projectConfig, &runOptions, nextFn)
 
 	require.NotNil(t, result)
 	require.NoError(t, err)
@@ -203,7 +203,7 @@ func Test_CommandHooks_Middleware_WithCmdAlias(t *testing.T) {
 
 	nextFn, actionRan := createNextFn()
 	hookRan := setupHookMock(mockContext, 0)
-	result, err := runMiddleware(mockContext, azdContext, envName, &projectConfig, &runOptions, nextFn)
+	result, err := runMiddleware(mockContext, envName, &projectConfig, &runOptions, nextFn)
 
 	require.NotNil(t, result)
 	require.NoError(t, err)
@@ -265,7 +265,7 @@ func Test_ServiceHooks_Registered(t *testing.T) {
 		return &actions.ActionResult{}, err
 	}
 
-	result, err := runMiddleware(mockContext, azdContext, envName, &projectConfig, &runOptions, nextFn)
+	result, err := runMiddleware(mockContext, envName, &projectConfig, &runOptions, nextFn)
 
 	require.NotNil(t, result)
 	require.NoError(t, err)
@@ -315,7 +315,6 @@ func setupHookMock(mockContext *mocks.MockContext, exitCode int) *bool {
 
 func runMiddleware(
 	mockContext *mocks.MockContext,
-	azdContext *azdcontext.AzdContext,
 	envName string,
 	projectConfig *project.ProjectConfig,
 	runOptions *Options,

--- a/cli/azd/docs/docgen.go
+++ b/cli/azd/docs/docgen.go
@@ -276,7 +276,7 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 }
 
 // printOptions is the same as the un-exported helper from spf13/cobra/docs@v1.3.0
-func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
+func printOptions(buf *bytes.Buffer, cmd *cobra.Command, _ string) error {
 	flags := cmd.NonInheritedFlags()
 	flags.SetOutput(buf)
 	if flags.HasAvailableFlags() {

--- a/cli/azd/internal/appdetect/appdetect_test.go
+++ b/cli/azd/internal/appdetect/appdetect_test.go
@@ -19,7 +19,7 @@ var testDataFs embed.FS
 // Verify standard detection for all languages and dependencies.
 func TestDetect(t *testing.T) {
 	dir := t.TempDir()
-	err := copyTestDataDir(t, "**", dir)
+	err := copyTestDataDir("**", dir)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -178,7 +178,7 @@ func TestDetect(t *testing.T) {
 // Verify docker detection.
 func TestDetectDocker(t *testing.T) {
 	dir := t.TempDir()
-	err := copyTestDataDir(t, "**/dotnet/**", dir)
+	err := copyTestDataDir("**/dotnet/**", dir)
 	require.NoError(t, err)
 
 	err = os.WriteFile(filepath.Join(dir, "dotnet", "Dockerfile"), []byte{}, 0600)
@@ -204,11 +204,11 @@ func TestDetectNested(t *testing.T) {
 
 	// Use 'src' under root to create further nesting
 	src := filepath.Join(dir, "src")
-	err := copyTestDataDir(t, "**/dotnet/**", src)
+	err := copyTestDataDir("**/dotnet/**", src)
 	require.NoError(t, err)
 
 	// nested directory, but is skipped because of dotnet being one level up
-	err = copyTestDataDir(t, "**/javascript/**", filepath.Join(src, "dotnet"))
+	err = copyTestDataDir("**/javascript/**", filepath.Join(src, "dotnet"))
 	require.NoError(t, err)
 
 	projects, err := Detect(context.Background(), dir)
@@ -222,7 +222,7 @@ func TestDetectNested(t *testing.T) {
 	})
 }
 
-func copyTestDataDir(t *testing.T, glob string, dst string) error {
+func copyTestDataDir(glob string, dst string) error {
 	root := "testdata"
 	return fs.WalkDir(testDataFs, root, func(name string, d fs.DirEntry, err error) error {
 		// If there was some error that was preventing is from walking into the directory, just fail now,

--- a/cli/azd/internal/telemetry/appinsights-exporter/transmitter_test.go
+++ b/cli/azd/internal/telemetry/appinsights-exporter/transmitter_test.go
@@ -70,7 +70,7 @@ func newTestClientServer() (Transmitter, *testServer) {
 	return client, server
 }
 
-func newTestTlsClientServer(t *testing.T) (Transmitter, *testServer) {
+func newTestTlsClientServer() (Transmitter, *testServer) {
 	server := &testServer{}
 	server.server = httptest.NewTLSServer(server)
 	server.notify = make(chan *testRequest, 1)
@@ -87,7 +87,7 @@ func newTestTlsClientServer(t *testing.T) (Transmitter, *testServer) {
 }
 
 func TestBasicTransitTls(t *testing.T) {
-	client, server := newTestTlsClientServer(t)
+	client, server := newTestTlsClientServer()
 
 	doBasicTransmit(client, server, t)
 }

--- a/cli/azd/internal/vsrpc/aspire_service.go
+++ b/cli/azd/internal/vsrpc/aspire_service.go
@@ -30,7 +30,7 @@ func newAspireService(server *Server) *aspireService {
 func (s *aspireService) GetAspireHostAsync(
 	ctx context.Context, rc RequestContext, aspireEnv string, observer IObserver[ProgressMessage],
 ) (*AspireHost, error) {
-	session, err := s.server.validateSession(ctx, rc.Session)
+	session, err := s.server.validateSession(rc.Session)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func (s *aspireService) GetAspireHostAsync(
 func (s *aspireService) RenameAspireHostAsync(
 	ctx context.Context, rc RequestContext, newPath string, observer IObserver[ProgressMessage],
 ) error {
-	_, err := s.server.validateSession(ctx, rc.Session)
+	_, err := s.server.validateSession(rc.Session)
 	if err != nil {
 		return err
 	}

--- a/cli/azd/internal/vsrpc/debug_service.go
+++ b/cli/azd/internal/vsrpc/debug_service.go
@@ -74,7 +74,7 @@ func (s *debugService) TestPanicAsync(ctx context.Context, message string) error
 //
 // It fetches an access token for the current user and returns it.
 func (s *debugService) FetchTokenAsync(ctx context.Context, sessionId Session) (azcore.AccessToken, error) {
-	session, err := s.server.validateSession(ctx, sessionId)
+	session, err := s.server.validateSession(sessionId)
 	if err != nil {
 		return azcore.AccessToken{}, err
 	}

--- a/cli/azd/internal/vsrpc/environment_service.go
+++ b/cli/azd/internal/vsrpc/environment_service.go
@@ -33,7 +33,7 @@ func newEnvironmentService(server *Server) *environmentService {
 func (s *environmentService) GetEnvironmentsAsync(
 	ctx context.Context, rc RequestContext, observer IObserver[ProgressMessage],
 ) ([]*EnvironmentInfo, error) {
-	session, err := s.server.validateSession(ctx, rc.Session)
+	session, err := s.server.validateSession(rc.Session)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (s *environmentService) GetEnvironmentsAsync(
 func (s *environmentService) SetCurrentEnvironmentAsync(
 	ctx context.Context, rc RequestContext, name string, observer IObserver[ProgressMessage],
 ) (bool, error) {
-	session, err := s.server.validateSession(ctx, rc.Session)
+	session, err := s.server.validateSession(rc.Session)
 	if err != nil {
 		return false, err
 	}
@@ -108,7 +108,7 @@ const (
 func (s *environmentService) DeleteEnvironmentAsync(
 	ctx context.Context, rc RequestContext, name string, mode int, observer IObserver[ProgressMessage],
 ) (bool, error) {
-	session, err := s.server.validateSession(ctx, rc.Session)
+	session, err := s.server.validateSession(rc.Session)
 	if err != nil {
 		return false, err
 	}

--- a/cli/azd/internal/vsrpc/environment_service_create.go
+++ b/cli/azd/internal/vsrpc/environment_service_create.go
@@ -20,7 +20,7 @@ import (
 func (s *environmentService) CreateEnvironmentAsync(
 	ctx context.Context, rc RequestContext, newEnv Environment, observer IObserver[ProgressMessage],
 ) (bool, error) {
-	session, err := s.server.validateSession(ctx, rc.Session)
+	session, err := s.server.validateSession(rc.Session)
 	if err != nil {
 		return false, err
 	}

--- a/cli/azd/internal/vsrpc/environment_service_deploy.go
+++ b/cli/azd/internal/vsrpc/environment_service_deploy.go
@@ -19,7 +19,7 @@ import (
 func (s *environmentService) DeployAsync(
 	ctx context.Context, rc RequestContext, name string, observer IObserver[ProgressMessage],
 ) (*Environment, error) {
-	session, err := s.server.validateSession(ctx, rc.Session)
+	session, err := s.server.validateSession(rc.Session)
 	if err != nil {
 		return nil, err
 	}
@@ -81,9 +81,9 @@ func (s *environmentService) DeployAsync(
 		}
 	})
 
-	ioc.RegisterInstance[*cmd.ProvisionFlags](container.NestedContainer, provisionFlags)
-	ioc.RegisterInstance[*cmd.DeployFlags](container.NestedContainer, deployFlags)
-	ioc.RegisterInstance[[]string](container.NestedContainer, []string{})
+	ioc.RegisterInstance(container.NestedContainer, provisionFlags)
+	ioc.RegisterInstance(container.NestedContainer, deployFlags)
+	ioc.RegisterInstance(container.NestedContainer, []string{})
 
 	container.MustRegisterNamedTransient("provisionAction", cmd.NewProvisionAction)
 	container.MustRegisterNamedTransient("deployAction", cmd.NewDeployAction)

--- a/cli/azd/internal/vsrpc/environment_service_load.go
+++ b/cli/azd/internal/vsrpc/environment_service_load.go
@@ -23,7 +23,7 @@ import (
 func (s *environmentService) OpenEnvironmentAsync(
 	ctx context.Context, rc RequestContext, name string, observer IObserver[ProgressMessage],
 ) (*Environment, error) {
-	session, err := s.server.validateSession(ctx, rc.Session)
+	session, err := s.server.validateSession(rc.Session)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (s *environmentService) OpenEnvironmentAsync(
 func (s *environmentService) LoadEnvironmentAsync(
 	ctx context.Context, rc RequestContext, name string, observer IObserver[ProgressMessage],
 ) (*Environment, error) {
-	session, err := s.server.validateSession(ctx, rc.Session)
+	session, err := s.server.validateSession(rc.Session)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/internal/vsrpc/environment_service_refresh.go
+++ b/cli/azd/internal/vsrpc/environment_service_refresh.go
@@ -28,7 +28,7 @@ import (
 func (s *environmentService) RefreshEnvironmentAsync(
 	ctx context.Context, rc RequestContext, name string, observer IObserver[ProgressMessage],
 ) (*Environment, error) {
-	session, err := s.server.validateSession(ctx, rc.Session)
+	session, err := s.server.validateSession(rc.Session)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/internal/vsrpc/server_session.go
+++ b/cli/azd/internal/vsrpc/server_session.go
@@ -1,7 +1,6 @@
 package vsrpc
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
@@ -66,7 +65,7 @@ func (s *Server) sessionFromId(id string) (*serverSession, bool) {
 
 // validateSession ensures the session id is valid and returns the corresponding and serverSession object. If there
 // is an error it will be of type *jsonrpc2.Error.
-func (s *Server) validateSession(ctx context.Context, session Session) (*serverSession, error) {
+func (s *Server) validateSession(session Session) (*serverSession, error) {
 	if session.Id == "" {
 		return nil, jsonrpc2.NewError(jsonrpc2.InvalidParams, "session.Id is required")
 	}

--- a/cli/azd/pkg/azdo/paged_response_api.go
+++ b/cli/azd/pkg/azdo/paged_response_api.go
@@ -14,7 +14,6 @@ import (
 
 // getDefinitionsPager providers a pager to iterate for all the pages from GetDefinitions.
 func getDefinitionsPager(
-	ctx context.Context,
 	client build.Client,
 	projectId *string,
 	pipelineName *string,

--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -62,7 +62,7 @@ func getPipelineDefinition(
 
 	// GetDefinitions return just the first page (it could be more)
 	// using pager to iterate pages
-	definitionsPager := getDefinitionsPager(ctx, client, projectId, pipelineName)
+	definitionsPager := getDefinitionsPager(client, projectId, pipelineName)
 
 	for definitionsPager.More() {
 		page, err := definitionsPager.NextPage(ctx)
@@ -134,7 +134,7 @@ func CreatePipeline(
 	}
 
 	createDefinitionArgs, err := createAzureDevPipelineArgs(
-		ctx, projectId, name, repoName, credentials, env, queue,
+		projectId, name, repoName, credentials, env, queue,
 		provisioningProvider, additionalSecrets, additionalVariables)
 	if err != nil {
 		return nil, err
@@ -198,7 +198,6 @@ Visit %s for more information on configuring Terraform remote state`,
 
 // create Azure Deploy Pipeline parameters
 func createAzureDevPipelineArgs(
-	ctx context.Context,
 	projectId string,
 	name string,
 	repoName string,

--- a/cli/azd/pkg/azdo/project.go
+++ b/cli/azd/pkg/azdo/project.go
@@ -34,7 +34,6 @@ func createProject(
 	connection *azuredevops.Connection,
 	name string,
 	description string,
-	console input.Console,
 ) (*core.TeamProjectReference, error) {
 	coreClient, err := core.NewClient(ctx, connection)
 	if err != nil {
@@ -124,7 +123,7 @@ func GetProjectFromNew(
 			return "", "", fmt.Errorf("asking for new project name: %w", err)
 		}
 		var message string = ""
-		newProject, err := createProject(ctx, connection, name, projectDescription, console)
+		newProject, err := createProject(ctx, connection, name, projectDescription)
 		if err != nil {
 			message = err.Error()
 		}

--- a/cli/azd/pkg/azdo/utils.go
+++ b/cli/azd/pkg/azdo/utils.go
@@ -14,7 +14,7 @@ import (
 )
 
 // helper method to verify that a configuration exists in the .env file or in system environment variables
-func ensureConfigExists(ctx context.Context, env *environment.Environment, key string, label string) (string, error) {
+func ensureConfigExists(env *environment.Environment, key string, label string) (string, error) {
 	value, exists := env.LookupEnv(key)
 	if !exists || value == "" {
 		return value, fmt.Errorf("%s not found in environment variable %s", label, key)
@@ -25,7 +25,7 @@ func ensureConfigExists(ctx context.Context, env *environment.Environment, key s
 // helper method to ensure an Azure DevOps PAT exists either in .env or system environment variables
 func EnsurePatExists(ctx context.Context, env *environment.Environment, console input.Console) (
 	string, bool, error) {
-	value, err := ensureConfigExists(ctx, env, AzDoPatName, "azure devops personal access token")
+	value, err := ensureConfigExists(env, AzDoPatName, "azure devops personal access token")
 	if err != nil {
 		console.Message(ctx, fmt.Sprintf(
 			"You need an %s. Create a PAT by following the instructions here %s",
@@ -58,7 +58,7 @@ func EnsureOrgNameExists(
 	console input.Console,
 ) (
 	string, bool, error) {
-	value, err := ensureConfigExists(ctx, env, AzDoEnvironmentOrgName, "azure devops organization name")
+	value, err := ensureConfigExists(env, AzDoEnvironmentOrgName, "azure devops organization name")
 	if err != nil {
 		orgName, err := console.Prompt(ctx, input.ConsoleOptions{
 			Message:      "Enter an Azure DevOps Organization Name:",

--- a/cli/azd/pkg/azsdk/storage/storage_file_share_service.go
+++ b/cli/azd/pkg/azsdk/storage/storage_file_share_service.go
@@ -48,7 +48,7 @@ func (f *fileShareClient) UploadPath(ctx context.Context, subId, shareUrl, sourc
 		}
 		if !info.IsDir() {
 			destination := strings.TrimPrefix(path, source+string(filepath.Separator))
-			if err := f.uploadFile(ctx, subId, shareUrl, path, destination, credential); err != nil {
+			if err := f.uploadFile(ctx, shareUrl, path, destination, credential); err != nil {
 				return fmt.Errorf("error uploading file to file share: %w", err)
 			}
 		}
@@ -59,7 +59,7 @@ func (f *fileShareClient) UploadPath(ctx context.Context, subId, shareUrl, sourc
 
 // uploadFile implements FileShareService.
 func (f *fileShareClient) uploadFile(
-	ctx context.Context, subId, fileShareUrl, source, dest string, credential azcore.TokenCredential) error {
+	ctx context.Context, fileShareUrl, source, dest string, credential azcore.TokenCredential) error {
 
 	client, err := share.NewClient(fileShareUrl, credential, &share.ClientOptions{
 		ClientOptions:     f.options.ClientOptions,

--- a/cli/azd/pkg/config/config.go
+++ b/cli/azd/pkg/config/config.go
@@ -183,11 +183,9 @@ func (c *config) Unset(path string) error {
 			return nil
 		}
 
-		if value != nil {
-			node, ok = value.(map[string]any)
-			if !ok {
-				return fmt.Errorf("failed converting node at path '%s' to map", part)
-			}
+		node, ok = value.(map[string]any)
+		if !ok {
+			return fmt.Errorf("failed converting node at path '%s' to map", part)
 		}
 
 		currentNode[part] = node

--- a/cli/azd/pkg/devcenter/template_source_test.go
+++ b/cli/azd/pkg/devcenter/template_source_test.go
@@ -18,7 +18,7 @@ func Test_TemplateSource_ListTemplates(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		templateSource := newTemplateSourceForTest(t, mockContext, &Config{}, nil)
-		setupDevCenterSuccessMocks(t, mockContext, templateSource)
+		setupDevCenterSuccessMocks(mockContext, templateSource)
 
 		templateList, err := templateSource.ListTemplates(*mockContext.Context)
 		require.NoError(t, err)
@@ -50,7 +50,7 @@ func Test_TemplateSource_ListTemplates(t *testing.T) {
 
 		mockContext := mocks.NewMockContext(context.Background())
 		templateSource := newTemplateSourceForTest(t, mockContext, &Config{}, nil)
-		setupDevCenterSuccessMocks(t, mockContext, templateSource)
+		setupDevCenterSuccessMocks(mockContext, templateSource)
 		mockdevcentersdk.MockListEnvironmentDefinitions(
 			mockContext,
 			"Project1",
@@ -93,7 +93,7 @@ func Test_TemplateSource_ListTemplates(t *testing.T) {
 
 		mockContext := mocks.NewMockContext(context.Background())
 		templateSource := newTemplateSourceForTest(t, mockContext, &Config{}, nil)
-		setupDevCenterSuccessMocks(t, mockContext, templateSource)
+		setupDevCenterSuccessMocks(mockContext, templateSource)
 		mockdevcentersdk.MockListEnvironmentDefinitions(
 			mockContext,
 			"Project1",
@@ -127,7 +127,7 @@ func Test_TemplateSource_ListTemplates(t *testing.T) {
 
 		mockContext := mocks.NewMockContext(context.Background())
 		templateSource := newTemplateSourceForTest(t, mockContext, &Config{}, nil)
-		setupDevCenterSuccessMocks(t, mockContext, templateSource)
+		setupDevCenterSuccessMocks(mockContext, templateSource)
 		mockdevcentersdk.MockListEnvironmentDefinitions(
 			mockContext,
 			"Project1",
@@ -143,7 +143,7 @@ func Test_TemplateSource_ListTemplates(t *testing.T) {
 	t.Run("Fail", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		templateSource := newTemplateSourceForTest(t, mockContext, &Config{}, nil)
-		setupDevCenterSuccessMocks(t, mockContext, templateSource)
+		setupDevCenterSuccessMocks(mockContext, templateSource)
 		// Mock will throw 404 not found for this API call causing a failure
 		mockdevcentersdk.MockListEnvironmentDefinitions(mockContext, "Project2", nil)
 
@@ -157,7 +157,7 @@ func Test_TemplateSource_GetTemplate(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		templateSource := newTemplateSourceForTest(t, mockContext, &Config{}, nil)
-		setupDevCenterSuccessMocks(t, mockContext, templateSource)
+		setupDevCenterSuccessMocks(mockContext, templateSource)
 
 		template, err := templateSource.GetTemplate(*mockContext.Context, "DEV_CENTER_01/SampleCatalog/EnvDefinition_02")
 		require.NoError(t, err)
@@ -167,7 +167,7 @@ func Test_TemplateSource_GetTemplate(t *testing.T) {
 	t.Run("TemplateNotFound", func(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		templateSource := newTemplateSourceForTest(t, mockContext, &Config{}, nil)
-		setupDevCenterSuccessMocks(t, mockContext, templateSource)
+		setupDevCenterSuccessMocks(mockContext, templateSource)
 
 		// Expected to fail because the template path is not found
 		template, err := templateSource.GetTemplate(*mockContext.Context, "DEV_CENTER_01/SampleCatalog/NotFound")
@@ -176,7 +176,7 @@ func Test_TemplateSource_GetTemplate(t *testing.T) {
 	})
 }
 
-func setupDevCenterSuccessMocks(t *testing.T, mockContext *mocks.MockContext, templateSource *TemplateSource) {
+func setupDevCenterSuccessMocks(mockContext *mocks.MockContext, templateSource *TemplateSource) {
 	mockdevcentersdk.MockDevCenterGraphQuery(mockContext, mockDevCenterList)
 	mockdevcentersdk.MockListEnvironmentDefinitions(mockContext, "Project1", mockEnvDefinitions)
 	mockdevcentersdk.MockListEnvironmentDefinitions(mockContext, "Project2", []*devcentersdk.EnvironmentDefinition{})

--- a/cli/azd/pkg/devcentersdk/entity_item_request_builder.go
+++ b/cli/azd/pkg/devcentersdk/entity_item_request_builder.go
@@ -54,10 +54,6 @@ func (b *EntityItemRequestBuilder[T]) createRequest(
 		return nil, fmt.Errorf("failed creating request: %w", err)
 	}
 
-	if err != nil {
-		return nil, err
-	}
-
 	raw := req.Raw()
 	query := raw.URL.Query()
 

--- a/cli/azd/pkg/environment/environment_test.go
+++ b/cli/azd/pkg/environment/environment_test.go
@@ -39,7 +39,7 @@ func TestConfigRoundTrips(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	root := t.TempDir()
 
-	envManager, _ := createEnvManager(t, mockContext, root)
+	envManager, _ := createEnvManager(mockContext, root)
 
 	// Create a new config from an empty root.
 	env := New("test")
@@ -84,7 +84,7 @@ func TestFromRoot(t *testing.T) {
 	t.Run("EmptyWhenMissing", func(t *testing.T) {
 		t.Parallel()
 
-		envManager, _ := createEnvManager(t, mockContext, t.TempDir())
+		envManager, _ := createEnvManager(mockContext, t.TempDir())
 		env, err := envManager.Get(*mockContext.Context, "test")
 		require.ErrorIs(t, err, ErrNotFound)
 		require.Nil(t, env)
@@ -96,7 +96,7 @@ func TestFromRoot(t *testing.T) {
 	t.Run("Upgrade", func(t *testing.T) {
 		t.Parallel()
 
-		envManager, azdCtx := createEnvManager(t, mockContext, t.TempDir())
+		envManager, azdCtx := createEnvManager(mockContext, t.TempDir())
 		envRoot := azdCtx.EnvironmentRoot("testEnv")
 
 		err := os.MkdirAll(envRoot, osutil.PermissionDirectory)
@@ -118,7 +118,7 @@ func Test_SaveAndReload(t *testing.T) {
 	ostest.Chdir(t, tempDir)
 
 	mockContext := mocks.NewMockContext(context.Background())
-	envManager, azdCtx := createEnvManager(t, mockContext, t.TempDir())
+	envManager, azdCtx := createEnvManager(mockContext, t.TempDir())
 
 	env := New("test")
 	require.NotNil(t, env)
@@ -186,7 +186,7 @@ func TestCleanName(t *testing.T) {
 
 func TestRoundTripNumberWithLeadingZeros(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
-	envManager, _ := createEnvManager(t, mockContext, t.TempDir())
+	envManager, _ := createEnvManager(mockContext, t.TempDir())
 	env := New("test")
 	env.DotenvSet("TEST", "01")
 	err := envManager.Save(*mockContext.Context, env)
@@ -266,7 +266,7 @@ func Test_fixupUnquotedDotenv(t *testing.T) {
 	require.Equal(t, "TEST_SHOULD_NOT_QUOTE=1\nTEST_SHOULD_QUOTE=\"01\"", fixed)
 }
 
-func createEnvManager(t *testing.T, mockContext *mocks.MockContext, root string) (Manager, *azdcontext.AzdContext) {
+func createEnvManager(mockContext *mocks.MockContext, root string) (Manager, *azdcontext.AzdContext) {
 	azdCtx := azdcontext.NewAzdContextWithDirectory(root)
 	configManager := config.NewFileConfigManager(config.NewManager())
 	localDataStore := NewLocalFileDataStore(azdCtx, configManager)

--- a/cli/azd/pkg/environment/manager.go
+++ b/cli/azd/pkg/environment/manager.go
@@ -136,7 +136,7 @@ func (m *manager) Create(ctx context.Context, spec Spec) (*Environment, error) {
 	case errors.Is(err, ErrNotFound):
 	case err != nil:
 		return nil, fmt.Errorf("checking for existing environment: %w", err)
-	case err == nil:
+	default:
 		return nil, fmt.Errorf("environment '%s' already exists", spec.Name)
 	}
 
@@ -206,7 +206,7 @@ func (m *manager) loadOrInitEnvironment(ctx context.Context, environmentName str
 			}
 		case err != nil:
 			return nil, false, fmt.Errorf("loading environment '%s': %w", environmentName, err)
-		case err == nil:
+		default:
 			return env, false, nil
 		}
 	}

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -144,10 +144,6 @@ func (t *TerraformProvider) plan(ctx context.Context) (*Deployment, *terraformDe
 		return nil, nil, fmt.Errorf("terraform init failed: %s , err: %w", initRes, err)
 	}
 
-	if err != nil {
-		return nil, nil, err
-	}
-
 	err = t.createInputParametersFile(ctx, t.parametersTemplateFilePath(), t.parametersFilePath())
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating parameters file: %w", err)
@@ -165,7 +161,7 @@ func (t *TerraformProvider) plan(ctx context.Context) (*Deployment, *terraformDe
 	}
 
 	//create deployment plan
-	deployment, err := t.createDeployment(ctx, modulePath)
+	deployment, err := t.createDeployment(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create terraform template failed: %w", err)
 	}
@@ -474,7 +470,7 @@ func (t *TerraformProvider) showCurrentState(
 }
 
 // Creates the deployment object from the specified module path
-func (t *TerraformProvider) createDeployment(ctx context.Context, modulePath string) (*Deployment, error) {
+func (t *TerraformProvider) createDeployment(ctx context.Context) (*Deployment, error) {
 	templateParameters := make(map[string]InputParameter)
 
 	//build the template parameters.

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -238,7 +238,7 @@ func (c *AskerConsole) updateLastBytes(msg string) {
 }
 
 func (c *AskerConsole) WarnForFeature(ctx context.Context, key alpha.FeatureId) {
-	if shouldWarn(key) {
+	if shouldWarn() {
 		c.MessageUxItem(ctx, &ux.MultilineMessage{
 			Lines: []string{
 				"",
@@ -252,7 +252,7 @@ func (c *AskerConsole) WarnForFeature(ctx context.Context, key alpha.FeatureId) 
 }
 
 // shouldWarn returns true if a warning should be emitted when using a given alpha feature.
-func shouldWarn(key alpha.FeatureId) bool {
+func shouldWarn() bool {
 	noAlphaWarnings, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_NO_ALPHA_WARNINGS"))
 
 	return err != nil || !noAlphaWarnings
@@ -386,7 +386,7 @@ func (c *AskerConsole) ShowSpinner(ctx context.Context, title string, format Spi
 	c.spinnerLineMu.Lock()
 	c.spinnerCurrentTitle = title
 
-	indentPrefix := c.getIndent(format)
+	indentPrefix := c.getIndent()
 	line := c.spinnerLine(title, indentPrefix)
 
 	_ = c.spinner.Pause()
@@ -435,7 +435,7 @@ func setIndentation(spaces int) string {
 	return string(bytes)
 }
 
-func (c *AskerConsole) getIndent(format SpinnerUxType) string {
+func (c *AskerConsole) getIndent() string {
 	requiredSize := 2
 	if requiredSize != len(c.currentIndent.Load()) {
 		c.currentIndent.Store(setIndentation(requiredSize))
@@ -492,7 +492,7 @@ func (c *AskerConsole) getStopChar(format SpinnerUxType) string {
 	case StepSkipped:
 		stopChar = output.WithGrayFormat("(-) Skipped:")
 	}
-	return fmt.Sprintf("%s%s", c.getIndent(format), stopChar)
+	return fmt.Sprintf("%s%s", c.getIndent(), stopChar)
 }
 
 func promptFromOptions(options ConsoleOptions) survey.Prompt {

--- a/cli/azd/pkg/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/pipeline/azdo_provider.go
@@ -332,7 +332,7 @@ func (p *AzdoScmProvider) configureGitRemote(
 			return "", err
 		}
 	} else {
-		remoteUrl, err = p.getDefaultRepoRemote(ctx, projectName, projectId, p.console)
+		remoteUrl, err = p.getDefaultRepoRemote(ctx, projectName)
 		if err != nil {
 			return "", err
 		}
@@ -359,8 +359,6 @@ func (p *AzdoScmProvider) getCurrentGitBranch(ctx context.Context, repoPath stri
 func (p *AzdoScmProvider) getDefaultRepoRemote(
 	ctx context.Context,
 	projectName string,
-	projectId string,
-	console input.Console,
 ) (string, error) {
 	connection, err := p.getAzdoConnection(ctx)
 	if err != nil {

--- a/cli/azd/pkg/pipeline/github_provider.go
+++ b/cli/azd/pkg/pipeline/github_provider.go
@@ -179,7 +179,7 @@ func (p *GitHubScmProvider) preventGitPush(
 	// Only check when using an existing repo in case github actions are disabled
 	if !p.newGitHubRepoCreated {
 		slug := gitRepo.owner + "/" + gitRepo.repoName
-		return p.notifyWhenGitHubActionsAreDisabled(ctx, gitRepo.gitProjectPath, slug, remoteName, branchName)
+		return p.notifyWhenGitHubActionsAreDisabled(ctx, gitRepo.gitProjectPath, slug)
 	}
 	return false, nil
 }
@@ -219,8 +219,6 @@ func (p *GitHubScmProvider) notifyWhenGitHubActionsAreDisabled(
 	ctx context.Context,
 	gitProjectPath,
 	repoSlug string,
-	origin string,
-	branch string,
 ) (bool, error) {
 	ghActionsInUpstreamRepo, err := p.ghCli.GitHubActionsExists(ctx, repoSlug)
 	if err != nil {
@@ -475,7 +473,7 @@ func (p *GitHubCiProvider) configureConnection(
 
 	repoSlug := repoDetails.owner + "/" + repoDetails.repoName
 	if authType == AuthTypeClientCredentials {
-		err := p.configureClientCredentialsAuth(ctx, infraOptions, repoSlug, servicePrincipal, credentials)
+		err := p.configureClientCredentialsAuth(ctx, infraOptions, repoSlug, credentials)
 		if err != nil {
 			return fmt.Errorf("configuring client credentials auth: %w", err)
 		}
@@ -562,7 +560,6 @@ func (p *GitHubCiProvider) configureClientCredentialsAuth(
 	ctx context.Context,
 	infraOptions provisioning.Options,
 	repoSlug string,
-	servicePrincipal *graphsdk.ServicePrincipal,
 	credentials *entraid.AzureCredentials,
 ) error {
 	/* #nosec G101 - Potential hardcoded credentials - false positive */

--- a/cli/azd/pkg/pipeline/pipeline_manager_test.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager_test.go
@@ -37,7 +37,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 
 	//1. Test without a project file
 	t.Run("can't load project settings", func(t *testing.T) {
-		manager, err := createPipelineManager(t, mockContext, azdContext, nil, nil)
+		manager, err := createPipelineManager(mockContext, azdContext, nil, nil)
 		assert.Nil(t, manager)
 		assert.ErrorContains(
 			t, err, "Loading project configuration: reading project file:")
@@ -54,7 +54,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 
 		simulateUserInteraction(mockContext, gitHubLabel, true)
 
-		manager, err := createPipelineManager(t, mockContext, azdContext, nil, nil)
+		manager, err := createPipelineManager(mockContext, azdContext, nil, nil)
 		assert.NotNil(t, manager)
 
 		verifyProvider(t, manager, gitHubLabel, err)
@@ -76,7 +76,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 
 		simulateUserInteraction(mockContext, gitHubLabel, false)
 
-		_, err := createPipelineManager(t, mockContext, azdContext, nil, nil)
+		_, err := createPipelineManager(mockContext, azdContext, nil, nil)
 		// No error for GitHub, just a message to the console
 		assert.NoError(t, err)
 		assert.Contains(t,
@@ -90,7 +90,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 
 		simulateUserInteraction(mockContext, azdoLabel, false)
 
-		manager, err := createPipelineManager(t, mockContext, azdContext, nil, nil)
+		manager, err := createPipelineManager(mockContext, azdContext, nil, nil)
 		assert.Nil(t, manager)
 		assert.EqualError(t, err, fmt.Sprintf(
 			"%s provider selected, but %s is empty. Please add pipeline files and try again.",
@@ -105,7 +105,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 		simulateUserInteraction(mockContext, azdoLabel, true)
 
 		// Initialize the PipelineManager
-		manager, err := createPipelineManager(t, mockContext, azdContext, nil, nil)
+		manager, err := createPipelineManager(mockContext, azdContext, nil, nil)
 		assert.NotNil(t, manager)
 		assert.NoError(t, err)
 
@@ -128,7 +128,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 
 		simulateUserInteraction(mockContext, azdoLabel, false)
 
-		manager, err := createPipelineManager(t, mockContext, azdContext, env, nil)
+		manager, err := createPipelineManager(mockContext, azdContext, env, nil)
 		assert.Nil(t, manager)
 		assert.EqualError(t, err, fmt.Sprintf(
 			"%s provider selected, but %s is empty. Please add pipeline files and try again.",
@@ -144,7 +144,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 
 		simulateUserInteraction(mockContext, azdoLabel, true)
 
-		manager, err := createPipelineManager(t, mockContext, azdContext, env, nil)
+		manager, err := createPipelineManager(mockContext, azdContext, env, nil)
 		verifyProvider(t, manager, azdoLabel, err)
 
 		deleteYamlFiles(t, tempDir)
@@ -159,7 +159,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 
 		simulateUserInteraction(mockContext, gitHubLabel, false)
 
-		_, err := createPipelineManager(t, mockContext, azdContext, env, nil)
+		_, err := createPipelineManager(mockContext, azdContext, env, nil)
 		// No error for GitHub, just a message to the console
 		assert.NoError(t, err)
 		assert.Contains(t,
@@ -176,7 +176,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 
 		simulateUserInteraction(mockContext, gitHubLabel, true)
 
-		manager, err := createPipelineManager(t, mockContext, azdContext, env, nil)
+		manager, err := createPipelineManager(mockContext, azdContext, env, nil)
 
 		verifyProvider(t, manager, gitHubLabel, err)
 
@@ -192,7 +192,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 			PipelineProvider: "other",
 		}
 
-		manager, err := createPipelineManager(t, mockContext, azdContext, nil, args)
+		manager, err := createPipelineManager(mockContext, azdContext, nil, args)
 		assert.Nil(t, manager)
 		assert.EqualError(t, err, "other is not a known pipeline provider")
 
@@ -208,7 +208,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 		envValues[envPersistedKey] = "other"
 		env := environment.NewWithValues("test-env", envValues)
 
-		manager, err := createPipelineManager(t, mockContext, azdContext, env, nil)
+		manager, err := createPipelineManager(mockContext, azdContext, env, nil)
 		assert.Nil(t, manager)
 		assert.EqualError(t, err, "other is not a known pipeline provider")
 
@@ -221,7 +221,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 
 		appendToAzureYaml(t, projectFileName, "pipeline:\n\r  provider: other")
 
-		manager, err := createPipelineManager(t, mockContext, azdContext, nil, nil)
+		manager, err := createPipelineManager(mockContext, azdContext, nil, nil)
 		assert.Nil(t, manager)
 		assert.EqualError(t, err, "other is not a known pipeline provider")
 
@@ -239,7 +239,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 		envValues[envPersistedKey] = "persisted"
 		env := environment.NewWithValues("test-env", envValues)
 
-		manager, err := createPipelineManager(t, mockContext, azdContext, env, nil)
+		manager, err := createPipelineManager(mockContext, azdContext, env, nil)
 		assert.Nil(t, manager)
 		assert.EqualError(t, err, "fromYaml is not a known pipeline provider")
 
@@ -260,7 +260,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 			PipelineProvider: "arg",
 		}
 
-		manager, err := createPipelineManager(t, mockContext, azdContext, env, args)
+		manager, err := createPipelineManager(mockContext, azdContext, env, args)
 		assert.Nil(t, manager)
 		assert.EqualError(t, err, "arg is not a known pipeline provider")
 
@@ -272,7 +272,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 
 		simulateUserInteraction(mockContext, gitHubLabel, true)
 
-		manager, err := createPipelineManager(t, mockContext, azdContext, nil, nil)
+		manager, err := createPipelineManager(mockContext, azdContext, nil, nil)
 
 		verifyProvider(t, manager, gitHubLabel, err)
 
@@ -283,7 +283,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 
 		simulateUserInteraction(mockContext, azdoLabel, true)
 
-		manager, err := createPipelineManager(t, mockContext, azdContext, nil, nil)
+		manager, err := createPipelineManager(mockContext, azdContext, nil, nil)
 
 		verifyProvider(t, manager, azdoLabel, err)
 
@@ -297,7 +297,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 		simulateUserInteraction(mockContext, gitHubLabel, true)
 
 		// Initialize the PipelineManager
-		manager, err := createPipelineManager(t, mockContext, azdContext, nil, nil)
+		manager, err := createPipelineManager(mockContext, azdContext, nil, nil)
 		assert.NotNil(t, manager)
 		assert.NoError(t, err)
 
@@ -317,7 +317,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 		simulateUserInteraction(mockContext, azdoLabel, true)
 
 		// Initialize the PipelineManager
-		manager, err := createPipelineManager(t, mockContext, azdContext, nil, nil)
+		manager, err := createPipelineManager(mockContext, azdContext, nil, nil)
 		assert.NotNil(t, manager)
 		assert.NoError(t, err)
 
@@ -340,7 +340,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 			PipelineProvider: azdoLabel,
 		}
 
-		manager, err := createPipelineManager(t, mockContext, azdContext, env, args)
+		manager, err := createPipelineManager(mockContext, azdContext, env, args)
 
 		verifyProvider(t, manager, azdoLabel, err)
 
@@ -365,7 +365,7 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 		args := &PipelineManagerArgs{
 			PipelineProvider: azdoLabel,
 		}
-		manager, err := createPipelineManager(t, mockContext, azdContext, env, args)
+		manager, err := createPipelineManager(mockContext, azdContext, env, args)
 
 		verifyProvider(t, manager, azdoLabel, err)
 
@@ -413,7 +413,6 @@ func Test_PipelineManager_Initialize(t *testing.T) {
 }
 
 func createPipelineManager(
-	t *testing.T,
 	mockContext *mocks.MockContext,
 	azdContext *azdcontext.AzdContext,
 	env *environment.Environment,

--- a/cli/azd/pkg/project/framework_service.go
+++ b/cli/azd/pkg/project/framework_service.go
@@ -115,7 +115,7 @@ func validatePackageOutput(packagePath string) error {
 		return fmt.Errorf("package output '%s' does not exist, %w", packagePath, err)
 	} else if err != nil {
 		return fmt.Errorf("failed to read package output '%s', %w", packagePath, err)
-	} else if err == nil && len(entries) == 0 {
+	} else if len(entries) == 0 {
 		return fmt.Errorf("package output '%s' is empty", packagePath)
 	}
 

--- a/cli/azd/pkg/project/project_manager.go
+++ b/cli/azd/pkg/project/project_manager.go
@@ -201,9 +201,6 @@ func (pm *projectManager) EnsureFrameworkTools(
 		}
 
 		frameworkTools := frameworkService.RequiredExternalTools(ctx)
-		if err != nil {
-			return fmt.Errorf("getting service required tools: %w", err)
-		}
 
 		requiredTools = append(requiredTools, frameworkTools...)
 	}
@@ -238,9 +235,6 @@ func (pm *projectManager) EnsureServiceTargetTools(
 		}
 
 		serviceTargetTools := serviceTarget.RequiredExternalTools(ctx)
-		if err != nil {
-			return fmt.Errorf("getting service required tools: %w", err)
-		}
 
 		requiredTools = append(requiredTools, serviceTargetTools...)
 	}

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -189,7 +189,7 @@ func (t *aksTarget) Deploy(
 	targetResource *environment.TargetResource,
 	progress *async.Progress[ServiceProgress],
 ) (*ServiceDeployResult, error) {
-	if err := t.validateTargetResource(ctx, serviceConfig, targetResource); err != nil {
+	if err := t.validateTargetResource(targetResource); err != nil {
 		return nil, fmt.Errorf("validating target resource: %w", err)
 	}
 
@@ -492,7 +492,7 @@ func (t *aksTarget) Endpoints(
 
 	// Find endpoints for any matching services
 	// These endpoints would typically be internal cluster accessible endpoints
-	serviceEndpoints, err := t.getServiceEndpoints(ctx, serviceConfig, serviceName)
+	serviceEndpoints, err := t.getServiceEndpoints(ctx, serviceName)
 	if err != nil && !errors.Is(err, kubectl.ErrResourceNotFound) {
 		return nil, fmt.Errorf("failed retrieving service endpoints, %w", err)
 	}
@@ -510,8 +510,6 @@ func (t *aksTarget) Endpoints(
 }
 
 func (t *aksTarget) validateTargetResource(
-	ctx context.Context,
-	serviceConfig *ServiceConfig,
 	targetResource *environment.TargetResource,
 ) error {
 	if targetResource.ResourceGroupName() == "" {
@@ -746,7 +744,6 @@ func (t *aksTarget) waitForService(
 // Supports service types for LoadBalancer and ClusterIP
 func (t *aksTarget) getServiceEndpoints(
 	ctx context.Context,
-	serviceConfig *ServiceConfig,
 	serviceNameFilter string,
 ) ([]string, error) {
 	service, err := t.waitForService(ctx, serviceNameFilter)

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -76,7 +76,7 @@ func (at *containerAppTarget) Deploy(
 	targetResource *environment.TargetResource,
 	progress *async.Progress[ServiceProgress],
 ) (*ServiceDeployResult, error) {
-	if err := at.validateTargetResource(ctx, serviceConfig, targetResource); err != nil {
+	if err := at.validateTargetResource(targetResource); err != nil {
 		return nil, fmt.Errorf("validating target resource: %w", err)
 	}
 
@@ -141,8 +141,6 @@ func (at *containerAppTarget) Endpoints(
 }
 
 func (at *containerAppTarget) validateTargetResource(
-	ctx context.Context,
-	serviceConfig *ServiceConfig,
 	targetResource *environment.TargetResource,
 ) error {
 	if targetResource.ResourceGroupName() == "" {
@@ -158,7 +156,7 @@ func (at *containerAppTarget) validateTargetResource(
 	return nil
 }
 
-func (at *containerAppTarget) addPreProvisionChecks(ctx context.Context, serviceConfig *ServiceConfig) error {
+func (at *containerAppTarget) addPreProvisionChecks(_ context.Context, serviceConfig *ServiceConfig) error {
 	// Attempt to retrieve the target resource for the current service
 	// This allows the resource deployment to detect whether or not to pull existing container image during
 	// provision operation to avoid resetting the container app back to a default image

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -59,11 +59,9 @@ func TestNewContainerAppTargetTypeValidation(t *testing.T) {
 
 	for test, data := range tests {
 		t.Run(test, func(t *testing.T) {
-			mockContext := mocks.NewMockContext(context.Background())
 			serviceTarget := &containerAppTarget{}
-			serviceConfig := &ServiceConfig{}
 
-			err := serviceTarget.validateTargetResource(*mockContext.Context, serviceConfig, data.targetResource)
+			err := serviceTarget.validateTargetResource(data.targetResource)
 			if data.expectError {
 				require.Error(t, err)
 			} else {
@@ -83,7 +81,7 @@ func Test_ContainerApp_Deploy(t *testing.T) {
 	serviceConfig := createTestServiceConfig(tempDir, ContainerAppTarget, ServiceLanguageTypeScript)
 	env := createEnv()
 
-	serviceTarget := createContainerAppServiceTarget(mockContext, serviceConfig, env)
+	serviceTarget := createContainerAppServiceTarget(mockContext, env)
 
 	packageResult, err := logProgress(
 		t, func(progress *async.Progress[ServiceProgress]) (*ServicePackageResult, error) {
@@ -129,7 +127,6 @@ func Test_ContainerApp_Deploy(t *testing.T) {
 
 func createContainerAppServiceTarget(
 	mockContext *mocks.MockContext,
-	serviceConfig *ServiceConfig,
 	env *environment.Environment,
 ) ServiceTarget {
 	dockerCli := docker.NewCli(mockContext.CommandRunner)

--- a/cli/azd/pkg/project/service_target_dotnet_containerapp.go
+++ b/cli/azd/pkg/project/service_target_dotnet_containerapp.go
@@ -99,7 +99,7 @@ func (at *dotnetContainerAppTarget) Deploy(
 	targetResource *environment.TargetResource,
 	progress *async.Progress[ServiceProgress],
 ) (*ServiceDeployResult, error) {
-	if err := at.validateTargetResource(ctx, serviceConfig, targetResource); err != nil {
+	if err := at.validateTargetResource(targetResource); err != nil {
 		return nil, fmt.Errorf("validating target resource: %w", err)
 	}
 
@@ -314,8 +314,6 @@ func (at *dotnetContainerAppTarget) Endpoints(
 }
 
 func (at *dotnetContainerAppTarget) validateTargetResource(
-	ctx context.Context,
-	serviceConfig *ServiceConfig,
 	targetResource *environment.TargetResource,
 ) error {
 	if targetResource.ResourceGroupName() == "" {

--- a/cli/azd/pkg/project/service_target_functionapp.go
+++ b/cli/azd/pkg/project/service_target_functionapp.go
@@ -76,7 +76,7 @@ func (f *functionAppTarget) Deploy(
 	targetResource *environment.TargetResource,
 	progress *async.Progress[ServiceProgress],
 ) (*ServiceDeployResult, error) {
-	if err := f.validateTargetResource(ctx, serviceConfig, targetResource); err != nil {
+	if err := f.validateTargetResource(targetResource); err != nil {
 		return nil, fmt.Errorf("validating target resource: %w", err)
 	}
 
@@ -151,8 +151,6 @@ func (f *functionAppTarget) Endpoints(
 }
 
 func (f *functionAppTarget) validateTargetResource(
-	ctx context.Context,
-	serviceConfig *ServiceConfig,
 	targetResource *environment.TargetResource,
 ) error {
 	if !strings.EqualFold(targetResource.ResourceType(), string(infra.AzureResourceTypeWebSite)) {

--- a/cli/azd/pkg/project/service_target_functionapp_test.go
+++ b/cli/azd/pkg/project/service_target_functionapp_test.go
@@ -4,13 +4,11 @@
 package project
 
 import (
-	"context"
 	"strings"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
-	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,11 +34,9 @@ func TestNewFunctionAppTargetTypeValidation(t *testing.T) {
 
 	for test, data := range tests {
 		t.Run(test, func(t *testing.T) {
-			mockContext := mocks.NewMockContext(context.Background())
 			serviceTarget := &functionAppTarget{}
-			serviceConfig := &ServiceConfig{}
 
-			err := serviceTarget.validateTargetResource(*mockContext.Context, serviceConfig, data.targetResource)
+			err := serviceTarget.validateTargetResource(data.targetResource)
 			if data.expectError {
 				require.Error(t, err)
 			} else {

--- a/cli/azd/pkg/project/service_target_springapp.go
+++ b/cli/azd/pkg/project/service_target_springapp.go
@@ -76,7 +76,7 @@ func (st *springAppTarget) Deploy(
 	targetResource *environment.TargetResource,
 	progress *async.Progress[ServiceProgress],
 ) (*ServiceDeployResult, error) {
-	if err := st.validateTargetResource(ctx, serviceConfig, targetResource); err != nil {
+	if err := st.validateTargetResource(targetResource); err != nil {
 		return nil, fmt.Errorf("validating target resource: %w", err)
 	}
 
@@ -190,8 +190,6 @@ func (st *springAppTarget) Endpoints(
 }
 
 func (st *springAppTarget) validateTargetResource(
-	ctx context.Context,
-	serviceConfig *ServiceConfig,
 	targetResource *environment.TargetResource,
 ) error {
 	if targetResource.ResourceGroupName() == "" {

--- a/cli/azd/pkg/project/service_target_springapp_test.go
+++ b/cli/azd/pkg/project/service_target_springapp_test.go
@@ -4,13 +4,11 @@
 package project
 
 import (
-	"context"
 	"strings"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
-	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,11 +42,9 @@ func TestNewSpringAppTargetTypeValidation(t *testing.T) {
 
 	for test, data := range tests {
 		t.Run(test, func(t *testing.T) {
-			mockContext := mocks.NewMockContext(context.Background())
 			serviceTarget := &springAppTarget{}
-			serviceConfig := &ServiceConfig{}
 
-			err := serviceTarget.validateTargetResource(*mockContext.Context, serviceConfig, data.targetResource)
+			err := serviceTarget.validateTargetResource(data.targetResource)
 			if data.expectError {
 				require.Error(t, err)
 			} else {

--- a/cli/azd/pkg/project/service_target_staticwebapp.go
+++ b/cli/azd/pkg/project/service_target_staticwebapp.go
@@ -97,7 +97,7 @@ func (at *staticWebAppTarget) Deploy(
 	targetResource *environment.TargetResource,
 	progress *async.Progress[ServiceProgress],
 ) (*ServiceDeployResult, error) {
-	if err := at.validateTargetResource(ctx, serviceConfig, targetResource); err != nil {
+	if err := at.validateTargetResource(targetResource); err != nil {
 		return nil, fmt.Errorf("validating target resource: %w", err)
 	}
 
@@ -186,8 +186,6 @@ func (at *staticWebAppTarget) Endpoints(
 }
 
 func (at *staticWebAppTarget) validateTargetResource(
-	ctx context.Context,
-	serviceConfig *ServiceConfig,
 	targetResource *environment.TargetResource,
 ) error {
 	if !strings.EqualFold(targetResource.ResourceType(), string(infra.AzureResourceTypeStaticWebSite)) {

--- a/cli/azd/pkg/project/service_target_staticwebapp_test.go
+++ b/cli/azd/pkg/project/service_target_staticwebapp_test.go
@@ -4,13 +4,11 @@
 package project
 
 import (
-	"context"
 	"strings"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
-	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,11 +42,9 @@ func TestNewStaticWebAppTargetTypeValidation(t *testing.T) {
 
 	for test, data := range tests {
 		t.Run(test, func(t *testing.T) {
-			mockContext := mocks.NewMockContext(context.Background())
 			serviceTarget := &staticWebAppTarget{}
-			serviceConfig := &ServiceConfig{}
 
-			err := serviceTarget.validateTargetResource(*mockContext.Context, serviceConfig, data.targetResource)
+			err := serviceTarget.validateTargetResource(data.targetResource)
 			if data.expectError {
 				require.Error(t, err)
 			} else {

--- a/cli/azd/pkg/templates/source_manager.go
+++ b/cli/azd/pkg/templates/source_manager.go
@@ -138,7 +138,7 @@ func (sm *sourceManager) List(ctx context.Context) ([]*SourceConfig, error) {
 	} else {
 		// In the use case where template sources have never been configured,
 		// add Awesome-Azd as the default template source.
-		if err := sm.addInternal(ctx, SourceAwesomeAzd.Key, SourceAwesomeAzd); err != nil {
+		if err := sm.addInternal(SourceAwesomeAzd); err != nil {
 			return nil, fmt.Errorf("unable to default template source '%s': %w", SourceAwesomeAzd.Key, err)
 		}
 		allSourceConfigs = append(allSourceConfigs, SourceAwesomeAzd)
@@ -178,7 +178,7 @@ func (sm *sourceManager) Add(ctx context.Context, key string, source *SourceConf
 
 	source.Key = newKey
 
-	return sm.addInternal(ctx, source.Key, source)
+	return sm.addInternal(source)
 }
 
 // Remove removes a template source by the specified key.
@@ -242,7 +242,7 @@ func (sm *sourceManager) CreateSource(ctx context.Context, config *SourceConfig)
 	return source, nil
 }
 
-func (sm *sourceManager) addInternal(ctx context.Context, key string, source *SourceConfig) error {
+func (sm *sourceManager) addInternal(source *SourceConfig) error {
 	config, err := sm.configManager.Load()
 	if err != nil {
 		return fmt.Errorf("unable to load user configuration: %w", err)

--- a/cli/azd/test/mocks/mockaccount/mock_manager.go
+++ b/cli/azd/test/mocks/mockaccount/mock_manager.go
@@ -43,6 +43,7 @@ func (a *MockAccountManager) GetAccountDefaults(ctx context.Context) (*account.A
 }
 func (a *MockAccountManager) GetSubscriptionsWithDefaultSet(ctx context.Context) ([]account.Subscription, error) {
 	subscriptions := a.Subscriptions
+
 	for _, sub := range subscriptions {
 		if sub.Id == a.DefaultSubscription {
 			sub.IsDefault = true


### PR DESCRIPTION
`gopls` has a built in set of linters and we were failing some of them. This change cleans up some issues it identified related to tautological conditions (where I just removed the dead code) as well as unused parameters (where I removed the parameter and updated the call sites).