### PR TITLE
Remove `httputil.UserAgent`

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -145,9 +145,6 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	client := createHttpClient()
 	ioc.RegisterInstance[policy.Transporter](container, client)
 	ioc.RegisterInstance[auth.HttpClient](container, client)
-	container.MustRegisterSingleton(func() httputil.UserAgent {
-		return httputil.UserAgent(internal.UserAgent())
-	})
 
 	// Auth
 	container.MustRegisterSingleton(auth.NewLoggedInGuard)
@@ -474,10 +471,9 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 
 	container.MustRegisterSingleton(func(
 		transporter policy.Transporter,
-		userAgent httputil.UserAgent,
 		cloud *cloud.Cloud,
 	) *azsdk.ClientOptionsBuilderFactory {
-		return azsdk.NewClientOptionsBuilderFactory(transporter, string(userAgent), cloud)
+		return azsdk.NewClientOptionsBuilderFactory(transporter, internal.UserAgent(), cloud)
 	})
 
 	container.MustRegisterSingleton(func(

--- a/cli/azd/pkg/environment/manager_test.go
+++ b/cli/azd/pkg/environment/manager_test.go
@@ -8,14 +8,12 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk/storage"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
-	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/state"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -358,9 +356,6 @@ func Test_EnvManager_CreateFromContainer(t *testing.T) {
 func registerContainerComponents(t *testing.T, mockContext *mocks.MockContext) {
 	mockContext.Container.MustRegisterSingleton(func() context.Context {
 		return *mockContext.Context
-	})
-	mockContext.Container.MustRegisterSingleton(func() httputil.UserAgent {
-		return httputil.UserAgent(internal.UserAgent())
 	})
 	mockContext.Container.MustRegisterSingleton(func() auth.MultiTenantCredentialProvider {
 		return mockContext.MultiTenantCredentialProvider

--- a/cli/azd/pkg/httputil/http_client.go
+++ b/cli/azd/pkg/httputil/http_client.go
@@ -2,5 +2,3 @@
 // Licensed under the MIT License.
 
 package httputil
-
-type UserAgent string


### PR DESCRIPTION
This type existed so that we could inject the UserAgent as a component in our DI container but we never exploited this in any interesting way.