### PR TITLE
vscode signing

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -7,7 +7,7 @@ resources:
     - repository: azure-sdk-build-tools
       type: git
       name: internal/azure-sdk-build-tools
-      ref: refs/tags/azure-sdk-build-tools_20241025.1
+      ref: djurek/vsix-signing
 
 parameters:
 - name: stages

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -7,7 +7,7 @@ resources:
     - repository: azure-sdk-build-tools
       type: git
       name: internal/azure-sdk-build-tools
-      ref: djurek/vsix-signing
+      ref: refs/heads/djurek/vsix-signing
 
 parameters:
 - name: stages

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -7,7 +7,7 @@ resources:
     - repository: azure-sdk-build-tools
       type: git
       name: internal/azure-sdk-build-tools
-      ref: refs/heads/djurek/vsix-signing
+      ref: refs/tags/azure-sdk-build-tools_20241025.1
 
 parameters:
 - name: stages

--- a/eng/pipelines/templates/stages/vscode-publish-manual.yml
+++ b/eng/pipelines/templates/stages/vscode-publish-manual.yml
@@ -42,6 +42,7 @@ stages:
                     PublishLocations: vscode/release/$(VSIX_VERSION);vscode/release/latest
                     TagRepository: true
                     UpdateShield: true
+                    PublishToMarketplace: true
 
       - deployment: Increment_Version
         condition: >-

--- a/eng/pipelines/templates/stages/vscode-sign.yml
+++ b/eng/pipelines/templates/stages/vscode-sign.yml
@@ -22,6 +22,14 @@ stages:
               artifact: vsix
               path: vsix
 
+          - task: PowerShell@2
+            inputs:
+              targetType: filePath
+              filePath: eng/scripts/New-VsixSigningManifest.ps1
+              arguments: -Path $(Build.SourcesDirectory)\vsix
+              pwsh: true
+            displayName: Create signing manifest
+
           - ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual') }}:
             - template: pipelines/steps/azd-vscode-signing.yml@azure-sdk-build-tools
               parameters:

--- a/eng/pipelines/templates/stages/vscode-sign.yml
+++ b/eng/pipelines/templates/stages/vscode-sign.yml
@@ -33,7 +33,8 @@ stages:
           - ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual') }}:
             - template: pipelines/steps/azd-vscode-signing.yml@azure-sdk-build-tools
               parameters:
-                VsixPath: vsix
+                Path: $(Build.SourcesDirectory)\vsix
+                Pattern: '*.signature.p7s'
 
           - ${{ else }}:
             - pwsh: Write-Host "Skipping signing. Build reason - $(Build.Reason)"

--- a/eng/pipelines/templates/steps/publish-vscode.yml
+++ b/eng/pipelines/templates/steps/publish-vscode.yml
@@ -3,6 +3,7 @@ parameters:
   VsixVersion: $(VSIX_VERSION)
   UpdateShield: false
   StorageContainerName: azd
+  PublishToMarketplace: false
 
 steps:
   - task: DownloadPipelineArtifact@2
