### PR TITLE
core: Update `azure.yaml.json` for `remoteBuild`

### DIFF
--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -678,6 +678,11 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "remoteBuild": {
+                    "type": "boolean",
+                    "title": "Optional. Whether to build the image remotely",
+                    "description": "If set to true, the image will be built remotely using the Azure Container Registry remote build feature. If set to false, the image will be built locally using Docker."
                 }
             }
         },

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -704,6 +704,11 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "remoteBuild": {
+                    "type": "boolean",
+                    "title": "Optional. Whether to build the image remotely",
+                    "description": "If set to true, the image will be built remotely using the Azure Container Registry remote build feature. If set to false, the image will be built locally using Docker."
                 }
             }
         },


### PR DESCRIPTION
This adds the `remoteBuild` configuration knob which was added in azure/azure-dev#4161 to our schema for `azure.yaml`.

Fixes #4353