### PR TITLE
pkg/templates: Use `*policy.ClientOptions`

### DIFF
--- a/cli/azd/pkg/templates/awesome_source.go
+++ b/cli/azd/pkg/templates/awesome_source.go
@@ -25,11 +25,9 @@ func newAwesomeAzdTemplateSource(
 	ctx context.Context,
 	name string,
 	url string,
-	transport policy.Transporter,
+	clientOptions *policy.ClientOptions,
 ) (Source, error) {
-	pipeline := runtime.NewPipeline("azd-templates", "1.0.0", runtime.PipelineOptions{}, &policy.ClientOptions{
-		Transport: transport,
-	})
+	pipeline := runtime.NewPipeline("azd-templates", "1.0.0", runtime.PipelineOptions{}, clientOptions)
 
 	req, err := runtime.NewRequest(ctx, http.MethodGet, url)
 	if err != nil {

--- a/cli/azd/pkg/templates/awesome_source_test.go
+++ b/cli/azd/pkg/templates/awesome_source_test.go
@@ -29,7 +29,7 @@ func Test_NewAwesomeAzdTemplateSource_ValidUrl(t *testing.T) {
 	name := "test"
 	url := "https://aka.ms/awesome-azd/templates.json"
 
-	source, err := newAwesomeAzdTemplateSource(context.Background(), name, url, mockContext.HttpClient)
+	source, err := newAwesomeAzdTemplateSource(context.Background(), name, url, mockContext.CoreClientOptions)
 	require.Nil(t, err)
 
 	require.Equal(t, name, source.Name())
@@ -47,7 +47,7 @@ func Test_NewAwesomeAzdTemplateSource_ValidUrl_InvalidJson(t *testing.T) {
 		return mocks.CreateHttpResponseWithBody(req, http.StatusOK, "invalid json")
 	})
 
-	source, err := newAwesomeAzdTemplateSource(context.Background(), name, url, mockContext.HttpClient)
+	source, err := newAwesomeAzdTemplateSource(context.Background(), name, url, mockContext.CoreClientOptions)
 	require.Nil(t, source)
 	require.Error(t, err)
 }
@@ -64,7 +64,7 @@ func Test_NewAwesomeAzdTemplateSource_InvalidUrl(t *testing.T) {
 		return mocks.CreateEmptyHttpResponse(req, http.StatusNotFound)
 	})
 
-	source, err := newAwesomeAzdTemplateSource(context.Background(), name, url, mockContext.HttpClient)
+	source, err := newAwesomeAzdTemplateSource(context.Background(), name, url, mockContext.CoreClientOptions)
 	require.Nil(t, source)
 	require.Error(t, err)
 }

--- a/cli/azd/pkg/templates/source_manager.go
+++ b/cli/azd/pkg/templates/source_manager.go
@@ -75,7 +75,7 @@ type sourceManager struct {
 	options        *SourceOptions
 	serviceLocator ioc.ServiceLocator
 	configManager  config.UserConfigManager
-	transport      policy.Transporter
+	clientOptions  *policy.ClientOptions
 }
 
 // NewSourceManager creates a new SourceManager.
@@ -83,7 +83,7 @@ func NewSourceManager(
 	options *SourceOptions,
 	serviceLocator ioc.ServiceLocator,
 	configManager config.UserConfigManager,
-	transport policy.Transporter,
+	clientOptions *policy.ClientOptions,
 ) SourceManager {
 	if options == nil {
 		options = NewSourceOptions()
@@ -93,7 +93,7 @@ func NewSourceManager(
 		options:        options,
 		serviceLocator: serviceLocator,
 		configManager:  configManager,
-		transport:      transport,
+		clientOptions:  clientOptions,
 	}
 }
 
@@ -225,9 +225,9 @@ func (sm *sourceManager) CreateSource(ctx context.Context, config *SourceConfig)
 	case SourceKindFile:
 		source, err = newFileTemplateSource(config.Name, config.Location)
 	case SourceKindUrl:
-		source, err = newUrlTemplateSource(ctx, config.Name, config.Location, sm.transport)
+		source, err = newUrlTemplateSource(ctx, config.Name, config.Location, sm.clientOptions)
 	case SourceKindAwesomeAzd:
-		source, err = newAwesomeAzdTemplateSource(ctx, SourceAwesomeAzd.Name, SourceAwesomeAzd.Location, sm.transport)
+		source, err = newAwesomeAzdTemplateSource(ctx, SourceAwesomeAzd.Name, SourceAwesomeAzd.Location, sm.clientOptions)
 	case SourceKindResource:
 		source, err = newJsonTemplateSource(SourceDefault.Name, string(resources.TemplatesJson))
 	case SourceKindGh:

--- a/cli/azd/pkg/templates/source_manager_test.go
+++ b/cli/azd/pkg/templates/source_manager_test.go
@@ -29,7 +29,7 @@ func Test_sourceManager_List(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	configManager := &mockUserConfigManager{}
 	addGhMocks(mockContext)
-	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.HttpClient)
+	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.CoreClientOptions)
 
 	config := config.NewConfig(nil)
 	_ = config.Set("template.sources", map[string]interface{}{
@@ -52,7 +52,7 @@ func Test_sourceManager_List_EmptySources(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	configManager := &mockUserConfigManager{}
 	addGhMocks(mockContext)
-	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.HttpClient)
+	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.CoreClientOptions)
 
 	config := config.NewConfig(nil)
 	_ = config.Set("template.sources", map[string]interface{}{})
@@ -70,7 +70,7 @@ func Test_sourceManager_List_UndefinedSources(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	configManager := &mockUserConfigManager{}
 	addGhMocks(mockContext)
-	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.HttpClient)
+	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.CoreClientOptions)
 
 	config := config.NewConfig(nil)
 	configManager.On("Load").Return(config, nil)
