### PR TITLE
easy-init: generate resources in `azure.yaml`

### DIFF
--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -3,8 +3,11 @@ package repository
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
@@ -38,6 +41,8 @@ var dbMap = map[appdetect.DatabaseDep]struct{}{
 	appdetect.DbPostgres: {},
 	appdetect.DbRedis:    {},
 }
+
+var featureCompose = alpha.MustFeatureKey("compose")
 
 // InitFromApp initializes the infra directory and project file from the current existing app.
 func (i *Initializer) InitFromApp(
@@ -244,30 +249,31 @@ func (i *Initializer) InitFromApp(
 
 	// Create the infra spec
 	var infraSpec *scaffold.InfraSpec
-	if !i.features.IsEnabled(alpha.Compose) { // backwards compatibility
+	composeEnabled := i.features.IsEnabled(featureCompose)
+	if !composeEnabled { // backwards compatibility
 		spec, err := i.infraSpecFromDetect(ctx, detect)
 		if err != nil {
 			return err
 		}
 		infraSpec = &spec
-	}
 
-	// Prompt for environment before proceeding with generation
-	_, err = initializeEnv()
-	if err != nil {
-		return err
+		// Prompt for environment before proceeding with generation
+		_, err = initializeEnv()
+		if err != nil {
+			return err
+		}
 	}
 
 	tracing.SetUsageAttributes(fields.AppInitLastStep.String("generate"))
 
-	i.console.Message(ctx, "\n"+output.WithBold("Generating files to run your app on Azure:")+"\n")
 	title = "Generating " + output.WithHighLightFormat("./"+azdcontext.ProjectFileName)
 	i.console.ShowSpinner(ctx, title, input.Step)
-	err = i.genProjectFile(ctx, azdCtx, detect)
+	err = i.genProjectFile(ctx, azdCtx, detect, composeEnabled)
 	if err != nil {
 		i.console.StopSpinner(ctx, title, input.GetStepResultFormat(err))
 		return err
 	}
+	i.console.Message(ctx, "\n"+output.WithBold("Generating files to run your app on Azure:")+"\n")
 	i.console.StopSpinner(ctx, title, input.StepDone)
 
 	if infraSpec != nil {
@@ -279,6 +285,20 @@ func (i *Initializer) InitFromApp(
 			return err
 		}
 		i.console.StopSpinner(ctx, title, input.StepDone)
+	} else {
+		t, err := scaffold.Load()
+		if err != nil {
+			return fmt.Errorf("loading scaffold templates: %w", err)
+		}
+
+		err = scaffold.Execute(t, "next-steps-alpha.md", nil, filepath.Join(azdCtx.ProjectDirectory(), "next-steps.md"))
+		if err != nil {
+			return err
+		}
+
+		i.console.MessageUxItem(ctx, &ux.DoneMessage{
+			Message: "Generating " + output.WithHighLightFormat("./next-steps.md"),
+		})
 	}
 
 	return nil
@@ -341,8 +361,9 @@ func (i *Initializer) genFromInfra(
 func (i *Initializer) genProjectFile(
 	ctx context.Context,
 	azdCtx *azdcontext.AzdContext,
-	detect detectConfirm) error {
-	config, err := prjConfigFromDetect(azdCtx.ProjectDirectory(), detect)
+	detect detectConfirm,
+	addResources bool) error {
+	config, err := i.prjConfigFromDetect(ctx, azdCtx.ProjectDirectory(), detect, addResources)
 	if err != nil {
 		return fmt.Errorf("converting config: %w", err)
 	}
@@ -359,9 +380,11 @@ func (i *Initializer) genProjectFile(
 
 const InitGenTemplateId = "azd-init"
 
-func prjConfigFromDetect(
+func (i *Initializer) prjConfigFromDetect(
+	ctx context.Context,
 	root string,
-	detect detectConfirm) (project.ProjectConfig, error) {
+	detect detectConfirm,
+	addResources bool) (project.ProjectConfig, error) {
 	config := project.ProjectConfig{
 		Name: azdcontext.ProjectName(root),
 		Metadata: &project.ProjectMetadata{
@@ -369,6 +392,8 @@ func prjConfigFromDetect(
 		},
 		Services: map[string]*project.ServiceConfig{},
 	}
+
+	svcMapping := map[string]string{}
 	for _, prj := range detect.Services {
 		rel, err := filepath.Rel(root, prj.Path)
 		if err != nil {
@@ -429,7 +454,108 @@ func prjConfigFromDetect(
 			name = config.Name
 		}
 		name = names.LabelName(name)
+		svc.Name = name
 		config.Services[name] = &svc
+
+		svcMapping[prj.Path] = name
+	}
+
+	if addResources {
+		config.Resources = map[string]*project.ResourceConfig{}
+		dbNames := map[appdetect.DatabaseDep]string{}
+
+		databases := slices.SortedFunc(maps.Keys(detect.Databases),
+			func(a appdetect.DatabaseDep, b appdetect.DatabaseDep) int {
+				return strings.Compare(string(a), string(b))
+			})
+
+		for _, database := range databases {
+			if database == appdetect.DbRedis {
+				redis := project.ResourceConfig{
+					Type: project.ResourceTypeDbRedis,
+					Name: "redis",
+				}
+				config.Resources[redis.Name] = &redis
+				dbNames[database] = redis.Name
+				continue
+			}
+
+			var dbType project.ResourceType
+			switch database {
+			case appdetect.DbMongo:
+				dbType = project.ResourceTypeDbMongo
+			case appdetect.DbPostgres:
+				dbType = project.ResourceTypeDbPostgres
+			}
+
+			db := project.ResourceConfig{
+				Type: dbType,
+			}
+
+			for {
+				dbName, err := promptDbName(i.console, ctx, database)
+				if err != nil {
+					return config, err
+				}
+
+				if dbName == "" {
+					i.console.Message(ctx, "Database name is required.")
+					continue
+				}
+
+				db.Name = dbName
+				break
+			}
+
+			config.Resources[db.Name] = &db
+			dbNames[database] = db.Name
+		}
+
+		backends := []*project.ResourceConfig{}
+		frontends := []*project.ResourceConfig{}
+
+		for _, svc := range detect.Services {
+			name := svcMapping[svc.Path]
+			resSpec := project.ResourceConfig{
+				Type: project.ResourceTypeHostContainerApp,
+			}
+
+			props := project.ContainerAppProps{
+				Port: -1,
+			}
+
+			port, err := promptPort(i.console, ctx, name, svc)
+			if err != nil {
+				return config, err
+			}
+			props.Port = port
+
+			for _, db := range svc.DatabaseDeps {
+				// filter out databases that were removed
+				if _, ok := detect.Databases[db]; !ok {
+					continue
+				}
+
+				resSpec.Uses = append(resSpec.Uses, dbNames[db])
+			}
+
+			resSpec.Name = name
+			resSpec.Props = props
+			config.Resources[name] = &resSpec
+
+			frontend := svc.HasWebUIFramework()
+			if frontend {
+				frontends = append(frontends, &resSpec)
+			} else {
+				backends = append(backends, &resSpec)
+			}
+		}
+
+		for _, frontend := range frontends {
+			for _, backend := range backends {
+				frontend.Uses = append(frontend.Uses, backend.Name)
+			}
+		}
 	}
 
 	return config, nil

--- a/cli/azd/internal/repository/app_init_test.go
+++ b/cli/azd/internal/repository/app_init_test.go
@@ -1,0 +1,321 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/internal/appdetect"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitializer_prjConfigFromDetect(t *testing.T) {
+	tests := []struct {
+		name         string
+		detect       detectConfirm
+		interactions []string
+		want         project.ProjectConfig
+	}{
+		{
+			name: "api",
+			detect: detectConfirm{
+				Services: []appdetect.Project{
+					{
+						Language: appdetect.DotNet,
+						Path:     "dotnet",
+					},
+				},
+			},
+			interactions: []string{},
+			want: project.ProjectConfig{
+				Services: map[string]*project.ServiceConfig{
+					"dotnet": {
+						Language:     project.ServiceLanguageDotNet,
+						RelativePath: "dotnet",
+						Host:         project.ContainerAppTarget,
+					},
+				},
+				Resources: map[string]*project.ResourceConfig{
+					"dotnet": {
+						Type: project.ResourceTypeHostContainerApp,
+						Name: "dotnet",
+						Props: project.ContainerAppProps{
+							Port: 80,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "web",
+			detect: detectConfirm{
+				Services: []appdetect.Project{
+					{
+						Language: appdetect.JavaScript,
+						Path:     "js",
+						Dependencies: []appdetect.Dependency{
+							appdetect.JsReact,
+						},
+					},
+				},
+			},
+			interactions: []string{},
+			want: project.ProjectConfig{
+				Services: map[string]*project.ServiceConfig{
+					"js": {
+						Language:     project.ServiceLanguageJavaScript,
+						Host:         project.ContainerAppTarget,
+						RelativePath: "js",
+						OutputPath:   "build",
+					},
+				},
+				Resources: map[string]*project.ResourceConfig{
+					"js": {
+						Type: project.ResourceTypeHostContainerApp,
+						Name: "js",
+						Props: project.ContainerAppProps{
+							Port: 80,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "api with docker",
+			detect: detectConfirm{
+				Services: []appdetect.Project{
+					{
+						Language: appdetect.DotNet,
+						Path:     "dotnet",
+						Docker:   &appdetect.Docker{Path: "Dockerfile"},
+					},
+				},
+			},
+			interactions: []string{
+				// prompt for port -- hit multiple validation cases
+				"notAnInteger",
+				"-2",
+				"65536",
+				"1234",
+			},
+			want: project.ProjectConfig{
+				Services: map[string]*project.ServiceConfig{
+					"dotnet": {
+						Language:     project.ServiceLanguageDotNet,
+						Host:         project.ContainerAppTarget,
+						RelativePath: "dotnet",
+						Docker: project.DockerProjectOptions{
+							Path: "Dockerfile",
+						},
+					},
+				},
+				Resources: map[string]*project.ResourceConfig{
+					"dotnet": {
+						Type: project.ResourceTypeHostContainerApp,
+						Name: "dotnet",
+						Props: project.ContainerAppProps{
+							Port: 1234,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "api and web",
+			detect: detectConfirm{
+				Services: []appdetect.Project{
+					{
+						Language: appdetect.Python,
+						Path:     "py",
+					},
+					{
+						Language: appdetect.JavaScript,
+						Path:     "js",
+						Dependencies: []appdetect.Dependency{
+							appdetect.JsReact,
+						},
+					},
+				},
+			},
+			interactions: []string{},
+			want: project.ProjectConfig{
+				Services: map[string]*project.ServiceConfig{
+					"py": {
+						Language:     project.ServiceLanguagePython,
+						Host:         project.ContainerAppTarget,
+						RelativePath: "py",
+					},
+					"js": {
+						Language:     project.ServiceLanguageJavaScript,
+						Host:         project.ContainerAppTarget,
+						RelativePath: "js",
+						OutputPath:   "build",
+					},
+				},
+
+				Resources: map[string]*project.ResourceConfig{
+					"py": {
+						Type: project.ResourceTypeHostContainerApp,
+						Name: "py",
+						Props: project.ContainerAppProps{
+							Port: 80,
+						},
+					},
+					"js": {
+						Type: project.ResourceTypeHostContainerApp,
+						Name: "js",
+						Uses: []string{"py"},
+						Props: project.ContainerAppProps{
+							Port: 80,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "full",
+			detect: detectConfirm{
+				Services: []appdetect.Project{
+					{
+						Language: appdetect.Python,
+						Path:     "py",
+						DatabaseDeps: []appdetect.DatabaseDep{
+							appdetect.DbPostgres,
+							appdetect.DbMongo,
+							appdetect.DbRedis,
+						},
+					},
+					{
+						Language: appdetect.JavaScript,
+						Path:     "js",
+						Dependencies: []appdetect.Dependency{
+							appdetect.JsReact,
+						},
+					},
+				},
+				Databases: map[appdetect.DatabaseDep]EntryKind{
+					appdetect.DbPostgres: EntryKindDetected,
+					appdetect.DbMongo:    EntryKindDetected,
+					appdetect.DbRedis:    EntryKindDetected,
+				},
+			},
+			interactions: []string{
+				// prompt for db -- hit multiple validation cases
+				"my app db",
+				"n",
+				"my$special$db",
+				"n",
+				"mongodb", // fill in db name
+				// prompt for db -- hit multiple validation cases
+				"my$special$db",
+				"n",
+				"postgres", // fill in db name
+			},
+			want: project.ProjectConfig{
+				Services: map[string]*project.ServiceConfig{
+					"py": {
+						Language:     project.ServiceLanguagePython,
+						Host:         project.ContainerAppTarget,
+						RelativePath: "py",
+					},
+					"js": {
+						Language:     project.ServiceLanguageJavaScript,
+						Host:         project.ContainerAppTarget,
+						RelativePath: "js",
+						OutputPath:   "build",
+					},
+				},
+				Resources: map[string]*project.ResourceConfig{
+					"redis": {
+						Type: project.ResourceTypeDbRedis,
+						Name: "redis",
+					},
+					"mongodb": {
+						Type: project.ResourceTypeDbMongo,
+						Name: "mongodb",
+					},
+					"postgres": {
+						Type: project.ResourceTypeDbPostgres,
+						Name: "postgres",
+					},
+					"py": {
+						Type: project.ResourceTypeHostContainerApp,
+						Name: "py",
+						Uses: []string{"postgres", "mongodb", "redis"},
+						Props: project.ContainerAppProps{
+							Port: 80,
+						},
+					},
+					"js": {
+						Type: project.ResourceTypeHostContainerApp,
+						Name: "js",
+						Uses: []string{"py"},
+						Props: project.ContainerAppProps{
+							Port: 80,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &Initializer{
+				console: input.NewConsole(
+					false,
+					false,
+					input.Writers{Output: os.Stdout},
+					input.ConsoleHandles{
+						Stderr: os.Stderr,
+						Stdin:  strings.NewReader(strings.Join(tt.interactions, "\n") + "\n"),
+						Stdout: os.Stdout,
+					},
+					nil,
+					nil),
+			}
+
+			dir := t.TempDir()
+
+			prjName := dir
+			tt.want.Name = filepath.Base(prjName)
+			tt.want.Metadata = &project.ProjectMetadata{
+				Template: fmt.Sprintf("%s@%s", InitGenTemplateId, internal.VersionInfo().Version),
+			}
+
+			if tt.want.Resources == nil {
+				tt.want.Resources = map[string]*project.ResourceConfig{}
+			}
+
+			for k, svc := range tt.want.Services {
+				svc.Name = k
+			}
+
+			// Convert relative to absolute paths
+			for idx, svc := range tt.detect.Services {
+				tt.detect.Services[idx].Path = filepath.Join(dir, svc.Path)
+				if tt.detect.Services[idx].Docker != nil {
+					tt.detect.Services[idx].Docker.Path = filepath.Join(dir, svc.Path, svc.Docker.Path)
+				}
+			}
+
+			spec, err := i.prjConfigFromDetect(
+				context.Background(),
+				dir,
+				tt.detect,
+				true)
+
+			// Print extra newline to avoid mangling `go test -v` final test result output while waiting for final stdin,
+			// which may result in incorrect `gotestsum` reporting
+			fmt.Println()
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, spec)
+		})
+	}
+}

--- a/cli/azd/pkg/alpha/alpha_features.go
+++ b/cli/azd/pkg/alpha/alpha_features.go
@@ -1,6 +1,0 @@
-package alpha
-
-const (
-	TerraformId FeatureId = "terraform"
-	Compose     FeatureId = "compose"
-)

--- a/cli/azd/pkg/project/importer.go
+++ b/cli/azd/pkg/project/importer.go
@@ -120,6 +120,8 @@ const (
 	DefaultPath   = "infra"
 )
 
+var featureCompose = alpha.MustFeatureKey("compose")
+
 // ProjectInfrastructure parses the project configuration and returns the infrastructure configuration.
 // The configuration can be explicitly defined on azure.yaml using path and module, or in case these values
 // are not explicitly defined, the project importer uses default values to find the infrastructure.
@@ -163,7 +165,7 @@ func (im *ImportManager) ProjectInfrastructure(ctx context.Context, projectConfi
 		}
 	}
 
-	composeEnabled := im.dotNetImporter.alphaFeatureManager.IsEnabled(alpha.FeatureId(alpha.Compose))
+	composeEnabled := im.dotNetImporter.alphaFeatureManager.IsEnabled(featureCompose)
 	if composeEnabled && len(projectConfig.Resources) > 0 {
 		return tempInfra(ctx, projectConfig)
 	}
@@ -171,7 +173,7 @@ func (im *ImportManager) ProjectInfrastructure(ctx context.Context, projectConfi
 	if !composeEnabled && len(projectConfig.Resources) > 0 {
 		return nil, fmt.Errorf(
 			"compose is currently under alpha support and must be explicitly enabled."+
-				" Run `%s` to enable this feature", alpha.GetEnableCommand(alpha.Compose))
+				" Run `%s` to enable this feature", alpha.GetEnableCommand(featureCompose))
 	}
 
 	return &Infra{}, nil
@@ -205,7 +207,7 @@ func (im *ImportManager) SynthAllInfrastructure(ctx context.Context, projectConf
 		}
 	}
 
-	composeEnabled := im.dotNetImporter.alphaFeatureManager.IsEnabled(alpha.FeatureId(alpha.Compose))
+	composeEnabled := im.dotNetImporter.alphaFeatureManager.IsEnabled(featureCompose)
 	if composeEnabled && len(projectConfig.Resources) > 0 {
 		return infraFsForProject(ctx, projectConfig)
 	}
@@ -213,7 +215,7 @@ func (im *ImportManager) SynthAllInfrastructure(ctx context.Context, projectConf
 	if !composeEnabled && len(projectConfig.Resources) > 0 {
 		return nil, fmt.Errorf(
 			"compose is currently under alpha support and must be explicitly enabled."+
-				" Run `%s` to enable this feature", alpha.GetEnableCommand(alpha.Compose))
+				" Run `%s` to enable this feature", alpha.GetEnableCommand(featureCompose))
 	}
 
 	return nil, fmt.Errorf("this project does not contain any infrastructure to synthesize")

--- a/cli/azd/pkg/project/importer_test.go
+++ b/cli/azd/pkg/project/importer_test.go
@@ -399,8 +399,8 @@ resources:
 `
 
 func Test_ImportManager_ProjectInfrastructure_FromResources(t *testing.T) {
-	alpha.SetDefaultEnablement(string(alpha.Compose), true)
-	t.Cleanup(func() { alpha.SetDefaultEnablement(string(alpha.Compose), false) })
+	alpha.SetDefaultEnablement(string(featureCompose), true)
+	t.Cleanup(func() { alpha.SetDefaultEnablement(string(featureCompose), false) })
 
 	im := &ImportManager{
 		dotNetImporter: &DotNetImporter{
@@ -423,15 +423,15 @@ func Test_ImportManager_ProjectInfrastructure_FromResources(t *testing.T) {
 	assert.FileExists(t, filepath.Join(dir, "resources.bicep"))
 
 	// Disable the alpha feature and check that an error is returned
-	alpha.SetDefaultEnablement(string(alpha.Compose), false)
+	alpha.SetDefaultEnablement(string(featureCompose), false)
 
 	_, err = im.ProjectInfrastructure(context.Background(), prjConfig)
 	assert.Error(t, err)
 }
 
 func TestImportManager_SynthAllInfrastructure_FromResources(t *testing.T) {
-	alpha.SetDefaultEnablement(string(alpha.Compose), true)
-	t.Cleanup(func() { alpha.SetDefaultEnablement(string(alpha.Compose), false) })
+	alpha.SetDefaultEnablement(string(featureCompose), true)
+	t.Cleanup(func() { alpha.SetDefaultEnablement(string(featureCompose), false) })
 
 	im := &ImportManager{
 		dotNetImporter: &DotNetImporter{
@@ -457,7 +457,7 @@ func TestImportManager_SynthAllInfrastructure_FromResources(t *testing.T) {
 	}
 
 	// Disable the alpha feature
-	alpha.SetDefaultEnablement(string(alpha.Compose), false)
+	alpha.SetDefaultEnablement(string(featureCompose), false)
 
 	_, err = im.SynthAllInfrastructure(context.Background(), prjConfig)
 	assert.Error(t, err)

--- a/cli/azd/resources/scaffold/templates/next-steps-alpha.mdt
+++ b/cli/azd/resources/scaffold/templates/next-steps-alpha.mdt
@@ -1,0 +1,67 @@
+{{define "next-steps-alpha.md" -}}
+# Next Steps after `azd init`
+
+## Table of Contents
+
+1. [Next Steps](#next-steps)
+   1. [Provision infrastructure](#provision-infrastructure-and-deploy-application-code)
+   2. [Modify infrastructure](#modify-infrastructure)
+   3. [Getting to production-ready](#getting-to-production-ready)
+2. [Billing](#billing)
+3. [Troubleshooting](#troubleshooting)
+
+## Next Steps
+
+### Provision infrastructure and deploy application code
+
+Run `azd up` to provision your infrastructure and deploy to Azure in one step (or run `azd provision` then `azd deploy` to accomplish the tasks separately). Visit the service endpoints listed to see your application up-and-running!
+
+To troubleshoot any issues, see [troubleshooting](#troubleshooting).
+
+### Modify infrastructure
+
+To describe the infrastructure and application, `azure.yaml` was added. This file contains all services and resources that describe your application.
+
+To add new services or resources, run `azd add`. You may also edit the `azure.yaml` file directly if needed.
+
+### Getting to production-ready
+
+When needed, `azd` generates the required infrastructure as code in memory and uses it. If you would like to see or modify the infrastructure that `azd` uses, run `azd infra synth` to persist it to disk.
+
+If you do this, some additional directories will be created:
+
+```yaml
+- infra/            # Infrastructure as Code (bicep) files
+  - main.bicep      # main deployment module
+  - resources.bicep # resources shared across your application's services
+```
+
+*Note*: Once you have synthesized your infrastructure to disk, changes made to `azure.yaml` will not be reflected in the infrastructure. You can re-generate the infrastructure by running `azd infra synth` again. It will prompt you before overwriting files. You can pass `--force` to force `azd infra synth` to overwrite the files without prompting.
+
+*Note*: `azd infra synth` is currently an alpha feature and must be explicitly enabled by running `azd config set alpha.infraSynth on`. You only need to do this once.
+
+Finally, run `azd pipeline config` to configure a CI/CD deployment pipeline.
+
+## Billing
+
+Visit the *Cost Management + Billing* page in Azure Portal to track current spend. For more information about how you're billed, and how you can monitor the costs incurred in your Azure subscriptions, visit [billing overview](https://learn.microsoft.com/azure/developer/intro/azure-developer-billing).
+
+## Troubleshooting
+
+Q: I visited the service endpoint listed, and I'm seeing a blank page, a generic welcome page, or an error page.
+
+A: Your service may have failed to start, or it may be missing some configuration settings. To investigate further:
+
+1. Run `azd show`. Click on the link under "View in Azure Portal" to open the resource group in Azure Portal.
+2. Navigate to the specific Container App service that is failing to deploy.
+3. Click on the failing revision under "Revisions with Issues".
+4. Review "Status details" for more information about the type of failure.
+5. Observe the log outputs from Console log stream and System log stream to identify any errors.
+6. If logs are written to disk, use *Console* in the navigation to connect to a shell within the running container.
+
+For more troubleshooting information, visit [Container Apps troubleshooting](https://learn.microsoft.com/azure/container-apps/troubleshooting). 
+
+### Additional information
+
+For additional information about setting up your `azd` project, visit our official [docs](https://learn.microsoft.com/azure/developer/azure-developer-cli/make-azd-compatible?pivots=azd-convert).
+{{ end}}


### PR DESCRIPTION
Generate resources in `azure.yaml` and delay infrastructure generation if `alpha.compose` is enabled

Contributes to #4397,  https://github.com/Azure/azure-dev-pr/issues/1682

