### PR TITLE
Fix azd-pipeline-config for terraform forced client secret)

### DIFF
--- a/cli/azd/pkg/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/pipeline/azdo_provider.go
@@ -771,10 +771,10 @@ func (p *AzdoCiProvider) configureConnection(
 	repoDetails *gitRepositoryDetails,
 	provisioningProvider provisioning.Options,
 	servicePrincipal *graphsdk.ServicePrincipal,
-	authType PipelineAuthType,
+	credentialOptions *CredentialOptions,
 	credentials *entraid.AzureCredentials,
 ) error {
-	if authType == "" || authType == AuthTypeFederated {
+	if credentialOptions.EnableFederatedCredentials {
 		// default and federated credentials are set up in credentialOptions
 		return nil
 	}

--- a/cli/azd/pkg/pipeline/github_provider.go
+++ b/cli/azd/pkg/pipeline/github_provider.go
@@ -459,16 +459,11 @@ func (p *GitHubCiProvider) configureConnection(
 	repoDetails *gitRepositoryDetails,
 	infraOptions provisioning.Options,
 	servicePrincipal *graphsdk.ServicePrincipal,
-	authType PipelineAuthType,
+	credentialOptions *CredentialOptions,
 	credentials *entraid.AzureCredentials,
 ) error {
-	// Default auth type to client-credentials for terraform
-	if infraOptions.Provider == provisioning.Terraform && authType == "" {
-		authType = AuthTypeClientCredentials
-	}
-
 	repoSlug := repoDetails.owner + "/" + repoDetails.repoName
-	if authType == AuthTypeClientCredentials {
+	if credentialOptions.EnableClientCredentials {
 		err := p.configureClientCredentialsAuth(ctx, infraOptions, repoSlug, credentials)
 		if err != nil {
 			return fmt.Errorf("configuring client credentials auth: %w", err)

--- a/cli/azd/pkg/pipeline/pipeline.go
+++ b/cli/azd/pkg/pipeline/pipeline.go
@@ -122,7 +122,7 @@ type CiProvider interface {
 		gitRepo *gitRepositoryDetails,
 		provisioningProvider provisioning.Options,
 		servicePrincipal *graphsdk.ServicePrincipal,
-		authType PipelineAuthType,
+		credentialOptions *CredentialOptions,
 		credentials *entraid.AzureCredentials,
 	) error
 	// Gets the credential options that should be configured for the provider

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -375,7 +375,7 @@ func (pm *PipelineManager) Configure(ctx context.Context, projectName string) (r
 		gitRepoInfo,
 		infra.Options,
 		servicePrincipal,
-		PipelineAuthType(pm.args.PipelineAuthTypeName),
+		credentialOptions,
 		credentials,
 	)
 


### PR DESCRIPTION
Fixing a nil credential due to a wrong validation when user did not use --auth-type arg.
The azdo provider was taking the empty argument as a way to default to Federated Credential, ignoring if
Terraform forced the use of client-secret before.

This fix uses the CI provider's credential options that are generated before configuring the pipeline to know
the authentication type, instead of looking at the commands arguments again.

Fix: https://github.com/Azure/azure-dev/issues/4273