### PR TITLE
compose: `show <resource>`

### DIFF
--- a/cli/azd/cmd/testdata/TestUsage-azd-show.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-show.snap
@@ -8,6 +8,7 @@ Flags
         --docs               	: Opens the documentation for azd show in your web browser.
     -e, --environment string 	: The name of the environment to use.
     -h, --help               	: Gets help for show.
+        --show-secrets       	: Unmask secrets in output.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.

--- a/cli/azd/internal/cmd/add/add_preview.go
+++ b/cli/azd/internal/cmd/add/add_preview.go
@@ -24,7 +24,7 @@ type resourceMeta struct {
 	UseEnvVars []string
 }
 
-func metadata(r *project.ResourceConfig) resourceMeta {
+func Metadata(r *project.ResourceConfig) resourceMeta {
 	res := resourceMeta{}
 
 	// These are currently duplicated, static values maintained separately from the backend generation files
@@ -60,7 +60,7 @@ func metadata(r *project.ResourceConfig) resourceMeta {
 			"MONGODB_URL",
 		}
 	case project.ResourceTypeOpenAiModel:
-		res.AzureResourceType = "Microsoft.CognitiveAccounts/accounts/deployments"
+		res.AzureResourceType = "Microsoft.CognitiveServices/accounts/deployments"
 		res.UseEnvVars = []string{
 			"AZURE_OPENAI_ENDPOINT",
 		}
@@ -100,7 +100,7 @@ func (a *AddAction) previewProvision(
 	w := tabwriter.NewWriter(&previewWriter, 0, 0, 5, ' ', 0)
 
 	fmt.Fprintln(w, "b  Name\tResource type")
-	meta := metadata(resourceToAdd)
+	meta := Metadata(resourceToAdd)
 	fmt.Fprintf(w, "+  %s\t%s\n", resourceToAdd.Name, meta.AzureResourceType)
 
 	w.Flush()
@@ -111,7 +111,7 @@ func (a *AddAction) previewProvision(
 			if res, ok := prjConfig.Resources[use]; ok {
 				fmt.Fprintf(w, "   %s -> %s\n", resourceToAdd.Name, output.WithBold("%s", use))
 
-				meta := metadata(res)
+				meta := Metadata(res)
 				for _, envVar := range meta.UseEnvVars {
 					fmt.Fprintf(w, "g   + %s\n", envVar)
 				}
@@ -120,7 +120,7 @@ func (a *AddAction) previewProvision(
 			}
 		}
 	} else {
-		meta := metadata(resourceToAdd)
+		meta := Metadata(resourceToAdd)
 
 		for _, usedBy := range usedBy {
 			fmt.Fprintf(w, "   %s -> %s\n", usedBy, output.WithBold("%s", resourceToAdd.Name))

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -217,18 +217,19 @@ func (e *Environment) SetLocation(location string) {
 	e.DotenvSet(LocationEnvVarName, location)
 }
 
-func normalize(key string) string {
-	return strings.ReplaceAll(strings.ToUpper(key), "-", "_")
+// Key returns the environment key name for the given name.
+func Key(name string) string {
+	return strings.ReplaceAll(strings.ToUpper(name), "-", "_")
 }
 
 // GetServiceProperty is shorthand for Getenv(SERVICE_$SERVICE_NAME_$PROPERTY_NAME)
 func (e *Environment) GetServiceProperty(serviceName string, propertyName string) string {
-	return e.Getenv(fmt.Sprintf("SERVICE_%s_%s", normalize(serviceName), propertyName))
+	return e.Getenv(fmt.Sprintf("SERVICE_%s_%s", Key(serviceName), propertyName))
 }
 
 // Sets the value of a service-namespaced property in the environment.
 func (e *Environment) SetServiceProperty(serviceName string, propertyName string, value string) {
-	e.DotenvSet(fmt.Sprintf("SERVICE_%s_%s", normalize(serviceName), propertyName), value)
+	e.DotenvSet(fmt.Sprintf("SERVICE_%s_%s", Key(serviceName), propertyName), value)
 }
 
 // Creates a slice of key value pairs, based on the entries in the `.env` file like `KEY=VALUE` that

--- a/cli/azd/pkg/infra/util.go
+++ b/cli/azd/pkg/infra/util.go
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package infra
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+)
+
+// ResourceId returns the resource ID for the corresponding name.
+//
+// If the name is a resource ID string, it is immediately parsed without translation.
+func ResourceId(name string, env *environment.Environment) (resId *arm.ResourceID, err error) {
+	resId, err = arm.ParseResourceID(name)
+	if err == nil {
+		return resId, nil
+	}
+
+	key := fmt.Sprintf("AZURE_RESOURCE_%s_ID", environment.Key(name))
+	resourceId, ok := env.LookupEnv(key)
+	if !ok {
+		return resId, fmt.Errorf("%s is not set as an output variable", key)
+	}
+
+	if resourceId == "" {
+		return resId, fmt.Errorf("%s is empty", key)
+	}
+
+	resId, err = arm.ParseResourceID(resourceId)
+	if err != nil {
+		return resId, fmt.Errorf("parsing %s: %w", key, err)
+	}
+
+	return resId, nil
+}

--- a/cli/azd/pkg/output/ux/show.go
+++ b/cli/azd/pkg/output/ux/show.go
@@ -5,6 +5,7 @@ package ux
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -14,6 +15,38 @@ import (
 type ShowService struct {
 	Name      string
 	IngresUrl string
+	Env       map[string]string
+}
+
+func (s *ShowService) ToString(currentIndentation string) string {
+	return fmt.Sprintf(
+		"%s\n"+
+			"  Endpoint: %s\n"+
+			"  Environment variables:\n"+
+			color.HiBlueString(formatEnv("    ", s.Env)),
+		color.HiMagentaString("%s (Container App)", s.Name),
+		output.WithLinkFormat(s.IngresUrl))
+}
+
+func (s *ShowService) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func formatEnv(prefix string, values map[string]string) string {
+	environ := make([]string, 0, len(values))
+	for k, v := range values {
+		environ = append(environ, k+"="+v)
+	}
+	slices.Sort(environ)
+
+	var sb strings.Builder
+	for _, env := range environ {
+		sb.WriteString(prefix)
+		sb.WriteString(env)
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
 }
 
 type ShowEnvironment struct {

--- a/cli/azd/pkg/project/scaffold_gen.go
+++ b/cli/azd/pkg/project/scaffold_gen.go
@@ -270,6 +270,8 @@ func mapHostUses(
 			svcSpec.Frontend.Backends = append(svcSpec.Frontend.Backends,
 				scaffold.ServiceReference{Name: use})
 			backendMapping[use] = res.Name // record the backend -> frontend mapping
+		case ResourceTypeOpenAiModel:
+			svcSpec.AIModels = append(svcSpec.AIModels, scaffold.AIModelReference{Name: use})
 		}
 	}
 

--- a/cli/azd/resources/scaffold/templates/main.bicept
+++ b/cli/azd/resources/scaffold/templates/main.bicept
@@ -52,11 +52,19 @@ module resources 'resources.bicep' = {
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = resources.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT
 output AZURE_KEY_VAULT_ENDPOINT string = resources.outputs.AZURE_KEY_VAULT_ENDPOINT
 output AZURE_KEY_VAULT_NAME string = resources.outputs.AZURE_KEY_VAULT_NAME
+{{- range .Services}}
+output AZURE_RESOURCE_{{alphaSnakeUpper .Name}}_ID string = resources.outputs.AZURE_RESOURCE_{{alphaSnakeUpper .Name}}_ID
+{{- end}}
+{{- end}}
+{{- if  .AIModels}}
+{{- range .AIModels}}
+output AZURE_RESOURCE_{{alphaSnakeUpper .Name}}_ID string = resources.outputs.AZURE_RESOURCE_{{alphaSnakeUpper .Name}}_ID
+{{- end}}
 {{- end}}
 {{- if .DbRedis}}
-output AZURE_CACHE_REDIS_ID string = resources.outputs.AZURE_CACHE_REDIS_ID
+output AZURE_RESOURCE_REDIS_ID string = resources.outputs.AZURE_RESOURCE_REDIS_ID
 {{- end}}
 {{- if .DbPostgres}}
-output AZURE_POSTGRES_FLEXIBLE_SERVER_ID string = resources.outputs.AZURE_POSTGRES_FLEXIBLE_SERVER_ID
+output AZURE_RESOURCE_{{alphaSnakeUpper .DbPostgres.DatabaseName}}_ID string = resources.outputs.AZURE_RESOURCE_{{alphaSnakeUpper .DbPostgres.DatabaseName}}_ID
 {{- end}}
 {{ end}}

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -450,14 +450,19 @@ module keyVault 'br/public:avm/res/key-vault/vault:0.6.1' = {
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.outputs.loginServer
 output AZURE_KEY_VAULT_ENDPOINT string = keyVault.outputs.uri
 output AZURE_KEY_VAULT_NAME string = keyVault.outputs.name
+{{- range .Services}}
+output AZURE_RESOURCE_{{alphaSnakeUpper .Name}}_ID string = {{bicepName .Name}}.outputs.resourceId
+{{- end}}
 {{- end}}
 {{- if  .AIModels}}
-output AZURE_COGNITIVE_ACCOUNT_ID string = account.outputs.resourceId
+{{- range .AIModels}}
+output AZURE_RESOURCE_{{alphaSnakeUpper .Name}}_ID string = '${account.outputs.resourceId}/deployments/{{.Name}}'
+{{- end}}
 {{- end}}
 {{- if .DbRedis}}
-output AZURE_CACHE_REDIS_ID string = redis.outputs.resourceId
+output AZURE_RESOURCE_REDIS_ID string = redis.outputs.resourceId
 {{- end}}
 {{- if .DbPostgres}}
-output AZURE_POSTGRES_FLEXIBLE_SERVER_ID string = postgreServer.outputs.resourceId
+output AZURE_RESOURCE_{{alphaSnakeUpper .DbPostgres.DatabaseName}}_ID string = '${postgreServer.outputs.resourceId}/databases/{{.DbPostgres.DatabaseName}}'
 {{- end}}
 {{ end}}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v2 v2.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.1.1
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.4.1
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v0.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v2 v2.6.0

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthoriza
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.1.1/go.mod h1:WqyxV5S0VtXD2+2d6oPqOvyhGubCvzLCKSAKgQ004Uk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.4.1 h1:ynIxbR7wH5nBEJzprbeBFVBtoYTYcQbN39vM7eNS3Xc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.4.1/go.mod h1:nUhnLNlOtAVpn/PRwJKIf3ulXLvdMiWlGk8nufEUaKc=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.6.0 h1:TiYjDq0LCNgtee1teMayYT5FjHmlunWUpthVANUXYPM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.6.0/go.mod h1:yErdzWZBzjNJCnbC1DcUcSVhjTgllT4PyOenFSeXSJI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v0.6.0 h1:Z5/bDxQL2Zc9t6ZDwdRU60bpLHZvoKOeuaM7XVbf2z0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v0.6.0/go.mod h1:0FPu3oDRGPvuX1H8TtHJ5XGA0KrXLunomcixR+PQGGA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.2.0 h1:3L+gX5ssCABAToH0VQ64/oNz7rr+ShW+2sB+sonzIlY=


### PR DESCRIPTION
Allow for `show <resource>`

The only supported resources are: Container Apps, and Open AI Models.

Contributes to #4397,  https://github.com/Azure/azure-dev-pr/issues/1682 