### PR TITLE
azcli: Remove some dead code

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -583,22 +583,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	})
 
 	// Tools
-	container.MustRegisterSingleton(func(
-		rootOptions *internal.GlobalCommandOptions,
-		credentialProvider account.SubscriptionCredentialProvider,
-		httpClient httputil.HttpClient,
-		armClientOptions *arm.ClientOptions,
-	) azcli.AzCli {
-		return azcli.NewAzCli(
-			credentialProvider,
-			httpClient,
-			azcli.NewAzCliArgs{
-				EnableDebug:     rootOptions.EnableDebugLogging,
-				EnableTelemetry: rootOptions.EnableTelemetry,
-			},
-			armClientOptions,
-		)
-	})
+	container.MustRegisterSingleton(azcli.NewAzCli)
 	container.MustRegisterSingleton(azapi.NewDeployments)
 	container.MustRegisterSingleton(azapi.NewDeploymentOperations)
 	container.MustRegisterSingleton(docker.NewCli)

--- a/cli/azd/pkg/devcenter/provision_provider_test.go
+++ b/cli/azd/pkg/devcenter/provision_provider_test.go
@@ -465,8 +465,6 @@ func newProvisionProviderForTest(
 
 	azCli := azcli.NewAzCli(
 		mockContext.SubscriptionCredentialProvider,
-		mockContext.HttpClient,
-		azcli.NewAzCliArgs{},
 		mockContext.ArmClientOptions,
 	)
 	resourceManager := infra.NewAzureResourceManager(

--- a/cli/azd/pkg/tools/azcli/azcli.go
+++ b/cli/azd/pkg/tools/azcli/azcli.go
@@ -11,14 +11,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
 var (
 	ErrAzCliNotLoggedIn         = errors.New("cli is not logged in. Try running \"az login\" to fix")
 	ErrAzCliRefreshTokenExpired = errors.New("refresh token has expired. Try running \"az login\" to fix")
-	ErrClientAssertionExpired   = errors.New("client assertion expired")
-	ErrNoConfigurationValue     = errors.New("no value configured")
 )
 
 type AzCli interface {
@@ -128,18 +125,6 @@ type AzCliResourceExtended struct {
 	Kind string `json:"kind"`
 }
 
-// AzCliConfigValue represents the value returned by `az config get`.
-type AzCliConfigValue struct {
-	Name   string `json:"name"`
-	Source string `json:"source"`
-	Value  string `json:"value"`
-}
-
-// AzCliConfigValue represents the value in the array returned by `az extension list`.
-type AzCliExtensionInfo struct {
-	Name string
-}
-
 // Optional parameters for resource group listing.
 type ListResourceGroupOptions struct {
 	// An optional tag filter
@@ -161,34 +146,17 @@ type Filter struct {
 	Value string
 }
 
-type NewAzCliArgs struct {
-	EnableDebug     bool
-	EnableTelemetry bool
-}
-
 func NewAzCli(
 	credentialProvider account.SubscriptionCredentialProvider,
-	httpClient httputil.HttpClient,
-	args NewAzCliArgs,
 	armClientOptions *arm.ClientOptions,
 ) AzCli {
 	return &azCli{
 		credentialProvider: credentialProvider,
-		enableDebug:        args.EnableDebug,
-		enableTelemetry:    args.EnableTelemetry,
-		httpClient:         httpClient,
 		armClientOptions:   armClientOptions,
 	}
 }
 
 type azCli struct {
-	enableDebug     bool
-	enableTelemetry bool
-
-	// Allows us to mock the Http Requests from the go modules
-	httpClient httputil.HttpClient
-
 	credentialProvider account.SubscriptionCredentialProvider
-
-	armClientOptions *arm.ClientOptions
+	armClientOptions   *arm.ClientOptions
 }

--- a/cli/azd/pkg/tools/azcli/azcli_test.go
+++ b/cli/azd/pkg/tools/azcli/azcli_test.go
@@ -92,8 +92,6 @@ func newAzCliFromMockContext(mockContext *mocks.MockContext) AzCli {
 		mockaccount.SubscriptionCredentialProviderFunc(func(_ context.Context, _ string) (azcore.TokenCredential, error) {
 			return mockContext.Credentials, nil
 		}),
-		mockContext.HttpClient,
-		NewAzCliArgs{},
 		mockContext.ArmClientOptions,
 	)
 }

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -263,8 +263,6 @@ func Test_CLI_InfraCreateAndDelete(t *testing.T) {
 		func(_ context.Context, _ string) (azcore.TokenCredential, error) {
 			return cred, nil
 		}),
-		client,
-		azcli.NewAzCliArgs{},
 		armClientOptions,
 	)
 	deploymentOperations := azapi.NewDeploymentOperations(
@@ -480,8 +478,6 @@ func Test_CLI_InfraCreateAndDeleteUpperCase(t *testing.T) {
 		func(_ context.Context, _ string) (azcore.TokenCredential, error) {
 			return cred, nil
 		}),
-		client,
-		azcli.NewAzCliArgs{},
 		armClientOptions,
 	)
 	deploymentOperations := azapi.NewDeploymentOperations(

--- a/cli/azd/test/mocks/mockazcli/mocks.go
+++ b/cli/azd/test/mocks/mockazcli/mocks.go
@@ -17,8 +17,6 @@ func NewAzCliFromMockContext(mockContext *mocks.MockContext) azcli.AzCli {
 		mockaccount.SubscriptionCredentialProviderFunc(func(_ context.Context, _ string) (azcore.TokenCredential, error) {
 			return mockContext.Credentials, nil
 		}),
-		mockContext.HttpClient,
-		azcli.NewAzCliArgs{},
 		mockContext.ArmClientOptions,
 	)
 }


### PR DESCRIPTION
When we started the project, we used the `azcli` package to run an instance of `az` to do most of our management plane operations. Over time we moved away from this (mostly rewrting it implementation on top of `azure-sdk-for-go` packages) and as we did this we moved a bunch of the logic out of the `azcli` package and into other packages.

As we did that, we ended up leaving some dead code behind that wasn't obviously dead (either becaue it was exported but not consumed or because our DI pattern makes it non obvious when an injected value is unused because it is written to via an exported constructor).

This change cleans up this dead code, simplifying the codebase.