### PR TITLE
recording: Use fixed port in `TestBlobClientGetProperties`

### DIFF
--- a/cli/azd/test/recording/proxy_test.go
+++ b/cli/azd/test/recording/proxy_test.go
@@ -8,13 +8,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/dnaeon/go-vcr.v3/recorder"
 )
 
 // Test_gzip2HttpRoundTripper_ContentLength validates that a response served with gzip encoding is correctly expanded
@@ -67,17 +67,16 @@ func (f funcRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 func TestBlobClientGetProperties(t *testing.T) {
 	msg := "Hello, world."
 
-	session := Start(t, WithRecordMode(recorder.ModeRecordOnly))
-	proxyClient, err := proxyClient(session.ProxyUrl)
-	require.NoError(t, err)
-
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(msg)))
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte(msg))
 		require.NoError(t, err)
 	}))
-	defer server.Close()
+
+	session := Start(t, WithHostMapping(strings.TrimPrefix(server.URL, "http://"), "127.0.0.1:80"))
+	proxyClient, err := proxyClient(session.ProxyUrl)
+	require.NoError(t, err)
 
 	blobClient, err := blockblob.NewClientWithNoCredential(server.URL+"/test.txt", &blockblob.ClientOptions{
 		ClientOptions: azcore.ClientOptions{
@@ -90,4 +89,6 @@ func TestBlobClientGetProperties(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, props.ContentLength)
 	assert.Equal(t, int64(len(msg)), *props.ContentLength)
+
+	server.Close()
 }

--- a/cli/azd/test/recording/recording.go
+++ b/cli/azd/test/recording/recording.go
@@ -32,7 +32,8 @@ import (
 )
 
 type recordOptions struct {
-	mode recorder.Mode
+	mode        recorder.Mode
+	hostMapping map[string]string
 }
 
 type Options interface {
@@ -49,6 +50,28 @@ type modeOption struct {
 
 func (in modeOption) Apply(out recordOptions) recordOptions {
 	out.mode = in.mode
+	return out
+}
+
+// WithHostMapping allows mapping one host to another in a recording. This is useful in cases where you are using
+// [httptest.NewServer] in a recorded test, since the host for the server differs across runs due to the randomly assigned
+// port. In this case you can call WithHostMapping(strings.TrimPrefix(server.URL, "http://"), "127.0.0.1:80") to ensure
+// that in the recording the host is always set to the same value.
+func WithHostMapping(from, to string) Options {
+	return hostMappingOption{from: from, to: to}
+}
+
+type hostMappingOption struct {
+	from string
+	to   string
+}
+
+func (in hostMappingOption) Apply(out recordOptions) recordOptions {
+	if out.hostMapping == nil {
+		out.hostMapping = map[string]string{}
+	}
+
+	out.hostMapping[in.from] = in.to
 	return out
 }
 
@@ -186,6 +209,12 @@ func Start(t *testing.T, opts ...Options) *Session {
 			return r.Method == i.Method && r.URL.String() == recorded.String()
 		}
 
+		if opt.hostMapping != nil {
+			if to, has := opt.hostMapping[r.URL.Host]; has {
+				r.URL.Host = to
+			}
+		}
+
 		return cassette.DefaultMatcher(r, i)
 	})
 
@@ -197,6 +226,23 @@ func Start(t *testing.T, opts ...Options) *Session {
 	vcr.AddHook(func(i *cassette.Interaction) error {
 		return TrimSubscriptionsDeployment(i, session.Variables)
 	}, recorder.BeforeSaveHook)
+
+	vcr.AddHook(func(i *cassette.Interaction) error {
+		if opt.hostMapping == nil {
+			return nil
+		}
+
+		if to, has := opt.hostMapping[i.Request.Host]; has {
+			oldHost := i.Request.Host
+
+			i.Request.Host = to
+			i.Request.RemoteAddr = to
+			i.Request.URL = strings.Replace(i.Request.URL, oldHost, to, 1)
+			i.Request.RequestURI = strings.Replace(i.Request.RequestURI, oldHost, to, 1)
+		}
+
+		return nil
+	}, recorder.AfterCaptureHook)
 
 	// Sanitize
 	vcr.AddHook(func(i *cassette.Interaction) error {

--- a/cli/azd/test/recording/testdata/recordings/TestBlobClientGetProperties.yaml
+++ b/cli/azd/test/recording/testdata/recordings/TestBlobClientGetProperties.yaml
@@ -9,9 +9,9 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: 127.0.0.1:61535
-        remote_addr: 127.0.0.1:61536
-        request_uri: http://127.0.0.1:61535/test.txt
+        host: 127.0.0.1:80
+        remote_addr: 127.0.0.1:80
+        request_uri: http://127.0.0.1:80/test.txt
         body: ""
         form: {}
         headers:
@@ -23,7 +23,7 @@ interactions:
                 - azsdk-go-azblob/v1.3.1 (go1.23.0; darwin)
             X-Ms-Version:
                 - "2023-11-03"
-        url: http://127.0.0.1:61535/test.txt
+        url: http://127.0.0.1:80/test.txt
         method: HEAD
       response:
         proto: HTTP/1.1
@@ -40,9 +40,9 @@ interactions:
             Content-Type:
                 - text/plain; charset=utf-8
             Date:
-                - Wed, 21 Aug 2024 01:32:41 GMT
+                - Fri, 23 Aug 2024 22:33:36 GMT
         status: 200 OK
         code: 200
-        duration: 218.542µs
+        duration: 277.625µs
 ---
-time: "1724203960"
+time: "1724452415"


### PR DESCRIPTION
When developing the test I unintentionally set
`recorder.ModeRecordOnly` causing us to recrate the recording per run. Turning that off exposed an issue where since the `httptest` package picks a different port each run it meant that the recording would not match because the port was different, causing us to fail to playback the test.

For now, use a fixed port for our test server, which ensures we have a stable `host` value across runs, at the expense of disallowing multiple copies of the test from running at the same time.