### PR TITLE
remove preview from test templates

### DIFF
--- a/templates/tests/test-templates.sh
+++ b/templates/tests/test-templates.sh
@@ -102,14 +102,8 @@ function deployTemplate {
         azd env new "$3" --subscription "$4" --location "$5" --no-prompt
     fi
 
-    echo "Create provision preview for $3..."
-    azd provision -e "$3" --preview
-
     echo "Provisioning infrastructure for $3..."
     azd provision -e "$3"
-
-    echo "Create (delta) provision preview after provision..."
-    azd provision -e "$3" --preview
 
     echo "Deploying apps for $3..."
     azd deploy -e "$3"


### PR DESCRIPTION
Removing `--preview` checks from test-template.
We decided to do this because `--preview` is not compatible with deployment stacks, which is ON for test-template pipeline after turning all alpha features ON.

The `provision --preview` tests will be covered as functional test in azd-cli pipelines.