### PR TITLE
Update appservice.bicep with App Insights env var

### DIFF
--- a/templates/common/infra/bicep/core/host/appservice.bicep
+++ b/templates/common/infra/bicep/core/host/appservice.bicep
@@ -92,6 +92,7 @@ module configAppSettings 'appservice-appsettings.bicep' = {
       {
         SCM_DO_BUILD_DURING_DEPLOYMENT: string(scmDoBuildDuringDeployment)
         ENABLE_ORYX_BUILD: string(enableOryxBuild)
+        ApplicationInsightsAgent_EXTENSION_VERSION: contains(kind, 'linux') ? '~3' : '~2'
       },
       runtimeName == 'python' && appCommandLine == '' ? { PYTHON_ENABLE_GUNICORN_MULTIWORKERS: 'true'} : {},
       !empty(applicationInsightsName) ? { APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.properties.ConnectionString } : {},


### PR DESCRIPTION
Per https://learn.microsoft.com/en-us/azure/azure-monitor/app/codeless-app-service?tabs=python#automate-monitoring , an additional environment variable is required for application monitoring in App Service.

I'm adding the same var to azure-search-openai-demo in this PR:
https://github.com/Azure-Samples/azure-search-openai-demo/pull/2083/files
And testing the deploy now.