### PR TITLE
project: Pass `ServiceConfig` to `RequiredExternalTools`

### DIFF
--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -177,7 +177,7 @@ func (ch *ContainerHelper) LocalImageTag(ctx context.Context, serviceConfig *Ser
 	return configuredImage.Local(), nil
 }
 
-func (ch *ContainerHelper) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (ch *ContainerHelper) RequiredExternalTools(ctx context.Context, serviceConfig *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{ch.docker}
 }
 

--- a/cli/azd/pkg/project/framework_service.go
+++ b/cli/azd/pkg/project/framework_service.go
@@ -64,7 +64,7 @@ type FrameworkPackageRequirements struct {
 // restore and build commands
 type FrameworkService interface {
 	// Gets a list of the required external tools for the framework service
-	RequiredExternalTools(ctx context.Context) []tools.ExternalTool
+	RequiredExternalTools(ctx context.Context, serviceConfig *ServiceConfig) []tools.ExternalTool
 
 	// Initializes the framework service for the specified service configuration
 	// This is useful if the framework needs to subscribe to any service events

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -162,7 +162,7 @@ func (p *dockerProject) Requirements() FrameworkRequirements {
 }
 
 // Gets the required external tools for the project
-func (p *dockerProject) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (p *dockerProject) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{p.docker}
 }
 

--- a/cli/azd/pkg/project/framework_service_dotnet.go
+++ b/cli/azd/pkg/project/framework_service_dotnet.go
@@ -49,7 +49,7 @@ func (dp *dotnetProject) Requirements() FrameworkRequirements {
 }
 
 // Gets the required external tools for the project
-func (dp *dotnetProject) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (dp *dotnetProject) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{dp.dotnetCli}
 }
 

--- a/cli/azd/pkg/project/framework_service_maven.go
+++ b/cli/azd/pkg/project/framework_service_maven.go
@@ -44,7 +44,7 @@ func (m *mavenProject) Requirements() FrameworkRequirements {
 }
 
 // Gets the required external tools for the project
-func (m *mavenProject) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (m *mavenProject) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{
 		m.mavenCli,
 		m.javacCli,

--- a/cli/azd/pkg/project/framework_service_noop.go
+++ b/cli/azd/pkg/project/framework_service_noop.go
@@ -14,7 +14,7 @@ func NewNoOpProject(env *environment.Environment) FrameworkService {
 	return &noOpProject{}
 }
 
-func (n *noOpProject) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+func (n *noOpProject) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{}
 }
 

--- a/cli/azd/pkg/project/framework_service_npm.go
+++ b/cli/azd/pkg/project/framework_service_npm.go
@@ -39,7 +39,7 @@ func (np *npmProject) Requirements() FrameworkRequirements {
 }
 
 // Gets the required external tools for the project
-func (np *npmProject) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (np *npmProject) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{np.cli}
 }
 

--- a/cli/azd/pkg/project/framework_service_python.go
+++ b/cli/azd/pkg/project/framework_service_python.go
@@ -41,7 +41,7 @@ func (pp *pythonProject) Requirements() FrameworkRequirements {
 }
 
 // Gets the required external tools for the project
-func (pp *pythonProject) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (pp *pythonProject) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{pp.cli}
 }
 

--- a/cli/azd/pkg/project/framework_service_swa.go
+++ b/cli/azd/pkg/project/framework_service_swa.go
@@ -63,7 +63,7 @@ func (p *swaProject) Requirements() FrameworkRequirements {
 }
 
 // Gets the required external tools for the project
-func (p *swaProject) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (p *swaProject) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{p.swa}
 }
 

--- a/cli/azd/pkg/project/project_manager.go
+++ b/cli/azd/pkg/project/project_manager.go
@@ -200,7 +200,7 @@ func (pm *projectManager) EnsureFrameworkTools(
 			return fmt.Errorf("getting framework service: %w", err)
 		}
 
-		frameworkTools := frameworkService.RequiredExternalTools(ctx)
+		frameworkTools := frameworkService.RequiredExternalTools(ctx, svc)
 		if err != nil {
 			return fmt.Errorf("getting service required tools: %w", err)
 		}
