### PR TITLE
Remove experimentation middleware from global middleware list

### DIFF
--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -332,7 +332,6 @@ func NewRootCmd(
 	root.
 		UseMiddleware("debug", middleware.NewDebugMiddleware).
 		UseMiddleware("ux", middleware.NewUxMiddleware).
-		UseMiddleware("experimentation", middleware.NewExperimentationMiddleware).
 		UseMiddlewareWhen("telemetry", middleware.NewTelemetryMiddleware, func(descriptor *actions.ActionDescriptor) bool {
 			return !descriptor.Options.DisableTelemetry
 		})

--- a/cli/azd/test/functional/experiment_test.go
+++ b/cli/azd/test/functional/experiment_test.go
@@ -19,6 +19,8 @@ import (
 
 // Verifies that the assignment context returned is included in the telemetry events we capture.
 func Test_CLI_Experiment_AssignmentContextInTelemetry(t *testing.T) {
+	t.Skip("Skipping while experimentation is not enabled")
+
 	// CLI process and working directory are isolated
 	t.Parallel()
 	ctx, cancel := newTestContext(t)


### PR DESCRIPTION
While we troubleshoot blocking issues when communicating with our backend experimentation we will remove the experimentation middleware from the global middleware list since we are not running any active experiments.

fix: https://github.com/Azure/azure-dev/issues/4410