### PR TITLE
Fix `gopls check` issues

### DIFF
--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -280,21 +280,12 @@ type walkDirFunc func(path string, entries []fs.DirEntry) error
 // walkDirectories walks the file tree rooted at root, calling fn for each directory in the tree, including root.
 // The directories are walked in lexical order.
 func walkDirectories(root string, fn walkDirFunc) error {
-	info, err := os.Lstat(root)
-	if err != nil {
-		return err
-	}
-
-	return walkDirRecursive(root, fs.FileInfoToDirEntry(info), fn)
-}
-
-func walkDirRecursive(path string, d fs.DirEntry, fn walkDirFunc) error {
-	entries, err := os.ReadDir(path)
+	entries, err := os.ReadDir(root)
 	if err != nil {
 		return fmt.Errorf("reading directory: %w", err)
 	}
 
-	err = fn(path, entries)
+	err = fn(root, entries)
 	if errors.Is(err, filepath.SkipDir) {
 		// skip the directory
 		return nil
@@ -305,8 +296,8 @@ func walkDirRecursive(path string, d fs.DirEntry, fn walkDirFunc) error {
 
 	for _, entry := range entries {
 		if entry.IsDir() {
-			dir := filepath.Join(path, entry.Name())
-			err = walkDirRecursive(dir, entry, fn)
+			dir := filepath.Join(root, entry.Name())
+			err = walkDirectories(dir, fn)
 			if err != nil {
 				return err
 			}

--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -277,15 +277,15 @@ func detectAny(ctx context.Context, detectors []projectDetector, path string, en
 // path is the directory being visited. entries are the file entries (including directories) in that directory.
 type walkDirFunc func(path string, entries []fs.DirEntry) error
 
-// walkDirectories walks the file tree rooted at root, calling fn for each directory in the tree, including root.
+// walkDirectories recursively descends the file tree located at path, calling fn for each directory in the tree.
 // The directories are walked in lexical order.
-func walkDirectories(root string, fn walkDirFunc) error {
-	entries, err := os.ReadDir(root)
+func walkDirectories(path string, fn walkDirFunc) error {
+	entries, err := os.ReadDir(path)
 	if err != nil {
 		return fmt.Errorf("reading directory: %w", err)
 	}
 
-	err = fn(root, entries)
+	err = fn(path, entries)
 	if errors.Is(err, filepath.SkipDir) {
 		// skip the directory
 		return nil
@@ -296,7 +296,7 @@ func walkDirectories(root string, fn walkDirFunc) error {
 
 	for _, entry := range entries {
 		if entry.IsDir() {
-			dir := filepath.Join(root, entry.Name())
+			dir := filepath.Join(path, entry.Name())
 			err = walkDirectories(dir, fn)
 			if err != nil {
 				return err

--- a/cli/azd/pkg/osutil/osversion/osversion.go
+++ b/cli/azd/pkg/osutil/osversion/osversion.go
@@ -2,6 +2,8 @@
 
 package osversion
 
-func GetVersion() string {
-	return ""
+import "errors"
+
+func GetVersion() (string, error) {
+	return "", errors.New("unsupported OS")
 }

--- a/cli/azd/test/cmdrecord/proxy/main.go
+++ b/cli/azd/test/cmdrecord/proxy/main.go
@@ -103,7 +103,7 @@ func (a *App) record(id int) error {
 		return err
 	}
 	var exitError *exec.ExitError
-	if errors.Is(runErr, exitError) && !exitError.Exited() {
+	if errors.As(runErr, &exitError) && !exitError.Exited() {
 		return errSignalTerm
 	}
 
@@ -222,7 +222,7 @@ func (a *App) passthrough() error {
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
 	var exitError *exec.ExitError
-	if errors.Is(err, exitError) && !exitError.Exited() {
+	if errors.As(err, &exitError) && !exitError.Exited() {
 		return errSignalTerm
 	}
 
@@ -360,7 +360,7 @@ func main() {
 		// The current process should stop at this point.
 		// This should be unreachable, but in case anything happens, panic on err.
 		panic(err)
-	} else if errors.Is(err, exitCodeErr) {
+	} else if errors.As(err, &exitCodeErr) {
 		os.Exit(exitCodeErr.ExitCode)
 	} else if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/cli/azd/test/mocks/mockaccount/mock_manager.go
+++ b/cli/azd/test/mocks/mockaccount/mock_manager.go
@@ -2,6 +2,7 @@ package mockaccount
 
 import (
 	"context"
+	"slices"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
@@ -42,10 +43,11 @@ func (a *MockAccountManager) GetAccountDefaults(ctx context.Context) (*account.A
 	}, nil
 }
 func (a *MockAccountManager) GetSubscriptionsWithDefaultSet(ctx context.Context) ([]account.Subscription, error) {
-	subscriptions := a.Subscriptions
-	for _, sub := range subscriptions {
+	subscriptions := slices.Clone(a.Subscriptions)
+
+	for i, sub := range subscriptions {
 		if sub.Id == a.DefaultSubscription {
-			sub.IsDefault = true
+			subscriptions[i].IsDefault = true
 		}
 	}
 	return subscriptions, nil


### PR DESCRIPTION
This addresses a handful of issues identified by `gopls check` but which require some careful inspection:

- `appdetect.go` was ignoring a parameter for a directory entry, once that was removed, we were able to combine some methods together.

- `main.go` in the recorder proxy was using `errors.Is` when instead of `errors.As` leading to possible nil derefrences later.

- `mock_manager.go` was modifying state of a value which was discarded during loop iterations, it has been rewritten to mutate the value in the slice which will be returned, which seemed like what was intended.

- `osversion.go` has a return value mismatch on the platforms we don't care about, so the dummy implementation was fixed to match the others.