### PR TITLE
Updates `azure.yaml` schema to support single or multi hook configuration

### DIFF
--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -144,42 +144,42 @@
                             "predeploy": {
                                 "title": "pre deploy hook",
                                 "description": "Runs before the service is deployed to Azure",
-                                "$ref": "#/definitions/hook"
+                                "$ref": "#/definitions/hooks"
                             },
                             "postdeploy": {
                                 "title": "post deploy hook",
                                 "description": "Runs after the service is deployed to Azure",
-                                "$ref": "#/definitions/hook"
+                                "$ref": "#/definitions/hooks"
                             },
                             "prerestore": {
                                 "title": "pre restore hook",
                                 "description": "Runs before the service dependencies are restored",
-                                "$ref": "#/definitions/hook"
+                                "$ref": "#/definitions/hooks"
                             },
                             "postrestore": {
                                 "title": "post restore hook",
                                 "description": "Runs after the service dependencies are restored",
-                                "$ref": "#/definitions/hook"
+                                "$ref": "#/definitions/hooks"
                             },
                             "prebuild": {
                                 "title": "pre build hook",
                                 "description": "Runs before the service is built",
-                                "$ref": "#/definitions/hook"
+                                "$ref": "#/definitions/hooks"
                             },
                             "postbuild": {
                                 "title": "post build hook",
                                 "description": "Runs after the service is built",
-                                "$ref": "#/definitions/hook"
+                                "$ref": "#/definitions/hooks"
                             },
                             "prepackage": {
                                 "title": "pre package hook",
                                 "description": "Runs before the service is deployment package is created",
-                                "$ref": "#/definitions/hook"
+                                "$ref": "#/definitions/hooks"
                             },
                             "postpackage": {
                                 "title": "post package hook",
                                 "description": "Runs after the service is deployment package is created",
-                                "$ref": "#/definitions/hook"
+                                "$ref": "#/definitions/hooks"
                             }
                         }
                     }
