### PR TITLE
project: Use `/` as path seperator in `azure.yaml`

### DIFF
--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -383,7 +383,7 @@ func GenerateProjectArtifacts(
 	projectFileContext := genProjectFileContext{
 		Name: projectName,
 		Services: map[string]string{
-			"app": fmt.Sprintf(".%s%s", string(filepath.Separator), appHostRel),
+			"app": fmt.Sprintf("./%s", filepath.ToSlash(appHostRel)),
 		},
 	}
 


### PR DESCRIPTION
Since we expect an `azd` project to be used across operating systems which use `/` and `\` as path seperators, we need a common way of writing paths in `azure.yaml` that works across both. In the path we supported using both `\` and `/` in `azure.yaml` (and went out ouf or way in the Aspire case to write the platform specific version during `init`) but in some cases this would lead to weird behavior when you then puth the project into GitHub actions and *nix runners would look for files that may not exist, due to the path seperator.

To address this, we update our `ProjectConfig` yaml parsing and saving to assume forward slash seperated paths, and then use `filepath.FromSlash` and `filepath.ToSlash` on the boundaries. This means the data stored at runtime inside `ProjectConfig` is using the correct platform seperator, but when being saved to disk, we always use `/`.

To support backwards compatability, for paths which have only `\` and no `/`, we treat as if they were written with `/` instead of `\` (and we will fix them up if we end up rewrting azure.yaml).

Fixes #3891