### PR TITLE
Enable remote build support for AKS

### DIFF
--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -200,7 +200,7 @@ func (t *aksTarget) Deploy(
 	// Only deploy the container image if a package output has been defined
 	// Empty package details is a valid scenario for any AKS deployment that does not build any containers
 	// Ex) Helm charts, or other manifests that reference external images
-	if packageOutput.Details != nil || packageOutput.PackagePath != "" {
+	if serviceConfig.Docker.RemoteBuild || packageOutput.Details != nil || packageOutput.PackagePath != "" {
 		// Login, tag & push container image to ACR
 		_, err := t.containerHelper.Deploy(ctx, serviceConfig, packageOutput, targetResource, true, progress)
 		if err != nil {


### PR DESCRIPTION
Fixes #4376,  Enables remote build support for AKS. 

## Example
Set the `docker.remoteBuild` property to `true` in the `azure.yaml` file.
```yaml
# azure.yaml

name: todo-nodejs-mongo-aks
metadata:
  template: todo-nodejs-mongo-aks@0.0.1-beta
services:
  web:
    project: ./src/web
    dist: dist
    language: js
    host: aks
    docker:
      remoteBuild: true
  api:
    project: ./src/api
    language: js
    host: aks
    docker:
      remoteBuild: true
    k8s:
      ingress:
        relativePath: api
```