### PR TITLE
chore: refactor infra generation app_init.go 

### DIFF
--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -242,7 +242,7 @@ func (i *Initializer) InitFromApp(
 	tracing.SetUsageAttributes(fields.AppInitLastStep.String("config"))
 
 	// Create the infra spec
-	spec, err := i.infraSpecFromDetect(ctx, detect)
+	infraSpec, err := i.infraSpecFromDetect(ctx, detect)
 	if err != nil {
 		return err
 	}
@@ -256,16 +256,32 @@ func (i *Initializer) InitFromApp(
 	tracing.SetUsageAttributes(fields.AppInitLastStep.String("generate"))
 
 	i.console.Message(ctx, "\n"+output.WithBold("Generating files to run your app on Azure:")+"\n")
+	title = "Generating " + output.WithHighLightFormat("./"+azdcontext.ProjectFileName)
+	i.console.ShowSpinner(ctx, title, input.Step)
 	err = i.genProjectFile(ctx, azdCtx, detect)
 	if err != nil {
+		i.console.StopSpinner(ctx, title, input.GetStepResultFormat(err))
 		return err
 	}
+	i.console.StopSpinner(ctx, title, input.StepDone)
 
-	infra := filepath.Join(azdCtx.ProjectDirectory(), "infra")
 	title = "Generating Infrastructure as Code files in " + output.WithHighLightFormat("./infra")
 	i.console.ShowSpinner(ctx, title, input.Step)
-	defer i.console.StopSpinner(ctx, title, input.GetStepResultFormat(err))
+	err = i.genFromInfra(ctx, azdCtx, infraSpec)
+	if err != nil {
+		i.console.StopSpinner(ctx, title, input.GetStepResultFormat(err))
+		return err
+	}
+	i.console.StopSpinner(ctx, title, input.StepDone)
 
+	return nil
+}
+
+func (i *Initializer) genFromInfra(
+	ctx context.Context,
+	azdCtx *azdcontext.AzdContext,
+	spec scaffold.InfraSpec) error {
+	infra := filepath.Join(azdCtx.ProjectDirectory(), "infra")
 	staging, err := os.MkdirTemp("", "azd-infra")
 	if err != nil {
 		return fmt.Errorf("mkdir temp: %w", err)
@@ -319,12 +335,6 @@ func (i *Initializer) genProjectFile(
 	ctx context.Context,
 	azdCtx *azdcontext.AzdContext,
 	detect detectConfirm) error {
-	title := "Generating " + output.WithHighLightFormat("./"+azdcontext.ProjectFileName)
-
-	i.console.ShowSpinner(ctx, title, input.Step)
-	var err error
-	defer i.console.StopSpinner(ctx, title, input.GetStepResultFormat(err))
-
 	config, err := prjConfigFromDetect(azdCtx.ProjectDirectory(), detect)
 	if err != nil {
 		return fmt.Errorf("converting config: %w", err)

--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -32,6 +33,7 @@ type Initializer struct {
 	console        input.Console
 	gitCli         *git.Cli
 	dotnetCli      *dotnet.Cli
+	features       *alpha.FeatureManager
 	lazyEnvManager *lazy.Lazy[environment.Manager]
 }
 
@@ -39,6 +41,7 @@ func NewInitializer(
 	console input.Console,
 	gitCli *git.Cli,
 	dotnetCli *dotnet.Cli,
+	features *alpha.FeatureManager,
 	lazyEnvManager *lazy.Lazy[environment.Manager],
 ) *Initializer {
 	return &Initializer{
@@ -46,6 +49,7 @@ func NewInitializer(
 		gitCli:         gitCli,
 		lazyEnvManager: lazyEnvManager,
 		dotnetCli:      dotnetCli,
+		features:       features,
 	}
 }
 

--- a/cli/azd/internal/repository/initializer_test.go
+++ b/cli/azd/internal/repository/initializer_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
@@ -59,6 +61,7 @@ func Test_Initializer_Initialize(t *testing.T) {
 				mockContext.Console,
 				git.NewCli(mockContext.CommandRunner),
 				dotnet.NewCli(mockContext.CommandRunner),
+				mockContext.AlphaFeaturesManager,
 				lazy.From[environment.Manager](mockEnv),
 			)
 			err := i.Initialize(*mockContext.Context, azdCtx, &templates.Template{RepositoryPath: "local"}, "")
@@ -103,6 +106,7 @@ func Test_Initializer_DevCenter(t *testing.T) {
 		mockContext.Console,
 		git.NewCli(mockContext.CommandRunner),
 		dotnet.NewCli(mockContext.CommandRunner),
+		mockContext.AlphaFeaturesManager,
 		lazy.From[environment.Manager](mockEnv),
 	)
 	err := i.Initialize(*mockContext.Context, azdCtx, template, "")
@@ -173,6 +177,7 @@ func Test_Initializer_InitializeWithOverwritePrompt(t *testing.T) {
 				console,
 				git.NewCli(mockRunner),
 				dotnet.NewCli(mockRunner),
+				alpha.NewFeaturesManagerWithConfig(config.NewEmptyConfig()),
 				lazy.From[environment.Manager](mockEnv),
 			)
 			err = i.Initialize(context.Background(), azdCtx, &templates.Template{RepositoryPath: "local"}, "")
@@ -376,7 +381,9 @@ func Test_Initializer_WriteCoreAssets(t *testing.T) {
 			envManager.On("Save", mock.Anything, mock.Anything).Return(nil)
 
 			i := NewInitializer(
-				console, git.NewCli(realRunner), nil, lazy.From[environment.Manager](envManager))
+				console, git.NewCli(realRunner), nil,
+				alpha.NewFeaturesManagerWithConfig(config.NewEmptyConfig()),
+				lazy.From[environment.Manager](envManager))
 			err := i.writeCoreAssets(context.Background(), azdCtx)
 			require.NoError(t, err)
 


### PR DESCRIPTION
Refactor infra generation logic into a new method.

To set up a cleaner future diff, add alpha feature manager as well.