### PR TITLE
Devcenter environments Outputs API Integration

### DIFF
--- a/cli/azd/pkg/devcenter/manager.go
+++ b/cli/azd/pkg/devcenter/manager.go
@@ -2,7 +2,6 @@ package devcenter
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"regexp"
 	"slices"
@@ -364,21 +363,6 @@ func createOutputParameters(
 		paramType, err := mapDevCenterTypeToParamType(devCenterParam.Type)
 		if err != nil {
 			return nil, err
-		}
-
-		requiresJsonMarshalling := slices.Contains(
-			[]devcentersdk.OutputParameterType{
-				devcentersdk.OutputParameterTypeObject,
-				devcentersdk.OutputParameterTypeArray,
-			}, devCenterParam.Type)
-
-		if requiresJsonMarshalling {
-			jsonBytes, err := json.Marshal(devCenterParam.Value)
-			if err != nil {
-				return nil, fmt.Errorf("failed marshalling output value: %w", err)
-			}
-
-			value = string(jsonBytes)
 		}
 
 		outputParams[paramName] = provisioning.OutputParameter{

--- a/cli/azd/pkg/devcenter/manager.go
+++ b/cli/azd/pkg/devcenter/manager.go
@@ -331,16 +331,16 @@ func (m *manager) Outputs(
 }
 
 func mapDevCenterTypeToParamType(devCenterType devcentersdk.OutputParameterType) (provisioning.ParameterType, error) {
-	switch devCenterType {
-	case devcentersdk.OutputParameterTypeString:
+	switch strings.ToLower(string(devCenterType)) {
+	case string(devcentersdk.OutputParameterTypeString):
 		return provisioning.ParameterTypeString, nil
-	case devcentersdk.OutputParameterTypeBoolean:
+	case string(devcentersdk.OutputParameterTypeBoolean):
 		return provisioning.ParameterTypeBoolean, nil
-	case devcentersdk.OutputParameterTypeNumber:
+	case string(devcentersdk.OutputParameterTypeNumber):
 		return provisioning.ParameterTypeNumber, nil
-	case devcentersdk.OutputParameterTypeObject:
+	case string(devcentersdk.OutputParameterTypeObject):
 		return provisioning.ParameterTypeObject, nil
-	case devcentersdk.OutputParameterTypeArray:
+	case string(devcentersdk.OutputParameterTypeArray):
 		return provisioning.ParameterTypeArray, nil
 	default:
 		return "", fmt.Errorf("unexpected output parameter type: '%s'", string(devCenterType))

--- a/cli/azd/pkg/devcenter/manager.go
+++ b/cli/azd/pkg/devcenter/manager.go
@@ -306,45 +306,9 @@ func (m *manager) Outputs(
 		return nil, fmt.Errorf("failed getting outputs: %w", err)
 	}
 
-	outputs := map[string]provisioning.OutputParameter{}
-
-	// Store any outputs from the deployment response
-	for key, output := range outputsResponse.Outputs {
-		var paramType provisioning.ParameterType
-		var value any
-
-		switch output.Type {
-		case devcentersdk.OutputParameterTypeString:
-			paramType = provisioning.ParameterTypeString
-			value = output.Value
-		case devcentersdk.OutputParameterTypeNumber:
-			paramType = provisioning.ParameterTypeNumber
-			value = output.Value
-		case devcentersdk.OutputParameterTypeBoolean:
-			paramType = provisioning.ParameterTypeBoolean
-			value = output.Value
-		case devcentersdk.OutputParameterTypeArray:
-			jsonBytes, err := json.Marshal(output.Value)
-			if err != nil {
-				return nil, fmt.Errorf("failed marshalling output value: %w", err)
-			}
-
-			paramType = provisioning.ParameterTypeArray
-			value = string(jsonBytes)
-		case devcentersdk.OutputParameterTypeObject:
-			jsonBytes, err := json.Marshal(output.Value)
-			if err != nil {
-				return nil, fmt.Errorf("failed marshalling output value: %w", err)
-			}
-
-			paramType = provisioning.ParameterTypeObject
-			value = string(jsonBytes)
-		}
-
-		outputs[strings.ToUpper(key)] = provisioning.OutputParameter{
-			Type:  paramType,
-			Value: value,
-		}
+	outputs, err := createOutputParameters(outputsResponse)
+	if err != nil {
+		return nil, fmt.Errorf("failed resolving output parameters: %w", err)
 	}
 
 	// Set up AZURE_SUBSCRIPTION_ID and AZURE_RESOURCE_GROUP environment variables
@@ -364,4 +328,64 @@ func (m *manager) Outputs(
 	}
 
 	return outputs, nil
+}
+
+func mapDevCenterTypeToParamType(devCenterType devcentersdk.OutputParameterType) (provisioning.ParameterType, error) {
+	switch devCenterType {
+	case devcentersdk.OutputParameterTypeString:
+		return provisioning.ParameterTypeString, nil
+	case devcentersdk.OutputParameterTypeBoolean:
+		return provisioning.ParameterTypeBoolean, nil
+	case devcentersdk.OutputParameterTypeNumber:
+		return provisioning.ParameterTypeNumber, nil
+	case devcentersdk.OutputParameterTypeObject:
+		return provisioning.ParameterTypeObject, nil
+	case devcentersdk.OutputParameterTypeArray:
+		return provisioning.ParameterTypeArray, nil
+	default:
+		return "", fmt.Errorf("unexpected output parameter type: '%s'", string(devCenterType))
+	}
+}
+
+// Creates a normalized view of the azure output parameters and resolves inconsistencies in the output parameter name
+// casings.
+func createOutputParameters(
+	outputsResponse *devcentersdk.OutputListResponse,
+) (map[string]provisioning.OutputParameter, error) {
+	outputParams := map[string]provisioning.OutputParameter{}
+
+	for key, devCenterParam := range outputsResponse.Outputs {
+		// To support BYOI (bring your own infrastructure) scenarios we will default to UPPER when canonical casing
+		// is not found in the parameters file to workaround strange azure behavior with OUTPUT values that look
+		// like `azurE_RESOURCE_GROUP`
+		paramName := strings.ToUpper(key)
+		value := devCenterParam.Value
+
+		paramType, err := mapDevCenterTypeToParamType(devCenterParam.Type)
+		if err != nil {
+			return nil, err
+		}
+
+		requiresJsonMarshalling := slices.Contains(
+			[]devcentersdk.OutputParameterType{
+				devcentersdk.OutputParameterTypeObject,
+				devcentersdk.OutputParameterTypeArray,
+			}, devCenterParam.Type)
+
+		if requiresJsonMarshalling {
+			jsonBytes, err := json.Marshal(devCenterParam.Value)
+			if err != nil {
+				return nil, fmt.Errorf("failed marshalling output value: %w", err)
+			}
+
+			value = string(jsonBytes)
+		}
+
+		outputParams[paramName] = provisioning.OutputParameter{
+			Type:  paramType,
+			Value: value,
+		}
+	}
+
+	return outputParams, nil
 }

--- a/cli/azd/pkg/devcenter/manager_test.go
+++ b/cli/azd/pkg/devcenter/manager_test.go
@@ -1,0 +1,66 @@
+package devcenter
+
+import (
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/devcentersdk"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Map_Outputs(t *testing.T) {
+	outputsResponse := &devcentersdk.OutputListResponse{
+		Outputs: map[string]devcentersdk.OutputParameter{
+			"test_Bool": {
+				Type:      devcentersdk.OutputParameterTypeBoolean,
+				Value:     true,
+				Sensitive: false,
+			},
+			"test_String": {
+				Type:      devcentersdk.OutputParameterTypeString,
+				Value:     "test",
+				Sensitive: false,
+			},
+			"test_Number": {
+				Type:      devcentersdk.OutputParameterTypeNumber,
+				Value:     11,
+				Sensitive: false,
+			},
+			"test_Array": {
+				Type:      devcentersdk.OutputParameterTypeArray,
+				Value:     []interface{}{"test1", "test2"},
+				Sensitive: false,
+			},
+			"test_Object": {
+				Type:      devcentersdk.OutputParameterTypeObject,
+				Value:     map[string]interface{}{"key1": "value1", "key2": "value2"},
+				Sensitive: false,
+			},
+		},
+	}
+
+	outputs, err := createOutputParameters(outputsResponse)
+	require.NoError(t, err)
+	require.Len(t, outputs, len(outputsResponse.Outputs))
+
+	require.Equal(t, provisioning.OutputParameter{
+		Type:  provisioning.ParameterTypeBoolean,
+		Value: true,
+	}, outputs["TEST_BOOL"])
+	require.Equal(t, provisioning.OutputParameter{
+		Type:  provisioning.ParameterTypeString,
+		Value: "test",
+	}, outputs["TEST_STRING"])
+	require.Equal(t, provisioning.OutputParameter{
+		Type:  provisioning.ParameterTypeNumber,
+		Value: 11,
+	}, outputs["TEST_NUMBER"])
+	require.Equal(t, provisioning.OutputParameter{
+		Type:  provisioning.ParameterTypeArray,
+		Value: "[\"test1\",\"test2\"]",
+	}, outputs["TEST_ARRAY"])
+	require.Equal(t, provisioning.OutputParameter{
+		Type:  provisioning.ParameterTypeObject,
+		Value: "{\"key1\":\"value1\",\"key2\":\"value2\"}",
+	}, outputs["TEST_OBJECT"])
+}

--- a/cli/azd/pkg/devcenter/manager_test.go
+++ b/cli/azd/pkg/devcenter/manager_test.go
@@ -57,10 +57,10 @@ func Test_Map_Outputs(t *testing.T) {
 	}, outputs["TEST_NUMBER"])
 	require.Equal(t, provisioning.OutputParameter{
 		Type:  provisioning.ParameterTypeArray,
-		Value: "[\"test1\",\"test2\"]",
+		Value: []interface{}{"test1", "test2"},
 	}, outputs["TEST_ARRAY"])
 	require.Equal(t, provisioning.OutputParameter{
 		Type:  provisioning.ParameterTypeObject,
-		Value: "{\"key1\":\"value1\",\"key2\":\"value2\"}",
+		Value: map[string]interface{}{"key1": "value1", "key2": "value2"},
 	}, outputs["TEST_OBJECT"])
 }

--- a/cli/azd/pkg/devcenter/provision_provider.go
+++ b/cli/azd/pkg/devcenter/provision_provider.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/devcentersdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"

--- a/cli/azd/pkg/devcenter/provision_provider.go
+++ b/cli/azd/pkg/devcenter/provision_provider.go
@@ -9,10 +9,8 @@ import (
 	"os"
 	"slices"
 	"strconv"
-	"strings"
 	"time"
 
-	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/devcentersdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
@@ -497,45 +495,6 @@ func (p *ProvisionProvider) pollForProgress(ctx context.Context, deployment infr
 			timer.Reset(regularDelay)
 		}
 	}
-}
-
-func mapBicepTypeToInterfaceType(s string) provisioning.ParameterType {
-	switch s {
-	case "String", "string", "secureString", "securestring":
-		return provisioning.ParameterTypeString
-	case "Bool", "bool":
-		return provisioning.ParameterTypeBoolean
-	case "Int", "int":
-		return provisioning.ParameterTypeNumber
-	case "Object", "object", "secureObject", "secureobject":
-		return provisioning.ParameterTypeObject
-	case "Array", "array":
-		return provisioning.ParameterTypeArray
-	default:
-		panic(fmt.Sprintf("unexpected bicep type: '%s'", s))
-	}
-}
-
-// Creates a normalized view of the azure output parameters and resolves inconsistencies in the output parameter name
-// casings.
-func createOutputParameters(
-	deploymentOutputs map[string]azapi.AzCliDeploymentOutput,
-) map[string]provisioning.OutputParameter {
-	outputParams := map[string]provisioning.OutputParameter{}
-
-	for key, azureParam := range deploymentOutputs {
-		// To support BYOI (bring your own infrastructure) scenarios we will default to UPPER when canonical casing
-		// is not found in the parameters file to workaround strange azure behavior with OUTPUT values that look
-		// like `azurE_RESOURCE_GROUP`
-		paramName := strings.ToUpper(key)
-
-		outputParams[paramName] = provisioning.OutputParameter{
-			Type:  mapBicepTypeToInterfaceType(azureParam.Type),
-			Value: azureParam.Value,
-		}
-	}
-
-	return outputParams
 }
 
 func createInputParameters(

--- a/cli/azd/pkg/devcentersdk/api_version_policy.go
+++ b/cli/azd/pkg/devcentersdk/api_version_policy.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	apiVersionName    = "api-version"
-	defaultApiVersion = "2023-04-01"
+	defaultApiVersion = "2024-02-01"
 )
 
 type apiVersionPolicy struct {

--- a/cli/azd/pkg/devcentersdk/developer_client_test.go
+++ b/cli/azd/pkg/devcentersdk/developer_client_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
@@ -18,7 +17,7 @@ import (
 )
 
 func Test_DevCenter_Client(t *testing.T) {
-	//t.Skip("azure/azure-dev#2944")
+	t.Skip("azure/azure-dev#2944")
 
 	publicCloud := cloud.AzurePublic()
 
@@ -43,9 +42,6 @@ func Test_DevCenter_Client(t *testing.T) {
 
 	credentials, err := authManager.CredentialForCurrentUser(*mockContext.Context, nil)
 	require.NoError(t, err)
-
-	token, err := credentials.GetToken(*mockContext.Context, policy.TokenRequestOptions{})
-	fmt.Println(token.Token)
 
 	resourceGraphClient, err := armresourcegraph.NewClient(credentials, armClientOptions)
 	require.NoError(t, err)
@@ -194,18 +190,19 @@ func Test_DevCenter_Client(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, outputs)
 
+	// Update environment
+	err = projectClient.
+		EnvironmentsByMe().
+		EnvironmentByName(envName).
+		Put(*mockContext.Context, envSpec)
+
+	require.NoError(t, err)
+
 	// Delete environment
 	err = projectClient.
 		EnvironmentsByMe().
 		EnvironmentByName(envName).
 		Delete(*mockContext.Context)
-
-	require.NoError(t, err)
-
-	err = projectClient.
-		EnvironmentsByMe().
-		EnvironmentByName(envName).
-		Put(*mockContext.Context, envSpec)
 
 	require.NoError(t, err)
 

--- a/cli/azd/pkg/devcentersdk/developer_client_test.go
+++ b/cli/azd/pkg/devcentersdk/developer_client_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
-	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -20,15 +19,8 @@ func Test_DevCenter_Client(t *testing.T) {
 	t.Skip("azure/azure-dev#2944")
 
 	publicCloud := cloud.AzurePublic()
-
-	clientOptionsBuilder := azsdk.NewClientOptionsBuilder().
-		WithTransport(http.DefaultClient).
-		WithCloud(publicCloud.Configuration)
-
-	armClientOptions := clientOptionsBuilder.BuildArmClientOptions()
-	coreClientOptions := clientOptionsBuilder.BuildCoreClientOptions()
-
 	mockContext := mocks.NewMockContext(context.Background())
+
 	fileConfigManager := config.NewFileConfigManager(config.NewManager())
 	authManager, err := auth.NewManager(
 		fileConfigManager,
@@ -43,12 +35,12 @@ func Test_DevCenter_Client(t *testing.T) {
 	credentials, err := authManager.CredentialForCurrentUser(*mockContext.Context, nil)
 	require.NoError(t, err)
 
-	resourceGraphClient, err := armresourcegraph.NewClient(credentials, armClientOptions)
+	resourceGraphClient, err := armresourcegraph.NewClient(credentials, mockContext.ArmClientOptions)
 	require.NoError(t, err)
 
 	client, err := NewDevCenterClient(
 		credentials,
-		coreClientOptions,
+		mockContext.CoreClientOptions,
 		resourceGraphClient,
 		publicCloud,
 	)

--- a/cli/azd/pkg/devcentersdk/environment_request_builders.go
+++ b/cli/azd/pkg/devcentersdk/environment_request_builders.go
@@ -192,3 +192,7 @@ func (c *EnvironmentItemRequestBuilder) Delete(ctx context.Context) error {
 
 	return nil
 }
+
+func (c *EnvironmentItemRequestBuilder) Outputs() *OutputsRequestBuilder {
+	return NewOutputsRequestBuilder(c.client, c.devCenter, c.projectName, c.userId, c.id)
+}

--- a/cli/azd/pkg/devcentersdk/models.go
+++ b/cli/azd/pkg/devcentersdk/models.go
@@ -211,7 +211,17 @@ type OutputListResponse struct {
 }
 
 type OutputParameter struct {
-	Type      string `json:"type"`
-	Value     any    `json:"value"`
-	Sensitive bool   `json:"sensitive"`
+	Type      OutputParameterType `json:"type"`
+	Value     any                 `json:"value"`
+	Sensitive bool                `json:"sensitive"`
 }
+
+type OutputParameterType string
+
+const (
+	OutputParameterTypeArray   OutputParameterType = "array"
+	OutputParameterTypeBoolean OutputParameterType = "boolean"
+	OutputParameterTypeNumber  OutputParameterType = "number"
+	OutputParameterTypeObject  OutputParameterType = "object"
+	OutputParameterTypeString  OutputParameterType = "string"
+)

--- a/cli/azd/pkg/devcentersdk/models.go
+++ b/cli/azd/pkg/devcentersdk/models.go
@@ -173,14 +173,14 @@ const (
 )
 
 type Environment struct {
-	Name                      string
-	EnvironmentType           string
-	User                      string
-	ProvisioningState         ProvisioningState
-	ResourceGroupId           string
-	CatalogName               string
-	EnvironmentDefinitionName string
-	Parameters                map[string]any
+	Name                      string            `json:"name"`
+	EnvironmentType           string            `json:"environmentType"`
+	User                      string            `json:"user"`
+	ProvisioningState         ProvisioningState `json:"provisioningState"`
+	ResourceGroupId           string            `json:"resourceGroupId"`
+	CatalogName               string            `json:"catalogName"`
+	EnvironmentDefinitionName string            `json:"environmentDefinitionName"`
+	Parameters                map[string]any    `json:"parameters"`
 }
 
 type EnvironmentListResponse struct {
@@ -204,4 +204,14 @@ type OperationStatus struct {
 	Status    string    `json:"status"`
 	StartTime time.Time `json:"startTime"`
 	EndTime   time.Time `json:"endTime"`
+}
+
+type OutputListResponse struct {
+	Outputs map[string]OutputParameter `json:"outputs"`
+}
+
+type OutputParameter struct {
+	Type      string `json:"type"`
+	Value     any    `json:"value"`
+	Sensitive bool   `json:"sensitive"`
 }

--- a/cli/azd/pkg/devcentersdk/outputs_request_builder.go
+++ b/cli/azd/pkg/devcentersdk/outputs_request_builder.go
@@ -1,0 +1,50 @@
+package devcentersdk
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
+)
+
+type OutputsRequestBuilder struct {
+	*EntityItemRequestBuilder[OutputsRequestBuilder]
+	projectName string
+	userId      string
+}
+
+func NewOutputsRequestBuilder(
+	c *devCenterClient,
+	devCenter *DevCenter,
+	projectName string,
+	userId string,
+	environmentName string,
+) *OutputsRequestBuilder {
+	builder := &OutputsRequestBuilder{}
+	builder.EntityItemRequestBuilder = newEntityItemRequestBuilder(builder, c, devCenter, environmentName)
+	builder.projectName = projectName
+	builder.userId = userId
+
+	return builder
+}
+
+func (c *OutputsRequestBuilder) Get(ctx context.Context) (*OutputListResponse, error) {
+	requestUrl := fmt.Sprintf("projects/%s/users/%s/environments/%s/outputs", c.projectName, c.userId, c.id)
+	req, err := c.createRequest(ctx, http.MethodGet, requestUrl)
+	if err != nil {
+		return nil, fmt.Errorf("failed creating request: %w", err)
+	}
+
+	res, err := c.client.pipeline.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if !runtime.HasStatusCode(res, http.StatusOK) {
+		return nil, runtime.NewResponseError(res)
+	}
+
+	return httputil.ReadRawResponse[OutputListResponse](res)
+}

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_DevCenter_Init_Up_Down.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_DevCenter_Init_Up_Down.yaml
@@ -26,9 +26,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - azsdk-go-armresourcegraph.Client/v0.7.1 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-armresourcegraph.Client/v0.7.1 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
         url: https://management.azure.com:443/providers/Microsoft.ResourceGraph/resources?api-version=2021-06-01-preview
         method: POST
       response:
@@ -37,18 +37,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 9182
+        content_length: 12296
         uncompressed: false
-        body: '{"totalRecords":15,"count":15,"data":[{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioClient","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSVendors","properties":{"provisioningState":"Succeeded","description":"Project for vendors","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/basic","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"basic","properties":{"provisioningState":"Succeeded","description":"project with basic image","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"MicroBuild","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourceGroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DevDivAzureService","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourceGroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"LanguageAndFrameworkServices","properties":{"provisioningState":"Succeeded","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourceGroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSCode","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourceGroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ServerlessPaaS","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourceGroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"PMUXDesign","properties":{"provisioningState":"Succeeded","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourceGroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"NuGet","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/qiaozha-test/providers/Microsoft.DevCenter/projects/jsmgmt","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"jsmgmt","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-jsmgmtsdktest.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/qiaozha-test/providers/Microsoft.DevCenter/devcenters/jsmgmtsdktest"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-1","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/devcenters/dc-azd-o2pst6gaydv5o"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-2","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/devcenters/dc-azd-o2pst6gaydv5o"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourceGroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DataAndAI","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/f91f9734-8835-4fa4-8564-1dd169bc29dd/resourceGroups/project-8489/providers/Microsoft.DevCenter/projects/VisualStudioServicing","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioServicing","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"}],"facets":[],"resultTruncated":"false"}'
+        body: '{"totalRecords":20,"count":20,"data":[{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioClient","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSVendors","properties":{"provisioningState":"Succeeded","description":"Project for vendors","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/basic","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"basic","properties":{"provisioningState":"Succeeded","description":"project with basic image","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"MicroBuild","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourceGroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DevDivAzureService","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourceGroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"LanguageAndFrameworkServices","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourceGroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSCode","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourceGroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ServerlessPaaS","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourceGroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"PMUXDesign","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourceGroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"NuGet","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/qiaozha-test/providers/Microsoft.DevCenter/projects/jsmgmt","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"jsmgmt","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-jsmgmtsdktest.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/qiaozha-test/providers/Microsoft.DevCenter/devcenters/jsmgmtsdktest"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-1","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/devcenters/dc-azd-o2pst6gaydv5o"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-2","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/devcenters/dc-azd-o2pst6gaydv5o"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-contoso-ecomm-pe/providers/Microsoft.DevCenter/projects/contoso-ecomm","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"contoso-ecomm","properties":{"provisioningState":"Succeeded","description":"Ecommerce team","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-pv44d74rp44bs.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/devcenters/dc-pv44d74rp44bs","maxDevBoxesPerUser":2},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/projects/dcprj-pv44d74rp44bs","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"dcprj-pv44d74rp44bs","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-pv44d74rp44bs.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/devcenters/dc-pv44d74rp44bs"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project1","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ade-project1","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-ade-fidalgo-dev2.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/ade-fidalgo-dev2"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project2","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ade-project2","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-ade-fidalgo-dev2.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/ade-fidalgo-dev2"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/Inventory-Management-Project","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Inventory-Management-Project","properties":{"provisioningState":"Succeeded","description":"Inventory Management project","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-logistics-system-devcenter.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/Logistics-System-DevCenter"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourceGroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DataAndAI","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/f91f9734-8835-4fa4-8564-1dd169bc29dd/resourceGroups/project-8489/providers/Microsoft.DevCenter/projects/VisualStudioServicing","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioServicing","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"}],"facets":[],"resultTruncated":"false"}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "9182"
+                - "12296"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:12 GMT
+                - Fri, 14 Jun 2024 21:32:29 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -60,26 +60,26 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe-738b-1855-fc53-f5fe00f94ea1
+                - b5458087-c80a-1210-e8f4-e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Tenant-Reads:
                 - "11999"
             X-Ms-Ratelimit-Remaining-Tenant-Resource-Requests:
                 - "14"
             X-Ms-Request-Id:
-                - 7b009f23-28ad-43b5-92f4-c60fb90f59db
+                - 31caa20a-ff04-40ed-a1fe-2665b64dec59
             X-Ms-Resource-Graph-Request-Duration:
-                - "0:00:00:00.5905371"
+                - "0:00:00:00.8322830"
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001213Z:7b009f23-28ad-43b5-92f4-c60fb90f59db
+                - WESTUS:20240614T213230Z:31caa20a-ff04-40ed-a1fe-2665b64dec59
             X-Ms-User-Quota-Remaining:
                 - "14"
             X-Ms-User-Quota-Resets-After:
                 - "00:00:05"
             X-Msedge-Ref:
-                - 'Ref A: 71690911889F40A69365D64776843B2A Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:12Z'
+                - 'Ref A: 99478EAFDC0244F19DB03D6971227B6C Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:29Z'
         status: 200 OK
         code: 200
-        duration: 730.5922ms
+        duration: 1.0228285s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -101,10 +101,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourcegroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-2/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourcegroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -112,18 +112,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1929
+        content_length: 990
         uncompressed: false
-        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "1929"
+                - "990"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:13 GMT
+                - Fri, 14 Jun 2024 21:32:30 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -137,18 +137,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11998"
+                - "11999"
             X-Ms-Request-Id:
-                - 6cbc91e2-a4de-4a53-9edf-ab9595c04c9a
+                - 6257b615-9cb6-43bd-8bb6-73cecd6d41ec
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001213Z:a22d0997-2ad3-430c-a5ba-744d962aa3ce
+                - WESTUS:20240614T213230Z:25cef395-125e-494b-ba1b-afe3f38c2fd1
             X-Msedge-Ref:
-                - 'Ref A: AC26F6B60C9E4BAE9C2AA52D9E5EA4AD Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:13Z'
+                - 'Ref A: 66692E5A7EB34B76BAD23E762857757D Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
         status: 200 OK
         code: 200
-        duration: 411.3815ms
+        duration: 159.3576ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -170,10 +170,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourcegroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -192,7 +192,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:13 GMT
+                - Fri, 14 Jun 2024 21:32:30 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -206,18 +206,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 327774e3-7bca-4510-81d3-07f0297f4928
+                - 1eb11fee-a3af-4329-8de5-ac1d9092c74e
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001213Z:a436ffba-7e40-4213-aa19-fd95a8027527
+                - WESTUS:20240614T213230Z:31dda3f3-dc6f-4ef0-b5f2-9609e6af7382
             X-Msedge-Ref:
-                - 'Ref A: F00CFFEF90DD4CEE9A41C9F32C1BCD4D Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:13Z'
+                - 'Ref A: 4056C4E3F6FD4201AA2A0780AB6F863D Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
         status: 200 OK
         code: 200
-        duration: 383.8193ms
+        duration: 178.9829ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -239,10 +239,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/basic/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/f91f9734-8835-4fa4-8564-1dd169bc29dd/resourcegroups/project-8489/providers/Microsoft.DevCenter/projects/VisualStudioServicing/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -261,7 +261,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:13 GMT
+                - Fri, 14 Jun 2024 21:32:30 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -275,18 +275,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 7f3f11b3-e3f4-4247-b5a5-70aff0a3a9a4
+                - 6cac16ba-beae-4ed5-b318-87c57291d3b5
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001213Z:1a51ca5a-a0b5-4d34-a637-4fd160ce3def
+                - WESTUS:20240614T213230Z:122151d9-d0b9-4eb3-bd74-8f45741e4020
             X-Msedge-Ref:
-                - 'Ref A: A02194F6547940BF915D3AAA157BDF8F Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:13Z'
+                - 'Ref A: 246214096683450098E29B9ABC5FF0DB Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
         status: 200 OK
         code: 200
-        duration: 399.8942ms
+        duration: 201.182ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -308,10 +308,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourcegroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourcegroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -330,7 +330,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:13 GMT
+                - Fri, 14 Jun 2024 21:32:30 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -344,18 +344,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - e614a9a8-4977-4561-813b-0cb3a4c59460
+                - a23bbc7d-b18a-45a9-b0c5-e889a4cb9099
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001213Z:7d78ef5b-3376-411e-9168-60640558cb0f
+                - WESTUS:20240614T213230Z:240f16ab-f003-425a-be26-533032e9ff2c
             X-Msedge-Ref:
-                - 'Ref A: 66C4903985A04A2BAE61F63D6125FCC1 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:13Z'
+                - 'Ref A: 3848A17AA24E49C3BA38FD1EC0A79B96 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
         status: 200 OK
         code: 200
-        duration: 408.9453ms
+        duration: 202.6828ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -377,10 +377,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourcegroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-1/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/basic/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -388,18 +388,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1929
+        content_length: 990
         uncompressed: false
-        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "1929"
+                - "990"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:13 GMT
+                - Fri, 14 Jun 2024 21:32:30 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -413,18 +413,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11998"
+                - "11999"
             X-Ms-Request-Id:
-                - 3bc3ae93-3530-48e2-8898-569ab0f442f5
+                - 6f6c3a3a-96c7-49ab-a270-fb25f3c1b417
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001213Z:77e3c5e2-83af-44c0-81e1-c12513b8200c
+                - WESTUS:20240614T213230Z:f346a9fd-fe30-41d9-abff-4427f505018d
             X-Msedge-Ref:
-                - 'Ref A: C5BE3AAC07DF4A43B2C620A6F0B79E5D Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:13Z'
+                - 'Ref A: DED14037C55549DE8C4D626211A60392 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
         status: 200 OK
         code: 200
-        duration: 408.3669ms
+        duration: 239.8777ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -446,10 +446,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourcegroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -468,7 +468,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:13 GMT
+                - Fri, 14 Jun 2024 21:32:30 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -482,18 +482,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 9cdab150-eb0d-493c-9693-990e41b57fd2
+                - 91f71581-43a2-4692-8a4e-c69e4bbf2e83
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001213Z:06ee20df-1dd5-460c-8382-2a8bd9da9c21
+                - WESTUS:20240614T213230Z:873a6fde-5b66-4495-bcc9-c3aa2eea0cee
             X-Msedge-Ref:
-                - 'Ref A: DB2A047794B44F55A242114222007AA0 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:13Z'
+                - 'Ref A: 8574246AC5C54BA8AF26AAA823711DCE Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
         status: 200 OK
         code: 200
-        duration: 389.4282ms
+        duration: 234.2108ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -515,10 +515,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourcegroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourcegroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -537,7 +537,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:13 GMT
+                - Fri, 14 Jun 2024 21:32:30 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -551,18 +551,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 302993b1-1dce-466c-ad53-dc9d9e9a2954
+                - 690c7fe8-0d90-4334-961f-f543e540afab
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001213Z:24ef6abe-5bd4-44e0-85d1-8cab3f692f37
+                - WESTUS:20240614T213230Z:f7dbb8a5-b813-4521-8672-22299e9b468f
             X-Msedge-Ref:
-                - 'Ref A: 0312EBA0D1704614A918A41161684813 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:13Z'
+                - 'Ref A: D95CC0E730E34F089A28797A1D10D0DC Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
         status: 200 OK
         code: 200
-        duration: 414.038ms
+        duration: 248.3614ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -584,10 +584,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/f91f9734-8835-4fa4-8564-1dd169bc29dd/resourcegroups/project-8489/providers/Microsoft.DevCenter/projects/VisualStudioServicing/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourcegroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -606,7 +606,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:13 GMT
+                - Fri, 14 Jun 2024 21:32:30 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -620,18 +620,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 989c8c59-279d-41e1-a55e-d77737ea63ec
+                - 25d017cd-923f-428a-a448-e0b79c802e8d
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001213Z:80e7a32f-128b-47dd-8bac-07101fa37329
+                - WESTUS:20240614T213230Z:2f355f8c-8d30-45fc-94ab-0b26b654ced0
             X-Msedge-Ref:
-                - 'Ref A: 53158A5F17C94EEBB287D5BA688E6683 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:13Z'
+                - 'Ref A: 7D283F848B0345FCB2CB7B9A5A32A976 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
         status: 200 OK
         code: 200
-        duration: 411.3221ms
+        duration: 243.6708ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -653,10 +653,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourcegroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -675,7 +675,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:13 GMT
+                - Fri, 14 Jun 2024 21:32:30 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -689,18 +689,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - e1169dc4-0151-42fe-ac21-5ea4503b9274
+                - 7af85af3-406b-4556-9d3e-1d1fed27755c
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001213Z:d4d4f9ef-0a16-4689-8aad-48c703a6f82f
+                - WESTUS:20240614T213230Z:679442f5-5962-4f7c-83a2-2c4f54c83d98
             X-Msedge-Ref:
-                - 'Ref A: 101B70C2F9F74BB6B395FB022E8D3AE0 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:13Z'
+                - 'Ref A: 7B095D7D83254804B0F7D4774167EABD Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
         status: 200 OK
         code: 200
-        duration: 431.3597ms
+        duration: 257.1802ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -722,10 +722,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourcegroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project2/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -733,18 +733,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 990
+        content_length: 82
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "990"
+                - "82"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:13 GMT
+                - Fri, 14 Jun 2024 21:32:30 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -758,18 +758,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 9eccb47b-9627-4c5c-8540-8989f1cf806c
+                - 3069b3c3-55ee-4ad9-b60f-cc091b456ab6
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001213Z:f4989860-dc8e-41c7-b6f3-7ac81a4217ba
+                - WESTUS:20240614T213230Z:5e57745a-bd4e-46cc-b4c0-c390e2e41ecf
             X-Msedge-Ref:
-                - 'Ref A: 275ED1D80AC44334829631A5DD06AAB1 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:13Z'
+                - 'Ref A: 8021C23B882943A5BEEB13510184D330 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
         status: 200 OK
         code: 200
-        duration: 411.048ms
+        duration: 277.8987ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -791,9 +791,9 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
         url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
@@ -813,7 +813,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:13 GMT
+                - Fri, 14 Jun 2024 21:32:30 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -827,18 +827,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - fa91536b-d6f1-40a1-a51a-51f2f6c04615
+                - aff37891-0f57-480b-a898-dab001bf997b
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001213Z:fa80a081-807e-4ccb-9240-2dfb4e6004f0
+                - WESTUS:20240614T213230Z:8e8ccdde-657b-424e-ba74-7c862f3d40ff
             X-Msedge-Ref:
-                - 'Ref A: F9B4540EB8604DEC879B343E18540C10 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:13Z'
+                - 'Ref A: FA9240E8783E4DA2B6AA00BD637A4B88 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
         status: 200 OK
         code: 200
-        duration: 442.7966ms
+        duration: 274.4042ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -860,10 +860,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourcegroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-contoso-ecomm-pe/providers/Microsoft.DevCenter/projects/contoso-ecomm/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -871,18 +871,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 990
+        content_length: 82
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "990"
+                - "82"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:13 GMT
+                - Fri, 14 Jun 2024 21:32:30 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -896,18 +896,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 5a50c083-42ab-46e0-a4b3-afc9e760181e
+                - 104b750b-3170-4681-a161-96751b582c6f
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001213Z:62ace0f3-be57-4426-b125-1f502c31dcc2
+                - WESTUS:20240614T213230Z:0619e473-5600-4796-9ddb-b46aa2c8b0dc
             X-Msedge-Ref:
-                - 'Ref A: 419A50BB10A243489973B50695E6D584 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:13Z'
+                - 'Ref A: C4B5685464A740D1A7CBEDF8E921D263 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
         status: 200 OK
         code: 200
-        duration: 452.6571ms
+        duration: 281.7219ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -929,10 +929,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project1/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -940,18 +940,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 990
+        content_length: 82
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "990"
+                - "82"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:13 GMT
+                - Fri, 14 Jun 2024 21:32:30 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -965,18 +965,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - f668efb8-c820-4047-a1d3-eca83fcb4cbc
+                - 48bb8fbe-a10e-4430-9452-70aa2545b674
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001213Z:b27363bc-3290-4114-8c8b-f493b80bc206
+                - WESTUS:20240614T213230Z:9911c42e-76a5-4ce4-af17-9930b6f8612b
             X-Msedge-Ref:
-                - 'Ref A: 000D707163EA46BDB73FBE235E1DD9D5 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:13Z'
+                - 'Ref A: D1C6B3A27F1D4546A14AC26398D3898A Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
         status: 200 OK
         code: 200
-        duration: 464.2667ms
+        duration: 275.8517ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -998,10 +998,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourcegroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-demo-test101/providers/Microsoft.DevCenter/projects/dcprj-pv44d74rp44bs/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -1009,18 +1009,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 990
+        content_length: 82
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "990"
+                - "82"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:13 GMT
+                - Fri, 14 Jun 2024 21:32:30 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1034,18 +1034,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 9305391b-21d5-4c5d-b4fe-6d1afaf2170f
+                - c6111b6c-86ca-4a54-887a-0f1515ec30dd
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001214Z:6b1b5d09-c772-43c2-9e60-fb6fa57f8d7c
+                - WESTUS:20240614T213230Z:62aaf63c-dec2-4fec-8d01-1d017ec92fac
             X-Msedge-Ref:
-                - 'Ref A: CEBFD60DC9AF4E7F8C63857BEB823243 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:13Z'
+                - 'Ref A: 92DF5501C95F4921B1260D050F490D6D Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
         status: 200 OK
         code: 200
-        duration: 562.7728ms
+        duration: 289.4015ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -1067,9 +1067,216 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/Inventory-Management-Project/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 82
+        uncompressed: false
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "82"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Jun 2024 21:32:30 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 832a01f9-0ebf-4946-bc3c-b7801f57c69f
+            X-Ms-Routing-Request-Id:
+                - WESTUS:20240614T213231Z:85e4f570-5fe9-4963-9f51-a07521c85ccd
+            X-Msedge-Ref:
+                - 'Ref A: C41C3114141C42D59070D97786D8D953 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
+        status: 200 OK
+        code: 200
+        duration: 305.1122ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourcegroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Jun 2024 21:32:30 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - b4304462-80df-425b-b40a-66c7096c4da0
+            X-Ms-Routing-Request-Id:
+                - WESTUS:20240614T213231Z:a3293e6e-f2ba-4f1e-976f-a9080de228a4
+            X-Msedge-Ref:
+                - 'Ref A: 389B6B53D54A47B983B434B645780012 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
+        status: 200 OK
+        code: 200
+        duration: 297.2927ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourcegroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-2/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3705
+        uncompressed: false
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3705"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Jun 2024 21:32:30 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 5e6bf88c-f0da-4d8a-b8ff-00f7ddc1ab73
+            X-Ms-Routing-Request-Id:
+                - WESTUS:20240614T213231Z:9049f06a-ba83-4379-98b6-81cfe3e6c073
+            X-Msedge-Ref:
+                - 'Ref A: 0A425078E51A4482B0D081C783BAEF4C Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
+        status: 200 OK
+        code: 200
+        duration: 356.7164ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
         url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourcegroups/qiaozha-test/providers/Microsoft.DevCenter/projects/jsmgmt/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
@@ -1089,7 +1296,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:13 GMT
+                - Fri, 14 Jun 2024 21:32:30 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -1103,19 +1310,19 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 112c3d66-de0e-4b52-9e37-38cfdc1a90fa
+                - 30eaee15-fd1a-4795-8685-277159d0d896
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001214Z:42149a92-163d-453a-b35c-a446eb660ddc
+                - WESTUS:20240614T213231Z:45b18b0e-2e7f-4005-9fe9-45005eb93a48
             X-Msedge-Ref:
-                - 'Ref A: 160163F3610E4CB59259BFBA18ED6F78 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:13Z'
+                - 'Ref A: 5CCB63D567494CB19C3EB4142292A754 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
         status: 200 OK
         code: 200
-        duration: 670.353ms
-    - id: 16
+        duration: 350.6108ms
+    - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1123,21 +1330,23 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com
+        host: management.azure.com
         remote_addr: ""
         request_uri: ""
         body: ""
         form: {}
         headers:
+            Accept:
+                - application/json
             Accept-Encoding:
                 - gzip
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-devcenter/1.0.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/environmentDefinitions?api-version=2023-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourcegroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-1/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -1145,346 +1354,113 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: |-
-            {
-              "value": [
-                {
-                  "id": "/projects/Project-1/catalogs/example/environmentDefinitions/webapp",
-                  "name": "WebApp",
-                  "catalogName": "Example",
-                  "description": "Deploys an Azure Web App without a data store",
-                  "parameters": [],
-                  "parametersSchema": "{\"type\":\"object\"}",
-                  "templatePath": "Environment-Definitions/ARMTemplates/WebApp/azuredeploy.json"
-                },
-                {
-                  "id": "/projects/Project-1/catalogs/test/environmentDefinitions/sandbox",
-                  "name": "Sandbox",
-                  "catalogName": "test",
-                  "description": "Deploys a sandbox environment",
-                  "parameters": [],
-                  "parametersSchema": "{\"type\":\"object\"}",
-                  "templatePath": "Environment-Definitions/ARMTemplates/Sandbox/azuredeploy.json"
-                },
-                {
-                  "id": "/projects/Project-1/catalogs/test/environmentDefinitions/webapp",
-                  "name": "WebApp",
-                  "catalogName": "test",
-                  "description": "Deploys an Azure Web App without a data store",
-                  "parameters": [],
-                  "parametersSchema": "{\"type\":\"object\"}",
-                  "templatePath": "Environment-Definitions/ARMTemplates/WebApp/azuredeploy.json"
-                },
-                {
-                  "id": "/projects/Project-1/catalogs/test/environmentDefinitions/app-service-with-cosmos_azd-template",
-                  "name": "App-Service-with-Cosmos_AZD-template",
-                  "catalogName": "test",
-                  "description": "Deploys an Azure App Service with Cosmos, it is compatible with azd.",
-                  "parameters": [
-                    {
-                      "id": "runtimeType",
-                      "name": "Runtime Type",
-                      "description": "Runtime Type of the App Service runtime,eg python, nodejs or java.",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": true,
-                      "allowed": [
-                        "python",
-                        "nodejs",
-                        "java"
-                      ]
-                    },
-                    {
-                      "id": "repoUrl",
-                      "name": "Repository URL",
-                      "description": "Path the the application source code",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": false,
-                      "allowed": [
-                        "https://github.com/azure-samples/todo-java-mongo",
-                        "https://github.com/azure-samples/todo-nodejs-mongo",
-                        "https://github.com/azure-samples/todo-python-mongo"
-                      ]
-                    }
-                  ],
-                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the App Service runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo\",\"https://github.com/azure-samples/todo-nodejs-mongo\",\"https://github.com/azure-samples/todo-python-mongo\"]}},\"required\":[\"runtimeType\"]}",
-                  "templatePath": "Environment-Definitions/ARMTemplates/App-Service-with-Cosmos_AZD-template/azuredeploy.json"
-                },
-                {
-                  "id": "/projects/Project-1/catalogs/example/environmentDefinitions/sandbox",
-                  "name": "Sandbox",
-                  "catalogName": "Example",
-                  "description": "Deploys a sandbox environment",
-                  "parameters": [],
-                  "parametersSchema": "{\"type\":\"object\"}",
-                  "templatePath": "Environment-Definitions/ARMTemplates/Sandbox/azuredeploy.json"
-                },
-                {
-                  "id": "/projects/Project-1/catalogs/wbreza/environmentDefinitions/helloworld",
-                  "name": "HelloWorld",
-                  "catalogName": "wbreza",
-                  "description": "Deploys an Azure App Service within App Service Plan",
-                  "parameters": [
-                    {
-                      "id": "environmentName",
-                      "name": "Environment Name",
-                      "description": "Name of the environment",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": false
-                    },
-                    {
-                      "id": "repoUrl",
-                      "name": "Repository URL",
-                      "description": "Path the the application source code",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": false,
-                      "allowed": [
-                        "https://github.com/wbreza/azd-hello-world"
-                      ]
-                    }
-                  ],
-                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"environmentName\":{\"title\":\"Environment Name\",\"description\":\"Name of the environment\"},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/wbreza/azd-hello-world\"]}}}",
-                  "templatePath": "EnvironmentDefinitions/HelloWorld/azuredeploy.json"
-                },
-                {
-                  "id": "/projects/Project-1/catalogs/test/environmentDefinitions/function-app-with-cosmos_azd-template",
-                  "name": "Function-App-with-Cosmos_AZD-template",
-                  "catalogName": "test",
-                  "description": "Deploys an Azure Function App with Cosmos, it is compatible with azd.",
-                  "parameters": [
-                    {
-                      "id": "runtimeType",
-                      "name": "Runtime Type",
-                      "description": "Runtime Type of the Function App runtime,eg python or nodejs",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": true,
-                      "allowed": [
-                        "python",
-                        "nodejs"
-                      ]
-                    },
-                    {
-                      "id": "repoUrl",
-                      "name": "Repository URL",
-                      "description": "Path the the application source code",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": false,
-                      "allowed": [
-                        "https://github.com/azure-samples/todo-nodejs-mongo-swa-func",
-                        "https://github.com/azure-samples/todo-python-mongo-swa-func"
-                      ]
-                    }
-                  ],
-                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the Function App runtime,eg python or nodejs\",\"enum\":[\"python\",\"nodejs\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-nodejs-mongo-swa-func\",\"https://github.com/azure-samples/todo-python-mongo-swa-func\"]}},\"required\":[\"runtimeType\"]}",
-                  "templatePath": "Environment-Definitions/ARMTemplates/Function-App-with-Cosmos_AZD-template/azuredeploy.json"
-                },
-                {
-                  "id": "/projects/Project-1/catalogs/example/environmentDefinitions/function-app-with-cosmos_azd-template",
-                  "name": "Function-App-with-Cosmos_AZD-template",
-                  "catalogName": "Example",
-                  "description": "Deploys an Azure Function App with Cosmos, it is compatible with azd.",
-                  "parameters": [
-                    {
-                      "id": "runtimeType",
-                      "name": "Runtime Type",
-                      "description": "Runtime Type of the Function App runtime,eg python or nodejs",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": true,
-                      "allowed": [
-                        "python",
-                        "nodejs"
-                      ]
-                    },
-                    {
-                      "id": "repoUrl",
-                      "name": "Repository URL",
-                      "description": "Path the the application source code",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": false,
-                      "allowed": [
-                        "https://github.com/azure-samples/todo-nodejs-mongo-swa-func",
-                        "https://github.com/azure-samples/todo-python-mongo-swa-func"
-                      ]
-                    }
-                  ],
-                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the Function App runtime,eg python or nodejs\",\"enum\":[\"python\",\"nodejs\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-nodejs-mongo-swa-func\",\"https://github.com/azure-samples/todo-python-mongo-swa-func\"]}},\"required\":[\"runtimeType\"]}",
-                  "templatePath": "Environment-Definitions/ARMTemplates/Function-App-with-Cosmos_AZD-template/azuredeploy.json"
-                },
-                {
-                  "id": "/projects/Project-1/catalogs/example/environmentDefinitions/app-service-with-cosmos_azd-template",
-                  "name": "App-Service-with-Cosmos_AZD-template",
-                  "catalogName": "Example",
-                  "description": "Deploys an Azure App Service with Cosmos, it is compatible with azd.",
-                  "parameters": [
-                    {
-                      "id": "runtimeType",
-                      "name": "Runtime Type",
-                      "description": "Runtime Type of the App Service runtime,eg python, nodejs or java.",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": true,
-                      "allowed": [
-                        "python",
-                        "nodejs",
-                        "java"
-                      ]
-                    },
-                    {
-                      "id": "repoUrl",
-                      "name": "Repository URL",
-                      "description": "Path the the application source code",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": false,
-                      "allowed": [
-                        "https://github.com/azure-samples/todo-java-mongo",
-                        "https://github.com/azure-samples/todo-nodejs-mongo",
-                        "https://github.com/azure-samples/todo-python-mongo"
-                      ]
-                    }
-                  ],
-                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the App Service runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo\",\"https://github.com/azure-samples/todo-nodejs-mongo\",\"https://github.com/azure-samples/todo-python-mongo\"]}},\"required\":[\"runtimeType\"]}",
-                  "templatePath": "Environment-Definitions/ARMTemplates/App-Service-with-Cosmos_AZD-template/azuredeploy.json"
-                },
-                {
-                  "id": "/projects/Project-1/catalogs/example/environmentDefinitions/container-app-with-cosmos_azd-template",
-                  "name": "Container-App-with-Cosmos_AZD-template",
-                  "catalogName": "Example",
-                  "description": "Deploys an Azure Container App with Cosmos, it is compatible with azd.",
-                  "parameters": [
-                    {
-                      "id": "runtimeType",
-                      "name": "Runtime Type",
-                      "description": "Runtime Type of the container App runtime,eg python, nodejs or java.",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": true,
-                      "allowed": [
-                        "python",
-                        "nodejs",
-                        "java"
-                      ]
-                    },
-                    {
-                      "id": "repoUrl",
-                      "name": "Repository URL",
-                      "description": "Path the the application source code",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": false,
-                      "allowed": [
-                        "https://github.com/azure-samples/todo-java-mongo-aca",
-                        "https://github.com/azure-samples/todo-nodejs-mongo-aca",
-                        "https://github.com/azure-samples/todo-python-mongo-aca"
-                      ]
-                    }
-                  ],
-                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the container App runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo-aca\",\"https://github.com/azure-samples/todo-nodejs-mongo-aca\",\"https://github.com/azure-samples/todo-python-mongo-aca\"]}},\"required\":[\"runtimeType\"]}",
-                  "templatePath": "Environment-Definitions/ARMTemplates/Container-App-with-Cosmos_AZD-template/azuredeploy.json"
-                },
-                {
-                  "id": "/projects/Project-1/catalogs/wbreza/environmentDefinitions/todo",
-                  "name": "Todo",
-                  "catalogName": "wbreza",
-                  "description": "Deploys an Azure Container App within Container App environment",
-                  "parameters": [
-                    {
-                      "id": "environmentName",
-                      "name": "Environment Name",
-                      "description": "Name of the environment",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": false
-                    },
-                    {
-                      "id": "repoUrl",
-                      "name": "Repository URL",
-                      "description": "Path the the application source code",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": false,
-                      "allowed": [
-                        "https://github.com/azure-samples/todo-nodejs-mongo-aca"
-                      ]
-                    }
-                  ],
-                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"environmentName\":{\"title\":\"Environment Name\",\"description\":\"Name of the environment\"},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-nodejs-mongo-aca\"]}}}",
-                  "templatePath": "EnvironmentDefinitions/Todo/main.bicep"
-                },
-                {
-                  "id": "/projects/Project-1/catalogs/test/environmentDefinitions/container-app-with-cosmos_azd-template",
-                  "name": "Container-App-with-Cosmos_AZD-template",
-                  "catalogName": "test",
-                  "description": "Deploys an Azure Container App with Cosmos, it is compatible with azd.",
-                  "parameters": [
-                    {
-                      "id": "runtimeType",
-                      "name": "Runtime Type",
-                      "description": "Runtime Type of the container App runtime,eg python, nodejs or java.",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": true,
-                      "allowed": [
-                        "python",
-                        "nodejs",
-                        "java"
-                      ]
-                    },
-                    {
-                      "id": "repoUrl",
-                      "name": "Repository URL",
-                      "description": "Path the the application source code",
-                      "type": "string",
-                      "readOnly": false,
-                      "required": false,
-                      "allowed": [
-                        "https://github.com/azure-samples/todo-java-mongo-aca",
-                        "https://github.com/azure-samples/todo-nodejs-mongo-aca",
-                        "https://github.com/azure-samples/todo-python-mongo-aca"
-                      ]
-                    }
-                  ],
-                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the container App runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo-aca\",\"https://github.com/azure-samples/todo-nodejs-mongo-aca\",\"https://github.com/azure-samples/todo-python-mongo-aca\"]}},\"required\":[\"runtimeType\"]}",
-                  "templatePath": "Environment-Definitions/ARMTemplates/Container-App-with-Cosmos_AZD-template/azuredeploy.json"
-                }
-              ]
-            }
+        content_length: 3705
+        uncompressed: false
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]}]}'
         headers:
-            Access-Control-Allow-Origin:
-                - '*'
-            Access-Control-Expose-Headers:
-                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
-            Access-Control-Max-Age:
-                - "86400"
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3705"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:14 GMT
+                - Fri, 14 Jun 2024 21:32:30 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
             Strict-Transport-Security:
-                - max-age=15724800; includeSubDomains
-            X-Ms-Client-Request-Id:
-                - 77aa9416-e789-4703-9943-2746fdb1f968
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-            X-Rate-Limit-Limit:
-                - 1m
-            X-Rate-Limit-Remaining:
-                - "299"
-            X-Rate-Limit-Reset:
-                - "2024-06-11T00:13:14.7936557Z"
+                - b5458087c80a1210e8f4e4bdf53b40fb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - ef39d361-b6c3-4c09-b831-d239074ebe50
+            X-Ms-Routing-Request-Id:
+                - WESTUS:20240614T213231Z:3f4055f0-c0ae-4212-b0e5-6b2492a18701
+            X-Msedge-Ref:
+                - 'Ref A: FD833F1D409244E3A9785C88CAB347D3 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
         status: 200 OK
         code: 200
-        duration: 764.8703ms
-    - id: 17
+        duration: 355.5842ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourcegroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Jun 2024 21:32:30 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 561fd7db-1add-463b-95bd-c10fb07d48b2
+            X-Ms-Routing-Request-Id:
+                - WESTUS:20240614T213231Z:9f046fa4-0e6c-4d4b-ade0-5597a77c6c95
+            X-Msedge-Ref:
+                - 'Ref A: AD02FA1A2C5D48BCA4D0CEE82E722A12 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:30Z'
+        status: 200 OK
+        code: 200
+        duration: 354.2636ms
+    - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1503,10 +1479,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-devcenter/1.0.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-2/environmentDefinitions?api-version=2023-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-2/environmentDefinitions?api-version=2024-02-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -1520,6 +1496,7 @@ interactions:
             {
               "value": [
                 {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-2/catalogs/Example/environmentDefinitions/WebApp",
                   "id": "/projects/Project-2/catalogs/example/environmentDefinitions/webapp",
                   "name": "WebApp",
                   "catalogName": "Example",
@@ -1529,6 +1506,7 @@ interactions:
                   "templatePath": "Environment-Definitions/ARMTemplates/WebApp/azuredeploy.json"
                 },
                 {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-2/catalogs/test/environmentDefinitions/Sandbox",
                   "id": "/projects/Project-2/catalogs/test/environmentDefinitions/sandbox",
                   "name": "Sandbox",
                   "catalogName": "test",
@@ -1538,6 +1516,7 @@ interactions:
                   "templatePath": "Environment-Definitions/ARMTemplates/Sandbox/azuredeploy.json"
                 },
                 {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-2/catalogs/test/environmentDefinitions/WebApp",
                   "id": "/projects/Project-2/catalogs/test/environmentDefinitions/webapp",
                   "name": "WebApp",
                   "catalogName": "test",
@@ -1547,6 +1526,7 @@ interactions:
                   "templatePath": "Environment-Definitions/ARMTemplates/WebApp/azuredeploy.json"
                 },
                 {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-2/catalogs/test/environmentDefinitions/App-Service-with-Cosmos_AZD-template",
                   "id": "/projects/Project-2/catalogs/test/environmentDefinitions/app-service-with-cosmos_azd-template",
                   "name": "App-Service-with-Cosmos_AZD-template",
                   "catalogName": "test",
@@ -1583,6 +1563,7 @@ interactions:
                   "templatePath": "Environment-Definitions/ARMTemplates/App-Service-with-Cosmos_AZD-template/azuredeploy.json"
                 },
                 {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-2/catalogs/Example/environmentDefinitions/Sandbox",
                   "id": "/projects/Project-2/catalogs/example/environmentDefinitions/sandbox",
                   "name": "Sandbox",
                   "catalogName": "Example",
@@ -1592,6 +1573,7 @@ interactions:
                   "templatePath": "Environment-Definitions/ARMTemplates/Sandbox/azuredeploy.json"
                 },
                 {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-2/catalogs/wbreza/environmentDefinitions/HelloWorld",
                   "id": "/projects/Project-2/catalogs/wbreza/environmentDefinitions/helloworld",
                   "name": "HelloWorld",
                   "catalogName": "wbreza",
@@ -1621,6 +1603,7 @@ interactions:
                   "templatePath": "EnvironmentDefinitions/HelloWorld/azuredeploy.json"
                 },
                 {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-2/catalogs/test/environmentDefinitions/Function-App-with-Cosmos_AZD-template",
                   "id": "/projects/Project-2/catalogs/test/environmentDefinitions/function-app-with-cosmos_azd-template",
                   "name": "Function-App-with-Cosmos_AZD-template",
                   "catalogName": "test",
@@ -1655,6 +1638,37 @@ interactions:
                   "templatePath": "Environment-Definitions/ARMTemplates/Function-App-with-Cosmos_AZD-template/azuredeploy.json"
                 },
                 {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-2/catalogs/wbreza/environmentDefinitions/HelloWorld-Bicep",
+                  "id": "/projects/Project-2/catalogs/wbreza/environmentDefinitions/helloworld-bicep",
+                  "name": "HelloWorld-Bicep",
+                  "catalogName": "wbreza",
+                  "description": "Deploys an Azure App Service within App Service Plan",
+                  "parameters": [
+                    {
+                      "id": "environmentName",
+                      "name": "Environment Name",
+                      "description": "Name of the environment",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/wbreza/azd-hello-world"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"environmentName\":{\"title\":\"Environment Name\",\"description\":\"Name of the environment\"},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/wbreza/azd-hello-world\"]}}}",
+                  "templatePath": "EnvironmentDefinitions/HelloWorld-Bicep/main.bicep"
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-2/catalogs/Example/environmentDefinitions/Function-App-with-Cosmos_AZD-template",
                   "id": "/projects/Project-2/catalogs/example/environmentDefinitions/function-app-with-cosmos_azd-template",
                   "name": "Function-App-with-Cosmos_AZD-template",
                   "catalogName": "Example",
@@ -1689,6 +1703,7 @@ interactions:
                   "templatePath": "Environment-Definitions/ARMTemplates/Function-App-with-Cosmos_AZD-template/azuredeploy.json"
                 },
                 {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-2/catalogs/Example/environmentDefinitions/App-Service-with-Cosmos_AZD-template",
                   "id": "/projects/Project-2/catalogs/example/environmentDefinitions/app-service-with-cosmos_azd-template",
                   "name": "App-Service-with-Cosmos_AZD-template",
                   "catalogName": "Example",
@@ -1725,6 +1740,7 @@ interactions:
                   "templatePath": "Environment-Definitions/ARMTemplates/App-Service-with-Cosmos_AZD-template/azuredeploy.json"
                 },
                 {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-2/catalogs/Example/environmentDefinitions/Container-App-with-Cosmos_AZD-template",
                   "id": "/projects/Project-2/catalogs/example/environmentDefinitions/container-app-with-cosmos_azd-template",
                   "name": "Container-App-with-Cosmos_AZD-template",
                   "catalogName": "Example",
@@ -1761,6 +1777,7 @@ interactions:
                   "templatePath": "Environment-Definitions/ARMTemplates/Container-App-with-Cosmos_AZD-template/azuredeploy.json"
                 },
                 {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-2/catalogs/wbreza/environmentDefinitions/Todo",
                   "id": "/projects/Project-2/catalogs/wbreza/environmentDefinitions/todo",
                   "name": "Todo",
                   "catalogName": "wbreza",
@@ -1790,6 +1807,7 @@ interactions:
                   "templatePath": "EnvironmentDefinitions/Todo/main.bicep"
                 },
                 {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-2/catalogs/test/environmentDefinitions/Container-App-with-Cosmos_AZD-template",
                   "id": "/projects/Project-2/catalogs/test/environmentDefinitions/container-app-with-cosmos_azd-template",
                   "name": "Container-App-with-Cosmos_AZD-template",
                   "catalogName": "test",
@@ -1837,298 +1855,22 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:14 GMT
+                - Fri, 14 Jun 2024 21:32:31 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - d8302036-df3e-4618-8ae0-0c78e6828270
+                - 85e7fcd2-bd28-4651-bc93-bc1482a46dcd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
-                - "299"
+                - "293"
             X-Rate-Limit-Reset:
-                - "2024-06-11T00:13:14.8270684Z"
+                - "2024-06-14T21:32:43.1509356Z"
         status: 200 OK
         code: 200
-        duration: 776.3893ms
-    - id: 18
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: management.azure.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Accept-Encoding:
-                - gzip
-            Authorization:
-                - SANITIZED
-            User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
-            X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourcegroups/qiaozha-test/providers/Microsoft.DevCenter/projects/jsmgmt/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 153
-        uncompressed: false
-        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "153"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Tue, 11 Jun 2024 00:12:19 GMT
-            Expires:
-                - "-1"
-            Pragma:
-                - no-cache
-            Set-Cookie:
-                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
-            Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains
-            X-Cache:
-                - CONFIG_NOCACHE
-            X-Content-Type-Options:
-                - nosniff
-            X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-            X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11998"
-            X-Ms-Request-Id:
-                - 32f0faf2-c0f3-45e3-97f2-7a6406d17e2b
-            X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001220Z:2dca7902-eb68-4384-b38b-748e1261a32f
-            X-Msedge-Ref:
-                - 'Ref A: 2AAE093B9CDE42D482DCB9A0F9A7B161 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:20Z'
-        status: 200 OK
-        code: 200
-        duration: 154.2234ms
-    - id: 19
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: management.azure.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Accept-Encoding:
-                - gzip
-            Authorization:
-                - SANITIZED
-            User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
-            X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/f91f9734-8835-4fa4-8564-1dd169bc29dd/resourcegroups/project-8489/providers/Microsoft.DevCenter/projects/VisualStudioServicing/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 990
-        uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "990"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Tue, 11 Jun 2024 00:12:19 GMT
-            Expires:
-                - "-1"
-            Pragma:
-                - no-cache
-            Set-Cookie:
-                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
-            Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains
-            X-Cache:
-                - CONFIG_NOCACHE
-            X-Content-Type-Options:
-                - nosniff
-            X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-            X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
-            X-Ms-Request-Id:
-                - 4b0a806d-8bd7-4a30-aff8-766c94eb14bc
-            X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001220Z:2677c20d-66ed-48d4-b0c7-8c5b7cdc0e9e
-            X-Msedge-Ref:
-                - 'Ref A: 1EDFCF47CE11427D976A62067CC797FB Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:20Z'
-        status: 200 OK
-        code: 200
-        duration: 164.835ms
-    - id: 20
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: management.azure.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Accept-Encoding:
-                - gzip
-            Authorization:
-                - SANITIZED
-            User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
-            X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourcegroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 990
-        uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "990"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Tue, 11 Jun 2024 00:12:19 GMT
-            Expires:
-                - "-1"
-            Pragma:
-                - no-cache
-            Set-Cookie:
-                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
-            Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains
-            X-Cache:
-                - CONFIG_NOCACHE
-            X-Content-Type-Options:
-                - nosniff
-            X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-            X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
-            X-Ms-Request-Id:
-                - d2f76a1f-ff11-4399-bd1a-7558f3881093
-            X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001220Z:de87dc9b-4fd3-4992-834a-c8667f2cf5e5
-            X-Msedge-Ref:
-                - 'Ref A: 2191111C74C843389DE012E455EB86AD Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:20Z'
-        status: 200 OK
-        code: 200
-        duration: 161.4797ms
-    - id: 21
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: management.azure.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Accept-Encoding:
-                - gzip
-            Authorization:
-                - SANITIZED
-            User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
-            X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourcegroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 990
-        uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "990"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Tue, 11 Jun 2024 00:12:19 GMT
-            Expires:
-                - "-1"
-            Pragma:
-                - no-cache
-            Set-Cookie:
-                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
-            Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains
-            X-Cache:
-                - CONFIG_NOCACHE
-            X-Content-Type-Options:
-                - nosniff
-            X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-            X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
-            X-Ms-Request-Id:
-                - 16e8d0eb-e708-4600-b9ff-62b2a791887c
-            X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001220Z:9fa3d0c7-bf66-48cd-8091-9a262cd5fdfb
-            X-Msedge-Ref:
-                - 'Ref A: DF55A067CD4E4178AA77C4081A0C0B79 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:20Z'
-        status: 200 OK
-        code: 200
-        duration: 136.9793ms
+        duration: 373.326ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -2137,23 +1879,21 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: management.azure.com
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com
         remote_addr: ""
         request_uri: ""
         body: ""
         form: {}
         headers:
-            Accept:
-                - application/json
             Accept-Encoding:
                 - gzip
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourcegroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-2/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/environmentDefinitions?api-version=2024-02-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2161,43 +1901,387 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1929
-        uncompressed: false
-        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]}]}'
+        content_length: -1
+        uncompressed: true
+        body: |-
+            {
+              "value": [
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/catalogs/Example/environmentDefinitions/WebApp",
+                  "id": "/projects/Project-1/catalogs/example/environmentDefinitions/webapp",
+                  "name": "WebApp",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure Web App without a data store",
+                  "parameters": [],
+                  "parametersSchema": "{\"type\":\"object\"}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/WebApp/azuredeploy.json"
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/catalogs/test/environmentDefinitions/Sandbox",
+                  "id": "/projects/Project-1/catalogs/test/environmentDefinitions/sandbox",
+                  "name": "Sandbox",
+                  "catalogName": "test",
+                  "description": "Deploys a sandbox environment",
+                  "parameters": [],
+                  "parametersSchema": "{\"type\":\"object\"}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Sandbox/azuredeploy.json"
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/catalogs/test/environmentDefinitions/WebApp",
+                  "id": "/projects/Project-1/catalogs/test/environmentDefinitions/webapp",
+                  "name": "WebApp",
+                  "catalogName": "test",
+                  "description": "Deploys an Azure Web App without a data store",
+                  "parameters": [],
+                  "parametersSchema": "{\"type\":\"object\"}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/WebApp/azuredeploy.json"
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/catalogs/test/environmentDefinitions/App-Service-with-Cosmos_AZD-template",
+                  "id": "/projects/Project-1/catalogs/test/environmentDefinitions/app-service-with-cosmos_azd-template",
+                  "name": "App-Service-with-Cosmos_AZD-template",
+                  "catalogName": "test",
+                  "description": "Deploys an Azure App Service with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the App Service runtime,eg python, nodejs or java.",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs",
+                        "java"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-java-mongo",
+                        "https://github.com/azure-samples/todo-nodejs-mongo",
+                        "https://github.com/azure-samples/todo-python-mongo"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the App Service runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo\",\"https://github.com/azure-samples/todo-nodejs-mongo\",\"https://github.com/azure-samples/todo-python-mongo\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/App-Service-with-Cosmos_AZD-template/azuredeploy.json"
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/catalogs/Example/environmentDefinitions/Sandbox",
+                  "id": "/projects/Project-1/catalogs/example/environmentDefinitions/sandbox",
+                  "name": "Sandbox",
+                  "catalogName": "Example",
+                  "description": "Deploys a sandbox environment",
+                  "parameters": [],
+                  "parametersSchema": "{\"type\":\"object\"}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Sandbox/azuredeploy.json"
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/catalogs/wbreza/environmentDefinitions/HelloWorld",
+                  "id": "/projects/Project-1/catalogs/wbreza/environmentDefinitions/helloworld",
+                  "name": "HelloWorld",
+                  "catalogName": "wbreza",
+                  "description": "Deploys an Azure App Service within App Service Plan",
+                  "parameters": [
+                    {
+                      "id": "environmentName",
+                      "name": "Environment Name",
+                      "description": "Name of the environment",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/wbreza/azd-hello-world"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"environmentName\":{\"title\":\"Environment Name\",\"description\":\"Name of the environment\"},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/wbreza/azd-hello-world\"]}}}",
+                  "templatePath": "EnvironmentDefinitions/HelloWorld/azuredeploy.json"
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/catalogs/test/environmentDefinitions/Function-App-with-Cosmos_AZD-template",
+                  "id": "/projects/Project-1/catalogs/test/environmentDefinitions/function-app-with-cosmos_azd-template",
+                  "name": "Function-App-with-Cosmos_AZD-template",
+                  "catalogName": "test",
+                  "description": "Deploys an Azure Function App with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the Function App runtime,eg python or nodejs",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-nodejs-mongo-swa-func",
+                        "https://github.com/azure-samples/todo-python-mongo-swa-func"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the Function App runtime,eg python or nodejs\",\"enum\":[\"python\",\"nodejs\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-nodejs-mongo-swa-func\",\"https://github.com/azure-samples/todo-python-mongo-swa-func\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Function-App-with-Cosmos_AZD-template/azuredeploy.json"
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/catalogs/wbreza/environmentDefinitions/HelloWorld-Bicep",
+                  "id": "/projects/Project-1/catalogs/wbreza/environmentDefinitions/helloworld-bicep",
+                  "name": "HelloWorld-Bicep",
+                  "catalogName": "wbreza",
+                  "description": "Deploys an Azure App Service within App Service Plan",
+                  "parameters": [
+                    {
+                      "id": "environmentName",
+                      "name": "Environment Name",
+                      "description": "Name of the environment",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/wbreza/azd-hello-world"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"environmentName\":{\"title\":\"Environment Name\",\"description\":\"Name of the environment\"},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/wbreza/azd-hello-world\"]}}}",
+                  "templatePath": "EnvironmentDefinitions/HelloWorld-Bicep/main.bicep"
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/catalogs/Example/environmentDefinitions/Function-App-with-Cosmos_AZD-template",
+                  "id": "/projects/Project-1/catalogs/example/environmentDefinitions/function-app-with-cosmos_azd-template",
+                  "name": "Function-App-with-Cosmos_AZD-template",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure Function App with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the Function App runtime,eg python or nodejs",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-nodejs-mongo-swa-func",
+                        "https://github.com/azure-samples/todo-python-mongo-swa-func"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the Function App runtime,eg python or nodejs\",\"enum\":[\"python\",\"nodejs\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-nodejs-mongo-swa-func\",\"https://github.com/azure-samples/todo-python-mongo-swa-func\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Function-App-with-Cosmos_AZD-template/azuredeploy.json"
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/catalogs/Example/environmentDefinitions/App-Service-with-Cosmos_AZD-template",
+                  "id": "/projects/Project-1/catalogs/example/environmentDefinitions/app-service-with-cosmos_azd-template",
+                  "name": "App-Service-with-Cosmos_AZD-template",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure App Service with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the App Service runtime,eg python, nodejs or java.",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs",
+                        "java"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-java-mongo",
+                        "https://github.com/azure-samples/todo-nodejs-mongo",
+                        "https://github.com/azure-samples/todo-python-mongo"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the App Service runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo\",\"https://github.com/azure-samples/todo-nodejs-mongo\",\"https://github.com/azure-samples/todo-python-mongo\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/App-Service-with-Cosmos_AZD-template/azuredeploy.json"
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/catalogs/Example/environmentDefinitions/Container-App-with-Cosmos_AZD-template",
+                  "id": "/projects/Project-1/catalogs/example/environmentDefinitions/container-app-with-cosmos_azd-template",
+                  "name": "Container-App-with-Cosmos_AZD-template",
+                  "catalogName": "Example",
+                  "description": "Deploys an Azure Container App with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the container App runtime,eg python, nodejs or java.",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs",
+                        "java"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-java-mongo-aca",
+                        "https://github.com/azure-samples/todo-nodejs-mongo-aca",
+                        "https://github.com/azure-samples/todo-python-mongo-aca"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the container App runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo-aca\",\"https://github.com/azure-samples/todo-nodejs-mongo-aca\",\"https://github.com/azure-samples/todo-python-mongo-aca\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Container-App-with-Cosmos_AZD-template/azuredeploy.json"
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/catalogs/wbreza/environmentDefinitions/Todo",
+                  "id": "/projects/Project-1/catalogs/wbreza/environmentDefinitions/todo",
+                  "name": "Todo",
+                  "catalogName": "wbreza",
+                  "description": "Deploys an Azure Container App within Container App environment",
+                  "parameters": [
+                    {
+                      "id": "environmentName",
+                      "name": "Environment Name",
+                      "description": "Name of the environment",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-nodejs-mongo-aca"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"environmentName\":{\"title\":\"Environment Name\",\"description\":\"Name of the environment\"},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-nodejs-mongo-aca\"]}}}",
+                  "templatePath": "EnvironmentDefinitions/Todo/main.bicep"
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/catalogs/test/environmentDefinitions/Container-App-with-Cosmos_AZD-template",
+                  "id": "/projects/Project-1/catalogs/test/environmentDefinitions/container-app-with-cosmos_azd-template",
+                  "name": "Container-App-with-Cosmos_AZD-template",
+                  "catalogName": "test",
+                  "description": "Deploys an Azure Container App with Cosmos, it is compatible with azd.",
+                  "parameters": [
+                    {
+                      "id": "runtimeType",
+                      "name": "Runtime Type",
+                      "description": "Runtime Type of the container App runtime,eg python, nodejs or java.",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": true,
+                      "allowed": [
+                        "python",
+                        "nodejs",
+                        "java"
+                      ]
+                    },
+                    {
+                      "id": "repoUrl",
+                      "name": "Repository URL",
+                      "description": "Path the the application source code",
+                      "type": "string",
+                      "readOnly": false,
+                      "required": false,
+                      "allowed": [
+                        "https://github.com/azure-samples/todo-java-mongo-aca",
+                        "https://github.com/azure-samples/todo-nodejs-mongo-aca",
+                        "https://github.com/azure-samples/todo-python-mongo-aca"
+                      ]
+                    }
+                  ],
+                  "parametersSchema": "{\"type\":\"object\",\"properties\":{\"runtimeType\":{\"title\":\"Runtime Type\",\"description\":\"Runtime Type of the container App runtime,eg python, nodejs or java.\",\"enum\":[\"python\",\"nodejs\",\"java\"]},\"repoUrl\":{\"title\":\"Repository URL\",\"description\":\"Path the the application source code\",\"enum\":[\"https://github.com/azure-samples/todo-java-mongo-aca\",\"https://github.com/azure-samples/todo-nodejs-mongo-aca\",\"https://github.com/azure-samples/todo-python-mongo-aca\"]}},\"required\":[\"runtimeType\"]}",
+                  "templatePath": "Environment-Definitions/ARMTemplates/Container-App-with-Cosmos_AZD-template/azuredeploy.json"
+                }
+              ]
+            }
         headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "1929"
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:19 GMT
-            Expires:
-                - "-1"
-            Pragma:
-                - no-cache
-            Set-Cookie:
-                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+                - Fri, 14 Jun 2024 21:32:31 GMT
             Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains
-            X-Cache:
-                - CONFIG_NOCACHE
-            X-Content-Type-Options:
-                - nosniff
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - 6bab10a1-24de-4700-94e9-31c0250cb6de
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-            X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
-            X-Ms-Request-Id:
-                - 63cde0e2-d1f3-45de-a5d8-e92c4ea8df59
-            X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001220Z:edff8ffa-fb3e-4e3d-9d36-c476ef9df632
-            X-Msedge-Ref:
-                - 'Ref A: C9D12BEF807049D68685A8F9E34D68FD Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:20Z'
+                - b5458087c80a1210e8f4e4bdf53b40fb
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "291"
+            X-Rate-Limit-Reset:
+                - "2024-06-14T21:32:41.0016042Z"
         status: 200 OK
         code: 200
-        duration: 179.6755ms
+        duration: 392.3835ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -2219,10 +2303,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourcegroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2241,7 +2325,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:19 GMT
+                - Fri, 14 Jun 2024 21:32:31 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2255,18 +2339,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - b5815ee0-367d-420a-9873-6caef556240d
+                - d5a6b9ab-0c3e-46e2-a1e5-b450ab4c61ea
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001220Z:66bf2d37-cb23-46d4-beae-b8e8f6d0e953
+                - WESTUS:20240614T213232Z:3ce28b77-d829-4aed-93f0-1416b9556b8f
             X-Msedge-Ref:
-                - 'Ref A: 02E14540C6904681A913066C695CDBBC Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:20Z'
+                - 'Ref A: 9CF73C55F3674B18BFE8134517D7832F Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
         status: 200 OK
         code: 200
-        duration: 167.3592ms
+        duration: 144.9001ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -2288,10 +2372,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourcegroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-1/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/f91f9734-8835-4fa4-8564-1dd169bc29dd/resourcegroups/project-8489/providers/Microsoft.DevCenter/projects/VisualStudioServicing/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2299,18 +2383,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 1929
+        content_length: 990
         uncompressed: false
-        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "1929"
+                - "990"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:19 GMT
+                - Fri, 14 Jun 2024 21:32:31 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2324,18 +2408,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 051595c9-a453-4d8f-b80e-fe87d4bba0e3
+                - e9cc17e6-20d7-49d5-b437-310ec3908253
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001220Z:19189aac-014a-4f2f-b39c-1e2bbe562089
+                - WESTUS:20240614T213232Z:4085ca52-b176-4067-8b61-31ff5b63f99a
             X-Msedge-Ref:
-                - 'Ref A: 4DCB26F5F2D0459F836CAD0720D224A8 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:20Z'
+                - 'Ref A: 7F2DE31FAF1740E1B4EBB17AB630F5DD Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
         status: 200 OK
         code: 200
-        duration: 189.7663ms
+        duration: 154.2145ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -2357,10 +2441,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourcegroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourcegroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2379,7 +2463,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:19 GMT
+                - Fri, 14 Jun 2024 21:32:31 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2393,18 +2477,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - e1534a2a-096e-44a9-bf46-b016b5cc298a
+                - b2a4ee51-c07f-4782-9f10-4cea0751a8cb
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001220Z:1f329e69-7ae6-4856-8485-893326ab5f75
+                - WESTUS:20240614T213232Z:363e0c67-8ae0-497b-8c74-8d6abc15785b
             X-Msedge-Ref:
-                - 'Ref A: E8A53CCD711E48F5A46CF2FC4CC11285 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:20Z'
+                - 'Ref A: 232A67CF3D4A464180C8713758E647B9 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
         status: 200 OK
         code: 200
-        duration: 125.8109ms
+        duration: 153.3388ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -2426,10 +2510,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourcegroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/basic/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2448,7 +2532,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:19 GMT
+                - Fri, 14 Jun 2024 21:32:31 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2462,18 +2546,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - a2d8395b-6a59-4d34-9b69-484599f447f7
+                - 4d161f51-3469-45ad-85a7-25977bd4e013
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001220Z:51e5df24-c800-4641-abc3-b229525215e8
+                - WESTUS:20240614T213232Z:b1a9a856-59e2-43f9-95d9-b61ce5de3d0c
             X-Msedge-Ref:
-                - 'Ref A: 09D44BFD4E694FAA97DA33142DDED683 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:20Z'
+                - 'Ref A: 578C2B2332794C0EB90509826CE8B69F Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
         status: 200 OK
         code: 200
-        duration: 173.8495ms
+        duration: 148.7175ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -2495,10 +2579,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-demo-test101/providers/Microsoft.DevCenter/projects/dcprj-pv44d74rp44bs/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2506,18 +2590,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 990
+        content_length: 82
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "990"
+                - "82"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:19 GMT
+                - Fri, 14 Jun 2024 21:32:32 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2531,18 +2615,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
+                - "11998"
             X-Ms-Request-Id:
-                - 87565f10-4252-4bd5-9108-e15bcd611527
+                - 937a2faa-aba0-4329-bf92-912fdfcbbcc2
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001220Z:f57bae7e-e146-40fa-95e9-8cf548371822
+                - WESTUS:20240614T213232Z:44eaa35b-dc37-46f2-8142-9514847fc95b
             X-Msedge-Ref:
-                - 'Ref A: 35B0A015814D4809A6A4DA7DD957DABE Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:20Z'
+                - 'Ref A: 84D869F899584055B40BDC92177EFDC8 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
         status: 200 OK
         code: 200
-        duration: 119.0054ms
+        duration: 204.2049ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -2564,10 +2648,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourcegroups/qiaozha-test/providers/Microsoft.DevCenter/projects/jsmgmt/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2575,18 +2659,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 990
+        content_length: 153
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "990"
+                - "153"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:19 GMT
+                - Fri, 14 Jun 2024 21:32:32 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2600,18 +2684,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - f8fb9617-26fd-4ff6-a1db-421f0326674b
+                - 6a48244c-7be5-4351-9f90-ea810c67a86e
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001220Z:30d78510-bbd2-49d6-8484-4aff8bd2d229
+                - WESTUS:20240614T213232Z:6e4c9bd3-0f54-4dd3-9c6d-d876fe5a52b9
             X-Msedge-Ref:
-                - 'Ref A: D7C82B9502F342F38A2CC827CAA215F7 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:20Z'
+                - 'Ref A: 27115AA631E7495D809565AE758F9151 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
         status: 200 OK
         code: 200
-        duration: 184.4602ms
+        duration: 218.1795ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -2633,10 +2717,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project2/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2644,18 +2728,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 990
+        content_length: 82
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "990"
+                - "82"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:19 GMT
+                - Fri, 14 Jun 2024 21:32:32 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2669,18 +2753,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - bfba1333-4130-45d0-a659-77f0cb37eaa3
+                - f0b35927-7dec-4375-9d03-e4ed3dc1ea83
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001220Z:9d13a48f-8d7c-459a-ba87-1e6df38668e0
+                - WESTUS:20240614T213232Z:2345b762-14b2-4e71-adcd-7bb69845e99b
             X-Msedge-Ref:
-                - 'Ref A: 66940FE968AF472892600DB7D538B26B Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:20Z'
+                - 'Ref A: E6EC7CE9646F4D66A4C56C1BC490B691 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
         status: 200 OK
         code: 200
-        duration: 164.4074ms
+        duration: 223.3733ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -2702,10 +2786,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/basic/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourcegroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2724,7 +2808,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:19 GMT
+                - Fri, 14 Jun 2024 21:32:32 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2738,18 +2822,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 0a30a2c0-1741-47f0-97dc-d902bc348894
+                - 2c7372ce-bda2-467e-bc3b-a17fdb6fbf23
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001220Z:617d19ed-accf-4998-acda-8b7473085eaf
+                - WESTUS:20240614T213232Z:243326d8-8a5b-4bf0-8cae-287c29eb822a
             X-Msedge-Ref:
-                - 'Ref A: D125DECF0A174473BE92B151D06939AD Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:20Z'
+                - 'Ref A: 7DA347A8D64F48B785B0C974B164CF73 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
         status: 200 OK
         code: 200
-        duration: 153.9679ms
+        duration: 218.191ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -2771,10 +2855,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://management.azure.com:443/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourcegroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourcegroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-2/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2782,18 +2866,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 990
+        content_length: 3705
         uncompressed: false
-        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]}]}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "990"
+                - "3705"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:19 GMT
+                - Fri, 14 Jun 2024 21:32:32 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2807,18 +2891,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - fdf208c7-b06c-43f4-814f-dee758261380
+                - 6e92ed1e-8c93-4fc6-abff-7b13c99652f2
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001220Z:c002ecf1-4d6f-403f-aa14-58b836de63e9
+                - WESTUS:20240614T213232Z:0d63e54d-934c-4c10-a4b3-1ab6130b2fba
             X-Msedge-Ref:
-                - 'Ref A: FEDE96146512442C8A904A3404D23940 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:20Z'
+                - 'Ref A: B0BBD19B64194F008311763824985C35 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
         status: 200 OK
         code: 200
-        duration: 158.3607ms
+        duration: 220.279ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -2840,9 +2924,9 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.22.1; Windows_NT),azd
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
         url: https://management.azure.com:443/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourcegroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
         method: GET
       response:
@@ -2862,7 +2946,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:19 GMT
+                - Fri, 14 Jun 2024 21:32:32 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -2876,19 +2960,709 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 4c276a9d-677a-4735-b75b-78ef828501fc
+                - ad0b8083-aa0e-40ea-b4cb-622f5c253adb
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001220Z:a5112038-2707-4c05-b041-6f9ec08c665f
+                - WESTUS:20240614T213232Z:15b69594-9da4-46ba-916b-c23f4e84a543
             X-Msedge-Ref:
-                - 'Ref A: 6A657477F870419EB0DB5AAEE1449209 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:20Z'
+                - 'Ref A: 32C71F5F3F2C406484C26A10D6AA98C4 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
         status: 200 OK
         code: 200
-        duration: 360.4819ms
+        duration: 216.6165ms
     - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/Inventory-Management-Project/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 82
+        uncompressed: false
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "82"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Jun 2024 21:32:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 0aecc44c-56e1-4e64-86f7-6a5fc3042d1e
+            X-Ms-Routing-Request-Id:
+                - WESTUS:20240614T213232Z:78fb1fe0-4371-4813-9dc2-66a13efbb24b
+            X-Msedge-Ref:
+                - 'Ref A: CDFD0F2ECB4845C7ACF686ADD7A32DA5 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
+        status: 200 OK
+        code: 200
+        duration: 225.3738ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourcegroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Jun 2024 21:32:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - f5824fe3-6ba8-4cae-850a-d725d17367b3
+            X-Ms-Routing-Request-Id:
+                - WESTUS:20240614T213232Z:c59e5408-3931-4694-a5f6-3f37b508a9b3
+            X-Msedge-Ref:
+                - 'Ref A: E89D7B025C084B179CF4612AAECFE263 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
+        status: 200 OK
+        code: 200
+        duration: 221.9613ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourcegroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Jun 2024 21:32:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 9cf41429-b73e-4d26-a512-99bdcc7df29d
+            X-Ms-Routing-Request-Id:
+                - WESTUS:20240614T213232Z:1192cac2-59b6-4851-892e-9fe8df0a328b
+            X-Msedge-Ref:
+                - 'Ref A: 11669895912440EFBF8593390F5D6512 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
+        status: 200 OK
+        code: 200
+        duration: 227.0461ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourcegroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Jun 2024 21:32:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - e12639fe-1fe7-4394-b117-e0c509700349
+            X-Ms-Routing-Request-Id:
+                - WESTUS:20240614T213232Z:aa54c845-af89-4e35-9368-ef204f0d2736
+            X-Msedge-Ref:
+                - 'Ref A: 52BC3AC82DC644D1B9F7690B0B9A67FB Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
+        status: 200 OK
+        code: 200
+        duration: 222.882ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourcegroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Jun 2024 21:32:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 02f1f4cd-e69f-4eab-88bf-3ecd1fe326ee
+            X-Ms-Routing-Request-Id:
+                - WESTUS:20240614T213232Z:7e387796-2e63-4ed8-ae85-7a4e07b6edc6
+            X-Msedge-Ref:
+                - 'Ref A: 3D639A45FA74470F9917BF84BC30B67D Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
+        status: 200 OK
+        code: 200
+        duration: 224.9195ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourcegroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Jun 2024 21:32:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - ddd9ad89-7b65-4a54-bb7b-e562ad1ed56c
+            X-Ms-Routing-Request-Id:
+                - WESTUS:20240614T213232Z:2b35c554-0aef-4759-adf1-7a3d5d27b1dc
+            X-Msedge-Ref:
+                - 'Ref A: 4280CB18EC894DCD931595161530DAEC Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
+        status: 200 OK
+        code: 200
+        duration: 236.0117ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourcegroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-1/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3705
+        uncompressed: false
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]},{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]},{"actions":["Microsoft.DevCenter/projects/*","Microsoft.Authorization/*/read","Microsoft.Resources/deployments/*","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":["Microsoft.DevCenter/projects/write","Microsoft.DevCenter/projects/delete"],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/adminStart/action","Microsoft.DevCenter/projects/users/devboxes/adminStop/action","Microsoft.DevCenter/projects/users/devboxes/adminRead/action","Microsoft.DevCenter/projects/users/devboxes/adminWrite/action","Microsoft.DevCenter/projects/users/devboxes/adminDelete/action","Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/environments/adminRead/action","Microsoft.DevCenter/projects/users/environments/userWrite/action","Microsoft.DevCenter/projects/users/environments/adminWrite/action","Microsoft.DevCenter/projects/users/environments/userDelete/action","Microsoft.DevCenter/projects/users/environments/adminDelete/action","Microsoft.DevCenter/projects/users/environments/adminAction/action","Microsoft.DevCenter/projects/users/environments/adminActionRead/action","Microsoft.DevCenter/projects/users/environments/adminActionManage/action","Microsoft.DevCenter/projects/users/environments/adminOutputsRead/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3705"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Jun 2024 21:32:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 27ac7550-1718-45de-beda-f2f22206b812
+            X-Ms-Routing-Request-Id:
+                - WESTUS:20240614T213232Z:3e675192-e650-4657-9001-702c89aa2efd
+            X-Msedge-Ref:
+                - 'Ref A: 9568387B695841C1A355A933AD591CE8 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
+        status: 200 OK
+        code: 200
+        duration: 252.7722ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project1/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 82
+        uncompressed: false
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "82"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Jun 2024 21:32:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - 7b70aa15-1081-4bb7-bd6a-7301d6e59e2e
+            X-Ms-Routing-Request-Id:
+                - WESTUS:20240614T213232Z:5dee9dcf-dea6-45b0-8d28-ae5fa8ebbf36
+            X-Msedge-Ref:
+                - 'Ref A: F40C1035F27E4F4FA1F943FBB6FFF8A7 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
+        status: 200 OK
+        code: 200
+        duration: 303.8074ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourcegroups/rg-contoso-ecomm-pe/providers/Microsoft.DevCenter/projects/contoso-ecomm/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 82
+        uncompressed: false
+        body: '{"value":[{"actions":["*"],"notActions":[],"dataActions":[],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "82"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Jun 2024 21:32:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - e3facfaa-0ac4-4e13-bc80-8c476609c17b
+            X-Ms-Routing-Request-Id:
+                - WESTUS:20240614T213232Z:ed41293b-55bf-4f96-81cc-b46736a3749c
+            X-Msedge-Ref:
+                - 'Ref A: 1EC1F988C8784ECD8AFFFD40A8E7E9D4 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
+        status: 200 OK
+        code: 200
+        duration: 320.8461ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armauthorization.PermissionsClient/v2.1.1 (go1.21.6; Windows_NT),azd
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://management.azure.com:443/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourcegroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode/providers/Microsoft.Authorization/permissions?api-version=2022-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 990
+        uncompressed: false
+        body: '{"value":[{"actions":["Microsoft.DevCenter/projects/read","Microsoft.DevCenter/projects/*/read","Microsoft.Authorization/*/read","Microsoft.Resources/subscriptions/resourceGroups/read"],"notActions":[],"dataActions":["Microsoft.DevCenter/projects/users/devboxes/userStop/action","Microsoft.DevCenter/projects/users/devboxes/userStart/action","Microsoft.DevCenter/projects/users/devboxes/userGetRemoteConnection/action","Microsoft.DevCenter/projects/users/devboxes/userRead/action","Microsoft.DevCenter/projects/users/devboxes/userWrite/action","Microsoft.DevCenter/projects/users/devboxes/userDelete/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userUpcomingActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userActionRead/action","Microsoft.DevCenter/projects/users/devboxes/userActionManage/action","Microsoft.DevCenter/projects/users/devboxes/userCustomize/action"],"notDataActions":[]}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "990"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Jun 2024 21:32:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Set-Cookie:
+                - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - b5458087c80a1210e8f4e4bdf53b40fb
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "11999"
+            X-Ms-Request-Id:
+                - ebc1a31a-7cdf-45a2-8ea3-b6b9ac0366eb
+            X-Ms-Routing-Request-Id:
+                - WESTUS:20240614T213233Z:de05dd77-59ea-4839-ab7b-9d565f4c2e39
+            X-Msedge-Ref:
+                - 'Ref A: D579806C02DA4240A9BDD1B73F4CD52A Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:32Z'
+        status: 200 OK
+        code: 200
+        duration: 389.601ms
+    - id: 43
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2907,10 +3681,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-devcenter/1.0.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/environments?api-version=2023-04-01
+                - b5458087c80a1210e8f4e4bdf53b40fb
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/environments?api-version=2024-02-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -2924,106 +3698,11 @@ interactions:
             {
               "value": [
                 {
-                  "name": "wabrez-hello-dev",
-                  "environmentType": "Dev",
-                  "user": "19a2053b-445a-4023-95d3-c339051e0f32",
-                  "provisioningState": "Succeeded",
-                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-wabrez-hello-dev",
-                  "catalogName": "wbreza",
-                  "environmentDefinitionName": "HelloWorld",
-                  "parameters": {
-                    "environmentName": "wabrez-hello-dev",
-                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
-                  }
-                },
-                {
-                  "name": "wabrez-hello-prod",
-                  "environmentType": "Prod",
-                  "user": "19a2053b-445a-4023-95d3-c339051e0f32",
-                  "provisioningState": "Succeeded",
-                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-wabrez-hello-prod",
-                  "catalogName": "wbreza",
-                  "environmentDefinitionName": "HelloWorld",
-                  "parameters": {
-                    "environmentName": "wabrez-hello-prod",
-                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
-                  }
-                },
-                {
-                  "name": "wabrez-hello-test",
-                  "environmentType": "Test",
-                  "user": "19a2053b-445a-4023-95d3-c339051e0f32",
-                  "provisioningState": "Succeeded",
-                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-wabrez-hello-test",
-                  "catalogName": "wbreza",
-                  "environmentDefinitionName": "HelloWorld",
-                  "parameters": {
-                    "environmentName": "wabrez-hello-test",
-                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
-                  }
-                },
-                {
-                  "name": "wabrez-hello-dev2",
-                  "environmentType": "Dev",
-                  "user": "19a2053b-445a-4023-95d3-c339051e0f32",
-                  "provisioningState": "Succeeded",
-                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-wabrez-hello-dev2",
-                  "catalogName": "wbreza",
-                  "environmentDefinitionName": "HelloWorld",
-                  "parameters": {
-                    "environmentName": "wabrez-hello-dev2",
-                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
-                  }
-                },
-                {
-                  "name": "wabrez-hello-test2",
-                  "environmentType": "Test",
-                  "user": "19a2053b-445a-4023-95d3-c339051e0f32",
-                  "provisioningState": "Succeeded",
-                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-wabrez-hello-test2",
-                  "catalogName": "wbreza",
-                  "environmentDefinitionName": "HelloWorld",
-                  "parameters": {
-                    "environmentName": "wabrez-hello-test2",
-                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
-                  }
-                },
-                {
-                  "name": "azdtest-m59751b",
-                  "environmentType": "Dev",
-                  "user": "30511c9d-ba1a-4c7b-b422-5b543da11b3f",
-                  "provisioningState": "Failed",
-                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-m59751b",
-                  "catalogName": "wbreza",
-                  "environmentDefinitionName": "HelloWorld",
-                  "error": {
-                    "code": "DeploymentFailed",
-                    "message": "{/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-m59751b/providers/Microsoft.Web/serverfarms/plan-5dobjz64v64wa: {Error Code: Conflict, Error Message: No available instances to satisfy this request. App Service is attempting to increase capacity. Please retry your request later. If urgent, this can be mitigated by deploying this to a new resource group., Error Details: [{Error Code: , Error Message: No available instances to satisfy this request. App Service is attempting to increase capacity. Please retry your request later. If urgent, this can be mitigated by deploying this to a new resource group., Error Details: []},{Error Code: Conflict, Error Message: , Error Details: []},{Error Code: , Error Message: , Error Details: []}]}}",
-                    "details": []
-                  },
-                  "parameters": {
-                    "environmentName": "azdtest-m59751b",
-                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
-                  }
-                },
-                {
-                  "name": "azdtest-mdfdc7d",
-                  "environmentType": "Dev",
-                  "user": "30511c9d-ba1a-4c7b-b422-5b543da11b3f",
-                  "provisioningState": "Succeeded",
-                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-mdfdc7d",
-                  "catalogName": "wbreza",
-                  "environmentDefinitionName": "HelloWorld",
-                  "parameters": {
-                    "environmentName": "azdtest-mdfdc7d",
-                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
-                  }
-                },
-                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/users/547aa7c1-2f57-48d9-8969-ecf696948ca7/environments/azdtest-wcdb814",
                   "name": "azdtest-wcdb814",
                   "environmentType": "Dev",
                   "user": "547aa7c1-2f57-48d9-8969-ecf696948ca7",
-                  "provisioningState": "Succeeded",
+                  "provisioningState": "Deleting",
                   "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wcdb814",
                   "catalogName": "wbreza",
                   "environmentDefinitionName": "HelloWorld",
@@ -3033,15 +3712,142 @@ interactions:
                   }
                 },
                 {
-                  "name": "azdtest-w6a168c",
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/users/19a2053b-445a-4023-95d3-c339051e0f32/environments/wabrez-hello-01",
+                  "name": "wabrez-hello-01",
                   "environmentType": "Dev",
-                  "user": "547aa7c1-2f57-48d9-8969-ecf696948ca7",
-                  "provisioningState": "Succeeded",
-                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-w6a168c",
+                  "user": "19a2053b-445a-4023-95d3-c339051e0f32",
+                  "provisioningState": "Deleting",
+                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-wabrez-hello-01",
                   "catalogName": "wbreza",
                   "environmentDefinitionName": "HelloWorld",
                   "parameters": {
-                    "environmentName": "azdtest-w6a168c",
+                    "environmentName": "wabrez-hello-01",
+                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
+                  }
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/users/19a2053b-445a-4023-95d3-c339051e0f32/environments/wabrez-todo-bicep",
+                  "name": "wabrez-todo-bicep",
+                  "environmentType": "Dev",
+                  "user": "19a2053b-445a-4023-95d3-c339051e0f32",
+                  "provisioningState": "Deleting",
+                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-wabrez-todo-bicep",
+                  "catalogName": "wbreza",
+                  "environmentDefinitionName": "Todo",
+                  "parameters": {
+                    "environmentName": "wabrez-todo-bicep",
+                    "repoUrl": "https://github.com/azure-samples/todo-nodejs-mongo-aca"
+                  }
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/users/19a2053b-445a-4023-95d3-c339051e0f32/environments/wabreza-hello-bicep02",
+                  "name": "wabreza-hello-bicep02",
+                  "environmentType": "Dev",
+                  "user": "19a2053b-445a-4023-95d3-c339051e0f32",
+                  "provisioningState": "Deleting",
+                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-wabreza-hello-bicep02",
+                  "catalogName": "wbreza",
+                  "environmentDefinitionName": "HelloWorld-Bicep",
+                  "parameters": {
+                    "environmentName": "wabreza-hello-bicep02",
+                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
+                  }
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/users/30511c9d-ba1a-4c7b-b422-5b543da11b3f/environments/azdtest-mdb0451",
+                  "name": "azdtest-mdb0451",
+                  "environmentType": "Dev",
+                  "user": "30511c9d-ba1a-4c7b-b422-5b543da11b3f",
+                  "provisioningState": "Deleting",
+                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-mdb0451",
+                  "catalogName": "wbreza",
+                  "environmentDefinitionName": "HelloWorld",
+                  "parameters": {
+                    "environmentName": "azdtest-mdb0451",
+                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
+                  }
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/users/30511c9d-ba1a-4c7b-b422-5b543da11b3f/environments/azdtest-lcf5cdc",
+                  "name": "azdtest-lcf5cdc",
+                  "environmentType": "Dev",
+                  "user": "30511c9d-ba1a-4c7b-b422-5b543da11b3f",
+                  "provisioningState": "Deleting",
+                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-lcf5cdc",
+                  "catalogName": "wbreza",
+                  "environmentDefinitionName": "HelloWorld",
+                  "parameters": {
+                    "environmentName": "azdtest-lcf5cdc",
+                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
+                  }
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/users/30511c9d-ba1a-4c7b-b422-5b543da11b3f/environments/azdtest-m8314ee",
+                  "name": "azdtest-m8314ee",
+                  "environmentType": "Dev",
+                  "user": "30511c9d-ba1a-4c7b-b422-5b543da11b3f",
+                  "provisioningState": "Deleting",
+                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-m8314ee",
+                  "catalogName": "wbreza",
+                  "environmentDefinitionName": "HelloWorld",
+                  "parameters": {
+                    "environmentName": "azdtest-m8314ee",
+                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
+                  }
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/users/30511c9d-ba1a-4c7b-b422-5b543da11b3f/environments/azdtest-me73c60",
+                  "name": "azdtest-me73c60",
+                  "environmentType": "Dev",
+                  "user": "30511c9d-ba1a-4c7b-b422-5b543da11b3f",
+                  "provisioningState": "Deleting",
+                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-me73c60",
+                  "catalogName": "wbreza",
+                  "environmentDefinitionName": "HelloWorld",
+                  "parameters": {
+                    "environmentName": "azdtest-me73c60",
+                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
+                  }
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/users/19a2053b-445a-4023-95d3-c339051e0f32/environments/azdtest-w15efe0",
+                  "name": "azdtest-w15efe0",
+                  "environmentType": "Dev",
+                  "user": "19a2053b-445a-4023-95d3-c339051e0f32",
+                  "provisioningState": "Deleting",
+                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-w15efe0",
+                  "catalogName": "wbreza",
+                  "environmentDefinitionName": "HelloWorld",
+                  "parameters": {
+                    "environmentName": "azdtest-w15efe0",
+                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
+                  }
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/users/19a2053b-445a-4023-95d3-c339051e0f32/environments/azdtest-w49b668",
+                  "name": "azdtest-w49b668",
+                  "environmentType": "Dev",
+                  "user": "19a2053b-445a-4023-95d3-c339051e0f32",
+                  "provisioningState": "Deleting",
+                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-w49b668",
+                  "catalogName": "wbreza",
+                  "environmentDefinitionName": "HelloWorld",
+                  "parameters": {
+                    "environmentName": "azdtest-w49b668",
+                    "repoUrl": "https://github.com/wbreza/azd-hello-world"
+                  }
+                },
+                {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/users/19a2053b-445a-4023-95d3-c339051e0f32/environments/azdtest-w1a8a87",
+                  "name": "azdtest-w1a8a87",
+                  "environmentType": "Dev",
+                  "user": "19a2053b-445a-4023-95d3-c339051e0f32",
+                  "provisioningState": "Deleting",
+                  "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-w1a8a87",
+                  "catalogName": "wbreza",
+                  "environmentDefinitionName": "HelloWorld",
+                  "parameters": {
+                    "environmentName": "azdtest-w1a8a87",
                     "repoUrl": "https://github.com/wbreza/azd-hello-world"
                   }
                 }
@@ -3057,23 +3863,23 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:21 GMT
+                - Fri, 14 Jun 2024 21:32:33 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 2aa9c067-04b6-4fcb-bc57-b9b822dc9667
+                - dd3e9109-e73d-4f38-9daf-5e44dc8bab44
             X-Ms-Correlation-Request-Id:
-                - 246f2ebe738b1855fc53f5fe00f94ea1
+                - b5458087c80a1210e8f4e4bdf53b40fb
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
-                - "299"
+                - "291"
             X-Rate-Limit-Reset:
-                - "2024-06-11T00:13:20.5895831Z"
+                - "2024-06-14T21:32:43.1509356Z"
         status: 200 OK
         code: 200
-        duration: 712.9594ms
-    - id: 34
+        duration: 529.8587ms
+    - id: 44
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3098,9 +3904,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - azsdk-go-armresourcegraph.Client/v0.7.1 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-armresourcegraph.Client/v0.7.1 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
+                - 1722edc87f18d41245d84ec3fb288193
         url: https://management.azure.com:443/providers/Microsoft.ResourceGraph/resources?api-version=2021-06-01-preview
         method: POST
       response:
@@ -3109,18 +3915,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 9182
+        content_length: 12296
         uncompressed: false
-        body: '{"totalRecords":15,"count":15,"data":[{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioClient","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSVendors","properties":{"provisioningState":"Succeeded","description":"Project for vendors","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/basic","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"basic","properties":{"provisioningState":"Succeeded","description":"project with basic image","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"MicroBuild","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourceGroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DevDivAzureService","properties":{"provisioningState":"Succeeded","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourceGroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"LanguageAndFrameworkServices","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourceGroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSCode","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourceGroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ServerlessPaaS","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourceGroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"PMUXDesign","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourceGroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"NuGet","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/qiaozha-test/providers/Microsoft.DevCenter/projects/jsmgmt","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"jsmgmt","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-jsmgmtsdktest.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/qiaozha-test/providers/Microsoft.DevCenter/devcenters/jsmgmtsdktest"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-1","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/devcenters/dc-azd-o2pst6gaydv5o"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-2","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/devcenters/dc-azd-o2pst6gaydv5o"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourceGroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DataAndAI","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/f91f9734-8835-4fa4-8564-1dd169bc29dd/resourceGroups/project-8489/providers/Microsoft.DevCenter/projects/VisualStudioServicing","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioServicing","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"}],"facets":[],"resultTruncated":"false"}'
+        body: '{"totalRecords":20,"count":20,"data":[{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioClient","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSVendors","properties":{"provisioningState":"Succeeded","description":"Project for vendors","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/basic","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"basic","properties":{"provisioningState":"Succeeded","description":"project with basic image","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"MicroBuild","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourceGroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DevDivAzureService","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourceGroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"LanguageAndFrameworkServices","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourceGroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSCode","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourceGroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ServerlessPaaS","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourceGroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"PMUXDesign","properties":{"provisioningState":"Succeeded","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourceGroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"NuGet","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/qiaozha-test/providers/Microsoft.DevCenter/projects/jsmgmt","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"jsmgmt","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-jsmgmtsdktest.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/qiaozha-test/providers/Microsoft.DevCenter/devcenters/jsmgmtsdktest"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-1","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/devcenters/dc-azd-o2pst6gaydv5o"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-2","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/devcenters/dc-azd-o2pst6gaydv5o"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-contoso-ecomm-pe/providers/Microsoft.DevCenter/projects/contoso-ecomm","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"contoso-ecomm","properties":{"provisioningState":"Succeeded","description":"Ecommerce team","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-pv44d74rp44bs.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/devcenters/dc-pv44d74rp44bs","maxDevBoxesPerUser":2},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/projects/dcprj-pv44d74rp44bs","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"dcprj-pv44d74rp44bs","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-pv44d74rp44bs.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/devcenters/dc-pv44d74rp44bs"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project1","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ade-project1","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-ade-fidalgo-dev2.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/ade-fidalgo-dev2"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project2","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ade-project2","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-ade-fidalgo-dev2.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/ade-fidalgo-dev2"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/Inventory-Management-Project","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Inventory-Management-Project","properties":{"provisioningState":"Succeeded","description":"Inventory Management project","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-logistics-system-devcenter.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/Logistics-System-DevCenter"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourceGroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DataAndAI","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/f91f9734-8835-4fa4-8564-1dd169bc29dd/resourceGroups/project-8489/providers/Microsoft.DevCenter/projects/VisualStudioServicing","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioServicing","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"}],"facets":[],"resultTruncated":"false"}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "9182"
+                - "12296"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:22 GMT
+                - Fri, 14 Jun 2024 21:32:33 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3132,27 +3938,27 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - fd3de1de-57fd-7a67-210f-b26cd6ff7ac5
+                - 1722edc8-7f18-d412-45d8-4ec3fb288193
             X-Ms-Ratelimit-Remaining-Tenant-Reads:
                 - "11999"
             X-Ms-Ratelimit-Remaining-Tenant-Resource-Requests:
-                - "14"
+                - "13"
             X-Ms-Request-Id:
-                - f7f3b0f1-e316-4375-afdb-9e1dde1d75ef
+                - 54014782-cb22-4213-ab8d-5a36a38e255c
             X-Ms-Resource-Graph-Request-Duration:
-                - "0:00:00:00.4598272"
+                - "0:00:00:00.8599666"
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001223Z:f7f3b0f1-e316-4375-afdb-9e1dde1d75ef
+                - WESTUS2:20240614T213234Z:54014782-cb22-4213-ab8d-5a36a38e255c
             X-Ms-User-Quota-Remaining:
-                - "14"
+                - "13"
             X-Ms-User-Quota-Resets-After:
-                - "00:00:04"
+                - "00:00:05"
             X-Msedge-Ref:
-                - 'Ref A: 95ECE5143AC94E91A8AFD13A16137C65 Ref B: CO6AA3150218027 Ref C: 2024-06-11T00:12:22Z'
+                - 'Ref A: 7BB17BA476684DF0893EA2004038C3D2 Ref B: CO6AA3150220045 Ref C: 2024-06-14T21:32:33Z'
         status: 200 OK
         code: 200
-        duration: 501.911ms
-    - id: 35
+        duration: 901.2989ms
+    - id: 45
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3171,10 +3977,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-devcenter/1.0.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/environmentTypes?api-version=2023-04-01
+                - 1722edc87f18d41245d84ec3fb288193
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/environmentTypes?api-version=2024-02-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3188,19 +3994,25 @@ interactions:
             {
               "value": [
                 {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/environmenttypes/Dev",
                   "name": "Dev",
                   "deploymentTargetId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b",
-                  "status": "Enabled"
+                  "status": "Enabled",
+                  "displayName": "Dev"
                 },
                 {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/environmenttypes/Prod",
                   "name": "Prod",
                   "deploymentTargetId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b",
-                  "status": "Enabled"
+                  "status": "Enabled",
+                  "displayName": "Prod"
                 },
                 {
+                  "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/environmenttypes/Test",
                   "name": "Test",
                   "deploymentTargetId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b",
-                  "status": "Enabled"
+                  "status": "Enabled",
+                  "displayName": "Test"
                 }
               ]
             }
@@ -3214,23 +4026,23 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:23 GMT
+                - Fri, 14 Jun 2024 21:32:34 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 270a175e-17ac-4dcc-8052-549d15ed8119
+                - 7703f4df-deac-48de-b454-f33072628f41
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
+                - 1722edc87f18d41245d84ec3fb288193
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
-                - "298"
+                - "296"
             X-Rate-Limit-Reset:
-                - "2024-06-11T00:13:14.7936557Z"
+                - "2024-06-14T21:33:11.4514994Z"
         status: 200 OK
         code: 200
-        duration: 111.4904ms
-    - id: 36
+        duration: 119.1755ms
+    - id: 46
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3249,10 +4061,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-devcenter/1.0.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/catalogs/wbreza/environmentDefinitions/HelloWorld?api-version=2023-04-01
+                - 1722edc87f18d41245d84ec3fb288193
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/catalogs/wbreza/environmentDefinitions/HelloWorld?api-version=2024-02-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3264,6 +4076,7 @@ interactions:
         uncompressed: true
         body: |-
             {
+              "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/Project-1/catalogs/wbreza/environmentDefinitions/HelloWorld",
               "id": "/projects/Project-1/catalogs/wbreza/environmentDefinitions/helloworld",
               "name": "HelloWorld",
               "catalogName": "wbreza",
@@ -3302,23 +4115,23 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:31 GMT
+                - Fri, 14 Jun 2024 21:32:36 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 6e01c8c6-54ea-4c41-87d4-91a3d4fbd413
+                - 2f1d802b-6aaa-4881-92bc-1898aa8e3915
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
+                - 1722edc87f18d41245d84ec3fb288193
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
-                - "298"
+                - "290"
             X-Rate-Limit-Reset:
-                - "2024-06-11T00:13:14.8270684Z"
+                - "2024-06-14T21:32:41.0016042Z"
         status: 200 OK
         code: 200
-        duration: 254.4809ms
-    - id: 37
+        duration: 178.3264ms
+    - id: 47
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3337,10 +4150,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-devcenter/1.0.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-wa68d26?api-version=2023-04-01
+                - 1722edc87f18d41245d84ec3fb288193
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-wb1885c?api-version=2024-02-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3355,7 +4168,7 @@ interactions:
               "status": "Failed",
               "error": {
                 "code": "EnvironmentNotFound",
-                "message": "The environment azdtest-wa68d26 cannot be found.",
+                "message": "The environment azdtest-wb1885c cannot be found.",
                 "details": [],
                 "additionalInfo": []
               }
@@ -3372,23 +4185,23 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:31 GMT
+                - Fri, 14 Jun 2024 21:32:37 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 4723f4e9-33e8-433b-bf82-fc3bc7764b38
+                - eb5d906b-1cc4-4a2d-a150-525efcf51473
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
+                - 1722edc87f18d41245d84ec3fb288193
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
-                - "298"
+                - "290"
             X-Rate-Limit-Reset:
-                - "2024-06-11T00:13:20.5895831Z"
+                - "2024-06-14T21:32:43.1509356Z"
         status: 404 Not Found
         code: 404
-        duration: 105.8512ms
-    - id: 38
+        duration: 119.6391ms
+    - id: 48
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3400,7 +4213,7 @@ interactions:
         host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com
         remote_addr: ""
         request_uri: ""
-        body: '{"catalogName":"wbreza","environmentDefinitionName":"HelloWorld","environmentType":"Dev","parameters":{"environmentName":"azdtest-wa68d26","repoUrl":"https://github.com/wbreza/azd-hello-world"}}'
+        body: '{"catalogName":"wbreza","environmentDefinitionName":"HelloWorld","environmentType":"Dev","parameters":{"environmentName":"azdtest-wb1885c","repoUrl":"https://github.com/wbreza/azd-hello-world"}}'
         form: {}
         headers:
             Accept-Encoding:
@@ -3410,10 +4223,10 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - azsdk-go-devcenter/1.0.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-wa68d26?api-version=2023-04-01
+                - 1722edc87f18d41245d84ec3fb288193
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-wb1885c?api-version=2024-02-01
         method: PUT
       response:
         proto: HTTP/2.0
@@ -3421,18 +4234,19 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 340
+        content_length: 537
         uncompressed: false
         body: |-
             {
-              "name": "azdtest-wa68d26",
+              "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/users/19a2053b-445a-4023-95d3-c339051e0f32/environments/azdtest-wb1885c",
+              "name": "azdtest-wb1885c",
               "environmentType": "Dev",
-              "user": "547aa7c1-2f57-48d9-8969-ecf696948ca7",
+              "user": "19a2053b-445a-4023-95d3-c339051e0f32",
               "provisioningState": "Creating",
               "catalogName": "wbreza",
               "environmentDefinitionName": "HelloWorld",
               "parameters": {
-                "environmentName": "azdtest-wa68d26",
+                "environmentName": "azdtest-wb1885c",
                 "repoUrl": "https://github.com/wbreza/azd-hello-world"
               }
             }
@@ -3444,31 +4258,31 @@ interactions:
             Access-Control-Max-Age:
                 - "86400"
             Content-Length:
-                - "340"
+                - "537"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:12:32 GMT
+                - Fri, 14 Jun 2024 21:32:37 GMT
             Location:
-                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/80cfe5b7-7d7c-4f67-8f09-c226bf21ba41?api-version=2023-04-01&monitor=true
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/13096926-323d-4e7f-8bb4-7da5a9560247?api-version=2024-02-01&monitor=true
             Operation-Location:
-                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/80cfe5b7-7d7c-4f67-8f09-c226bf21ba41?api-version=2023-04-01
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/13096926-323d-4e7f-8bb4-7da5a9560247?api-version=2024-02-01
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 5289eb33-8dd9-4d17-950a-0bb9ffaa2f43
+                - 61a2f64c-471f-4121-868d-d33c5ce3ce84
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
+                - 1722edc87f18d41245d84ec3fb288193
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
-                - "297"
+                - "295"
             X-Rate-Limit-Reset:
-                - "2024-06-11T00:13:14.7936557Z"
+                - "2024-06-14T21:33:11.4514994Z"
         status: 201 Created
         code: 201
-        duration: 540.5673ms
-    - id: 39
+        duration: 448.4844ms
+    - id: 49
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3487,10 +4301,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-devcenter/1.0.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/project-1/operationstatuses/80cfe5b7-7d7c-4f67-8f09-c226bf21ba41?api-version=2023-04-01
+                - 1722edc87f18d41245d84ec3fb288193
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/project-1/operationstatuses/13096926-323d-4e7f-8bb4-7da5a9560247?api-version=2024-02-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3502,11 +4316,11 @@ interactions:
         uncompressed: true
         body: |-
             {
-              "id": "/projects/project-1/operationStatuses/80cfe5b7-7d7c-4f67-8f09-c226bf21ba41",
-              "name": "80cfe5b7-7d7c-4f67-8f09-c226bf21ba41",
+              "id": "/projects/project-1/operationStatuses/13096926-323d-4e7f-8bb4-7da5a9560247",
+              "name": "13096926-323d-4e7f-8bb4-7da5a9560247",
               "status": "Succeeded",
-              "startTime": "2024-06-11T00:12:32.0065039+00:00",
-              "endTime": "2024-06-11T00:15:43.7783386+00:00"
+              "startTime": "2024-06-14T21:32:37.4313603+00:00",
+              "endTime": "2024-06-14T21:36:40.8111842+00:00"
             }
         headers:
             Access-Control-Allow-Origin:
@@ -3518,29 +4332,29 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:16:03 GMT
+                - Fri, 14 Jun 2024 21:37:09 GMT
             Location:
-                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/80cfe5b7-7d7c-4f67-8f09-c226bf21ba41?api-version=2023-04-01&monitor=true
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/13096926-323d-4e7f-8bb4-7da5a9560247?api-version=2024-02-01&monitor=true
             Operation-Location:
-                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/80cfe5b7-7d7c-4f67-8f09-c226bf21ba41?api-version=2023-04-01
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/13096926-323d-4e7f-8bb4-7da5a9560247?api-version=2024-02-01
             Retry-After:
                 - "30"
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 9caf7658-9475-4e91-bea9-82bb865f8224
+                - 6623787a-c20a-4f5f-9bcc-800dcb41f9b4
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
+                - 1722edc87f18d41245d84ec3fb288193
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
-                - "299"
+                - "296"
             X-Rate-Limit-Reset:
-                - "2024-06-11T00:17:03.8455617Z"
+                - "2024-06-14T21:37:25.2104763Z"
         status: 200 OK
         code: 200
-        duration: 115.9907ms
-    - id: 40
+        duration: 155.9321ms
+    - id: 50
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3559,10 +4373,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-devcenter/1.0.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-wa68d26?api-version=2023-04-01
+                - 1722edc87f18d41245d84ec3fb288193
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-wb1885c?api-version=2024-02-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3574,15 +4388,16 @@ interactions:
         uncompressed: true
         body: |-
             {
-              "name": "azdtest-wa68d26",
+              "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/users/19a2053b-445a-4023-95d3-c339051e0f32/environments/azdtest-wb1885c",
+              "name": "azdtest-wb1885c",
               "environmentType": "Dev",
-              "user": "547aa7c1-2f57-48d9-8969-ecf696948ca7",
+              "user": "19a2053b-445a-4023-95d3-c339051e0f32",
               "provisioningState": "Succeeded",
-              "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26",
+              "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c",
               "catalogName": "wbreza",
               "environmentDefinitionName": "HelloWorld",
               "parameters": {
-                "environmentName": "azdtest-wa68d26",
+                "environmentName": "azdtest-wb1885c",
                 "repoUrl": "https://github.com/wbreza/azd-hello-world"
               }
             }
@@ -3596,23 +4411,23 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:16:04 GMT
+                - Fri, 14 Jun 2024 21:37:09 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - cacad0c1-df45-48c0-8e0b-5e49af621ace
+                - 4fa72042-d631-48f1-97dc-f0d0f1a3bf1f
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
+                - 1722edc87f18d41245d84ec3fb288193
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
-                - "299"
+                - "297"
             X-Rate-Limit-Reset:
-                - "2024-06-11T00:17:04.3997273Z"
+                - "2024-06-14T21:37:25.1251501Z"
         status: 200 OK
         code: 200
-        duration: 520.2917ms
-    - id: 41
+        duration: 275.1256ms
+    - id: 51
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3631,10 +4446,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-devcenter/1.0.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-wa68d26?api-version=2023-04-01
+                - 1722edc87f18d41245d84ec3fb288193
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-wb1885c?api-version=2024-02-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3646,15 +4461,16 @@ interactions:
         uncompressed: true
         body: |-
             {
-              "name": "azdtest-wa68d26",
+              "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/users/19a2053b-445a-4023-95d3-c339051e0f32/environments/azdtest-wb1885c",
+              "name": "azdtest-wb1885c",
               "environmentType": "Dev",
-              "user": "547aa7c1-2f57-48d9-8969-ecf696948ca7",
+              "user": "19a2053b-445a-4023-95d3-c339051e0f32",
               "provisioningState": "Succeeded",
-              "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26",
+              "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c",
               "catalogName": "wbreza",
               "environmentDefinitionName": "HelloWorld",
               "parameters": {
-                "environmentName": "azdtest-wa68d26",
+                "environmentName": "azdtest-wb1885c",
                 "repoUrl": "https://github.com/wbreza/azd-hello-world"
               }
             }
@@ -3668,23 +4484,103 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:16:04 GMT
+                - Fri, 14 Jun 2024 21:37:09 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 3950fe07-6c3c-421b-b0f5-b71be014515d
+                - 843cff93-1eba-419b-9f2a-b6f3c7c9d495
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
+                - 1722edc87f18d41245d84ec3fb288193
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
-                - "298"
+                - "294"
             X-Rate-Limit-Reset:
-                - "2024-06-11T00:16:33.7003010Z"
+                - "2024-06-14T21:37:25.1486350Z"
         status: 200 OK
         code: 200
-        duration: 396.1108ms
-    - id: 42
+        duration: 619.0429ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
+            X-Ms-Correlation-Request-Id:
+                - 1722edc87f18d41245d84ec3fb288193
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/users/19a2053b-445a-4023-95d3-c339051e0f32/environments/azdtest-wb1885c/outputs?api-version=2024-02-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |-
+            {
+              "outputs": {
+                "azurE_LOCATION": {
+                  "type": "String",
+                  "value": "eastus2",
+                  "sensitive": false
+                },
+                "azurE_TENANT_ID": {
+                  "type": "String",
+                  "value": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                  "sensitive": false
+                },
+                "servicE_API_ENDPOINTS": {
+                  "type": "Array",
+                  "value": [
+                    []
+                  ],
+                  "sensitive": false
+                }
+              }
+            }
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Jun 2024 21:37:10 GMT
+            Strict-Transport-Security:
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - 5911cc6f-0ce8-4cff-a718-8c7cb75be03b
+            X-Ms-Correlation-Request-Id:
+                - 1722edc87f18d41245d84ec3fb288193
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "295"
+            X-Rate-Limit-Reset:
+                - "2024-06-14T21:37:25.2104763Z"
+        status: 200 OK
+        code: 200
+        duration: 349.962ms
+    - id: 53
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3705,77 +4601,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-armresources.Client/v1.1.1 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
-        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourcegroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/?api-version=2021-04-01
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 13691
-        uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/app-helloworld-jo3wbujju2yeq-appSettings","name":"app-helloworld-jo3wbujju2yeq-appSettings","type":"Microsoft.Resources/deployments","properties":{"templateHash":"1502109241172037927","parameters":{"name":{"type":"String","value":"app-helloworld-jo3wbujju2yeq"},"appSettings":{"type":"Object","value":{"SCM_DO_BUILD_DURING_DEPLOYMENT":"True","ENABLE_ORYX_BUILD":"True"}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-06-11T00:14:39.1163918Z","duration":"PT11.5951217S","correlationId":"fd3de1de57fd7a67210fb26cd6ff7ac5","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"sites/config","locations":[null]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/config/appsettings"}]}},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/app-helloworld-jo3wbujju2yeq-app-module","name":"app-helloworld-jo3wbujju2yeq-app-module","type":"Microsoft.Resources/deployments","properties":{"templateHash":"3548910797978781823","parameters":{"name":{"type":"String","value":"app-helloworld-jo3wbujju2yeq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-wa68d26","azd-service-name":"helloworld"}},"applicationInsightsName":{"type":"String","value":""},"appServicePlanId":{"type":"String","value":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/serverfarms/plan-jo3wbujju2yeq"},"keyVaultName":{"type":"String","value":""},"managedIdentity":{"type":"Bool","value":false},"runtimeName":{"type":"String","value":"node"},"runtimeNameAndVersion":{"type":"String","value":"node|18-lts"},"runtimeVersion":{"type":"String","value":"18-lts"},"kind":{"type":"String","value":"app,linux"},"allowedOrigins":{"type":"Array","value":[]},"alwaysOn":{"type":"Bool","value":true},"appCommandLine":{"type":"String","value":""},"clientAffinityEnabled":{"type":"Bool","value":false},"enableOryxBuild":{"type":"Bool","value":true},"functionAppScaleLimit":{"type":"Int","value":-1},"linuxFxVersion":{"type":"String","value":"node|18-lts"},"minimumElasticInstanceCount":{"type":"Int","value":-1},"numberOfWorkers":{"type":"Int","value":-1},"scmDoBuildDuringDeployment":{"type":"Bool","value":true},"use32BitWorkerProcess":{"type":"Bool","value":false},"ftpsState":{"type":"String","value":"FtpsOnly"},"healthCheckPath":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-06-11T00:14:43.0316156Z","duration":"PT38.9919542S","correlationId":"fd3de1de57fd7a67210fb26cd6ff7ac5","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"sites/config","locations":[null]},{"resourceType":"sites/basicPublishingCredentialsPolicies","locations":[null]},{"resourceType":"sites","locations":["eastus2"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-jo3wbujju2yeq"}],"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/config/logs","resourceType":"Microsoft.Web/sites/config","resourceName":"app-helloworld-jo3wbujju2yeq/logs"},{"dependsOn":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-jo3wbujju2yeq"}],"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/basicPublishingCredentialsPolicies/ftp","resourceType":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","resourceName":"app-helloworld-jo3wbujju2yeq/ftp"},{"dependsOn":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-jo3wbujju2yeq"}],"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/basicPublishingCredentialsPolicies/scm","resourceType":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","resourceName":"app-helloworld-jo3wbujju2yeq/scm"},{"dependsOn":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-jo3wbujju2yeq"}],"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/app-helloworld-jo3wbujju2yeq-appSettings","resourceType":"Microsoft.Resources/deployments","resourceName":"app-helloworld-jo3wbujju2yeq-appSettings"}],"outputs":{"identityPrincipalId":{"type":"String","value":""},"name":{"type":"String","value":"app-helloworld-jo3wbujju2yeq"},"uri":{"type":"String","value":"https://app-helloworld-jo3wbujju2yeq.azurewebsites.net"}},"outputResources":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/config/appsettings"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/config/logs"}]}},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/helloworld","name":"helloworld","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12313645452229774503","parameters":{"name":{"type":"String","value":"app-helloworld-jo3wbujju2yeq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-wa68d26"}},"appCommandLine":{"type":"String","value":""},"appServicePlanId":{"type":"String","value":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/serverfarms/plan-jo3wbujju2yeq"},"serviceName":{"type":"String","value":"helloworld"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-06-11T00:14:50.4425347Z","duration":"PT47.6590017S","correlationId":"fd3de1de57fd7a67210fb26cd6ff7ac5","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"servicE_HELLOWORLD_IDENTITY_PRINCIPAL_ID":{"type":"String","value":""},"servicE_HELLOWORLD_NAME":{"type":"String","value":"app-helloworld-jo3wbujju2yeq"},"servicE_HELLOWORLD_URI":{"type":"String","value":"https://app-helloworld-jo3wbujju2yeq.azurewebsites.net"}},"outputResources":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/config/appsettings"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/config/logs"}]}},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/appserviceplan","name":"appserviceplan","type":"Microsoft.Resources/deployments","properties":{"templateHash":"7476659406584400671","parameters":{"name":{"type":"String","value":"plan-jo3wbujju2yeq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-wa68d26"}},"kind":{"type":"String","value":""},"reserved":{"type":"Bool","value":true},"sku":{"type":"Object","value":{"name":"B1"}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-06-11T00:13:48.7283826Z","duration":"PT5.4413133S","correlationId":"fd3de1de57fd7a67210fb26cd6ff7ac5","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"serverfarms","locations":["eastus2"]}]}],"dependencies":[],"outputs":{"id":{"type":"String","value":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/serverfarms/plan-jo3wbujju2yeq"},"name":{"type":"String","value":"plan-jo3wbujju2yeq"}},"outputResources":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/serverfarms/plan-jo3wbujju2yeq"}]}},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/project-1.azdtest-wa68d26.133625384160969148","name":"project-1.azdtest-wa68d26.133625384160969148","type":"Microsoft.Resources/deployments","tags":{"AdeEnvironmentName":"azdtest-wa68d26","AdeProjectName":"project-1","AdeDevCenterName":"dc-azd-o2pst6gaydv5o","AdeEnvironmentTypeName":"Dev"},"properties":{"templateLink":{"uri":"https://6de81a5616dfc5cb.blob.core.windows.net/templates/project-1.azdtest-wa68d26.133625384160969148/EnvironmentDefinitions/HelloWorld/azuredeploy.json","contentVersion":"1.0.0.0"},"templateHash":"17645299908346333518","parameters":{"repoUrl":{"type":"String","value":"https://github.com/wbreza/azd-hello-world"},"environmentName":{"type":"String","value":"azdtest-wa68d26"},"location":{"type":"String","value":"eastus2"},"serviceName":{"type":"String","value":""},"appServicePlanName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-06-11T00:15:05.470736Z","duration":"PT1M23.6080887S","correlationId":"fd3de1de57fd7a67210fb26cd6ff7ac5","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/appserviceplan","resourceType":"Microsoft.Resources/deployments","resourceName":"appserviceplan"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/appserviceplan","resourceType":"Microsoft.Resources/deployments","resourceName":"appserviceplan","apiVersion":"2022-09-01"}],"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/helloworld","resourceType":"Microsoft.Resources/deployments","resourceName":"helloworld"}],"outputs":{"azurE_LOCATION":{"type":"String","value":"eastus2"},"azurE_TENANT_ID":{"type":"String","value":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"servicE_API_ENDPOINTS":{"type":"Array","value":["https://app-helloworld-jo3wbujju2yeq.azurewebsites.net"]}},"outputResources":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/serverfarms/plan-jo3wbujju2yeq"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/config/appsettings"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/config/logs"}]}}]}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "13691"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Tue, 11 Jun 2024 00:16:05 GMT
-            Expires:
-                - "-1"
-            Pragma:
-                - no-cache
-            Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains
-            X-Cache:
-                - CONFIG_NOCACHE
-            X-Content-Type-Options:
-                - nosniff
-            X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
-            X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
-            X-Ms-Request-Id:
-                - d7bd9885-5cd4-4131-8b87-b1d32cfbbcc8
-            X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001605Z:d7bd9885-5cd4-4131-8b87-b1d32cfbbcc8
-            X-Msedge-Ref:
-                - 'Ref A: 9726F7DE408E49E383BD9F9D26251655 Ref B: CO6AA3150218023 Ref C: 2024-06-11T00:16:05Z'
-        status: 200 OK
-        code: 200
-        duration: 606.4808ms
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: management.azure.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Accept-Encoding:
-                - gzip
-            Authorization:
-                - SANITIZED
-            User-Agent:
-                - azsdk-go-armresources.Client/v1.1.1 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
-            X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
-        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27helloworld%27&api-version=2021-04-01
+                - 1722edc87f18d41245d84ec3fb288193
+        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27helloworld%27&api-version=2021-04-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3785,7 +4614,7 @@ interactions:
         trailer: {}
         content_length: 479
         uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq","name":"app-helloworld-jo3wbujju2yeq","type":"Microsoft.Web/sites","kind":"app,linux","managedBy":"","location":"eastus2","tags":{"env":"dev","product":"azdev","project":"Project-1","azd-env-name":"azd-devcenter","azd-service-name":"helloworld","Owners":"rajeshkamal,hemarina,matell,vivazqu,wabrez,weilim"}}]}'
+        body: '{"value":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c/providers/Microsoft.Web/sites/app-helloworld-ypjumqxip7z4q","name":"app-helloworld-ypjumqxip7z4q","type":"Microsoft.Web/sites","kind":"app,linux","managedBy":"","location":"eastus2","tags":{"env":"dev","product":"azdev","project":"Project-1","Owners":"rajeshkamal,hemarina,matell,vivazqu,wabrez,weilim","azd-service-name":"helloworld","azd-env-name":"azd-devcenter"}}]}'
         headers:
             Cache-Control:
                 - no-cache
@@ -3794,7 +4623,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:16:05 GMT
+                - Fri, 14 Jun 2024 21:37:11 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -3806,19 +4635,19 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
+                - 1722edc87f18d41245d84ec3fb288193
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11998"
             X-Ms-Request-Id:
-                - 1ce2b7e2-e1cc-480c-a075-efe12d1b5683
+                - 1c0301d6-041a-4f97-8eb5-64477b537f59
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001606Z:1ce2b7e2-e1cc-480c-a075-efe12d1b5683
+                - WESTUS2:20240614T213712Z:1c0301d6-041a-4f97-8eb5-64477b537f59
             X-Msedge-Ref:
-                - 'Ref A: 9E8BEC4AD27445609581E41B33E09AEA Ref B: CO6AA3150218023 Ref C: 2024-06-11T00:16:05Z'
+                - 'Ref A: CDB9417807FF45C8B31AEB246AADC5BC Ref B: CO6AA3150220047 Ref C: 2024-06-14T21:37:11Z'
         status: 200 OK
         code: 200
-        duration: 90.0049ms
-    - id: 44
+        duration: 598.2389ms
+    - id: 54
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3839,10 +4668,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armappservice/v2.3.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-armappservice/v2.3.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
-        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq?api-version=2023-01-01
+                - 1722edc87f18d41245d84ec3fb288193
+        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c/providers/Microsoft.Web/sites/app-helloworld-ypjumqxip7z4q?api-version=2023-01-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -3850,20 +4679,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 7855
+        content_length: 7860
         uncompressed: false
-        body: '{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq","name":"app-helloworld-jo3wbujju2yeq","type":"Microsoft.Web/sites","kind":"app,linux","location":"East US 2","tags":{"azd-env-name":"azd-devcenter","azd-service-name":"helloworld","env":"dev","Owners":"rajeshkamal,hemarina,matell,vivazqu,wabrez,weilim","product":"azdev","project":"Project-1"},"properties":{"name":"app-helloworld-jo3wbujju2yeq","state":"Running","hostNames":["app-helloworld-jo3wbujju2yeq.azurewebsites.net"],"webSpace":"project-1-azdtest-wa68d26-EastUS2webspace-Linux","selfLink":"https://waws-prod-bn1-247.api.azurewebsites.windows.net:454/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/webspaces/project-1-azdtest-wa68d26-EastUS2webspace-Linux/sites/app-helloworld-jo3wbujju2yeq","repositorySiteName":"app-helloworld-jo3wbujju2yeq","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"afdEnabled":false,"enabledHostNames":["app-helloworld-jo3wbujju2yeq.azurewebsites.net","app-helloworld-jo3wbujju2yeq.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"node|18-lts"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"app-helloworld-jo3wbujju2yeq.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"app-helloworld-jo3wbujju2yeq.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/serverfarms/plan-jo3wbujju2yeq","reserved":true,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2024-06-11T00:14:28.61","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"node|18-lts","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"app-helloworld-jo3wbujju2yeq","slotName":null,"trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"A9A29753FAB61CCC59FE93B4201B3B7B610A524BA93A022DB96880F7EBF2B0C1","kind":"app,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.119.136.19","possibleInboundIpAddresses":"20.119.136.19","ftpUsername":"app-helloworld-jo3wbujju2yeq\\$app-helloworld-jo3wbujju2yeq","ftpsHostName":"ftps://waws-prod-bn1-247.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"4.153.178.225,4.153.178.227,4.153.178.233,4.153.178.236,4.153.178.248,4.153.178.251,4.153.177.229,4.153.177.246,4.153.178.55,4.153.178.68,4.153.178.71,4.153.178.101,20.119.136.19","possibleOutboundIpAddresses":"4.153.178.225,4.153.178.227,4.153.178.233,4.153.178.236,4.153.178.248,4.153.178.251,4.153.177.229,4.153.177.246,4.153.178.55,4.153.178.68,4.153.178.71,4.153.178.101,4.153.178.110,4.153.178.125,4.153.178.132,4.153.178.169,4.153.178.180,4.153.178.186,4.153.178.192,4.153.178.200,4.153.178.205,4.153.178.207,4.153.178.218,4.153.178.223,4.153.178.225,4.153.178.227,4.153.178.233,4.153.178.236,4.153.178.248,4.153.178.251,4.153.177.63,4.153.178.253,4.153.179.14,4.153.179.36,4.153.179.68,4.153.179.106,20.119.136.19","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bn1-247","cloningInfo":null,"hostingEnvironmentId":null,"tags":{"azd-env-name":"azd-devcenter","azd-service-name":"helloworld","env":"dev","Owners":"rajeshkamal,hemarina,matell,vivazqu,wabrez,weilim","product":"azdev","project":"Project-1"},"resourceGroup":"project-1-azdtest-wa68d26","defaultHostName":"app-helloworld-jo3wbujju2yeq.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":["SiteContainers"],"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null}}'
+        body: '{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c/providers/Microsoft.Web/sites/app-helloworld-ypjumqxip7z4q","name":"app-helloworld-ypjumqxip7z4q","type":"Microsoft.Web/sites","kind":"app,linux","location":"East US 2","tags":{"azd-env-name":"azd-devcenter","azd-service-name":"helloworld","env":"dev","Owners":"rajeshkamal,hemarina,matell,vivazqu,wabrez,weilim","product":"azdev","project":"Project-1"},"properties":{"name":"app-helloworld-ypjumqxip7z4q","state":"Running","hostNames":["app-helloworld-ypjumqxip7z4q.azurewebsites.net"],"webSpace":"project-1-azdtest-wb1885c-EastUS2webspace-Linux","selfLink":"https://waws-prod-bn1-247.api.azurewebsites.windows.net:454/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/webspaces/project-1-azdtest-wb1885c-EastUS2webspace-Linux/sites/app-helloworld-ypjumqxip7z4q","repositorySiteName":"app-helloworld-ypjumqxip7z4q","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"afdEnabled":false,"enabledHostNames":["app-helloworld-ypjumqxip7z4q.azurewebsites.net","app-helloworld-ypjumqxip7z4q.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"node|18-lts"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"app-helloworld-ypjumqxip7z4q.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"app-helloworld-ypjumqxip7z4q.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c/providers/Microsoft.Web/serverfarms/plan-ypjumqxip7z4q","reserved":true,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2024-06-14T21:34:58.8166667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"node|18-lts","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"app-helloworld-ypjumqxip7z4q","slotName":null,"trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"A9A29753FAB61CCC59FE93B4201B3B7B610A524BA93A022DB96880F7EBF2B0C1","kind":"app,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.119.136.19","possibleInboundIpAddresses":"20.119.136.19","ftpUsername":"app-helloworld-ypjumqxip7z4q\\$app-helloworld-ypjumqxip7z4q","ftpsHostName":"ftps://waws-prod-bn1-247.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"4.153.178.225,4.153.178.227,4.153.178.233,4.153.178.236,4.153.178.248,4.153.178.251,4.153.177.229,4.153.177.246,4.153.178.55,4.153.178.68,4.153.178.71,4.153.178.101,20.119.136.19","possibleOutboundIpAddresses":"4.153.178.225,4.153.178.227,4.153.178.233,4.153.178.236,4.153.178.248,4.153.178.251,4.153.177.229,4.153.177.246,4.153.178.55,4.153.178.68,4.153.178.71,4.153.178.101,4.153.178.110,4.153.178.125,4.153.178.132,4.153.178.169,4.153.178.180,4.153.178.186,4.153.178.192,4.153.178.200,4.153.178.205,4.153.178.207,4.153.178.218,4.153.178.223,4.153.178.225,4.153.178.227,4.153.178.233,4.153.178.236,4.153.178.248,4.153.178.251,4.153.177.63,4.153.178.253,4.153.179.14,4.153.179.36,4.153.179.68,4.153.179.106,20.119.136.19","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bn1-247","cloningInfo":null,"hostingEnvironmentId":null,"tags":{"azd-env-name":"azd-devcenter","azd-service-name":"helloworld","env":"dev","Owners":"rajeshkamal,hemarina,matell,vivazqu,wabrez,weilim","product":"azdev","project":"Project-1"},"resourceGroup":"project-1-azdtest-wb1885c","defaultHostName":"app-helloworld-ypjumqxip7z4q.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":["SiteContainers"],"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null}}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "7855"
+                - "7860"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Jun 2024 00:16:06 GMT
+                - Fri, 14 Jun 2024 21:37:12 GMT
             Etag:
-                - '"1DABB9453309E20"'
+                - '"1DABEA2B4CD0A0B"'
             Expires:
                 - "-1"
             Pragma:
@@ -3877,21 +4706,21 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
+                - 1722edc87f18d41245d84ec3fb288193
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 87fe3e49-d0e7-4170-bf3b-dc1b2f250377
+                - 814dce8f-d459-4037-abae-28cd6d62c379
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001606Z:879f4962-e5f1-4c70-b455-155291237e01
+                - WESTUS2:20240614T213712Z:610d129d-de56-49e9-84a2-d9ec12efd461
             X-Msedge-Ref:
-                - 'Ref A: D91F33A4B2E44424B65170ABFF8E2BCE Ref B: CO6AA3150218023 Ref C: 2024-06-11T00:16:06Z'
+                - 'Ref A: 16EDEF991D9E4300BE2580067F69AFF4 Ref B: CO6AA3150220047 Ref C: 2024-06-14T21:37:12Z'
             X-Powered-By:
                 - ASP.NET
         status: 200 OK
         code: 200
-        duration: 287.2479ms
-    - id: 45
+        duration: 552.2754ms
+    - id: 55
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3899,11 +4728,11 @@ interactions:
         content_length: 9699
         transfer_encoding: []
         trailer: {}
-        host: app-helloworld-jo3wbujju2yeq.scm.azurewebsites.net
+        host: app-helloworld-ypjumqxip7z4q.scm.azurewebsites.net
         remote_addr: ""
         request_uri: ""
         body: !!binary |
-            UEsDBBQACAAIAI6JylgAAAAAAAAAAAAAAAAKAAkALmdpdGlnbm9yZVVUBQABbZZnZnRVTW
+            UEsDBBQACAAIABJ0zlgAAAAAAAAAAAAAAAAKAAkALmdpdGlnbm9yZVVUBQAB9bZsZnRVTW
             /cNhC981cMsIfUC0hqektvddwEDdy0sHspimJBkbMy19SQ4AzXq/z6gtRH7Li5rPVmHkcz
             j2/kHdyGgZUvP/vWh0FRHBuLfR4K2qtJJ3qFMaWQZuwxkX5OUDu4cXqgwOIMJIwhCcMPDy
             KRf+46ChZP3IY0dDq6bs63DzL6K7WAf35s3v27//8/Jw5UXnGXSdyIYLVoFZ0t3Udn1b5l
@@ -3919,8 +4748,8 @@ interactions:
             X7aXFAuyhe/VpHcATygBBz750B7whLyB1hCjlBTOGERsre81pJk4U9BdmvbaodbC7Hiyzz
             9D4MFTfvmre7uX6zGajhHMsHsGhUU6XVc8aYkL+dew1360j3mM6YfGE+X4+Wt3h1yIfMeB
             0uq+OOmbEPl5q6mUiP4eYaboPRfhXH1qjt5wXBRJ/uoTS53K5goqY2rXbwy5ecED5kMsWG
-            DDqJO2oj5f+L0b5llPKh4voV/y8AAP//UEsHCBcl+6EvAwAAegYAAFBLAwQUAAgACACOic
-            pYAAAAAAAAAAAAAAAACQAJAFJFQURNRS5tZFVUBQABbZZnZnyTQW/iOhSF9/yKIyG9Rxel
+            DDqJO2oj5f+L0b5llPKh4voV/y8AAP//UEsHCBcl+6EvAwAAegYAAFBLAwQUAAgACAASdM
+            5YAAAAAAAAAAAAAAAACQAJAFJFQURNRS5tZFVUBQAB9bZsZnyTQW/iOhSF9/yKIyG9Rxel
             RW/xOqwmTaNOJAiIpBppNsQkF2LJ2B77Gsr8+pEDnbaqOjsn997v3OOcDFGYlnCU3KE6Wf
             KNk5aRPVtH3mOVlRWSZT4YDIcoiYONpyGWjhz9DNJLJj8YXJ8po8ndePL/eHIVXyznGH0Z
             38WnfmRmGqGQ6YN0Ru9J82CQOhJMEKjHpA/1eQvuCFujlDlKvUNj9FbughMsjZ5GpTr58b
@@ -3931,14 +4760,14 @@ interactions:
             WLf5CavZWK3gBc0NjEas/ZXPqac1+flDeZbWIEpWbTF+rxTSs91zFLLbmzUgSLV5tvlDwL
             x71Kf+oRL/seSBkbEwtP7hBZMxF002HjzNGTw1fUHbOd3tz0I53xPP1vcntbj1F1hMvFwY
             odIRZ9j19Y0vEu8ZTj2JEjnExAIzTYnWDCeYn48/0OAAD//1BLBwihoHHtDQIAAKUDAABQ
-            SwMEFAAIAAgAjonKWAAAAAAAAAAAAAAAAAgACQBpbmRleC5qc1VUBQABbZZnZkyQUWsiMR
+            SwMEFAAIAAgAEnTOWAAAAAAAAAAAAAAAAAgACQBpbmRleC5qc1VUBQAB9bZsZkyQUWsiMR
             SF3/MrzsLCRBhmhH0U92VX2kKhRS19NThXDcTceG9GCup/L5lR6FO4J/ec8yVti5djYsk+
             7iF06r1QhyN3fSA1frgCfSUhVeyEj6juUzUzpm3xT8gNZhexuO+5lILfuuw5mi1HzUXB/J
             FjJ6P1P+18JDgI95mQGQcXu0B4WqwHFtKsRc4HgjBnfCxfjUup2VO2VVvVsEKnGkI6wfwv
             LgZAmRql2NnqmULgGp8softVTWbmVppHouFhcyThLak2FM/N+9tyjesVf6bT6Ui4ym78mU
             KgJGcScBy9ZWuACV4zRVvEGvYHSCniQE3gvd2sRrdXSB9jyXwE/b6U47a5830HAAD//1BL
-            BwjQN+xoCwEAAJIBAABQSwMEFAAIAAgAjonKWAAAAAAAAAAAAAAAABEACQBwYWNrYWdlLW
-            xvY2suanNvblVUBQABbZZnZsR8aZOiXtLv+/kUHf3Wa7HJ4sT9TwSiKCiLggjeuHODTUD2
+            BwjQN+xoCwEAAJIBAABQSwMEFAAIAAgAEnTOWAAAAAAAAAAAAAAAABEACQBwYWNrYWdlLW
+            xvY2suanNvblVUBQAB9bZsZsR8aZOiXtLv+/kUHf3Wa7HJ4sT9TwSiKCiLggjeuHODTUD2
             fbnPzGd/Qq2u0uqyirK7n3lRURwO/JBf5sk8JzMP//9v3759j/TQ/v73b9+L2IqHUWzZwy
             If2k2S2Xk+DOPIib//r9N1lZ3lXhydLgWfoCfwcjaITf/gBbby0oucz2d2WnqZnX//+7ci
             K+3zuUQ3fd05nzs9+du37y9H/X/H+dp3f8u5J/BMO8rPQBwjv5637MSOLDsyvavnn3ueH3
@@ -4076,18 +4905,18 @@ interactions:
             kky7cdKJ8n5HtoaRLxbxbAp0BVf4FaDEmqy1kruNCMj9iiU4ebVey4Tnrx/cWf49ENI6AQ
             LD87++9YITfm7sVgcLtLeibri+ulVC8EiUZbWZtbKLxtVGB6w2roFJShp7tqUG6GE7YLq1
             0IXkstNSbUMyUrxxrXWG2MweENX0i4mCt+r2t9Pfv/723wEAAP//UEsHCHbot40uHAAAn2
-            MAAFBLAwQUAAgACACOicpYAAAAAAAAAAAAAAAADAAJAHBhY2thZ2UuanNvblVUBQABbZZn
+            MAAFBLAwQUAAgACAASdM5YAAAAAAAAAAAAAAAADAAJAHBhY2thZ2UuanNvblVUBQAB9bZs
             ZlyPTUsDQQyG7/srwpzdsQsepDfBHnoQRPcsLJugI91kmKSlIvvfJTP1A69vnvcjnx1A4G
             mhsIVggtKzIPWmPZ1zIdV+EX6VcOXciYomYUc3cYibpiLpXFK2y2XXfDAKCjztnke4e9w3
             0j5y7VkEjwdq2jKlasOkdp0Y6RzftZ1arIYt+EoXbCrmsG+EH7gDWKthOtqbFAdawCHNxF
             orH/bj99pMjMRzoj/Jl2edfLmJw20cflORTvf/TGu3fgUAAP//UEsHCNa/M9vCAAAAOQEA
-            AFBLAQIUABQACAAIAI6JylgXJfuhLwMAAHoGAAAKAAkAAAAAAAAAAAAAAAAAAAAuZ2l0aW
-            dub3JlVVQFAAFtlmdmUEsBAhQAFAAIAAgAjonKWKGgce0NAgAApQMAAAkACQAAAAAAAAAA
-            AAAAcAMAAFJFQURNRS5tZFVUBQABbZZnZlBLAQIUABQACAAIAI6JyljQN+xoCwEAAJIBAA
-            AIAAkAAAAAAAAAAAAAAL0FAABpbmRleC5qc1VUBQABbZZnZlBLAQIUABQACAAIAI6Jylh2
-            6LeNLhwAAJ9jAAARAAkAAAAAAAAAAAAAAAcHAABwYWNrYWdlLWxvY2suanNvblVUBQABbZ
-            ZnZlBLAQIUABQACAAIAI6JyljWvzPbwgAAADkBAAAMAAkAAAAAAAAAAAAAAH0jAABwYWNr
-            YWdlLmpzb25VVAUAAW2WZ2ZQSwUGAAAAAAUABQBLAQAAgiQAAAAA
+            AFBLAQIUABQACAAIABJ0zlgXJfuhLwMAAHoGAAAKAAkAAAAAAAAAAAAAAAAAAAAuZ2l0aW
+            dub3JlVVQFAAH1tmxmUEsBAhQAFAAIAAgAEnTOWKGgce0NAgAApQMAAAkACQAAAAAAAAAA
+            AAAAcAMAAFJFQURNRS5tZFVUBQAB9bZsZlBLAQIUABQACAAIABJ0zljQN+xoCwEAAJIBAA
+            AIAAkAAAAAAAAAAAAAAL0FAABpbmRleC5qc1VUBQAB9bZsZlBLAQIUABQACAAIABJ0zlh2
+            6LeNLhwAAJ9jAAARAAkAAAAAAAAAAAAAAAcHAABwYWNrYWdlLWxvY2suanNvblVUBQAB9b
+            ZsZlBLAQIUABQACAAIABJ0zljWvzPbwgAAADkBAAAMAAkAAAAAAAAAAAAAAH0jAABwYWNr
+            YWdlLmpzb25VVAUAAfW2bGZQSwUGAAAAAAUABQBLAQAAgiQAAAAA
         form: {}
         headers:
             Accept:
@@ -4101,10 +4930,10 @@ interactions:
             Content-Type:
                 - application/octet-stream
             User-Agent:
-                - azsdk-go-zip-deploy/1.0.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-zip-deploy/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
-        url: https://app-helloworld-jo3wbujju2yeq.scm.azurewebsites.net:443/api/zipdeploy?isAsync=true
+                - 1722edc87f18d41245d84ec3fb288193
+        url: https://app-helloworld-ypjumqxip7z4q.scm.azurewebsites.net:443/api/zipdeploy?isAsync=true
         method: POST
       response:
         proto: HTTP/1.1
@@ -4119,22 +4948,22 @@ interactions:
             Content-Length:
                 - "0"
             Date:
-                - Tue, 11 Jun 2024 00:17:07 GMT
+                - Fri, 14 Jun 2024 21:38:02 GMT
             Location:
-                - https://app-helloworld-jo3wbujju2yeq.scm.azurewebsites.net:443/api/deployments/latest?deployer=Push-Deployer&time=2024-06-11_00-17-07Z
+                - https://app-helloworld-ypjumqxip7z4q.scm.azurewebsites.net:443/api/deployments/latest?deployer=Push-Deployer&time=2024-06-14_21-38-02Z
             Retryafter:
                 - "30"
             Scm-Deployment-Id:
-                - fe3ee568-80d5-45d2-a5ea-43cde6add50f
+                - 197e7738-a356-47bb-ad18-80ae8d419a3a
             Server:
                 - Kestrel
             Set-Cookie:
-                - ARRAffinity=80fa370e688dca2b88312acd83eb0059bdb22388056f36ce8b5a46f963d6eec6;Path=/;HttpOnly;Secure;Domain=app-helloworld-jo3wbujju2yeq.scm.azurewebsites.net
-                - ARRAffinitySameSite=80fa370e688dca2b88312acd83eb0059bdb22388056f36ce8b5a46f963d6eec6;Path=/;HttpOnly;SameSite=None;Secure;Domain=app-helloworld-jo3wbujju2yeq.scm.azurewebsites.net
+                - ARRAffinity=fca6ece7e4bf6263fc35aa1445683163f744b5308fb7a5c0f532cafc6094a168;Path=/;HttpOnly;Secure;Domain=app-helloworld-ypjumqxip7z4q.scm.azurewebsites.net
+                - ARRAffinitySameSite=fca6ece7e4bf6263fc35aa1445683163f744b5308fb7a5c0f532cafc6094a168;Path=/;HttpOnly;SameSite=None;Secure;Domain=app-helloworld-ypjumqxip7z4q.scm.azurewebsites.net
         status: 202 Accepted
         code: 202
-        duration: 1m1.651563s
-    - id: 46
+        duration: 50.1590588s
+    - id: 56
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4155,10 +4984,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armappservice/v2.3.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-armappservice/v2.3.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
-        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/deploymentStatus/fe3ee568-80d5-45d2-a5ea-43cde6add50f?api-version=2023-01-01
+                - 1722edc87f18d41245d84ec3fb288193
+        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c/providers/Microsoft.Web/sites/app-helloworld-ypjumqxip7z4q/deploymentStatus/197e7738-a356-47bb-ad18-80ae8d419a3a?api-version=2023-01-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -4168,7 +4997,7 @@ interactions:
         trailer: {}
         content_length: 481
         uncompressed: false
-        body: '{"Code":"NotFound","Message":"The operation fe3ee568-80d5-45d2-a5ea-43cde6add50f is not found.","Target":null,"Details":[{"Message":"The operation fe3ee568-80d5-45d2-a5ea-43cde6add50f is not found."},{"Code":"NotFound"},{"ErrorEntity":{"ExtendedCode":"01025","MessageTemplate":"The operation {0} is not found.","Parameters":["fe3ee568-80d5-45d2-a5ea-43cde6add50f"],"Code":"NotFound","Message":"The operation fe3ee568-80d5-45d2-a5ea-43cde6add50f is not found."}}],"Innererror":null}'
+        body: '{"Code":"NotFound","Message":"The operation 197e7738-a356-47bb-ad18-80ae8d419a3a is not found.","Target":null,"Details":[{"Message":"The operation 197e7738-a356-47bb-ad18-80ae8d419a3a is not found."},{"Code":"NotFound"},{"ErrorEntity":{"ExtendedCode":"01025","MessageTemplate":"The operation {0} is not found.","Parameters":["197e7738-a356-47bb-ad18-80ae8d419a3a"],"Code":"NotFound","Message":"The operation 197e7738-a356-47bb-ad18-80ae8d419a3a is not found."}}],"Innererror":null}'
         headers:
             Cache-Control:
                 - no-cache
@@ -4177,9 +5006,9 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:17:11 GMT
+                - Fri, 14 Jun 2024 21:38:03 GMT
             Etag:
-                - '"1DABB9453309E20"'
+                - '"1DABEA2B4CD0A0B"'
             Expires:
                 - "-1"
             Pragma:
@@ -4193,21 +5022,21 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
+                - 1722edc87f18d41245d84ec3fb288193
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
                 - "11999"
             X-Ms-Request-Id:
-                - 1532292a-8df1-4f8f-bbf8-b0da45221a8e
+                - 34b39222-80de-4319-936d-61068ac63ad9
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001711Z:1532292a-8df1-4f8f-bbf8-b0da45221a8e
+                - WESTUS2:20240614T213803Z:34b39222-80de-4319-936d-61068ac63ad9
             X-Msedge-Ref:
-                - 'Ref A: 65A86561BD16479C8A37A911E729A00F Ref B: CO6AA3150218023 Ref C: 2024-06-11T00:17:08Z'
+                - 'Ref A: E2E0EB66A5064DFA9255BA65279FFDC9 Ref B: CO6AA3150220047 Ref C: 2024-06-14T21:38:02Z'
             X-Powered-By:
                 - ASP.NET
         status: 404 Not Found
         code: 404
-        duration: 3.73454s
-    - id: 47
+        duration: 911.418ms
+    - id: 57
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4228,10 +5057,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armappservice/v2.3.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-armappservice/v2.3.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
-        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/deploymentStatus/fe3ee568-80d5-45d2-a5ea-43cde6add50f?api-version=2023-01-01
+                - 1722edc87f18d41245d84ec3fb288193
+        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c/providers/Microsoft.Web/sites/app-helloworld-ypjumqxip7z4q/deploymentStatus/197e7738-a356-47bb-ad18-80ae8d419a3a?api-version=2023-01-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -4241,7 +5070,7 @@ interactions:
         trailer: {}
         content_length: 743
         uncompressed: false
-        body: '{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/deploymentStatus/fe3ee568-80d5-45d2-a5ea-43cde6add50f","name":"fe3ee568-80d5-45d2-a5ea-43cde6add50f","type":"Microsoft.Web/sites/deploymentStatus","location":"East US 2","tags":{"azd-env-name":"azd-devcenter","azd-service-name":"helloworld","env":"dev","Owners":"rajeshkamal,hemarina,matell,vivazqu,wabrez,weilim","product":"azdev","project":"Project-1"},"properties":{"deploymentId":"fe3ee568-80d5-45d2-a5ea-43cde6add50f","status":"BuildInProgress","numberOfInstancesInProgress":0,"numberOfInstancesSuccessful":0,"numberOfInstancesFailed":0,"failedInstancesLogs":null,"errors":null}}'
+        body: '{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c/providers/Microsoft.Web/sites/app-helloworld-ypjumqxip7z4q/deploymentStatus/197e7738-a356-47bb-ad18-80ae8d419a3a","name":"197e7738-a356-47bb-ad18-80ae8d419a3a","type":"Microsoft.Web/sites/deploymentStatus","location":"East US 2","tags":{"azd-env-name":"azd-devcenter","azd-service-name":"helloworld","env":"dev","Owners":"rajeshkamal,hemarina,matell,vivazqu,wabrez,weilim","product":"azdev","project":"Project-1"},"properties":{"deploymentId":"197e7738-a356-47bb-ad18-80ae8d419a3a","status":"BuildInProgress","numberOfInstancesInProgress":0,"numberOfInstancesSuccessful":0,"numberOfInstancesFailed":0,"failedInstancesLogs":null,"errors":null}}'
         headers:
             Cache-Control:
                 - no-cache
@@ -4250,13 +5079,13 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Jun 2024 00:17:19 GMT
+                - Fri, 14 Jun 2024 21:38:09 GMT
             Etag:
-                - '"1DABB9453309E20"'
+                - '"1DABEA2B4CD0A0B"'
             Expires:
                 - "-1"
             Location:
-                - https://management.azure.com/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/deploymentStatus/fe3ee568-80d5-45d2-a5ea-43cde6add50f?api-version=2023-01-01&t=638536619895012534&c=MIIHpTCCBo2gAwIBAgITfwM6vSxODJvqjFP4oQAEAzq9LDANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjQwNTE1MTI0NjQwWhcNMjUwNTEwMTI0NjQwWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKa4cOTKf-wVpLKiG5Zei1-Oc5u5PvibFdqWIGFZDLmSA3G2jYrx6dKQ8NH10xxzVOMT_dqQOb2nPmPDhnS3CUlhwx_iI9VSftq8J182Ci01SlOzoieOj_kBg-1yQ4TB3DD7Rwgy40TMWgK-1lkliuLAgSHruwrRW8Kj8Q96A0oGxy1RQggyCNWVG8EsUp1ngtGu-yi1BZRa4Q-v_x9KFfbvtOc9KIfKRFs2r2zg4MWc4xCzQCYrRXIVfS-sFxEn1GbDqtYc4-y5T978_4OnKXidZCkJqT4v1ZRcgxKZpH8d4GmacrEfBoCqjg9ZayboCoIPz5wEIF9LOngoqXqnmYECAwEAAaOCBJIwggSOMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBRCKTJWBui0JqrIiMW81zJdA9-tSDAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwEwDAYKKwYBBAGCN3sEATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAGJpRHLgYBJ-Hg0664G6_TgQ8luNO24um3ktexLaPrnailsQdaNThyJ4w9TTpMvyG31DlS7euSnKy8IsfMzCDxu1mmgziF9Urf-OpUw3u-ze-9z_PmzXym0G-rk8OrPpWWdAeApaUIHmydJGO_yrSQURQDLY9ATNa4gS1c9rQLruie0ZkPwjhAJCwpdK615q7s9ssaQ_HZEXM9r3mojVMYMB6b7TQJcwlVHBvkRO5u4HnAI26O2e-pcDzgccXJ6mqM158VJM-AyU1D2gWCqHj4zml1U005Ot-Fx-C3N3HCVImLvAllBxeQdwzOTae6Br-eXo1NCFf1ahI2fP4G_nB7o&s=MRxuwyOraee7vT_pxfiA_87SwACHphModBWHdnxnKZHcHYrlCorO0TCT5tetKXuztWbvKTG5CL1NMFFWsHS9sm569W9iB9XBHOkBLmtJKAR3CWVMhhVjShGPfPd_xM8nU6nZCWGkkjtQAERVILkO0_KN7vuYmEVfzl_oxLZJbxHYlyiue2JUh4CqYgieti25lC3mIBSffAl09KYBdfAcGbv28NBUk8baYpRaLkxd1TkDey0wKb2a-vtOgbniwtW7dEBzkl2Ci4lpYbv6K76XL22862bEwwfKN0U8LcXG2Ww1_YjLX-BjZYEtFCrYKDpwZDR7rQPNCx0d9PfcLfFTzA&h=SW9CkYFiLuYtqBzpMBtuBXZdN-IYlsyqOiwmBJXiC-E
+                - https://management.azure.com/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c/providers/Microsoft.Web/sites/app-helloworld-ypjumqxip7z4q/deploymentStatus/197e7738-a356-47bb-ad18-80ae8d419a3a?api-version=2023-01-01&t=638539979661831426&c=MIIHpTCCBo2gAwIBAgITfwM6vSxODJvqjFP4oQAEAzq9LDANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjQwNTE1MTI0NjQwWhcNMjUwNTEwMTI0NjQwWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKa4cOTKf-wVpLKiG5Zei1-Oc5u5PvibFdqWIGFZDLmSA3G2jYrx6dKQ8NH10xxzVOMT_dqQOb2nPmPDhnS3CUlhwx_iI9VSftq8J182Ci01SlOzoieOj_kBg-1yQ4TB3DD7Rwgy40TMWgK-1lkliuLAgSHruwrRW8Kj8Q96A0oGxy1RQggyCNWVG8EsUp1ngtGu-yi1BZRa4Q-v_x9KFfbvtOc9KIfKRFs2r2zg4MWc4xCzQCYrRXIVfS-sFxEn1GbDqtYc4-y5T978_4OnKXidZCkJqT4v1ZRcgxKZpH8d4GmacrEfBoCqjg9ZayboCoIPz5wEIF9LOngoqXqnmYECAwEAAaOCBJIwggSOMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBRCKTJWBui0JqrIiMW81zJdA9-tSDAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwEwDAYKKwYBBAGCN3sEATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAGJpRHLgYBJ-Hg0664G6_TgQ8luNO24um3ktexLaPrnailsQdaNThyJ4w9TTpMvyG31DlS7euSnKy8IsfMzCDxu1mmgziF9Urf-OpUw3u-ze-9z_PmzXym0G-rk8OrPpWWdAeApaUIHmydJGO_yrSQURQDLY9ATNa4gS1c9rQLruie0ZkPwjhAJCwpdK615q7s9ssaQ_HZEXM9r3mojVMYMB6b7TQJcwlVHBvkRO5u4HnAI26O2e-pcDzgccXJ6mqM158VJM-AyU1D2gWCqHj4zml1U005Ot-Fx-C3N3HCVImLvAllBxeQdwzOTae6Br-eXo1NCFf1ahI2fP4G_nB7o&s=BLMGkqTc35MoOiaviGfR2-uXcnsU3TyfUvrFs22DEgGHY_1NpKEd5NRvUjh0WBvdXEjKpv00mbJRPX0mzCNb4Ox7SXk70lXy2I2D4fnj7DUkSiQ60uch44sabo60Kigf67CYz5CK1tUn7KHmBZVR9ED_KkSoOevilzlO6deg52pQzeiITcWDQXBQvA3iak6f498Gx0Ria4xEOhOeeyciMqlu9hgXSy4uevKkv4GLfZKiV_gW2xXnTReZ2Wpl0ZOYAWtG57P6lzPTDW970bs5MeTHI_JCzpcxrGzKqxxQthnow95xJ_olyUJGmpMzOODFFaR5RKxL0NPOEkeefT4WkA&h=y0Cadpw365YGp2g6Be3Mhqgl8YcioFsbaRn1qmuzrSg
             Pragma:
                 - no-cache
             Retry-After:
@@ -4270,21 +5099,21 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
+                - 1722edc87f18d41245d84ec3fb288193
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11998"
+                - "11999"
             X-Ms-Request-Id:
-                - 08f75220-8275-41e0-b1b0-9d0c40e9cf57
+                - c623c3b1-822e-4521-8c3a-d0a4f3ee45c3
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T001719Z:08f75220-8275-41e0-b1b0-9d0c40e9cf57
+                - WESTUS2:20240614T213809Z:c623c3b1-822e-4521-8c3a-d0a4f3ee45c3
             X-Msedge-Ref:
-                - 'Ref A: A098C8E0ADE74BFC99F306F3916F6CF3 Ref B: CO6AA3150218023 Ref C: 2024-06-11T00:17:16Z'
+                - 'Ref A: 6BC820DEE2034E36AE514A42D4B9097C Ref B: CO6AA3150220047 Ref C: 2024-06-14T21:38:09Z'
             X-Powered-By:
                 - ASP.NET
         status: 202 Accepted
         code: 202
-        duration: 2.4511353s
-    - id: 48
+        duration: 684.0431ms
+    - id: 58
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4303,10 +5132,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armappservice/v2.3.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-armappservice/v2.3.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
-        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/deploymentStatus/fe3ee568-80d5-45d2-a5ea-43cde6add50f?api-version=2023-01-01&t=638536619895012534&c=MIIHpTCCBo2gAwIBAgITfwM6vSxODJvqjFP4oQAEAzq9LDANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjQwNTE1MTI0NjQwWhcNMjUwNTEwMTI0NjQwWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKa4cOTKf-wVpLKiG5Zei1-Oc5u5PvibFdqWIGFZDLmSA3G2jYrx6dKQ8NH10xxzVOMT_dqQOb2nPmPDhnS3CUlhwx_iI9VSftq8J182Ci01SlOzoieOj_kBg-1yQ4TB3DD7Rwgy40TMWgK-1lkliuLAgSHruwrRW8Kj8Q96A0oGxy1RQggyCNWVG8EsUp1ngtGu-yi1BZRa4Q-v_x9KFfbvtOc9KIfKRFs2r2zg4MWc4xCzQCYrRXIVfS-sFxEn1GbDqtYc4-y5T978_4OnKXidZCkJqT4v1ZRcgxKZpH8d4GmacrEfBoCqjg9ZayboCoIPz5wEIF9LOngoqXqnmYECAwEAAaOCBJIwggSOMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBRCKTJWBui0JqrIiMW81zJdA9-tSDAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwEwDAYKKwYBBAGCN3sEATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAGJpRHLgYBJ-Hg0664G6_TgQ8luNO24um3ktexLaPrnailsQdaNThyJ4w9TTpMvyG31DlS7euSnKy8IsfMzCDxu1mmgziF9Urf-OpUw3u-ze-9z_PmzXym0G-rk8OrPpWWdAeApaUIHmydJGO_yrSQURQDLY9ATNa4gS1c9rQLruie0ZkPwjhAJCwpdK615q7s9ssaQ_HZEXM9r3mojVMYMB6b7TQJcwlVHBvkRO5u4HnAI26O2e-pcDzgccXJ6mqM158VJM-AyU1D2gWCqHj4zml1U005Ot-Fx-C3N3HCVImLvAllBxeQdwzOTae6Br-eXo1NCFf1ahI2fP4G_nB7o&s=MRxuwyOraee7vT_pxfiA_87SwACHphModBWHdnxnKZHcHYrlCorO0TCT5tetKXuztWbvKTG5CL1NMFFWsHS9sm569W9iB9XBHOkBLmtJKAR3CWVMhhVjShGPfPd_xM8nU6nZCWGkkjtQAERVILkO0_KN7vuYmEVfzl_oxLZJbxHYlyiue2JUh4CqYgieti25lC3mIBSffAl09KYBdfAcGbv28NBUk8baYpRaLkxd1TkDey0wKb2a-vtOgbniwtW7dEBzkl2Ci4lpYbv6K76XL22862bEwwfKN0U8LcXG2Ww1_YjLX-BjZYEtFCrYKDpwZDR7rQPNCx0d9PfcLfFTzA&h=SW9CkYFiLuYtqBzpMBtuBXZdN-IYlsyqOiwmBJXiC-E
+                - 1722edc87f18d41245d84ec3fb288193
+        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c/providers/Microsoft.Web/sites/app-helloworld-ypjumqxip7z4q/deploymentStatus/197e7738-a356-47bb-ad18-80ae8d419a3a?api-version=2023-01-01&t=638539979661831426&c=MIIHpTCCBo2gAwIBAgITfwM6vSxODJvqjFP4oQAEAzq9LDANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDIwHhcNMjQwNTE1MTI0NjQwWhcNMjUwNTEwMTI0NjQwWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKa4cOTKf-wVpLKiG5Zei1-Oc5u5PvibFdqWIGFZDLmSA3G2jYrx6dKQ8NH10xxzVOMT_dqQOb2nPmPDhnS3CUlhwx_iI9VSftq8J182Ci01SlOzoieOj_kBg-1yQ4TB3DD7Rwgy40TMWgK-1lkliuLAgSHruwrRW8Kj8Q96A0oGxy1RQggyCNWVG8EsUp1ngtGu-yi1BZRa4Q-v_x9KFfbvtOc9KIfKRFs2r2zg4MWc4xCzQCYrRXIVfS-sFxEn1GbDqtYc4-y5T978_4OnKXidZCkJqT4v1ZRcgxKZpH8d4GmacrEfBoCqjg9ZayboCoIPz5wEIF9LOngoqXqnmYECAwEAAaOCBJIwggSOMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CTDJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSW5mcmElMjBDQSUyMDAyKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQkwyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMEluZnJhJTIwQ0ElMjAwMig0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JMMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3J0MB0GA1UdDgQWBBRCKTJWBui0JqrIiMW81zJdA9-tSDAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJbmZyYSUyMENBJTIwMDIoNCkuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwEwDAYKKwYBBAGCN3sEATAfBgNVHSMEGDAWgBSuecJrXSWIEwb2BwnDl3x7l48dVTAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAGJpRHLgYBJ-Hg0664G6_TgQ8luNO24um3ktexLaPrnailsQdaNThyJ4w9TTpMvyG31DlS7euSnKy8IsfMzCDxu1mmgziF9Urf-OpUw3u-ze-9z_PmzXym0G-rk8OrPpWWdAeApaUIHmydJGO_yrSQURQDLY9ATNa4gS1c9rQLruie0ZkPwjhAJCwpdK615q7s9ssaQ_HZEXM9r3mojVMYMB6b7TQJcwlVHBvkRO5u4HnAI26O2e-pcDzgccXJ6mqM158VJM-AyU1D2gWCqHj4zml1U005Ot-Fx-C3N3HCVImLvAllBxeQdwzOTae6Br-eXo1NCFf1ahI2fP4G_nB7o&s=BLMGkqTc35MoOiaviGfR2-uXcnsU3TyfUvrFs22DEgGHY_1NpKEd5NRvUjh0WBvdXEjKpv00mbJRPX0mzCNb4Ox7SXk70lXy2I2D4fnj7DUkSiQ60uch44sabo60Kigf67CYz5CK1tUn7KHmBZVR9ED_KkSoOevilzlO6deg52pQzeiITcWDQXBQvA3iak6f498Gx0Ria4xEOhOeeyciMqlu9hgXSy4uevKkv4GLfZKiV_gW2xXnTReZ2Wpl0ZOYAWtG57P6lzPTDW970bs5MeTHI_JCzpcxrGzKqxxQthnow95xJ_olyUJGmpMzOODFFaR5RKxL0NPOEkeefT4WkA&h=y0Cadpw365YGp2g6Be3Mhqgl8YcioFsbaRn1qmuzrSg
         method: GET
       response:
         proto: HTTP/2.0
@@ -4316,7 +5145,7 @@ interactions:
         trailer: {}
         content_length: 745
         uncompressed: false
-        body: '{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/deploymentStatus/fe3ee568-80d5-45d2-a5ea-43cde6add50f","name":"fe3ee568-80d5-45d2-a5ea-43cde6add50f","type":"Microsoft.Web/sites/deploymentStatus","location":"East US 2","tags":{"azd-env-name":"azd-devcenter","azd-service-name":"helloworld","env":"dev","Owners":"rajeshkamal,hemarina,matell,vivazqu,wabrez,weilim","product":"azdev","project":"Project-1"},"properties":{"deploymentId":"fe3ee568-80d5-45d2-a5ea-43cde6add50f","status":"RuntimeSuccessful","numberOfInstancesInProgress":0,"numberOfInstancesSuccessful":1,"numberOfInstancesFailed":0,"failedInstancesLogs":null,"errors":null}}'
+        body: '{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c/providers/Microsoft.Web/sites/app-helloworld-ypjumqxip7z4q/deploymentStatus/197e7738-a356-47bb-ad18-80ae8d419a3a","name":"197e7738-a356-47bb-ad18-80ae8d419a3a","type":"Microsoft.Web/sites/deploymentStatus","location":"East US 2","tags":{"azd-env-name":"azd-devcenter","azd-service-name":"helloworld","env":"dev","Owners":"rajeshkamal,hemarina,matell,vivazqu,wabrez,weilim","product":"azdev","project":"Project-1"},"properties":{"deploymentId":"197e7738-a356-47bb-ad18-80ae8d419a3a","status":"RuntimeSuccessful","numberOfInstancesInProgress":0,"numberOfInstancesSuccessful":1,"numberOfInstancesFailed":0,"failedInstancesLogs":null,"errors":null}}'
         headers:
             Cache-Control:
                 - no-cache
@@ -4325,9 +5154,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Jun 2024 00:20:12 GMT
+                - Fri, 14 Jun 2024 21:39:46 GMT
             Etag:
-                - '"1DABB9453309E20"'
+                - '"1DABEA2B4CD0A0B"'
             Expires:
                 - "-1"
             Pragma:
@@ -4341,21 +5170,21 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
+                - 1722edc87f18d41245d84ec3fb288193
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11998"
+                - "11999"
             X-Ms-Request-Id:
-                - f557d67e-002c-403a-b4de-235809c172cf
+                - e3967f25-79e0-4688-bedb-f932810e41ca
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T002012Z:30446b09-5253-4c15-8a7b-ab0ccd13a2f7
+                - WESTUS2:20240614T213946Z:0cdab2db-b503-44aa-8517-5fdc1e235b9b
             X-Msedge-Ref:
-                - 'Ref A: A7C71553996D4423A4CBB4E3D0773590 Ref B: CO6AA3150218023 Ref C: 2024-06-11T00:20:09Z'
+                - 'Ref A: D97CF5A2839D463D91BBCF2B21595EC1 Ref B: CO6AA3150220047 Ref C: 2024-06-14T21:39:46Z'
             X-Powered-By:
                 - ASP.NET
         status: 200 OK
         code: 200
-        duration: 2.8599374s
-    - id: 49
+        duration: 655.4926ms
+    - id: 59
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4376,10 +5205,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-armappservice/v2.3.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-armappservice/v2.3.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
-        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq?api-version=2023-01-01
+                - 1722edc87f18d41245d84ec3fb288193
+        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c/providers/Microsoft.Web/sites/app-helloworld-ypjumqxip7z4q?api-version=2023-01-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -4387,20 +5216,20 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 7855
+        content_length: 7860
         uncompressed: false
-        body: '{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq","name":"app-helloworld-jo3wbujju2yeq","type":"Microsoft.Web/sites","kind":"app,linux","location":"East US 2","tags":{"azd-env-name":"azd-devcenter","azd-service-name":"helloworld","env":"dev","Owners":"rajeshkamal,hemarina,matell,vivazqu,wabrez,weilim","product":"azdev","project":"Project-1"},"properties":{"name":"app-helloworld-jo3wbujju2yeq","state":"Running","hostNames":["app-helloworld-jo3wbujju2yeq.azurewebsites.net"],"webSpace":"project-1-azdtest-wa68d26-EastUS2webspace-Linux","selfLink":"https://waws-prod-bn1-247.api.azurewebsites.windows.net:454/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/webspaces/project-1-azdtest-wa68d26-EastUS2webspace-Linux/sites/app-helloworld-jo3wbujju2yeq","repositorySiteName":"app-helloworld-jo3wbujju2yeq","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"afdEnabled":false,"enabledHostNames":["app-helloworld-jo3wbujju2yeq.azurewebsites.net","app-helloworld-jo3wbujju2yeq.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"node|18-lts"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"app-helloworld-jo3wbujju2yeq.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"app-helloworld-jo3wbujju2yeq.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/serverfarms/plan-jo3wbujju2yeq","reserved":true,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2024-06-11T00:14:28.61","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"node|18-lts","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"app-helloworld-jo3wbujju2yeq","slotName":null,"trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"A9A29753FAB61CCC59FE93B4201B3B7B610A524BA93A022DB96880F7EBF2B0C1","kind":"app,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.119.136.19","possibleInboundIpAddresses":"20.119.136.19","ftpUsername":"app-helloworld-jo3wbujju2yeq\\$app-helloworld-jo3wbujju2yeq","ftpsHostName":"ftps://waws-prod-bn1-247.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"4.153.178.225,4.153.178.227,4.153.178.233,4.153.178.236,4.153.178.248,4.153.178.251,4.153.177.229,4.153.177.246,4.153.178.55,4.153.178.68,4.153.178.71,4.153.178.101,20.119.136.19","possibleOutboundIpAddresses":"4.153.178.225,4.153.178.227,4.153.178.233,4.153.178.236,4.153.178.248,4.153.178.251,4.153.177.229,4.153.177.246,4.153.178.55,4.153.178.68,4.153.178.71,4.153.178.101,4.153.178.110,4.153.178.125,4.153.178.132,4.153.178.169,4.153.178.180,4.153.178.186,4.153.178.192,4.153.178.200,4.153.178.205,4.153.178.207,4.153.178.218,4.153.178.223,4.153.178.225,4.153.178.227,4.153.178.233,4.153.178.236,4.153.178.248,4.153.178.251,4.153.177.63,4.153.178.253,4.153.179.14,4.153.179.36,4.153.179.68,4.153.179.106,20.119.136.19","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bn1-247","cloningInfo":null,"hostingEnvironmentId":null,"tags":{"azd-env-name":"azd-devcenter","azd-service-name":"helloworld","env":"dev","Owners":"rajeshkamal,hemarina,matell,vivazqu,wabrez,weilim","product":"azdev","project":"Project-1"},"resourceGroup":"project-1-azdtest-wa68d26","defaultHostName":"app-helloworld-jo3wbujju2yeq.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":["SiteContainers"],"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null}}'
+        body: '{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c/providers/Microsoft.Web/sites/app-helloworld-ypjumqxip7z4q","name":"app-helloworld-ypjumqxip7z4q","type":"Microsoft.Web/sites","kind":"app,linux","location":"East US 2","tags":{"azd-env-name":"azd-devcenter","azd-service-name":"helloworld","env":"dev","Owners":"rajeshkamal,hemarina,matell,vivazqu,wabrez,weilim","product":"azdev","project":"Project-1"},"properties":{"name":"app-helloworld-ypjumqxip7z4q","state":"Running","hostNames":["app-helloworld-ypjumqxip7z4q.azurewebsites.net"],"webSpace":"project-1-azdtest-wb1885c-EastUS2webspace-Linux","selfLink":"https://waws-prod-bn1-247.api.azurewebsites.windows.net:454/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/webspaces/project-1-azdtest-wb1885c-EastUS2webspace-Linux/sites/app-helloworld-ypjumqxip7z4q","repositorySiteName":"app-helloworld-ypjumqxip7z4q","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"afdEnabled":false,"enabledHostNames":["app-helloworld-ypjumqxip7z4q.azurewebsites.net","app-helloworld-ypjumqxip7z4q.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":"node|18-lts"},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"app-helloworld-ypjumqxip7z4q.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"app-helloworld-ypjumqxip7z4q.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"virtualIPv6":null,"thumbprint":null,"certificateResourceId":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c/providers/Microsoft.Web/serverfarms/plan-ypjumqxip7z4q","reserved":true,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2024-06-14T21:34:58.8166667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"node|18-lts","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":true,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":null,"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null,"sitePrivateLinkHostEnabled":null,"clusteringEnabled":false},"functionAppConfig":null,"daprConfig":null,"deploymentId":"app-helloworld-ypjumqxip7z4q","slotName":null,"trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"ipMode":"IPv4","vnetBackupRestoreEnabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"A9A29753FAB61CCC59FE93B4201B3B7B610A524BA93A022DB96880F7EBF2B0C1","kind":"app,linux","managedEnvironmentId":null,"workloadProfileName":null,"resourceConfig":null,"inboundIpAddress":"20.119.136.19","possibleInboundIpAddresses":"20.119.136.19","ftpUsername":"app-helloworld-ypjumqxip7z4q\\$app-helloworld-ypjumqxip7z4q","ftpsHostName":"ftps://waws-prod-bn1-247.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"4.153.178.225,4.153.178.227,4.153.178.233,4.153.178.236,4.153.178.248,4.153.178.251,4.153.177.229,4.153.177.246,4.153.178.55,4.153.178.68,4.153.178.71,4.153.178.101,20.119.136.19","possibleOutboundIpAddresses":"4.153.178.225,4.153.178.227,4.153.178.233,4.153.178.236,4.153.178.248,4.153.178.251,4.153.177.229,4.153.177.246,4.153.178.55,4.153.178.68,4.153.178.71,4.153.178.101,4.153.178.110,4.153.178.125,4.153.178.132,4.153.178.169,4.153.178.180,4.153.178.186,4.153.178.192,4.153.178.200,4.153.178.205,4.153.178.207,4.153.178.218,4.153.178.223,4.153.178.225,4.153.178.227,4.153.178.233,4.153.178.236,4.153.178.248,4.153.178.251,4.153.177.63,4.153.178.253,4.153.179.14,4.153.179.36,4.153.179.68,4.153.179.106,20.119.136.19","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bn1-247","cloningInfo":null,"hostingEnvironmentId":null,"tags":{"azd-env-name":"azd-devcenter","azd-service-name":"helloworld","env":"dev","Owners":"rajeshkamal,hemarina,matell,vivazqu,wabrez,weilim","product":"azdev","project":"Project-1"},"resourceGroup":"project-1-azdtest-wb1885c","defaultHostName":"app-helloworld-ypjumqxip7z4q.azurewebsites.net","slotSwapStatus":null,"httpsOnly":true,"endToEndEncryptionEnabled":false,"functionsRuntimeAdminIsolationEnabled":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"AppServiceAppLogs,AppServiceAuditLogs,AppServiceConsoleLogs,AppServiceHTTPLogs,AppServiceIPSecAuditLogs,AppServicePlatformLogs,ScanLogs,AppServiceAuthenticationLogs","inFlightFeatures":["SiteContainers"],"storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","autoGeneratedDomainNameLabelScope":null,"defaultHostNameScope":"Global","privateLinkIdentifiers":null,"sshEnabled":null}}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "7855"
+                - "7860"
             Content-Type:
                 - application/json
             Date:
-                - Tue, 11 Jun 2024 00:20:15 GMT
+                - Fri, 14 Jun 2024 21:39:47 GMT
             Etag:
-                - '"1DABB9453309E20"'
+                - '"1DABEA2B4CD0A0B"'
             Expires:
                 - "-1"
             Pragma:
@@ -4414,21 +5243,21 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - fd3de1de57fd7a67210fb26cd6ff7ac5
+                - 1722edc87f18d41245d84ec3fb288193
             X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11997"
+                - "11999"
             X-Ms-Request-Id:
-                - aa7a2a8a-b269-4793-87c3-ceb86807d5e5
+                - ca6d5bdf-e908-4d43-b83f-c675b21bebe7
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T002015Z:0f237bad-390c-4d7d-9d1d-c31c8f852c3a
+                - WESTUS2:20240614T213947Z:d7a3ef01-0254-4b63-a8e3-df70f5cc41e0
             X-Msedge-Ref:
-                - 'Ref A: 35B0166882E846CDB4C60ADFF4F0CBAD Ref B: CO6AA3150218023 Ref C: 2024-06-11T00:20:12Z'
+                - 'Ref A: 14155E9BD09B4D61878C5DE62ED88C13 Ref B: CO6AA3150220047 Ref C: 2024-06-14T21:39:46Z'
             X-Powered-By:
                 - ASP.NET
         status: 200 OK
         code: 200
-        duration: 3.0486909s
-    - id: 50
+        duration: 507.4905ms
+    - id: 60
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4453,9 +5282,9 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - azsdk-go-armresourcegraph.Client/v0.7.1 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-armresourcegraph.Client/v0.7.1 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - 6d237093a1be7f84577d96754512d62e
+                - e7a76b217ca2107a559f3c4317a2a7f0
         url: https://management.azure.com:443/providers/Microsoft.ResourceGraph/resources?api-version=2021-06-01-preview
         method: POST
       response:
@@ -4464,18 +5293,18 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 9182
+        content_length: 12296
         uncompressed: false
-        body: '{"totalRecords":15,"count":15,"data":[{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioClient","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSVendors","properties":{"provisioningState":"Succeeded","description":"Project for vendors","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/basic","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"basic","properties":{"provisioningState":"Succeeded","description":"project with basic image","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"MicroBuild","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourceGroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DevDivAzureService","properties":{"provisioningState":"Succeeded","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourceGroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"LanguageAndFrameworkServices","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourceGroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSCode","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourceGroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ServerlessPaaS","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourceGroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"PMUXDesign","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourceGroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"NuGet","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/qiaozha-test/providers/Microsoft.DevCenter/projects/jsmgmt","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"jsmgmt","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-jsmgmtsdktest.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/qiaozha-test/providers/Microsoft.DevCenter/devcenters/jsmgmtsdktest"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-1","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/devcenters/dc-azd-o2pst6gaydv5o"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-2","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/devcenters/dc-azd-o2pst6gaydv5o"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourceGroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DataAndAI","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/f91f9734-8835-4fa4-8564-1dd169bc29dd/resourceGroups/project-8489/providers/Microsoft.DevCenter/projects/VisualStudioServicing","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioServicing","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"}],"facets":[],"resultTruncated":"false"}'
+        body: '{"totalRecords":20,"count":20,"data":[{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VisualStudioClient","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioClient","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0a86e8d0-8c17-4765-90eb-aa50dae47299/resourceGroups/project-12719/providers/Microsoft.DevCenter/projects/VSVendors","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSVendors","properties":{"provisioningState":"Succeeded","description":"Project for vendors","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/basic","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"basic","properties":{"provisioningState":"Succeeded","description":"project with basic image","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/0f6b8985-2847-41a6-a1be-9ce8c00b369b/resourceGroups/project-13636/providers/Microsoft.DevCenter/projects/MicroBuild","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"MicroBuild","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1603ca8f-8a37-42c0-9e39-26fb03b3cbb6/resourceGroups/project-50/providers/Microsoft.DevCenter/projects/DevDivAzureService","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DevDivAzureService","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/16cb61da-05bc-4f08-8bd4-b2cdf51f8035/resourceGroups/project-3429/providers/Microsoft.DevCenter/projects/LanguageAndFrameworkServices","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"LanguageAndFrameworkServices","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1702e86b-0726-4f19-9ae5-25cad10e4f26/resourceGroups/project-3435/providers/Microsoft.DevCenter/projects/VSCode","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VSCode","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/17c9d6d4-b083-4266-a260-cbcb366a27a4/resourceGroups/project-8974/providers/Microsoft.DevCenter/projects/ServerlessPaaS","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ServerlessPaaS","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1ba77102-f6a9-4834-93c3-cc42bad6686e/resourceGroups/project-3436/providers/Microsoft.DevCenter/projects/PMUXDesign","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"PMUXDesign","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/1e627736-1411-423a-81c4-aa35ca55f2b3/resourceGroups/project-9387/providers/Microsoft.DevCenter/projects/NuGet","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"NuGet","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/qiaozha-test/providers/Microsoft.DevCenter/projects/jsmgmt","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"jsmgmt","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-jsmgmtsdktest.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/qiaozha-test/providers/Microsoft.DevCenter/devcenters/jsmgmtsdktest"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-1","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-1","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/devcenters/dc-azd-o2pst6gaydv5o"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/projects/Project-2","location":"eastus2","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Project-2","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/","devCenterId":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/rg-azd-devcenter/providers/Microsoft.DevCenter/devcenters/dc-azd-o2pst6gaydv5o"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-contoso-ecomm-pe/providers/Microsoft.DevCenter/projects/contoso-ecomm","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"contoso-ecomm","properties":{"provisioningState":"Succeeded","description":"Ecommerce team","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-pv44d74rp44bs.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/devcenters/dc-pv44d74rp44bs","maxDevBoxesPerUser":2},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/projects/dcprj-pv44d74rp44bs","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"dcprj-pv44d74rp44bs","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-pv44d74rp44bs.eastus.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-demo-test101/providers/Microsoft.DevCenter/devcenters/dc-pv44d74rp44bs"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project1","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ade-project1","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-ade-fidalgo-dev2.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/ade-fidalgo-dev2"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/ade-project2","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"ade-project2","properties":{"provisioningState":"Succeeded","description":"","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-ade-fidalgo-dev2.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/ade-fidalgo-dev2"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/projects/Inventory-Management-Project","location":"eastus","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"Inventory-Management-Project","properties":{"provisioningState":"Succeeded","description":"Inventory Management project","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-logistics-system-devcenter.devcenter.azure.com/","devCenterId":"/subscriptions/50144203-25d7-4aa0-8c7b-3e0d936b07f0/resourceGroups/rg-devbox-pub/providers/Microsoft.DevCenter/devcenters/Logistics-System-DevCenter"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/ed99ad84-f5da-479f-81df-23460857ccca/resourceGroups/project-7341/providers/Microsoft.DevCenter/projects/DataAndAI","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"DataAndAI","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"},{"id":"/subscriptions/f91f9734-8835-4fa4-8564-1dd169bc29dd/resourceGroups/project-8489/providers/Microsoft.DevCenter/projects/VisualStudioServicing","location":"westus3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","name":"VisualStudioServicing","properties":{"provisioningState":"Succeeded","devCenterUri":"https://72f988bf-86f1-41af-91ab-2d7cd011db47-devcenter-tfotz75rskxty-dc.westus3.devcenter.azure.com/","devCenterId":"/subscriptions/8f22e2e8-b4c1-4f7d-a889-49aec29b9c75/resourceGroups/devcenter-16-25/providers/Microsoft.DevCenter/devcenters/devcenter-tfotz75rskxty-dc"},"type":"microsoft.devcenter/projects"}],"facets":[],"resultTruncated":"false"}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "9182"
+                - "12296"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:20:18 GMT
+                - Fri, 14 Jun 2024 21:39:49 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -4487,27 +5316,27 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Correlation-Request-Id:
-                - 6d237093-a1be-7f84-577d-96754512d62e
+                - e7a76b21-7ca2-107a-559f-3c4317a2a7f0
             X-Ms-Ratelimit-Remaining-Tenant-Reads:
                 - "11999"
             X-Ms-Ratelimit-Remaining-Tenant-Resource-Requests:
                 - "14"
             X-Ms-Request-Id:
-                - edecf24c-2a27-4c43-9681-b52af6f48e22
+                - 8db3eb48-6cca-4f3e-b1c6-8efbfcec7c4b
             X-Ms-Resource-Graph-Request-Duration:
-                - "0:00:00:00.5862680"
+                - "0:00:00:01.1651612"
             X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T002018Z:edecf24c-2a27-4c43-9681-b52af6f48e22
+                - WESTUS2:20240614T213949Z:8db3eb48-6cca-4f3e-b1c6-8efbfcec7c4b
             X-Ms-User-Quota-Remaining:
                 - "14"
             X-Ms-User-Quota-Resets-After:
-                - "00:00:04"
+                - "00:00:05"
             X-Msedge-Ref:
-                - 'Ref A: 84572AA7C1AB4D8791ADBB4080396FCB Ref B: CO6AA3150218023 Ref C: 2024-06-11T00:20:17Z'
+                - 'Ref A: EA51326478D04DBF97F04165572C352D Ref B: CO6AA3150220047 Ref C: 2024-06-14T21:39:48Z'
         status: 200 OK
         code: 200
-        duration: 699.139ms
-    - id: 51
+        duration: 1.274318s
+    - id: 61
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4526,10 +5355,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-devcenter/1.0.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - 6d237093a1be7f84577d96754512d62e
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-wa68d26?api-version=2023-04-01
+                - e7a76b217ca2107a559f3c4317a2a7f0
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-wb1885c?api-version=2024-02-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -4541,15 +5370,16 @@ interactions:
         uncompressed: true
         body: |-
             {
-              "name": "azdtest-wa68d26",
+              "uri": "https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/users/19a2053b-445a-4023-95d3-c339051e0f32/environments/azdtest-wb1885c",
+              "name": "azdtest-wb1885c",
               "environmentType": "Dev",
-              "user": "547aa7c1-2f57-48d9-8969-ecf696948ca7",
+              "user": "19a2053b-445a-4023-95d3-c339051e0f32",
               "provisioningState": "Succeeded",
-              "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26",
+              "resourceGroupId": "/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wb1885c",
               "catalogName": "wbreza",
               "environmentDefinitionName": "HelloWorld",
               "parameters": {
-                "environmentName": "azdtest-wa68d26",
+                "environmentName": "azdtest-wb1885c",
                 "repoUrl": "https://github.com/wbreza/azd-hello-world"
               }
             }
@@ -4563,90 +5393,23 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:20:20 GMT
+                - Fri, 14 Jun 2024 21:39:49 GMT
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - a4b1de29-7a61-49e3-b7b6-bc355fbca728
+                - 544ae359-8e32-41fa-aa3f-e944af33ace7
             X-Ms-Correlation-Request-Id:
-                - 6d237093a1be7f84577d96754512d62e
+                - e7a76b217ca2107a559f3c4317a2a7f0
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
-                - "299"
+                - "296"
             X-Rate-Limit-Reset:
-                - "2024-06-11T00:21:20.0656437Z"
+                - "2024-06-14T21:40:13.3466114Z"
         status: 200 OK
         code: 200
-        duration: 910.4193ms
-    - id: 52
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: management.azure.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Accept:
-                - application/json
-            Accept-Encoding:
-                - gzip
-            Authorization:
-                - SANITIZED
-            User-Agent:
-                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
-            X-Ms-Correlation-Request-Id:
-                - 6d237093a1be7f84577d96754512d62e
-        url: https://management.azure.com:443/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourcegroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/?api-version=2021-04-01
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 13691
-        uncompressed: false
-        body: '{"value":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/app-helloworld-jo3wbujju2yeq-appSettings","name":"app-helloworld-jo3wbujju2yeq-appSettings","type":"Microsoft.Resources/deployments","properties":{"templateHash":"1502109241172037927","parameters":{"name":{"type":"String","value":"app-helloworld-jo3wbujju2yeq"},"appSettings":{"type":"Object","value":{"SCM_DO_BUILD_DURING_DEPLOYMENT":"True","ENABLE_ORYX_BUILD":"True"}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-06-11T00:14:39.1163918Z","duration":"PT11.5951217S","correlationId":"fd3de1de57fd7a67210fb26cd6ff7ac5","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"sites/config","locations":[null]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/config/appsettings"}]}},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/app-helloworld-jo3wbujju2yeq-app-module","name":"app-helloworld-jo3wbujju2yeq-app-module","type":"Microsoft.Resources/deployments","properties":{"templateHash":"3548910797978781823","parameters":{"name":{"type":"String","value":"app-helloworld-jo3wbujju2yeq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-wa68d26","azd-service-name":"helloworld"}},"applicationInsightsName":{"type":"String","value":""},"appServicePlanId":{"type":"String","value":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/serverfarms/plan-jo3wbujju2yeq"},"keyVaultName":{"type":"String","value":""},"managedIdentity":{"type":"Bool","value":false},"runtimeName":{"type":"String","value":"node"},"runtimeNameAndVersion":{"type":"String","value":"node|18-lts"},"runtimeVersion":{"type":"String","value":"18-lts"},"kind":{"type":"String","value":"app,linux"},"allowedOrigins":{"type":"Array","value":[]},"alwaysOn":{"type":"Bool","value":true},"appCommandLine":{"type":"String","value":""},"clientAffinityEnabled":{"type":"Bool","value":false},"enableOryxBuild":{"type":"Bool","value":true},"functionAppScaleLimit":{"type":"Int","value":-1},"linuxFxVersion":{"type":"String","value":"node|18-lts"},"minimumElasticInstanceCount":{"type":"Int","value":-1},"numberOfWorkers":{"type":"Int","value":-1},"scmDoBuildDuringDeployment":{"type":"Bool","value":true},"use32BitWorkerProcess":{"type":"Bool","value":false},"ftpsState":{"type":"String","value":"FtpsOnly"},"healthCheckPath":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-06-11T00:14:43.0316156Z","duration":"PT38.9919542S","correlationId":"fd3de1de57fd7a67210fb26cd6ff7ac5","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"sites/config","locations":[null]},{"resourceType":"sites/basicPublishingCredentialsPolicies","locations":[null]},{"resourceType":"sites","locations":["eastus2"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-jo3wbujju2yeq"}],"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/config/logs","resourceType":"Microsoft.Web/sites/config","resourceName":"app-helloworld-jo3wbujju2yeq/logs"},{"dependsOn":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-jo3wbujju2yeq"}],"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/basicPublishingCredentialsPolicies/ftp","resourceType":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","resourceName":"app-helloworld-jo3wbujju2yeq/ftp"},{"dependsOn":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-jo3wbujju2yeq"}],"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/basicPublishingCredentialsPolicies/scm","resourceType":"Microsoft.Web/sites/basicPublishingCredentialsPolicies","resourceName":"app-helloworld-jo3wbujju2yeq/scm"},{"dependsOn":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq","resourceType":"Microsoft.Web/sites","resourceName":"app-helloworld-jo3wbujju2yeq"}],"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/app-helloworld-jo3wbujju2yeq-appSettings","resourceType":"Microsoft.Resources/deployments","resourceName":"app-helloworld-jo3wbujju2yeq-appSettings"}],"outputs":{"identityPrincipalId":{"type":"String","value":""},"name":{"type":"String","value":"app-helloworld-jo3wbujju2yeq"},"uri":{"type":"String","value":"https://app-helloworld-jo3wbujju2yeq.azurewebsites.net"}},"outputResources":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/config/appsettings"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/config/logs"}]}},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/helloworld","name":"helloworld","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12313645452229774503","parameters":{"name":{"type":"String","value":"app-helloworld-jo3wbujju2yeq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-wa68d26"}},"appCommandLine":{"type":"String","value":""},"appServicePlanId":{"type":"String","value":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/serverfarms/plan-jo3wbujju2yeq"},"serviceName":{"type":"String","value":"helloworld"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-06-11T00:14:50.4425347Z","duration":"PT47.6590017S","correlationId":"fd3de1de57fd7a67210fb26cd6ff7ac5","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"servicE_HELLOWORLD_IDENTITY_PRINCIPAL_ID":{"type":"String","value":""},"servicE_HELLOWORLD_NAME":{"type":"String","value":"app-helloworld-jo3wbujju2yeq"},"servicE_HELLOWORLD_URI":{"type":"String","value":"https://app-helloworld-jo3wbujju2yeq.azurewebsites.net"}},"outputResources":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/config/appsettings"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/config/logs"}]}},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/appserviceplan","name":"appserviceplan","type":"Microsoft.Resources/deployments","properties":{"templateHash":"7476659406584400671","parameters":{"name":{"type":"String","value":"plan-jo3wbujju2yeq"},"location":{"type":"String","value":"eastus2"},"tags":{"type":"Object","value":{"azd-env-name":"azdtest-wa68d26"}},"kind":{"type":"String","value":""},"reserved":{"type":"Bool","value":true},"sku":{"type":"Object","value":{"name":"B1"}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-06-11T00:13:48.7283826Z","duration":"PT5.4413133S","correlationId":"fd3de1de57fd7a67210fb26cd6ff7ac5","providers":[{"namespace":"Microsoft.Web","resourceTypes":[{"resourceType":"serverfarms","locations":["eastus2"]}]}],"dependencies":[],"outputs":{"id":{"type":"String","value":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/serverfarms/plan-jo3wbujju2yeq"},"name":{"type":"String","value":"plan-jo3wbujju2yeq"}},"outputResources":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/serverfarms/plan-jo3wbujju2yeq"}]}},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/project-1.azdtest-wa68d26.133625384160969148","name":"project-1.azdtest-wa68d26.133625384160969148","type":"Microsoft.Resources/deployments","tags":{"AdeEnvironmentName":"azdtest-wa68d26","AdeProjectName":"project-1","AdeDevCenterName":"dc-azd-o2pst6gaydv5o","AdeEnvironmentTypeName":"Dev"},"properties":{"templateLink":{"uri":"https://6de81a5616dfc5cb.blob.core.windows.net/templates/project-1.azdtest-wa68d26.133625384160969148/EnvironmentDefinitions/HelloWorld/azuredeploy.json","contentVersion":"1.0.0.0"},"templateHash":"17645299908346333518","parameters":{"repoUrl":{"type":"String","value":"https://github.com/wbreza/azd-hello-world"},"environmentName":{"type":"String","value":"azdtest-wa68d26"},"location":{"type":"String","value":"eastus2"},"serviceName":{"type":"String","value":""},"appServicePlanName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-06-11T00:15:05.470736Z","duration":"PT1M23.6080887S","correlationId":"fd3de1de57fd7a67210fb26cd6ff7ac5","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/appserviceplan","resourceType":"Microsoft.Resources/deployments","resourceName":"appserviceplan"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/appserviceplan","resourceType":"Microsoft.Resources/deployments","resourceName":"appserviceplan","apiVersion":"2022-09-01"}],"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Resources/deployments/helloworld","resourceType":"Microsoft.Resources/deployments","resourceName":"helloworld"}],"outputs":{"azurE_LOCATION":{"type":"String","value":"eastus2"},"azurE_TENANT_ID":{"type":"String","value":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"servicE_API_ENDPOINTS":{"type":"Array","value":["https://app-helloworld-jo3wbujju2yeq.azurewebsites.net"]}},"outputResources":[{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/serverfarms/plan-jo3wbujju2yeq"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/basicPublishingCredentialsPolicies/ftp"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/basicPublishingCredentialsPolicies/scm"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/config/appsettings"},{"id":"/subscriptions/2cd617ea-1866-46b1-90e3-fffb087ebf9b/resourceGroups/project-1-azdtest-wa68d26/providers/Microsoft.Web/sites/app-helloworld-jo3wbujju2yeq/config/logs"}]}}]}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "13691"
-            Content-Type:
-                - application/json; charset=utf-8
-            Date:
-                - Tue, 11 Jun 2024 00:20:20 GMT
-            Expires:
-                - "-1"
-            Pragma:
-                - no-cache
-            Strict-Transport-Security:
-                - max-age=31536000; includeSubDomains
-            X-Cache:
-                - CONFIG_NOCACHE
-            X-Content-Type-Options:
-                - nosniff
-            X-Ms-Correlation-Request-Id:
-                - 6d237093a1be7f84577d96754512d62e
-            X-Ms-Ratelimit-Remaining-Subscription-Reads:
-                - "11999"
-            X-Ms-Request-Id:
-                - 2f6dd0cb-93df-4dd9-ba24-8926d024cc3d
-            X-Ms-Routing-Request-Id:
-                - WESTUS2:20240611T002020Z:2f6dd0cb-93df-4dd9-ba24-8926d024cc3d
-            X-Msedge-Ref:
-                - 'Ref A: 102F63147FD44B2AAADBE6503046EF89 Ref B: CO6AA3150218023 Ref C: 2024-06-11T00:20:20Z'
-        status: 200 OK
-        code: 200
-        duration: 527.5625ms
-    - id: 53
+        duration: 337.5185ms
+    - id: 62
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4665,10 +5428,90 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-devcenter/1.0.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - 6d237093a1be7f84577d96754512d62e
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-wa68d26?api-version=2023-04-01
+                - e7a76b217ca2107a559f3c4317a2a7f0
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/users/19a2053b-445a-4023-95d3-c339051e0f32/environments/azdtest-wb1885c/outputs?api-version=2024-02-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |-
+            {
+              "outputs": {
+                "azurE_LOCATION": {
+                  "type": "String",
+                  "value": "eastus2",
+                  "sensitive": false
+                },
+                "azurE_TENANT_ID": {
+                  "type": "String",
+                  "value": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                  "sensitive": false
+                },
+                "servicE_API_ENDPOINTS": {
+                  "type": "Array",
+                  "value": [
+                    []
+                  ],
+                  "sensitive": false
+                }
+              }
+            }
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - Location,Operation-Location,x-ms-correlation-request-id,x-ms-client-request-id
+            Access-Control-Max-Age:
+                - "86400"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Jun 2024 21:39:50 GMT
+            Strict-Transport-Security:
+                - max-age=15724800; includeSubDomains
+            X-Ms-Client-Request-Id:
+                - 49383ccb-9ff4-415a-aadb-0a6157da3195
+            X-Ms-Correlation-Request-Id:
+                - e7a76b217ca2107a559f3c4317a2a7f0
+            X-Rate-Limit-Limit:
+                - 1m
+            X-Rate-Limit-Remaining:
+                - "299"
+            X-Rate-Limit-Reset:
+                - "2024-06-14T21:40:49.9945283Z"
+        status: 200 OK
+        code: 200
+        duration: 197.3617ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
+            X-Ms-Correlation-Request-Id:
+                - e7a76b217ca2107a559f3c4317a2a7f0
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/Project-1/users/me/environments/azdtest-wb1885c?api-version=2024-02-01
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4680,10 +5523,10 @@ interactions:
         uncompressed: false
         body: |-
             {
-              "id": "/projects/project-1/operationStatuses/b7b94bdf-27da-4f68-b604-1acf9b1eedb0",
-              "name": "b7b94bdf-27da-4f68-b604-1acf9b1eedb0",
+              "id": "/projects/project-1/operationStatuses/438833da-3a72-4718-aa43-2d7a0ea0c9d1",
+              "name": "438833da-3a72-4718-aa43-2d7a0ea0c9d1",
               "status": "NotStarted",
-              "resourceId": "/projects/project-1/users/547aa7c1-2f57-48d9-8969-ecf696948ca7/environments/azdtest-wa68d26"
+              "resourceId": "/projects/project-1/users/19a2053b-445a-4023-95d3-c339051e0f32/environments/azdtest-wb1885c"
             }
         headers:
             Access-Control-Allow-Origin:
@@ -4697,27 +5540,27 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:20:21 GMT
+                - Fri, 14 Jun 2024 21:39:50 GMT
             Location:
-                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/b7b94bdf-27da-4f68-b604-1acf9b1eedb0?api-version=2023-04-01&monitor=true
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/438833da-3a72-4718-aa43-2d7a0ea0c9d1?api-version=2024-02-01&monitor=true
             Operation-Location:
-                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/b7b94bdf-27da-4f68-b604-1acf9b1eedb0?api-version=2023-04-01
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/438833da-3a72-4718-aa43-2d7a0ea0c9d1?api-version=2024-02-01
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - aea58c57-e4c7-4e1b-b3b1-97375861ddd4
+                - 0dda85ec-997b-4bd1-90eb-60bba7988b8b
             X-Ms-Correlation-Request-Id:
-                - 6d237093a1be7f84577d96754512d62e
+                - e7a76b217ca2107a559f3c4317a2a7f0
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
-                - "299"
+                - "296"
             X-Rate-Limit-Reset:
-                - "2024-06-11T00:21:21.1887837Z"
+                - "2024-06-14T21:40:13.7399578Z"
         status: 202 Accepted
         code: 202
-        duration: 727.8986ms
-    - id: 54
+        duration: 616.6225ms
+    - id: 64
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4736,10 +5579,10 @@ interactions:
             Authorization:
                 - SANITIZED
             User-Agent:
-                - azsdk-go-devcenter/1.0.0 (go1.22.1; Windows_NT),azdev/0.0.0-dev.0 (Go go1.22.1; windows/amd64)
+                - azsdk-go-devcenter/1.0.0 (go1.21.6; Windows_NT),azdev/0.0.0-dev.0 (Go go1.21.6; windows/amd64)
             X-Ms-Correlation-Request-Id:
-                - 6d237093a1be7f84577d96754512d62e
-        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/project-1/operationstatuses/b7b94bdf-27da-4f68-b604-1acf9b1eedb0?api-version=2023-04-01
+                - e7a76b217ca2107a559f3c4317a2a7f0
+        url: https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com:443/projects/project-1/operationstatuses/438833da-3a72-4718-aa43-2d7a0ea0c9d1?api-version=2024-02-01
         method: GET
       response:
         proto: HTTP/2.0
@@ -4751,11 +5594,11 @@ interactions:
         uncompressed: true
         body: |-
             {
-              "id": "/projects/project-1/operationStatuses/b7b94bdf-27da-4f68-b604-1acf9b1eedb0",
-              "name": "b7b94bdf-27da-4f68-b604-1acf9b1eedb0",
+              "id": "/projects/project-1/operationStatuses/438833da-3a72-4718-aa43-2d7a0ea0c9d1",
+              "name": "438833da-3a72-4718-aa43-2d7a0ea0c9d1",
               "status": "Succeeded",
-              "startTime": "2024-06-11T00:20:21.2812146+00:00",
-              "endTime": "2024-06-11T00:20:47.1640504+00:00"
+              "startTime": "2024-06-14T21:39:50.5374742+00:00",
+              "endTime": "2024-06-14T21:45:02.5385271+00:00"
             }
         headers:
             Access-Control-Allow-Origin:
@@ -4767,28 +5610,28 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Tue, 11 Jun 2024 00:20:52 GMT
+                - Fri, 14 Jun 2024 21:45:23 GMT
             Location:
-                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/b7b94bdf-27da-4f68-b604-1acf9b1eedb0?api-version=2023-04-01&monitor=true
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/438833da-3a72-4718-aa43-2d7a0ea0c9d1?api-version=2024-02-01&monitor=true
             Operation-Location:
-                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/b7b94bdf-27da-4f68-b604-1acf9b1eedb0?api-version=2023-04-01
+                - https://72f988bf-86f1-41af-91ab-2d7cd011db47-dc-azd-o2pst6gaydv5o.eastus2.devcenter.azure.com/projects/project-1/operationstatuses/438833da-3a72-4718-aa43-2d7a0ea0c9d1?api-version=2024-02-01
             Retry-After:
                 - "30"
             Strict-Transport-Security:
                 - max-age=15724800; includeSubDomains
             X-Ms-Client-Request-Id:
-                - 2fddaeec-d5b2-4f24-8310-d2a48291896e
+                - 008e7425-7d20-4af2-9dcc-978a4e4dce35
             X-Ms-Correlation-Request-Id:
-                - 6d237093a1be7f84577d96754512d62e
+                - e7a76b217ca2107a559f3c4317a2a7f0
             X-Rate-Limit-Limit:
                 - 1m
             X-Rate-Limit-Remaining:
-                - "298"
+                - "299"
             X-Rate-Limit-Reset:
-                - "2024-06-11T00:21:20.0656437Z"
+                - "2024-06-14T21:46:23.5480650Z"
         status: 200 OK
         code: 200
-        duration: 145.9762ms
+        duration: 139.8269ms
 ---
-env_name: azdtest-wa68d26
-time: "1718064715"
+env_name: azdtest-wb1885c
+time: "1718400745"


### PR DESCRIPTION
Resolves #3958 

This update moves away from manually reading Azure deployment outputs to leveraging the Outputs API directly from the ADE team. This enables a seamless outputs experience across their supported runners including ARM, Bicep, Terraform and other custom runners.