### PR TITLE
relax gh pipeline provider even more

### DIFF
--- a/cli/azd/pkg/pipeline/github_provider.go
+++ b/cli/azd/pkg/pipeline/github_provider.go
@@ -132,7 +132,7 @@ func (p *GitHubScmProvider) configureGitRemote(
 }
 
 // defines the structure of an ssl git remote
-var gitHubRemoteGitUrlRegex = regexp.MustCompile(`^git@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}:(.*?)(?:\.git)?$`)
+var gitHubRemoteGitUrlRegex = regexp.MustCompile(`^git@[a-zA-Z0-9.-_]+:(.*?)(?:\.git)?$`)
 
 // defines the structure of an HTTPS git remote
 var gitHubRemoteHttpsUrlRegex = regexp.MustCompile(`^https://(?:www\.)?[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/(.*?)(?:\.git)?$`)


### PR DESCRIPTION
Allow a hostname without a .xxx suffix. This will allow hostname alias like `foo` to be a valid hostname
fix: https://github.com/Azure/azure-dev/issues/4185