### PR TITLE
maven: Use `exec.ErrNotFound` in `errors.Is`

### DIFF
--- a/cli/azd/pkg/tools/maven/maven.go
+++ b/cli/azd/pkg/tools/maven/maven.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -125,7 +124,7 @@ func getMavenWrapperPath(projectPath string, rootProjectPath string) (string, er
 			return mvnw, nil
 		}
 
-		if !errors.Is(err, os.ErrNotExist) {
+		if !errors.Is(err, osexec.ErrNotFound) {
 			return "", err
 		}
 


### PR DESCRIPTION
`exec.LookPath` returns `exec.ErrNotFound` when it fails to find a binary, but we were testing against `os.ErrNotExist`. In versions previous to go 1.23 this worked out, but in go 1.23 it no longer does (and a handful of the unit tests around this code started to fail), so we need to start testing against the correct error.