### PR TITLE
docs: display `--docs` and `--help` as global flags

### DIFF
--- a/cli/azd/cmd/testdata/TestUsage-azd-add.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-add.snap
@@ -4,13 +4,11 @@ Add a component to your project. (Alpha)
 Usage
   azd add [flags]
 
-Flags
-        --docs 	: Opens the documentation for azd add in your web browser.
-    -h, --help 	: Gets help for add.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd add in your web browser.
+    -h, --help       	: Gets help for add.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-auth-login.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-auth-login.snap
@@ -9,9 +9,7 @@ Flags
         --client-certificate string            	: The path to the client certificate for the service principal to authenticate with.
         --client-id string                     	: The client id for the service principal to authenticate with.
         --client-secret string                 	: The client secret for the service principal to authenticate with. Set to the empty string to read the value from the console.
-        --docs                                 	: Opens the documentation for azd auth login in your web browser.
         --federated-credential-provider string 	: The provider to use to acquire a federated token to authenticate with.
-    -h, --help                                 	: Gets help for login.
         --managed-identity                     	: Use a managed identity to authenticate.
         --redirect-port int                    	: Choose the port to be used as part of the redirect URI during interactive login.
         --tenant-id string                     	: The tenant id or domain name to authenticate with.
@@ -20,6 +18,8 @@ Flags
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd auth login in your web browser.
+    -h, --help       	: Gets help for login.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-auth-logout.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-auth-logout.snap
@@ -4,13 +4,11 @@ Log out of Azure.
 Usage
   azd auth logout [flags]
 
-Flags
-        --docs 	: Opens the documentation for azd auth logout in your web browser.
-    -h, --help 	: Gets help for logout.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd auth logout in your web browser.
+    -h, --help       	: Gets help for logout.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-auth.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-auth.snap
@@ -8,13 +8,11 @@ Available Commands
   login 	: Log in to Azure.
   logout	: Log out of Azure.
 
-Flags
-        --docs 	: Opens the documentation for azd auth in your web browser.
-    -h, --help 	: Gets help for auth.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd auth in your web browser.
+    -h, --help       	: Gets help for auth.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Use azd auth [command] --help to view examples and more information about a specific command.

--- a/cli/azd/cmd/testdata/TestUsage-azd-config-get.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-config-get.snap
@@ -4,13 +4,11 @@ Gets a configuration.
 Usage
   azd config get <path> [flags]
 
-Flags
-        --docs 	: Opens the documentation for azd config get in your web browser.
-    -h, --help 	: Gets help for get.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd config get in your web browser.
+    -h, --help       	: Gets help for get.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-config-list-alpha.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-config-list-alpha.snap
@@ -4,13 +4,11 @@ Display the list of available features in alpha stage.
 Usage
   azd config list-alpha [flags]
 
-Flags
-        --docs 	: Opens the documentation for azd config list-alpha in your web browser.
-    -h, --help 	: Gets help for list-alpha.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd config list-alpha in your web browser.
+    -h, --help       	: Gets help for list-alpha.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Examples

--- a/cli/azd/cmd/testdata/TestUsage-azd-config-reset.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-config-reset.snap
@@ -5,13 +5,13 @@ Usage
   azd config reset [flags]
 
 Flags
-        --docs  	: Opens the documentation for azd config reset in your web browser.
     -f, --force 	: Force reset without confirmation.
-    -h, --help  	: Gets help for reset.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd config reset in your web browser.
+    -h, --help       	: Gets help for reset.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-config-set.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-config-set.snap
@@ -4,13 +4,11 @@ Sets a configuration.
 Usage
   azd config set <path> <value> [flags]
 
-Flags
-        --docs 	: Opens the documentation for azd config set in your web browser.
-    -h, --help 	: Gets help for set.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd config set in your web browser.
+    -h, --help       	: Gets help for set.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-config-show.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-config-show.snap
@@ -4,13 +4,11 @@ Show all the configuration values.
 Usage
   azd config show [flags]
 
