### PR TITLE
WIP: Service Level provisioning

### DIFF
--- a/cli/azd/cmd/down.go
+++ b/cli/azd/cmd/down.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
@@ -10,6 +13,8 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -20,6 +25,8 @@ import (
 )
 
 type downFlags struct {
+	all         bool
+	platform    bool
 	forceDelete bool
 	purgeDelete bool
 	global      *internal.GlobalCommandOptions
@@ -35,6 +42,19 @@ func (i *downFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOpt
 		//nolint:lll
 		"Does not require confirmation before it permanently deletes resources that are soft-deleted by default (for example, key vaults).",
 	)
+	local.BoolVar(
+		&i.all,
+		"all",
+		false,
+		"Deploys all services that are listed in "+azdcontext.ProjectFileName,
+	)
+	local.BoolVar(
+		&i.platform,
+		"platform",
+		false,
+		"Deploys the root platform infrastructure",
+	)
+
 	i.EnvFlag.Bind(local, global)
 	i.global = global
 }
@@ -48,13 +68,16 @@ func newDownFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *do
 
 func newDownCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "down",
+		Use:   "down [<service>]",
 		Short: "Delete Azure resources for an application.",
+		Args:  cobra.MaximumNArgs(1),
 	}
 }
 
 type downAction struct {
+	args                []string
 	flags               *downFlags
+	projectManager      project.ProjectManager
 	provisionManager    *provisioning.Manager
 	importManager       *project.ImportManager
 	env                 *environment.Environment
@@ -64,7 +87,9 @@ type downAction struct {
 }
 
 func newDownAction(
+	args []string,
 	flags *downFlags,
+	projectManager project.ProjectManager,
 	provisionManager *provisioning.Manager,
 	env *environment.Environment,
 	projectConfig *project.ProjectConfig,
@@ -73,7 +98,9 @@ func newDownAction(
 	importManager *project.ImportManager,
 ) actions.Action {
 	return &downAction{
+		args:                args,
 		flags:               flags,
+		projectManager:      projectManager,
 		provisionManager:    provisionManager,
 		env:                 env,
 		console:             console,
@@ -84,6 +111,23 @@ func newDownAction(
 }
 
 func (a *downAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	var targetServiceName string
+	if len(a.args) == 1 {
+		targetServiceName = strings.TrimSpace(a.args[0])
+	}
+
+	if targetServiceName != "" && a.flags.all {
+		return nil, fmt.Errorf("cannot specify both --all and <service>")
+	}
+
+	if targetServiceName != "" && a.flags.platform {
+		return nil, fmt.Errorf("cannot specify both --platform and <service>")
+	}
+
+	if a.flags.platform && a.flags.all {
+		return nil, fmt.Errorf("cannot specify both --platform and --all")
+	}
+
 	// Command title
 	a.console.MessageUxItem(ctx, &ux.MessageTitle{
 		Title:     "Deleting all resources and deployed code on Azure (azd down)",
@@ -98,17 +142,34 @@ func (a *downAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	}
 	defer func() { _ = infra.Cleanup() }()
 
-	if err := a.provisionManager.Initialize(ctx, a.projectConfig.Path, infra.Options); err != nil {
-		return nil, fmt.Errorf("initializing provisioning manager: %w", err)
-	}
-
 	if a.alphaFeatureManager.IsEnabled(azapi.FeatureDeploymentStacks) {
 		a.console.WarnForFeature(ctx, azapi.FeatureDeploymentStacks)
 	}
 
 	destroyOptions := provisioning.NewDestroyOptions(a.flags.forceDelete, a.flags.purgeDelete)
-	if _, err := a.provisionManager.Destroy(ctx, destroyOptions); err != nil {
-		return nil, fmt.Errorf("deleting infrastructure: %w", err)
+
+	results := map[string]*provisioning.DestroyResult{}
+
+	// Deprovision services infrastructure
+	serviceResults, err := a.deprovisionServices(ctx, targetServiceName, destroyOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	for svcName, result := range serviceResults {
+		results[svcName] = result
+	}
+
+	// Deprovision root platform infrastructure
+	platformResult, err := a.deprovisionPlatform(ctx, targetServiceName, destroyOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceResults["_"] = platformResult
+
+	if len(results) == 0 {
+		return nil, nil
 	}
 
 	return &actions.ActionResult{
@@ -116,6 +177,177 @@ func (a *downAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 			Header: fmt.Sprintf("Your application was removed from Azure in %s.", ux.DurationAsText(since(startTime))),
 		},
 	}, nil
+}
+
+func (a *downAction) deprovisionPlatform(
+	ctx context.Context,
+	targetServiceName string,
+	destroyOptions provisioning.DestroyOptions,
+) (*provisioning.DestroyResult, error) {
+	projectInfra, err := a.importManager.ProjectInfrastructure(ctx, a.projectConfig)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = projectInfra.Cleanup() }()
+
+	stepMessage := "Initializing"
+	a.console.Message(ctx, output.WithBold("\nDeprovisioning platform infrastructure"))
+	a.console.ShowSpinner(ctx, stepMessage, input.Step)
+
+	if targetServiceName != "" {
+		a.console.StopSpinner(ctx, "Platform not selected", input.StepSkipped)
+		return nil, nil
+	}
+
+	infraOptions := projectInfra.Options
+
+	if err := a.provisionManager.Initialize(ctx, a.projectConfig.Path, infraOptions); err != nil {
+		a.console.ShowSpinner(ctx, stepMessage, input.Step)
+
+		if errors.Is(err, os.ErrNotExist) {
+			a.console.StopSpinner(ctx, "No infrastructure found", input.StepSkipped)
+			return nil, nil
+		} else {
+			a.console.StopSpinner(ctx, "Deprovisioning Infrastructure", input.StepFailed)
+			return nil, fmt.Errorf("initializing provisioning manager: %w", err)
+		}
+	}
+
+	projectEventArgs := project.ProjectLifecycleEventArgs{
+		Project: a.projectConfig,
+	}
+
+	var destroyResult *provisioning.DestroyResult
+
+	err = a.projectConfig.Invoke(ctx, project.ProjectEventDown, projectEventArgs, func() error {
+		result, err := a.provisionManager.Destroy(ctx, destroyOptions)
+		if err != nil {
+			if errors.Is(err, infra.ErrDeploymentsNotFound) {
+				a.console.ShowSpinner(ctx, stepMessage, input.Step)
+				a.console.StopSpinner(ctx, "No deployments found", input.StepSkipped)
+				return nil
+			}
+
+			return err
+		}
+
+		destroyResult = result
+		return nil
+	})
+
+	if err != nil {
+		a.console.StopSpinner(ctx, stepMessage, input.StepFailed)
+		return nil, err
+	}
+
+	a.console.StopSpinner(ctx, stepMessage, input.StepDone)
+
+	return destroyResult, nil
+}
+
+func (a *downAction) deprovisionServices(
+	ctx context.Context,
+	targetServiceName string,
+	destroyOptions provisioning.DestroyOptions,
+) (map[string]*provisioning.DestroyResult, error) {
+	stableServices, err := a.importManager.ServiceStable(ctx, a.projectConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	targetServiceName, err = getTargetServiceName(
+		ctx,
+		a.projectManager,
+		a.importManager,
+		a.projectConfig,
+		string(project.ServiceEventDown),
+		targetServiceName,
+		a.flags.all,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	destroyResults := map[string]*provisioning.DestroyResult{}
+
+	for index, svc := range stableServices {
+		if index > 0 {
+			a.console.Message(ctx, "")
+		}
+
+		a.console.Message(
+			ctx,
+			fmt.Sprintf("%s %s %s",
+				output.WithBold("Provisioning infrastructure for"),
+				output.WithHighLightFormat(svc.Name),
+				output.WithBold("service"),
+			),
+		)
+
+		stepMessage := "Initializing"
+		a.console.ShowSpinner(ctx, stepMessage, input.Step)
+
+		if a.flags.platform {
+			a.console.StopSpinner(ctx, stepMessage, input.StepSkipped)
+			return nil, nil
+		}
+
+		// Skip this service if both cases are true:
+		// 1. The user specified a service name
+		// 2. This service is not the one the user specified
+		if targetServiceName != "" && targetServiceName != svc.Name {
+			a.console.StopSpinner(ctx, "Service not selected", input.StepSkipped)
+			continue
+		}
+
+		infraOptions := svc.Infra
+		if infraOptions.Name == "" {
+			infraOptions.Name = fmt.Sprintf("%s-%s", a.env.Name(), svc.Name)
+		}
+
+		if err := a.provisionManager.Initialize(ctx, svc.Path(), infraOptions); err != nil {
+			a.console.ShowSpinner(ctx, stepMessage, input.Step)
+
+			if errors.Is(err, os.ErrNotExist) {
+				a.console.StopSpinner(ctx, "No infrastructure found", input.StepSkipped)
+				continue
+			} else {
+				a.console.StopSpinner(ctx, stepMessage, input.StepFailed)
+				return nil, err
+			}
+		}
+
+		serviceEventArgs := project.ServiceLifecycleEventArgs{
+			Project: a.projectConfig,
+			Service: svc,
+		}
+
+		err = svc.Invoke(ctx, project.ServiceEventProvision, serviceEventArgs, func() error {
+			destroyResult, err := a.provisionManager.Destroy(ctx, destroyOptions)
+			if err != nil {
+				if errors.Is(err, infra.ErrDeploymentsNotFound) {
+					a.console.ShowSpinner(ctx, stepMessage, input.Step)
+					a.console.StopSpinner(ctx, "No deployments found", input.StepSkipped)
+					return nil
+				}
+
+				return err
+			}
+
+			destroyResults[svc.Name] = destroyResult
+
+			return nil
+		})
+
+		if err != nil {
+			a.console.StopSpinner(ctx, stepMessage, input.StepFailed)
+			return nil, err
+		}
+
+		a.console.StopSpinner(ctx, stepMessage, input.StepDone)
+	}
+
+	return destroyResults, nil
 }
 
 func getCmdDownHelpDescription(*cobra.Command) string {
@@ -128,6 +360,10 @@ func getCmdDownHelpFooter(*cobra.Command) string {
 	return generateCmdHelpSamplesBlock(map[string]string{
 		"Delete all resources for an application." +
 			" You will be prompted to confirm your decision.": output.WithHighLightFormat("azd down"),
+		//nolint:lll
+		"Delete all resources for a specific service within the application. ": output.WithHighLightFormat("azd down <service>"),
+		//nolint:lll
+		"Delete the root platform infrastructure for the application. ":    output.WithHighLightFormat("azd down --platform"),
 		"Forcibly delete all applications resources without confirmation.": output.WithHighLightFormat("azd down --force"),
 		"Permanently delete resources that are soft-deleted by default," +
 			" without confirmation.": output.WithHighLightFormat("azd down --purge"),

--- a/cli/azd/cmd/restore.go
+++ b/cli/azd/cmd/restore.go
@@ -124,8 +124,6 @@ func (ra *restoreAction) Run(ctx context.Context) (*actions.ActionResult, error)
 
 	startTime := time.Now()
 
-	serviceNameWarningCheck(ra.console, ra.flags.serviceName, "restore")
-
 	targetServiceName := ra.flags.serviceName
 	if len(ra.args) == 1 {
 		targetServiceName = ra.args[0]

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -227,7 +227,7 @@ func NewRootCmd(
 			DefaultFormat:  output.NoneFormat,
 			HelpOptions: actions.ActionHelpOptions{
 				Description: cmd.GetCmdProvisionHelpDescription,
-				Footer:      getCmdHelpDefaultFooter,
+				Footer:      cmd.GetCmdProvisionHelpFooter,
 			},
 			GroupingOptions: actions.CommandGroupOptions{
 				RootLevelHelp: actions.CmdGroupManage,

--- a/cli/azd/cmd/testdata/TestUsage-azd-down.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-down.snap
@@ -2,13 +2,15 @@
 Delete Azure resources for an application. Running azd down will not delete application files on your local machine.
 
 Usage
-  azd down [flags]
+  azd down [<service>] [flags]
 
 Flags
+        --all                	: Deploys all services that are listed in azure.yaml
         --docs               	: Opens the documentation for azd down in your web browser.
     -e, --environment string 	: The name of the environment to use.
         --force              	: Does not require confirmation before it deletes resources.
     -h, --help               	: Gets help for down.
+        --platform           	: Deploys the root platform infrastructure
         --purge              	: Does not require confirmation before it permanently deletes resources that are soft-deleted by default (for example, key vaults).
 
 Global Flags
@@ -17,8 +19,14 @@ Global Flags
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Examples
+  Delete all resources for a specific service within the application. 
+    azd down <service>
+
   Delete all resources for an application. You will be prompted to confirm your decision.
     azd down
+
+  Delete the root platform infrastructure for the application. 
+    azd down --platform
 
   Forcibly delete all applications resources without confirmation.
     azd down --force

--- a/cli/azd/cmd/testdata/TestUsage-azd-provision.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-provision.snap
@@ -7,7 +7,7 @@ This command prompts you to input the following:
   • Azure subscription: The Azure subscription where your resources will be deployed.
 
 Usage
-  azd provision <service> [flags]
+  azd provision [<service>] [flags]
 
 Flags
         --all                	: Deploys all services that are listed in azure.yaml
@@ -23,6 +23,14 @@ Global Flags
         --debug      	: Enables debugging and diagnostics logging.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
-Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.
+Examples
+  Provision all resources for a specific service within the application. 
+    azd provision <service>
+
+  Provision all resources for an application.
+    azd provision
+
+  Provision the root platform infrastructure for the application. 
+    azd provision --platform
 
 

--- a/cli/azd/cmd/testdata/TestUsage-azd-provision.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-provision.snap
@@ -7,13 +7,15 @@ This command prompts you to input the following:
   • Azure subscription: The Azure subscription where your resources will be deployed.
 
 Usage
-  azd provision [flags]
+  azd provision <service> [flags]
 
 Flags
+        --all                	: Deploys all services that are listed in azure.yaml
         --docs               	: Opens the documentation for azd provision in your web browser.
     -e, --environment string 	: The name of the environment to use.
     -h, --help               	: Gets help for provision.
         --no-state           	: Do not use latest Deployment State (bicep only).
+        --platform           	: Deploys the root platform infrastructure
         --preview            	: Preview changes to Azure resources.
 
 Global Flags

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -9,7 +9,6 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
-	"github.com/azure/azure-dev/cli/azd/internal/cmd"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
@@ -25,8 +24,6 @@ import (
 )
 
 type upFlags struct {
-	cmd.ProvisionFlags
-	cmd.DeployFlags
 	global *internal.GlobalCommandOptions
 	internal.EnvFlag
 }
@@ -34,11 +31,6 @@ type upFlags struct {
 func (u *upFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
 	u.EnvFlag.Bind(local, global)
 	u.global = global
-
-	u.ProvisionFlags.BindNonCommon(local, global)
-	u.ProvisionFlags.SetCommon(&u.EnvFlag)
-	u.DeployFlags.BindNonCommon(local, global)
-	u.DeployFlags.SetCommon(&u.EnvFlag)
 }
 
 func newUpFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *upFlags {
@@ -71,7 +63,7 @@ var defaultUpWorkflow = &workflow.Workflow{
 	Name: "up",
 	Steps: []*workflow.Step{
 		{AzdCommand: workflow.Command{Args: []string{"package", "--all"}}},
-		{AzdCommand: workflow.Command{Args: []string{"provision"}}},
+		{AzdCommand: workflow.Command{Args: []string{"provision", "--all"}}},
 		{AzdCommand: workflow.Command{Args: []string{"deploy", "--all"}}},
 	},
 }

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -37,18 +37,6 @@ func azurePortalLink(portalUrlBase, subscriptionId, resourceGroupName string) st
 		resourceGroupName))
 }
 
-func serviceNameWarningCheck(console input.Console, serviceNameFlag string, commandName string) {
-	if serviceNameFlag == "" {
-		return
-	}
-
-	fmt.Fprintln(
-		console.Handles().Stderr,
-		output.WithWarningFormat("WARNING: The `--service` flag is deprecated and will be removed in a future release."),
-	)
-	fmt.Fprintf(console.Handles().Stderr, "Next time use `azd %s <service>`.\n\n", commandName)
-}
-
 func getTargetServiceName(
 	ctx context.Context,
 	projectManager project.ProjectManager,

--- a/cli/azd/internal/cmd/deploy.go
+++ b/cli/azd/internal/cmd/deploy.go
@@ -30,7 +30,6 @@ import (
 )
 
 type DeployFlags struct {
-	serviceName string
 	All         bool
 	fromPackage string
 	global      *internal.GlobalCommandOptions
@@ -45,15 +44,6 @@ func (d *DeployFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandO
 func (d *DeployFlags) BindNonCommon(
 	local *pflag.FlagSet,
 	global *internal.GlobalCommandOptions) {
-	local.StringVar(
-		&d.serviceName,
-		"service",
-		"",
-		//nolint:lll
-		"Deploys a specific service (when the string is unspecified, all services that are listed in the "+azdcontext.ProjectFileName+" file are deployed).",
-	)
-	//deprecate:flag hide --service
-	_ = local.MarkHidden("service")
 	d.global = global
 }
 
@@ -169,12 +159,10 @@ type DeploymentResult struct {
 }
 
 func (da *DeployAction) Run(ctx context.Context) (*actions.ActionResult, error) {
-	targetServiceName := da.flags.serviceName
+	var targetServiceName string
 	if len(da.args) == 1 {
 		targetServiceName = da.args[0]
 	}
-
-	serviceNameWarningCheck(da.console, da.flags.serviceName, "deploy")
 
 	if da.env.GetSubscriptionId() == "" {
 		return nil, errors.New(

--- a/cli/azd/internal/cmd/deploy.go
+++ b/cli/azd/internal/cmd/deploy.go
@@ -97,8 +97,8 @@ func NewDeployCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy <service>",
 		Short: "Deploy the application's code to Azure.",
+		Args:  cobra.MaximumNArgs(1),
 	}
-	cmd.Args = cobra.MaximumNArgs(1)
 
 	return cmd
 }

--- a/cli/azd/internal/cmd/provision.go
+++ b/cli/azd/internal/cmd/provision.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
@@ -166,14 +167,14 @@ func (p *ProvisionAction) SetFlags(flags *ProvisionFlags) {
 func (p *ProvisionAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	var targetServiceName string
 	if len(p.args) == 1 {
-		targetServiceName = p.args[0]
+		targetServiceName = strings.TrimSpace(p.args[0])
 	}
 
 	if targetServiceName != "" && p.flags.all {
 		return nil, fmt.Errorf("cannot specify both --all and <service>")
 	}
 
-	if targetServiceName == "" && p.flags.platform {
+	if targetServiceName != "" && p.flags.platform {
 		return nil, fmt.Errorf("cannot specify both --platform and <service>")
 	}
 

--- a/cli/azd/internal/cmd/provision.go
+++ b/cli/azd/internal/cmd/provision.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
@@ -17,17 +16,20 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
+	"github.com/golobby/container/v3"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"go.uber.org/multierr"
 )
 
 type ProvisionFlags struct {
+	serviceName           string
 	noProgress            bool
 	preview               bool
 	ignoreDeploymentState bool
@@ -49,6 +51,13 @@ func (i *ProvisionFlags) Bind(local *pflag.FlagSet, global *internal.GlobalComma
 }
 
 func (i *ProvisionFlags) BindNonCommon(local *pflag.FlagSet, global *internal.GlobalCommandOptions) {
+	local.StringVar(
+		&i.serviceName,
+		"service",
+		"",
+		//nolint:lll
+		"Provisions infrastructure for a specific service (when the string is unspecified, all services that are listed in the "+azdcontext.ProjectFileName+" file are deployed).",
+	)
 	local.BoolVar(&i.noProgress, "no-progress", false, "Suppresses progress information.")
 	//deprecate:Flag hide --no-progress
 	_ = local.MarkHidden("no-progress")
@@ -89,14 +98,16 @@ func NewProvisionFlagsFromEnvAndOptions(envFlag *internal.EnvFlag, global *inter
 
 func NewProvisionCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "provision",
+		Use:   "provision <service>",
 		Short: "Provision the Azure resources for an application.",
+		Args:  cobra.MaximumNArgs(1),
 	}
 }
 
 type ProvisionAction struct {
+	args                []string
 	flags               *ProvisionFlags
-	provisionManager    *provisioning.Manager
+	serviceLocator      ioc.ServiceLocator
 	projectManager      project.ProjectManager
 	resourceManager     project.ResourceManager
 	env                 *environment.Environment
@@ -112,8 +123,9 @@ type ProvisionAction struct {
 }
 
 func NewProvisionAction(
+	args []string,
 	flags *ProvisionFlags,
-	provisionManager *provisioning.Manager,
+	serviceLocator ioc.ServiceLocator,
 	projectManager project.ProjectManager,
 	importManager *project.ImportManager,
 	resourceManager project.ResourceManager,
@@ -128,8 +140,9 @@ func NewProvisionAction(
 	cloud *cloud.Cloud,
 ) actions.Action {
 	return &ProvisionAction{
+		args:                args,
 		flags:               flags,
-		provisionManager:    provisionManager,
+		serviceLocator:      serviceLocator,
 		projectManager:      projectManager,
 		resourceManager:     resourceManager,
 		env:                 env,
@@ -154,7 +167,168 @@ func (p *ProvisionAction) SetFlags(flags *ProvisionFlags) {
 	p.flags = flags
 }
 
+func (p *ProvisionAction) provisionPlatform(ctx context.Context, preview bool) (*provisioning.DeployResult, *provisioning.DeployPreviewResult, error) {
+	infra, err := p.importManager.ProjectInfrastructure(ctx, p.projectConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = infra.Cleanup() }()
+
+	var deployResult *provisioning.DeployResult
+	var deployPreviewResult *provisioning.DeployPreviewResult
+
+	err = p.serviceLocator.Invoke(func(provisionManager *provisioning.Manager) error {
+		infraOptions := infra.Options
+		infraOptions.IgnoreDeploymentState = p.flags.ignoreDeploymentState
+
+		if err := provisionManager.Initialize(ctx, p.projectConfig.Path, infraOptions); err != nil {
+			return fmt.Errorf("initializing provisioning manager: %w", err)
+		}
+
+		// Get Subscription to Display in Command Title Note
+		// Subscription and Location are ONLY displayed when they are available (found from env), otherwise, this message
+		// is not displayed.
+		// This needs to happen after the provisionManager initializes to make sure the env is ready for the provisioning
+		// provider
+		subscription, subErr := p.subManager.GetSubscription(ctx, p.env.GetSubscriptionId())
+		if subErr == nil {
+			location, err := p.subManager.GetLocation(ctx, p.env.GetSubscriptionId(), p.env.GetLocation())
+			var locationDisplay string
+			if err != nil {
+				log.Printf("failed getting location: %v", err)
+			} else {
+				locationDisplay = location.DisplayName
+			}
+
+			var subscriptionDisplay string
+			if v, err := strconv.ParseBool(os.Getenv("AZD_DEMO_MODE")); err == nil && v {
+				subscriptionDisplay = subscription.Name
+			} else {
+				subscriptionDisplay = fmt.Sprintf("%s (%s)", subscription.Name, subscription.Id)
+			}
+
+			p.console.MessageUxItem(ctx, &ux.EnvironmentDetails{
+				Subscription: subscriptionDisplay,
+				Location:     locationDisplay,
+			})
+
+		} else {
+			log.Printf("failed getting subscriptions. Skip displaying sub and location: %v", subErr)
+		}
+
+		projectEventArgs := project.ProjectLifecycleEventArgs{
+			Project: p.projectConfig,
+			Args: map[string]any{
+				"preview": preview,
+			},
+		}
+
+		if p.alphaFeatureManager.IsEnabled(azapi.FeatureDeploymentStacks) {
+			p.console.WarnForFeature(ctx, azapi.FeatureDeploymentStacks)
+		}
+
+		return p.projectConfig.Invoke(ctx, project.ProjectEventProvision, projectEventArgs, func() error {
+			var err error
+			if preview {
+				deployPreviewResult, err = provisionManager.Preview(ctx)
+			} else {
+				deployResult, err = provisionManager.Deploy(ctx)
+			}
+			return err
+		})
+	})
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return deployResult, deployPreviewResult, nil
+}
+
+func (p *ProvisionAction) provisionServices(ctx context.Context, targetServiceName string, preview bool) (map[string]*provisioning.DeployResult, map[string]*provisioning.DeployPreviewResult, error) {
+	stableServices, err := p.importManager.ServiceStable(ctx, p.projectConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	targetServiceName, err = getTargetServiceName(
+		ctx,
+		p.projectManager,
+		p.importManager,
+		p.projectConfig,
+		string(project.ServiceEventDeploy),
+		targetServiceName,
+		targetServiceName == "",
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	deployResults := map[string]*provisioning.DeployResult{}
+	previewResults := map[string]*provisioning.DeployPreviewResult{}
+
+	for _, svc := range stableServices {
+		stepMessage := fmt.Sprintf("Provisioning service %s", svc.Name)
+		p.console.ShowSpinner(ctx, stepMessage, input.Step)
+
+		// Skip this service if both cases are true:
+		// 1. The user specified a service name
+		// 2. This service is not the one the user specified
+		if targetServiceName != "" && targetServiceName != svc.Name {
+			p.console.StopSpinner(ctx, stepMessage, input.StepSkipped)
+			continue
+		}
+
+		err := container.Call(func(provisionManager *provisioning.Manager) error {
+			if err := provisionManager.Initialize(ctx, svc.Path(), svc.Infra); err != nil {
+				return err
+			}
+
+			serviceEventArgs := project.ServiceLifecycleEventArgs{
+				Project: p.projectConfig,
+				Service: svc,
+				Args: map[string]any{
+					"preview": preview,
+				},
+			}
+
+			return svc.Invoke(ctx, project.ServiceEventProvision, serviceEventArgs, func() error {
+				if preview {
+					previewResult, err := provisionManager.Preview(ctx)
+					if err != nil {
+						return err
+					}
+
+					previewResults[svc.Name] = previewResult
+				} else {
+					deployResult, err := provisionManager.Deploy(ctx)
+					if err != nil {
+						return err
+					}
+
+					deployResults[svc.Name] = deployResult
+				}
+
+				return nil
+			})
+		})
+
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return deployResults, previewResults, nil
+}
+
 func (p *ProvisionAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	targetServiceName := p.flags.serviceName
+	if len(p.args) == 1 {
+		targetServiceName = p.args[0]
+	}
+
+	serviceNameWarningCheck(p.console, p.flags.serviceName, "provision")
+
 	if p.flags.noProgress {
 		fmt.Fprintln(
 			p.console.Handles().Stderr,
@@ -185,193 +359,136 @@ func (p *ProvisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 		return nil, err
 	}
 
-	infra, err := p.importManager.ProjectInfrastructure(ctx, p.projectConfig)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = infra.Cleanup() }()
-
-	infraOptions := infra.Options
-	infraOptions.IgnoreDeploymentState = p.flags.ignoreDeploymentState
-	if err := p.provisionManager.Initialize(ctx, p.projectConfig.Path, infraOptions); err != nil {
-		return nil, fmt.Errorf("initializing provisioning manager: %w", err)
-	}
-
-	// Get Subscription to Display in Command Title Note
-	// Subscription and Location are ONLY displayed when they are available (found from env), otherwise, this message
-	// is not displayed.
-	// This needs to happen after the provisionManager initializes to make sure the env is ready for the provisioning
-	// provider
-	subscription, subErr := p.subManager.GetSubscription(ctx, p.env.GetSubscriptionId())
-	if subErr == nil {
-		location, err := p.subManager.GetLocation(ctx, p.env.GetSubscriptionId(), p.env.GetLocation())
-		var locationDisplay string
-		if err != nil {
-			log.Printf("failed getting location: %v", err)
-		} else {
-			locationDisplay = location.DisplayName
-		}
-
-		var subscriptionDisplay string
-		if v, err := strconv.ParseBool(os.Getenv("AZD_DEMO_MODE")); err == nil && v {
-			subscriptionDisplay = subscription.Name
-		} else {
-			subscriptionDisplay = fmt.Sprintf("%s (%s)", subscription.Name, subscription.Id)
-		}
-
-		p.console.MessageUxItem(ctx, &ux.EnvironmentDetails{
-			Subscription: subscriptionDisplay,
-			Location:     locationDisplay,
-		})
-
-	} else {
-		log.Printf("failed getting subscriptions. Skip displaying sub and location: %v", subErr)
-	}
-
-	var deployResult *provisioning.DeployResult
-	var deployPreviewResult *provisioning.DeployPreviewResult
-
-	projectEventArgs := project.ProjectLifecycleEventArgs{
-		Project: p.projectConfig,
-		Args: map[string]any{
-			"preview": previewMode,
-		},
-	}
-
-	if p.alphaFeatureManager.IsEnabled(azapi.FeatureDeploymentStacks) {
-		p.console.WarnForFeature(ctx, azapi.FeatureDeploymentStacks)
-	}
-
-	err = p.projectConfig.Invoke(ctx, project.ProjectEventProvision, projectEventArgs, func() error {
-		var err error
-		if previewMode {
-			deployPreviewResult, err = p.provisionManager.Preview(ctx)
-		} else {
-			deployResult, err = p.provisionManager.Deploy(ctx)
-		}
-		return err
-	})
-
-	if err != nil {
-		if p.formatter.Kind() == output.JsonFormat {
-			stateResult, err := p.provisionManager.State(ctx, nil)
-			if err != nil {
-				return nil, fmt.Errorf(
-					"deployment failed and the deployment result is unavailable: %w",
-					multierr.Combine(err, err),
-				)
-			}
-
-			if err := p.formatter.Format(
-				provisioning.NewEnvRefreshResultFromState(stateResult.State), p.writer, nil); err != nil {
-				return nil, fmt.Errorf(
-					"deployment failed and the deployment result could not be displayed: %w",
-					multierr.Combine(err, err),
-				)
-			}
-		}
-
-		//if user don't have access to openai
-		errorMsg := err.Error()
-		if strings.Contains(errorMsg, specialFeatureOrQuotaIdRequired) && strings.Contains(errorMsg, "OpenAI") {
-			requestAccessLink := "https://go.microsoft.com/fwlink/?linkid=2259205&clcid=0x409"
-			return nil, &internal.ErrorWithSuggestion{
-				Err: err,
-				Suggestion: "\nSuggested Action: The selected subscription does not have access to" +
-					" Azure OpenAI Services. Please visit " + output.WithLinkFormat("%s", requestAccessLink) +
-					" to request access.",
-			}
-		}
-
-		if strings.Contains(errorMsg, AINotValid) &&
-			strings.Contains(errorMsg, openAIsubscriptionNoQuotaId) {
-			return nil, &internal.ErrorWithSuggestion{
-				Suggestion: "\nSuggested Action: The selected " +
-					"subscription has not been enabled for use of Azure AI service and does not have quota for " +
-					"any pricing tiers. Please visit " + output.WithLinkFormat("%s", p.portalUrlBase) +
-					" and select 'Create' on specific services to request access.",
-				Err: err,
-			}
-		}
-
-		//if user haven't agree to Responsible AI terms
-		if strings.Contains(errorMsg, responsibleAITerms) {
-			return nil, &internal.ErrorWithSuggestion{
-				Suggestion: "\nSuggested Action: Please visit azure portal in " +
-					output.WithLinkFormat("%s", p.portalUrlBase) + ". Create the resource in azure portal " +
-					"to go through Responsible AI terms, and then delete it. " +
-					"After that, run 'azd provision' again",
-				Err: err,
-			}
-		}
-
-		return nil, fmt.Errorf("deployment failed: %w", err)
-	}
-
-	if previewMode {
-		p.console.MessageUxItem(ctx, deployResultToUx(deployPreviewResult))
-
-		return &actions.ActionResult{
-			Message: &actions.ResultMessage{
-				Header: fmt.Sprintf(
-					"Generated provisioning preview in %s.", ux.DurationAsText(since(startTime))),
-				FollowUp: getResourceGroupFollowUp(
-					ctx,
-					p.formatter,
-					p.portalUrlBase,
-					p.projectConfig,
-					p.resourceManager,
-					p.env,
-					true,
-				),
-			},
-		}, nil
-	}
-
-	if deployResult.SkippedReason == provisioning.DeploymentStateSkipped {
-		return &actions.ActionResult{
-			Message: &actions.ResultMessage{
-				Header: "There are no changes to provision for your application.",
-			},
-		}, nil
-	}
-
-	servicesStable, err := p.importManager.ServiceStable(ctx, p.projectConfig)
+	_, _, err := p.provisionPlatform(ctx, previewMode)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, svc := range servicesStable {
-		eventArgs := project.ServiceLifecycleEventArgs{
-			Project: p.projectConfig,
-			Service: svc,
-			Args: map[string]any{
-				"bicepOutput": deployResult.Deployment.Outputs,
-			},
-		}
-
-		if err := svc.RaiseEvent(ctx, project.ServiceEventEnvUpdated, eventArgs); err != nil {
-			return nil, err
-		}
+	_, _, err = p.provisionServices(ctx, targetServiceName, previewMode)
+	if err != nil {
+		return nil, err
 	}
 
-	if p.formatter.Kind() == output.JsonFormat {
-		stateResult, err := p.provisionManager.State(ctx, nil)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"deployment succeeded but the deployment result is unavailable: %w",
-				multierr.Combine(err, err),
-			)
-		}
+	// if err != nil {
+	// 	if p.formatter.Kind() == output.JsonFormat {
+	// 		stateResult, err := p.provisionManager.State(ctx, nil)
+	// 		if err != nil {
+	// 			return nil, fmt.Errorf(
+	// 				"deployment failed and the deployment result is unavailable: %w",
+	// 				multierr.Combine(err, err),
+	// 			)
+	// 		}
 
-		if err := p.formatter.Format(
-			provisioning.NewEnvRefreshResultFromState(stateResult.State), p.writer, nil); err != nil {
-			return nil, fmt.Errorf(
-				"deployment succeeded but the deployment result could not be displayed: %w",
-				multierr.Combine(err, err),
-			)
-		}
-	}
+	// 		if err := p.formatter.Format(
+	// 			provisioning.NewEnvRefreshResultFromState(stateResult.State), p.writer, nil); err != nil {
+	// 			return nil, fmt.Errorf(
+	// 				"deployment failed and the deployment result could not be displayed: %w",
+	// 				multierr.Combine(err, err),
+	// 			)
+	// 		}
+	// 	}
+
+	// 	//if user don't have access to openai
+	// 	errorMsg := err.Error()
+	// 	if strings.Contains(errorMsg, specialFeatureOrQuotaIdRequired) && strings.Contains(errorMsg, "OpenAI") {
+	// 		requestAccessLink := "https://go.microsoft.com/fwlink/?linkid=2259205&clcid=0x409"
+	// 		return nil, &internal.ErrorWithSuggestion{
+	// 			Err: err,
+	// 			Suggestion: "\nSuggested Action: The selected subscription does not have access to" +
+	// 				" Azure OpenAI Services. Please visit " + output.WithLinkFormat("%s", requestAccessLink) +
+	// 				" to request access.",
+	// 		}
+	// 	}
+
+	// 	if strings.Contains(errorMsg, AINotValid) &&
+	// 		strings.Contains(errorMsg, openAIsubscriptionNoQuotaId) {
+	// 		return nil, &internal.ErrorWithSuggestion{
+	// 			Suggestion: "\nSuggested Action: The selected " +
+	// 				"subscription has not been enabled for use of Azure AI service and does not have quota for " +
+	// 				"any pricing tiers. Please visit " + output.WithLinkFormat("%s", p.portalUrlBase) +
+	// 				" and select 'Create' on specific services to request access.",
+	// 			Err: err,
+	// 		}
+	// 	}
+
+	// 	//if user haven't agree to Responsible AI terms
+	// 	if strings.Contains(errorMsg, responsibleAITerms) {
+	// 		return nil, &internal.ErrorWithSuggestion{
+	// 			Suggestion: "\nSuggested Action: Please visit azure portal in " +
+	// 				output.WithLinkFormat("%s", p.portalUrlBase) + ". Create the resource in azure portal " +
+	// 				"to go through Responsible AI terms, and then delete it. " +
+	// 				"After that, run 'azd provision' again",
+	// 			Err: err,
+	// 		}
+	// 	}
+
+	// 	return nil, fmt.Errorf("deployment failed: %w", err)
+	// }
+
+	// if previewMode {
+	// 	p.console.MessageUxItem(ctx, deployResultToUx(deployPreviewResult))
+
+	// 	return &actions.ActionResult{
+	// 		Message: &actions.ResultMessage{
+	// 			Header: fmt.Sprintf(
+	// 				"Generated provisioning preview in %s.", ux.DurationAsText(since(startTime))),
+	// 			FollowUp: getResourceGroupFollowUp(
+	// 				ctx,
+	// 				p.formatter,
+	// 				p.portalUrlBase,
+	// 				p.projectConfig,
+	// 				p.resourceManager,
+	// 				p.env,
+	// 				true,
+	// 			),
+	// 		},
+	// 	}, nil
+	// }
+
+	// if deployResult.SkippedReason == provisioning.DeploymentStateSkipped {
+	// 	return &actions.ActionResult{
+	// 		Message: &actions.ResultMessage{
+	// 			Header: "There are no changes to provision for your application.",
+	// 		},
+	// 	}, nil
+	// }
+
+	// servicesStable, err := p.importManager.ServiceStable(ctx, p.projectConfig)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// for _, svc := range servicesStable {
+	// 	eventArgs := project.ServiceLifecycleEventArgs{
+	// 		Project: p.projectConfig,
+	// 		Service: svc,
+	// 		Args: map[string]any{
+	// 			"bicepOutput": deployResult.Deployment.Outputs,
+	// 		},
+	// 	}
+
+	// 	if err := svc.RaiseEvent(ctx, project.ServiceEventEnvUpdated, eventArgs); err != nil {
+	// 		return nil, err
+	// 	}
+	// }
+
+	// if p.formatter.Kind() == output.JsonFormat {
+	// 	stateResult, err := p.provisionManager.State(ctx, nil)
+	// 	if err != nil {
+	// 		return nil, fmt.Errorf(
+	// 			"deployment succeeded but the deployment result is unavailable: %w",
+	// 			multierr.Combine(err, err),
+	// 		)
+	// 	}
+
+	// 	if err := p.formatter.Format(
+	// 		provisioning.NewEnvRefreshResultFromState(stateResult.State), p.writer, nil); err != nil {
+	// 		return nil, fmt.Errorf(
+	// 			"deployment succeeded but the deployment result could not be displayed: %w",
+	// 			multierr.Combine(err, err),
+	// 		)
+	// 	}
+	// }
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{

--- a/cli/azd/internal/cmd/util.go
+++ b/cli/azd/internal/cmd/util.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"strconv"
 	"time"
 
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
@@ -34,19 +32,22 @@ func getResourceGroupFollowUp(
 		projectConfig.ResourceGroupName,
 	)
 	if err == nil {
-		suffix := ":\n" + azurePortalLink(portalUrlBase, subscriptionId, resourceGroupName)
-
-		if v, err := strconv.ParseBool(os.Getenv("AZD_DEMO_MODE")); err == nil && v {
-			suffix = "."
-		}
+		resourceGroupLink := azurePortalLink(portalUrlBase, subscriptionId, resourceGroupName)
+		azurePortalHyperlink := output.WithHyperlink(resourceGroupLink, "Azure Portal")
 
 		defaultFollowUpText := fmt.Sprintf(
-			"You can view the resources created under the resource group %s in Azure Portal", resourceGroupName)
+			"You can view the resources created under the resource group %s in the %s",
+			output.WithHighLightFormat(resourceGroupName),
+			azurePortalHyperlink,
+		)
 		if whatIf {
 			defaultFollowUpText = fmt.Sprintf(
-				"You can view the current resources under the resource group %s in Azure Portal", resourceGroupName)
+				"You can view the current resources under the resource group %s in the %s",
+				output.WithHighLightFormat(resourceGroupName),
+				azurePortalHyperlink,
+			)
 		}
-		followUp = defaultFollowUpText + suffix
+		followUp = defaultFollowUpText
 	}
 
 	return followUp
@@ -56,11 +57,11 @@ func azurePortalLink(portalUrlBase, subscriptionId, resourceGroupName string) st
 	if subscriptionId == "" || resourceGroupName == "" {
 		return ""
 	}
-	return output.WithLinkFormat(fmt.Sprintf(
+	return fmt.Sprintf(
 		"%s/#@/resource/subscriptions/%s/resourceGroups/%s/overview",
 		portalUrlBase,
 		subscriptionId,
-		resourceGroupName))
+		resourceGroupName)
 }
 
 func getTargetServiceName(

--- a/cli/azd/internal/cmd/util.go
+++ b/cli/azd/internal/cmd/util.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
-	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 )
@@ -62,18 +61,6 @@ func azurePortalLink(portalUrlBase, subscriptionId, resourceGroupName string) st
 		portalUrlBase,
 		subscriptionId,
 		resourceGroupName))
-}
-
-func serviceNameWarningCheck(console input.Console, serviceNameFlag string, commandName string) {
-	if serviceNameFlag == "" {
-		return
-	}
-
-	fmt.Fprintln(
-		console.Handles().Stderr,
-		output.WithWarningFormat("WARNING: The `--service` flag is deprecated and will be removed in a future release."),
-	)
-	fmt.Fprintf(console.Handles().Stderr, "Next time use `azd %s <service>`.\n\n", commandName)
 }
 
 func getTargetServiceName(

--- a/cli/azd/pkg/infra/deployment_manager.go
+++ b/cli/azd/pkg/infra/deployment_manager.go
@@ -76,7 +76,7 @@ func (dm *DeploymentManager) ResourceGroupDeployment(
 func (dm *DeploymentManager) CompletedDeployments(
 	ctx context.Context,
 	scope Scope,
-	envName string,
+	deploymentName string,
 	hint string,
 ) ([]*azapi.ResourceDeployment, error) {
 	deployments, err := scope.ListDeployments(ctx)
@@ -90,7 +90,7 @@ func (dm *DeploymentManager) CompletedDeployments(
 
 	// If hint is not provided, use the environment name as the hint
 	if hint == "" {
-		hint = envName
+		hint = deploymentName
 	}
 
 	// Environment matching strategy
@@ -107,7 +107,8 @@ func (dm *DeploymentManager) CompletedDeployments(
 		}
 
 		// Match on current azd strategy (tags) or old azd strategy (deployment name)
-		if v, has := deployment.Tags[azure.TagKeyAzdEnvName]; has && *v == envName || deployment.Name == envName {
+		if v, has := deployment.Tags[azure.TagKeyAzdEnvName]; has && *v == deploymentName ||
+			deployment.Name == deploymentName {
 			return []*azapi.ResourceDeployment{deployment}, nil
 		}
 
@@ -118,7 +119,7 @@ func (dm *DeploymentManager) CompletedDeployments(
 	}
 
 	if len(matchingDeployments) == 0 {
-		return nil, fmt.Errorf("'%s': %w", envName, ErrDeploymentsNotFound)
+		return nil, fmt.Errorf("'%s': %w", deploymentName, ErrDeploymentsNotFound)
 	}
 
 	return matchingDeployments, nil

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -19,6 +19,7 @@ const (
 )
 
 type Options struct {
+	Name             string         `yaml:"-"`
 	Provider         ProviderKind   `yaml:"provider,omitempty"`
 	Path             string         `yaml:"path,omitempty"`
 	Module           string         `yaml:"module,omitempty"`

--- a/cli/azd/pkg/infra/provisioning_progress_display.go
+++ b/cli/azd/pkg/infra/provisioning_progress_display.go
@@ -7,9 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -63,26 +61,13 @@ func (display *ProvisioningProgressDisplay) ReportProgress(
 			return err
 		}
 
-		deploymentLink := fmt.Sprintf(output.WithLinkFormat("%s\n"), deploymentUrl)
-
+		deploymentLink := output.WithHyperlink(deploymentUrl, "Azure Portal")
 		display.console.EnsureBlankLine(ctx)
-
-		lines := []string{
-			"You can view detailed progress in the Azure Portal:",
-			deploymentLink,
-		}
-
-		if v, err := strconv.ParseBool(os.Getenv("AZD_DEMO_MODE")); err == nil && v {
-			lines = []string{
-				"You can view detailed progress in the Azure Portal.",
-				"\n",
-			}
-		}
 
 		display.console.MessageUxItem(
 			ctx,
 			&ux.MultilineMessage{
-				Lines: lines,
+				Lines: []string{fmt.Sprintf("You can view detailed progress in the %s.\n", deploymentLink)},
 			},
 		)
 	}

--- a/cli/azd/pkg/infra/provisioning_progress_display_test.go
+++ b/cli/azd/pkg/infra/provisioning_progress_display_test.go
@@ -145,7 +145,8 @@ func TestReportProgress(t *testing.T) {
 
 	outputLength++
 	assert.Len(t, mockContext.Console.Output(), outputLength)
-	assert.Contains(t, mockContext.Console.Output()[0], "You can view detailed progress in the Azure Portal:")
+	assert.Contains(t, mockContext.Console.Output()[0], "You can view detailed progress in the")
+	assert.Contains(t, mockContext.Console.Output()[0], "Azure Portal")
 
 	mockResourceManager.AddInProgressOperation()
 	err = progressDisplay.ReportProgress(*mockContext.Context, &startTime)

--- a/cli/azd/pkg/output/ux/environment_details.go
+++ b/cli/azd/pkg/output/ux/environment_details.go
@@ -6,9 +6,9 @@ package ux
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
-	"github.com/fatih/color"
 )
 
 type EnvironmentDetails struct {
@@ -17,15 +17,14 @@ type EnvironmentDetails struct {
 }
 
 func (t *EnvironmentDetails) ToString(currentIndentation string) string {
-	var location string
+	lines := []string{}
 	if t.Location != "" {
-		location = fmt.Sprintf("\nLocation: %s", color.BlueString(t.Location))
+		lines = append(lines, fmt.Sprintf("Location: %s", output.WithHighLightFormat(t.Location)))
 	}
-	return fmt.Sprintf(
-		"Subscription: %s%s\n",
-		color.BlueString(t.Subscription),
-		location,
-	)
+
+	lines = append(lines, fmt.Sprintf("Subscription: %s", output.WithHighLightFormat(t.Subscription)))
+
+	return strings.Join(lines, "\n") + "\n"
 }
 
 func (t *EnvironmentDetails) MarshalJSON() ([]byte, error) {

--- a/cli/azd/pkg/output/ux/testdata/TestEnvironmentDetails.snap
+++ b/cli/azd/pkg/output/ux/testdata/TestEnvironmentDetails.snap
@@ -1,3 +1,3 @@
-Subscription: Foo (bar)
 Location: Somewhere cool
+Subscription: Foo (bar)
 

--- a/cli/azd/pkg/project/project_manager.go
+++ b/cli/azd/pkg/project/project_manager.go
@@ -19,6 +19,7 @@ import (
 const (
 	ProjectEventDeploy    ext.Event = "deploy"
 	ProjectEventProvision ext.Event = "provision"
+	ProjectEventDown      ext.Event = "down"
 )
 
 var (

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -26,6 +26,7 @@ const (
 	ServiceEventEnvUpdated ext.Event = "environment updated"
 	ServiceEventRestore    ext.Event = "restore"
 	ServiceEventBuild      ext.Event = "build"
+	ServiceEventProvision  ext.Event = "package"
 	ServiceEventPackage    ext.Event = "package"
 	ServiceEventDeploy     ext.Event = "deploy"
 )

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -26,17 +26,20 @@ const (
 	ServiceEventEnvUpdated ext.Event = "environment updated"
 	ServiceEventRestore    ext.Event = "restore"
 	ServiceEventBuild      ext.Event = "build"
-	ServiceEventProvision  ext.Event = "package"
+	ServiceEventProvision  ext.Event = "provision"
 	ServiceEventPackage    ext.Event = "package"
 	ServiceEventDeploy     ext.Event = "deploy"
+	ServiceEventDown       ext.Event = "down"
 )
 
 var (
 	ServiceEvents []ext.Event = []ext.Event{
 		ServiceEventEnvUpdated,
 		ServiceEventRestore,
+		ServiceEventProvision,
 		ServiceEventPackage,
 		ServiceEventDeploy,
+		ServiceEventDown,
 	}
 )
 


### PR DESCRIPTION
## Commands

`azd provision` - provisions platform infra plus any infra defined for all services

`azd provision --platform` - only provisions root infrastructure for project

`azd provision <service>` - only provisions service level infra for specified service

## `azd provision` User Experience
<img width="734" alt="image" src="https://github.com/user-attachments/assets/d44c48b4-446c-4159-a188-31ab33e8cbf0">

## `azd down` User Experience
<img width="589" alt="image" src="https://github.com/user-attachments/assets/72d44ecf-7381-447d-9e8e-1c6fbb0422e5">

## Test / Usage

`azd init -t wbreza/todo-nodejs-mongo-aca -b aca-poc-updates`

Deploy with [branch of Todo ACA sample](https://github.com/wbreza/todo-nodejs-mongo-aca/tree/aca-poc-updates)