### PR TITLE
Support configurable `api-version` for container app deployments

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -12,6 +12,7 @@ words:
   - azcloud
   - usgovcloudapi
   - chinacloudapi
+  - unmarshals
 languageSettings:
   - languageId: go
     ignoreRegExpList:

--- a/cli/azd/pkg/config/config.go
+++ b/cli/azd/pkg/config/config.go
@@ -29,12 +29,23 @@ type Config interface {
 	Raw() map[string]any
 	// similar to Raw() but it will resolve any vault references
 	ResolvedRaw() map[string]any
+	// Get retrieves the value stored at the specified path
 	Get(path string) (any, bool)
+	// GetString retrieves the value stored at the specified path as a string
 	GetString(path string) (string, bool)
+	// GetSection retrieves the value stored at the specified path and unmarshals it into the provided section
 	GetSection(path string, section any) (bool, error)
+	// GetMap retrieves the map stored at the specified path
+	GetMap(path string) (map[string]any, bool)
+	// GetSlice retrieves the slice stored at the specified path
+	GetSlice(path string) ([]any, bool)
+	// Set stores the value at the specified path
 	Set(path string, value any) error
+	// SetSecret stores the secrets at the specified path within a local user vault
 	SetSecret(path string, value string) error
+	// Unset removes the value stored at the specified path
 	Unset(path string) error
+	// IsEmpty returns a value indicating whether the configuration is empty
 	IsEmpty() bool
 }
 
@@ -228,6 +239,28 @@ func (c *config) Get(path string) (any, bool) {
 	}
 
 	return nil, false
+}
+
+// GetMap retrieves the map stored at the specified path
+func (c *config) GetMap(path string) (map[string]any, bool) {
+	value, ok := c.Get(path)
+	if !ok {
+		return nil, false
+	}
+
+	node, ok := value.(map[string]any)
+	return node, ok
+}
+
+// GetSlice retrieves the slice stored at the specified path
+func (c *config) GetSlice(path string) ([]any, bool) {
+	value, ok := c.Get(path)
+	if !ok {
+		return nil, false
+	}
+
+	node, ok := value.([]any)
+	return node, ok
 }
 
 // Gets the value stored at the specified location as a string

--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -337,7 +337,10 @@ func (cas *containerAppService) AddRevision(
 		return fmt.Errorf("getting revision template: %w", err)
 	}
 
