### PR TITLE
WIP: provisioning: Consider `resourceGroup` from `azure.yaml`

### DIFF
--- a/cli/azd/cmd/down.go
+++ b/cli/azd/cmd/down.go
@@ -98,7 +98,8 @@ func (a *downAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	}
 	defer func() { _ = infra.Cleanup() }()
 
-	if err := a.provisionManager.Initialize(ctx, a.projectConfig.Path, infra.Options); err != nil {
+	err = a.provisionManager.Initialize(ctx, a.projectConfig.Path, infra.Options, a.projectConfig.ResourceGroupName)
+	if err != nil {
 		return nil, fmt.Errorf("initializing provisioning manager: %w", err)
 	}
 

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -458,7 +458,7 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 	defer func() { _ = infra.Cleanup() }()
 
 	// env refresh supports "BYOI" infrastructure where bicep isn't available
-	err = ef.provisionManager.Initialize(ctx, ef.projectConfig.Path, infra.Options)
+	err = ef.provisionManager.Initialize(ctx, ef.projectConfig.Path, infra.Options, ef.projectConfig.ResourceGroupName)
 	if errors.Is(err, bicep.ErrEnsureEnvPreReqBicepCompileFailed) {
 		// If bicep is not available, we continue to prompt for subscription and location unfiltered
 		err = provisioning.EnsureSubscriptionAndLocation(ctx, ef.envManager, ef.env, ef.prompters,

--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -165,7 +165,7 @@ func (p *pipelineConfigAction) Run(ctx context.Context) (*actions.ActionResult, 
 	}
 	defer func() { _ = infra.Cleanup() }()
 
-	err = p.provisioningManager.Initialize(ctx, p.projectConfig.Path, infra.Options)
+	err = p.provisioningManager.Initialize(ctx, p.projectConfig.Path, infra.Options, p.projectConfig.ResourceGroupName)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -110,7 +110,7 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 	// TODO(weilim): remove this once we have decided if it's okay to not set AZURE_SUBSCRIPTION_ID and AZURE_LOCATION
 	// early in the up workflow in #3745
-	err = u.provisioningManager.Initialize(ctx, u.projectConfig.Path, infra.Options)
+	err = u.provisioningManager.Initialize(ctx, u.projectConfig.Path, infra.Options, u.projectConfig.ResourceGroupName)
 	if errors.Is(err, bicep.ErrEnsureEnvPreReqBicepCompileFailed) {
 		// If bicep is not available, we continue to prompt for subscription and location unfiltered
 		err = provisioning.EnsureSubscriptionAndLocation(ctx, u.envManager, u.env, u.prompters, nil)

--- a/cli/azd/internal/cmd/provision.go
+++ b/cli/azd/internal/cmd/provision.go
@@ -193,7 +193,8 @@ func (p *ProvisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 
 	infraOptions := infra.Options
 	infraOptions.IgnoreDeploymentState = p.flags.ignoreDeploymentState
-	if err := p.provisionManager.Initialize(ctx, p.projectConfig.Path, infraOptions); err != nil {
+	err = p.provisionManager.Initialize(ctx, p.projectConfig.Path, infraOptions, p.projectConfig.ResourceGroupName)
+	if err != nil {
 		return nil, fmt.Errorf("initializing provisioning manager: %w", err)
 	}
 

--- a/cli/azd/internal/vsrpc/environment_service.go
+++ b/cli/azd/internal/vsrpc/environment_service.go
@@ -168,7 +168,9 @@ func (s *environmentService) DeleteEnvironmentAsync(
 		}
 		defer func() { _ = projectInfra.Cleanup() }()
 
-		if err := c.provisionManager.Initialize(ctx, c.projectConfig.Path, projectInfra.Options); err != nil {
+		err = c.provisionManager.Initialize(
+			ctx, c.projectConfig.Path, projectInfra.Options, c.projectConfig.ResourceGroupName)
+		if err != nil {
 			return false, fmt.Errorf("initializing provisioning manager: %w", err)
 		}
 

--- a/cli/azd/internal/vsrpc/environment_service_refresh.go
+++ b/cli/azd/internal/vsrpc/environment_service_refresh.go
@@ -15,6 +15,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/bicep"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 )
 
@@ -82,7 +83,7 @@ func (s *environmentService) refreshEnvironmentAsync(
 	}
 	defer func() { _ = infra.Cleanup() }()
 
-	if err := bicepProvider.Initialize(ctx, c.projectConfig.Path, infra.Options); err != nil {
+	if err := bicepProvider.Initialize(ctx, c.projectConfig.Path, infra.Options, osutil.EmptyExpandableString); err != nil {
 		return nil, fmt.Errorf("initializing provisioning manager: %w", err)
 	}
 

--- a/cli/azd/pkg/devcenter/provision_provider.go
+++ b/cli/azd/pkg/devcenter/provision_provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
@@ -74,7 +75,12 @@ func (p *ProvisionProvider) Name() string {
 }
 
 // Initialize initializes the provider
-func (p *ProvisionProvider) Initialize(ctx context.Context, projectPath string, options provisioning.Options) error {
+func (p *ProvisionProvider) Initialize(
+	ctx context.Context,
+	projectPath string,
+	options provisioning.Options,
+	_ osutil.ExpandableString,
+) error {
 	p.options = options
 
 	return p.EnsureEnv(ctx)

--- a/cli/azd/pkg/devcenter/provision_provider_test.go
+++ b/cli/azd/pkg/devcenter/provision_provider_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockdevcentersdk"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockenv"
@@ -40,7 +41,7 @@ func Test_ProvisionProvider_Initialize(t *testing.T) {
 		_ = env.Config.Set("platform.config", configMap)
 
 		provider := newProvisionProviderForTest(t, mockContext, config, env, nil)
-		err = provider.Initialize(*mockContext.Context, "project/path", provisioning.Options{})
+		err = provider.Initialize(*mockContext.Context, "project/path", provisioning.Options{}, osutil.EmptyExpandableString)
 		require.NoError(t, err)
 	})
 
@@ -68,7 +69,7 @@ func Test_ProvisionProvider_Initialize(t *testing.T) {
 		}).Respond(selectedEnvironmentTypeIndex)
 
 		provider := newProvisionProviderForTest(t, mockContext, config, env, nil)
-		err = provider.Initialize(*mockContext.Context, "project/path", provisioning.Options{})
+		err = provider.Initialize(*mockContext.Context, "project/path", provisioning.Options{}, osutil.EmptyExpandableString)
 		require.NoError(t, err)
 
 		actualEnvironmentType, ok := env.Config.Get(DevCenterEnvTypePath)
@@ -199,7 +200,7 @@ func Test_ProvisionProvider_Deploy(t *testing.T) {
 
 		provider := newProvisionProviderForTest(t, mockContext, config, env, manager)
 
-		err := provider.Initialize(*mockContext.Context, "project/path", provisioning.Options{})
+		err := provider.Initialize(*mockContext.Context, "project/path", provisioning.Options{}, osutil.EmptyExpandableString)
 		require.NoError(t, err)
 
 		result, err := provider.Deploy(*mockContext.Context)

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/keyvault"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/bicep"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -384,7 +385,7 @@ func createBicepProvider(t *testing.T, mockContext *mocks.MockContext) *BicepPro
 		cloud.AzurePublic(),
 	)
 
-	err = provider.Initialize(*mockContext.Context, projectDir, options)
+	err = provider.Initialize(*mockContext.Context, projectDir, options, osutil.EmptyExpandableString)
 	require.NoError(t, err)
 
 	return provider.(*BicepProvider)

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -48,7 +48,7 @@ const (
 	defaultPath   = "infra"
 )
 
-func (m *Manager) Initialize(ctx context.Context, projectPath string, options Options) error {
+func (m *Manager) Initialize(ctx context.Context, projectPath string, options Options, rg osutil.ExpandableString) error {
 	// applied defaults if missing
 	if options.Module == "" {
 		options.Module = defaultModule
@@ -66,7 +66,7 @@ func (m *Manager) Initialize(ctx context.Context, projectPath string, options Op
 	}
 
 	m.provider = provider
-	return m.provider.Initialize(ctx, projectPath, options)
+	return m.provider.Initialize(ctx, projectPath, options, rg)
 }
 
 // Gets the latest deployment details for the specified scope

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/test"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -56,7 +57,7 @@ func TestProvisionInitializesEnvironment(t *testing.T) {
 		nil,
 		cloud.AzurePublic(),
 	)
-	err := mgr.Initialize(*mockContext.Context, "", provisioning.Options{Provider: "test"})
+	err := mgr.Initialize(*mockContext.Context, "", provisioning.Options{Provider: "test"}, osutil.NewExpandableString(""))
 	require.NoError(t, err)
 
 	require.Equal(t, "00000000-0000-0000-0000-000000000000", env.GetSubscriptionId())
@@ -83,7 +84,7 @@ func TestManagerPreview(t *testing.T) {
 		nil,
 		cloud.AzurePublic(),
 	)
-	err := mgr.Initialize(*mockContext.Context, "", provisioning.Options{Provider: "test"})
+	err := mgr.Initialize(*mockContext.Context, "", provisioning.Options{Provider: "test"}, osutil.NewExpandableString(""))
 	require.NoError(t, err)
 
 	deploymentPlan, err := mgr.Preview(*mockContext.Context)
@@ -112,7 +113,7 @@ func TestManagerGetState(t *testing.T) {
 		nil,
 		cloud.AzurePublic(),
 	)
-	err := mgr.Initialize(*mockContext.Context, "", provisioning.Options{Provider: "test"})
+	err := mgr.Initialize(*mockContext.Context, "", provisioning.Options{Provider: "test"}, osutil.NewExpandableString(""))
 	require.NoError(t, err)
 
 	getResult, err := mgr.State(*mockContext.Context, nil)
@@ -141,7 +142,7 @@ func TestManagerDeploy(t *testing.T) {
 		nil,
 		cloud.AzurePublic(),
 	)
-	err := mgr.Initialize(*mockContext.Context, "", provisioning.Options{Provider: "test"})
+	err := mgr.Initialize(*mockContext.Context, "", provisioning.Options{Provider: "test"}, osutil.NewExpandableString(""))
 	require.NoError(t, err)
 
 	deployResult, err := mgr.Deploy(*mockContext.Context)
@@ -176,7 +177,7 @@ func TestManagerDestroyWithPositiveConfirmation(t *testing.T) {
 		nil,
 		cloud.AzurePublic(),
 	)
-	err := mgr.Initialize(*mockContext.Context, "", provisioning.Options{Provider: "test"})
+	err := mgr.Initialize(*mockContext.Context, "", provisioning.Options{Provider: "test"}, osutil.NewExpandableString(""))
 	require.NoError(t, err)
 
 	destroyOptions := provisioning.NewDestroyOptions(false, false)
@@ -212,7 +213,7 @@ func TestManagerDestroyWithNegativeConfirmation(t *testing.T) {
 		nil,
 		cloud.AzurePublic(),
 	)
-	err := mgr.Initialize(*mockContext.Context, "", provisioning.Options{Provider: "test"})
+	err := mgr.Initialize(*mockContext.Context, "", provisioning.Options{Provider: "test"}, osutil.NewExpandableString(""))
 	require.NoError(t, err)
 
 	destroyOptions := provisioning.NewDestroyOptions(false, false)

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -5,6 +5,8 @@ package provisioning
 
 import (
 	"context"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 )
 
 type ProviderKind string
@@ -52,10 +54,9 @@ type StateResult struct {
 
 type Provider interface {
 	Name() string
-	Initialize(ctx context.Context, projectPath string, options Options) error
+	Initialize(ctx context.Context, projectPath string, options Options, rg osutil.ExpandableString) error
 	State(ctx context.Context, options *StateOptions) (*StateResult, error)
 	Deploy(ctx context.Context) (*DeployResult, error)
 	Preview(ctx context.Context) (*DeployPreviewResult, error)
 	Destroy(ctx context.Context, options DestroyOptions) (*DestroyResult, error)
-	EnsureEnv(ctx context.Context) error
 }

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -76,7 +76,12 @@ func NewTerraformProvider(
 	return provider
 }
 
-func (t *TerraformProvider) Initialize(ctx context.Context, projectPath string, options provisioning.Options) error {
+func (t *TerraformProvider) Initialize(
+	ctx context.Context,
+	projectPath string,
+	options provisioning.Options,
+	_ osutil.ExpandableString,
+) error {
 	t.projectPath = projectPath
 	t.options = options
 	if t.options.Module == "" {

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
 	terraformTools "github.com/azure/azure-dev/cli/azd/pkg/tools/terraform"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -137,7 +138,7 @@ func createTerraformProvider(t *testing.T, mockContext *mocks.MockContext) *Terr
 		prompt.NewDefaultPrompter(env, mockContext.Console, accountManager, resourceService, cloud.AzurePublic()),
 	)
 
-	err := provider.Initialize(*mockContext.Context, projectDir, options)
+	err := provider.Initialize(*mockContext.Context, projectDir, options, osutil.EmptyExpandableString)
 	require.NoError(t, err)
 
 	return provider.(*TerraformProvider)

--- a/cli/azd/pkg/infra/provisioning/test/test_provider.go
+++ b/cli/azd/pkg/infra/provisioning/test/test_provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 )
@@ -36,7 +37,12 @@ func (p *TestProvider) RequiredExternalTools() []tools.ExternalTool {
 	return []tools.ExternalTool{}
 }
 
-func (p *TestProvider) Initialize(ctx context.Context, projectPath string, options provisioning.Options) error {
+func (p *TestProvider) Initialize(
+	ctx context.Context,
+	projectPath string,
+	options provisioning.Options,
+	_ osutil.ExpandableString,
+) error {
 	p.projectPath = projectPath
 	p.options = options
 

--- a/cli/azd/pkg/osutil/expandable_string.go
+++ b/cli/azd/pkg/osutil/expandable_string.go
@@ -9,6 +9,9 @@ import (
 	"github.com/drone/envsubst"
 )
 
+// EmptyExpandableString is an expandable string that is empty.
+var EmptyExpandableString = NewExpandableString("")
+
 func NewExpandableString(template string) ExpandableString {
 	return ExpandableString{
 		template: template,


### PR DESCRIPTION
We allow specifying the resource group which is used for discovery of resources (instead of probing for a resource group taged with `azd-env-name` inside `azure.yaml`. When doing a resource group scoped deployment, we should consider this value if set and use it instead of prompting the user to select a resource group or create a new one.

Fixes #4287