@@ -237,7 +237,7 @@ func (pm *projectManager) EnsureServiceTargetTools(
 			return fmt.Errorf("getting service target: %w", err)
 		}
 
-		serviceTargetTools := serviceTarget.RequiredExternalTools(ctx)
+		serviceTargetTools := serviceTarget.RequiredExternalTools(ctx, svc)
 		if err != nil {
 			return fmt.Errorf("getting service required tools: %w", err)
 		}

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -148,8 +148,8 @@ func (sm *serviceManager) GetRequiredTools(ctx context.Context, serviceConfig *S
 	}
 
 	requiredTools := []tools.ExternalTool{}
-	requiredTools = append(requiredTools, frameworkService.RequiredExternalTools(ctx)...)
-	requiredTools = append(requiredTools, serviceTarget.RequiredExternalTools(ctx)...)
+	requiredTools = append(requiredTools, frameworkService.RequiredExternalTools(ctx, serviceConfig)...)
+	requiredTools = append(requiredTools, serviceTarget.RequiredExternalTools(ctx, serviceConfig)...)
 
 	return tools.Unique(requiredTools), nil
 }

--- a/cli/azd/pkg/project/service_manager_test.go
+++ b/cli/azd/pkg/project/service_manager_test.go
@@ -491,7 +491,7 @@ func (f *fakeFramework) Requirements() FrameworkRequirements {
 	}
 }
 
-func (f *fakeFramework) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+func (f *fakeFramework) RequiredExternalTools(_ context.Context, _ *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{&fakeTool{}}
 }
 
@@ -581,7 +581,7 @@ func (st *fakeServiceTarget) Initialize(ctx context.Context, serviceConfig *Serv
 	return nil
 }
 
-func (st *fakeServiceTarget) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+func (st *fakeServiceTarget) RequiredExternalTools(ctx context.Context, serviceConfig *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{&fakeTool{}}
 }
 

