### PR TITLE
WIP: Prompt user to select or create new resource

### DIFF
--- a/cli/azd/pkg/azure/arm_template.go
+++ b/cli/azd/pkg/azure/arm_template.go
@@ -100,9 +100,10 @@ type AutoGenInput struct {
 // ResourceInputMetadata is set on ARM/Bicep parameter properties
 // This metadata is used to generate a resource picker in the CLI
 type ResourceInputMetadata struct {
-	DisplayName string `json:"displayName"`
-	Description string `json:"description"`
-	Type        string `json:"type"`
+	DisplayName string   `json:"displayName"`
+	Description string   `json:"description"`
+	Type        string   `json:"type"`
+	Kinds       []string `json:"kind"`
 }
 
 // OptionalResource is used to represent a resource that may or may not exist in the Azure subscription.

--- a/cli/azd/pkg/azure/arm_template.go
+++ b/cli/azd/pkg/azure/arm_template.go
@@ -97,16 +97,35 @@ type AutoGenInput struct {
 	MinSpecial *uint `json:"minSpecial,omitempty"`
 }
 
+// ResourceInputMetadata is set on ARM/Bicep parameter properties
+// This metadata is used to generate a resource picker in the CLI
+type ResourceInputMetadata struct {
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
+}
+
+// OptionalResource is used to represent a resource that may or may not exist in the Azure subscription.
+// This value is used as an input value to the ARM/Bicep parameter for parameters with azd type resource metadata.
+type OptionalResource struct {
+	Name           string `json:"name"`
+	SubscriptionId string `json:"subscriptionId"`
+	ResourceGroup  string `json:"resourceGroup"`
+	Exists         bool   `json:"exists"`
+}
+
 type AzdMetadataType string
 
 const AzdMetadataTypeLocation AzdMetadataType = "location"
 const AzdMetadataTypeGenerate AzdMetadataType = "generate"
 const AzdMetadataTypeGenerateOrManual AzdMetadataType = "generateOrManual"
+const AzdMetadataTypeResource AzdMetadataType = "resource"
 
 type AzdMetadata struct {
-	Type               *AzdMetadataType `json:"type,omitempty"`
-	AutoGenerateConfig *AutoGenInput    `json:"config,omitempty"`
-	DefaultValueExpr   *string          `json:"defaultValueExpr,omitempty"`
+	Type               *AzdMetadataType       `json:"type,omitempty"`
+	AutoGenerateConfig *AutoGenInput          `json:"config,omitempty"`
+	DefaultValueExpr   *string                `json:"defaultValueExpr,omitempty"`
+	Resource           *ResourceInputMetadata `json:"resource,omitempty"`
 }
 
 // Description returns the value of the "Description" string metadata for this parameter or empty if it can not be found.

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -1888,6 +1888,7 @@ func (p *BicepProvider) ensureParameters(
 			// Prompt user to select an existing resource to link to the template
 			selectedResource, err := p.prompters.PromptResource(ctx, prompt.PromptResourceOptions{
 				ResourceType: azdMetadata.Resource.Type,
+				Kinds:        azdMetadata.Resource.Kinds,
 				DisplayName:  azdMetadata.Resource.DisplayName,
 				Description:  azdMetadata.Resource.Description,
 			})

--- a/cli/azd/pkg/prompt/prompter.go
+++ b/cli/azd/pkg/prompt/prompter.go
@@ -197,7 +197,7 @@ func (p *DefaultPrompter) PromptResource(ctx context.Context, options PromptReso
 	choices[0] = fmt.Sprintf("Create a new %s", resourceTypeDisplayName)
 
 	for idx, resource := range resources {
-		parsedResource, err := arm.ParseResourceID(*&resource.Id)
+		parsedResource, err := arm.ParseResourceID(resource.Id)
 		if err != nil {
 			return nil, fmt.Errorf("parsing resource id: %w", err)
 		}


### PR DESCRIPTION
Authoring bicep templates that work well across a wide range of scenarios is hard.  One difficult scenario is supporting a bicep module where the resource is conditionally created based on whether the consumer wants to use a new resource or leverage an existing resource.

We are seeing this scenario multiple times in various AI use cases where customers may already have AI studio hubs, projects already created or want to leverage existing services like an Azure Open AI Service, etc.

## Idea
Leverage custom `azd` metadata within bicep to enable authors to mark up parameters that map to a new or existing resource using bicep user defined types.

### Example of user defined type

```bicep
type OptionalResource = {
  name: string
  subscriptionId: string?
  resourceGroup: string?
  exists: bool
}
```

Then when specifying a bicep parameter additional `azd` metadata can be added to light up new experiences in `azd`

### Example of using parameters with custom metadata

```bicep
@metadata({
  azd: {
    type: 'resource'
    resource: {
      displayName: 'Key Vault'
      description: 'The key vault to use for storing secrets'
      type: 'Microsoft.KeyVault/vaults'
    }
  }
})
param keyVault OptionalResource
```

## `azd` Experience

When calling `azd provision` users will automatically be prompted to select a resource if this is the first time they are deploying the project.

<img width="580" alt="image" src="https://github.com/user-attachments/assets/904a61f1-8760-49a6-ad50-831d8dcbb6fd">

The data for the custom input is serialized and sent in as bicep input parameters

<img width="889" alt="image" src="https://github.com/user-attachments/assets/439ae081-e949-455a-bd09-8ce91713e309">

The provisioning continues as normal and is up to the author of the bicep to ensure they reuse or create the resource based upon the input value.

<img width="821" alt="image" src="https://github.com/user-attachments/assets/07411ee8-5c49-4aa5-a066-99c984a00dcc">

