### PR TITLE
chore: Remove "lowercase c" pattern from the codebase

### DIFF
--- a/cli/azd/cmd/auth_login.go
+++ b/cli/azd/cmd/auth_login.go
@@ -18,6 +18,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/internal/runcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
@@ -257,8 +258,6 @@ func newLoginAction(
 	}
 }
 
-const cLoginSuccessMessage = "Logged in to Azure."
-
 func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	if len(la.flags.scopes) == 0 {
 		la.flags.scopes = la.authManager.LoginScopes()
@@ -300,7 +299,7 @@ func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 			var msg string
 			switch res.Status {
 			case contracts.LoginStatusSuccess:
-				msg = cLoginSuccessMessage
+				msg = "Logged in to Azure."
 			case contracts.LoginStatusUnauthenticated:
 				msg = "Not logged in, run `azd auth login` to login to Azure."
 			default:
@@ -331,7 +330,7 @@ func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		}
 	}
 
-	la.console.Message(ctx, cLoginSuccessMessage)
+	la.console.Message(ctx, "Logged in to Azure.")
 	return nil, nil
 }
 
@@ -534,7 +533,7 @@ func parseUseDeviceCode(ctx context.Context, flag boolPtr, commandRunner exec.Co
 		useDevCode = runningOnCodespacesBrowser(ctx, commandRunner)
 	}
 
