### PR TITLE
Remove the feature to include `golangci-lint` since it's already included with `ghcr.io/devcontainers/features/go:1`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
         "ghcr.io/devcontainers/features/go:1": {
             "version": "1.23"
         },
-        "ghcr.io/guiyomh/features/golangci-lint:0":{
+        "ghcr.io/pablozaiden/devcontainers-features/golangci-lint:0":{
             "version": "1.60.1"
         },
         "ghcr.io/devcontainers/features/docker-in-docker:2.11.0": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,9 +5,6 @@
         "ghcr.io/devcontainers/features/go:1": {
             "version": "1.23"
         },
-        "ghcr.io/pablozaiden/devcontainers-features/golangci-lint:0":{
-            "version": "1.60.1"
-        },
         "ghcr.io/devcontainers/features/docker-in-docker:2.11.0": {
             "version": "latest",
             "moby": true

--- a/.devcontainer/light/devcontainer.json
+++ b/.devcontainer/light/devcontainer.json
@@ -5,7 +5,7 @@
         "ghcr.io/devcontainers/features/go:1": {
             "version": "1.23"
         },
-        "ghcr.io/guiyomh/features/golangci-lint:0":{
+        "ghcr.io/pablozaiden/devcontainers-features/golangci-lint:0":{
             "version": "1.60.1"
         },
         "ghcr.io/devcontainers/features/docker-in-docker:2.11.0": {

--- a/.devcontainer/light/devcontainer.json
+++ b/.devcontainer/light/devcontainer.json
@@ -5,9 +5,6 @@
         "ghcr.io/devcontainers/features/go:1": {
             "version": "1.23"
         },
-        "ghcr.io/pablozaiden/devcontainers-features/golangci-lint:0":{
-            "version": "1.60.1"
-        },
         "ghcr.io/devcontainers/features/docker-in-docker:2.11.0": {
             "version": "latest",
             "moby": true


### PR DESCRIPTION
The old repo used for the golangci-lint feature is abandoned and a new working release was created in a new repo.
The current release properly supports ARM-based computers.

This PR Fixes #4505