### PR TITLE
go.mod: update library gopkg.in/yaml.v3 to github.com/braydonk/yaml

### DIFF
--- a/.vscode/cspell-github-user-aliases.txt
+++ b/.vscode/cspell-github-user-aliases.txt
@@ -6,6 +6,7 @@ benbjohnson
 blang
 bmatcuk
 bradleyjkemp
+braydonk
 briandowns
 buger
 cobey

--- a/cli/azd/pkg/ai/config.go
+++ b/cli/azd/pkg/ai/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
-	"gopkg.in/yaml.v3"
+	"github.com/braydonk/yaml"
 )
 
 // ComponentConfig is a base configuration structure used by multiple AI components

--- a/cli/azd/pkg/alpha/alpha_feature.go
+++ b/cli/azd/pkg/alpha/alpha_feature.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/resources"
-	"gopkg.in/yaml.v3"
+	"github.com/braydonk/yaml"
 )
 
 // Feature defines the structure for a feature in alpha mode.

--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -28,8 +28,8 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/resources"
+	"github.com/braydonk/yaml"
 	"github.com/psanford/memfs"
-	"gopkg.in/yaml.v3"
 )
 
 const RedisContainerAppService = "redis"

--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -20,7 +20,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/benbjohnson/clock"
-	"gopkg.in/yaml.v3"
+	"github.com/braydonk/yaml"
 )
 
 const (

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -22,7 +22,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
-	"gopkg.in/yaml.v3"
+	"github.com/braydonk/yaml"
 )
 
 type DefaultProviderResolver func() (ProviderKind, error)

--- a/cli/azd/pkg/osutil/expandable_string_test.go
+++ b/cli/azd/pkg/osutil/expandable_string_test.go
@@ -6,8 +6,8 @@ package osutil
 import (
 	"testing"
 
+	"github.com/braydonk/yaml"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 )
 
 func TestExpandableStringYaml(t *testing.T) {

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -18,7 +18,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/blang/semver/v4"
-	"gopkg.in/yaml.v3"
+	"github.com/braydonk/yaml"
 )
 
 const (

--- a/cli/azd/pkg/project/project_config_test.go
+++ b/cli/azd/pkg/project/project_config_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/snapshot"
+	"github.com/braydonk/yaml"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 )
 
 // Tests invalid project configurations.

--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -18,9 +18,9 @@ import (
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockarmresources"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazcli"
 	"github.com/azure/azure-dev/cli/azd/test/snapshot"
+	"github.com/braydonk/yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 )
 
 // Specifying resource name in the project file should override the default

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -35,9 +35,9 @@ import (
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockenv"
 	"github.com/azure/azure-dev/cli/azd/test/ostest"
 	"github.com/benbjohnson/clock"
+	"github.com/braydonk/yaml"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 )
 
 func Test_NewAksTarget(t *testing.T) {

--- a/cli/azd/pkg/tools/kubectl/kube_config.go
+++ b/cli/azd/pkg/tools/kubectl/kube_config.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
-	"gopkg.in/yaml.v3"
+	"github.com/braydonk/yaml"
 )
 
 // Manages k8s configurations available to the k8s CLI

--- a/cli/azd/pkg/tools/kubectl/models_test.go
+++ b/cli/azd/pkg/tools/kubectl/models_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/braydonk/yaml"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 )
 
 func Test_Port_TargetPort_Unmarshalling(t *testing.T) {

--- a/cli/azd/pkg/tools/kubectl/util.go
+++ b/cli/azd/pkg/tools/kubectl/util.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/braydonk/yaml"
 	"github.com/sethvargo/go-retry"
-	"gopkg.in/yaml.v3"
 )
 
 var (

--- a/cli/azd/pkg/workflow/config_test.go
+++ b/cli/azd/pkg/workflow/config_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/braydonk/yaml"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 )
 
 var testWorkflow = &Workflow{

--- a/cli/azd/pkg/workflow/workflow.go
+++ b/cli/azd/pkg/workflow/workflow.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"github.com/braydonk/yaml"
 )
 
 // Workflow stores a list of steps to execute

--- a/cli/azd/test/cmdrecord/cassette.go
+++ b/cli/azd/test/cmdrecord/cassette.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"gopkg.in/yaml.v3"
+	"github.com/braydonk/yaml"
 )
 
 const InteractionIdFile = "int-id.txt"

--- a/cli/azd/test/cmdrecord/cmdrecorder_test.go
+++ b/cli/azd/test/cmdrecord/cmdrecorder_test.go
@@ -10,9 +10,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/braydonk/yaml"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
-	"gopkg.in/yaml.v3"
 )
 
 // Verify that record + playback work together.

