### PR TITLE
Updates `azure.yaml` schema for deployment stacks configuration

### DIFF
--- a/.vscode/cspell.global.yaml
+++ b/.vscode/cspell.global.yaml
@@ -150,6 +150,7 @@ ignoreWords:
     - tfstate
     - tfvars
     - traf
+    - unmanage
     - useragent
     - versioncontrol
     - vmss

--- a/.vscode/cspell.misc.yaml
+++ b/.vscode/cspell.misc.yaml
@@ -40,3 +40,4 @@ overrides:
           - azdev
           - myimage
           - azureai
+          - entra

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -1079,11 +1079,6 @@
             "oneOf": [
                 {
                     "required": [
-                        "bypassStackOutOfSyncError"
-                    ]
-                },
-                {
-                    "required": [
                         "actionOnUnmanage"
                     ]
                 },
@@ -1094,32 +1089,15 @@
                 }
             ],
             "properties": {
-                "bypassStackOutOfSyncError": {
-                    "type": "boolean",
-                    "title": "Whether to bypass the stack out of sync error",
-                    "description": "Flag to bypass service errors that indicate the stack resource list is not correctly synchronized.",
-                    "default": false
-                },
                 "actionOnUnmanage": {
                     "type": "object",
                     "title": "The action to take when when resources become unmanaged",
                     "description": "Defines the behavior of resources that are no longer managed after the Deployment stack is updated or deleted. Defaults to 'delete' for all resource scopes.",
                     "required": [
-                        "managementGroups",
                         "resourceGroups",
                         "resources"
                     ],
                     "properties": {
-                        "managementGroups": {
-                            "type": "string",
-                            "title": "Required. The action on unmanage setting for management groups",
-                            "description": "Specifies an action for a newly unmanaged resource. Delete will attempt to delete the resource from Azure. Detach will leave the resource in it's current state.",
-                            "default": "delete",
-                            "enum": [
-                                "delete",
-                                "detach"
-                            ]
-                        },
                         "resourceGroups": {
                             "type": "string",
                             "title": "Required. The action on unmanage setting for resource groups",

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -35,7 +35,10 @@
             "type": "object",
             "title": "The infrastructure configuration used for the application",
             "description": "Optional. Provides additional configuration for Azure infrastructure provisioning.",
-            "additionalProperties": true,
+            "additionalProperties": false,
+            "required": [
+                "provider"
+            ],
             "properties": {
                 "provider": {
                     "type": "string",
@@ -55,8 +58,29 @@
                     "type": "string",
                     "title": "Name of the default module within the Azure provisioning templates",
                     "description": "Optional. The name of the Azure provisioning module used when provisioning resources. (Default: main)"
+                },
+                "deploymentStacks": {
+                    "$ref": "#/definitions/deploymentStacksConfig"
                 }
-            }
+            },
+            "allOf": [
+                {
+                    "if": {
+                        "not": {
+                            "properties": {
+                                "provider": {
+                                    "const": "bicep"
+                                }
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "deploymentStacks": false
+                        }
+                    }
+                }
+            ]
         },
         "services": {
             "type": "object",
@@ -1047,6 +1071,111 @@
             "required": [
                 "deployment"
             ]
+        },
+        "deploymentStacksConfig": {
+            "type": "object",
+            "title": "The deployment stack configuration used for the project.",
+            "additionalProperties": false,
+            "oneOf": [
+                {
+                    "required": [
+                        "bypassStackOutOfSyncError"
+                    ]
+                },
+                {
+                    "required": [
+                        "actionOnUnmanage"
+                    ]
+                },
+                {
+                    "required": [
+                        "denySettings"
+                    ]
+                }
+            ],
+            "properties": {
+                "bypassStackOutOfSyncError": {
+                    "type": "boolean",
+                    "title": "Whether to bypass the stack out of sync error",
+                    "description": "Flag to bypass service errors that indicate the stack resource list is not correctly synchronized.",
+                    "default": false
+                },
+                "actionOnUnmanage": {
+                    "type": "object",
+                    "title": "The action to take when when resources become unmanaged",
+                    "description": "Defines the behavior of resources that are no longer managed after the Deployment stack is updated or deleted. Defaults to 'delete' for all resource scopes.",
+                    "required": [
+                        "managementGroups",
+                        "resourceGroups",
+                        "resources"
+                    ],
+                    "properties": {
+                        "managementGroups": {
+                            "type": "string",
+                            "title": "Required. The action on unmanage setting for management groups",
+                            "description": "Specifies an action for a newly unmanaged resource. Delete will attempt to delete the resource from Azure. Detach will leave the resource in it's current state.",
+                            "default": "delete",
+                            "enum": [
+                                "delete",
+                                "detach"
+                            ]
+                        },
+                        "resourceGroups": {
+                            "type": "string",
+                            "title": "Required. The action on unmanage setting for resource groups",
+                            "description": "Specifies an action for a newly unmanaged resource. Delete will attempt to delete the resource from Azure. Detach will leave the resource in it's current state.",
+                            "default": "delete",
+                            "enum": [
+                                "delete",
+                                "detach"
+                            ]
+                        },
+                        "resources": {
+                            "type": "string",
+                            "title": "Required. The action on unmanage setting for resources",
+                            "description": "Specifies an action for a newly unmanaged resource. Delete will attempt to delete the resource from Azure. Detach will leave the resource in it's current state.",
+                            "default": "delete",
+                            "enum": [
+                                "delete",
+                                "detach"
+                            ]
+                        }
+                    }
+                },
+                "denySettings": {
+                    "type": "object",
+                    "title": "The deny settings for the deployment stack",
+                    "description": "Defines how resources deployed by the stack are locked. Defaults to 'none'.",
+                    "required": [
+                        "mode"
+                    ],
+                    "properties": {
+                        "mode": {
+                            "type": "string",
+                            "title": "Required. Mode that defines denied actions.",
+                            "default": "none",
+                            "enum": [
+                                "none",
+                                "denyDelete",
+                                "denyWriteAndDelete"
+                            ]
+                        },
+                        "applyToChildScopes": {
+                            "type": "boolean",
+                            "title": "Whether the deny settings apply to child scopes.",
+                            "description": "DenySettings will be applied to child resource scopes of every managed resource with a deny assignment."
+                        },
+                        "excludedActions": {
+                            "type": "array",
+                            "title": "List of role-based management operations that are excluded from the denySettings."
+                        },
+                        "excludedPrincipals": {
+                            "type": "array",
+                            "title": "List of Entra ID principal IDs excluded from the lock. Up to 5 principals are permitted."
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Do not merge till after release

Updates the alpha schema for `azure.yaml` to include the optional deployment stacks configuration.

The `deploymentStacks` property will light up when `provider: bicep`. When specifying the `deploymentStacks` property the user must configure at least one of the properties otherwise the whole property can be omitted and use the internal defaults.