### PR TITLE
Adds support for multiple hooks per event

### DIFF
--- a/cli/azd/cmd/hooks.go
+++ b/cli/azd/cmd/hooks.go
@@ -126,13 +126,15 @@ func (hra *hooksRunAction) Run(ctx context.Context) (*actions.ActionResult, erro
 	}
 
 	// Project level hooks
+	projectHooks := hra.projectConfig.Hooks[hookName]
+
 	if err := hra.processHooks(
 		ctx,
 		hra.projectConfig.Path,
 		hookName,
-		fmt.Sprintf("Running %s command hook for project", hookName),
+		fmt.Sprintf("Running %d %s command hook(s) for project", len(projectHooks), hookName),
 		fmt.Sprintf("Project: %s Hook Output", hookName),
-		hra.projectConfig.Hooks,
+		projectHooks,
 		false,
 	); err != nil {
 		return nil, err
@@ -145,15 +147,16 @@ func (hra *hooksRunAction) Run(ctx context.Context) (*actions.ActionResult, erro
 
 	// Service level hooks
 	for _, service := range stableServices {
+		serviceHooks := service.Hooks[hookName]
 		skip := hra.flags.service != "" && service.Name != hra.flags.service
 
 		if err := hra.processHooks(
 			ctx,
 			service.RelativePath,
 			hookName,
-			fmt.Sprintf("Running %s service hook for %s", hookName, service.Name),
+			fmt.Sprintf("Running %d %s service hook(s) for %s", len(serviceHooks), hookName, service.Name),
 			fmt.Sprintf("%s: %s hook output", service.Name, hookName),
-			service.Hooks,
+			serviceHooks,
 			skip,
 		); err != nil {
 			return nil, err
@@ -173,7 +176,7 @@ func (hra *hooksRunAction) processHooks(
 	hookName string,
 	spinnerMessage string,
 	previewMessage string,
-	hooksMap map[string][]*ext.HookConfig,
+	hooks []*ext.HookConfig,
 	skip bool,
 ) error {
 	hra.console.ShowSpinner(ctx, spinnerMessage, input.Step)
@@ -183,8 +186,7 @@ func (hra *hooksRunAction) processHooks(
 		return nil
 	}
 
-	hooks, ok := hooksMap[hookName]
-	if !ok {
+	if len(hooks) == 0 {
 		hra.console.StopSpinner(ctx, spinnerMessage+noHookFoundMessage, input.StepWarning)
 		return nil
 	}
@@ -220,7 +222,7 @@ func (hra *hooksRunAction) execHook(
 	hookName := string(hookType) + commandName
 
 	hooksMap := map[string][]*ext.HookConfig{
-		hookName: []*ext.HookConfig{hook},
+		hookName: {hook},
 	}
 
 	hooksManager := ext.NewHooksManager(cwd)

--- a/cli/azd/cmd/middleware/hooks_test.go
+++ b/cli/azd/cmd/middleware/hooks_test.go
@@ -29,10 +29,12 @@ func Test_CommandHooks_Middleware_WithValidProjectAndMatchingCommand(t *testing.
 
 	projectConfig := project.ProjectConfig{
 		Name: envName,
-		Hooks: map[string]*ext.HookConfig{
+		Hooks: map[string][]*ext.HookConfig{
 			"precommand": {
-				Run:   "echo 'hello'",
-				Shell: ext.ShellTypeBash,
+				{
+					Run:   "echo 'hello'",
+					Shell: ext.ShellTypeBash,
+				},
 			},
 		},
 	}
@@ -61,10 +63,12 @@ func Test_CommandHooks_Middleware_ValidProjectWithDifferentCommand(t *testing.T)
 
 	projectConfig := project.ProjectConfig{
 		Name: envName,
-		Hooks: map[string]*ext.HookConfig{
+		Hooks: map[string][]*ext.HookConfig{
 			"precommand": {
-				Run:   "echo 'hello'",
-				Shell: ext.ShellTypeBash,
+				{
+					Run:   "echo 'hello'",
+					Shell: ext.ShellTypeBash,
+				},
 			},
 		},
 	}
@@ -119,10 +123,12 @@ func Test_CommandHooks_Middleware_PreHookWithError(t *testing.T) {
 
 	projectConfig := project.ProjectConfig{
 		Name: envName,
-		Hooks: map[string]*ext.HookConfig{
+		Hooks: map[string][]*ext.HookConfig{
 			"precommand": {
-				Run:   "exit 1",
-				Shell: ext.ShellTypeBash,
+				{
+					Run:   "exit 1",
+					Shell: ext.ShellTypeBash,
+				},
 			},
 		},
 	}
@@ -154,11 +160,13 @@ func Test_CommandHooks_Middleware_PreHookWithErrorAndContinue(t *testing.T) {
 
 	projectConfig := project.ProjectConfig{
 		Name: envName,
-		Hooks: map[string]*ext.HookConfig{
+		Hooks: map[string][]*ext.HookConfig{
 			"precommand": {
-				Run:             "exit 1",
-				Shell:           ext.ShellTypeBash,
-				ContinueOnError: true,
+				{
+					Run:             "exit 1",
+					Shell:           ext.ShellTypeBash,
+					ContinueOnError: true,
+				},
 			},
 		},
 	}
@@ -190,10 +198,12 @@ func Test_CommandHooks_Middleware_WithCmdAlias(t *testing.T) {
 
 	projectConfig := project.ProjectConfig{
 		Name: envName,
-		Hooks: map[string]*ext.HookConfig{
+		Hooks: map[string][]*ext.HookConfig{
 			"prealias": {
-				Run:   "echo 'hello'",
-				Shell: ext.ShellTypeBash,
+				{
+					Run:   "echo 'hello'",
+					Shell: ext.ShellTypeBash,
+				},
 			},
 		},
 	}
@@ -230,10 +240,12 @@ func Test_ServiceHooks_Registered(t *testing.T) {
 		Language:        "ts",
 		RelativePath:    "./src/api",
 		Host:            "appservice",
-		Hooks: map[string]*ext.HookConfig{
+		Hooks: map[string][]*ext.HookConfig{
 			"predeploy": {
-				Shell: ext.ShellTypeBash,
-				Run:   "echo 'Hello'",
+				{
+					Shell: ext.ShellTypeBash,
+					Run:   "echo 'Hello'",
+				},
 			},
 		},
 	}

--- a/cli/azd/pkg/ext/hooks_manager_test.go
+++ b/cli/azd/pkg/ext/hooks_manager_test.go
@@ -17,39 +17,47 @@ func Test_GetAllHookConfigs(t *testing.T) {
 	ostest.Chdir(t, tempDir)
 
 	t.Run("With Valid Configuration", func(t *testing.T) {
-		hooks := map[string]*HookConfig{
+		hooksMap := map[string][]*HookConfig{
 			"preinit": {
-				Run: "scripts/preinit.sh",
+				{
+					Run: "scripts/preinit.sh",
+				},
 			},
 			"postinit": {
-				Run: "scripts/postinit.sh",
+				{
+					Run: "scripts/postinit.sh",
+				},
 			},
 		}
 
-		ensureScriptsExist(t, hooks)
+		ensureScriptsExist(t, hooksMap)
 
 		hooksManager := NewHooksManager(tempDir)
-		validHooks, err := hooksManager.GetAll(hooks)
+		validHooks, err := hooksManager.GetAll(hooksMap)
 
-		require.Len(t, validHooks, len(hooks))
+		require.Len(t, validHooks, len(hooksMap))
 		require.NoError(t, err)
 	})
 
 	t.Run("With Invalid Configuration", func(t *testing.T) {
-		// All hooks are invalid because they are missing a script type
-		hooks := map[string]*HookConfig{
+		// All hooksMap are invalid because they are missing a script type
+		hooksMap := map[string][]*HookConfig{
 			"preinit": {
-				Run: "echo 'Hello'",
+				{
+					Run: "echo 'Hello'",
+				},
 			},
 			"postinit": {
-				Run: "echo 'Hello'",
+				{
+					Run: "echo 'Hello'",
+				},
 			},
 		}
 
-		ensureScriptsExist(t, hooks)
+		ensureScriptsExist(t, hooksMap)
 
 		hooksManager := NewHooksManager(tempDir)
-		validHooks, err := hooksManager.GetAll(hooks)
+		validHooks, err := hooksManager.GetAll(hooksMap)
 
 		require.Nil(t, validHooks)
 		require.Error(t, err)
@@ -61,55 +69,65 @@ func Test_GetByParams(t *testing.T) {
 	ostest.Chdir(t, tempDir)
 
 	t.Run("With Valid Configuration", func(t *testing.T) {
-		hooks := map[string]*HookConfig{
+		hooksMap := map[string][]*HookConfig{
 			"preinit": {
-				Run: "scripts/preinit.sh",
+				{
+					Run: "scripts/preinit.sh",
+				},
 			},
 			"postinit": {
-				Run: "scripts/postinit.sh",
+				{
+					Run: "scripts/postinit.sh",
+				},
 			},
 		}
 
-		ensureScriptsExist(t, hooks)
+		ensureScriptsExist(t, hooksMap)
 
 		hooksManager := NewHooksManager(tempDir)
-		validHooks, err := hooksManager.GetByParams(hooks, HookTypePre, "init")
+		validHooks, err := hooksManager.GetByParams(hooksMap, HookTypePre, "init")
 
 		require.Len(t, validHooks, 1)
-		require.Equal(t, hooks["preinit"], validHooks[0])
+		require.Equal(t, hooksMap["preinit"][0], validHooks[0])
 		require.NoError(t, err)
 	})
 
 	t.Run("With Invalid Configuration", func(t *testing.T) {
-		// All hooks are invalid because they are missing a script type
-		hooks := map[string]*HookConfig{
+		// All hooksMap are invalid because they are missing a script type
+		hooksMap := map[string][]*HookConfig{
 			"preinit": {
-				Run: "echo 'Hello'",
+				{
+					Run: "echo 'Hello'",
+				},
 			},
 			"postinit": {
-				Run: "echo 'Hello'",
+				{
+					Run: "echo 'Hello'",
+				},
 			},
 		}
 
-		ensureScriptsExist(t, hooks)
+		ensureScriptsExist(t, hooksMap)
 
 		hooksManager := NewHooksManager(tempDir)
-		validHooks, err := hooksManager.GetByParams(hooks, HookTypePre, "init")
+		validHooks, err := hooksManager.GetByParams(hooksMap, HookTypePre, "init")
 
 		require.Nil(t, validHooks)
 		require.Error(t, err)
 	})
 }
 
-func ensureScriptsExist(t *testing.T, configs map[string]*HookConfig) {
-	for _, hook := range configs {
-		ext := filepath.Ext(hook.Run)
+func ensureScriptsExist(t *testing.T, configs map[string][]*HookConfig) {
+	for _, hooks := range configs {
+		for _, hook := range hooks {
+			ext := filepath.Ext(hook.Run)
 
-		if isValidFileExtension(ext) {
-			err := os.MkdirAll(filepath.Dir(hook.Run), osutil.PermissionDirectory)
-			require.NoError(t, err)
-			err = os.WriteFile(hook.Run, nil, osutil.PermissionExecutableFile)
-			require.NoError(t, err)
+			if isValidFileExtension(ext) {
+				err := os.MkdirAll(filepath.Dir(hook.Run), osutil.PermissionDirectory)
+				require.NoError(t, err)
+				err = os.WriteFile(hook.Run, nil, osutil.PermissionExecutableFile)
+				require.NoError(t, err)
+			}
 		}
 	}
 }

--- a/cli/azd/pkg/ext/hooks_runner.go
+++ b/cli/azd/pkg/ext/hooks_runner.go
@@ -23,7 +23,7 @@ type HooksRunner struct {
 	commandRunner exec.CommandRunner
 	console       input.Console
 	cwd           string
-	hooks         map[string]*HookConfig
+	hooks         map[string][]*HookConfig
 	env           *environment.Environment
 	envManager    environment.Manager
 }
@@ -36,7 +36,7 @@ func NewHooksRunner(
 	envManager environment.Manager,
 	console input.Console,
 	cwd string,
-	hooks map[string]*HookConfig,
+	hooks map[string][]*HookConfig,
 	env *environment.Environment,
 ) *HooksRunner {
 	if cwd == "" {

--- a/cli/azd/pkg/project/project_config.go
+++ b/cli/azd/pkg/project/project_config.go
@@ -69,7 +69,7 @@ type ProjectMetadata struct {
 // and new multiple hook configurations
 type HooksConfig map[string][]*ext.HookConfig
 
-// UnmarshalYAML unmarshals the hooks configuration from YAML supporting both legacy single hook configurations
+// UnmarshalYAML converts the hooks configuration from YAML supporting both legacy single hook configurations
 // and new multiple hook configurations
 func (ch *HooksConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var legacyConfig map[string]*ext.HookConfig

--- a/cli/azd/pkg/project/project_config_test.go
+++ b/cli/azd/pkg/project/project_config_test.go
@@ -420,6 +420,27 @@ metadata:
 }
 
 func Test_Hooks_Config_Yaml_Marshalling(t *testing.T) {
+	t.Run("No hooks", func(t *testing.T) {
+		expected := &ProjectConfig{
+			Name: "test-proj",
+			Services: map[string]*ServiceConfig{
+				"api": {
+					Host:         ContainerAppTarget,
+					Language:     ServiceLanguageTypeScript,
+					RelativePath: "src/api",
+				},
+			},
+		}
+
+		yamlBytes, err := yaml.Marshal(expected)
+		require.NoError(t, err)
+		snapshot.SnapshotT(t, string(yamlBytes))
+
+		actual, err := Parse(context.Background(), string(yamlBytes))
+		require.NoError(t, err)
+		require.Equal(t, expected.Hooks, actual.Hooks)
+	})
+
 	t.Run("Single hooks per event", func(t *testing.T) {
 		expected := &ProjectConfig{
 			Name: "test-proj",

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -37,7 +37,7 @@ type ServiceConfig struct {
 	// The infrastructure provisioning configuration
 	Infra provisioning.Options `yaml:"infra,omitempty"`
 	// Hook configuration for service
-	Hooks map[string]*ext.HookConfig `yaml:"hooks,omitempty"`
+	Hooks HooksConfig `yaml:"hooks,omitempty"`
 	// Options specific to the DotNetContainerApp target. These are set by the importer and
 	// can not be controlled via the project file today.
 	DotNetContainerApp *DotNetContainerAppOptions `yaml:"-,omitempty"`

--- a/cli/azd/pkg/project/testdata/Test_Hooks_Config_Yaml_Marshalling-Multiple_hooks_per_event.snap
+++ b/cli/azd/pkg/project/testdata/Test_Hooks_Config_Yaml_Marshalling-Multiple_hooks_per_event.snap
@@ -1,0 +1,19 @@
+name: test-proj
+services:
+    api:
+        project: src/api
+        host: containerapp
+        language: ts
+        hooks:
+            postprovision:
+                - shell: sh
+                  run: scripts/postprovision1.sh
+                - shell: sh
+                  run: scripts/postprovision2.sh
+hooks:
+    postprovision:
+        - shell: sh
+          run: scripts/postprovision1.sh
+        - shell: sh
+          run: scripts/postprovision2.sh
+

--- a/cli/azd/pkg/project/testdata/Test_Hooks_Config_Yaml_Marshalling-No_hooks.snap
+++ b/cli/azd/pkg/project/testdata/Test_Hooks_Config_Yaml_Marshalling-No_hooks.snap
@@ -1,0 +1,7 @@
+name: test-proj
+services:
+    api:
+        project: src/api
+        host: containerapp
+        language: ts
+

--- a/cli/azd/pkg/project/testdata/Test_Hooks_Config_Yaml_Marshalling-Single_hooks_per_event.snap
+++ b/cli/azd/pkg/project/testdata/Test_Hooks_Config_Yaml_Marshalling-Single_hooks_per_event.snap
@@ -1,0 +1,15 @@
+name: test-proj
+services:
+    api:
+        project: src/api
+        host: containerapp
+        language: ts
+        hooks:
+            postprovision:
+                shell: sh
+                run: scripts/postprovision.sh
+hooks:
+    postprovision:
+        shell: sh
+        run: scripts/postprovision.sh
+


### PR DESCRIPTION
As we start to mature the `azd` hooks experience with specialized hook implementations / operations we will need to support the concept of running multiple hooks per event.

For example post provisioning you may want to run a custom azd operation hook followed by a more generic script hook.

This PR extends the hook configuration to support single hook configuration as supported today as well as multiple hooks per event name.

## Supports single hook per event (legacy)
```yaml
name: test-proj
services:
    api:
        project: src/api
        host: containerapp
        language: ts
        hooks:
            postprovision:
                shell: sh
                run: scripts/postprovision.sh
hooks:
    postprovision:
        shell: sh
        run: scripts/postprovision.sh
```

## Supports multiple hooks per event (new)
```yaml
name: test-proj
services:
    api:
        project: src/api
        host: containerapp
        language: ts
        hooks:
            postprovision:
                - shell: sh
                  run: scripts/postprovision1.sh
                - shell: sh
                  run: scripts/postprovision2.sh
hooks:
    postprovision:
        - shell: sh
          run: scripts/postprovision1.sh
        - shell: sh
          run: scripts/postprovision2.sh
```