### PR TITLE
bicep: Fix panic during deployment progress rendering

### DIFF
--- a/cli/azd/pkg/infra/azure_resource_manager.go
+++ b/cli/azd/pkg/infra/azure_resource_manager.go
@@ -68,7 +68,9 @@ func (rm *AzureResourceManager) GetDeploymentResourceOperations(
 	} else {
 		// Otherwise find the resource group within the deployment operations
 		for _, operation := range topLevelDeploymentOperations {
-			if operation.Properties.TargetResource != nil &&
+			if operation.Properties != nil &&
+				operation.Properties.TargetResource != nil &&
+				operation.Properties.TargetResource.ResourceType != nil &&
 				*operation.Properties.TargetResource.ResourceType == string(AzureResourceTypeResourceGroup) {
 				resourceGroupName = *operation.Properties.TargetResource.ResourceName
 				break
@@ -87,10 +89,15 @@ func (rm *AzureResourceManager) GetDeploymentResourceOperations(
 	// Recursively append any resource group deployments that are found
 	innerLevelDeploymentOperations := make(map[string]*armresources.DeploymentOperation)
 	for _, operation := range topLevelDeploymentOperations {
-		if operation.Properties.TargetResource == nil {
+		if operation.Properties == nil ||
+			operation.Properties.TargetResource == nil ||
+			operation.Properties.TargetResource.ID == nil ||
+			operation.Properties.TargetResource.ResourceType == nil ||
+			operation.Properties.ProvisioningOperation == nil {
 			// Operations w/o target data can't be resolved. Ignoring them
 			continue
 		}
+
 		if !strings.HasPrefix(*operation.Properties.TargetResource.ID, resourceIdPrefix) {
 			// topLevelDeploymentOperations might include deployments NOT within the resource group which we don't want to
 			// resolve

--- a/cli/azd/pkg/tools/bicep/bicep.go
+++ b/cli/azd/pkg/tools/bicep/bicep.go
@@ -27,7 +27,7 @@ import (
 
 // Version is the minimum version of bicep that we require (and the one we fetch when we fetch bicep on behalf of a
 // user).
-var Version semver.Version = semver.MustParse("0.28.1")
+var Version semver.Version = semver.MustParse("0.29.47")
 
 // NewCli creates a new Bicep CLI. Azd manages its own copy of the bicep CLI, stored in `$AZD_CONFIG_DIR/bin`. If
 // bicep is not present at this location, or if it is present but is older than the minimum supported version, it is


### PR DESCRIPTION
We had a panic in our display code when rendering data if you were using a the microsoft graph provider in bicep (a new extensibility feature) because some of the properties of the ARM operation object were not present.

This change adds additional guards to our rendering logic to ignore operations that don't have a complete set of data.

Fixes #4169