### PR TITLE
fix gh cli breaking change parsing err msg

### DIFF
--- a/cli/azd/pkg/tools/github/github.go
+++ b/cli/azd/pkg/tools/github/github.go
@@ -438,7 +438,7 @@ var isGhCliNotLoggedInMessageRegex = regexp.MustCompile(
 var repositoryNameInUseRegex = regexp.MustCompile(`GraphQL: Name already exists on this account \(createRepository\)`)
 
 var notLoggedIntoAnyGitHubHostsMessageRegex = regexp.MustCompile(
-	"You are not logged into any GitHub hosts. Run gh auth login to authenticate.",
+	"You are not logged into any GitHub hosts.",
 )
 
 var isUserNotAuthorizedMessageRegex = regexp.MustCompile(

--- a/cli/azd/pkg/tools/github/github_test.go
+++ b/cli/azd/pkg/tools/github/github_test.go
@@ -142,6 +142,45 @@ func TestNewGitHubCli(t *testing.T) {
 	require.Equal(t, Version.String(), ver)
 }
 
+func TestGetAuthStatus(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(args.Cmd, "gh") && len(args.Args) == 1 && args.Args[0] == "--version"
+	}).Respond(exec.NewRunResult(
+		0,
+		fmt.Sprintf("gh version %s (abcdef0123)", Version.String()),
+		"",
+	))
+
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(args.Cmd, "gh") && args.Args[0] == "auth" && args.Args[1] == "status"
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		return exec.NewRunResult(1, "", notLoggedIntoAnyGitHubHostsMessageRegex.String()), fmt.Errorf("error")
+	})
+
+	mockExtract := func(src, dst string) (string, error) {
+		exp, _ := azdGithubCliPath()
+		_ = osutil.Rename(context.Background(), src, exp)
+		return src, nil
+	}
+
+	cli, err := newGitHubCliImplementation(
+		*mockContext.Context,
+		mockContext.Console,
+		mockContext.CommandRunner,
+		mockContext.HttpClient,
+		downloadGh,
+		mockExtract,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, cli)
+
+	status, err := cli.GetAuthStatus(*mockContext.Context, "test")
+	require.NoError(t, err)
+	require.Equal(t, AuthStatus{}, status)
+}
+
 func TestNewGitHubCliUpdate(t *testing.T) {
 	configRoot := t.TempDir()
 	t.Setenv("AZD_CONFIG_DIR", configRoot)


### PR DESCRIPTION
Updating the expected message for gh-cli not-logged-in error after a regression on newer gh-cli version.
The wording was changed for newer version making azd to fail to recognize the error message. The change here make make azd
to know when this error happens again.

fix: https://github.com/Azure/azure-dev/issues/4275
