### PR TITLE
Remove under-utilized events

### DIFF
--- a/cli/azd/internal/tracing/events/events.go
+++ b/cli/azd/internal/tracing/events/events.go
@@ -15,18 +15,5 @@ const CommandEventPrefix = "cmd."
 // Prefix for vsrpc events.
 const VsRpcEventPrefix = "vsrpc."
 
-// BicepInstallEvent is the name of the event which tracks the overall bicep install operation.
-const BicepInstallEvent = "tools.bicep.install"
-
-// GitHubCliInstallEvent is the name of the event which tracks the overall GitHub cli install operation.
-const GitHubCliInstallEvent = "tools.gh.install"
-
-// PackCliInstallEvent is the name of the event which tracks the overall pack cli install operation.
-const PackCliInstallEvent = "tools.pack.install"
-
 // PackBuildEvent is the name of the event which tracks the overall pack build operation.
 const PackBuildEvent = "tools.pack.build"
-
-// AccountSubscriptionsListEvent is the name of the event which tracks listing of account subscriptions .
-// See fields.AccountSubscriptionsListTenantsFound for additional event fields.
-const AccountSubscriptionsListEvent = "account.subscriptions.list"

--- a/cli/azd/internal/tracing/fields/fields.go
+++ b/cli/azd/internal/tracing/fields/fields.go
@@ -166,14 +166,6 @@ const (
 // The value used for ServiceNameKey
 const ServiceNameAzd = "azd"
 
-// Additional fields of events.AccountSubscriptionsListEvent
-const (
-	// Number of tenants found
-	AccountSubscriptionsListTenantsFound = attribute.Key("tenants.found")
-	// Number of tenants where listing of subscriptions failed
-	AccountSubscriptionsListTenantsFailed = attribute.Key("tenants.failed")
-)
-
 // Error related fields
 const (
 	// Error code that describes an error.

--- a/cli/azd/pkg/account/subscriptions_manager.go
+++ b/cli/azd/pkg/account/subscriptions_manager.go
@@ -11,9 +11,6 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
-	"github.com/azure/azure-dev/cli/azd/internal/tracing"
-	"github.com/azure/azure-dev/cli/azd/internal/tracing/events"
-	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -202,10 +199,6 @@ type tenantSubsResult struct {
 
 // ListSubscription lists subscriptions accessible by the current account by calling azure management services.
 func (m *SubscriptionsManager) ListSubscriptions(ctx context.Context) ([]Subscription, error) {
-	var err error
-	ctx, span := tracing.Start(ctx, events.AccountSubscriptionsListEvent)
-	defer span.EndWithStatus(err)
-
 	msg := "Retrieving subscriptions..."
 	m.console.ShowSpinner(ctx, msg, input.Step)
 	defer m.console.StopSpinner(ctx, "", input.StepDone)
@@ -235,8 +228,6 @@ func (m *SubscriptionsManager) ListSubscriptions(ctx context.Context) ([]Subscri
 	if err != nil {
 		return nil, fmt.Errorf("listing tenants: %w", err)
 	}
-
-	span.SetAttributes(fields.AccountSubscriptionsListTenantsFound.Int(len(tenants)))
 
 	listForTenant := func(
 		jobs <-chan armsubscriptions.TenantIDDescription,
@@ -309,8 +300,6 @@ func (m *SubscriptionsManager) ListSubscriptions(ctx context.Context) ([]Subscri
 	sort.Slice(allSubscriptions, func(i, j int) bool {
 		return allSubscriptions[i].Name < allSubscriptions[j].Name
 	})
-
-	span.SetAttributes(fields.AccountSubscriptionsListTenantsFailed.Int(len(errors)))
 
 	if !oneSuccess && len(tenants) > 0 {
 		return nil, multierr.Combine(errors...)

--- a/cli/azd/pkg/tools/bicep/bicep.go
+++ b/cli/azd/pkg/tools/bicep/bicep.go
@@ -15,8 +15,6 @@ import (
 	"runtime"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/azure/azure-dev/cli/azd/internal/tracing"
-	"github.com/azure/azure-dev/cli/azd/internal/tracing/events"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -177,11 +175,7 @@ func downloadBicep(ctx context.Context, transporter policy.Transporter, bicepVer
 
 	log.Printf("downloading bicep release %s -> %s", bicepReleaseUrl, name)
 
-	var err error
-	spanCtx, span := tracing.Start(ctx, events.BicepInstallEvent)
-	defer span.EndWithStatus(err)
-
-	req, err := http.NewRequestWithContext(spanCtx, "GET", bicepReleaseUrl, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", bicepReleaseUrl, nil)
 	if err != nil {
 		return err
 	}

--- a/cli/azd/pkg/tools/github/github.go
+++ b/cli/azd/pkg/tools/github/github.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/azure/azure-dev/cli/azd/internal/tracing"
-	"github.com/azure/azure-dev/cli/azd/internal/tracing/events"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -572,10 +570,7 @@ func downloadGh(
 
 	log.Printf("downloading github cli release %s -> %s", ghReleaseUrl, releaseName)
 
-	spanCtx, span := tracing.Start(ctx, events.GitHubCliInstallEvent)
-	defer span.End()
-
-	req, err := http.NewRequestWithContext(spanCtx, "GET", ghReleaseUrl, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", ghReleaseUrl, nil)
 	if err != nil {
 		return err
 	}

--- a/cli/azd/pkg/tools/pack/pack.go
+++ b/cli/azd/pkg/tools/pack/pack.go
@@ -18,8 +18,6 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/azure/azure-dev/cli/azd/internal/tracing"
-	"github.com/azure/azure-dev/cli/azd/internal/tracing/events"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -383,10 +381,7 @@ func downloadPack(
 	ghReleaseUrl := fmt.Sprintf("https://github.com/buildpacks/pack/releases/download/v%s/%s", version, releaseName)
 	log.Printf("downloading pack cli release %s -> %s", ghReleaseUrl, releaseName)
 
-	spanCtx, span := tracing.Start(ctx, events.PackCliInstallEvent)
-	defer span.End()
-
-	req, err := http.NewRequestWithContext(spanCtx, "GET", ghReleaseUrl, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", ghReleaseUrl, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
These events were added with some intent of utilization that hasn't come to fruition. Cleaning them up to make way for more important events.