### PR TITLE
filter out location for STG

### DIFF
--- a/cli/azd/pkg/azureutil/location.go
+++ b/cli/azd/pkg/azureutil/location.go
@@ -34,6 +34,9 @@ func PromptLocationWithFilter(
 	locations := make([]account.Location, 0, len(allLocations))
 
 	for _, location := range allLocations {
+		if strings.Contains(location.RegionalDisplayName, "STG") {
+			continue
+		}
 		if shouldDisplay == nil || shouldDisplay(location) {
 			locations = append(locations, location)
 		}


### PR DESCRIPTION
fix #4184 
STG location was originally used for some testing on Aspire. With current usage, we should delete it as we are not using it anymore and we shouldn't expose and confuse users these internal STG locations.