@@ -352,82 +352,82 @@
                 "preprovision": {
                     "title": "pre provision hook",
                     "description": "Runs before the `provision` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "postprovision": {
                     "title": "post provision hook",
                     "description": "Runs after the `provision` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "preinfracreate": {
                     "title": "pre infra create hook",
                     "description": "Runs before the `infra create` or `provision` commands",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "postinfracreate": {
                     "title": "post infra create hook",
                     "description": "Runs after the `infra create` or `provision` commands",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "preinfradelete": {
                     "title": "pre infra delete hook",
                     "description": "Runs before the `infra delete` or `down` commands",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "postinfradelete": {
                     "title": "post infra delete hook",
                     "description": "Runs after the `infra delete` or `down` commands",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "predown": {
                     "title": "pre down hook",
                     "description": "Runs before the `infra delete` or `down` commands",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "postdown": {
                     "title": "post down hook",
                     "description": "Runs after the `infra delete` or `down` commands",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "preup": {
                     "title": "pre up hook",
                     "description": "Runs before the `up` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "postup": {
                     "title": "post up hook",
                     "description": "Runs after the `up` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "prepackage": {
                     "title": "pre package hook",
                     "description": "Runs before the `package` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "postpackage": {
                     "title": "post package hook",
                     "description": "Runs after the `package` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "predeploy": {
                     "title": "pre deploy hook",
                     "description": "Runs before the `deploy` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "postdeploy": {
                     "title": "post deploy hook",
                     "description": "Runs after the `deploy` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "prerestore": {
                     "title": "pre restore hook",
                     "description": "Runs before the `restore` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "postrestore": {
                     "title": "post restore hook",
                     "description": "Runs after the `restore` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 }
             }
         },
@@ -554,6 +554,20 @@
         }
     },
     "definitions": {
+        "hooks": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/hook"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "$ref": "#/definitions/hook"
+                    }
+                }
+            ]
+        },
         "hook": {
             "type": "object",
             "additionalProperties": false,
@@ -982,7 +996,9 @@
         },
         "aiDeploymentConfig": {
             "allOf": [
-                { "$ref": "#/definitions/aiComponentConfig" },
+                {
+                    "$ref": "#/definitions/aiComponentConfig"
+                },
                 {
                     "type": "object",
                     "properties": {
@@ -990,7 +1006,7 @@
                             "type": "object",
                             "title": "A map of key/value pairs to set as environment variables for the deployment.",
                             "description": "Optional. Values support OS & AZD environment variable substitution.",
-                            "additionalProperties":{
+                            "additionalProperties": {
                                 "type": "string"
                             }
                         }

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -139,48 +139,48 @@
                             "predeploy": {
                                 "title": "pre deploy hook",
                                 "description": "Runs before the service is deployed to Azure",
-                                "$ref": "#/definitions/hook"
+                                "$ref": "#/definitions/hooks"
                             },
                             "postdeploy": {
                                 "title": "post deploy hook",
                                 "description": "Runs after the service is deployed to Azure",
-                                "$ref": "#/definitions/hook"
+                                "$ref": "#/definitions/hooks"
                             },
                             "prerestore": {
                                 "title": "pre restore hook",
                                 "description": "Runs before the service dependencies are restored",
-                                "$ref": "#/definitions/hook"
+                                "$ref": "#/definitions/hooks"
                             },
                             "postrestore": {
                                 "title": "post restore hook",
                                 "description": "Runs after the service dependencies are restored",
-                                "$ref": "#/definitions/hook"
+                                "$ref": "#/definitions/hooks"
                             },
                             "prebuild": {
                                 "title": "pre build hook",
                                 "description": "Runs before the service is built",
-                                "$ref": "#/definitions/hook"
+                                "$ref": "#/definitions/hooks"
                             },
                             "postbuild": {
                                 "title": "post build hook",
                                 "description": "Runs after the service is built",
-                                "$ref": "#/definitions/hook"
+                                "$ref": "#/definitions/hooks"
                             },
                             "prepackage": {
                                 "title": "pre package hook",
                                 "description": "Runs before the service is deployment package is created",
-                                "$ref": "#/definitions/hook"
+                                "$ref": "#/definitions/hooks"
                             },
                             "postpackage": {
                                 "title": "post package hook",
                                 "description": "Runs after the service is deployment package is created",
-                                "$ref": "#/definitions/hook"
+                                "$ref": "#/definitions/hooks"
                             }
                         }
                     }
                 },
                 "allOf": [
-{
+                    {
                         "if": {
                             "properties": {
                                 "host": {
@@ -363,82 +363,82 @@
                 "preprovision": {
                     "title": "pre provision hook",
                     "description": "Runs before the `provision` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "postprovision": {
                     "title": "post provision hook",
                     "description": "Runs after the `provision` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "preinfracreate": {
                     "title": "pre infra create hook",
                     "description": "Runs before the `infra create` or `provision` commands",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "postinfracreate": {
                     "title": "post infra create hook",
                     "description": "Runs after the `infra create` or `provision` commands",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "preinfradelete": {
                     "title": "pre infra delete hook",
                     "description": "Runs before the `infra delete` or `down` commands",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "postinfradelete": {
                     "title": "post infra delete hook",
                     "description": "Runs after the `infra delete` or `down` commands",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "predown": {
                     "title": "pre down hook",
                     "description": "Runs before the `infra delete` or `down` commands",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "postdown": {
                     "title": "post down hook",
                     "description": "Runs after the `infra delete` or `down` commands",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "preup": {
                     "title": "pre up hook",
                     "description": "Runs before the `up` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "postup": {
                     "title": "post up hook",
                     "description": "Runs after the `up` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "prepackage": {
                     "title": "pre package hook",
                     "description": "Runs before the `package` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "postpackage": {
                     "title": "post package hook",
                     "description": "Runs after the `package` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "predeploy": {
                     "title": "pre deploy hook",
                     "description": "Runs before the `deploy` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "postdeploy": {
                     "title": "post deploy hook",
                     "description": "Runs after the `deploy` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "prerestore": {
                     "title": "pre restore hook",
                     "description": "Runs before the `restore` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 },
                 "postrestore": {
                     "title": "post restore hook",
                     "description": "Runs after the `restore` command",
-                    "$ref": "#/definitions/hook"
+                    "$ref": "#/definitions/hooks"
                 }
             }
         },
@@ -569,11 +569,31 @@
             "description": "Optional. Provides additional configuration for deploying to sovereign clouds such as Azure Government. The default cloud is AzureCloud.",
             "additionalProperties": false,
             "properties": {
-                "name": { "enum": [ "AzureCloud", "AzureChinaCloud", "AzureUSGovernment" ] }
+                "name": {
+                    "enum": [
+                        "AzureCloud",
+                        "AzureChinaCloud",
+                        "AzureUSGovernment"
+                    ]
+                }
             }
         }
     },
     "definitions": {
+        "hooks": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/hook"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "$ref": "#/definitions/hook"
+                    }
+                }
+            ]
+        },
         "hook": {
             "type": "object",
             "additionalProperties": false,
@@ -743,7 +763,7 @@
                             "description": "When set will be appended to the root of your ingress resource path."
                         }
                     }
-},
+                },
                 "helm": {
                     "type": "object",
                     "title": "Optional. The helm configuration",
@@ -1002,7 +1022,9 @@
         },
         "aiDeploymentConfig": {
             "allOf": [
-                { "$ref": "#/definitions/aiComponentConfig" },
+                {
+                    "$ref": "#/definitions/aiComponentConfig"
+                },
                 {
                     "type": "object",
                     "properties": {
@@ -1010,7 +1032,7 @@
                             "type": "object",
                             "title": "A map of key/value pairs to set as environment variables for the deployment.",
                             "description": "Optional. Values support OS & AZD environment variable substitution.",
-                            "additionalProperties":{
+                            "additionalProperties": {
                                 "type": "string"
                             }
                         }


### PR DESCRIPTION
Updates `azure.yaml` schema to support both single and multi-hook configuration

> [!IMPORTANT] 
> Should not merge till release day since schema updates are not managed as part of the release.

## Supports single hook per event (legacy)
```yaml
name: test-proj
services:
    api:
        project: src/api
        host: containerapp
        language: ts
        hooks:
            postprovision:
                shell: sh
                run: scripts/postprovision.sh
hooks:
    postprovision:
        shell: sh
        run: scripts/postprovision.sh
```

## Supports multiple hooks per event (new)
```yaml
name: test-proj
services:
    api:
        project: src/api
        host: containerapp
        language: ts
        hooks:
            postprovision:
                - shell: sh
                  run: scripts/postprovision1.sh
                - shell: sh
                  run: scripts/postprovision2.sh
hooks:
    postprovision:
        - shell: sh
          run: scripts/postprovision1.sh
        - shell: sh
          run: scripts/postprovision2.sh
```

