### PR TITLE
easy-init: allow for longer container app names

### DIFF
--- a/cli/azd/internal/repository/detect_confirm.go
+++ b/cli/azd/internal/repository/detect_confirm.go
@@ -263,6 +263,7 @@ func (d *detectConfirm) remove(ctx context.Context) error {
 		confirm, err := d.console.Confirm(ctx, input.ConsoleOptions{
 			Message: fmt.Sprintf(
 				"Remove %s in %s?", projectDisplayName(svc), relSafe(d.root, svc.Path)),
+			DefaultValue: true,
 		})
 		if err != nil {
 			return err
@@ -280,6 +281,7 @@ func (d *detectConfirm) remove(ctx context.Context) error {
 		confirm, err := d.console.Confirm(ctx, input.ConsoleOptions{
 			Message: fmt.Sprintf(
 				"Remove %s?", db.Display()),
+			DefaultValue: true,
 		})
 		if err != nil {
 			return err

--- a/cli/azd/internal/scaffold/funcs.go
+++ b/cli/azd/internal/scaffold/funcs.go
@@ -99,16 +99,9 @@ func lowerCase(r byte) byte {
 	return r
 }
 
-// Provide a reasonable limit for the container app infix to avoid name length issues
-// This is calculated as follows:
-//  1. Start with max initial length of 32 characters from the Container App name
-//     https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftapp
-//  2. Prefix abbreviation of 'ca-' from abbreviations.json (4 characters)
-//  3. Bicep resource token (13 characters) + separator '-' (1 character) -- total of 14 characters
+// 32 characters are allowed for the Container App name. See
+// https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftapp
 //
-// Which leaves us with: 32 - 4 - 14 = 14 characters.
-const containerAppNameInfixMaxLen = 12
-
 // We allow 2 additional characters for wiggle-room. We've seen failures when container app name is exactly at 32.
 const containerAppNameMaxLen = 30
 
@@ -171,14 +164,6 @@ var camelCaseRegex = regexp.MustCompile(`([a-z0-9])([A-Z])`)
 func EnvFormat(src string) string {
 	snake := strings.ReplaceAll(strings.ToUpper(camelCaseRegex.ReplaceAllString(src, "${1}_${2}")), "-", "_")
 	return fmt.Sprintf("${AZURE_%s}", snake)
-}
-
-// ContainerAppInfix returns a suitable infix for a container app resource.
-//
-// The name is treated to only contain alphanumeric and dash characters, with no repeated dashes, and no dashes
-// as the first or last character.
-func ContainerAppInfix(name string) string {
-	return containerAppName(name, containerAppNameInfixMaxLen)
 }
 
 // Formats a parameter value for use in a bicep file.

--- a/cli/azd/internal/scaffold/scaffold.go
+++ b/cli/azd/internal/scaffold/scaffold.go
@@ -54,11 +54,11 @@ func copyFS(embedFs fs.FS, root string, target string) error {
 // To execute a named template, call Execute with the defined name.
 func Load() (*template.Template, error) {
 	funcMap := template.FuncMap{
-		"bicepName":         BicepName,
-		"containerAppInfix": ContainerAppInfix,
-		"upper":             strings.ToUpper,
-		"lower":             strings.ToLower,
-		"formatParam":       FormatParameter,
+		"bicepName":        BicepName,
+		"containerAppName": ContainerAppName,
+		"upper":            strings.ToUpper,
+		"lower":            strings.ToLower,
+		"formatParam":      FormatParameter,
 	}
 
 	t, err := template.New("templates").

--- a/cli/azd/resources/scaffold/templates/main.bicept
+++ b/cli/azd/resources/scaffold/templates/main.bicept
@@ -131,17 +131,17 @@ module postgresDb './app/db-postgres.bicep' = {
 module {{bicepName .Name}} './app/{{.Name}}.bicep' = {
   name: '{{.Name}}'
   params: {
-    name: '${abbrs.appContainerApps}{{containerAppInfix .Name}}-${resourceToken}'
+    name: '{{containerAppName .Name}}'
     location: location
     tags: tags
-    identityName: '${abbrs.managedIdentityUserAssignedIdentities}{{containerAppInfix .Name}}-${resourceToken}'
+    identityName: '${abbrs.managedIdentityUserAssignedIdentities}{{.Name}}-${resourceToken}'
     applicationInsightsName: monitoring.outputs.applicationInsightsName
     containerAppsEnvironmentName: appsEnv.outputs.name
     containerRegistryName: registry.outputs.name
     exists: {{bicepName .Name}}Exists
     appDefinition: {{bicepName .Name}}Definition
     {{- if .DbRedis}}
-    redisName: 'rd-{{containerAppInfix .Name}}-${resourceToken}'
+    redisName: 'rd-{{containerAppName .Name}}'
     {{- end}}
     {{- if .DbCosmosMongo}}
     cosmosDbConnectionString: vault.getSecret(cosmosDb.outputs.connectionStringKey)
@@ -162,7 +162,7 @@ module {{bicepName .Name}} './app/{{.Name}}.bicep' = {
     {{- if (and .Backend .Backend.Frontends)}}
     allowedOrigins: [
       {{- range .Backend.Frontends}}
-      'https://${abbrs.appContainerApps}{{containerAppInfix .Name}}-${resourceToken}.${appsEnv.outputs.domain}'
+      'https://{{containerAppName .Name}}.${appsEnv.outputs.domain}'
       {{- end}}
     ]
     {{- end}}


### PR DESCRIPTION
In the generated bicep for easy-init, remove resource token and `ca-` from the container app name.

This makes it inline with Aspire's generation experience. Overall, the new naming scheme improves DX: developers have matching service names with corresponding app/image name.

Fixes  #4433 