### PR TITLE
Remove `httputil.HttpClient` in favor of `policy.Transporter`

### DIFF
--- a/cli/azd/internal/vsrpc/server_session.go
+++ b/cli/azd/internal/vsrpc/server_session.go
@@ -140,9 +140,9 @@ func (s *serverSession) newContainer(rc RequestContext) (*container, error) {
 			},
 			&output.NoneFormatter{},
 			&input.ExternalPromptConfiguration{
-				Endpoint: s.externalServicesEndpoint,
-				Key:      s.externalServicesKey,
-				Client:   s.externalServicesClient,
+				Endpoint:    s.externalServicesEndpoint,
+				Key:         s.externalServicesKey,
+				Transporter: s.externalServicesClient,
 			})
 	})
 
@@ -166,9 +166,9 @@ func (s *serverSession) newContainer(rc RequestContext) (*container, error) {
 
 	c.MustRegisterScoped(func() auth.ExternalAuthConfiguration {
 		return auth.ExternalAuthConfiguration{
-			Endpoint: s.externalServicesEndpoint,
-			Key:      s.externalServicesKey,
-			Client:   s.externalServicesClient,
+			Endpoint:    s.externalServicesEndpoint,
+			Key:         s.externalServicesKey,
+			Transporter: s.externalServicesClient,
 		}
 	})
 

--- a/cli/azd/pkg/auth/cloudshell_credential.go
+++ b/cli/azd/pkg/auth/cloudshell_credential.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
 type TokenFromCloudShell struct {
@@ -27,11 +26,11 @@ type TokenFromCloudShell struct {
 }
 
 type CloudShellCredential struct {
-	httpClient httputil.HttpClient
+	transporter policy.Transporter
 }
 
-func NewCloudShellCredential(httpClient httputil.HttpClient) *CloudShellCredential {
-	cloudShellCredential := CloudShellCredential{httpClient: httpClient}
+func NewCloudShellCredential(transporter policy.Transporter) *CloudShellCredential {
+	cloudShellCredential := CloudShellCredential{transporter: transporter}
 	return &cloudShellCredential
 }
 
@@ -57,7 +56,7 @@ func (t CloudShellCredential) GetToken(ctx context.Context, options policy.Token
 	req.Header.Add("Metadata", "true")
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := t.httpClient.Do(req)
+	resp, err := t.transporter.Do(req)
 	if err != nil {
 		return azcore.AccessToken{}, err
 	}

--- a/cli/azd/pkg/auth/manager_test.go
+++ b/cli/azd/pkg/auth/manager_test.go
@@ -14,7 +14,7 @@ import (
 
 	_ "embed"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
@@ -143,7 +143,7 @@ func TestServicePrincipalLoginFederatedTokenProvider(t *testing.T) {
 		configManager:     newMemoryConfigManager(),
 		userConfigManager: newMemoryUserConfigManager(),
 		credentialCache:   credentialCache,
-		ghClient: github.NewFederatedTokenClient(&policy.ClientOptions{
+		ghClient: github.NewFederatedTokenClient(&azcore.ClientOptions{
 			Transport: mockContext.HttpClient,
 			Cloud:     cloud.AzurePublic().Configuration,
 		}),

--- a/cli/azd/pkg/auth/remote_credential.go
+++ b/cli/azd/pkg/auth/remote_credential.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
 // RemoteCredential implements azcore.TokenCredential by using the remote credential protocol.
@@ -21,16 +20,16 @@ type RemoteCredential struct {
 	key string
 	// Tenant ID to use to authenticate, instead of the default. Optional.
 	tenantID string
-	// The HTTP client to use to make requests.
-	httpClient httputil.HttpClient
+	// The transport to use to make requests.
+	transporter policy.Transporter
 }
 
-func newRemoteCredential(endpoint, key, tenantID string, httpClient httputil.HttpClient) *RemoteCredential {
+func newRemoteCredential(endpoint, key, tenantID string, transporter policy.Transporter) *RemoteCredential {
 	return &RemoteCredential{
-		endpoint:   endpoint,
-		key:        key,
-		tenantID:   tenantID,
-		httpClient: httpClient,
+		endpoint:    endpoint,
+		key:         key,
+		tenantID:    tenantID,
+		transporter: transporter,
 	}
 }
 
@@ -65,7 +64,7 @@ func (rc *RemoteCredential) GetToken(ctx context.Context, options policy.TokenRe
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", rc.key))
 
-	res, err := rc.httpClient.Do(req)
+	res, err := rc.transporter.Do(req)
 	if err != nil {
 		return azcore.AccessToken{}, remoteCredentialError("making request", err)
 	}

--- a/cli/azd/pkg/azsdk/azsdk.go
+++ b/cli/azd/pkg/azsdk/azsdk.go
@@ -3,7 +3,6 @@ package azsdk
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
 type ClientOptionsBuilderFactory struct {
@@ -13,12 +12,12 @@ type ClientOptionsBuilderFactory struct {
 }
 
 func NewClientOptionsBuilderFactory(
-	httpClient httputil.HttpClient,
+	transport policy.Transporter,
 	userAgent string,
 	cloud *cloud.Cloud,
 ) *ClientOptionsBuilderFactory {
 	return &ClientOptionsBuilderFactory{
-		defaultTransport: httpClient,
+		defaultTransport: transport,
 		defaultUserAgent: userAgent,
 		cloud:            cloud,
 	}

--- a/cli/azd/pkg/azsdk/client_options_builder.go
+++ b/cli/azd/pkg/azsdk/client_options_builder.go
@@ -60,7 +60,7 @@ func (b *ClientOptionsBuilder) BuildCoreClientOptions() *azcore.ClientOptions {
 // These options include the underlying transport to be used.
 func (b *ClientOptionsBuilder) BuildArmClientOptions() *arm.ClientOptions {
 	return &arm.ClientOptions{
-		ClientOptions: policy.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
 			// Supports mocking for unit tests
 			Transport: b.transport,
 			// Per request policies to inject into HTTP pipeline

--- a/cli/azd/pkg/experimentation/assignment.go
+++ b/cli/azd/pkg/experimentation/assignment.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/resource"
@@ -50,7 +51,7 @@ func NewAssignmentsManager(endpoint string, transport policy.Transporter) (*Assi
 		return nil, err
 	}
 
-	client, err := newTasClient(endpoint, &policy.ClientOptions{
+	client, err := newTasClient(endpoint, &azcore.ClientOptions{
 		Transport: transport,
 	})
 	if err != nil {

--- a/cli/azd/pkg/github/federated_token_client.go
+++ b/cli/azd/pkg/github/federated_token_client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
@@ -78,7 +79,7 @@ type FederatedTokenClient struct {
 	pipeline runtime.Pipeline
 }
 
-func NewFederatedTokenClient(options *policy.ClientOptions) *FederatedTokenClient {
+func NewFederatedTokenClient(options *azcore.ClientOptions) *FederatedTokenClient {
 	pipeline := runtime.NewPipeline("github", "1.0.0", runtime.PipelineOptions{
 		PerRetry: []policy.Policy{
 			&bearerTokenAuthPolicy{},

--- a/cli/azd/pkg/github/federated_token_client_test.go
+++ b/cli/azd/pkg/github/federated_token_client_test.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +30,7 @@ func TestTokenForAudience(t *testing.T) {
 		Body:       io.NopCloser(bytes.NewBufferString(`{ "value": "abc" }`)),
 	})
 
-	client := NewFederatedTokenClient(&policy.ClientOptions{
+	client := NewFederatedTokenClient(&azcore.ClientOptions{
 		Transport: mockContext.HttpClient,
 	})
 
@@ -57,7 +57,7 @@ func TestTokenForAudienceDefault(t *testing.T) {
 		Body:       io.NopCloser(bytes.NewBufferString(`{ "value": "abc" }`)),
 	})
 
-	client := NewFederatedTokenClient(&policy.ClientOptions{
+	client := NewFederatedTokenClient(&azcore.ClientOptions{
 		Transport: mockContext.HttpClient,
 	})
 
@@ -82,7 +82,7 @@ func TestTokenForAudienceFailure(t *testing.T) {
 		Body:       io.NopCloser(bytes.NewBufferString("")),
 	})
 
-	client := NewFederatedTokenClient(&policy.ClientOptions{
+	client := NewFederatedTokenClient(&azcore.ClientOptions{
 		Transport: mockContext.HttpClient,
 	})
 

--- a/cli/azd/pkg/httputil/http_client.go
+++ b/cli/azd/pkg/httputil/http_client.go
@@ -3,12 +3,4 @@
 
 package httputil
 
-import (
-	"net/http"
-)
-
 type UserAgent string
-
-type HttpClient interface {
-	Do(req *http.Request) (*http.Response, error)
-}

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -23,11 +23,11 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/resource"
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	tm "github.com/buger/goterm"
@@ -994,9 +994,9 @@ type Writers struct {
 
 // ExternalPromptConfiguration allows configuring the console to delegate prompts to an external service.
 type ExternalPromptConfiguration struct {
-	Endpoint string
-	Key      string
-	Client   httputil.HttpClient
+	Endpoint    string
+	Key         string
+	Transporter policy.Transporter
 }
 
 // Creates a new console with the specified writers, handles and formatter. When externalPromptCfg is non nil, it is used
@@ -1026,7 +1026,8 @@ func NewConsole(
 	}
 
 	if externalPromptCfg != nil {
-		c.promptClient = newExternalPromptClient(externalPromptCfg.Endpoint, externalPromptCfg.Key, externalPromptCfg.Client)
+		c.promptClient = newExternalPromptClient(
+			externalPromptCfg.Endpoint, externalPromptCfg.Key, externalPromptCfg.Transporter)
 	}
 
 	spinnerConfig := yacspin.Config{

--- a/cli/azd/pkg/input/external_prompt_client.go
+++ b/cli/azd/pkg/input/external_prompt_client.go
@@ -8,14 +8,14 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
 // externalPromptClient is a client for the external prompt service, as described in [../../docs/external-prompt.md].
 type externalPromptClient struct {
-	endpoint string
-	key      string
-	pipeline httputil.HttpClient
+	endpoint    string
+	key         string
+	transporter policy.Transporter
 }
 
 type promptOptions struct {
@@ -82,11 +82,11 @@ type externalPromptDialogResponseInput struct {
 	Value json.RawMessage `json:"value"`
 }
 
-func newExternalPromptClient(endpoint string, key string, pipeline httputil.HttpClient) *externalPromptClient {
+func newExternalPromptClient(endpoint string, key string, transporter policy.Transporter) *externalPromptClient {
 	return &externalPromptClient{
-		endpoint: endpoint,
-		key:      key,
-		pipeline: pipeline,
+		endpoint:    endpoint,
+		key:         key,
+		transporter: transporter,
 	}
 }
 
@@ -115,7 +115,7 @@ func (c *externalPromptClient) PromptDialog(
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.key))
 
-	res, err := c.pipeline.Do(req)
+	res, err := c.transporter.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("making request: %w", err)
 	}
@@ -160,7 +160,7 @@ func (c *externalPromptClient) Prompt(ctx context.Context, options promptOptions
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.key))
 
-	res, err := c.pipeline.Do(req)
+	res, err := c.transporter.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("making request: %w", err)
 	}

--- a/cli/azd/pkg/templates/awesome_source.go
+++ b/cli/azd/pkg/templates/awesome_source.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/azure/azure-dev/cli/azd/pkg/github"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
 type awesomeAzdTemplate struct {
@@ -26,10 +25,10 @@ func NewAwesomeAzdTemplateSource(
 	ctx context.Context,
 	name string,
 	url string,
-	httpClient httputil.HttpClient,
+	transport policy.Transporter,
 ) (Source, error) {
 	pipeline := runtime.NewPipeline("azd-templates", "1.0.0", runtime.PipelineOptions{}, &policy.ClientOptions{
-		Transport: httpClient,
+		Transport: transport,
 	})
 
 	req, err := runtime.NewRequest(ctx, http.MethodGet, url)

--- a/cli/azd/pkg/templates/source_manager.go
+++ b/cli/azd/pkg/templates/source_manager.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/azure/azure-dev/cli/azd/resources"
 )
@@ -73,7 +73,7 @@ type sourceManager struct {
 	options        *SourceOptions
 	serviceLocator ioc.ServiceLocator
 	configManager  config.UserConfigManager
-	httpClient     httputil.HttpClient
+	transport      policy.Transporter
 }
 
 // NewSourceManager creates a new SourceManager.
@@ -81,7 +81,7 @@ func NewSourceManager(
 	options *SourceOptions,
 	serviceLocator ioc.ServiceLocator,
 	configManager config.UserConfigManager,
-	httpClient httputil.HttpClient,
+	transport policy.Transporter,
 ) SourceManager {
 	if options == nil {
 		options = NewSourceOptions()
@@ -91,7 +91,7 @@ func NewSourceManager(
 		options:        options,
 		serviceLocator: serviceLocator,
 		configManager:  configManager,
-		httpClient:     httpClient,
+		transport:      transport,
 	}
 }
 
@@ -223,9 +223,9 @@ func (sm *sourceManager) CreateSource(ctx context.Context, config *SourceConfig)
 	case SourceKindFile:
 		source, err = NewFileTemplateSource(config.Name, config.Location)
 	case SourceKindUrl:
-		source, err = NewUrlTemplateSource(ctx, config.Name, config.Location, sm.httpClient)
+		source, err = NewUrlTemplateSource(ctx, config.Name, config.Location, sm.transport)
 	case SourceKindAwesomeAzd:
-		source, err = NewAwesomeAzdTemplateSource(ctx, SourceAwesomeAzd.Name, SourceAwesomeAzd.Location, sm.httpClient)
+		source, err = NewAwesomeAzdTemplateSource(ctx, SourceAwesomeAzd.Name, SourceAwesomeAzd.Location, sm.transport)
 	case SourceKindResource:
 		source, err = NewJsonTemplateSource(SourceDefault.Name, string(resources.TemplatesJson))
 	default:

--- a/cli/azd/pkg/templates/url_source.go
+++ b/cli/azd/pkg/templates/url_source.go
@@ -8,13 +8,12 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
 // NewUrlTemplateSource creates a new template source from a URL.
-func NewUrlTemplateSource(ctx context.Context, name string, url string, httpClient httputil.HttpClient) (Source, error) {
+func NewUrlTemplateSource(ctx context.Context, name string, url string, transport policy.Transporter) (Source, error) {
 	pipeline := runtime.NewPipeline("azd-templates", "1.0.0", runtime.PipelineOptions{}, &policy.ClientOptions{
-		Transport: httpClient,
+		Transport: transport,
 	})
 
 	req, err := runtime.NewRequest(ctx, http.MethodGet, url)

--- a/cli/azd/test/functional/up_test.go
+++ b/cli/azd/test/functional/up_test.go
@@ -15,8 +15,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -319,7 +319,7 @@ func Test_CLI_Up_ResourceGroupScope(t *testing.T) {
 	require.NoError(t, err)
 
 	rgClient, err := armresources.NewResourceGroupsClient(subscriptionId, cred, &arm.ClientOptions{
-		ClientOptions: policy.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
 			Transport: client,
 		},
 	})

--- a/cli/azd/test/mocks/mock_context.go
+++ b/cli/azd/test/mocks/mock_context.go
@@ -10,7 +10,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockconfig"
@@ -74,7 +73,7 @@ func registerCommonMocks(mockContext *MockContext) {
 	mockContext.Container.MustRegisterSingleton(func() ioc.ServiceLocator {
 		return mockContext.Container
 	})
-	mockContext.Container.MustRegisterSingleton(func() httputil.HttpClient {
+	mockContext.Container.MustRegisterSingleton(func() policy.Transporter {
 		return mockContext.HttpClient
 	})
 	mockContext.Container.MustRegisterSingleton(func() exec.CommandRunner {


### PR DESCRIPTION
We needed to control the ability to replace the HTTP Transporter to
use before we adopted any types from the azure-sdk. Now that we are
built around azure-sdk, instead of having our own copy of this
abstraction, just use the version from azure-sdk.