@@ -88,7 +88,7 @@ func Test_sourceManager_Get(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	configManager := &mockUserConfigManager{}
 	addGhMocks(mockContext)
-	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.HttpClient)
+	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.CoreClientOptions)
 
 	config := config.NewConfig(nil)
 	_ = config.Set("template.sources", map[string]interface{}{
@@ -110,7 +110,7 @@ func Test_sourceManager_Add(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	configManager := &mockUserConfigManager{}
 	addGhMocks(mockContext)
-	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.HttpClient)
+	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.CoreClientOptions)
 
 	config := config.NewConfig(defaultTemplateSourceData)
 	configManager.On("Load").Return(config, nil)
@@ -129,7 +129,7 @@ func Test_sourceManager_Add_DuplicateKey(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	configManager := &mockUserConfigManager{}
 	addGhMocks(mockContext)
-	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.HttpClient)
+	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.CoreClientOptions)
 
 	key := "test"
 	config := config.NewConfig(nil)
@@ -149,7 +149,7 @@ func Test_sourceManager_Remove(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	configManager := &mockUserConfigManager{}
 	addGhMocks(mockContext)
-	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.HttpClient)
+	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.CoreClientOptions)
 
 	key := "test"
 	config := config.NewConfig(defaultTemplateSourceData)
@@ -165,7 +165,7 @@ func Test_sourceManager_Remove_SourceNotFound(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	configManager := &mockUserConfigManager{}
 	addGhMocks(mockContext)
-	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.HttpClient)
+	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.CoreClientOptions)
 
 	key := "invalid"
 	config := config.NewConfig(defaultTemplateSourceData)
@@ -182,7 +182,7 @@ func Test_sourceManager_CreateSource(t *testing.T) {
 
 	configManager := &mockUserConfigManager{}
 	addGhMocks(mockContext)
-	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.HttpClient)
+	sm := NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.CoreClientOptions)
 
 	configDir, err := config.GetUserConfigDir()
 	require.NoError(t, err)

--- a/cli/azd/pkg/templates/template_manager_test.go
+++ b/cli/azd/pkg/templates/template_manager_test.go
@@ -30,7 +30,7 @@ func Test_Templates_NewTemplateManager(t *testing.T) {
 			NewSourceOptions(),
 			mockContext.Container,
 			config.NewUserConfigManager(config.NewFileConfigManager(config.NewManager())),
-			mockContext.HttpClient,
+			mockContext.CoreClientOptions,
 		),
 		mockContext.Console,
 	)
@@ -47,7 +47,7 @@ func Test_Templates_ListTemplates(t *testing.T) {
 	addGhMocks(mockContext)
 
 	templateManager, err := NewTemplateManager(
-		NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.HttpClient),
+		NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.CoreClientOptions),
 		mockContext.Console,
 	)
 	require.NoError(t, err)
@@ -72,7 +72,7 @@ func Test_Templates_ListTemplates_WithTagFilter(t *testing.T) {
 	addGhMocks(mockContext)
 
 	templateManager, err := NewTemplateManager(
-		NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.HttpClient),
+		NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.CoreClientOptions),
 		mockContext.Console,
 	)
 	require.NoError(t, err)
