### PR TITLE
compose: with existing infra

### DIFF
--- a/cli/azd/internal/vsrpc/environment_service_refresh.go
+++ b/cli/azd/internal/vsrpc/environment_service_refresh.go
@@ -88,7 +88,7 @@ func (s *environmentService) refreshEnvironmentAsync(
 
 	_ = observer.OnNext(ctx, newInfoProgressMessage("Loading latest deployment information"))
 
-	deployment, err := bicepProvider.LastDeployment(ctx)
+	deployment, err := bicepProvider.LastRootDeployment(ctx)
 	if err != nil {
 		log.Printf("failed to get latest deployment result: %v", err)
 	} else {

--- a/cli/azd/pkg/azapi/resource_service.go
+++ b/cli/azd/pkg/azapi/resource_service.go
@@ -2,8 +2,11 @@ package azapi
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"slices"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
@@ -194,6 +197,11 @@ func (rs *ResourceService) DeleteResourceGroup(ctx context.Context, subscription
 	}
 
 	poller, err := client.BeginDelete(ctx, resourceGroupName, nil)
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) && respErr.StatusCode == 404 { // Resource group is already deleted
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("beginning resource group deletion: %w", err)
 	}
@@ -259,12 +267,16 @@ func GroupByResourceGroup(resources []*armresources.ResourceReference) (map[stri
 
 		resourceType := resourceId.ResourceType.String()
 		if resourceType != string(AzureResourceTypeResourceGroup) {
-			groupResources = append(groupResources, &Resource{
-				Id:       *resource.ID,
-				Name:     resourceId.Name,
-				Type:     resourceType,
-				Location: resourceId.Location,
-			})
+			if !slices.ContainsFunc(groupResources, func(r *Resource) bool {
+				return r.Id == *resource.ID
+			}) {
+				groupResources = append(groupResources, &Resource{
+					Id:       *resource.ID,
+					Name:     resourceId.Name,
+					Type:     resourceType,
+					Location: resourceId.Location,
+				})
+			}
 		}
 
 		resourceMap[resourceId.ResourceGroupName] = groupResources

--- a/cli/azd/pkg/azure/tags.go
+++ b/cli/azd/pkg/azure/tags.go
@@ -7,6 +7,11 @@ const (
 	// TagKeyAzdEnvName is the name of the key in the tags map of a resource
 	// used to store the azd environment a resource is associated with.
 	TagKeyAzdEnvName = "azd-env-name"
+
+	// TagKeyAzdModuleName is the name of the key in the tags map of a resource
+	// used to store the Bicep module a resource is associated with.
+	TagKeyAzdModuleName = "azd-module-name"
+
 	/* #nosec G101 - Potential hardcoded credentials - false positive */
 	// TagKeyAzdDeploymentStateParamHashName is the name of the key in the tags map of a deployment
 	// used to store the parameters hash.

--- a/cli/azd/pkg/devcenter/provision_provider.go
+++ b/cli/azd/pkg/devcenter/provision_provider.go
@@ -475,7 +475,8 @@ func (p *ProvisionProvider) pollForProgress(ctx context.Context, deployment infr
 	}
 
 	// Report incremental progress
-	progressDisplay := p.deploymentManager.ProgressDisplay(deployment)
+	demoMode, _ := strconv.ParseBool(os.Getenv("AZD_DEMO_MODE"))
+	progressDisplay := p.deploymentManager.ProgressDisplay(demoMode, 1)
 
 	initialDelay := 3 * time.Second
 	regularDelay := 10 * time.Second
@@ -488,7 +489,7 @@ func (p *ProvisionProvider) pollForProgress(ctx context.Context, deployment infr
 			timer.Stop()
 			return
 		case <-timer.C:
-			if err := progressDisplay.ReportProgress(ctx, &queryStartTime); err != nil {
+			if err := progressDisplay.ReportProgress(ctx, deployment, &queryStartTime); err != nil {
 				// We don't want to fail the whole deployment if a progress reporting error occurs
 				log.Printf("error while reporting progress: %s", err.Error())
 			}

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -73,7 +73,7 @@ type BicepProvider struct {
 	curPrincipal          provisioning.CurrentPrincipalIdProvider
 	ignoreDeploymentState bool
 	// compileBicepResult is cached to avoid recompiling the same bicep file multiple times in the same azd run.
-	compileBicepMemoryCache *compileBicepResult
+	compileBicepMemoryCache map[string]compileBicepResult
 	keyvaultService         keyvault.KeyVaultService
 	portalUrlBase           string
 }
@@ -1547,8 +1547,8 @@ type compileBicepResult struct {
 func (p *BicepProvider) compileBicep(
 	ctx context.Context, modulePath string,
 ) (*compileBicepResult, error) {
-	if p.compileBicepMemoryCache != nil {
-		return p.compileBicepMemoryCache, nil
+	if val, ok := p.compileBicepMemoryCache[modulePath]; ok {
+		return &val, nil
 	}
 
 	var compiled string
@@ -1649,13 +1649,14 @@ func (p *BicepProvider) compileBicep(
 			}
 		}
 	}
-	p.compileBicepMemoryCache = &compileBicepResult{
+	result := compileBicepResult{
 		RawArmTemplate: rawTemplate,
 		Template:       template,
 		Parameters:     parameters,
 	}
 
-	return p.compileBicepMemoryCache, nil
+	p.compileBicepMemoryCache[modulePath] = result
+	return &result, nil
 }
 
 func combineMetadata(base map[string]json.RawMessage, override map[string]json.RawMessage) map[string]json.RawMessage {

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -48,7 +48,7 @@ func TestBicepPlan(t *testing.T) {
 	prepareBicepMocks(mockContext)
 	infraProvider := createBicepProvider(t, mockContext)
 
-	deploymentPlan, err := infraProvider.plan(*mockContext.Context)
+	deploymentPlan, err := infraProvider.plan(*mockContext.Context, infraProvider.rootModulePath())
 
 	require.Nil(t, err)
 
@@ -104,7 +104,7 @@ func TestBicepPlanPrompt(t *testing.T) {
 	}).Respond(false)
 
 	infraProvider := createBicepProvider(t, mockContext)
-	plan, err := infraProvider.plan(*mockContext.Context)
+	plan, err := infraProvider.plan(*mockContext.Context, infraProvider.rootModulePath())
 
 	require.NoError(t, err)
 
@@ -290,7 +290,7 @@ func TestPlanForResourceGroup(t *testing.T) {
 	infraProvider := createBicepProvider(t, mockContext)
 	// The computed plan should target the resource group we picked.
 
-	planResult, err := infraProvider.plan(*mockContext.Context)
+	planResult, err := infraProvider.plan(*mockContext.Context, infraProvider.rootModulePath())
 	require.Nil(t, err)
 	require.NotNil(t, planResult)
 	require.Equal(t, "rg-test-env",
@@ -868,7 +868,7 @@ func TestFindCompletedDeployments(t *testing.T) {
 		*mockContext.Context, &mockedScope{
 			baseDate: baseDate,
 			envTag:   envTag,
-		}, envTag, "")
+		}, envTag, "", "")
 	require.NoError(t, err)
 	require.Equal(t, 1, len(deployments))
 	// should take the base date + 2 years

--- a/cli/azd/pkg/infra/provisioning_progress_display_test.go
+++ b/cli/azd/pkg/infra/provisioning_progress_display_test.go
@@ -139,8 +139,8 @@ func TestReportProgress(t *testing.T) {
 	startTime := time.Now()
 	outputLength := 0
 	mockResourceManager := mockResourceManager{}
-	progressDisplay := NewProvisioningProgressDisplay(&mockResourceManager, mockContext.Console, deployment)
-	err := progressDisplay.ReportProgress(*mockContext.Context, &startTime)
+	progressDisplay := NewProvisioningProgressDisplay(&mockResourceManager, mockContext.Console, false, 1)
+	err := progressDisplay.ReportProgress(*mockContext.Context, deployment, &startTime)
 	require.NoError(t, err)
 
 	outputLength++
@@ -148,7 +148,7 @@ func TestReportProgress(t *testing.T) {
 	assert.Contains(t, mockContext.Console.Output()[0], "You can view detailed progress in the Azure Portal:")
 
 	mockResourceManager.AddInProgressOperation()
-	err = progressDisplay.ReportProgress(*mockContext.Context, &startTime)
+	err = progressDisplay.ReportProgress(*mockContext.Context, deployment, &startTime)
 	require.NoError(t, err)
 	assert.Len(t, mockContext.Console.Output(), outputLength)
 }

--- a/cli/azd/pkg/project/importer_test.go
+++ b/cli/azd/pkg/project/importer_test.go
@@ -233,7 +233,8 @@ func TestImportManagerProjectInfrastructure(t *testing.T) {
 		lazyEnvManager: lazy.NewLazy(func() (environment.Manager, error) {
 			return mockEnv, nil
 		}),
-		hostCheck: make(map[string]hostCheckResult),
+		hostCheck:           make(map[string]hostCheckResult),
+		alphaFeatureManager: mockContext.AlphaFeaturesManager,
 	})
 
 	// Do not use defaults


### PR DESCRIPTION
This change allows for composability to work with an existing `infra` directory unmanaged by azd.

**Infra provisioning.** The provisioning engine has been updated to serially provision the root `./infra`, then `./infra/azd` if it exists. The following behavioral changes have been applied:

1. **Deployment order.** Sequential; the progress display shows the root deployment URL, then displays resources created as each deployment runs in the background.
2. **Outputs.** Outputs are written to the environment in the deployment order. This means in cases of output collisions, the last deployment wins.
3. **Preview.** Merge deployment resources into a single preview list, deduplicate resource ID + type.
4. **Destroy.** Merge deployment resources for display, and for purge. For destroy, each deployment is executed sequentially. This works well for stack deployments if resources are mutually exclusive. For standard deployments, this works since the second deletion on RG is a no-opt.
5. **State.** The deployments are fetched and applied to the environment in the same order as the deployment order. This shares the same last-write-win semantics.

**Composability synth.** The synthesized infra directory has a `.azd` file to serve as a sentinel. If `.azd` exists in a directory, i.e. `./infra/foo`, it means the directory `./infra/foo` is "azd managed". This used to achieve the following behavior when running `infra synth`:
- If `./infra/.azd` exists, we overwrite `./infra`.
- Otherwise, we write to `./infra/azd`.

## UX

Provision:
![image](https://github.com/user-attachments/assets/9071bb06-d525-43cc-93b8-4c74fad04e6c)

Destroy:
TBD

Fixes #4578