-Flags
-        --docs 	: Opens the documentation for azd config show in your web browser.
-    -h, --help 	: Gets help for show.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd config show in your web browser.
+    -h, --help       	: Gets help for show.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-config-unset.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-config-unset.snap
@@ -4,13 +4,11 @@ Unsets a configuration.
 Usage
   azd config unset <path> [flags]
 
-Flags
-        --docs 	: Opens the documentation for azd config unset in your web browser.
-    -h, --help 	: Gets help for unset.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd config unset in your web browser.
+    -h, --help       	: Gets help for unset.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-config.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-config.snap
@@ -16,13 +16,11 @@ Available Commands
   show      	: Show all the configuration values.
   unset     	: Unsets a configuration.
 
-Flags
-        --docs 	: Opens the documentation for azd config in your web browser.
-    -h, --help 	: Gets help for config.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd config in your web browser.
+    -h, --help       	: Gets help for config.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Use azd config [command] --help to view examples and more information about a specific command.

--- a/cli/azd/cmd/testdata/TestUsage-azd-deploy.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-deploy.snap
@@ -10,14 +10,14 @@ Usage
 
 Flags
         --all                 	: Deploys all services that are listed in azure.yaml
-        --docs                	: Opens the documentation for azd deploy in your web browser.
     -e, --environment string  	: The name of the environment to use.
         --from-package string 	: Deploys the application from an existing package.
-    -h, --help                	: Gets help for deploy.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd deploy in your web browser.
+    -h, --help       	: Gets help for deploy.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Examples

--- a/cli/azd/cmd/testdata/TestUsage-azd-down.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-down.snap
@@ -5,15 +5,15 @@ Usage
   azd down [flags]
 
 Flags
-        --docs               	: Opens the documentation for azd down in your web browser.
     -e, --environment string 	: The name of the environment to use.
         --force              	: Does not require confirmation before it deletes resources.
-    -h, --help               	: Gets help for down.
         --purge              	: Does not require confirmation before it permanently deletes resources that are soft-deleted by default (for example, key vaults).
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd down in your web browser.
+    -h, --help       	: Gets help for down.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Examples

--- a/cli/azd/cmd/testdata/TestUsage-azd-env-get-value.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env-get-value.snap
@@ -5,13 +5,13 @@ Usage
   azd env get-value <keyName> [flags]
 
 Flags
-        --docs               	: Opens the documentation for azd env get-value in your web browser.
     -e, --environment string 	: The name of the environment to use.
-    -h, --help               	: Gets help for get-value.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd env get-value in your web browser.
+    -h, --help       	: Gets help for get-value.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-env-get-values.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env-get-values.snap
@@ -5,13 +5,13 @@ Usage
   azd env get-values [flags]
 
 Flags
-        --docs               	: Opens the documentation for azd env get-values in your web browser.
     -e, --environment string 	: The name of the environment to use.
-    -h, --help               	: Gets help for get-values.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd env get-values in your web browser.
+    -h, --help       	: Gets help for get-values.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-env-list.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env-list.snap
@@ -4,13 +4,11 @@ List environments.
 Usage
   azd env list [flags]
 
-Flags
-        --docs 	: Opens the documentation for azd env list in your web browser.
-    -h, --help 	: Gets help for list.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd env list in your web browser.
+    -h, --help       	: Gets help for list.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-env-new.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env-new.snap
@@ -5,14 +5,14 @@ Usage
   azd env new <environment> [flags]
 
 Flags
-        --docs                	: Opens the documentation for azd env new in your web browser.
-    -h, --help                	: Gets help for new.
     -l, --location string     	: Azure location for the new environment
         --subscription string 	: Name or ID of an Azure subscription to use for the new environment
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd env new in your web browser.
+    -h, --help       	: Gets help for new.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-env-refresh.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env-refresh.snap
@@ -5,14 +5,14 @@ Usage
   azd env refresh <environment> [flags]
 
 Flags
-        --docs               	: Opens the documentation for azd env refresh in your web browser.
     -e, --environment string 	: The name of the environment to use.
-    -h, --help               	: Gets help for refresh.
         --hint string        	: Hint to help identify the environment to refresh
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd env refresh in your web browser.
+    -h, --help       	: Gets help for refresh.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-env-select.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env-select.snap
@@ -4,13 +4,11 @@ Set the default environment.
 Usage
   azd env select <environment> [flags]
 
