### PR TITLE
Fix error about passing by value in `for range`

### DIFF
--- a/cli/azd/pkg/project/scaffold_gen.go
+++ b/cli/azd/pkg/project/scaffold_gen.go
@@ -186,7 +186,8 @@ func infraSpec(projectConfig *ProjectConfig) (*scaffold.InfraSpec, error) {
 	}
 
 	// create reverse frontends -> backends mapping
-	for _, svc := range infraSpec.Services {
+	for i := range infraSpec.Services {
+		svc := &infraSpec.Services[i]
 		if front, ok := backendMapping[svc.Name]; ok {
 			if svc.Backend == nil {
 				svc.Backend = &scaffold.Backend{}


### PR DESCRIPTION
Fix error about passing by value in `for range`. 
Refs: https://go.dev/wiki/Range
> ![image](https://github.com/user-attachments/assets/2bc38735-6546-49b2-9f1d-8ee2c45ad9a4)
