### PR TITLE
chore: Remove `convert.RefOf` in favor of `to.Ptr`

### DIFF
--- a/cli/azd/internal/vsrpc/environment_service_refresh.go
+++ b/cli/azd/internal/vsrpc/environment_service_refresh.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/internal"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
@@ -135,10 +135,10 @@ func (s *environmentService) refreshEnvironmentAsync(
 					resSvc := env.Services[svcIdx]
 
 					if len(resourceIds) > 0 {
-						resSvc.ResourceId = convert.RefOf(resourceIds[0])
+						resSvc.ResourceId = to.Ptr(resourceIds[0])
 					}
 
-					resSvc.Endpoint = convert.RefOf(s.serviceEndpoint(
+					resSvc.Endpoint = to.Ptr(s.serviceEndpoint(
 						ctx, subId, serviceConfig, c.resourceManager, c.serviceManager,
 					))
 				}

--- a/cli/azd/pkg/account/manager_test.go
+++ b/cli/azd/pkg/account/manager_test.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockarmresources"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockconfig"
@@ -538,22 +538,22 @@ func Test_HasDefaults(t *testing.T) {
 
 var allTestSubscriptions []*armsubscriptions.Subscription = []*armsubscriptions.Subscription{
 	{
-		ID:             convert.RefOf("subscriptions/SUBSCRIPTION_01"),
-		SubscriptionID: convert.RefOf("SUBSCRIPTION_01"),
-		DisplayName:    convert.RefOf("Subscription 1"),
-		TenantID:       convert.RefOf("TENANT_ID"),
+		ID:             to.Ptr("subscriptions/SUBSCRIPTION_01"),
+		SubscriptionID: to.Ptr("SUBSCRIPTION_01"),
+		DisplayName:    to.Ptr("Subscription 1"),
+		TenantID:       to.Ptr("TENANT_ID"),
 	},
 	{
-		ID:             convert.RefOf("subscriptions/SUBSCRIPTION_02"),
-		SubscriptionID: convert.RefOf("SUBSCRIPTION_02"),
-		DisplayName:    convert.RefOf("Subscription 2"),
-		TenantID:       convert.RefOf("TENANT_ID"),
+		ID:             to.Ptr("subscriptions/SUBSCRIPTION_02"),
+		SubscriptionID: to.Ptr("SUBSCRIPTION_02"),
+		DisplayName:    to.Ptr("Subscription 2"),
+		TenantID:       to.Ptr("TENANT_ID"),
 	},
 	{
-		ID:             convert.RefOf("subscriptions/SUBSCRIPTION_03"),
-		SubscriptionID: convert.RefOf("SUBSCRIPTION_03"),
-		DisplayName:    convert.RefOf("Subscription 3"),
-		TenantID:       convert.RefOf("TENANT_ID"),
+		ID:             to.Ptr("subscriptions/SUBSCRIPTION_03"),
+		SubscriptionID: to.Ptr("SUBSCRIPTION_03"),
+		DisplayName:    to.Ptr("Subscription 3"),
+		TenantID:       to.Ptr("TENANT_ID"),
 	},
 }
 
@@ -567,10 +567,10 @@ func setupGetSubscriptionMock(mockHttp *mockhttp.MockHttpClient, subscription *S
 	}
 
 	mockarmresources.MockGetSubscription(mockHttp, subscription.Id, armsubscriptions.Subscription{
-		ID:             convert.RefOf(subscription.Id),
-		SubscriptionID: convert.RefOf(subscription.Id),
-		DisplayName:    convert.RefOf(subscription.Name),
-		TenantID:       convert.RefOf(subscription.TenantId),
+		ID:             to.Ptr(subscription.Id),
+		SubscriptionID: to.Ptr(subscription.Id),
+		DisplayName:    to.Ptr(subscription.Name),
+		TenantID:       to.Ptr(subscription.TenantId),
 	})
 }
 
@@ -615,8 +615,8 @@ func setupAccountMocks(mockHttp *mockhttp.MockHttpClient) {
 	mockarmresources.MockListTenants(mockHttp, armsubscriptions.TenantListResult{
 		Value: []*armsubscriptions.TenantIDDescription{
 			{
-				DisplayName: convert.RefOf("TENANT"),
-				TenantID:    convert.RefOf("TENANT_ID"),
+				DisplayName: to.Ptr("TENANT"),
+				TenantID:    to.Ptr("TENANT_ID"),
 			},
 		},
 	})
@@ -626,39 +626,39 @@ func setupAccountMocks(mockHttp *mockhttp.MockHttpClient) {
 			armsubscriptions.LocationListResult{
 				Value: []*armsubscriptions.Location{
 					{
-						ID:                  convert.RefOf("westus"),
-						Name:                convert.RefOf("westus"),
-						DisplayName:         convert.RefOf("West US"),
-						RegionalDisplayName: convert.RefOf("(US) West US"),
+						ID:                  to.Ptr("westus"),
+						Name:                to.Ptr("westus"),
+						DisplayName:         to.Ptr("West US"),
+						RegionalDisplayName: to.Ptr("(US) West US"),
 						Metadata: &armsubscriptions.LocationMetadata{
-							RegionType: convert.RefOf(armsubscriptions.RegionTypePhysical),
+							RegionType: to.Ptr(armsubscriptions.RegionTypePhysical),
 						},
 					},
 					{
-						ID:                  convert.RefOf("westus2"),
-						Name:                convert.RefOf("westus2"),
-						DisplayName:         convert.RefOf("West US 2"),
-						RegionalDisplayName: convert.RefOf("(US) West US 2"),
+						ID:                  to.Ptr("westus2"),
+						Name:                to.Ptr("westus2"),
+						DisplayName:         to.Ptr("West US 2"),
+						RegionalDisplayName: to.Ptr("(US) West US 2"),
 						Metadata: &armsubscriptions.LocationMetadata{
-							RegionType: convert.RefOf(armsubscriptions.RegionTypePhysical),
+							RegionType: to.Ptr(armsubscriptions.RegionTypePhysical),
 						},
 					},
 					{
-						ID:                  convert.RefOf("eastus"),
-						Name:                convert.RefOf("eastus"),
-						DisplayName:         convert.RefOf("East US"),
-						RegionalDisplayName: convert.RefOf("(US) East US"),
+						ID:                  to.Ptr("eastus"),
+						Name:                to.Ptr("eastus"),
+						DisplayName:         to.Ptr("East US"),
+						RegionalDisplayName: to.Ptr("(US) East US"),
 						Metadata: &armsubscriptions.LocationMetadata{
-							RegionType: convert.RefOf(armsubscriptions.RegionTypePhysical),
+							RegionType: to.Ptr(armsubscriptions.RegionTypePhysical),
 						},
 					},
 					{
-						ID:                  convert.RefOf("eastus2"),
-						Name:                convert.RefOf("eastus2"),
-						DisplayName:         convert.RefOf("East US 2"),
-						RegionalDisplayName: convert.RefOf("(US) East US 2"),
+						ID:                  to.Ptr("eastus2"),
+						Name:                to.Ptr("eastus2"),
+						DisplayName:         to.Ptr("East US 2"),
+						RegionalDisplayName: to.Ptr("(US) East US 2"),
 						Metadata: &armsubscriptions.LocationMetadata{
-							RegionType: convert.RefOf(armsubscriptions.RegionTypePhysical),
+							RegionType: to.Ptr(armsubscriptions.RegionTypePhysical),
 						},
 					},
 				},

--- a/cli/azd/pkg/account/subscriptions_manager_test.go
+++ b/cli/azd/pkg/account/subscriptions_manager_test.go
@@ -10,8 +10,8 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockarmresources"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockhttp"
@@ -37,7 +37,7 @@ func TestSubscriptionsManager_ListSubscriptions(t *testing.T) {
 			args: args{
 				principalInfo: &principalInfoProviderMock{
 					GetLoggedInServicePrincipalTenantIDFunc: func(context.Context) (*string, error) {
-						return convert.RefOf("TENANT_ID_1"), nil
+						return to.Ptr("TENANT_ID_1"), nil
 					},
 				},
 				tenants:       generateTenants(1),
@@ -180,9 +180,9 @@ func generateTenants(total int) []*armsubscriptions.TenantIDDescription {
 	results := make([]*armsubscriptions.TenantIDDescription, 0, total)
 	for i := 1; i <= total; i++ {
 		results = append(results, &armsubscriptions.TenantIDDescription{
-			DisplayName:   convert.RefOf(fmt.Sprintf("TENANT_%d", i)),
-			TenantID:      convert.RefOf(fmt.Sprintf("TENANT_ID_%d", i)),
-			DefaultDomain: convert.RefOf(fmt.Sprintf("TENANT_DOMAIN_%d", i)),
+			DisplayName:   to.Ptr(fmt.Sprintf("TENANT_%d", i)),
+			TenantID:      to.Ptr(fmt.Sprintf("TENANT_ID_%d", i)),
+			DefaultDomain: to.Ptr(fmt.Sprintf("TENANT_DOMAIN_%d", i)),
 		})
 	}
 	return results
@@ -205,9 +205,9 @@ func generateSubscriptions(total int, tenantIDs ...string) map[string][]*armsubs
 		subs := make([]*armsubscriptions.Subscription, 0, total)
 		for i := 1; i <= total; i++ {
 			subs = append(subs, &armsubscriptions.Subscription{
-				ID:             convert.RefOf(fmt.Sprintf("subscriptions/SUBSCRIPTION_%d", i)),
-				SubscriptionID: convert.RefOf(fmt.Sprintf("SUBSCRIPTION_%d_%s", i, tenantID)),
-				DisplayName:    convert.RefOf(fmt.Sprintf("Subscription %d (%s)", i, tenantID)),
+				ID:             to.Ptr(fmt.Sprintf("subscriptions/SUBSCRIPTION_%d", i)),
+				SubscriptionID: to.Ptr(fmt.Sprintf("SUBSCRIPTION_%d_%s", i, tenantID)),
+				DisplayName:    to.Ptr(fmt.Sprintf("Subscription %d (%s)", i, tenantID)),
 				TenantID:       &tenantID,
 			})
 		}

--- a/cli/azd/pkg/auth/manager_test.go
+++ b/cli/azd/pkg/auth/manager_test.go
@@ -15,11 +15,11 @@ import (
 	_ "embed"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/github"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
@@ -268,7 +268,7 @@ func TestAuthFileConfigUpgrade(t *testing.T) {
 	userCfgMgr := newMemoryUserConfigManager()
 
 	err := userCfg.Set(cCurrentUserKey, &userProperties{
-		HomeAccountID: convert.RefOf("homeAccountID"),
+		HomeAccountID: to.Ptr("homeAccountID"),
 	})
 	require.NoError(t, err)
 

--- a/cli/azd/pkg/azsdk/correlation_policy_test.go
+++ b/cli/azd/pkg/azsdk/correlation_policy_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockhttp"
 	"github.com/stretchr/testify/require"
@@ -42,7 +42,7 @@ func Test_simpleCorrelationPolicy_Do(t *testing.T) {
 				context.Background(),
 				trace.SpanContext{}.WithTraceID(traceId),
 			),
-			expect:                convert.RefOf(traceId.String()),
+			expect:                to.Ptr(traceId.String()),
 			headerName:            cMsCorrelationIdHeader,
 			correlationPolicyFunc: NewMsCorrelationPolicy,
 		},
@@ -53,7 +53,7 @@ func Test_simpleCorrelationPolicy_Do(t *testing.T) {
 				context.Background(),
 				trace.SpanContext{}.WithTraceID(invalidTraceId),
 			),
-			expect:                convert.RefOf(""),
+			expect:                to.Ptr(""),
 			headerName:            cMsCorrelationIdHeader,
 			correlationPolicyFunc: NewMsCorrelationPolicy,
 		},
@@ -70,7 +70,7 @@ func Test_simpleCorrelationPolicy_Do(t *testing.T) {
 				context.Background(),
 				trace.SpanContext{}.WithTraceID(traceId),
 			),
-			expect:                convert.RefOf(traceId.String()),
+			expect:                to.Ptr(traceId.String()),
 			headerName:            cMsGraphCorrelationIdHeader,
 			correlationPolicyFunc: NewMsGraphCorrelationPolicy,
 		},
@@ -81,7 +81,7 @@ func Test_simpleCorrelationPolicy_Do(t *testing.T) {
 				context.Background(),
 				trace.SpanContext{}.WithTraceID(invalidTraceId),
 			),
-			expect:                convert.RefOf(""),
+			expect:                to.Ptr(""),
 			headerName:            cMsGraphCorrelationIdHeader,
 			correlationPolicyFunc: NewMsGraphCorrelationPolicy,
 		},

--- a/cli/azd/pkg/azsdk/zip_deploy_client_test.go
+++ b/cli/azd/pkg/azsdk/zip_deploy_client_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
 )
@@ -105,7 +105,7 @@ func registerPollingMocks(mockContext *mocks.MockContext) {
 				Status:     http.StatusAccepted,
 				StatusText: "Accepted",
 				Message:    "Doing deploy things",
-				Progress:   convert.RefOf("Running ORYX build"),
+				Progress:   to.Ptr("Running ORYX build"),
 				Complete:   false,
 				Active:     false,
 				SiteName:   "APP_NAME",

--- a/cli/azd/pkg/azure/resource_ids.go
+++ b/cli/azd/pkg/azure/resource_ids.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 )
 
 // SubscriptionFromRID returns the subscription id component of a resource or panics if the resource id does not
@@ -109,5 +109,5 @@ func GetResourceGroupName(resourceId string) *string {
 		return nil
 	}
 
-	return convert.RefOf(string(matches[1]))
+	return to.Ptr(string(matches[1]))
 }

--- a/cli/azd/pkg/compare/compare_test.go
+++ b/cli/azd/pkg/compare/compare_test.go
@@ -3,7 +3,7 @@ package compare
 import (
 	"testing"
 
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 )
 
 func Test_StringUtil_IsStringNilOrEmpty(t *testing.T) {
@@ -19,17 +19,17 @@ func Test_StringUtil_IsStringNilOrEmpty(t *testing.T) {
 		},
 		{
 			name:  "empty",
-			value: convert.RefOf(""),
+			value: to.Ptr(""),
 			want:  true,
 		},
 		{
 			name:  "whitespace",
-			value: convert.RefOf("  "),
+			value: to.Ptr("  "),
 			want:  true,
 		},
 		{
 			name:  "non-empty",
-			value: convert.RefOf("foo"),
+			value: to.Ptr("foo"),
 			want:  false,
 		},
 	}
@@ -57,19 +57,19 @@ func Test_StringUtil_PtrValueEquals(t *testing.T) {
 		},
 		{
 			name:     "empty",
-			actual:   convert.RefOf(""),
+			actual:   to.Ptr(""),
 			expected: "foo",
 			want:     false,
 		},
 		{
 			name:     "whitespace",
-			actual:   convert.RefOf("  "),
+			actual:   to.Ptr("  "),
 			expected: "foo",
 			want:     false,
 		},
 		{
 			name:     "non-empty",
-			actual:   convert.RefOf("foo"),
+			actual:   to.Ptr("foo"),
 			expected: "foo",
 			want:     true,
 		},

--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -13,12 +13,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3"
 	azdinternal "github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/benbjohnson/clock"
 	"gopkg.in/yaml.v3"
@@ -292,8 +292,8 @@ func (cas *containerAppService) AddRevision(
 
 	// Update the revision with the new image name and suffix
 	revision := revisionResponse.Revision
-	revision.Properties.Template.RevisionSuffix = convert.RefOf(fmt.Sprintf("azd-%d", cas.clock.Now().Unix()))
-	revision.Properties.Template.Containers[0].Image = convert.RefOf(imageName)
+	revision.Properties.Template.RevisionSuffix = to.Ptr(fmt.Sprintf("azd-%d", cas.clock.Now().Unix()))
+	revision.Properties.Template.Containers[0].Image = to.Ptr(imageName)
 
 	// Update the container app with the new revision
 	containerApp.Properties.Template = revision.Properties.Template
@@ -390,7 +390,7 @@ func (cas *containerAppService) setTrafficWeights(
 	containerApp.Properties.Configuration.Ingress.Traffic = []*armappcontainers.TrafficWeight{
 		{
 			RevisionName: &revisionName,
-			Weight:       convert.RefOf[int32](100),
+			Weight:       to.Ptr[int32](100),
 		},
 	}
 

--- a/cli/azd/pkg/containerapps/container_app_test.go
+++ b/cli/azd/pkg/containerapps/container_app_test.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazsdk"
 	"github.com/benbjohnson/clock"
@@ -26,7 +26,7 @@ func Test_ContainerApp_GetIngressConfiguration(t *testing.T) {
 		Name:     &appName,
 		Properties: &armappcontainers.ContainerAppProperties{
 			Configuration: &armappcontainers.Configuration{
-				ActiveRevisionsMode: convert.RefOf(armappcontainers.ActiveRevisionsModeSingle),
+				ActiveRevisionsMode: to.Ptr(armappcontainers.ActiveRevisionsModeSingle),
 				Ingress: &armappcontainers.Ingress{
 					Fqdn: &hostName,
 				},
@@ -75,10 +75,10 @@ func Test_ContainerApp_AddRevision(t *testing.T) {
 		Properties: &armappcontainers.ContainerAppProperties{
 			LatestRevisionName: &originalRevisionName,
 			Configuration: &armappcontainers.Configuration{
-				ActiveRevisionsMode: convert.RefOf(armappcontainers.ActiveRevisionsModeSingle),
+				ActiveRevisionsMode: to.Ptr(armappcontainers.ActiveRevisionsModeSingle),
 				Secrets: []*armappcontainers.Secret{
 					{
-						Name:  convert.RefOf("secret"),
+						Name:  to.Ptr("secret"),
 						Value: nil,
 					},
 				},
@@ -108,8 +108,8 @@ func Test_ContainerApp_AddRevision(t *testing.T) {
 	secrets := &armappcontainers.SecretsCollection{
 		Value: []*armappcontainers.ContainerAppSecret{
 			{
-				Name:  convert.RefOf("secret"),
-				Value: convert.RefOf("value"),
+				Name:  to.Ptr("secret"),
+				Value: to.Ptr("value"),
 			},
 		},
 	}

--- a/cli/azd/pkg/convert/util.go
+++ b/cli/azd/pkg/convert/util.go
@@ -20,11 +20,6 @@ func ToValueWithDefault[T any](ptr *T, defaultValue T) T {
 	return *ptr
 }
 
-// Returns a pointer for the specified value
-func RefOf[T any](value T) *T {
-	return &value
-}
-
 // Attempts to convert the specified value to a string, otherwise returns the default value
 func ToStringWithDefault(value any, defaultValue string) string {
 	if value == nil {

--- a/cli/azd/pkg/convert/util_test.go
+++ b/cli/azd/pkg/convert/util_test.go
@@ -3,6 +3,7 @@ package convert
 import (
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,12 +37,12 @@ func Test_ToStringWithDefault(t *testing.T) {
 		},
 		{
 			name:     "StringPointer",
-			input:    RefOf("apple"),
+			input:    to.Ptr("apple"),
 			expected: "apple",
 		},
 		{
 			name:     "NotStringPointer",
-			input:    RefOf(1),
+			input:    to.Ptr(1),
 			expected: "default",
 		},
 	}
@@ -56,12 +57,12 @@ func Test_ToStringWithDefault(t *testing.T) {
 
 func Test_ToValueWithDefault(t *testing.T) {
 	t.Run("String", func(t *testing.T) {
-		value := ToValueWithDefault(RefOf("apple"), "default")
+		value := ToValueWithDefault(to.Ptr("apple"), "default")
 		require.Equal(t, "apple", value)
 	})
 
 	t.Run("Int", func(t *testing.T) {
-		value := ToValueWithDefault(RefOf(1), 0)
+		value := ToValueWithDefault(to.Ptr(1), 0)
 		require.Equal(t, 1, value)
 	})
 
@@ -71,20 +72,8 @@ func Test_ToValueWithDefault(t *testing.T) {
 	})
 
 	t.Run("EmptyString", func(t *testing.T) {
-		value := ToValueWithDefault(RefOf(""), "default")
+		value := ToValueWithDefault(to.Ptr(""), "default")
 		require.Equal(t, "default", value)
-	})
-}
-
-func Test_RefOf(t *testing.T) {
-	t.Run("String", func(t *testing.T) {
-		value := RefOf("apple")
-		require.Equal(t, "apple", *value)
-	})
-
-	t.Run("Int", func(t *testing.T) {
-		value := RefOf(1)
-		require.Equal(t, 1, *value)
 	})
 }
 

--- a/cli/azd/pkg/devcentersdk/api_version_policy.go
+++ b/cli/azd/pkg/devcentersdk/api_version_policy.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 )
 
 const (
@@ -19,7 +19,7 @@ type apiVersionPolicy struct {
 // Policy to ensure the AZD custom user agent is set on all HTTP requests.
 func NewApiVersionPolicy(apiVersion *string) policy.Policy {
 	if apiVersion == nil {
-		apiVersion = convert.RefOf(defaultApiVersion)
+		apiVersion = to.Ptr(defaultApiVersion)
 	}
 
 	return &apiVersionPolicy{

--- a/cli/azd/pkg/devcentersdk/developer_client.go
+++ b/cli/azd/pkg/devcentersdk/developer_client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
@@ -84,7 +85,7 @@ func (c *devCenterClient) projectList(ctx context.Context) ([]*Project, error) {
 	queryRequest := armresourcegraph.QueryRequest{
 		Query: &query,
 		Options: &armresourcegraph.QueryRequestOptions{
-			AllowPartialScopes: convert.RefOf(true),
+			AllowPartialScopes: to.Ptr(true),
 		},
 	}
 	res, err := c.resourceGraphClient.Resources(ctx, queryRequest, nil)

--- a/cli/azd/pkg/entraid/entraid.go
+++ b/cli/azd/pkg/entraid/entraid.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/google/uuid"
 	"github.com/sethvargo/go-retry"
@@ -545,7 +545,7 @@ func (ad *entraIdService) getRoleDefinition(
 	}
 
 	pager := roleDefinitionsClient.NewListPager(scope, &armauthorization.RoleDefinitionsClientListOptions{
-		Filter: convert.RefOf(fmt.Sprintf("roleName eq '%s'", roleName)),
+		Filter: to.Ptr(fmt.Sprintf("roleName eq '%s'", roleName)),
 	})
 
 	roleDefinitions := []*armauthorization.RoleDefinition{}

--- a/cli/azd/pkg/entraid/entraid_test.go
+++ b/cli/azd/pkg/entraid/entraid_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockgraphsdk"
@@ -24,23 +24,23 @@ var expectedServicePrincipalCredential AzureCredentials = AzureCredentials{
 
 func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 	newApplication := graphsdk.Application{
-		Id:          convert.RefOf("UNIQUE_ID"),
+		Id:          to.Ptr("UNIQUE_ID"),
 		AppId:       &expectedServicePrincipalCredential.ClientId,
 		DisplayName: "MY_APP",
 	}
 	servicePrincipal := graphsdk.ServicePrincipal{
-		Id:                     convert.RefOf("SPN_ID"),
+		Id:                     to.Ptr("SPN_ID"),
 		AppId:                  expectedServicePrincipalCredential.ClientId,
 		DisplayName:            "SPN_NAME",
 		AppOwnerOrganizationId: &expectedServicePrincipalCredential.TenantId,
 	}
 	credential := &graphsdk.ApplicationPasswordCredential{
-		KeyId:       convert.RefOf("KEY_ID"),
-		DisplayName: convert.RefOf("Azure Developer CLI"),
+		KeyId:       to.Ptr("KEY_ID"),
+		DisplayName: to.Ptr("Azure Developer CLI"),
 		SecretText:  &expectedServicePrincipalCredential.ClientSecret,
 	}
 	existingApplication := graphsdk.Application{
-		Id:          convert.RefOf("UNIQUE_ID"),
+		Id:          to.Ptr("UNIQUE_ID"),
 		AppId:       &expectedServicePrincipalCredential.ClientId,
 		DisplayName: "APPLICATION_NAME",
 		PasswordCredentials: []*graphsdk.ApplicationPasswordCredential{
@@ -49,9 +49,9 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 	}
 	roleDefinitions := []*armauthorization.RoleDefinition{
 		{
-			ID:   convert.RefOf("ROLE_ID"),
-			Name: convert.RefOf("Contributor"),
-			Type: convert.RefOf("ROLE_TYPE"),
+			ID:   to.Ptr("ROLE_ID"),
+			Name: to.Ptr("Contributor"),
+			Type: to.Ptr("ROLE_TYPE"),
 		},
 	}
 
@@ -244,10 +244,10 @@ func Test_CreateOrUpdateServicePrincipal(t *testing.T) {
 
 func Test_ApplyFederatedCredentials(t *testing.T) {
 	mockApplication := &graphsdk.Application{
-		Id:                  convert.RefOf("APPLICATION_ID"),
-		AppId:               convert.RefOf("CLIENT_ID"),
+		Id:                  to.Ptr("APPLICATION_ID"),
+		AppId:               to.Ptr("CLIENT_ID"),
 		DisplayName:         "APPLICATION_NAME",
-		Description:         convert.RefOf("DESCRIPTION"),
+		Description:         to.Ptr("DESCRIPTION"),
 		PasswordCredentials: []*graphsdk.ApplicationPasswordCredential{},
 	}
 
@@ -275,19 +275,19 @@ func Test_ApplyFederatedCredentials(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		mockCredentials := []graphsdk.FederatedIdentityCredential{
 			{
-				Id:          convert.RefOf("CREDENTIAL_ID"),
+				Id:          to.Ptr("CREDENTIAL_ID"),
 				Name:        "owner-repo-pull_request",
 				Issuer:      federatedIdentityIssuer,
 				Subject:     "repo:owner/repo:pull_request",
-				Description: convert.RefOf("DESCRIPTION"),
+				Description: to.Ptr("DESCRIPTION"),
 				Audiences:   []string{federatedIdentityAudience},
 			},
 			{
-				Id:          convert.RefOf("CREDENTIAL_ID"),
+				Id:          to.Ptr("CREDENTIAL_ID"),
 				Name:        "owner-repo-main",
 				Issuer:      federatedIdentityIssuer,
 				Subject:     "repo:owner/repo:ref:refs/heads/main",
-				Description: convert.RefOf("DESCRIPTION"),
+				Description: to.Ptr("DESCRIPTION"),
 				Audiences:   []string{federatedIdentityAudience},
 			},
 		}
@@ -332,27 +332,27 @@ func Test_ApplyFederatedCredentials(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		mockCredentials := []graphsdk.FederatedIdentityCredential{
 			{
-				Id:          convert.RefOf("CREDENTIAL_ID"),
+				Id:          to.Ptr("CREDENTIAL_ID"),
 				Name:        "owner-repo-pull_request",
 				Issuer:      federatedIdentityIssuer,
 				Subject:     "repo:owner/repo:pull_request",
-				Description: convert.RefOf("DESCRIPTION"),
+				Description: to.Ptr("DESCRIPTION"),
 				Audiences:   []string{federatedIdentityAudience},
 			},
 			{
-				Id:          convert.RefOf("CREDENTIAL_ID"),
+				Id:          to.Ptr("CREDENTIAL_ID"),
 				Name:        "owner-repo-main",
 				Issuer:      federatedIdentityIssuer,
 				Subject:     "repo:owner/repo:ref:refs/heads/main",
-				Description: convert.RefOf("DESCRIPTION"),
+				Description: to.Ptr("DESCRIPTION"),
 				Audiences:   []string{federatedIdentityAudience},
 			},
 			{
-				Id:          convert.RefOf("CREDENTIAL_ID"),
+				Id:          to.Ptr("CREDENTIAL_ID"),
 				Name:        "owner-repo-dev",
 				Issuer:      federatedIdentityIssuer,
 				Subject:     "repo:owner/repo:ref:refs/heads/dev",
-				Description: convert.RefOf("DESCRIPTION"),
+				Description: to.Ptr("DESCRIPTION"),
 				Audiences:   []string{federatedIdentityAudience},
 			},
 		}
@@ -397,19 +397,19 @@ func Test_ApplyFederatedCredentials(t *testing.T) {
 		mockContext := mocks.NewMockContext(context.Background())
 		mockCredentials := []graphsdk.FederatedIdentityCredential{
 			{
-				Id:          convert.RefOf("CREDENTIAL_ID"),
+				Id:          to.Ptr("CREDENTIAL_ID"),
 				Name:        "owner-repo-pull_request",
 				Issuer:      federatedIdentityIssuer,
 				Subject:     "repo:owner/repo:pull_request",
-				Description: convert.RefOf("DESCRIPTION"),
+				Description: to.Ptr("DESCRIPTION"),
 				Audiences:   []string{federatedIdentityAudience},
 			},
 			{
-				Id:          convert.RefOf("CREDENTIAL_ID"),
+				Id:          to.Ptr("CREDENTIAL_ID"),
 				Name:        "owner-repo-main",
 				Issuer:      federatedIdentityIssuer,
 				Subject:     "repo:owner/repo:ref:refs/heads/main",
-				Description: convert.RefOf("DESCRIPTION"),
+				Description: to.Ptr("DESCRIPTION"),
 				Audiences:   []string{federatedIdentityAudience},
 			},
 		}
@@ -443,25 +443,25 @@ func Test_ApplyFederatedCredentials(t *testing.T) {
 
 func Test_ResetPasswordCredentials(t *testing.T) {
 	mockApplicationPassword := &graphsdk.ApplicationPasswordCredential{
-		KeyId:       convert.RefOf("KEY_ID"),
-		DisplayName: convert.RefOf("KEY NAME"),
-		SecretText:  convert.RefOf("CLIENT_SECRET"),
+		KeyId:       to.Ptr("KEY_ID"),
+		DisplayName: to.Ptr("KEY NAME"),
+		SecretText:  to.Ptr("CLIENT_SECRET"),
 	}
 
 	mockApplication := &graphsdk.Application{
-		Id:                  convert.RefOf("APPLICATION_ID"),
-		AppId:               convert.RefOf("CLIENT_ID"),
+		Id:                  to.Ptr("APPLICATION_ID"),
+		AppId:               to.Ptr("CLIENT_ID"),
 		DisplayName:         "APPLICATION_NAME",
-		Description:         convert.RefOf("DESCRIPTION"),
+		Description:         to.Ptr("DESCRIPTION"),
 		PasswordCredentials: []*graphsdk.ApplicationPasswordCredential{mockApplicationPassword},
 	}
 
 	mockServicePrincipals := []graphsdk.ServicePrincipal{
 		{
-			Id:                     convert.RefOf("SPN_ID"),
+			Id:                     to.Ptr("SPN_ID"),
 			AppId:                  *mockApplication.AppId,
 			DisplayName:            mockApplication.DisplayName,
-			AppOwnerOrganizationId: convert.RefOf("TENANT_ID"),
+			AppOwnerOrganizationId: to.Ptr("TENANT_ID"),
 			AppDisplayName:         &mockApplication.DisplayName,
 			Description:            mockApplication.Description,
 		},

--- a/cli/azd/pkg/graphsdk/application_request_builders.go
+++ b/cli/azd/pkg/graphsdk/application_request_builders.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
@@ -181,7 +181,7 @@ func (c *ApplicationItemRequestBuilder) AddPassword(ctx context.Context) (*Appli
 	endDateTime := time.Now().Add(time.Hour * 24 * 180)
 	addPasswordRequest := ApplicationAddPasswordRequest{
 		PasswordCredential: ApplicationPasswordCredential{
-			DisplayName: convert.RefOf("Azure Developer CLI"),
+			DisplayName: to.Ptr("Azure Developer CLI"),
 			EndDateTime: &endDateTime,
 		},
 	}

--- a/cli/azd/pkg/graphsdk/application_request_builders_test.go
+++ b/cli/azd/pkg/graphsdk/application_request_builders_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockgraphsdk"
@@ -17,13 +17,13 @@ import (
 var (
 	applications []graphsdk.Application = []graphsdk.Application{
 		{
-			Id:          convert.RefOf("1"),
-			AppId:       convert.RefOf("app-01"),
+			Id:          to.Ptr("1"),
+			AppId:       to.Ptr("app-01"),
 			DisplayName: "App 1",
 		},
 		{
-			Id:          convert.RefOf("2"),
-			AppId:       convert.RefOf("app-02"),
+			Id:          to.Ptr("2"),
+			AppId:       to.Ptr("app-02"),
 			DisplayName: "App 2",
 		},
 	}
@@ -175,9 +175,9 @@ func TestApplicationAddPassword(t *testing.T) {
 		application := applications[0]
 
 		mockCredential := graphsdk.ApplicationPasswordCredential{
-			KeyId:       convert.RefOf("key1"),
-			DisplayName: convert.RefOf("Name"),
-			SecretText:  convert.RefOf("foobar"),
+			KeyId:       to.Ptr("key1"),
+			DisplayName: to.Ptr("Name"),
+			SecretText:  to.Ptr("foobar"),
 		}
 
 		mockContext := mocks.NewMockContext(context.Background())

--- a/cli/azd/pkg/graphsdk/entity_list_request_builder_test.go
+++ b/cli/azd/pkg/graphsdk/entity_list_request_builder_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockgraphsdk"
@@ -17,11 +17,11 @@ import (
 func TestEntityListRequestBuilder(t *testing.T) {
 	applications := []graphsdk.Application{
 		{
-			Id:          convert.RefOf("1"),
+			Id:          to.Ptr("1"),
 			DisplayName: "App 1",
 		},
 		{
-			Id:          convert.RefOf("2"),
+			Id:          to.Ptr("2"),
 			DisplayName: "App 2",
 		},
 	}

--- a/cli/azd/pkg/graphsdk/fic_request_builders_test.go
+++ b/cli/azd/pkg/graphsdk/fic_request_builders_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockgraphsdk"
@@ -16,26 +16,26 @@ import (
 
 var (
 	application graphsdk.Application = graphsdk.Application{
-		Id:          convert.RefOf("application-id"),
+		Id:          to.Ptr("application-id"),
 		DisplayName: "application name",
-		Description: convert.RefOf("app description"),
+		Description: to.Ptr("app description"),
 	}
 
 	federatedCredentials []graphsdk.FederatedIdentityCredential = []graphsdk.FederatedIdentityCredential{
 		{
-			Id:          convert.RefOf("cred-01"),
+			Id:          to.Ptr("cred-01"),
 			Name:        "Credential 1",
 			Issuer:      "ISSUER",
 			Subject:     "SUBJECT",
-			Description: convert.RefOf("DESCRIPTION"),
+			Description: to.Ptr("DESCRIPTION"),
 			Audiences:   []string{"AUDIENCE"},
 		},
 		{
-			Id:          convert.RefOf("cred-02"),
+			Id:          to.Ptr("cred-02"),
 			Name:        "Credential 2",
 			Issuer:      "ISSUER",
 			Subject:     "SUBJECT",
-			Description: convert.RefOf("DESCRIPTION"),
+			Description: to.Ptr("DESCRIPTION"),
 		},
 	}
 )

--- a/cli/azd/pkg/graphsdk/service_principal_request_builders_test.go
+++ b/cli/azd/pkg/graphsdk/service_principal_request_builders_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockgraphsdk"
@@ -17,11 +17,11 @@ import (
 var (
 	servicePrincipals []graphsdk.ServicePrincipal = []graphsdk.ServicePrincipal{
 		{
-			Id:          convert.RefOf("1"),
+			Id:          to.Ptr("1"),
 			DisplayName: "SPN 1",
 		},
 		{
-			Id:          convert.RefOf("2"),
+			Id:          to.Ptr("2"),
 			DisplayName: "SPN 2",
 		},
 	}

--- a/cli/azd/pkg/infra/azure_resource_manager_test.go
+++ b/cli/azd/pkg/infra/azure_resource_manager_test.go
@@ -15,9 +15,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazcli"
@@ -437,10 +437,10 @@ func TestFindResourceGroupForEnvironment(t *testing.T) {
 
 		for _, name := range groupNames {
 			res.Value = append(res.Value, &armresources.ResourceGroup{
-				ID:       convert.RefOf(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", SUBSCRIPTION_ID, name)),
-				Type:     convert.RefOf("Microsoft.Resources/resourceGroups"),
-				Name:     convert.RefOf(name),
-				Location: convert.RefOf("eastus2"),
+				ID:       to.Ptr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", SUBSCRIPTION_ID, name)),
+				Type:     to.Ptr("Microsoft.Resources/resourceGroups"),
+				Name:     to.Ptr(name),
+				Location: to.Ptr("eastus2"),
 			})
 		}
 

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
@@ -438,8 +437,8 @@ func prepareBicepMocks(
 }
 
 var cTestEnvDeployment armresources.DeploymentExtended = armresources.DeploymentExtended{
-	ID:   convert.RefOf("DEPLOYMENT_ID"),
-	Name: convert.RefOf("test-env"),
+	ID:   to.Ptr("DEPLOYMENT_ID"),
+	Name: to.Ptr("test-env"),
 	Properties: &armresources.DeploymentPropertiesExtended{
 		Outputs: map[string]interface{}{
 			"WEBSITE_URL": map[string]interface{}{"value": "http://myapp.azurewebsites.net", "type": "string"},
@@ -497,10 +496,10 @@ func prepareDestroyMocks(mockContext *mocks.MockContext) {
 			string(resourceType), resourceName)
 
 		return &armresources.GenericResourceExpanded{
-			ID:       convert.RefOf(id),
-			Name:     convert.RefOf(resourceName),
-			Type:     convert.RefOf(string(resourceType)),
-			Location: convert.RefOf("eastus2"),
+			ID:       to.Ptr(id),
+			Name:     to.Ptr(resourceName),
+			Type:     to.Ptr(string(resourceType)),
+			Location: to.Ptr("eastus2"),
 		}
 	}
 
@@ -617,14 +616,14 @@ func getKeyVaultMock(mockContext *mocks.MockContext, keyVaultString string, name
 	}).RespondFn(func(request *http.Request) (*http.Response, error) {
 		keyVaultResponse := armkeyvault.VaultsClientGetResponse{
 			Vault: armkeyvault.Vault{
-				ID: convert.RefOf(
+				ID: to.Ptr(
 					fmt.Sprintf("/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP/%s/%s",
 						string(infra.AzureResourceTypeKeyVault), name)),
-				Name:     convert.RefOf(name),
-				Location: convert.RefOf(location),
+				Name:     to.Ptr(name),
+				Location: to.Ptr(location),
 				Properties: &armkeyvault.VaultProperties{
-					EnableSoftDelete:      convert.RefOf(true),
-					EnablePurgeProtection: convert.RefOf(false),
+					EnableSoftDelete:      to.Ptr(true),
+					EnablePurgeProtection: to.Ptr(false),
 				},
 			},
 		}
@@ -644,14 +643,14 @@ func getManagedHSMMock(mockContext *mocks.MockContext, managedHSMString string, 
 	}).RespondFn(func(request *http.Request) (*http.Response, error) {
 		managedHSMResponse := armkeyvault.ManagedHsmsClientGetResponse{
 			ManagedHsm: armkeyvault.ManagedHsm{
-				ID: convert.RefOf(
+				ID: to.Ptr(
 					fmt.Sprintf("/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP/%s/%s",
 						string(infra.AzureResourceTypeManagedHSM), name)),
-				Name:     convert.RefOf(name),
-				Location: convert.RefOf(location),
+				Name:     to.Ptr(name),
+				Location: to.Ptr(location),
 				Properties: &armkeyvault.ManagedHsmProperties{
-					EnableSoftDelete:      convert.RefOf(true),
-					EnablePurgeProtection: convert.RefOf(false),
+					EnableSoftDelete:      to.Ptr(true),
+					EnablePurgeProtection: to.Ptr(false),
 				},
 			},
 		}
@@ -671,14 +670,14 @@ func getAppConfigMock(mockContext *mocks.MockContext, appConfigString string, na
 	}).RespondFn(func(request *http.Request) (*http.Response, error) {
 		appConfigResponse := armappconfiguration.ConfigurationStoresClientGetResponse{
 			ConfigurationStore: armappconfiguration.ConfigurationStore{
-				ID: convert.RefOf(
+				ID: to.Ptr(
 					fmt.Sprintf("/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP/%s/%s",
 						string(infra.AzureResourceTypeAppConfig), name)),
 
-				Name:     convert.RefOf(name),
-				Location: convert.RefOf(location),
+				Name:     to.Ptr(name),
+				Location: to.Ptr(location),
 				Properties: &armappconfiguration.ConfigurationStoreProperties{
-					EnablePurgeProtection: convert.RefOf(false),
+					EnablePurgeProtection: to.Ptr(false),
 				},
 			},
 		}
@@ -698,12 +697,12 @@ func getAPIMMock(mockContext *mocks.MockContext, apimString string, name string,
 	}).RespondFn(func(request *http.Request) (*http.Response, error) {
 		apimResponse := armapimanagement.ServiceClientGetResponse{
 			ServiceResource: armapimanagement.ServiceResource{
-				ID: convert.RefOf(
+				ID: to.Ptr(
 					fmt.Sprintf("/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP/%s/%s",
 						string(infra.AzureResourceTypeApim), name)),
 
-				Name:     convert.RefOf(name),
-				Location: convert.RefOf(location),
+				Name:     to.Ptr(name),
+				Location: to.Ptr(location),
 			},
 		}
 
@@ -743,26 +742,26 @@ func TestResourceGroupsFromDeployment(t *testing.T) {
 	t.Run("duplicate resource groups ignored", func(t *testing.T) {
 
 		mockDeployment := armresources.DeploymentExtended{
-			ID:   convert.RefOf("DEPLOYMENT_ID"),
-			Name: convert.RefOf("test-env"),
+			ID:   to.Ptr("DEPLOYMENT_ID"),
+			Name: to.Ptr("test-env"),
 			Properties: &armresources.DeploymentPropertiesExtended{
 				OutputResources: []*armresources.ResourceReference{
 					{
-						ID: convert.RefOf("/subscriptions/sub-id/resourceGroups/groupA"),
+						ID: to.Ptr("/subscriptions/sub-id/resourceGroups/groupA"),
 					},
 					{
-						ID: convert.RefOf(
+						ID: to.Ptr(
 							"/subscriptions/sub-id/resourceGroups/groupA/Microsoft.Storage/storageAccounts/storageAccount",
 						),
 					},
 					{
-						ID: convert.RefOf("/subscriptions/sub-id/resourceGroups/groupB"),
+						ID: to.Ptr("/subscriptions/sub-id/resourceGroups/groupB"),
 					},
 					{
-						ID: convert.RefOf("/subscriptions/sub-id/resourceGroups/groupB/Microsoft.web/sites/test"),
+						ID: to.Ptr("/subscriptions/sub-id/resourceGroups/groupB/Microsoft.web/sites/test"),
 					},
 					{
-						ID: convert.RefOf("/subscriptions/sub-id/resourceGroups/groupC"),
+						ID: to.Ptr("/subscriptions/sub-id/resourceGroups/groupC"),
 					},
 				},
 				ProvisioningState: to.Ptr(armresources.ProvisioningStateSucceeded),

--- a/cli/azd/pkg/infra/provisioning/bicep/prompt_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt_test.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
@@ -87,7 +87,7 @@ func TestPromptForParameterValidation(t *testing.T) {
 			name: "minValue",
 			param: azure.ArmTemplateParameterDefinition{
 				Type:     "int",
-				MinValue: convert.RefOf(1),
+				MinValue: to.Ptr(1),
 			},
 			provided: []string{"0", "1"},
 			expected: 1,
@@ -97,7 +97,7 @@ func TestPromptForParameterValidation(t *testing.T) {
 			name: "maxValue",
 			param: azure.ArmTemplateParameterDefinition{
 				Type:     "int",
-				MaxValue: convert.RefOf(10),
+				MaxValue: to.Ptr(10),
 			},
 			provided: []string{"11", "10"},
 			expected: 10,
@@ -107,8 +107,8 @@ func TestPromptForParameterValidation(t *testing.T) {
 			name: "rangeValue",
 			param: azure.ArmTemplateParameterDefinition{
 				Type:     "int",
-				MinValue: convert.RefOf(1),
-				MaxValue: convert.RefOf(10),
+				MinValue: to.Ptr(1),
+				MaxValue: to.Ptr(10),
 			},
 			provided: []string{"0", "11", "5"},
 			expected: 5,
@@ -118,7 +118,7 @@ func TestPromptForParameterValidation(t *testing.T) {
 			name: "minLength",
 			param: azure.ArmTemplateParameterDefinition{
 				Type:      "string",
-				MinLength: convert.RefOf(1),
+				MinLength: to.Ptr(1),
 			},
 			provided: []string{"", "ok"},
 			expected: "ok",
@@ -128,7 +128,7 @@ func TestPromptForParameterValidation(t *testing.T) {
 			name: "maxLength",
 			param: azure.ArmTemplateParameterDefinition{
 				Type:      "string",
-				MaxLength: convert.RefOf(10),
+				MaxLength: to.Ptr(10),
 			},
 			provided: []string{"this is a very long string and will be rejected", "ok"},
 			expected: "ok",
@@ -138,8 +138,8 @@ func TestPromptForParameterValidation(t *testing.T) {
 			name: "rangeLength",
 			param: azure.ArmTemplateParameterDefinition{
 				Type:      "string",
-				MinLength: convert.RefOf(1),
-				MaxLength: convert.RefOf(10),
+				MinLength: to.Ptr(1),
+				MaxLength: to.Ptr(10),
 			},
 			provided: []string{"this is a very long string and will be rejected", "", "ok"},
 			expected: "ok",
@@ -224,7 +224,7 @@ func TestPromptForParameterAllowedValues(t *testing.T) {
 
 	value, err := p.promptForParameter(*mockContext.Context, "testParam", azure.ArmTemplateParameterDefinition{
 		Type:          "string",
-		AllowedValues: convert.RefOf([]any{"three", "good", "choices"}),
+		AllowedValues: to.Ptr([]any{"three", "good", "choices"}),
 	})
 
 	require.NoError(t, err)
@@ -232,7 +232,7 @@ func TestPromptForParameterAllowedValues(t *testing.T) {
 
 	value, err = p.promptForParameter(*mockContext.Context, "testParam", azure.ArmTemplateParameterDefinition{
 		Type:          "int",
-		AllowedValues: convert.RefOf([]any{10, 20, 30}),
+		AllowedValues: to.Ptr([]any{10, 20, 30}),
 	})
 
 	require.NoError(t, err)

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/resource"
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
@@ -586,7 +586,7 @@ func (c *AskerConsole) Prompt(ctx context.Context, options ConsoleOptions) (stri
 		}
 
 		if value, ok := options.DefaultValue.(string); ok {
-			opts.Options.DefaultValue = convert.RefOf[any](value)
+			opts.Options.DefaultValue = to.Ptr[any](value)
 		}
 
 		result, err := c.promptClient.Prompt(ctx, opts)
@@ -627,7 +627,7 @@ func (c *AskerConsole) PromptDir(ctx context.Context, options ConsoleOptions) (s
 		}
 
 		if value, ok := options.DefaultValue.(string); ok {
-			opts.Options.DefaultValue = convert.RefOf[any](value)
+			opts.Options.DefaultValue = to.Ptr[any](value)
 		}
 
 		result, err := c.promptClient.Prompt(ctx, opts)
@@ -683,12 +683,12 @@ func (c *AskerConsole) Select(ctx context.Context, options ConsoleOptions) (int,
 			Options: promptOptionsOptions{
 				Message: options.Message,
 				Help:    options.Help,
-				Choices: convert.RefOf(choicesFromOptions(options)),
+				Choices: to.Ptr(choicesFromOptions(options)),
 			},
 		}
 
 		if value, ok := options.DefaultValue.(string); ok {
-			opts.Options.DefaultValue = convert.RefOf[any](value)
+			opts.Options.DefaultValue = to.Ptr[any](value)
 		}
 
 		result, err := c.promptClient.Prompt(ctx, opts)
@@ -763,12 +763,12 @@ func (c *AskerConsole) MultiSelect(ctx context.Context, options ConsoleOptions) 
 			Options: promptOptionsOptions{
 				Message: options.Message,
 				Help:    options.Help,
-				Choices: convert.RefOf(choicesFromOptions(options)),
+				Choices: to.Ptr(choicesFromOptions(options)),
 			},
 		}
 
 		if value, ok := options.DefaultValue.([]string); ok {
-			opts.Options.DefaultValue = convert.RefOf[any](value)
+			opts.Options.DefaultValue = to.Ptr[any](value)
 		}
 
 		result, err := c.promptClient.Prompt(ctx, opts)
@@ -835,7 +835,7 @@ func (c *AskerConsole) Confirm(ctx context.Context, options ConsoleOptions) (boo
 		}
 
 		if value, ok := options.DefaultValue.(bool); ok {
-			opts.Options.DefaultValue = convert.RefOf[any](value)
+			opts.Options.DefaultValue = to.Ptr[any](value)
 		}
 
 		result, err := c.promptClient.Prompt(ctx, opts)

--- a/cli/azd/pkg/input/console_test.go
+++ b/cli/azd/pkg/input/console_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/stretchr/testify/require"
 )
@@ -250,7 +250,7 @@ func newTestExternalPromptServer(handler func(promptOptions) json.RawMessage) *h
 
 		respBody, _ := json.Marshal(promptResponse{
 			Status: "success",
-			Value:  convert.RefOf(res),
+			Value:  to.Ptr(res),
 		})
 
 		_, _ = w.Write(respBody)

--- a/cli/azd/pkg/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/pipeline/azdo_provider.go
@@ -10,8 +10,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdo"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/entraid"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
@@ -749,7 +749,7 @@ func (p *AzdoCiProvider) credentialOptions(
 				Name:        "AzureDevOpsOIDC", //Must not contain a space character and 3 to 64 characters in length
 				Issuer:      (*sConnection.Authorization.Parameters)["workloadIdentityFederationIssuer"],
 				Subject:     (*sConnection.Authorization.Parameters)["workloadIdentityFederationSubject"],
-				Description: convert.RefOf("Created by Azure Developer CLI"),
+				Description: to.Ptr("Created by Azure Developer CLI"),
 				Audiences:   []string{federatedIdentityAudience},
 			},
 		}

--- a/cli/azd/pkg/pipeline/github_provider.go
+++ b/cli/azd/pkg/pipeline/github_provider.go
@@ -14,8 +14,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/entraid"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	githubRemote "github.com/azure/azure-dev/cli/azd/pkg/github"
@@ -424,7 +424,7 @@ func (p *GitHubCiProvider) credentialOptions(
 				Name:        url.PathEscape(fmt.Sprintf("%s-pull_request", credentialSafeName)),
 				Issuer:      federatedIdentityIssuer,
 				Subject:     fmt.Sprintf("repo:%s:pull_request", repoSlug),
-				Description: convert.RefOf("Created by Azure Developer CLI"),
+				Description: to.Ptr("Created by Azure Developer CLI"),
 				Audiences:   []string{federatedIdentityAudience},
 			},
 		}
@@ -434,7 +434,7 @@ func (p *GitHubCiProvider) credentialOptions(
 				Name:        url.PathEscape(fmt.Sprintf("%s-%s", credentialSafeName, branch)),
 				Issuer:      federatedIdentityIssuer,
 				Subject:     fmt.Sprintf("repo:%s:ref:refs/heads/%s", repoSlug, branch),
-				Description: convert.RefOf("Created by Azure Developer CLI"),
+				Description: to.Ptr("Created by Azure Developer CLI"),
 				Audiences:   []string{federatedIdentityAudience},
 			}
 

--- a/cli/azd/pkg/project/ai_helper.go
+++ b/cli/azd/pkg/project/ai_helper.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/ai"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
@@ -539,7 +539,7 @@ func (a *aiHelper) UpdateTraffic(
 
 	// Send all traffic to new deployment
 	onlineEndpoint.Properties.Traffic = map[string]*int32{
-		deploymentName: convert.RefOf(int32(100)),
+		deploymentName: to.Ptr(int32(100)),
 	}
 
 	poller, err := a.endpointsClient.BeginCreateOrUpdate(

--- a/cli/azd/pkg/project/ai_helper_test.go
+++ b/cli/azd/pkg/project/ai_helper_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
 	"github.com/azure/azure-dev/cli/azd/pkg/ai"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
@@ -329,13 +329,13 @@ func Test_AiHelper_UpdateTraffic(t *testing.T) {
 	mockContext.Clock.Set(time.Now())
 
 	trafficMap := map[string]*int32{
-		deploymentName: convert.RefOf(int32(100)),
+		deploymentName: to.Ptr(int32(100)),
 	}
 	endpoint := &armmachinelearning.OnlineEndpoint{
-		Name: convert.RefOf(endpointName),
+		Name: to.Ptr(endpointName),
 		Properties: &armmachinelearning.OnlineEndpointProperties{
 			Traffic: map[string]*int32{
-				deploymentName: convert.RefOf(int32(100)),
+				deploymentName: to.Ptr(int32(100)),
 			},
 		},
 	}
@@ -365,10 +365,10 @@ func Test_AiHelper_DeletePreviousDeployments(t *testing.T) {
 	deploymentName := "MY-DEPLOYMENT"
 
 	endpoint := &armmachinelearning.OnlineEndpoint{
-		Name: convert.RefOf(endpointName),
+		Name: to.Ptr(endpointName),
 		Properties: &armmachinelearning.OnlineEndpointProperties{
 			Traffic: map[string]*int32{
-				deploymentName: convert.RefOf(int32(100)),
+				deploymentName: to.Ptr(int32(100)),
 			},
 		},
 	}

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
@@ -51,13 +51,13 @@ services:
 
 	mockarmresources.AddAzResourceListMock(
 		mockContext.HttpClient,
-		convert.RefOf("rg-test"),
+		to.Ptr("rg-test"),
 		[]*armresources.GenericResourceExpanded{
 			{
-				ID:       convert.RefOf("app-api-abc123"),
-				Name:     convert.RefOf("test-containerapp-web"),
-				Type:     convert.RefOf(string(infra.AzureResourceTypeContainerApp)),
-				Location: convert.RefOf("eastus2"),
+				ID:       to.Ptr("app-api-abc123"),
+				Name:     to.Ptr("test-containerapp-web"),
+				Type:     to.Ptr(string(infra.AzureResourceTypeContainerApp)),
+				Location: to.Ptr("eastus2"),
 			},
 		})
 
@@ -153,13 +153,13 @@ services:
 
 	mockarmresources.AddAzResourceListMock(
 		mockContext.HttpClient,
-		convert.RefOf("rg-test"),
+		to.Ptr("rg-test"),
 		[]*armresources.GenericResourceExpanded{
 			{
-				ID:       convert.RefOf("app-api-abc123"),
-				Name:     convert.RefOf("test-containerapp-web"),
-				Type:     convert.RefOf(string(infra.AzureResourceTypeContainerApp)),
-				Location: convert.RefOf("eastus2"),
+				ID:       to.Ptr("app-api-abc123"),
+				Name:     to.Ptr("test-containerapp-web"),
+				Type:     to.Ptr(string(infra.AzureResourceTypeContainerApp)),
+				Location: to.Ptr("eastus2"),
 			},
 		})
 

--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -37,13 +37,13 @@ services:
 	mockContext := mocks.NewMockContext(context.Background())
 	mockarmresources.AddAzResourceListMock(
 		mockContext.HttpClient,
-		convert.RefOf("rg-test"),
+		to.Ptr("rg-test"),
 		[]*armresources.GenericResourceExpanded{
 			{
-				ID:       convert.RefOf("deployedApiSvc"),
-				Name:     convert.RefOf("deployedApiSvc"),
-				Type:     convert.RefOf(string(infra.AzureResourceTypeWebSite)),
-				Location: convert.RefOf("eastus2"),
+				ID:       to.Ptr("deployedApiSvc"),
+				Name:     to.Ptr("deployedApiSvc"),
+				Type:     to.Ptr(string(infra.AzureResourceTypeWebSite)),
+				Location: to.Ptr("eastus2"),
 			},
 		})
 	azCli := mockazcli.NewAzCliFromMockContext(mockContext)
@@ -81,15 +81,15 @@ services:
 	resourceName := "app-api-abc123"
 	mockarmresources.AddAzResourceListMock(
 		mockContext.HttpClient,
-		convert.RefOf("rg-test"),
+		to.Ptr("rg-test"),
 		[]*armresources.GenericResourceExpanded{
 			{
-				ID:       convert.RefOf("app-api-abc123"),
+				ID:       to.Ptr("app-api-abc123"),
 				Name:     &resourceName,
-				Type:     convert.RefOf(string(infra.AzureResourceTypeWebSite)),
-				Location: convert.RefOf("eastus2"),
+				Type:     to.Ptr(string(infra.AzureResourceTypeWebSite)),
+				Location: to.Ptr("eastus2"),
 				Tags: map[string]*string{
-					azure.TagKeyAzdServiceName: convert.RefOf("api"),
+					azure.TagKeyAzdServiceName: to.Ptr("api"),
 				},
 			},
 		},
@@ -135,18 +135,18 @@ services:
 		&resourceGroupName,
 		[]*armresources.GenericResourceExpanded{
 			{
-				ID:       convert.RefOf("deployedApiSvc"),
-				Name:     convert.RefOf("deployedApiSvc"),
-				Type:     convert.RefOf(string(infra.AzureResourceTypeWebSite)),
-				Location: convert.RefOf("eastus2"),
+				ID:       to.Ptr("deployedApiSvc"),
+				Name:     to.Ptr("deployedApiSvc"),
+				Type:     to.Ptr(string(infra.AzureResourceTypeWebSite)),
+				Location: to.Ptr("eastus2"),
 			},
 			{
-				ID:       convert.RefOf("webResource"),
-				Name:     convert.RefOf("webResource"),
-				Type:     convert.RefOf(string(infra.AzureResourceTypeWebSite)),
-				Location: convert.RefOf("eastus2"),
+				ID:       to.Ptr("webResource"),
+				Name:     to.Ptr("webResource"),
+				Type:     to.Ptr(string(infra.AzureResourceTypeWebSite)),
+				Location: to.Ptr("eastus2"),
 				Tags: map[string]*string{
-					azure.TagKeyAzdServiceName: convert.RefOf("web"),
+					azure.TagKeyAzdServiceName: to.Ptr("web"),
 				},
 			},
 		})
@@ -195,18 +195,18 @@ services:
 		&expectedResourceGroupName,
 		[]*armresources.GenericResourceExpanded{
 			{
-				ID:       convert.RefOf("deployedApiSvc"),
-				Name:     convert.RefOf("deployedApiSvc"),
-				Type:     convert.RefOf(string(infra.AzureResourceTypeWebSite)),
-				Location: convert.RefOf("eastus2"),
+				ID:       to.Ptr("deployedApiSvc"),
+				Name:     to.Ptr("deployedApiSvc"),
+				Type:     to.Ptr(string(infra.AzureResourceTypeWebSite)),
+				Location: to.Ptr("eastus2"),
 			},
 			{
-				ID:       convert.RefOf("webResource"),
-				Name:     convert.RefOf("webResource"),
-				Type:     convert.RefOf(string(infra.AzureResourceTypeWebSite)),
-				Location: convert.RefOf("eastus2"),
+				ID:       to.Ptr("webResource"),
+				Name:     to.Ptr("webResource"),
+				Type:     to.Ptr(string(infra.AzureResourceTypeWebSite)),
+				Location: to.Ptr("eastus2"),
 				Tags: map[string]*string{
-					azure.TagKeyAzdServiceName: convert.RefOf("web"),
+					azure.TagKeyAzdServiceName: to.Ptr("web"),
 				},
 			},
 		})

--- a/cli/azd/pkg/project/resource_manager_test.go
+++ b/cli/azd/pkg/project/resource_manager_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -26,14 +26,14 @@ type testInitFunc func(*mocks.MockContext)
 // 4. Resource group tagged with azd-env-name
 func Test_ResourceManager_GetTargetResource(t *testing.T) {
 	taggedResourceGroup := &armresources.ResourceGroup{
-		ID: convert.RefOf(fmt.Sprintf(
+		ID: to.Ptr(fmt.Sprintf(
 			"/subscriptions/%s/resourceGroups/%s",
 			"SUBSCRIPTION_id",
 			"TAGGED_RESOURCE_GROUP",
 		)),
-		Name:     convert.RefOf("TAGGED_RESOURCE_GROUP"),
-		Type:     convert.RefOf("Microsoft.Resources/resourceGroups"),
-		Location: convert.RefOf("eastus2"),
+		Name:     to.Ptr("TAGGED_RESOURCE_GROUP"),
+		Type:     to.Ptr("Microsoft.Resources/resourceGroups"),
+		Location: to.Ptr("eastus2"),
 	}
 
 	fromProjectConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageJavaScript)
@@ -101,10 +101,10 @@ func Test_ResourceManager_GetTargetResource(t *testing.T) {
 			}
 
 			expectedResource := &armresources.GenericResourceExpanded{
-				ID:       convert.RefOf("RESOURCE_ID"),
-				Name:     convert.RefOf("RESOURCE_NAME"),
-				Type:     convert.RefOf("Microsoft.Web/sites"),
-				Location: convert.RefOf("eastus2"),
+				ID:       to.Ptr("RESOURCE_ID"),
+				Name:     to.Ptr("RESOURCE_NAME"),
+				Type:     to.Ptr("Microsoft.Web/sites"),
+				Location: to.Ptr("eastus2"),
 			}
 
 			setupGetResourceMock(mockContext, expectedResource)

--- a/cli/azd/pkg/project/service_manager_test.go
+++ b/cli/azd/pkg/project/service_manager_test.go
@@ -6,12 +6,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
@@ -98,7 +98,7 @@ func Test_ServiceManager_Restore(t *testing.T) {
 		return nil
 	})
 
-	restoreCalled := convert.RefOf(false)
+	restoreCalled := to.Ptr(false)
 	ctx := context.WithValue(*mockContext.Context, frameworkRestoreCalled, restoreCalled)
 	result, err := logProgress(t, func(progess *async.Progress[ServiceProgress]) (*ServiceRestoreResult, error) {
 		return sm.Restore(ctx, serviceConfig, progess)
@@ -131,7 +131,7 @@ func Test_ServiceManager_Build(t *testing.T) {
 		return nil
 	})
 
-	buildCalled := convert.RefOf(false)
+	buildCalled := to.Ptr(false)
 	ctx := context.WithValue(*mockContext.Context, frameworkBuildCalled, buildCalled)
 
 	result, err := logProgress(t, func(progress *async.Progress[ServiceProgress]) (*ServiceBuildResult, error) {
@@ -165,8 +165,8 @@ func Test_ServiceManager_Package(t *testing.T) {
 		return nil
 	})
 
-	fakeFrameworkPackageCalled := convert.RefOf(false)
-	fakeServiceTargetPackageCalled := convert.RefOf(false)
+	fakeFrameworkPackageCalled := to.Ptr(false)
+	fakeServiceTargetPackageCalled := to.Ptr(false)
 	ctx := context.WithValue(*mockContext.Context, frameworkPackageCalled, fakeFrameworkPackageCalled)
 	ctx = context.WithValue(ctx, serviceTargetPackageCalled, fakeServiceTargetPackageCalled)
 
@@ -204,7 +204,7 @@ func Test_ServiceManager_Deploy(t *testing.T) {
 		return nil
 	})
 
-	deployCalled := convert.RefOf(false)
+	deployCalled := to.Ptr(false)
 	ctx := context.WithValue(*mockContext.Context, serviceTargetDeployCalled, deployCalled)
 
 	result, err := logProgress(t, func(progess *async.Progress[ServiceProgress]) (*ServiceDeployResult, error) {
@@ -282,7 +282,7 @@ func Test_ServiceManager_CacheResults(t *testing.T) {
 	sm := createServiceManager(mockContext, env, ServiceOperationCache{})
 	serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
-	buildCalled := convert.RefOf(false)
+	buildCalled := to.Ptr(false)
 	ctx := context.WithValue(*mockContext.Context, frameworkBuildCalled, buildCalled)
 
 	buildResult1, _ := logProgress(
@@ -314,7 +314,7 @@ func Test_ServiceManager_CacheResults_Across_Instances(t *testing.T) {
 	sm1 := createServiceManager(mockContext, env, operationCache)
 	serviceConfig := createTestServiceConfig("./src/api", ServiceTargetFake, ServiceLanguageFake)
 
-	packageCalled := convert.RefOf(false)
+	packageCalled := to.Ptr(false)
 	ctx := context.WithValue(*mockContext.Context, serviceTargetPackageCalled, packageCalled)
 
 	packageResult1, _ := logProgress(
@@ -447,24 +447,24 @@ func setupMocksForServiceManager(mockContext *mocks.MockContext) {
 
 	mockarmresources.AddResourceGroupListMock(mockContext.HttpClient, "SUBSCRIPTION_ID", []*armresources.ResourceGroup{
 		{
-			ID:       convert.RefOf("ID"),
-			Name:     convert.RefOf("RESOURCE_GROUP"),
-			Location: convert.RefOf("eastus2"),
-			Type:     convert.RefOf(string(infra.AzureResourceTypeResourceGroup)),
+			ID:       to.Ptr("ID"),
+			Name:     to.Ptr("RESOURCE_GROUP"),
+			Location: to.Ptr("eastus2"),
+			Type:     to.Ptr(string(infra.AzureResourceTypeResourceGroup)),
 		},
 	})
 
 	mockarmresources.AddAzResourceListMock(
 		mockContext.HttpClient,
-		convert.RefOf("RESOURCE_GROUP"),
+		to.Ptr("RESOURCE_GROUP"),
 		[]*armresources.GenericResourceExpanded{
 			{
-				ID:       convert.RefOf("ID"),
-				Name:     convert.RefOf("WEB_APP"),
-				Location: convert.RefOf("eastus2"),
-				Type:     convert.RefOf(string(infra.AzureResourceTypeWebSite)),
+				ID:       to.Ptr("ID"),
+				Name:     to.Ptr("WEB_APP"),
+				Location: to.Ptr("eastus2"),
+				Type:     to.Ptr(string(infra.AzureResourceTypeWebSite)),
 				Tags: map[string]*string{
-					azure.TagKeyAzdServiceName: convert.RefOf("api"),
+					azure.TagKeyAzdServiceName: to.Ptr("api"),
 				},
 			},
 		},

--- a/cli/azd/pkg/project/service_target_ai_endpoint_test.go
+++ b/cli/azd/pkg/project/service_target_ai_endpoint_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
 	"github.com/azure/azure-dev/cli/azd/pkg/ai"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
@@ -71,11 +71,11 @@ func Test_MlEndpointTarget_Deploy(t *testing.T) {
 	}
 
 	environmentVersion := &armmachinelearning.EnvironmentVersion{
-		Name: convert.RefOf("1"),
+		Name: to.Ptr("1"),
 	}
 
 	modelVersion := &armmachinelearning.ModelVersion{
-		Name: convert.RefOf("1"),
+		Name: to.Ptr("1"),
 	}
 
 	onlineDeployment := &armmachinelearning.OnlineDeployment{
@@ -83,12 +83,12 @@ func Test_MlEndpointTarget_Deploy(t *testing.T) {
 	}
 
 	onlineEndpoint := &armmachinelearning.OnlineEndpoint{
-		Name: convert.RefOf(endpointName),
+		Name: to.Ptr(endpointName),
 		Properties: &armmachinelearning.OnlineEndpointProperties{
-			ScoringURI: convert.RefOf("https://SCRORING_URI"),
-			SwaggerURI: convert.RefOf("https://SWAGGER_URI"),
+			ScoringURI: to.Ptr("https://SCRORING_URI"),
+			SwaggerURI: to.Ptr("https://SWAGGER_URI"),
 			Traffic: map[string]*int32{
-				deploymentName: convert.RefOf(int32(100)),
+				deploymentName: to.Ptr(int32(100)),
 			},
 		},
 	}

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -11,13 +11,13 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2"
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/helm"
@@ -480,12 +480,12 @@ func setupGetClusterMock(mockContext *mocks.MockContext, statusCode int) {
 	}).RespondFn(func(request *http.Request) (*http.Response, error) {
 		managedCluster := armcontainerservice.ManagedClustersClientGetResponse{
 			ManagedCluster: armcontainerservice.ManagedCluster{
-				ID:       convert.RefOf("cluster1"),
-				Location: convert.RefOf("eastus2"),
-				Type:     convert.RefOf("Microsoft.ContainerService/managedClusters"),
+				ID:       to.Ptr("cluster1"),
+				Location: to.Ptr("eastus2"),
+				Type:     to.Ptr("Microsoft.ContainerService/managedClusters"),
 				Properties: &armcontainerservice.ManagedClusterProperties{
-					EnableRBAC:           convert.RefOf(true),
-					DisableLocalAccounts: convert.RefOf(false),
+					EnableRBAC:           to.Ptr(true),
+					DisableLocalAccounts: to.Ptr(false),
 				},
 			},
 		}
@@ -512,7 +512,7 @@ func setupListClusterAdminCredentialsMock(mockContext *mocks.MockContext, status
 		creds := armcontainerservice.CredentialResults{
 			Kubeconfigs: []*armcontainerservice.CredentialResult{
 				{
-					Name:  convert.RefOf("context"),
+					Name:  to.Ptr("context"),
 					Value: kubeConfigBytes,
 				},
 			},
@@ -542,7 +542,7 @@ func setupListClusterUserCredentialsMock(mockContext *mocks.MockContext, statusC
 		creds := armcontainerservice.CredentialResults{
 			Kubeconfigs: []*armcontainerservice.CredentialResult{
 				{
-					Name:  convert.RefOf("context"),
+					Name:  to.Ptr("context"),
 					Value: kubeConfigBytes,
 				},
 			},
@@ -561,24 +561,24 @@ func setupListClusterUserCredentialsMock(mockContext *mocks.MockContext, statusC
 func setupMocksForAcr(mockContext *mocks.MockContext) {
 	mockazsdk.MockContainerRegistryList(mockContext, []*armcontainerregistry.Registry{
 		{
-			ID: convert.RefOf(
+			ID: to.Ptr(
 				//nolint:lll
 				"/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP/providers/Microsoft.ContainerRegistry/registries/REGISTRY",
 			),
-			Location: convert.RefOf("eastus2"),
-			Name:     convert.RefOf("REGISTRY"),
+			Location: to.Ptr("eastus2"),
+			Name:     to.Ptr("REGISTRY"),
 			Properties: &armcontainerregistry.RegistryProperties{
-				LoginServer: convert.RefOf("REGISTRY.azurecr.io"),
+				LoginServer: to.Ptr("REGISTRY.azurecr.io"),
 			},
 		},
 	})
 
 	mockazsdk.MockContainerRegistryCredentials(mockContext, &armcontainerregistry.RegistryListCredentialsResult{
-		Username: convert.RefOf("admin"),
+		Username: to.Ptr("admin"),
 		Passwords: []*armcontainerregistry.RegistryPassword{
 			{
-				Name:  convert.RefOf(armcontainerregistry.PasswordName("admin")),
-				Value: convert.RefOf("password"),
+				Name:  to.Ptr(armcontainerregistry.PasswordName("admin")),
+				Value: to.Ptr("password"),
 			},
 		},
 	})

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
 	"github.com/azure/azure-dev/cli/azd/pkg/containerapps"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
@@ -194,10 +194,10 @@ func setupMocksForContainerApps(mockContext *mocks.MockContext) {
 		Properties: &armappcontainers.ContainerAppProperties{
 			LatestRevisionName: &originalRevisionName,
 			Configuration: &armappcontainers.Configuration{
-				ActiveRevisionsMode: convert.RefOf(armappcontainers.ActiveRevisionsModeSingle),
+				ActiveRevisionsMode: to.Ptr(armappcontainers.ActiveRevisionsModeSingle),
 				Secrets: []*armappcontainers.Secret{
 					{
-						Name:  convert.RefOf("secret"),
+						Name:  to.Ptr("secret"),
 						Value: nil,
 					},
 				},

--- a/cli/azd/pkg/tools/azcli/azcli_functions_test.go
+++ b/cli/azd/pkg/tools/azcli/azcli_functions_test.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v2"
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
 )
@@ -31,11 +31,11 @@ func Test_GetFunctionAppProperties(t *testing.T) {
 
 			response := armappservice.WebAppsClientGetResponse{
 				Site: armappservice.Site{
-					Location: convert.RefOf("eastus2"),
-					Kind:     convert.RefOf("funcapp"),
-					Name:     convert.RefOf("FUNC_APP_NAME"),
+					Location: to.Ptr("eastus2"),
+					Kind:     to.Ptr("funcapp"),
+					Name:     to.Ptr("FUNC_APP_NAME"),
 					Properties: &armappservice.SiteProperties{
-						DefaultHostName: convert.RefOf("FUNC_APP_NAME.azurewebsites.net"),
+						DefaultHostName: to.Ptr("FUNC_APP_NAME.azurewebsites.net"),
 					},
 				},
 			}
@@ -150,16 +150,16 @@ func registerInfoMocks(mockContext *mocks.MockContext, ran *bool) {
 					Properties: &armappservice.SiteProperties{
 						HostNameSSLStates: []*armappservice.HostNameSSLState{
 							{
-								HostType: convert.RefOf(armappservice.HostTypeStandard),
-								Name:     convert.RefOf("INVALID"),
+								HostType: to.Ptr(armappservice.HostTypeStandard),
+								Name:     to.Ptr("INVALID"),
 							},
 							{
-								HostType: convert.RefOf(armappservice.HostTypeRepository),
-								Name:     convert.RefOf("FUNC_APP_NAME_SCM_HOST"),
+								HostType: to.Ptr(armappservice.HostTypeRepository),
+								Name:     to.Ptr("FUNC_APP_NAME_SCM_HOST"),
 							},
 						},
 						//nolint:lll
-						ServerFarmID: convert.RefOf("/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_ID/providers/Microsoft.Web/serverfarms/FUNC_APP_PLAN_NAME"),
+						ServerFarmID: to.Ptr("/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_ID/providers/Microsoft.Web/serverfarms/FUNC_APP_PLAN_NAME"),
 					},
 				},
 			},
@@ -182,8 +182,8 @@ func registerInfoMocks(mockContext *mocks.MockContext, ran *bool) {
 			armappservice.PlansClientGetResponse{
 				Plan: armappservice.Plan{
 					SKU: &armappservice.SKUDescription{
-						Name: convert.RefOf("Y1"),
-						Tier: convert.RefOf("Dynamic"),
+						Name: to.Ptr("Y1"),
+						Tier: to.Ptr("Dynamic"),
 					},
 				},
 			})

--- a/cli/azd/pkg/tools/azcli/azcli_linuxwebapp_test.go
+++ b/cli/azd/pkg/tools/azcli/azcli_linuxwebapp_test.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v2"
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
 )
@@ -105,18 +105,18 @@ func registerIsLinuxWebAppMocks(mockContext *mocks.MockContext, ran *bool) {
 		*ran = true
 		response := armappservice.WebAppsClientGetResponse{
 			Site: armappservice.Site{
-				Location: convert.RefOf("eastus2"),
-				Kind:     convert.RefOf("app,linux"),
-				Name:     convert.RefOf("LINUX_WEB_APP_NAME"),
+				Location: to.Ptr("eastus2"),
+				Kind:     to.Ptr("app,linux"),
+				Name:     to.Ptr("LINUX_WEB_APP_NAME"),
 				Properties: &armappservice.SiteProperties{
-					DefaultHostName: convert.RefOf("LINUX_WEB_APP_NAME.azurewebsites.net"),
+					DefaultHostName: to.Ptr("LINUX_WEB_APP_NAME.azurewebsites.net"),
 					SiteConfig: &armappservice.SiteConfig{
-						LinuxFxVersion: convert.RefOf("Python"),
+						LinuxFxVersion: to.Ptr("Python"),
 					},
 					HostNameSSLStates: []*armappservice.HostNameSSLState{
 						{
-							HostType: convert.RefOf(armappservice.HostTypeRepository),
-							Name:     convert.RefOf("LINUX_WEB_APP_NAME_SCM_HOST"),
+							HostType: to.Ptr(armappservice.HostTypeRepository),
+							Name:     to.Ptr("LINUX_WEB_APP_NAME_SCM_HOST"),
 						},
 					},
 				},
@@ -137,18 +137,18 @@ func registerLogicAppMocks(mockContext *mocks.MockContext, ran *bool) {
 		*ran = true
 		response := armappservice.WebAppsClientGetResponse{
 			Site: armappservice.Site{
-				Location: convert.RefOf("eastus2"),
-				Kind:     convert.RefOf("functionapp"),
-				Name:     convert.RefOf("WINDOWS_LOGIC_APP_NAME"),
+				Location: to.Ptr("eastus2"),
+				Kind:     to.Ptr("functionapp"),
+				Name:     to.Ptr("WINDOWS_LOGIC_APP_NAME"),
 				Properties: &armappservice.SiteProperties{
-					DefaultHostName: convert.RefOf("WINDOWS_LOGIC_APP_NAME.azurewebsites.net"),
+					DefaultHostName: to.Ptr("WINDOWS_LOGIC_APP_NAME.azurewebsites.net"),
 					SiteConfig: &armappservice.SiteConfig{
-						LinuxFxVersion: convert.RefOf(""),
+						LinuxFxVersion: to.Ptr(""),
 					},
 					HostNameSSLStates: []*armappservice.HostNameSSLState{
 						{
-							HostType: convert.RefOf(armappservice.HostTypeRepository),
-							Name:     convert.RefOf("WINDOWS_LOGIC_APP_SCM_HOST"),
+							HostType: to.Ptr(armappservice.HostTypeRepository),
+							Name:     to.Ptr("WINDOWS_LOGIC_APP_SCM_HOST"),
 						},
 					},
 				},
@@ -199,10 +199,10 @@ func registerLinuxWebAppDeployRuntimeSuccessfulMocks(mockContext *mocks.MockCont
 			armappservice.WebAppsClientGetProductionSiteDeploymentStatusResponse{
 				CsmDeploymentStatus: armappservice.CsmDeploymentStatus{
 					Properties: &armappservice.CsmDeploymentStatusProperties{
-						Status:                      convert.RefOf(armappservice.DeploymentBuildStatusRuntimeSuccessful),
-						NumberOfInstancesSuccessful: convert.RefOf(int32(1)),
-						NumberOfInstancesFailed:     convert.RefOf(int32(0)),
-						NumberOfInstancesInProgress: convert.RefOf(int32(0)),
+						Status:                      to.Ptr(armappservice.DeploymentBuildStatusRuntimeSuccessful),
+						NumberOfInstancesSuccessful: to.Ptr(int32(1)),
+						NumberOfInstancesFailed:     to.Ptr(int32(0)),
+						NumberOfInstancesInProgress: to.Ptr(int32(0)),
 					},
 				},
 			},
@@ -228,10 +228,10 @@ func registerLinuxWebAppDeployRuntimeFailedMocks(mockContext *mocks.MockContext,
 			armappservice.WebAppsClientGetProductionSiteDeploymentStatusResponse{
 				CsmDeploymentStatus: armappservice.CsmDeploymentStatus{
 					Properties: &armappservice.CsmDeploymentStatusProperties{
-						Status:                      convert.RefOf(armappservice.DeploymentBuildStatusRuntimeFailed),
-						NumberOfInstancesSuccessful: convert.RefOf(int32(0)),
-						NumberOfInstancesFailed:     convert.RefOf(int32(1)),
-						NumberOfInstancesInProgress: convert.RefOf(int32(0)),
+						Status:                      to.Ptr(armappservice.DeploymentBuildStatusRuntimeFailed),
+						NumberOfInstancesSuccessful: to.Ptr(int32(0)),
+						NumberOfInstancesFailed:     to.Ptr(int32(1)),
+						NumberOfInstancesInProgress: to.Ptr(int32(0)),
 					},
 				},
 			},

--- a/cli/azd/pkg/tools/azcli/azcli_staticwebapp_test.go
+++ b/cli/azd/pkg/tools/azcli/azcli_staticwebapp_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v2"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +30,7 @@ func Test_GetStaticWebAppProperties(t *testing.T) {
 			response := armappservice.StaticSitesClientGetStaticSiteResponse{
 				StaticSiteARMResource: armappservice.StaticSiteARMResource{
 					Properties: &armappservice.StaticSite{
-						DefaultHostname: convert.RefOf("https://test.com")},
+						DefaultHostname: to.Ptr("https://test.com")},
 				},
 			}
 
@@ -78,8 +78,8 @@ func Test_GetStaticWebAppEnvironmentProperties(t *testing.T) {
 			response := armappservice.StaticSitesClientGetStaticSiteBuildResponse{
 				StaticSiteBuildARMResource: armappservice.StaticSiteBuildARMResource{
 					Properties: &armappservice.StaticSiteBuildARMResourceProperties{
-						Hostname: convert.RefOf("default-environment-name.azurestaticapps.net"),
-						Status:   convert.RefOf(armappservice.BuildStatusReady),
+						Hostname: to.Ptr("default-environment-name.azurestaticapps.net"),
+						Status:   to.Ptr(armappservice.BuildStatusReady),
 					},
 				},
 			}
@@ -140,7 +140,7 @@ func Test_GetStaticWebAppApiKey(t *testing.T) {
 			response := armappservice.StaticSitesClientListStaticSiteSecretsResponse{
 				StringDictionary: armappservice.StringDictionary{
 					Properties: map[string]*string{
-						"apiKey": convert.RefOf("ABC123"),
+						"apiKey": to.Ptr("ABC123"),
 					},
 				},
 			}

--- a/cli/azd/pkg/tools/azcli/azcli_test.go
+++ b/cli/azd/pkg/tools/azcli/azcli_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockaccount"
 	"github.com/stretchr/testify/require"
@@ -24,11 +24,11 @@ func TestAZCLIWithUserAgent(t *testing.T) {
 	}).RespondFn(func(request *http.Request) (*http.Response, error) {
 		response := armresources.ClientGetByIDResponse{
 			GenericResource: armresources.GenericResource{
-				ID:       convert.RefOf("RESOURCE_ID"),
-				Kind:     convert.RefOf("RESOURCE_KIND"),
-				Name:     convert.RefOf("RESOURCE_NAME"),
-				Type:     convert.RefOf("RESOURCE_TYPE"),
-				Location: convert.RefOf("RESOURCE_LOCATION"),
+				ID:       to.Ptr("RESOURCE_ID"),
+				Kind:     to.Ptr("RESOURCE_KIND"),
+				Name:     to.Ptr("RESOURCE_NAME"),
+				Type:     to.Ptr("RESOURCE_TYPE"),
+				Location: to.Ptr("RESOURCE_LOCATION"),
 			},
 		}
 
@@ -59,11 +59,11 @@ func Test_AzSdk_User_Agent_Policy(t *testing.T) {
 	}).RespondFn(func(request *http.Request) (*http.Response, error) {
 		response := armresources.ClientGetByIDResponse{
 			GenericResource: armresources.GenericResource{
-				ID:       convert.RefOf("RESOURCE_ID"),
-				Kind:     convert.RefOf("RESOURCE_KIND"),
-				Name:     convert.RefOf("RESOURCE_NAME"),
-				Type:     convert.RefOf("RESOURCE_TYPE"),
-				Location: convert.RefOf("RESOURCE_LOCATION"),
+				ID:       to.Ptr("RESOURCE_ID"),
+				Kind:     to.Ptr("RESOURCE_KIND"),
+				Name:     to.Ptr("RESOURCE_NAME"),
+				Type:     to.Ptr("RESOURCE_TYPE"),
+				Location: to.Ptr("RESOURCE_LOCATION"),
 			},
 		}
 

--- a/cli/azd/pkg/tools/azcli/function_app.go
+++ b/cli/azd/pkg/tools/azcli/function_app.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v2"
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 )
 
 type AzCliFunctionAppProperties struct {
@@ -85,7 +85,7 @@ func (cli *azCli) DeployFunctionAppUsingZipFile(
 		if err != nil {
 			return nil, fmt.Errorf("publishing zip file: %w", err)
 		}
-		return convert.RefOf(response.StatusText), nil
+		return to.Ptr(response.StatusText), nil
 	}
 
 	client, err := cli.createZipDeployClient(ctx, subscriptionId, hostName)
@@ -98,5 +98,5 @@ func (cli *azCli) DeployFunctionAppUsingZipFile(
 		return nil, err
 	}
 
-	return convert.RefOf(response.StatusText), nil
+	return to.Ptr(response.StatusText), nil
 }

--- a/cli/azd/pkg/tools/azcli/webapp.go
+++ b/cli/azd/pkg/tools/azcli/webapp.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v2"
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 )
 
 type AzCliAppServiceProperties struct {
@@ -148,7 +148,7 @@ func (cli *azCli) DeployAppServiceZip(
 		} else {
 			// Deployment is successful
 			statusText := "OK"
-			return convert.RefOf(statusText), nil
+			return to.Ptr(statusText), nil
 		}
 	}
 
@@ -157,7 +157,7 @@ func (cli *azCli) DeployAppServiceZip(
 		return nil, err
 	}
 
-	return convert.RefOf(response.StatusText), nil
+	return to.Ptr(response.StatusText), nil
 }
 
 func (cli *azCli) createWebAppsClient(ctx context.Context, subscriptionId string) (*armappservice.WebAppsClient, error) {

--- a/cli/azd/pkg/tools/bash/bash_test.go
+++ b/cli/azd/pkg/tools/bash/bash_test.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -44,7 +44,7 @@ func Test_Bash_Execute(t *testing.T) {
 		runResult, err := bashScript.Execute(
 			*mockContext.Context,
 			scriptPath,
-			tools.ExecOptions{Interactive: convert.RefOf(true)},
+			tools.ExecOptions{Interactive: to.Ptr(true)},
 		)
 
 		require.NotNil(t, runResult)
@@ -64,7 +64,7 @@ func Test_Bash_Execute(t *testing.T) {
 		runResult, err := bashScript.Execute(
 			*mockContext.Context,
 			scriptPath,
-			tools.ExecOptions{Interactive: convert.RefOf(true)},
+			tools.ExecOptions{Interactive: to.Ptr(true)},
 		)
 
 		require.Equal(t, 1, runResult.ExitCode)
@@ -75,8 +75,8 @@ func Test_Bash_Execute(t *testing.T) {
 		name  string
 		value tools.ExecOptions
 	}{
-		{name: "Interactive", value: tools.ExecOptions{Interactive: convert.RefOf(true)}},
-		{name: "NonInteractive", value: tools.ExecOptions{Interactive: convert.RefOf(false)}},
+		{name: "Interactive", value: tools.ExecOptions{Interactive: to.Ptr(true)}},
+		{name: "NonInteractive", value: tools.ExecOptions{Interactive: to.Ptr(false)}},
 	}
 
 	for _, test := range tests {

--- a/cli/azd/pkg/tools/powershell/powershell_test.go
+++ b/cli/azd/pkg/tools/powershell/powershell_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -38,7 +38,7 @@ func Test_Powershell_Execute(t *testing.T) {
 		runResult, err := PowershellScript.Execute(
 			*mockContext.Context,
 			scriptPath,
-			tools.ExecOptions{Interactive: convert.RefOf(true)},
+			tools.ExecOptions{Interactive: to.Ptr(true)},
 		)
 
 		require.NotNil(t, runResult)
@@ -58,7 +58,7 @@ func Test_Powershell_Execute(t *testing.T) {
 		runResult, err := PowershellScript.Execute(
 			*mockContext.Context,
 			scriptPath,
-			tools.ExecOptions{Interactive: convert.RefOf(true)},
+			tools.ExecOptions{Interactive: to.Ptr(true)},
 		)
 
 		require.Equal(t, 1, runResult.ExitCode)
@@ -69,8 +69,8 @@ func Test_Powershell_Execute(t *testing.T) {
 		name  string
 		value tools.ExecOptions
 	}{
-		{name: "Interactive", value: tools.ExecOptions{Interactive: convert.RefOf(true)}},
-		{name: "NonInteractive", value: tools.ExecOptions{Interactive: convert.RefOf(false)}},
+		{name: "Interactive", value: tools.ExecOptions{Interactive: to.Ptr(true)}},
+		{name: "NonInteractive", value: tools.ExecOptions{Interactive: to.Ptr(false)}},
 	}
 
 	for _, test := range tests {

--- a/cli/azd/test/mocks/mockai/deployments.go
+++ b/cli/azd/test/mocks/mockai/deployments.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 )
 
@@ -98,7 +98,7 @@ func RegisterListOnlineDeployment(
 		deployments := []*armmachinelearning.OnlineDeployment{}
 		for _, deploymentName := range deploymentNames {
 			deployments = append(deployments, &armmachinelearning.OnlineDeployment{
-				Name: convert.RefOf(deploymentName),
+				Name: to.Ptr(deploymentName),
 			})
 		}
 

--- a/cli/azd/test/mocks/mockai/endpoints.go
+++ b/cli/azd/test/mocks/mockai/endpoints.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 )
 
@@ -79,7 +79,7 @@ func RegisterUpdateOnlineEndpoint(
 				Name: &endpointName,
 				Properties: &armmachinelearning.OnlineEndpointProperties{
 					Traffic:           trafficMap,
-					ProvisioningState: convert.RefOf(armmachinelearning.EndpointProvisioningStateSucceeded),
+					ProvisioningState: to.Ptr(armmachinelearning.EndpointProvisioningStateSucceeded),
 				},
 			},
 		}

--- a/cli/azd/test/mocks/mockai/environments.go
+++ b/cli/azd/test/mocks/mockai/environments.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 )
 
@@ -38,8 +38,8 @@ func RegisterGetEnvironment(
 			EnvironmentContainer: armmachinelearning.EnvironmentContainer{
 				Name: &environmentName,
 				Properties: &armmachinelearning.EnvironmentContainerProperties{
-					LatestVersion: convert.RefOf("2"),
-					NextVersion:   convert.RefOf("3"),
+					LatestVersion: to.Ptr("2"),
+					NextVersion:   to.Ptr("3"),
 				},
 			},
 		}
@@ -73,7 +73,7 @@ func RegisterGetEnvironmentVersion(
 
 		response := armmachinelearning.EnvironmentVersionsClientGetResponse{
 			EnvironmentVersion: armmachinelearning.EnvironmentVersion{
-				Name: convert.RefOf(fmt.Sprint(version)),
+				Name: to.Ptr(fmt.Sprint(version)),
 			},
 		}
 

--- a/cli/azd/test/mocks/mockai/models.go
+++ b/cli/azd/test/mocks/mockai/models.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 )
 
@@ -33,8 +33,8 @@ func RegisterGetModel(mockContext *mocks.MockContext, workspaceName string, mode
 			ModelContainer: armmachinelearning.ModelContainer{
 				Name: &modelName,
 				Properties: &armmachinelearning.ModelContainerProperties{
-					LatestVersion: convert.RefOf("2"),
-					NextVersion:   convert.RefOf("3"),
+					LatestVersion: to.Ptr("2"),
+					NextVersion:   to.Ptr("3"),
 				},
 			},
 		}
@@ -68,7 +68,7 @@ func RegisterGetModelVersion(
 
 		response := armmachinelearning.ModelVersionsClientGetResponse{
 			ModelVersion: armmachinelearning.ModelVersion{
-				Name: convert.RefOf(fmt.Sprint(version)),
+				Name: to.Ptr(fmt.Sprint(version)),
 			},
 		}
 

--- a/cli/azd/test/mocks/mockai/workspaces.go
+++ b/cli/azd/test/mocks/mockai/workspaces.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 )
 
@@ -27,8 +27,8 @@ func RegisterGetWorkspaceMock(mockContext *mocks.MockContext, workspaceName stri
 		response := armmachinelearning.WorkspacesClientGetResponse{
 			Workspace: armmachinelearning.Workspace{
 				Name:     &workspaceName,
-				ID:       convert.RefOf("ID"),
-				Location: convert.RefOf("eastus2"),
+				ID:       to.Ptr("ID"),
+				Location: to.Ptr("eastus2"),
 			},
 		}
 

--- a/cli/azd/test/mocks/mockarmresources/mockarmresources.go
+++ b/cli/azd/test/mocks/mockarmresources/mockarmresources.go
@@ -9,8 +9,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockhttp"
 )
@@ -88,7 +88,7 @@ func applyFilter(filter string, result []*armresources.GenericResourceExpanded) 
 			tagVal := resource.Tags[tagNameFilter]
 			if tagVal == nil {
 				// treat nil as empty string
-				tagVal = convert.RefOf("")
+				tagVal = to.Ptr("")
 			}
 
 			if tagValueFilter != *tagVal {
@@ -100,7 +100,7 @@ func applyFilter(filter string, result []*armresources.GenericResourceExpanded) 
 			name := resource.Name
 			if name == nil {
 				// treat nil as empty string
-				name = convert.RefOf("")
+				name = to.Ptr("")
 			}
 
 			if *name != nameFilter {

--- a/cli/azd/test/mocks/mockgraphsdk/mocks.go
+++ b/cli/azd/test/mocks/mockgraphsdk/mocks.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 )
@@ -237,9 +237,9 @@ func RegisterRoleAssignmentPutMock(mockContext *mocks.MockContext, statusCode in
 	}).RespondFn(func(request *http.Request) (*http.Response, error) {
 		response := armauthorization.RoleAssignmentsClientCreateResponse{
 			RoleAssignment: armauthorization.RoleAssignment{
-				ID:   convert.RefOf("ASSIGNMENT_ID"),
-				Name: convert.RefOf("ROLE_NAME"),
-				Type: convert.RefOf("ASSIGNMENT_TYPE"),
+				ID:   to.Ptr("ASSIGNMENT_ID"),
+				Name: to.Ptr("ROLE_NAME"),
+				Type: to.Ptr("ASSIGNMENT_TYPE"),
 			},
 		}
 

--- a/cli/azd/test/recording/sanitize.go
+++ b/cli/azd/test/recording/sanitize.go
@@ -6,8 +6,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3"
-	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"gopkg.in/dnaeon/go-vcr.v3/cassette"
 )
 
@@ -53,12 +53,12 @@ func sanitizeContainerAppListSecrets(i *cassette.Interaction) error {
 					val := *body.Value[i].Value
 					// Redis requirepass. Sanitize the password, remove other config.
 					if strings.Contains(val, "requirepass ") {
-						body.Value[i].Value = convert.RefOf("requirepass SANITIZED")
+						body.Value[i].Value = to.Ptr("requirepass SANITIZED")
 					}
 					continue
 				}
 
-				body.Value[i].Value = convert.RefOf("SANITIZED")
+				body.Value[i].Value = to.Ptr("SANITIZED")
 			}
 		}
 
@@ -95,7 +95,7 @@ func sanitizeContainerAppUpdate(i *cassette.Interaction) error {
 			ca.Properties.Configuration.Secrets != nil {
 			for i := range ca.Properties.Configuration.Secrets {
 				if ca.Properties.Configuration.Secrets[i] != nil {
-					ca.Properties.Configuration.Secrets[i].Value = convert.RefOf("SANITIZED")
+					ca.Properties.Configuration.Secrets[i].Value = to.Ptr("SANITIZED")
 				}
 			}
 		}


### PR DESCRIPTION
Both `convert.RefOf` and `to.Ptr` do the same thing.  We invented `convert.RefOf` while the Azure SDK team was adding `to.Ptr`.

Let's adopt `to.Ptr` and get rid of `convert.RefOf`, it's a shorter name and used more across the Azure SDKs and samples.