### PR TITLE
compose: refactor to add alpha switch

### DIFF
--- a/cli/azd/test/functional/init_test.go
+++ b/cli/azd/test/functional/init_test.go
@@ -174,7 +174,7 @@ func Test_CLI_Init_CanUseTemplate(t *testing.T) {
 	require.FileExists(t, filepath.Join(dir, "README.md"))
 }
 
-func Test_CLI_Init_From_App(t *testing.T) {
+func Test_CLI_Init_From_App_With_Infra(t *testing.T) {
 	// running this test in parallel is ok as it uses a t.TempDir()
 	t.Parallel()
 	ctx, cancel := newTestContext(t)
@@ -189,6 +189,7 @@ func Test_CLI_Init_From_App(t *testing.T) {
 	cli.WorkingDirectory = dir
 	cli.Env = append(os.Environ(), "AZURE_LOCATION=eastus2")
 	cli.Env = append(cli.Env, "AZD_CONFIG_DIR="+dir)
+	cli.Env = append(cli.Env, "AZD_ALPHA_ENABLE_COMPOSE=0")
 	cli.Env = append(cli.Env, "AZURE_DEV_COLLECT_TELEMETRY=no")
 
 	err = copySample(appDir, "py-postgres")


### PR DESCRIPTION
A small refactor to integrate the alpha switch change.

In the easy init flow, we would want `azd init` without composability alpha feature enabled to continue materializing infrastructure as-is. If composability is enabled, we would want to hold the infrastructure in-memory.