@@ -26,8 +27,13 @@ steps:
   - pwsh: |
       New-Item -ItemType Directory -Path release -Force
       Copy-Item signed/vsix/*.vsix release/
+      Copy-Item signed/vsix/*.p7s release/
+      Copy-Item signed/vsix/*.manifest release/
       Write-Host "Signed:"
       Get-ChildItem signed/
+
+      Write-Host "Release:"
+      Get-ChildItem release/
     displayName: Copy signed vsix to release location
 
   - task: AzurePowerShell@5
@@ -76,3 +82,15 @@ steps:
       displayName: Create GitHub Release and upload artifacts
       env:
         GH_TOKEN: $(azuresdk-github-pat)
+
+  - ${{ if eq('true', parameters.PublishToMarketplace) }}:
+    - task: AzureCLI@2
+      displayName: Publish (using vsce)
+      inputs:
+        azureSubscription: azure-sdk-vsmarketplace
+        scriptType: pscore
+        scriptLocation: inlineScript
+        workingDirectory: release
+        inlineScript: |
+          npm install -g @vscode/vsce
+          vsce publish --azure-credential

--- a/eng/pipelines/templates/steps/publish-vscode.yml
+++ b/eng/pipelines/templates/steps/publish-vscode.yml
@@ -93,4 +93,9 @@ steps:
         workingDirectory: release
         inlineScript: |
           npm install -g @vscode/vsce
-          vsce publish --azure-credential
+          $baseName = "azure-dev-${{ parameters.VsixVersion }}"
+          vsce publish `
+            --azure-credential `
+            --packagePath "$($baseName).vsix" `
+            --manifestPath "$($baseName).manifest" `
+            --signaturePath "$($baseName).p7s"

--- a/eng/scripts/New-VsixSigningManifest.ps1
+++ b/eng/scripts/New-VsixSigningManifest.ps1
@@ -1,0 +1,24 @@
+param(
+    [string]$Path = "$PSScriptRoot../../vsix"
+)
+
+$originalLocation = Get-Location
+try {
+    Set-Location $Path
+    $extensions = Get-ChildItem -Filter *.vsix -Recurse -File
+    foreach ($extension in $extensions) {
+        Write-Host "Generating signing manifest for $extension"
+        $manifestName = "$($extension.BaseName).manifest"
+        $signatureName = "$($extension.BaseName).signature.p7s"
+
+        npm exec --yes @vscode/vsce@latest -- generate-manifest --packagePath "$($extension.FullName)" -o $manifestName | Write-Host
+        if ($LASTEXITCODE) {
+            Write-Host "Failed to generate signing manifest for $extension"
+            exit $LASTEXITCODE
+        }
+
+        Copy-Item $manifestName $signatureName
+    }
+} finally {
+    Set-Location $originalLocation
+}


### PR DESCRIPTION
**DO NOT MERGE UNTIL 1es-redirect.yml is reverted** 

Uses `vsce` to prepare extension for signing and signs using ESRP. 

Signature verification example: 

```
> vsce verify-signature --packagePath E:\temp\vsix-sign\vsix-4\azure-dev-0.9.0-alpha.1.vsix --manifestPath E:\temp\vsix-sign\vsix-4\azure-dev-0.9.0-alpha.1.manifest --signaturePath E:\temp\vsix-sign\vsix-4\azure-dev-0.9.0-alpha.1.signature.p7s
Signature verification result: Success
Package file size:  722521
Signature archive file size:  9075
Manifest file size:  2644
Signature file size:  10359
Manifest file hash:  l6nQX6H2kYvVDTeM5Q+6+v3H6OLwvNgMKHTGQySTnWY=
Signature file hash:  1nMULsj/wyU9SApKOhgKu5d5O/jve4+oLOUaSQAgADg=
Package file hash:  rgG6yUjfu1vC4qJAhwRxA6zduhgx9oozVb68Q5HUHag=
ManifestPackageIntegrityPolicy succeeded.
SignatureIntegrityPolicy for primary signature succeeded.
SignatureValidityPolicy for primary signature succeeded.
SignatureIntegrityPolicy for primary timestamp signature succeeded.
SignatureValidityPolicy for primary timestamp signature succeeded.
X.509 certificate chain validation will use the current user's trust store for timestamping.
SignatureTrustPolicy for publisher primary signature timestamp signature succeeded.
X.509 certificate chain validation will use the current user's trust store for code signing.
SignatureTrustPolicy for publisher primary signature succeeded.
RepositoryCountersignaturePolicy for repository countersignature succeeded with NotPresent.
Primary signature type:  publisher primary signature
Primary signature status:  OK
Timestamp signature status:  OK
Repository countersignature status:  NotPresent
Repository countersignature timestamp status:  Unset
Exit code:  Success
```