@@ -121,7 +121,7 @@ func Test_Templates_ListTemplates_SourceError(t *testing.T) {
 	addGhMocks(mockContext)
 
 	templateManager, err := NewTemplateManager(
-		NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.HttpClient),
+		NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.CoreClientOptions),
 		mockContext.Console,
 	)
 	require.NoError(t, err)
@@ -140,7 +140,7 @@ func Test_Templates_GetTemplate_WithValidPath(t *testing.T) {
 	addGhMocks(mockContext)
 
 	templateManager, err := NewTemplateManager(
-		NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.HttpClient),
+		NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.CoreClientOptions),
 		mockContext.Console,
 	)
 	require.NoError(t, err)
@@ -163,7 +163,7 @@ func Test_Templates_GetTemplate_WithInvalidPath(t *testing.T) {
 	addGhMocks(mockContext)
 
 	templateManager, err := NewTemplateManager(
-		NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.HttpClient),
+		NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.CoreClientOptions),
 		mockContext.Console,
 	)
 	require.NoError(t, err)
@@ -182,7 +182,7 @@ func Test_Templates_GetTemplate_WithNotFoundPath(t *testing.T) {
 	addGhMocks(mockContext)
 
 	templateManager, err := NewTemplateManager(
-		NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.HttpClient),
+		NewSourceManager(NewSourceOptions(), mockContext.Container, configManager, mockContext.CoreClientOptions),
 		mockContext.Console,
 	)
 	require.NoError(t, err)

--- a/cli/azd/pkg/templates/url_source.go
+++ b/cli/azd/pkg/templates/url_source.go
@@ -11,10 +11,8 @@ import (
 )
 
 // newUrlTemplateSource creates a new template source from a URL.
-func newUrlTemplateSource(ctx context.Context, name string, url string, transport policy.Transporter) (Source, error) {
-	pipeline := runtime.NewPipeline("azd-templates", "1.0.0", runtime.PipelineOptions{}, &policy.ClientOptions{
-		Transport: transport,
-	})
+func newUrlTemplateSource(ctx context.Context, name, url string, clientOptions *policy.ClientOptions) (Source, error) {
+	pipeline := runtime.NewPipeline("azd-templates", "1.0.0", runtime.PipelineOptions{}, clientOptions)
 
 	req, err := runtime.NewRequest(ctx, http.MethodGet, url)
 	if err != nil {

--- a/cli/azd/pkg/templates/url_source_test.go
+++ b/cli/azd/pkg/templates/url_source_test.go
@@ -21,7 +21,7 @@ func Test_NewUrlTemplateSource_ValidUrl(t *testing.T) {
 		return mocks.CreateHttpResponseWithBody(req, http.StatusOK, testTemplates)
 	})
 
-	source, err := newUrlTemplateSource(context.Background(), name, url, mockContext.HttpClient)
+	source, err := newUrlTemplateSource(context.Background(), name, url, mockContext.CoreClientOptions)
 	require.Nil(t, err)
 
 	require.Equal(t, name, source.Name())
@@ -39,7 +39,7 @@ func Test_NewUrlTemplateSource_ValidUrl_InvalidJson(t *testing.T) {
 		return mocks.CreateHttpResponseWithBody(req, http.StatusOK, "invalid json")
 	})
 
-	source, err := newUrlTemplateSource(context.Background(), name, url, mockContext.HttpClient)
+	source, err := newUrlTemplateSource(context.Background(), name, url, mockContext.CoreClientOptions)
 	require.Nil(t, source)
 	require.Error(t, err)
 }
@@ -56,7 +56,7 @@ func Test_NewUrlTemplateSource_InvalidUrl(t *testing.T) {
 		return mocks.CreateEmptyHttpResponse(req, http.StatusNotFound)
 	})
 
-	source, err := newUrlTemplateSource(context.Background(), name, url, mockContext.HttpClient)
+	source, err := newUrlTemplateSource(context.Background(), name, url, mockContext.CoreClientOptions)
 	require.Nil(t, source)
 	require.Error(t, err)
 }


### PR DESCRIPTION
Instead of taking a `httputil.HttpClient` (which at runtime is just an `*http.Client`) and forming a `*policy.ClientOptions` ourselves, let's just take in a `*policy.ClientOptions` as an Azure SDK client would. Functionaly the change here means these calls will start using our centralized `*policy.ClientOptions` which includes this like adding tracing headers and a user-agent header for the REST calls we make, just like any client from the Azure SDKs.