--- a/cli/azd/pkg/project/service_target.go
+++ b/cli/azd/pkg/project/service_target.go
@@ -67,7 +67,7 @@ type ServiceTarget interface {
 
 	// RequiredExternalTools are the tools needed to run the deploy operation for this
 	// target.
-	RequiredExternalTools(ctx context.Context) []tools.ExternalTool
+	RequiredExternalTools(ctx context.Context, serviceConfig *ServiceConfig) []tools.ExternalTool
 
 	// Package prepares artifacts for deployment
 	Package(

--- a/cli/azd/pkg/project/service_target_ai_endpoint.go
+++ b/cli/azd/pkg/project/service_target_ai_endpoint.go
@@ -46,7 +46,7 @@ func (m *aiEndpointTarget) Initialize(ctx context.Context, serviceConfig *Servic
 }
 
 // RequiredExternalTools returns the required external tools for the machineLearningEndpointTarget
-func (m *aiEndpointTarget) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+func (m *aiEndpointTarget) RequiredExternalTools(ctx context.Context, serviceConfig *ServiceConfig) []tools.ExternalTool {
 	return m.aiHelper.RequiredExternalTools(ctx)
 }
 

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -121,9 +121,9 @@ func NewAksTarget(
 }
 
 // Gets the required external tools to support the AKS service
-func (t *aksTarget) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+func (t *aksTarget) RequiredExternalTools(ctx context.Context, serviceConfig *ServiceConfig) []tools.ExternalTool {
 	allTools := []tools.ExternalTool{}
-	allTools = append(allTools, t.containerHelper.RequiredExternalTools(ctx)...)
+	allTools = append(allTools, t.containerHelper.RequiredExternalTools(ctx, serviceConfig)...)
 	allTools = append(allTools, t.kubectl)
 
 	if t.featureManager.IsEnabled(featureHelm) {

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -67,7 +67,7 @@ func Test_Required_Tools(t *testing.T) {
 	userConfig := config.NewConfig(nil)
 	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env, userConfig)
 
-	requiredTools := serviceTarget.RequiredExternalTools(*mockContext.Context)
+	requiredTools := serviceTarget.RequiredExternalTools(*mockContext.Context, serviceConfig)
 	require.Len(t, requiredTools, 2)
 	require.IsType(t, &docker.Cli{}, requiredTools[0])
 	require.IsType(t, &kubectl.Cli{}, requiredTools[1])
@@ -89,7 +89,7 @@ func Test_Required_Tools_WithAlpha(t *testing.T) {
 	_ = userConfig.Set("alpha.aks.kustomize", "on")
 	serviceTarget := createAksServiceTarget(mockContext, serviceConfig, env, userConfig)
 
-	requiredTools := serviceTarget.RequiredExternalTools(*mockContext.Context)
+	requiredTools := serviceTarget.RequiredExternalTools(*mockContext.Context, serviceConfig)
 	require.Len(t, requiredTools, 4)
 	require.IsType(t, &docker.Cli{}, requiredTools[0])
 	require.IsType(t, &kubectl.Cli{}, requiredTools[1])

--- a/cli/azd/pkg/project/service_target_appservice.go
+++ b/cli/azd/pkg/project/service_target_appservice.go
@@ -34,7 +34,7 @@ func NewAppServiceTarget(
 }
 
 // Gets the required external tools
-func (st *appServiceTarget) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (st *appServiceTarget) RequiredExternalTools(ctx context.Context, serviceConfig *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{}
 }
 

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -45,8 +45,8 @@ func NewContainerAppTarget(
 }
 
 // Gets the required external tools
-func (at *containerAppTarget) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
-	return at.containerHelper.RequiredExternalTools(ctx)
+func (at *containerAppTarget) RequiredExternalTools(ctx context.Context, serviceConfig *ServiceConfig) []tools.ExternalTool {
+	return at.containerHelper.RequiredExternalTools(ctx, serviceConfig)
 }
 
 // Initializes the Container App target

--- a/cli/azd/pkg/project/service_target_dotnet_containerapp.go
+++ b/cli/azd/pkg/project/service_target_dotnet_containerapp.go
@@ -72,7 +72,7 @@ func NewDotNetContainerAppTarget(
 }
 
 // Gets the required external tools
-func (at *dotnetContainerAppTarget) RequiredExternalTools(ctx context.Context) []tools.ExternalTool {
+func (at *dotnetContainerAppTarget) RequiredExternalTools(ctx context.Context, svc *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{at.dotNetCli}
 }
 

--- a/cli/azd/pkg/project/service_target_functionapp.go
+++ b/cli/azd/pkg/project/service_target_functionapp.go
@@ -36,7 +36,7 @@ func NewFunctionAppTarget(
 }
 
 // Gets the required external tools for the Function app
-func (f *functionAppTarget) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (f *functionAppTarget) RequiredExternalTools(ctx context.Context, serviceConfig *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{}
 }
 

--- a/cli/azd/pkg/project/service_target_springapp.go
+++ b/cli/azd/pkg/project/service_target_springapp.go
@@ -50,7 +50,7 @@ func NewSpringAppTarget(
 	}
 }
 
-func (st *springAppTarget) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (st *springAppTarget) RequiredExternalTools(ctx context.Context, serviceConfig *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{}
 }
 

--- a/cli/azd/pkg/project/service_target_staticwebapp.go
+++ b/cli/azd/pkg/project/service_target_staticwebapp.go
@@ -43,7 +43,7 @@ func NewStaticWebAppTarget(
 }
 
 // Gets the required external tools for the Static Web App target
-func (at *staticWebAppTarget) RequiredExternalTools(context.Context) []tools.ExternalTool {
+func (at *staticWebAppTarget) RequiredExternalTools(ctx context.Context, serviceConfig *ServiceConfig) []tools.ExternalTool {
 	return []tools.ExternalTool{at.swa}
 }
 


### PR DESCRIPTION
This modifies the `RequiredExternalTools` method on both the `FrameworkService` and `ServiceTarget` interfaces to accept the `ServiceConfig` of the service in question we are fetching tools for.

This allows the set of tools a to be conditional based on the service configuration, which we will exploit later when supporting docker remote builds via ACR so we can say the docker CLI is not a required tool.