### PR TITLE
Fixes blinking provisioning output

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -639,7 +639,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 
 	container.MustRegisterSingleton(azapi.NewStandardDeployments)
 	container.MustRegisterSingleton(azapi.NewStackDeployments)
-	container.MustRegisterSingleton(infra.NewDeploymentManager)
+	container.MustRegisterScoped(infra.NewDeploymentManager)
 	container.MustRegisterSingleton(infra.NewAzureResourceManager)
 	container.MustRegisterScoped(provisioning.NewManager)
 	container.MustRegisterScoped(provisioning.NewPrincipalIdProvider)


### PR DESCRIPTION
Fixes the blinking provisioning output when calling `azd up`

Fixes #4266

## What was the issue?

The new `DeploymentManager` component was registered as a `singleton` within our IoC container and was also taking a dependency on a scoped `console` component.  

Since `azd up` creates a separate container scope per command invocation it was causing the console instance to be used from the root command invocation instead of the scoped instance of the provision command.

The calls to `console.ShowSpinner` used in the bicep provider vs the progress display component used different instances of the console component which allowed the bypassing of the mutex to ensure a progress lock was not already in place.

## What was the fix?

The fix was to update the `DeploymentManager` to also be registered as a scoped component to leverage the correct instance of the console which gets us back to a good state.

## Long term strategy

This was a weird issue where the lifetime registration caused an unintended UX side effect that could have taken a long time to discover and identify.  As we move forward to address some issues with the IoC container we can also perform some check at component registration time to ensure that a dependency of a component does not have a lifetime that is shorter than the current component being registered.