-Flags
-        --docs 	: Opens the documentation for azd env select in your web browser.
-    -h, --help 	: Gets help for select.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd env select in your web browser.
+    -h, --help       	: Gets help for select.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-env-set.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env-set.snap
@@ -5,13 +5,13 @@ Usage
   azd env set <key> <value> [flags]
 
 Flags
-        --docs               	: Opens the documentation for azd env set in your web browser.
     -e, --environment string 	: The name of the environment to use.
-    -h, --help               	: Gets help for set.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd env set in your web browser.
+    -h, --help       	: Gets help for set.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-env.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env.snap
@@ -18,13 +18,11 @@ Available Commands
   select    	: Set the default environment.
   set       	: Manage your environment settings.
 
-Flags
-        --docs 	: Opens the documentation for azd env in your web browser.
-    -h, --help 	: Gets help for env.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd env in your web browser.
+    -h, --help       	: Gets help for env.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Use azd env [command] --help to view examples and more information about a specific command.

--- a/cli/azd/cmd/testdata/TestUsage-azd-hooks-run.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-hooks-run.snap
@@ -5,15 +5,15 @@ Usage
   azd hooks run <name> [flags]
 
 Flags
-        --docs               	: Opens the documentation for azd hooks run in your web browser.
     -e, --environment string 	: The name of the environment to use.
-    -h, --help               	: Gets help for run.
         --platform string    	: Forces hooks to run for the specified platform.
         --service string     	: Only runs hooks for the specified service.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd hooks run in your web browser.
+    -h, --help       	: Gets help for run.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-hooks.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-hooks.snap
@@ -7,13 +7,11 @@ Usage
 Available Commands
   run	: Runs the specified hook for the project and services
 
-Flags
-        --docs 	: Opens the documentation for azd hooks in your web browser.
-    -h, --help 	: Gets help for hooks.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd hooks in your web browser.
+    -h, --help       	: Gets help for hooks.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Use azd hooks [command] --help to view examples and more information about a specific command.

--- a/cli/azd/cmd/testdata/TestUsage-azd-init.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-init.snap
@@ -9,11 +9,9 @@ Usage
 
 Flags
     -b, --branch string       	: The template branch to initialize from. Must be used with a template argument (--template or -t).
-        --docs                	: Opens the documentation for azd init in your web browser.
     -e, --environment string  	: The name of the environment to use.
     -f, --filter strings      	: The tag(s) used to filter template results. Supports comma-separated values.
         --from-code           	: Initializes a new application from your existing code.
-    -h, --help                	: Gets help for init.
     -l, --location string     	: Azure location for the new environment
     -s, --subscription string 	: Name or ID of an Azure subscription to use for the new environment
     -t, --template string     	: Initializes a new application from a template. You can use Full URI, <owner>/<repository>, or <repository> if it's part of the azure-samples organization.
@@ -21,6 +19,8 @@ Flags
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd init in your web browser.
+    -h, --help       	: Gets help for init.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Examples

--- a/cli/azd/cmd/testdata/TestUsage-azd-monitor.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-monitor.snap
@@ -5,9 +5,7 @@ Usage
   azd monitor [flags]
 
 Flags
-        --docs               	: Opens the documentation for azd monitor in your web browser.
     -e, --environment string 	: The name of the environment to use.
-    -h, --help               	: Gets help for monitor.
         --live               	: Open a browser to Application Insights Live Metrics. Live Metrics is currently not supported for Python apps.
         --logs               	: Open a browser to Application Insights Logs.
         --overview           	: Open a browser to Application Insights Overview Dashboard.
@@ -15,6 +13,8 @@ Flags
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd monitor in your web browser.
+    -h, --help       	: Gets help for monitor.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Examples

--- a/cli/azd/cmd/testdata/TestUsage-azd-package.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-package.snap
@@ -10,14 +10,14 @@ Usage
 
 Flags
         --all                	: Packages all services that are listed in azure.yaml
-        --docs               	: Opens the documentation for azd package in your web browser.
     -e, --environment string 	: The name of the environment to use.
