### PR TITLE
init: surface minimal option

### DIFF
--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -21,11 +21,6 @@ import (
 	"github.com/braydonk/yaml"
 )
 
-const (
-	//nolint:lll
-	projectSchemaAnnotation = "# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json"
-)
-
 func New(ctx context.Context, projectFilePath string, projectName string) (*ProjectConfig, error) {
 	newProject := &ProjectConfig{
 		Name: projectName,
@@ -257,7 +252,15 @@ func Save(ctx context.Context, projectConfig *ProjectConfig, projectFilePath str
 		return fmt.Errorf("marshalling project yaml: %w", err)
 	}
 
-	projectFileContents := bytes.NewBufferString(projectSchemaAnnotation + "\n\n")
+	version := "v1.0"
+	if projectConfig.MetaSchemaVersion != "" {
+		version = projectConfig.MetaSchemaVersion
+	}
+
+	annotation := fmt.Sprintf(
+		"# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/%s/azure.yaml.json",
+		version)
+	projectFileContents := bytes.NewBufferString(annotation + "\n\n")
 	_, err = projectFileContents.Write(projectBytes)
 	if err != nil {
 		return fmt.Errorf("preparing new project file contents: %w", err)

--- a/cli/azd/pkg/project/project_config.go
+++ b/cli/azd/pkg/project/project_config.go
@@ -17,6 +17,12 @@ import (
 // When changing project structure, make sure to update the JSON schema file for azure.yaml (<workspace
 // root>/schemas/vN.M/azure.yaml.json).
 type ProjectConfig struct {
+	// Metadata that specifies the schema version.
+	//
+	// This is currently only used during [Save] to write the file schema annotation for intellisense.
+	// This should include the "v" prefix used in official version numbers.
+	MetaSchemaVersion string `yaml:"-"`
+
 	RequiredVersions  *RequiredVersions          `yaml:"requiredVersions,omitempty"`
 	Name              string                     `yaml:"name"`
 	ResourceGroupName osutil.ExpandableString    `yaml:"resourceGroup,omitempty"`

--- a/cli/azd/pkg/templates/template_manager.go
+++ b/cli/azd/pkg/templates/template_manager.go
@@ -181,18 +181,16 @@ func (tm *TemplateManager) createSourcesFromConfig(
 }
 
 // PromptTemplate asks the user to select a template.
-// An empty Template can be returned if the user selects the minimal template. This corresponds to the minimal azd template.
-// See
 func PromptTemplate(
 	ctx context.Context,
 	message string,
 	templateManager *TemplateManager,
 	console input.Console,
 	options *ListOptions,
-) (*Template, error) {
+) (Template, error) {
 	templates, err := templateManager.ListTemplates(ctx, options)
 	if err != nil {
-		return nil, fmt.Errorf("prompting for template: %w", err)
+		return Template{}, fmt.Errorf("prompting for template: %w", err)
 	}
 
 	templateChoices := []*Template{}
@@ -213,12 +211,6 @@ func PromptTemplate(
 
 	templateNames := make([]string, 0, len(templates)+1)
 	templateDetails := make([]string, 0, len(templates)+1)
-
-	// Prepend the minimal template option to guarantee first selection
-	minimalChoice := "Minimal"
-
-	templateNames = append(templateNames, minimalChoice)
-	templateDetails = append(templateDetails, "")
 
 	for _, template := range templates {
 		templateChoice := template.Name
@@ -248,15 +240,11 @@ func PromptTemplate(
 	console.Message(ctx, "")
 
 	if err != nil {
-		return nil, fmt.Errorf("prompting for template: %w", err)
+		return Template{}, fmt.Errorf("prompting for template: %w", err)
 	}
 
-	if selected == 0 {
-		return nil, nil
-	}
-
-	template := templates[selected-1]
+	template := templates[selected]
 	log.Printf("Selected template: %s", fmt.Sprint(template.RepositoryPath))
 
-	return template, nil
+	return *template, nil
 }

--- a/cli/azd/test/functional/init_test.go
+++ b/cli/azd/test/functional/init_test.go
@@ -28,11 +28,13 @@ func Test_CLI_Init_Minimal(t *testing.T) {
 
 	cli := azdcli.NewCLI(t)
 	cli.WorkingDirectory = dir
-	cli.Env = append(os.Environ(), "AZURE_LOCATION=eastus2")
+	cli.Env = append(os.Environ(),
+		"AZURE_LOCATION=eastus2",
+		"AZD_ALPHA_ENABLE_COMPOSE=0")
 
 	_, err := cli.RunCommandWithStdIn(
 		ctx,
-		"Select a template\nMinimal\nTESTENV\n",
+		"Create a minimal project\nTESTENV\n",
 		"init",
 	)
 	require.NoError(t, err)
@@ -60,7 +62,9 @@ func Test_CLI_Init_Minimal_With_Existing_Infra(t *testing.T) {
 
 	cli := azdcli.NewCLI(t)
 	cli.WorkingDirectory = dir
-	cli.Env = append(os.Environ(), "AZURE_LOCATION=eastus2")
+	cli.Env = append(os.Environ(),
+		"AZURE_LOCATION=eastus2",
+		"AZD_ALPHA_ENABLE_COMPOSE=0")
 
 	err := os.MkdirAll(filepath.Join(dir, "infra"), osutil.PermissionDirectory)
 	require.NoError(t, err)
@@ -79,9 +83,7 @@ func Test_CLI_Init_Minimal_With_Existing_Infra(t *testing.T) {
 
 	_, err = cli.RunCommandWithStdIn(
 		ctx,
-		"Select a template\n"+
-			"y\n"+ // Say yes to initialize in existing folder
-			"Minimal\n"+ // Choose minimal
+		"Create a minimal project\n"+
 			"TESTENV\n", // Provide environment name
 		"init",
 	)
@@ -118,12 +120,13 @@ func Test_CLI_Init_WithinExistingProject(t *testing.T) {
 
 	cli := azdcli.NewCLI(t)
 	cli.WorkingDirectory = dir
-	cli.Env = append(os.Environ(), "AZURE_LOCATION=eastus2")
+	cli.Env = append(os.Environ(),
+		"AZURE_LOCATION=eastus2")
 
 	// Setup: Create a project
 	_, err := cli.RunCommandWithStdIn(
 		ctx,
-		"Select a template\nMinimal\nTESTENV\n",
+		"Create a minimal project\nTESTENV\n",
 		"init",
 	)
 	require.NoError(t, err)
@@ -134,7 +137,7 @@ func Test_CLI_Init_WithinExistingProject(t *testing.T) {
 	// Verify init within a nested directory. This should end up creating a new project.
 	_, err = cli.RunCommandWithStdIn(
 		ctx,
-		"Select a template\nMinimal\nTESTENV\n",
+		"Create a minimal project\nTESTENV\n",
 		"init",
 		"--cwd",
 		"nested",


### PR DESCRIPTION
This change surfaces "Create a minimal project" as a main menu option in `init`.

**Background**: Before this change, initializing a minimal project would require selecting "Initialize a template -> Minimal". This was found to be confusing for users during user studies. There has also been general user feedback about discoverability with this flow.

**Functional changes**: When compose is enabled, only a project file is generated. When compose is not enabled, the previous functional behavior is retained -- no UX changes made.

UX (compose enabled):
![image](https://github.com/user-attachments/assets/54a1249f-0650-4c26-9a4b-e06bb9917e98)

Contributes to #4397,  https://github.com/Azure/azure-dev-pr/issues/1682 