-	if auth.ShouldUseCloudShellAuth() {
+	if runcontext.IsRunningInCloudShell() {
 		// Following az CLI behavior in Cloud Shell, use device code authentication when the user is trying to
 		// authenticate. The normal interactive authentication flow will not work in Cloud Shell because the browser
 		// cannot be opened or (if it could) cannot be redirected back to a port on the Cloud Shell instance.

--- a/cli/azd/cmd/auth_token_test.go
+++ b/cli/azd/cmd/auth_token_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const cManagementScope = "https://management.azure.com//.default"
+const managementScope = "https://management.azure.com//.default"
 
 func TestAuthToken(t *testing.T) {
 	wasCalled := false
@@ -34,7 +34,7 @@ func TestAuthToken(t *testing.T) {
 		wasCalled = true
 
 		// Default value when explicit scopes are not provided to the command.
-		require.ElementsMatch(t, []string{cManagementScope}, options.Scopes)
+		require.ElementsMatch(t, []string{managementScope}, options.Scopes)
 
 		return azcore.AccessToken{
 			Token:     "ABC123",
@@ -70,7 +70,7 @@ func TestAuthTokenSysEnv(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	token := authTokenFn(func(ctx context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
-		require.ElementsMatch(t, []string{cManagementScope}, options.Scopes)
+		require.ElementsMatch(t, []string{managementScope}, options.Scopes)
 		return azcore.AccessToken{
 			Token:     "ABC123",
 			ExpiresOn: time.Unix(1669153000, 0).UTC(),
@@ -112,7 +112,7 @@ func TestAuthTokenSysEnvError(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	token := authTokenFn(func(ctx context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
-		require.ElementsMatch(t, []string{cManagementScope}, options.Scopes)
+		require.ElementsMatch(t, []string{managementScope}, options.Scopes)
 		return azcore.AccessToken{
 			Token:     "ABC123",
 			ExpiresOn: time.Unix(1669153000, 0).UTC(),
@@ -160,7 +160,7 @@ func TestAuthTokenAzdEnvError(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	token := authTokenFn(func(ctx context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
-		require.ElementsMatch(t, []string{cManagementScope}, options.Scopes)
+		require.ElementsMatch(t, []string{managementScope}, options.Scopes)
 		return azcore.AccessToken{
 			Token:     "ABC123",
 			ExpiresOn: time.Unix(1669153000, 0).UTC(),
@@ -204,7 +204,7 @@ func TestAuthTokenAzdEnv(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	token := authTokenFn(func(ctx context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
-		require.ElementsMatch(t, []string{cManagementScope}, options.Scopes)
+		require.ElementsMatch(t, []string{managementScope}, options.Scopes)
 		return azcore.AccessToken{
 			Token:     "ABC123",
 			ExpiresOn: time.Unix(1669153000, 0).UTC(),
@@ -245,7 +245,7 @@ func TestAuthTokenAzdEnvWithEmpty(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	token := authTokenFn(func(ctx context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
-		require.ElementsMatch(t, []string{cManagementScope}, options.Scopes)
+		require.ElementsMatch(t, []string{managementScope}, options.Scopes)
 		return azcore.AccessToken{
 			Token:     "ABC123",
 			ExpiresOn: time.Unix(1669153000, 0).UTC(),

--- a/cli/azd/cmd/cobra_builder.go
+++ b/cli/azd/cmd/cobra_builder.go
@@ -16,8 +16,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const cDocsFlagName = "docs"
-
 // CobraBuilder manages the construction of the cobra command tree from nested ActionDescriptors
 type CobraBuilder struct {
 	container *ioc.NestedContainer
@@ -196,7 +194,7 @@ func (df *docsFlag) Set(value string) error {
 		}
 
 		commandPath := strings.ReplaceAll(c.CommandPath(), " ", "-")
-		commandDocsUrl := cReferenceDocumentationUrl + commandPath
+		commandDocsUrl := referenceDocumentationUrl + commandPath
 		openWithDefaultBrowser(ctx, console, commandDocsUrl)
 	})
 
@@ -221,7 +219,7 @@ func (cb *CobraBuilder) bindCommand(cmd *cobra.Command, descriptor *actions.Acti
 		},
 	}
 	flag := cmd.Flags().VarPF(
-		docsFlag, cDocsFlagName, "", fmt.Sprintf("Opens the documentation for %s in your web browser.", cmd.CommandPath()))
+		docsFlag, "docs", "", fmt.Sprintf("Opens the documentation for %s in your web browser.", cmd.CommandPath()))
 	flag.NoOptDefVal = "true"
 
 	// Consistently registers output formats for the descriptor

--- a/cli/azd/cmd/cobra_builder_test.go
+++ b/cli/azd/cmd/cobra_builder_test.go
@@ -248,7 +248,7 @@ func Test_RunDocsFlow(t *testing.T) {
 	cmd.SetArgs([]string{"--docs"})
 	err = cmd.ExecuteContext(*testCtx.Context)
 	require.NoError(t, err)
-	require.Equal(t, cReferenceDocumentationUrl+"root", calledUrl)
+	require.Equal(t, referenceDocumentationUrl+"root", calledUrl)
 }
 
 func Test_RunDocsAndHelpFlow(t *testing.T) {

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -172,4 +172,4 @@ func openWithDefaultBrowser(ctx context.Context, console input.Console, url stri
 	console.Message(ctx, fmt.Sprintf("Azd was unable to open the next url. Please try it manually: %s", url))
 }
 
-const cReferenceDocumentationUrl = "https://learn.microsoft.com/azure/developer/azure-developer-cli/reference#"
+const referenceDocumentationUrl = "https://learn.microsoft.com/azure/developer/azure-developer-cli/reference#"

--- a/cli/azd/internal/runcontext/cloudshell.go
+++ b/cli/azd/internal/runcontext/cloudshell.go
@@ -6,10 +6,14 @@ import (
 	"strconv"
 )
 
-const cUseCloudShellAuthEnvVar = "AZD_IN_CLOUDSHELL"
+// AzdInCloudShellEnvVar is the environment variable that is set when running in Cloud Shell. It is set to a value recognized
+// by strconv.ParseBool.
+//
+// Use [IsRunningInCloudShell] to check if the current process is running in Cloud Shell.
+const AzdInCloudShellEnvVar = "AZD_IN_CLOUDSHELL"
 
 func IsRunningInCloudShell() bool {
-	if azdInCloudShell, has := os.LookupEnv(cUseCloudShellAuthEnvVar); has {
+	if azdInCloudShell, has := os.LookupEnv(AzdInCloudShellEnvVar); has {
 		if use, err := strconv.ParseBool(azdInCloudShell); err == nil && use {
 			log.Printf("running in Cloud Shell")
 			return true

--- a/cli/azd/internal/runcontext/cloudshell_test.go
+++ b/cli/azd/internal/runcontext/cloudshell_test.go
@@ -1,31 +1,25 @@
 package runcontext
 
 import (
-	"os"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/test/ostest"
 	"github.com/stretchr/testify/require"
 )
 
-const cAzdInCloudShellEnvVar = "AZD_IN_CLOUDSHELL"
-
 func TestIsRunningInCloudShellScenarios(t *testing.T) {
 	t.Run("returns true when AZD_IN_CLOUDSHELL is set to true-ish string", func(t *testing.T) {
-		t.Setenv(cAzdInCloudShellEnvVar, "1")
+		t.Setenv(AzdInCloudShellEnvVar, "1")
 		require.True(t, IsRunningInCloudShell())
 	})
 
 	t.Run("returns false when AZD_IN_CLOUDSHELL is set to false-ish string", func(t *testing.T) {
-		t.Setenv(cAzdInCloudShellEnvVar, "0")
+		t.Setenv(AzdInCloudShellEnvVar, "0")
 		require.False(t, IsRunningInCloudShell())
 	})
 
 	t.Run("returns false when AZD_IN_CLOUDSHELL is not set", func(t *testing.T) {
-		// Ensure that AZD_IN_CLOUDSHELL is not set otherwise the test is not
-		// accurate
-		_, envIsSet := os.LookupEnv(cAzdInCloudShellEnvVar)
-		require.False(t, envIsSet)
-
+		ostest.Unsetenv(t, AzdInCloudShellEnvVar)
 		require.False(t, IsRunningInCloudShell())
 	})
 

--- a/cli/azd/internal/telemetry/notice.go
+++ b/cli/azd/internal/telemetry/notice.go
@@ -7,22 +7,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/azure/azure-dev/cli/azd/internal/runcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 )
-
-// Telemetry notice text displayed to the user in some scenarios
-//
-//nolint:lll
-const cTelemetryNoticeText = `The Azure Developer CLI collects usage data and sends that usage data to Microsoft in order to help us improve your experience.
-You can opt-out of telemetry by setting the AZURE_DEV_COLLECT_TELEMETRY environment variable to 'no' in the shell you use.
-
-Read more about Azure Developer CLI telemetry: https://github.com/Azure/azure-dev#data-collection`
-
-// The name of the file created in the azd configuration directory after the
-// first run of the CLI. It's presence is used to determine if this is the
-// first run of the CLI.
-const cFirstRunFileName = "first-run"
 
 func FirstNotice() string {
 	// If the AZURE_DEV_COLLECT_TELEMETRY environment variable is set to any
@@ -39,7 +27,12 @@ func FirstNotice() string {
 			log.Printf("failed to setup first run: %v", err)
 		}
 
-		return cTelemetryNoticeText
+		//nolint:lll
+		return heredoc.Doc(`
+The Azure Developer CLI collects usage data and sends that usage data to Microsoft in order to help us improve your experience.
+You can opt-out of telemetry by setting the AZURE_DEV_COLLECT_TELEMETRY environment variable to 'no' in the shell you use.
+
+Read more about Azure Developer CLI telemetry: https://github.com/Azure/azure-dev#data-collection`)
 	}
 
 	return ""
@@ -73,7 +66,7 @@ func getFirstRunFilePath() (string, error) {
 		return "", err
 	}
 
-	return filepath.Join(configDir, cFirstRunFileName), nil
+	return filepath.Join(configDir, "first-run"), nil
 }
 
 func SetupFirstRun() error {

--- a/cli/azd/internal/telemetry/notice_test.go
+++ b/cli/azd/internal/telemetry/notice_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/internal/runcontext"
 	"github.com/azure/azure-dev/cli/azd/test/ostest"
 	"github.com/stretchr/testify/assert"
 )
@@ -65,7 +66,7 @@ func setupSuite(withFirstRunFile bool, t *testing.T) func(t *testing.T) {
 
 func Test_FirstNotice(t *testing.T) {
 	t.Run("in Cloud Shell", func(t *testing.T) {
-		ostest.Setenv(t, "AZD_IN_CLOUDSHELL", "1")
+		ostest.Setenv(t, runcontext.AzdInCloudShellEnvVar, "1")
 
 		t.Run("returns nothing if opted into telemetry", func(t *testing.T) {
 			teardown := setupSuite(false, t)
@@ -92,7 +93,7 @@ func Test_FirstNotice(t *testing.T) {
 	})
 
 	t.Run("not in Cloud Shell", func(t *testing.T) {
-		ostest.Unsetenv(t, "AZD_IN_CLOUDSHELL")
+		ostest.Unsetenv(t, runcontext.AzdInCloudShellEnvVar)
 
 		t.Run("returns nothing if first run file doesn't exist", func(t *testing.T) {
 			teardown := setupSuite(false, t)

--- a/cli/azd/internal/telemetry/telemetry.go
+++ b/cli/azd/internal/telemetry/telemetry.go
@@ -94,9 +94,6 @@ func GetTelemetrySystem() *TelemetrySystem {
 	return instance
 }
 
-// ref: go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/otlpconfig/DefaultCollectorHTTPPort
-const cDefaultCollectorHTTPPort uint16 = 4318
-
 func initialize() (*TelemetrySystem, error) {
 	if !IsTelemetryEnabled() {
 		log.Println("telemetry is disabled by user and will not be initialized.")
@@ -177,7 +174,8 @@ func initialize() (*TelemetrySystem, error) {
 		if u.Port() != "" {
 			traceOptions = append(traceOptions, otlptracehttp.WithEndpoint(u.Host))
 		} else {
-			hostWithDefaultPort := fmt.Sprintf("%s:%d", u.Host, cDefaultCollectorHTTPPort)
+			// ref: go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/otlpconfig/DefaultCollectorHTTPPort
+			hostWithDefaultPort := fmt.Sprintf("%s:%d", u.Host, 4318)
 			traceOptions = append(traceOptions, otlptracehttp.WithEndpoint(hostWithDefaultPort))
 		}
 

--- a/cli/azd/internal/tracing/resource/exec_environment.go
+++ b/cli/azd/internal/tracing/resource/exec_environment.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/internal/runcontext"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
 )
 
@@ -52,7 +53,7 @@ func execEnvFromCaller() string {
 }
 
 func execEnvForHosts() string {
-	if _, ok := os.LookupEnv("AZD_IN_CLOUDSHELL"); ok {
+	if _, ok := os.LookupEnv(runcontext.AzdInCloudShellEnvVar); ok {
 		return fields.EnvCloudShell
 	}
 

--- a/cli/azd/internal/version.go
+++ b/cli/azd/internal/version.go
@@ -10,9 +10,9 @@ import (
 	"github.com/blang/semver/v4"
 )
 
-// cDevVersionString is the default version that is used when [Version] is not overridden at build time, i.e.
+// devVersionString is the default version that is used when [Version] is not overridden at build time, i.e.
 // a developer building locally using `go install`.
-const cDevVersionString = "0.0.0-dev.0 (commit 0000000000000000000000000000000000000000)"
+const devVersionString = "0.0.0-dev.0 (commit 0000000000000000000000000000000000000000)"
 
 // The version string, as printed by `azd version`.
 //
@@ -32,7 +32,7 @@ const cDevVersionString = "0.0.0-dev.0 (commit 000000000000000000000000000000000
 // directly, use [VersionInfo] which returns a structured version of this value.
 //
 // nolint: lll
-var Version = cDevVersionString
+var Version = devVersionString
 
 func init() {
 	// VersionInfo panics if the version string is malformed, run the code at package startup to
@@ -47,7 +47,7 @@ type AzdVersionInfo struct {
 }
 
 func IsDevVersion() bool {
-	return Version == cDevVersionString
+	return Version == devVersionString
 }
 
 func IsNonProdVersion() bool {
@@ -61,10 +61,10 @@ func IsNonProdVersion() bool {
 	return strings.Contains(VersionInfo().Version.String(), "pr")
 }
 
-var cVersionStringRegexp = regexp.MustCompile(`^(\S+) \(commit ([0-9a-f]{40})\)$`)
+var versionStringRegexp = regexp.MustCompile(`^(\S+) \(commit ([0-9a-f]{40})\)$`)
 
 func VersionInfo() AzdVersionInfo {
-	matches := cVersionStringRegexp.FindStringSubmatch(Version)
+	matches := versionStringRegexp.FindStringSubmatch(Version)
 
 	if len(matches) != 3 {
 		panic("azd version is malformed, ensure github.com/azure/azure-dev/cli/azd/internal.Version is correct")

--- a/cli/azd/pkg/account/subscriptions_cache.go
+++ b/cli/azd/pkg/account/subscriptions_cache.go
@@ -15,7 +15,7 @@ import (
 )
 
 // The file name of the cache used for storing subscriptions accessible by local accounts.
-const cSubscriptionsCacheFile = "subscriptions.cache"
+const subscriptionsCacheFile = "subscriptions.cache"
 
 // subscriptionsCache caches the list of subscriptions accessible by local accounts.
 //
@@ -56,7 +56,7 @@ func (s *subscriptionsCache) Load(ctx context.Context, key string) ([]Subscripti
 	defer s.inMemoryLock.Unlock()
 
 	// load cache from disk
-	cacheFile, err := os.ReadFile(filepath.Join(s.cacheDir, cSubscriptionsCacheFile))
+	cacheFile, err := os.ReadFile(filepath.Join(s.cacheDir, subscriptionsCacheFile))
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func (s *subscriptionsCache) Save(ctx context.Context, key string, subscriptions
 	defer s.inMemoryLock.Unlock()
 
 	// Read the file if it exists
-	cacheFile, err := os.ReadFile(filepath.Join(s.cacheDir, cSubscriptionsCacheFile))
+	cacheFile, err := os.ReadFile(filepath.Join(s.cacheDir, subscriptionsCacheFile))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
@@ -92,7 +92,7 @@ func (s *subscriptionsCache) Save(ctx context.Context, key string, subscriptions
 	if cacheFile != nil {
 		err = json.Unmarshal(cacheFile, &cache)
 		if err != nil {
-			log.Printf("failed to unmarshal %s, ignoring: %v", cSubscriptionsCacheFile, err)
+			log.Printf("failed to unmarshal %s, ignoring: %v", subscriptionsCacheFile, err)
 		}
 	}
 
@@ -105,7 +105,7 @@ func (s *subscriptionsCache) Save(ctx context.Context, key string, subscriptions
 		return fmt.Errorf("failed to marshal subscriptions: %w", err)
 	}
 
-	err = os.WriteFile(filepath.Join(s.cacheDir, cSubscriptionsCacheFile), content, osutil.PermissionFile)
+	err = os.WriteFile(filepath.Join(s.cacheDir, subscriptionsCacheFile), content, osutil.PermissionFile)
 	if err != nil {
 		return fmt.Errorf("failed to write file: %w", err)
 	}
@@ -119,7 +119,7 @@ func (s *subscriptionsCache) Clear(ctx context.Context) error {
 	s.inMemoryLock.Lock()
 	defer s.inMemoryLock.Unlock()
 
-	err := os.Remove(filepath.Join(s.cacheDir, cSubscriptionsCacheFile))
+	err := os.Remove(filepath.Join(s.cacheDir, subscriptionsCacheFile))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}

--- a/cli/azd/pkg/auth/cache.go
+++ b/cli/azd/pkg/auth/cache.go
@@ -34,7 +34,7 @@ var contractFields = []string{
 // but note that the key is a partitioning key and not a unique user key.
 // Also, given that the data contains auth data for all users, we only need a single key
 // to store all cached auth information.
-const cCurrentUserCacheKey = ""
+const currentUserCacheKey = ""
 
 // msalCacheAdapter adapts our interface to the one expected by cache.ExportReplace.
 type msalCacheAdapter struct {
@@ -42,7 +42,7 @@ type msalCacheAdapter struct {
 }
 
 func (a *msalCacheAdapter) Replace(ctx context.Context, cache cache.Unmarshaler, _ cache.ReplaceHints) error {
-	val, err := a.cache.Read(cCurrentUserCacheKey)
+	val, err := a.cache.Read(currentUserCacheKey)
 	if errors.Is(err, errCacheKeyNotFound) {
 		return nil
 	} else if err != nil {
@@ -102,7 +102,7 @@ func (a *msalCacheAdapter) Export(ctx context.Context, cache cache.Marshaler, _ 
 		return err
 	}
 
-	return a.cache.Set(cCurrentUserCacheKey, val)
+	return a.cache.Set(currentUserCacheKey, val)
 }
 
 // Normalize keys by removing upper-case keys and replacing them with lower-case keys.

--- a/cli/azd/pkg/auth/cache_windows.go
+++ b/cli/azd/pkg/auth/cache_windows.go
@@ -27,10 +27,10 @@ type envelopedData struct {
 
 type encryptionType string
 
-// cCryptProtectDataEncryptionType is the encryption type that uses CryptProtectData/CryptUnprotectData for
+// cryptProtectDataEncryptionType is the encryption type that uses CryptProtectData/CryptUnprotectData for
 // encryption and decryption.  See https://learn.microsoft.com/windows/win32/api/dpapi/nf-dpapi-cryptprotectdata
 // for more information on these APIs.
-const cCryptProtectDataEncryptionType encryptionType = "CryptProtectData"
+const cryptProtectDataEncryptionType encryptionType = "CryptProtectData"
 
 func newCache(root string) cache.ExportReplace {
 	return &msalCacheAdapter{
@@ -90,7 +90,7 @@ func (c *encryptedCache) Read(key string) ([]byte, error) {
 		}
 	} else {
 
-		if data.Type != cCryptProtectDataEncryptionType {
+		if data.Type != cryptProtectDataEncryptionType {
 			return nil, fmt.Errorf("unsupported encryption type: %s", data.Type)
 		}
 
@@ -148,7 +148,7 @@ func (c *encryptedCache) Set(key string, val []byte) error {
 	}
 
 	toStore, err := json.Marshal(envelopedData{
-		Type: cCryptProtectDataEncryptionType,
+		Type: cryptProtectDataEncryptionType,
 		Data: base64.StdEncoding.EncodeToString(cs),
 	})
 

--- a/cli/azd/pkg/auth/cloudshell_credential.go
+++ b/cli/azd/pkg/auth/cloudshell_credential.go
@@ -16,11 +16,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
-// Use URL from https://learn.microsoft.com/azure/cloud-shell/msi-authorization
-const cLocalTokenUrl = "http://localhost:50342/oauth2/token" //#nosec G101 -- This is a false positive
-
-const cDefaultSuffix = "/.default"
-
 type TokenFromCloudShell struct {
 	AccessToken  string      `json:"access_token"`
 	RefreshToken string      `json:"refresh_token"`
@@ -47,13 +42,15 @@ func (t CloudShellCredential) GetToken(ctx context.Context, options policy.Token
 	}
 
 	// API expects an AAD v1 resource, not a v2 scope
-	scope := strings.TrimSuffix(options.Scopes[0], cDefaultSuffix)
+	scope := strings.TrimSuffix(options.Scopes[0], "/.default")
 
 	postData := url.Values{}
 	postData.Set("resource", scope)
 
+	// Use URL from https://learn.microsoft.com/azure/cloud-shell/msi-authorization
+	//#nosec G101 -- This is a false positive
 	req, err := http.NewRequestWithContext(
-		ctx, "POST", cLocalTokenUrl, strings.NewReader(postData.Encode()))
+		ctx, "POST", "http://localhost:50342/oauth2/token", strings.NewReader(postData.Encode()))
 	if err != nil {
 		return azcore.AccessToken{}, err
 	}

--- a/cli/azd/pkg/auth/cloudshell_credential_test.go
+++ b/cli/azd/pkg/auth/cloudshell_credential_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const cSuccessfulTokenResponse = `{
+const successfulTokenResponse = `{
 	"access_token": "sample-access-token",
 	"refresh_token": "",
 	"expires_in": "123",
@@ -63,7 +63,7 @@ func TestCloudShellCredentialGetToken(t *testing.T) {
 			request.FormValue("resource") == "https://management.azure.com/"
 	}).Respond(&http.Response{
 		StatusCode: 200,
-		Body:       io.NopCloser(bytes.NewBufferString(cSuccessfulTokenResponse)),
+		Body:       io.NopCloser(bytes.NewBufferString(successfulTokenResponse)),
 	})
 
 	token, err = cred.GetToken(*mockContext.Context, policy.TokenRequestOptions{

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -14,9 +14,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
 )
 
-const cLoginCmd = "azd auth login"
-const cDefaultReloginScenario = "reauthentication required"
-
 // ErrNoCurrentUser indicates that the current user is not logged in.
 // This is typically determined by inspecting the stored auth information and credentials on the machine.
 // If the auth information or credentials are not found or invalid, the user is considered not to be logged in.
@@ -57,8 +54,8 @@ func newReLoginRequiredError(
 }
 
 func (e *ReLoginRequiredError) init(response *AadErrorResponse, scopes []string, cloud *cloud.Cloud) {
-	e.scenario = cDefaultReloginScenario
-	e.loginCmd = cLoginCmd
+	e.scenario = "reauthentication required"
+	e.loginCmd = "azd auth login"
 	if !matchesLoginScopes(scopes, cloud) { // if matching default login scopes, no scopes need to be specified
 		for _, scope := range scopes {
 			e.loginCmd += fmt.Sprintf(" --scope %s", scope)

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
+	"github.com/azure/azure-dev/cli/azd/internal/runcontext"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
@@ -39,20 +40,18 @@ import (
 //
 // nolint:lll
 // https://github.com/Azure/azure-cli/blob/azure-cli-2.41.0/src/azure-cli-core/azure/cli/core/auth/identity.py#L23
-const cAZD_CLIENT_ID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
+const azdClientID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
 
-// cCurrentUserKey is the key we use in config for the storing identity information of the currently logged in user.
-const cCurrentUserKey = "auth.account.currentUser"
+// currentUserKey is the key we use in config for the storing identity information of the currently logged in user.
+const currentUserKey = "auth.account.currentUser"
 
-// cUseAzCli is the key we use in config to denote that we want to use the az CLI for authentication instead of managing
-// it ourselves. The value should be a string as specified by [strconv.ParseBool].
-const cUseAzCliAuthKey = "auth.useAzCliAuth"
+// useAzCliAuthKey is the key we use in config to denote that we want to use the az CLI for authentication instead of
+// managing it ourselves. The value should be a string as specified by [strconv.ParseBool].
+const useAzCliAuthKey = "auth.useAzCliAuth"
 
-// cAuthConfigFileName is the name of the file we store in the user configuration directory which is used to persist
+// authConfigFileName is the name of the file we store in the user configuration directory which is used to persist
 // auth related configuration information (e.g. the home account id of the current user). This information is not secret.
-const cAuthConfigFileName = "auth.json"
-
-const cUseCloudShellAuthEnvVar = "AZD_IN_CLOUDSHELL"
+const authConfigFileName = "auth.json"
 
 // HttpClient interface as required by MSAL library.
 type HttpClient interface {
@@ -130,7 +129,7 @@ func NewManager(
 		public.WithHTTPClient(httpClient),
 	}
 
-	publicClientApp, err := public.New(cAZD_CLIENT_ID, options...)
+	publicClientApp, err := public.New(azdClientID, options...)
 	if err != nil {
 		return nil, fmt.Errorf("creating msal client: %w", err)
 	}
@@ -213,7 +212,7 @@ func (m *Manager) CredentialForCurrentUser(
 	}
 
 	if shouldUseLegacyAuth(userConfig) {
-		log.Printf("delegating auth to az since %s is set to true", cUseAzCliAuthKey)
+		log.Printf("delegating auth to az since %s is set to true", useAzCliAuthKey)
 		cred, err := azidentity.NewAzureCLICredential(&azidentity.AzureCLICredentialOptions{
 			TenantID: options.TenantID,
 		})
@@ -231,7 +230,7 @@ func (m *Manager) CredentialForCurrentUser(
 	currentUser, err := readUserProperties(authConfig)
 	if errors.Is(err, ErrNoCurrentUser) {
 		// User is not logged in, not using az credentials, try CloudShell if possible
-		if ShouldUseCloudShellAuth() {
+		if runcontext.IsRunningInCloudShell() {
 			cloudShellCredential, err := m.newCredentialFromCloudShell()
 			if err != nil {
 				return nil, err
@@ -249,7 +248,7 @@ func (m *Manager) CredentialForCurrentUser(
 							tenant = "organizations"
 						}
 						authority := m.cloud.Configuration.ActiveDirectoryAuthorityHost + tenant
-						return oneauth.NewCredential(authority, cAZD_CLIENT_ID, oneauth.CredentialOptions{
+						return oneauth.NewCredential(authority, azdClientID, oneauth.CredentialOptions{
 							HomeAccountID: *user.HomeAccountID,
 						})
 					}
@@ -271,7 +270,7 @@ func (m *Manager) CredentialForCurrentUser(
 				return nil, fmt.Errorf("joining authority url: %w", err)
 			}
 
-			return oneauth.NewCredential(authority, cAZD_CLIENT_ID, oneauth.CredentialOptions{
+			return oneauth.NewCredential(authority, azdClientID, oneauth.CredentialOptions{
 				HomeAccountID: *currentUser.HomeAccountID,
 				NoPrompt:      options.NoPrompt,
 			})
@@ -295,7 +294,7 @@ func (m *Manager) CredentialForCurrentUser(
 					// override the default authority.
 					newOptions = append(newOptions, public.WithAuthority(newAuthority))
 
-					clientWithNewTenant, err := public.New(cAZD_CLIENT_ID, newOptions...)
+					clientWithNewTenant, err := public.New(azdClientID, newOptions...)
 					if err != nil {
 						return nil, err
 					}
@@ -370,19 +369,8 @@ func (m *Manager) ClaimsForCurrentUser(ctx context.Context, options *ClaimsForCu
 }
 
 func shouldUseLegacyAuth(cfg config.Config) bool {
-	if useLegacyAuth, has := cfg.Get(cUseAzCliAuthKey); has {
+	if useLegacyAuth, has := cfg.Get(useAzCliAuthKey); has {
 		if use, err := strconv.ParseBool(useLegacyAuth.(string)); err == nil && use {
-			return true
-		}
-	}
-
-	return false
-}
-
-func ShouldUseCloudShellAuth() bool {
-	if useCloudShellAuth, has := os.LookupEnv(cUseCloudShellAuthEnvVar); has {
-		if use, err := strconv.ParseBool(useCloudShellAuth); err == nil && use {
-			log.Printf("using CloudShell auth")
 			return true
 		}
 	}
@@ -422,7 +410,7 @@ func (m *Manager) GetLoggedInServicePrincipalTenantID(ctx context.Context) (*str
 	if err != nil {
 		// No user is logged in, if running in CloudShell use tenant id from
 		// CloudShell session (single tenant)
-		if ShouldUseCloudShellAuth() {
+		if runcontext.IsRunningInCloudShell() {
 			// Tenant ID is not required when requesting a token from CloudShell
 			credential, err := m.CredentialForCurrentUser(ctx, nil)
 			if err != nil {
@@ -616,7 +604,7 @@ func (m *Manager) LoginInteractive(
 // For example, it will log in the user currently signed in to Windows. This method never prompts for
 // user interaction and returns an error when the broker doesn't provide an account.
 func (m *Manager) LoginWithBrokerAccount() error {
-	accountID, err := oneauth.LogInSilently(cAZD_CLIENT_ID)
+	accountID, err := oneauth.LogInSilently(azdClientID)
 	if err == nil {
 		err = m.saveUserProperties(&userProperties{
 			FromOneAuth:   true,
@@ -632,7 +620,7 @@ func (m *Manager) LoginWithOneAuth(ctx context.Context, tenantID string, scopes 
 		scopes = m.LoginScopes()
 	}
 	authority := m.cloud.Configuration.ActiveDirectoryAuthorityHost + tenantID
-	accountID, err := oneauth.LogIn(authority, cAZD_CLIENT_ID, strings.Join(scopes, " "))
+	accountID, err := oneauth.LogIn(authority, azdClientID, strings.Join(scopes, " "))
 	if err == nil {
 		err = m.saveUserProperties(&userProperties{
 			FromOneAuth:   true,
@@ -663,7 +651,7 @@ func (m *Manager) LoginWithDeviceCode(
 
 	url := "https://microsoft.com/devicelogin"
 
-	if ShouldUseCloudShellAuth() {
+	if runcontext.IsRunningInCloudShell() {
 		m.console.MessageUxItem(ctx, &ux.MultilineMessage{
 			Lines: []string{
 				// nolint:lll
@@ -811,7 +799,7 @@ func (m *Manager) Logout(ctx context.Context) error {
 	currentUser, _ := readUserProperties(cfg)
 	if currentUser != nil {
 		if currentUser.FromOneAuth {
-			if err := oneauth.Logout(cAZD_CLIENT_ID); err != nil {
+			if err := oneauth.Logout(azdClientID); err != nil {
 				return fmt.Errorf("logging out of OneAuth: %w", err)
 			}
 		} else if currentUser.TenantID != nil && currentUser.ClientID != nil {
@@ -824,7 +812,7 @@ func (m *Manager) Logout(ctx context.Context) error {
 		}
 	}
 
-	if err := cfg.Unset(cCurrentUserKey); err != nil {
+	if err := cfg.Unset(currentUserKey); err != nil {
 		return fmt.Errorf("un-setting current user: %w", err)
 	}
 
@@ -906,7 +894,7 @@ func (m *Manager) saveUserProperties(user *userProperties) error {
 		return fmt.Errorf("fetching current user: %w", err)
 	}
 
-	if err := cfg.Set(cCurrentUserKey, *user); err != nil {
+	if err := cfg.Set(currentUserKey, *user); err != nil {
 		return fmt.Errorf("setting account id in config: %w", err)
 	}
 
@@ -921,7 +909,7 @@ func (m *Manager) readAuthConfig() (config.Config, error) {
 		return nil, fmt.Errorf("getting user config dir: %w", err)
 	}
 
-	authCfgFile := filepath.Join(cfgPath, cAuthConfigFileName)
+	authCfgFile := filepath.Join(cfgPath, authConfigFileName)
 
 	authCfg, err := m.configManager.Load(authCfgFile)
 	if err == nil {
@@ -938,13 +926,13 @@ func (m *Manager) readAuthConfig() (config.Config, error) {
 		return nil, fmt.Errorf("reading user config: %w", err)
 	}
 
-	curUserData, has := userCfg.Get(cCurrentUserKey)
+	curUserData, has := userCfg.Get(currentUserKey)
 	if !has {
 		return config.NewEmptyConfig(), nil
 	}
 
 	authCfg = config.NewEmptyConfig()
-	if err := authCfg.Set(cCurrentUserKey, curUserData); err != nil {
+	if err := authCfg.Set(currentUserKey, curUserData); err != nil {
 		return nil, err
 	}
 
@@ -952,7 +940,7 @@ func (m *Manager) readAuthConfig() (config.Config, error) {
 		return nil, err
 	}
 
-	if err := userCfg.Unset(cCurrentUserKey); err != nil {
+	if err := userCfg.Unset(currentUserKey); err != nil {
 		return nil, err
 	}
 
@@ -969,7 +957,7 @@ func (m *Manager) saveAuthConfig(c config.Config) error {
 		return fmt.Errorf("getting user config dir: %w", err)
 	}
 
-	authCfgFile := filepath.Join(cfgPath, cAuthConfigFileName)
+	authCfgFile := filepath.Join(cfgPath, authConfigFileName)
 
 	return m.configManager.Save(c, authCfgFile)
 }
@@ -1052,7 +1040,7 @@ type userProperties struct {
 }
 
 func readUserProperties(cfg config.Config) (*userProperties, error) {
-	currentUser, has := cfg.Get(cCurrentUserKey)
+	currentUser, has := cfg.Get(currentUserKey)
 	if !has {
 		return nil, ErrNoCurrentUser
 	}

--- a/cli/azd/pkg/auth/manager_test.go
+++ b/cli/azd/pkg/auth/manager_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
+	"github.com/azure/azure-dev/cli/azd/internal/runcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/github"
@@ -87,7 +88,7 @@ func TestServicePrincipalLoginClientSecret(t *testing.T) {
 }
 
 //go:embed testdata/certificate.pem
-var cTestClientCertificate []byte
+var testClientCertificate []byte
 
 func TestServicePrincipalLoginClientCertificate(t *testing.T) {
 	credentialCache := &memoryCache{
@@ -102,7 +103,7 @@ func TestServicePrincipalLoginClientCertificate(t *testing.T) {
 	}
 
 	cred, err := m.LoginWithServicePrincipalCertificate(
-		context.Background(), "testClientId", "testTenantId", cTestClientCertificate,
+		context.Background(), "testClientId", "testTenantId", testClientCertificate,
 	)
 
 	require.NoError(t, err)
@@ -176,7 +177,7 @@ func TestLegacyAzCliCredentialSupport(t *testing.T) {
 	cfg, err := mgr.Load()
 	require.NoError(t, err)
 
-	err = cfg.Set(cUseAzCliAuthKey, "true")
+	err = cfg.Set(useAzCliAuthKey, "true")
 	require.NoError(t, err)
 
 	err = mgr.Save(cfg)
@@ -193,7 +194,7 @@ func TestLegacyAzCliCredentialSupport(t *testing.T) {
 }
 
 func TestCloudShellCredentialSupport(t *testing.T) {
-	t.Setenv("AZD_IN_CLOUDSHELL", "1")
+	t.Setenv(runcontext.AzdInCloudShellEnvVar, "1")
 	m := Manager{
 		configManager:     newMemoryConfigManager(),
 		userConfigManager: newMemoryUserConfigManager(),
@@ -267,7 +268,7 @@ func TestAuthFileConfigUpgrade(t *testing.T) {
 	userCfg := config.NewEmptyConfig()
 	userCfgMgr := newMemoryUserConfigManager()
 
-	err := userCfg.Set(cCurrentUserKey, &userProperties{
+	err := userCfg.Set(currentUserKey, &userProperties{
 		HomeAccountID: to.Ptr("homeAccountID"),
 	})
 	require.NoError(t, err)
@@ -291,7 +292,7 @@ func TestAuthFileConfigUpgrade(t *testing.T) {
 
 	// as part of running readAuthConfig, we migrated the setting from the user config to the auth config
 	// so the current user key should no longer be set in the user configuration.
-	_, has := userCfgMgr.config.Get(cCurrentUserKey)
+	_, has := userCfgMgr.config.Get(currentUserKey)
 	require.False(t, has)
 }
 

--- a/cli/azd/pkg/azsdk/client_options_builder.go
+++ b/cli/azd/pkg/azsdk/client_options_builder.go
@@ -70,7 +70,7 @@ func (b *ClientOptionsBuilder) BuildArmClientOptions() *arm.ClientOptions {
 			// Logging policy options.
 			// Always allow Azure correlation header
 			Logging: policy.LogOptions{
-				AllowedHeaders: []string{cMsCorrelationIdHeader},
+				AllowedHeaders: []string{msCorrelationIdHeader},
 			},
 
 			Cloud: b.cloud,

--- a/cli/azd/pkg/azsdk/correlation_policy.go
+++ b/cli/azd/pkg/azsdk/correlation_policy.go
@@ -8,10 +8,10 @@ import (
 )
 
 // See https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/common-api-details.md#client-request-headers
-const cMsCorrelationIdHeader = "x-ms-correlation-request-id"
+const msCorrelationIdHeader = "x-ms-correlation-request-id"
 
 // See https://learn.microsoft.com/en-us/graph/best-practices-concept#reliability-and-support
-const cMsGraphCorrelationIdHeader = "client-request-id"
+const msGraphCorrelationIdHeader = "client-request-id"
 
 // simpleCorrelationPolicy is a policy that sets a simple correlation ID HTTP header.
 type simpleCorrelationPolicy struct {
@@ -33,10 +33,10 @@ func (p *simpleCorrelationPolicy) Do(req *policy.Request) (*http.Response, error
 // This works for Azure REST API, and could also work for other Microsoft-hosted services that do not yet honor distributed
 // tracing.
 func NewMsCorrelationPolicy() policy.Policy {
-	return &simpleCorrelationPolicy{headerName: cMsCorrelationIdHeader}
+	return &simpleCorrelationPolicy{headerName: msCorrelationIdHeader}
 }
 
 // NewMsGraphCorrelationPolicy creates a policy that sets Microsoft Graph correlation ID headers on HTTP requests.
 func NewMsGraphCorrelationPolicy() policy.Policy {
-	return &simpleCorrelationPolicy{headerName: cMsGraphCorrelationIdHeader}
+	return &simpleCorrelationPolicy{headerName: msGraphCorrelationIdHeader}
 }

--- a/cli/azd/pkg/azsdk/correlation_policy_test.go
+++ b/cli/azd/pkg/azsdk/correlation_policy_test.go
@@ -43,7 +43,7 @@ func Test_simpleCorrelationPolicy_Do(t *testing.T) {
 				trace.SpanContext{}.WithTraceID(traceId),
 			),
 			expect:                to.Ptr(traceId.String()),
-			headerName:            cMsCorrelationIdHeader,
+			headerName:            msCorrelationIdHeader,
 			correlationPolicyFunc: NewMsCorrelationPolicy,
 		},
 		{
@@ -54,14 +54,14 @@ func Test_simpleCorrelationPolicy_Do(t *testing.T) {
 				trace.SpanContext{}.WithTraceID(invalidTraceId),
 			),
 			expect:                to.Ptr(""),
-			headerName:            cMsCorrelationIdHeader,
+			headerName:            msCorrelationIdHeader,
 			correlationPolicyFunc: NewMsCorrelationPolicy,
 		},
 		{
 			name:                  "WithoutTraceId",
 			ctx:                   context.Background(),
 			expect:                nil,
-			headerName:            cMsCorrelationIdHeader,
+			headerName:            msCorrelationIdHeader,
 			correlationPolicyFunc: NewMsCorrelationPolicy,
 		},
 		{
@@ -71,7 +71,7 @@ func Test_simpleCorrelationPolicy_Do(t *testing.T) {
 				trace.SpanContext{}.WithTraceID(traceId),
 			),
 			expect:                to.Ptr(traceId.String()),
-			headerName:            cMsGraphCorrelationIdHeader,
+			headerName:            msGraphCorrelationIdHeader,
 			correlationPolicyFunc: NewMsGraphCorrelationPolicy,
 		},
 		{
@@ -82,14 +82,14 @@ func Test_simpleCorrelationPolicy_Do(t *testing.T) {
 				trace.SpanContext{}.WithTraceID(invalidTraceId),
 			),
 			expect:                to.Ptr(""),
-			headerName:            cMsGraphCorrelationIdHeader,
+			headerName:            msGraphCorrelationIdHeader,
 			correlationPolicyFunc: NewMsGraphCorrelationPolicy,
 		},
 		{
 			name:                  "WithoutTraceId",
 			ctx:                   context.Background(),
 			expect:                nil,
-			headerName:            cMsGraphCorrelationIdHeader,
+			headerName:            msGraphCorrelationIdHeader,
 			correlationPolicyFunc: NewMsGraphCorrelationPolicy,
 		},
 	}

--- a/cli/azd/pkg/azure/arm_template.go
+++ b/cli/azd/pkg/azure/arm_template.go
@@ -31,9 +31,6 @@ type ArmTemplate struct {
 	Definitions    ArmTemplateParameterDefinitions `json:"definitions"`
 }
 
-var cResourceDeploymentTemplateSchemaLower = strings.ToLower("deploymentTemplate.json")
-var cSubscriptionDeploymentTemplateSchemaLower = strings.ToLower("subscriptionDeploymentTemplate.json")
-
 // TargetScope uses the $schema property of the template to determine what scope this template should be deployed
 // at or an error if the scope could not be determined.
 func (t ArmTemplate) TargetScope() (DeploymentScope, error) {
@@ -46,10 +43,10 @@ func (t ArmTemplate) TargetScope() (DeploymentScope, error) {
 		return DeploymentScope(""), fmt.Errorf("error parsing schema: %w", err)
 	}
 
-	switch strings.ToLower(path.Base(u.Path)) {
-	case cSubscriptionDeploymentTemplateSchemaLower:
+	switch {
+	case strings.EqualFold(path.Base(u.Path), "subscriptionDeploymentTemplate.json"):
 		return DeploymentScopeSubscription, nil
-	case cResourceDeploymentTemplateSchemaLower:
+	case strings.EqualFold(path.Base(u.Path), "deploymentTemplate.json"):
 		return DeploymentScopeResourceGroup, nil
 	default:
 		return DeploymentScope(""), fmt.Errorf("unknown schema: %s", t.Schema)

--- a/cli/azd/pkg/config/manager.go
+++ b/cli/azd/pkg/config/manager.go
@@ -11,8 +11,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 )
 
-const cConfigDir = ".azd"
-
 // Config Manager provides the ability to load, parse and save azd configuration files
 type manager struct {
 }
@@ -74,7 +72,7 @@ func GetUserConfigDir() (string, error) {
 			return "", fmt.Errorf("could not determine current home directory: %w", err)
 		}
 
-		configDirPath = filepath.Join(homeDir, cConfigDir)
+		configDirPath = filepath.Join(homeDir, ".azd")
 	}
 
 	err := os.MkdirAll(configDirPath, osutil.PermissionDirectoryOwnerOnly)

--- a/cli/azd/pkg/exec/sanitizer.go
+++ b/cli/azd/pkg/exec/sanitizer.go
@@ -10,7 +10,8 @@ type redactData struct {
 	replaceString string
 }
 
-const cRedacted = "<redacted>"
+// redactedReplacement is the string that will replace sensitive data in the output.
+const redactedReplacement = "<redacted>"
 
 func RedactSensitiveArgs(args []string, sensitiveDataMatch []string) []string {
 	if len(sensitiveDataMatch) == 0 {
@@ -20,7 +21,7 @@ func RedactSensitiveArgs(args []string, sensitiveDataMatch []string) []string {
 	for i, arg := range args {
 		redacted := arg
 		for _, sensitiveData := range sensitiveDataMatch {
-			redacted = strings.ReplaceAll(redacted, sensitiveData, cRedacted)
+			redacted = strings.ReplaceAll(redacted, sensitiveData, redactedReplacement)
 		}
 		redactedArgs[i] = redacted
 	}
@@ -31,27 +32,27 @@ func RedactSensitiveData(msg string) string {
 	var regexpRedactRules = map[string]redactData{
 		"access token": {
 			regexp.MustCompile("\"accessToken\": \".*\""),
-			"\"accessToken\": \"" + cRedacted + "\"",
+			"\"accessToken\": \"" + redactedReplacement + "\"",
 		},
 		"deployment token": {
 			regexp.MustCompile(`--deployment-token \S+`),
-			"--deployment-token " + cRedacted,
+			"--deployment-token " + redactedReplacement,
 		},
 		"username": {
 			regexp.MustCompile(`--username \S+`),
-			"--username " + cRedacted,
+			"--username " + redactedReplacement,
 		},
 		"password": {
 			regexp.MustCompile(`--password \S+`),
-			"--password " + cRedacted,
+			"--password " + redactedReplacement,
 		},
 		"kubectl-from-literal": {
 			regexp.MustCompile(`--from-literal=([^=]+)=(\S+)`),
-			"--from-literal=$1=" + cRedacted,
+			"--from-literal=$1=" + redactedReplacement,
 		},
 		"combined-arg": {
 			regexp.MustCompile(`(.*)=(\S+)`),
-			"$1=" + cRedacted,
+			"$1=" + redactedReplacement,
 		},
 	}
 

--- a/cli/azd/pkg/experimentation/assignment.go
+++ b/cli/azd/pkg/experimentation/assignment.go
@@ -16,11 +16,11 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 )
 
-// cCacheFileName is the name of the file used to cache assignment information.
-const cCacheFileName string = "assign.cache"
+// cacheFileName is the name of the file used to cache assignment information.
+const cacheFileName string = "assign.cache"
 
-// cCacheDirectoryName is the name of the directory created under the user config directory that contains the cache.
-const cCacheDirectoryName string = "experimentation"
+// cacheDirectoryName is the name of the directory created under the user config directory that contains the cache.
+const cacheDirectoryName string = "experimentation"
 
 // MachineIdParameterName is the name of the parameter used to identify the machine ID in the assignment
 // request.
@@ -45,7 +45,7 @@ func NewAssignmentsManager(endpoint string, transport policy.Transporter) (*Assi
 		return nil, err
 	}
 
-	cacheRoot := filepath.Join(configRoot, cCacheDirectoryName)
+	cacheRoot := filepath.Join(configRoot, cacheDirectoryName)
 	if err := os.MkdirAll(cacheRoot, osutil.PermissionDirectory); err != nil {
 		return nil, err
 	}
@@ -152,13 +152,13 @@ func (am *AssignmentsManager) cacheResponse(response *treatmentAssignmentRespons
 		return err
 	}
 
-	cacheFilePath := filepath.Join(am.cacheRoot, cCacheFileName)
+	cacheFilePath := filepath.Join(am.cacheRoot, cacheFileName)
 	return os.WriteFile(cacheFilePath, cacheJson, osutil.PermissionFile)
 }
 
 // readResponseFromCache reads the cached response from the TAS service for the given machineId.
 func (am *AssignmentsManager) readResponseFromCache() (*treatmentAssignmentResponse, error) {
-	cache, err := os.ReadFile(filepath.Join(am.cacheRoot, cCacheFileName))
+	cache, err := os.ReadFile(filepath.Join(am.cacheRoot, cacheFileName))
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/pkg/experimentation/assignment_test.go
+++ b/cli/azd/pkg/experimentation/assignment_test.go
@@ -106,7 +106,7 @@ func TestCache(t *testing.T) {
 
 	// The response should have been cached, so we should have a single entry in the cache folder
 	// under the config root.
-	cacheRoot := filepath.Join(configRoot, cCacheDirectoryName)
+	cacheRoot := filepath.Join(configRoot, cacheDirectoryName)
 	cacheEntries, err := os.ReadDir(cacheRoot)
 	require.NoError(t, err)
 	require.Len(t, cacheEntries, 1)

--- a/cli/azd/pkg/infra/azure_resource_manager.go
+++ b/cli/azd/pkg/infra/azure_resource_manager.go
@@ -265,15 +265,15 @@ func (rm *AzureResourceManager) GetResourceTypeDisplayName(
 	}
 }
 
-// cWebAppApiVersion is the API Version we use when querying information about Web App resources
-const cWebAppApiVersion = "2021-03-01"
+// webAppApiVersion is the API Version we use when querying information about Web App resources
+const webAppApiVersion = "2021-03-01"
 
 func (rm *AzureResourceManager) getWebAppResourceTypeDisplayName(
 	ctx context.Context,
 	subscriptionId string,
 	resourceId string,
 ) (string, error) {
-	resource, err := rm.azCli.GetResource(ctx, subscriptionId, resourceId, cWebAppApiVersion)
+	resource, err := rm.azCli.GetResource(ctx, subscriptionId, resourceId, webAppApiVersion)
 
 	if err != nil {
 		return "", fmt.Errorf("getting web app resource type display names: %w", err)

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -427,19 +427,19 @@ func (p *BicepProvider) deploymentScope(deploymentScope azure.DeploymentScope) (
 	return nil, fmt.Errorf("unsupported scope: %s", deploymentScope)
 }
 
-// cArmDeploymentNameLengthMax is the maximum length of the name of a deployment in ARM.
-const cArmDeploymentNameLengthMax = 64
+// armDeploymentNameLengthMax is the maximum length of the name of a deployment in ARM.
+const armDeploymentNameLengthMax = 64
 
 // deploymentNameForEnv creates a name to use for the deployment object for a given environment. It appends the current
 // unix time to the environment name (separated by a hyphen) to provide a unique name for each deployment. If the resulting
 // name is longer than the ARM limit, the longest suffix of the name under the limit is returned.
 func deploymentNameForEnv(envName string, clock clock.Clock) string {
 	name := fmt.Sprintf("%s-%d", envName, clock.Now().Unix())
-	if len(name) <= cArmDeploymentNameLengthMax {
+	if len(name) <= armDeploymentNameLengthMax {
 		return name
 	}
 
-	return name[len(name)-cArmDeploymentNameLengthMax:]
+	return name[len(name)-armDeploymentNameLengthMax:]
 }
 
 // deploymentState returns the latests deployment if it is the same as the deployment within deploymentData or an error
@@ -780,7 +780,7 @@ func (p *BicepProvider) inferScopeFromEnv() (infra.Scope, error) {
 	}
 }
 
-const cEmptySubDeployTemplate = `{
+const emptySubDeployTemplate = `{
 	"$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
 	"contentVersion": "1.0.0.0",
 	"parameters": {},
@@ -789,7 +789,7 @@ const cEmptySubDeployTemplate = `{
 	"outputs": {}
   }`
 
-const cEmptyResourceGroupDeployTemplate = `{
+const emptyResourceGroupDeployTemplate = `{
 	"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
 	"contentVersion": "1.0.0.0",
 	"parameters": {},
@@ -945,9 +945,9 @@ func (p *BicepProvider) Destroy(ctx context.Context, options DestroyOptions) (*D
 
 	var emptyTemplate json.RawMessage
 	if targetScope == azure.DeploymentScopeSubscription {
-		emptyTemplate = []byte(cEmptySubDeployTemplate)
+		emptyTemplate = []byte(emptySubDeployTemplate)
 	} else {
-		emptyTemplate = []byte(cEmptyResourceGroupDeployTemplate)
+		emptyTemplate = []byte(emptyResourceGroupDeployTemplate)
 	}
 
 	// create empty deployment to void provision state

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -436,7 +436,7 @@ func prepareBicepMocks(
 	})
 }
 
-var cTestEnvDeployment armresources.DeploymentExtended = armresources.DeploymentExtended{
+var testEnvDeployment armresources.DeploymentExtended = armresources.DeploymentExtended{
 	ID:   to.Ptr("DEPLOYMENT_ID"),
 	Name: to.Ptr("test-env"),
 	Properties: &armresources.DeploymentPropertiesExtended{
@@ -454,7 +454,7 @@ var cTestEnvDeployment armresources.DeploymentExtended = armresources.Deployment
 }
 
 func prepareStateMocks(mockContext *mocks.MockContext) {
-	deployResultBytes, _ := json.Marshal(cTestEnvDeployment)
+	deployResultBytes, _ := json.Marshal(testEnvDeployment)
 
 	// Get deployment result
 	mockContext.HttpClient.When(func(request *http.Request) bool {
@@ -471,7 +471,7 @@ func prepareStateMocks(mockContext *mocks.MockContext) {
 
 	deploymentsPage := &armresources.DeploymentListResult{
 		Value: []*armresources.DeploymentExtended{
-			&cTestEnvDeployment,
+			&testEnvDeployment,
 		},
 	}
 

--- a/cli/azd/pkg/infra/scope.go
+++ b/cli/azd/pkg/infra/scope.go
@@ -97,7 +97,7 @@ func (s *ResourceGroupDeployment) Operations(ctx context.Context) ([]*armresourc
 func (s *ResourceGroupDeployment) PortalUrl() string {
 	return fmt.Sprintf("%s/%s/%s",
 		s.portalUrlBase,
-		cPortalUrlFragment,
+		portalUrlFragment,
 		url.PathEscape(azure.ResourceGroupDeploymentRID(s.subscriptionId, s.resourceGroupName, s.name)))
 }
 
@@ -105,7 +105,7 @@ func (s *ResourceGroupDeployment) PortalUrl() string {
 func (s *ResourceGroupDeployment) OutputsUrl() string {
 	return fmt.Sprintf("%s/%s/%s",
 		s.portalUrlBase,
-		cOutputsUrlFragment,
+		outputsUrlFragment,
 		url.PathEscape(azure.ResourceGroupDeploymentRID(s.subscriptionId, s.resourceGroupName, s.name)))
 }
 
@@ -160,8 +160,8 @@ func (s *ResourceGroupScope) ListDeployments(ctx context.Context) ([]*armresourc
 	return s.deployments.ListResourceGroupDeployments(ctx, s.subscriptionId, s.resourceGroupName)
 }
 
-const cPortalUrlFragment = "#view/HubsExtension/DeploymentDetailsBlade/~/overview/id"
-const cOutputsUrlFragment = "#view/HubsExtension/DeploymentDetailsBlade/~/outputs/id"
+const portalUrlFragment = "#view/HubsExtension/DeploymentDetailsBlade/~/overview/id"
+const outputsUrlFragment = "#view/HubsExtension/DeploymentDetailsBlade/~/outputs/id"
 
 type SubscriptionDeployment struct {
 	*SubscriptionScope
@@ -183,7 +183,7 @@ func (s *SubscriptionDeployment) SubscriptionId() string {
 func (s *SubscriptionDeployment) PortalUrl() string {
 	return fmt.Sprintf("%s/%s/%s",
 		s.portalUrlBase,
-		cPortalUrlFragment,
+		portalUrlFragment,
 		url.PathEscape(azure.SubscriptionDeploymentRID(s.subscriptionId, s.name)))
 }
 
@@ -191,7 +191,7 @@ func (s *SubscriptionDeployment) PortalUrl() string {
 func (s *SubscriptionDeployment) OutputsUrl() string {
 	return fmt.Sprintf("%s/%s/%s",
 		s.portalUrlBase,
-		cOutputsUrlFragment,
+		outputsUrlFragment,
 		url.PathEscape(azure.SubscriptionDeploymentRID(s.subscriptionId, s.name)))
 }
 

--- a/cli/azd/pkg/input/asker.go
+++ b/cli/azd/pkg/input/asker.go
@@ -113,7 +113,7 @@ func askOnePrompt(p survey.Prompt, response interface{}, isTerminal bool, stdout
 			opts = append(opts, withShowCursor)
 		}
 
-		survey.InputQuestionTemplate = cInputQuestionTemplate
+		survey.InputQuestionTemplate = inputQuestionTemplate
 
 		opts = append(opts, survey.WithIcons(func(icons *survey.IconSet) {
 			// use bold blue question mark for all questions
@@ -249,7 +249,7 @@ func askOnePrompt(p survey.Prompt, response interface{}, isTerminal bool, stdout
 // - Use color blue instead of cyan
 //
 //nolint:lll
-const cInputQuestionTemplate = `
+const inputQuestionTemplate = `
 {{- if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
 {{- color .Config.Icons.Question.Format }}{{ .Config.Icons.Question.Text }} {{color "reset"}}
 {{- color "default+hb"}}{{ .Message }} {{color "reset"}}

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -318,7 +318,8 @@ func (c *AskerConsole) StopPreviewer(ctx context.Context, keepLogs bool) {
 	_ = c.spinner.Unpause()
 }
 
-const cPostfix = "..."
+// truncationDots is the text we use to indicate that text has been truncated.
+const truncationDots = "..."
 
 // The line of text for the spinner, displayed in the format of: <prefix><spinner> <message>
 type spinnerLine struct {
@@ -349,7 +350,7 @@ func (c *AskerConsole) spinnerLine(title string, indent string) spinnerLine {
 		return spinnerLine{
 			CharSet: spinnerShortCharSet[:width],
 		}
-	case width <= spinnerLen+len(cPostfix): // show number of dots
+	case width <= spinnerLen+len(truncationDots): // show number of dots
 		return spinnerLine{
 			CharSet: spinnerShortCharSet,
 		}
@@ -357,7 +358,7 @@ func (c *AskerConsole) spinnerLine(title string, indent string) spinnerLine {
 		return spinnerLine{
 			Prefix:  indent,
 			CharSet: spinnerCharSet,
-			Message: title[:width-spinnerLen-len(cPostfix)] + cPostfix,
+			Message: title[:width-spinnerLen-len(truncationDots)] + truncationDots,
 		}
 	default:
 		return spinnerLine{
@@ -520,10 +521,10 @@ func promptFromOptions(options ConsoleOptions) survey.Prompt {
 	}
 }
 
-// cAfterIO is a sentinel used after Input/Output operations as the state for the last 2-bytes written.
+// afterIoSentinel is a sentinel value used after Input/Output operations as the state for the last 2-bytes written.
 // For example, after running Prompt or Confirm, the last characters on the terminal should be any char (represented by the
 // 0 in the sentinel), followed by a new line.
-const cAfterIO = "0\n"
+const afterIoSentinel = "0\n"
 
 func (c *AskerConsole) SupportsPromptDialog() bool {
 	return c.promptClient != nil
@@ -609,7 +610,7 @@ func (c *AskerConsole) Prompt(ctx context.Context, options ConsoleOptions) (stri
 	if err != nil {
 		return response, err
 	}
-	c.updateLastBytes(cAfterIO)
+	c.updateLastBytes(afterIoSentinel)
 	return response, nil
 }
 
@@ -656,7 +657,7 @@ func (c *AskerConsole) PromptDir(ctx context.Context, options ConsoleOptions) (s
 	if err != nil {
 		return response, err
 	}
-	c.updateLastBytes(cAfterIO)
+	c.updateLastBytes(afterIoSentinel)
 	return response, nil
 }
 
@@ -750,7 +751,7 @@ func (c *AskerConsole) Select(ctx context.Context, options ConsoleOptions) (int,
 		return -1, err
 	}
 
-	c.updateLastBytes(cAfterIO)
+	c.updateLastBytes(afterIoSentinel)
 	return response, nil
 }
 
@@ -882,7 +883,7 @@ func (c *AskerConsole) Confirm(ctx context.Context, options ConsoleOptions) (boo
 		return false, err
 	}
 
-	c.updateLastBytes(cAfterIO)
+	c.updateLastBytes(afterIoSentinel)
 	return response, nil
 }
 

--- a/cli/azd/pkg/input/console_test.go
+++ b/cli/azd/pkg/input/console_test.go
@@ -44,7 +44,7 @@ func (l *lineCapturer) Write(bytes []byte) (n int, err error) {
 func TestAskerConsole_Spinner_NonTty(t *testing.T) {
 	// The underlying spinner relies on non-blocking channels for paint updates.
 	// We need to give it some time to paint.
-	const cSleep = 50 * time.Millisecond
+	const waitTime = 50 * time.Millisecond
 
 	formatter, err := output.NewFormatter(string(output.NoneFormat))
 	require.NoError(t, err)
@@ -67,32 +67,32 @@ func TestAskerConsole_Spinner_NonTty(t *testing.T) {
 	require.Len(t, lines.captured, 0)
 	c.ShowSpinner(ctx, "Some title.", Step)
 
-	time.Sleep(cSleep)
+	time.Sleep(waitTime)
 	require.Len(t, lines.captured, 1)
 	require.Equal(t, lines.captured[0], "Some title.")
 
 	c.ShowSpinner(ctx, "Some title 2.", Step)
-	time.Sleep(cSleep)
+	time.Sleep(waitTime)
 	require.Len(t, lines.captured, 2)
 	require.Equal(t, lines.captured[1], "Some title 2.")
 
 	c.StopSpinner(ctx, "", StepDone)
-	time.Sleep(cSleep)
+	time.Sleep(waitTime)
 	require.Len(t, lines.captured, 2)
 	require.Equal(t, lines.captured[1], "Some title 2.")
 
 	c.ShowSpinner(ctx, "Some title 3.", Step)
-	time.Sleep(cSleep)
+	time.Sleep(waitTime)
 	require.Len(t, lines.captured, 3)
 	require.Equal(t, lines.captured[2], "Some title 3.")
 
 	c.Message(ctx, "Some message.")
-	time.Sleep(cSleep)
+	time.Sleep(waitTime)
 	require.Len(t, lines.captured, 4)
 	require.Equal(t, lines.captured[3], "Some message.")
 
 	c.StopSpinner(ctx, "Done.", StepDone)
-	time.Sleep(cSleep)
+	time.Sleep(waitTime)
 	require.Len(t, lines.captured, 5)
 }
 

--- a/cli/azd/pkg/input/progress_log.go
+++ b/cli/azd/pkg/input/progress_log.go
@@ -297,7 +297,7 @@ func (p *progressLog) buildTopBottom() {
 	if titleLen >= consoleLen {
 		// can't add lines as title is longer than what's available
 		// limit output to what's available
-		p.displayTitle = withPrefixTitle[:consoleLen-4] + cPostfix
+		p.displayTitle = withPrefixTitle[:consoleLen-4] + truncationDots
 		return
 	}
 

--- a/cli/azd/pkg/installer/installed_by.go
+++ b/cli/azd/pkg/installer/installed_by.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 )
 
-const cInstalledByFileName = ".installed-by.txt"
-
 type InstallType string
 
 const InstallTypeUnknown InstallType = ""
@@ -61,7 +59,7 @@ func RawInstalledBy() string {
 	}
 
 	exeDir := filepath.Dir(resolvedPath)
-	installedByFile := filepath.Join(exeDir, cInstalledByFileName)
+	installedByFile := filepath.Join(exeDir, ".installed-by.txt")
 
 	bytes, err := os.ReadFile(installedByFile)
 	if err != nil {

--- a/cli/azd/pkg/output/ux/show.go
+++ b/cli/azd/pkg/output/ux/show.go
@@ -29,34 +29,22 @@ type Show struct {
 	AzurePortalLink string
 }
 
-const (
-	cHeader            = "\nShowing deployed endpoints and environments for apps in this directory.\n"
-	cHeaderNotDeployed = "\nShowing services and environments for apps in this directory.\n"
-	cHeaderNote        = "To view a different environment, run "
-	cShowDifferentEnv  = "azd show -e <environment name>"
-	cServices          = "\n  Services:\n"
-	cEnvironments      = "\n  Environments:\n"
-	cCurrentEnv        = " [Current]"
-	cRemoteEnv         = " (Remote)"
-	cViewInPortal      = "\n  View in Azure Portal:\n"
-)
-
 func (s *Show) ToString(currentIndentation string) string {
-	pickHeader := cHeader
+	pickHeader := "\nShowing deployed endpoints and environments for apps in this directory.\n"
 	if s.AzurePortalLink == "" {
-		pickHeader = cHeaderNotDeployed
+		pickHeader = "\nShowing services and environments for apps in this directory.\n"
 	}
 	return fmt.Sprintf(
 		"%s%s%s%s%s%s%s%s%s    %s\n",
 		pickHeader,
-		cHeaderNote,
-		color.HiBlueString("%s\n\n", cShowDifferentEnv),
+		"To view a different environment, run ",
+		color.HiBlueString("%s\n\n", "azd show -e <environment name>"),
 		color.HiMagentaString(s.AppName),
-		cServices,
+		"\n  Services:\n",
 		services(s.Services),
-		cEnvironments,
+		"\n  Environments:\n",
 		environments(s.Environments),
-		cViewInPortal,
+		"\n  View in Azure Portal:\n",
 		azurePortalLink(s.AzurePortalLink),
 	)
 }
@@ -104,11 +92,11 @@ func environments(environments []*ShowEnvironment) string {
 	for index, environment := range environments {
 		var defaultEnv string
 		if environment.IsCurrent {
-			defaultEnv = cCurrentEnv
+			defaultEnv = " [Current]"
 		}
 		var isRemote string
 		if environment.IsRemote {
-			isRemote = cRemoteEnv
+			isRemote = " (Remote)"
 		}
 		lines[index] = fmt.Sprintf(
 			"    %s%s%s",

--- a/cli/azd/pkg/project/framework_service_npm.go
+++ b/cli/azd/pkg/project/framework_service_npm.go
@@ -148,8 +148,6 @@ func (np *npmProject) Package(
 	}, nil
 }
 
-const cNodeModulesName = "node_modules"
-
 func excludeNodeModules(path string, file os.FileInfo) bool {
-	return file.IsDir() && file.Name() == cNodeModulesName
+	return file.IsDir() && file.Name() == "node_modules"
 }

--- a/cli/azd/pkg/project/framework_service_python.go
+++ b/cli/azd/pkg/project/framework_service_python.go
@@ -150,11 +150,9 @@ func (pp *pythonProject) Package(
 	}, nil
 }
 
-const cVenvConfigFileName = "pyvenv.cfg"
-
 func isPythonVirtualEnv(path string) bool {
 	// check if `pyvenv.cfg` is within the folder
-	if _, err := os.Stat(filepath.Join(path, cVenvConfigFileName)); err == nil {
+	if _, err := os.Stat(filepath.Join(path, "pyvenv.cfg")); err == nil {
 		return true
 	}
 	return false

--- a/cli/azd/pkg/tools/github/github.go
+++ b/cli/azd/pkg/tools/github/github.go
@@ -137,7 +137,7 @@ func (cli *Cli) CheckInstalled(ctx context.Context) error {
 func expectedVersionInstalled(ctx context.Context, commandRunner exec.CommandRunner, binaryPath string) bool {
 	ghVersion, err := tools.ExecuteCommand(ctx, commandRunner, binaryPath, "--version")
 	if err != nil {
-		log.Printf("checking %s version: %s", cGhToolName, err.Error())
+		log.Printf("checking GitHub CLI version: %s", err.Error())
 		return false
 	}
 	ghSemver, err := tools.ExtractVersion(ghVersion)
@@ -152,10 +152,8 @@ func expectedVersionInstalled(ctx context.Context, commandRunner exec.CommandRun
 	return true
 }
 
-const cGhToolName = "GitHub CLI"
-
 func (cli *Cli) Name() string {
-	return cGhToolName
+	return "GitHub CLI"
 }
 
 func (cli *Cli) BinaryPath() string {
@@ -268,11 +266,11 @@ func (cli *Cli) DeleteVariable(ctx context.Context, repoSlug string, name string
 	return nil
 }
 
-// cGhCliVersionRegexp fetches the version number from the output of gh --version, which looks like this:
+// ghCliVersionRegexp fetches the version number from the output of gh --version, which looks like this:
 //
 // gh version 2.6.0 (2022-03-15)
 // https://github.com/cli/cli/releases/tag/v2.6.0
-var cGhCliVersionRegexp = regexp.MustCompile(`gh version ([0-9]+\.[0-9]+\.[0-9]+)`)
+var ghCliVersionRegexp = regexp.MustCompile(`gh version ([0-9]+\.[0-9]+\.[0-9]+)`)
 
 // logVersion writes the version of the GitHub CLI to the debug log for diagnostics purposes, or an error if
 // it could not be determined
@@ -292,7 +290,7 @@ func (cli *Cli) extractVersion(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("error running gh --version: %w", err)
 	}
 
-	matches := cGhCliVersionRegexp.FindStringSubmatch(res.Stdout)
+	matches := ghCliVersionRegexp.FindStringSubmatch(res.Stdout)
 	if len(matches) != 2 {
 		return "", fmt.Errorf("could not extract version from output: %s", res.Stdout)
 	}

--- a/cli/azd/pkg/tools/maven/maven.go
+++ b/cli/azd/pkg/tools/maven/maven.go
@@ -137,7 +137,7 @@ func getMavenWrapperPath(projectPath string, rootProjectPath string) (string, er
 	}
 }
 
-// cMavenVersionRegexp captures the version number of maven from the output of "mvn --version"
+// mavenVersionRegexp captures the version number of maven from the output of "mvn --version"
 //
 // the output of mvn --version looks something like this:
 // Apache Maven 3.9.1 (2e178502fcdbffc201671fb2537d0cb4b4cc58f8)
@@ -145,7 +145,7 @@ func getMavenWrapperPath(projectPath string, rootProjectPath string) (string, er
 // Java version: 17.0.6, vendor: Microsoft, runtime: C:\Program Files\Microsoft\jdk-17.0.6.10-hotspot
 // Default locale: en_US, platform encoding: Cp1252
 // OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"
-var cMavenVersionRegexp = regexp.MustCompile(`Apache Maven (.*) \(`)
+var mavenVersionRegexp = regexp.MustCompile(`Apache Maven (.*) \(`)
 
 func (cli *Cli) extractVersion(ctx context.Context) (string, error) {
 	mvnCmd, err := cli.mvnCmd()
@@ -159,7 +159,7 @@ func (cli *Cli) extractVersion(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("failed to run %s --version: %w", mvnCmd, err)
 	}
 
-	parts := cMavenVersionRegexp.FindStringSubmatch(res.Stdout)
+	parts := mavenVersionRegexp.FindStringSubmatch(res.Stdout)
 	if len(parts) != 2 {
 		return "", fmt.Errorf("could not parse %s --version output, did not match expected format", mvnCmd)
 	}

--- a/cli/azd/pkg/tools/swa/swa.go
+++ b/cli/azd/pkg/tools/swa/swa.go
@@ -16,8 +16,8 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 )
 
-// cSwaCliPackage is the npm package (including the version version) we execute with npx to run the SWA CLI.
-const cSwaCliPackage = "@azure/static-web-apps-cli@1.1.8"
+// swaCliPackage is the npm package (including the version version) we execute with npx to run the SWA CLI.
+const swaCliPackage = "@azure/static-web-apps-cli@1.1.8"
 
 var _ tools.ExternalTool = (*Cli)(nil)
 
@@ -121,7 +121,7 @@ func (cli *Cli) executeCommand(ctx context.Context, cwd string, args ...string) 
 
 func (cli *Cli) run(ctx context.Context, cwd string, buildProgress io.Writer, args ...string) (exec.RunResult, error) {
 	runArgs := exec.
-		NewRunArgs("npx", "-y", cSwaCliPackage).
+		NewRunArgs("npx", "-y", swaCliPackage).
 		AppendParams(args...).
 		WithCwd(cwd)
 

--- a/cli/azd/pkg/tools/swa/swa_test.go
+++ b/cli/azd/pkg/tools/swa/swa_test.go
@@ -31,7 +31,7 @@ func Test_SwaBuild(t *testing.T) {
 
 			require.Equal(t, testPath, args.Cwd)
 			require.Equal(t, []string{
-				"-y", cSwaCliPackage,
+				"-y", swaCliPackage,
 				"build", "-V",
 			}, args.Args)
 
@@ -61,7 +61,7 @@ func Test_SwaBuild(t *testing.T) {
 
 			require.Equal(t, testPath, args.Cwd)
 			require.Equal(t, []string{
-				"-y", cSwaCliPackage,
+				"-y", swaCliPackage,
 				"build", "-V",
 			}, args.Args)
 
@@ -96,7 +96,7 @@ func Test_SwaDeploy(t *testing.T) {
 
 			require.Equal(t, testPath, args.Cwd)
 			require.Equal(t, []string{
-				"-y", cSwaCliPackage,
+				"-y", swaCliPackage,
 				"deploy",
 				"--tenant-id", "tenantID",
 				"--subscription-id", "subscriptionID",
@@ -143,7 +143,7 @@ func Test_SwaDeploy(t *testing.T) {
 
 			require.Equal(t, testPath, args.Cwd)
 			require.Equal(t, []string{
-				"-y", cSwaCliPackage,
+				"-y", swaCliPackage,
 				"deploy",
 				"--tenant-id", "tenantID",
 				"--subscription-id", "subscriptionID",
@@ -195,7 +195,7 @@ func Test_SwaDeploy(t *testing.T) {
 
 			require.Equal(t, testPath, args.Cwd)
 			require.Equal(t, []string{
-				"-y", cSwaCliPackage,
+				"-y", swaCliPackage,
 				"deploy",
 				"--tenant-id", "tenantID",
 				"--subscription-id", "subscriptionID",


### PR DESCRIPTION
Early on in the project, we used to use this pattern where we'd prepend a lowercase c in front of `const` values (and var values which were logical constants but couldn't be marked as `const` because their values were not compile time constants). We did this to ensure the symbol was not exported but to still have something `ThatLookedLikeItWouldBeExported` with the idea that this would make it more obvious in code this was a constant value.

However, idiomatic go code doesn't do this, so we stopped doing it ourselves on new code. This change does a pass over the old pattern and removes it from the codebase. In most cases I just dropped the leading c and lowercased the first letter (so the symbol is not exported) but in a few cases where the symbol was only used in one or two places I inlined it or rewrote code slightly if I felt it would improve overall clarity.