-    -h, --help               	: Gets help for package.
         --output-path string 	: File or folder path where the generated packages will be saved.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd package in your web browser.
+    -h, --help       	: Gets help for package.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Examples

--- a/cli/azd/cmd/testdata/TestUsage-azd-pipeline-config.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-pipeline-config.snap
@@ -11,9 +11,7 @@ Usage
 Flags
     -m, --applicationServiceManagementReference string 	: Service Management Reference. References application or service contact information from a Service or Asset Management database. This value must be a Universally Unique Identifier (UUID). You can set this value globally by running azd config set pipeline.config.applicationServiceManagementReference <UUID>.
         --auth-type string                             	: The authentication type used between the pipeline provider and Azure for deployment (Only valid for GitHub provider). Valid values: federated, client-credentials.
-        --docs                                         	: Opens the documentation for azd pipeline config in your web browser.
     -e, --environment string                           	: The name of the environment to use.
-    -h, --help                                         	: Gets help for config.
         --principal-id string                          	: The client id of the service principal to use to grant access to Azure resources as part of the pipeline.
         --principal-name string                        	: The name of the service principal to use to grant access to Azure resources as part of the pipeline.
         --principal-role stringArray                   	: The roles to assign to the service principal. By default the service principal will be granted the Contributor and User Access Administrator roles.
@@ -23,6 +21,8 @@ Flags
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd pipeline config in your web browser.
+    -h, --help       	: Gets help for config.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Examples

--- a/cli/azd/cmd/testdata/TestUsage-azd-pipeline.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-pipeline.snap
@@ -11,13 +11,11 @@ Usage
 Available Commands
   config	: Configure your deployment pipeline to connect securely to Azure. (Beta)
 
-Flags
-        --docs 	: Opens the documentation for azd pipeline in your web browser.
-    -h, --help 	: Gets help for pipeline.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd pipeline in your web browser.
+    -h, --help       	: Gets help for pipeline.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Use azd pipeline [command] --help to view examples and more information about a specific command.

--- a/cli/azd/cmd/testdata/TestUsage-azd-provision.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-provision.snap
@@ -10,15 +10,15 @@ Usage
   azd provision [flags]
 
 Flags
-        --docs               	: Opens the documentation for azd provision in your web browser.
     -e, --environment string 	: The name of the environment to use.
-    -h, --help               	: Gets help for provision.
         --no-state           	: Do not use latest Deployment State (bicep only).
         --preview            	: Preview changes to Azure resources.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd provision in your web browser.
+    -h, --help       	: Gets help for provision.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-restore.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-restore.snap
@@ -9,13 +9,13 @@ Usage
 
 Flags
         --all                	: Restores all services that are listed in azure.yaml
-        --docs               	: Opens the documentation for azd restore in your web browser.
     -e, --environment string 	: The name of the environment to use.
-    -h, --help               	: Gets help for restore.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd restore in your web browser.
+    -h, --help       	: Gets help for restore.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Examples

--- a/cli/azd/cmd/testdata/TestUsage-azd-show.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-show.snap
@@ -5,13 +5,13 @@ Usage
   azd show [flags]
 
 Flags
-        --docs               	: Opens the documentation for azd show in your web browser.
     -e, --environment string 	: The name of the environment to use.
-    -h, --help               	: Gets help for show.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd show in your web browser.
+    -h, --help       	: Gets help for show.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-template-list.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-template-list.snap
@@ -5,14 +5,14 @@ Usage
   azd template list [flags]
 
 Flags
-        --docs           	: Opens the documentation for azd template list in your web browser.
     -f, --filter strings 	: The tag(s) used to filter template results. Supports comma-separated values.
-    -h, --help           	: Gets help for list.
     -s, --source string  	: Filters templates by source.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd template list in your web browser.
+    -h, --help       	: Gets help for list.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-template-show.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-template-show.snap
@@ -4,13 +4,11 @@ Show details for a given template. (Beta)
 Usage
   azd template show <template> [flags]
 
