### PR TITLE
Fixes panic on missing hook configuration

### DIFF
--- a/cli/azd/pkg/ext/hooks_manager.go
+++ b/cli/azd/pkg/ext/hooks_manager.go
@@ -2,6 +2,7 @@ package ext
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"runtime"
 	"strings"
@@ -81,6 +82,10 @@ func (h *HooksManager) filterConfigs(
 		}
 
 		for _, hook := range hooks {
+			if hook == nil {
+				log.Printf("hook configuration for '%s' is missing", scriptName)
+				continue
+			}
 
 			if predicate != nil && !predicate(scriptName, hook) {
 				continue

--- a/cli/azd/pkg/ext/hooks_manager_test.go
+++ b/cli/azd/pkg/ext/hooks_manager_test.go
@@ -62,6 +62,20 @@ func Test_GetAllHookConfigs(t *testing.T) {
 		require.Nil(t, validHooks)
 		require.Error(t, err)
 	})
+
+	t.Run("With Missing Configuration", func(t *testing.T) {
+		// All hooksMap are invalid because they are missing a script type
+		hooksMap := map[string][]*HookConfig{
+			"preprovision": nil,
+		}
+
+		hooksManager := NewHooksManager(tempDir)
+		validHooks, err := hooksManager.GetAll(hooksMap)
+
+		require.NoError(t, err)
+		require.NotNil(t, validHooks)
+		require.Len(t, validHooks, 0)
+	})
 }
 
 func Test_GetByParams(t *testing.T) {


### PR DESCRIPTION
Fixes #4451 

Resolves an issue when an `azure.yaml` has missing hook configuration:

```yaml
hooks:
  preprovision:                      # Missing configuration block
  postdeploy: 
    run: ./myscript.sh
```    
  