### PR TITLE
dotnet: Set `DOTNET_NOLOGO` when running external commands

### DIFF
--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -144,6 +144,7 @@ mysqldb
 nobanner
 nodeapp
 nolint
+nologo
 notrail
 omitempty
 oneauth

--- a/cli/azd/pkg/tools/dotnet/dotnet.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet.go
@@ -316,6 +316,7 @@ func newDotNetRunArgs(args ...string) exec.RunArgs {
 
 	runArgs = runArgs.WithEnv([]string{
 		"DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE=1",
+		"DOTNET_NOLOGO=1",
 	})
 
 	return runArgs


### PR DESCRIPTION
Per https://learn.microsoft.com/dotnet/core/tools/dotnet-environment-variables#dotnet_nologo:

> Specifies whether .NET welcome and telemetry messages are displayed
  on the first run. Set to true to mute these messages (values `true`,
  `1`, or `yes` accepted) or set to false to allow them (values
  `false`, `0`, or `no` accepted). If not set, the default is `false`
  and the messages will be displayed on the first run.

Since there are cases where we interpret the output of the `dotnet` CLI (for example, when calling `dotnet msbuild
--getProperty:IsAspireHost`) we should set this value to ensure that this message is not printed, which would break our deserialization logic, which expects just JSON data to be printed to stdout.

Fixes #4513