-Flags
-        --docs 	: Opens the documentation for azd template show in your web browser.
-    -h, --help 	: Gets help for show.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd template show in your web browser.
+    -h, --help       	: Gets help for show.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-template-source-add.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-template-source-add.snap
@@ -9,8 +9,6 @@ Usage
   azd template source add <key> [flags]
 
 Flags
-        --docs            	: Opens the documentation for azd template source add in your web browser.
-    -h, --help            	: Gets help for add.
     -l, --location string 	: Location of the template source. Required when using type flag.
     -n, --name string     	: Display name of the template source.
     -t, --type string     	: Kind of the template source. Supported types are 'file', 'url' and 'gh'.
@@ -18,6 +16,8 @@ Flags
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd template source add in your web browser.
+    -h, --help       	: Gets help for add.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Examples

--- a/cli/azd/cmd/testdata/TestUsage-azd-template-source-list.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-template-source-list.snap
@@ -4,13 +4,11 @@ Lists the configured azd template sources. (Beta)
 Usage
   azd template source list [flags]
 
-Flags
-        --docs 	: Opens the documentation for azd template source list in your web browser.
-    -h, --help 	: Gets help for list.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd template source list in your web browser.
+    -h, --help       	: Gets help for list.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-template-source-remove.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-template-source-remove.snap
@@ -4,13 +4,11 @@ Removes the specified azd template source (Beta)
 Usage
   azd template source remove <key> [flags]
 
-Flags
-        --docs 	: Opens the documentation for azd template source remove in your web browser.
-    -h, --help 	: Gets help for remove.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd template source remove in your web browser.
+    -h, --help       	: Gets help for remove.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-template-source.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-template-source.snap
@@ -12,13 +12,11 @@ Available Commands
   list  	: Lists the configured azd template sources. (Beta)
   remove	: Removes the specified azd template source (Beta)
 
-Flags
-        --docs 	: Opens the documentation for azd template source in your web browser.
-    -h, --help 	: Gets help for source.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd template source in your web browser.
+    -h, --help       	: Gets help for source.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Use azd template source [command] --help to view examples and more information about a specific command.

--- a/cli/azd/cmd/testdata/TestUsage-azd-template.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-template.snap
@@ -13,13 +13,11 @@ Available Commands
   show  	: Show details for a given template. (Beta)
   source	: View and manage template sources. (Beta)
 
-Flags
-        --docs 	: Opens the documentation for azd template in your web browser.
-    -h, --help 	: Gets help for template.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd template in your web browser.
+    -h, --help       	: Gets help for template.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Use azd template [command] --help to view examples and more information about a specific command.

--- a/cli/azd/cmd/testdata/TestUsage-azd-up.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-up.snap
@@ -20,13 +20,13 @@ Usage
   azd up [flags]
 
 Flags
-        --docs               	: Opens the documentation for azd up in your web browser.
     -e, --environment string 	: The name of the environment to use.
-    -h, --help               	: Gets help for up.
 
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd up in your web browser.
+    -h, --help       	: Gets help for up.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd-version.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-version.snap
@@ -4,13 +4,11 @@ Print the version number of Azure Developer CLI.
 Usage
   azd version [flags]
 
-Flags
-        --docs 	: Opens the documentation for azd version in your web browser.
-    -h, --help 	: Gets help for version.
-
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd version in your web browser.
+    -h, --help       	: Gets help for version.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
 
 Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.

--- a/cli/azd/cmd/testdata/TestUsage-azd.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd.snap
@@ -32,9 +32,11 @@ Commands
 Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.
-        --docs       	: Opens the documentation for azd in your web browser.
-    -h, --help       	: Gets help for azd.
         --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
+
+Global Flags
+        --docs 	: Opens the documentation for azd in your web browser.
+    -h, --help 	: Gets help for azd.
 
 Use azd [command] --help to view examples and more information about a specific command.
 


### PR DESCRIPTION
Display `--docs` and `--help` as global flags.

`--docs` and `--help` are implemented underneath-the-covers as a command-level flags to provide *command-specific* description, i.e. "Opens the documentation for *azd monitor* in your web browser."

However, these flags should be interpreted as global for all user intentions.  This change updates the help display to match the UX, instead of the internal implementation detail.

Contributes to #4330