### PR TITLE
recording: Improvements to `Content-Length` handeling

### DIFF
--- a/cli/azd/test/recording/proxy.go
+++ b/cli/azd/test/recording/proxy.go
@@ -5,6 +5,7 @@ package recording
 
 import (
 	"bufio"
+	"bytes"
 	"compress/gzip"
 	"crypto/tls"
 	"errors"
@@ -64,10 +65,26 @@ func (u *gzip2HttpRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 
 	if resp.Header.Get("Content-Encoding") == "gzip" {
 		resp.Header.Del("Content-Encoding")
-		resp.Header.Del("Content-Length")
-		resp.ContentLength = -1
-		resp.Body = &http2gzipReader{body: resp.Body}
-		resp.Uncompressed = true
+
+		if resp.Header.Get("Content-Length") != "" {
+			defer resp.Body.Close()
+			reader, err := gzip.NewReader(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			body, err := io.ReadAll(reader)
+			if err != nil {
+				return nil, fmt.Errorf("reading gzip body: %w", err)
+			}
+			resp.Header.Set("Content-Length", fmt.Sprintf("%d", len(body)))
+			resp.ContentLength = int64(len(body))
+			resp.Body = io.NopCloser(bytes.NewReader(body))
+			resp.Uncompressed = false
+		} else {
+			resp.ContentLength = -1
+			resp.Uncompressed = true
+			resp.Body = &http2gzipReader{body: resp.Body}
+		}
 	}
 
 	return resp, nil
@@ -102,8 +119,15 @@ func (p *recorderProxy) ServeConn(conn io.Writer, req *http.Request) {
 		resp.Body = io.NopCloser(strings.NewReader(fmt.Sprintf(`{"error":{"code":"%s"}}`, err.Error())))
 	}
 
-	// Always use chunked encoding for transferring the response back, which handles large response bodies.
-	resp.TransferEncoding = []string{"chunked"}
+	// Always use chunked encoding for transferring the response back, which handles large response bodies, except in the
+	// case of HEAD requests. The response for a HEAD request does not have a body and writing a chunked response would
+	// cause the Content-Length header to be dropped, which would break things like the blob storage sdk which uses a HEAD
+	// request during GetProperties. There, the lack of a Content-Length header in the response means the `ContentLength`
+	// property of the properties in nil, making it impossible to determine the size of the blob without reading it.
+	if req.Method != http.MethodHead {
+		resp.TransferEncoding = []string{"chunked"}
+	}
+
 	err = resp.Write(conn)
 	if err != nil {
 		p.panic(err.Error())

--- a/cli/azd/test/recording/proxy_test.go
+++ b/cli/azd/test/recording/proxy_test.go
@@ -1,0 +1,93 @@
+package recording
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/dnaeon/go-vcr.v3/recorder"
+)
+
+// Test_gzip2HttpRoundTripper_ContentLength validates that a response served with gzip encoding is correctly expanded
+// and the Content-Length header is updated to reflect the expanded size.
+func Test_gzip2HttpRoundTripper_ContentLength(t *testing.T) {
+	message := "This content was served via gzip"
+
+	buf := &bytes.Buffer{}
+	writer := gzip.NewWriter(buf)
+
+	_, err := writer.Write([]byte(message))
+	require.NoError(t, err)
+	err = writer.Close()
+	require.NoError(t, err)
+
+	rt := &gzip2HttpRoundTripper{
+		transport: funcRoundTripper(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "200 OK",
+				StatusCode: 200,
+				Header: http.Header{
+					"Content-Encoding": []string{"gzip"},
+					"Content-Length":   []string{fmt.Sprintf("%d", buf.Len())},
+				},
+				Body:          io.NopCloser(bytes.NewReader(buf.Bytes())),
+				ContentLength: int64(buf.Len()),
+			}, nil
+		}),
+	}
+
+	resp, err := rt.RoundTrip(httptest.NewRequest("GET", "http://example.com", nil))
+	assert.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, message, string(body))
+	assert.Equal(t, int64(len(message)), resp.ContentLength)
+	assert.Equal(t, fmt.Sprintf("%d", len(message)), resp.Header.Get("Content-Length"))
+}
+
+// funcRoundTripper is an http.RoundTripper backed by a function
+type funcRoundTripper func(req *http.Request) (*http.Response, error)
+
+// RoundTrip implements http.RoundTripper
+func (f funcRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+// TestBlobClientGetProperties validates that the azure-sdk-for-go block blob's client GetProperties method returns
+// a non nil value, when recording is enabled. The SDK relies on the Content-Length header being present in HEAD responses.
+func TestBlobClientGetProperties(t *testing.T) {
+	msg := "Hello, world."
+
+	session := Start(t, WithRecordMode(recorder.ModeRecordOnly))
+	proxyClient, err := proxyClient(session.ProxyUrl)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(msg)))
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(msg))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	blobClient, err := blockblob.NewClientWithNoCredential(server.URL+"/test.txt", &blockblob.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: proxyClient,
+		},
+	})
+	assert.NoError(t, err)
+
+	props, err := blobClient.GetProperties(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, props.ContentLength)
+	assert.Equal(t, int64(len(msg)), *props.ContentLength)
+}

--- a/cli/azd/test/recording/testdata/recordings/TestBlobClientGetProperties.yaml
+++ b/cli/azd/test/recording/testdata/recordings/TestBlobClientGetProperties.yaml
@@ -1,0 +1,48 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 127.0.0.1:61535
+        remote_addr: 127.0.0.1:61536
+        request_uri: http://127.0.0.1:61535/test.txt
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/xml
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-azblob/v1.3.1 (go1.23.0; darwin)
+            X-Ms-Version:
+                - "2023-11-03"
+        url: http://127.0.0.1:61535/test.txt
+        method: HEAD
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 13
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "13"
+            Content-Type:
+                - text/plain; charset=utf-8
+            Date:
+                - Wed, 21 Aug 2024 01:32:41 GMT
+        status: 200 OK
+        code: 200
+        duration: 218.542µs
+---
+time: "1724203960"


### PR DESCRIPTION
When you call the `blockblob.GetProperties`, the azure-sdk-for-go makes a HEAD request to fetch information about the target blob, and uses the result to hydrate the properties object that is returned. The `ContentLength` property (which tells you how big the blob is) is set based on the `Content-Length` header in the response. The type of `ContentLength` is `*int` and if the `Content-Length` header is not set in the response, then the value will remain `nil`.

As part of the new ACR remote build feature, to stream logs from the remote build to the console we use `blockblob.GetProperties` to fetch the length of the remote build log file and then do a range request to fetch the content that we have not yet processed. When I wrote an end to end test and tried to record it, this code ended up crashing with a nil reference because the `ContentLength` property was `nil`.

This ended up being due to logic in the recording proxy which uses chuncked encoding when returning the response from the proxy server to the client. Per the HTTP spec, when using chunked encoding, the response should not have a Content-Length header, and the indeed the go standard library removes the header before writing the response. Talking with Wei, we think this code to use chunked response was added early on in the development of the proxy to work around some content length mismatches he was facing and may not be needed long term.

For now, I've updated the logic to not used chunked encoding for HEAD requests. Since HEAD requests to have a body there's no real value in using chunked responses and doing this ensures the Content-Length header is returned in the response.

While in the area, I also updated the middleware that we have to expand gzip'd responses (so that the recording contains the expanded content) to update the Content-Length property when present to be the length of the expanded content instead of just dropping it. While investigating this issue I first thought this was where the problem was, but it ended up being the chunked encoding, the HEAD response returned by Blob Storage is not gzip encoded.