### PR TITLE
Fixes issues resolving target resource for service targets that support delayed provisioning

### DIFF
--- a/cli/azd/pkg/project/resource_manager.go
+++ b/cli/azd/pkg/project/resource_manager.go
@@ -240,7 +240,7 @@ func (rm *resourceManager) resolveServiceResource(
 	if err != nil &&
 		errors.As(err, &resourceNotFoundError) &&
 		ServiceTargetKind(serviceConfig.Host).SupportsDelayedProvisioning() {
-		return azureResource, nil
+		return &azapi.Resource{}, nil
 	}
 
 	if err != nil {


### PR DESCRIPTION
Fixes issue/panic where an empty ServiceTarget should be resolved for service targets that support delayed provisioning.

(Regression from Deployment stacks work)