-	containerApp.Set(pathTemplate, revisionTemplate)
+	if err := containerApp.Set(pathTemplate, revisionTemplate); err != nil {
+		return fmt.Errorf("setting template: %w", err)
+	}
+
 	containerApp, err = cas.syncSecrets(ctx, subscriptionId, resourceGroupName, appName, containerApp)
 	if err != nil {
 		return fmt.Errorf("syncing secrets: %w", err)
@@ -369,25 +372,6 @@ func (cas *containerAppService) AddRevision(
 	}
 
 	return nil
-}
-
-func (cas *containerAppService) listSecrets(
-	ctx context.Context,
-	subscriptionId string,
-	resourceGroupName string,
-	appName string,
-) ([]*armappcontainers.ContainerAppSecret, error) {
-	appClient, err := cas.createContainerAppsClient(ctx, subscriptionId, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	secretsResponse, err := appClient.ListSecrets(ctx, resourceGroupName, appName, nil)
-	if err != nil {
-		return nil, fmt.Errorf("listing secrets: %w", err)
-	}
-
-	return secretsResponse.Value, nil
 }
 
 func (cas *containerAppService) syncSecrets(

--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -151,16 +151,20 @@ func (cas *containerAppService) persistSettings(
 	objConfig := config.NewConfig(obj)
 
 	if shouldPersistDomains {
-		customDomains, ok := aca.GetSlice(pathConfigurationIngressCustomDomains)
-		if ok {
-			objConfig.Set(pathConfigurationIngressCustomDomains, customDomains)
+		customDomains, has := aca.GetSlice(pathConfigurationIngressCustomDomains)
+		if has {
+			if err := objConfig.Set(pathConfigurationIngressCustomDomains, customDomains); err != nil {
+				return nil, fmt.Errorf("setting custom domains: %w", err)
+			}
 		}
 	}
 
 	if shouldPersistIngressSessionAffinity {
 		stickySessions, has := aca.Get(pathConfigurationIngressStickySessions)
 		if has {
-			objConfig.Set(pathConfigurationIngressStickySessions, stickySessions)
+			if err := objConfig.Set(pathConfigurationIngressStickySessions, stickySessions); err != nil {
+				return nil, fmt.Errorf("setting sticky sessions: %w", err)
+			}
 		}
 	}
 

--- a/cli/azd/pkg/containerapps/container_app_test.go
+++ b/cli/azd/pkg/containerapps/container_app_test.go
@@ -43,7 +43,7 @@ func Test_ContainerApp_GetIngressConfiguration(t *testing.T) {
 		mockContext.ArmClientOptions,
 		mockContext.AlphaFeaturesManager,
 	)
-	ingressConfig, err := cas.GetIngressConfiguration(*mockContext.Context, subscriptionId, resourceGroup, appName)
+	ingressConfig, err := cas.GetIngressConfiguration(*mockContext.Context, subscriptionId, resourceGroup, appName, nil)
 	require.NoError(t, err)
 	require.NotNil(t, ingressConfig)
 
@@ -138,7 +138,7 @@ func Test_ContainerApp_AddRevision(t *testing.T) {
 		mockContext.ArmClientOptions,
 		mockContext.AlphaFeaturesManager,
 	)
-	err := cas.AddRevision(*mockContext.Context, subscriptionId, resourceGroup, appName, updatedImageName)
+	err := cas.AddRevision(*mockContext.Context, subscriptionId, resourceGroup, appName, updatedImageName, nil)
 	require.NoError(t, err)
 
 	// Verify lastest revision is read

--- a/cli/azd/pkg/containerapps/container_app_test.go
+++ b/cli/azd/pkg/containerapps/container_app_test.go
@@ -160,3 +160,92 @@ func Test_ContainerApp_AddRevision(t *testing.T) {
 	require.Equal(t, updatedImageName, *updatedContainerApp.Properties.Template.Containers[0].Image)
 	require.Equal(t, "azd-0", *updatedContainerApp.Properties.Template.RevisionSuffix)
 }
+
+func Test_ContainerApp_DeployYaml(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+
+	subscriptionId := "SUBSCRIPTION_ID"
+	location := "eastus2"
+	resourceGroup := "RESOURCE_GROUP"
+	appName := "APP_NAME"
+
+	containerAppYaml := `
+location: eastus2
+name: APP_NAME
+properties:
+  latestRevisionName: LATEST_REVISION_NAME
+  configuration:
+    activeRevisionsMode: Single
+  template:
+    containers:
+      - image: IMAGE_NAME
+`
+
+	expected := &armappcontainers.ContainerApp{
+		Location: to.Ptr(location),
+		Name:     to.Ptr(appName),
+		Properties: &armappcontainers.ContainerAppProperties{
+			LatestRevisionName: to.Ptr("LATEST_REVISION_NAME"),
+			Configuration: &armappcontainers.Configuration{
+				ActiveRevisionsMode: to.Ptr(armappcontainers.ActiveRevisionsModeSingle),
+				Ingress: &armappcontainers.Ingress{
+					CustomDomains: []*armappcontainers.CustomDomain{
+						{
+							Name: to.Ptr("DOMAIN_NAME"),
+						},
+					},
+					StickySessions: &armappcontainers.IngressStickySessions{
+						Affinity: to.Ptr(armappcontainers.AffinitySticky),
+					},
+				},
+			},
+			Template: &armappcontainers.Template{
+				Containers: []*armappcontainers.Container{
+					{
+						Image: to.Ptr("IMAGE_NAME"),
+					},
+				},
+			},
+		},
+	}
+
+	containerAppGetRequest := mockazsdk.MockContainerAppGet(
+		mockContext,
+		subscriptionId,
+		resourceGroup,
+		appName,
+		expected,
+	)
+	require.NotNil(t, containerAppGetRequest)
+
+	containerAppUpdateRequest := mockazsdk.MockContainerAppCreateOrUpdate(
+		mockContext,
+		subscriptionId,
+		resourceGroup,
+		appName,
+		expected,
+	)
+	require.NotNil(t, containerAppUpdateRequest)
+
+	cas := NewContainerAppService(
+		mockContext.SubscriptionCredentialProvider,
+		clock.NewMock(),
+		mockContext.ArmClientOptions,
+		mockContext.AlphaFeaturesManager,
+	)
+
+	err := mockContext.Config.Set("alpha.aca.persistDomains", "on")
+	require.NoError(t, err)
+	err = mockContext.Config.Set("alpha.aca.persistIngressSessionAffinity", "on")
+	require.NoError(t, err)
+
+	err = cas.DeployYaml(*mockContext.Context, subscriptionId, resourceGroup, appName, []byte(containerAppYaml), nil)
+	require.NoError(t, err)
+
+	var actual *armappcontainers.ContainerApp
+	err = mocks.ReadHttpBody(containerAppUpdateRequest.Body, &actual)
+	require.NoError(t, err)
+
+	require.Equal(t, expected.Properties.Configuration, actual.Properties.Configuration)
+	require.Equal(t, expected.Properties.Template, actual.Properties.Template)
+}

--- a/cli/azd/pkg/convert/util.go
+++ b/cli/azd/pkg/convert/util.go
@@ -64,6 +64,7 @@ func ToMap(value any) (map[string]any, error) {
 	return mapValue, nil
 }
 
+// ToJsonArray converts the specified value (slice) to a json array
 func ToJsonArray(value any) ([]any, error) {
 	if value == nil {
 		return nil, nil
@@ -89,6 +90,7 @@ func ParseDuration(value string) (time.Duration, error) {
 	return time.ParseDuration(value)
 }
 
+// FromHttpResponse reads the response body from the specified http response and converts it into the specified value
 func FromHttpResponse(res *http.Response, v any) error {
 	defer res.Body.Close()
 	body, err := io.ReadAll(res.Body)

--- a/cli/azd/pkg/convert/util.go
+++ b/cli/azd/pkg/convert/util.go
@@ -3,6 +3,8 @@ package convert
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"reflect"
 	"strings"
 	"time"
@@ -67,4 +69,19 @@ func ParseDuration(value string) (time.Duration, error) {
 	value = strings.ToLower(value)
 
 	return time.ParseDuration(value)
+}
+
+func FromHttpResponse(res *http.Response, v any) error {
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	err = json.Unmarshal(body, &v)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal response body: %w", err)
+	}
+
+	return nil
 }

--- a/cli/azd/pkg/convert/util.go
+++ b/cli/azd/pkg/convert/util.go
@@ -56,12 +56,30 @@ func ToMap(value any) (map[string]any, error) {
 		return nil, fmt.Errorf("failed to convert value to json: %w", err)
 	}
 
-	mapValue := map[string]any{}
+	var mapValue map[string]any
 	if err := json.Unmarshal(jsonValue, &mapValue); err != nil {
 		return nil, fmt.Errorf("failed to convert value to map: %w", err)
 	}
 
 	return mapValue, nil
+}
+
+func ToJsonArray(value any) ([]any, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	jsonValue, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert value to json: %w", err)
+	}
+
+	var sliceValue []any
+	if err := json.Unmarshal(jsonValue, &sliceValue); err != nil {
+		return nil, fmt.Errorf("failed to convert value to slice: %w", err)
+	}
+
+	return sliceValue, nil
 }
 
 func ParseDuration(value string) (time.Duration, error) {

--- a/cli/azd/pkg/convert/util.go
+++ b/cli/azd/pkg/convert/util.go
@@ -96,8 +96,7 @@ func FromHttpResponse(res *http.Response, v any) error {
 		return fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	err = json.Unmarshal(body, &v)
-	if err != nil {
+	if err := json.Unmarshal(body, &v); err != nil {
 		return fmt.Errorf("failed to unmarshal response body: %w", err)
 	}
 

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -18,6 +18,8 @@ type ServiceConfig struct {
 	ResourceGroupName osutil.ExpandableString `yaml:"resourceGroup,omitempty"`
 	// The name used to override the default azure resource name
 	ResourceName osutil.ExpandableString `yaml:"resourceName,omitempty"`
+	// The ARM api version to use for the service. If not specified, the latest version is used.
+	ApiVersion string `yaml:"apiVersion,omitempty"`
 	// The relative path to the project folder from the project root
 	RelativePath string `yaml:"project"`
 	// The azure hosting model to use, ex) appservice, function, containerapp

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -86,6 +86,10 @@ func (at *containerAppTarget) Deploy(
 		return nil, err
 	}
 
+	containerAppOptions := containerapps.ContainerAppOptions{
+		ApiVersion: serviceConfig.ApiVersion,
+	}
+
 	imageName := at.env.GetServiceProperty(serviceConfig.Name, "IMAGE_NAME")
 	progress.SetProgress(NewServiceProgress("Updating container app revision"))
 	err = at.containerAppService.AddRevision(
@@ -94,6 +98,7 @@ func (at *containerAppTarget) Deploy(
 		targetResource.ResourceGroupName(),
 		targetResource.ResourceName(),
 		imageName,
+		&containerAppOptions,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("updating container app service: %w", err)
@@ -123,11 +128,16 @@ func (at *containerAppTarget) Endpoints(
 	serviceConfig *ServiceConfig,
 	targetResource *environment.TargetResource,
 ) ([]string, error) {
+	containerAppOptions := containerapps.ContainerAppOptions{
+		ApiVersion: serviceConfig.ApiVersion,
+	}
+
 	if ingressConfig, err := at.containerAppService.GetIngressConfiguration(
 		ctx,
 		targetResource.SubscriptionId(),
 		targetResource.ResourceGroupName(),
 		targetResource.ResourceName(),
+		&containerAppOptions,
 	); err != nil {
 		return nil, fmt.Errorf("fetching service properties: %w", err)
 	} else {

--- a/cli/azd/pkg/project/service_target_dotnet_containerapp.go
+++ b/cli/azd/pkg/project/service_target_dotnet_containerapp.go
@@ -254,12 +254,17 @@ func (at *dotnetContainerAppTarget) Deploy(
 		return nil, fmt.Errorf("failed executing template file: %w", err)
 	}
 
+	containerAppOptions := containerapps.ContainerAppOptions{
+		ApiVersion: serviceConfig.ApiVersion,
+	}
+
 	err = at.containerAppService.DeployYaml(
 		ctx,
 		targetResource.SubscriptionId(),
 		targetResource.ResourceGroupName(),
 		serviceConfig.Name,
 		[]byte(builder.String()),
+		&containerAppOptions,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("updating container app service: %w", err)
@@ -296,11 +301,16 @@ func (at *dotnetContainerAppTarget) Endpoints(
 	serviceConfig *ServiceConfig,
 	targetResource *environment.TargetResource,
 ) ([]string, error) {
+	containerAppOptions := containerapps.ContainerAppOptions{
+		ApiVersion: serviceConfig.ApiVersion,
+	}
+
 	if ingressConfig, err := at.containerAppService.GetIngressConfiguration(
 		ctx,
 		targetResource.SubscriptionId(),
 		targetResource.ResourceGroupName(),
 		targetResource.ResourceName(),
+		&containerAppOptions,
 	); err != nil {
 		return nil, fmt.Errorf("fetching service properties: %w", err)
 	} else {

--- a/cli/azd/test/mocks/mockazsdk/container_apps.go
+++ b/cli/azd/test/mocks/mockazsdk/container_apps.go
@@ -41,6 +41,36 @@ func MockContainerAppGet(
 	return mockRequest
 }
 
+func MockContainerAppCreateOrUpdate(
+	mockContext *mocks.MockContext,
+	subscriptionId string,
+	resourceGroup string,
+	appName string,
+	containerApp *armappcontainers.ContainerApp,
+) *http.Request {
+	mockRequest := &http.Request{}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodPut && strings.Contains(
+			request.URL.Path,
+			fmt.Sprintf(
+				"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/containerApps/%s",
+				subscriptionId,
+				resourceGroup,
+				appName,
+			),
+		)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*mockRequest = *request
+
+		response := armappcontainers.ContainerAppsClientCreateOrUpdateResponse{}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusCreated, response)
+	})
+
+	return mockRequest
+}
+
 func MockContainerAppUpdate(
 	mockContext *mocks.MockContext,
 	subscriptionId string,

--- a/cli/azd/test/mocks/util.go
+++ b/cli/azd/test/mocks/util.go
@@ -31,3 +31,15 @@ func CreateEmptyHttpResponse(request *http.Request, statusCode int) (*http.Respo
 		Body:       http.NoBody,
 	}, nil
 }
+
+// ReadHttpBody reads the body of an HTTP request or response and converts it into the specified object
+func ReadHttpBody(body io.ReadCloser, v any) error {
+	defer body.Close()
+
+	jsonBytes, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(jsonBytes, v)
+}


### PR DESCRIPTION
## Features

- Adds support to specify an explicit `api-version` to use for Container apps that is leveraged during container app deployment to avoid getting and unmarshalling to incompatible api-versions and losing configuration data set in bicep.

- Updates deployment scenarios to be more loosely coupled to avoid loosing custom configuration data during JSON marshalling to hard coded SDK versions.

If an `apiVersion` is not set in the service config the SDK will fall back to use the SDK `api-version` it was originally from.

Fixes: #4264

## Usage Example

```yaml
name: todo-nodejs-mongo-aca
services:
  web:
    project: ./src/web
    language: js
    host: containerapp
    apiVersion: 2024-02-02-preview # Force `azd` to use this API version for GET/PATCH operations
  api:
    project: ./src/api
    language: js
    host: containerapp
    apiVersion: 2024-02-02-preview # Force `azd` to use this API version for GET/PATCH operations
```

App can be validated with the following fork of todo-aca sample
```bash
azd init -t https://github.com/wbreza/todo-nodejs-mongo-aca -b api-version
```