--- a/cli/azd/test/cmdrecord/proxy/main.go
+++ b/cli/azd/test/cmdrecord/proxy/main.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/test/cmdrecord"
+	"github.com/braydonk/yaml"
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
-	"gopkg.in/yaml.v3"
 )
 
 type ErrExitCode struct {

--- a/cli/azd/test/recording/recording.go
+++ b/cli/azd/test/recording/recording.go
@@ -26,9 +26,9 @@ import (
 	"time"
 
 	"github.com/azure/azure-dev/cli/azd/test/cmdrecord"
+	"github.com/braydonk/yaml"
 	"gopkg.in/dnaeon/go-vcr.v3/cassette"
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
-	"gopkg.in/yaml.v3"
 )
 
 type recordOptions struct {

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/bradleyjkemp/cupaloy/v2 v2.8.0
+	github.com/braydonk/yaml v0.7.0
 	github.com/buger/goterm v1.0.4
 	github.com/cli/browser v1.1.0
 	github.com/drone/envsubst v1.0.3
@@ -69,7 +70,6 @@ require (
 	go.uber.org/multierr v1.8.0
 	golang.org/x/sys v0.21.0
 	gopkg.in/dnaeon/go-vcr.v3 v3.1.2
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -106,4 +106,5 @@ require (
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/grpc v1.56.3 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvz
 github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
+github.com/braydonk/yaml v0.7.0 h1:ySkqO7r0MGoCNhiRJqE0Xe9yhINMyvOAB3nFjgyJn2k=
+github.com/braydonk/yaml v0.7.0/go.mod h1:hcm3h581tudlirk8XEUPDBAimBPbmnL0Y45hCRl47N4=
 github.com/buger/goterm v1.0.4 h1:Z9YvGmOih81P0FbVtEYTFF6YsSgxSUKEhf/f9bTMXbY=
 github.com/buger/goterm v1.0.4/go.mod h1:HiFWV3xnkolgrBV3mY8m0X0Pumt4zg4QhbdOzQtB8tE=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=


### PR DESCRIPTION
Update library gopkg.in/yaml.v3 to github.com/braydonk/yaml.

> Note: gopkg.in/yaml.v3 library has not had any activity since May 27, 2022.

In upcoming features for azd, we will start round-tripping YAML by marshaling and unmarshaling text. When YAML is round-tripped this way using the current gopkg.in/yaml.v3 library, certain textual characteristic is lost.

### Round-tripping differences

#### Multi-line blocks:
```yaml
cmd: >
   echo "Hello"
   echo "World!"
```

When marshaled, then unmarshaled, results in:
```yaml
cmd: echo "Hello" echo "World"
```

#### Sequences:
```yaml
sequences:
- a
- b
```

When marshaled, then unmarshaled, results in:
```yaml
sequences:
  - a
  - b
 ```

i.e. Sequences are always indented once.

Fortunately, [github.com/braydonk/yaml](https://github.com/braydonk/yaml) is a fork of gopkg.in/yaml.v3 that powers [yamlfmt](https://github.com/google/yamlfmt/), a popular tool for formatting YAML. The fork has minor feature [additions](https://github.com/go-yaml/yaml/compare/v3...braydonk:yaml:v3) to support these formatting use-cases.

We will likely need additional functionality in the future that we can consider contributing upstream.