### PR TITLE
tests: Re-enable tests disabled against #4341

### DIFF
--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -785,8 +785,6 @@ func newTestContext(t *testing.T) (context.Context, context.CancelFunc) {
 }
 
 func Test_CLI_InfraCreateAndDeleteResourceTerraform(t *testing.T) {
-	t.Skip("azure/azure-dev#4341")
-
 	// running this test in parallel is ok as it uses a t.TempDir()
 	t.Parallel()
 	ctx, cancel := newTestContext(t)
@@ -828,7 +826,7 @@ func Test_CLI_InfraCreateAndDeleteResourceTerraform(t *testing.T) {
 }
 
 func Test_CLI_InfraCreateAndDeleteResourceTerraformRemote(t *testing.T) {
-	t.Skip("azure/azure-dev#4341")
+	t.Skip("azure/azure-dev#4564")
 
 	ctx, cancel := newTestContext(t)
 	defer cancel()

--- a/cli/azd/test/functional/deployment_stacks_test.go
+++ b/cli/azd/test/functional/deployment_stacks_test.go
@@ -18,8 +18,6 @@ import (
 )
 
 func Test_DeploymentStacks(t *testing.T) {
-	t.Skip("azure/azure-dev#4341")
-
 	t.Run("Subscription_Scope_Up_Down", func(t *testing.T) {
 		t.Parallel()
 		ctx, cancel := newTestContext(t)

--- a/cli/azd/test/functional/login_test.go
+++ b/cli/azd/test/functional/login_test.go
@@ -53,47 +53,6 @@ func Test_CLI_AuthLoginStatus(t *testing.T) {
 	}
 }
 
-func Test_CLI_LoginServicePrincipal(t *testing.T) {
-	t.Skip("azure/azure-dev#4341")
-
-	ctx, cancel := newTestContext(t)
-	defer cancel()
-
-	dir := t.TempDir()
-
-	cli := azdcli.NewCLI(t)
-	// Isolate login to a separate configuration directory
-	cli.Env = append(cli.Env, "AZD_CONFIG_DIR="+dir)
-	if cfg.ClientID == "" || cfg.TenantID == "" /* || cfg.ClientSecret == "" */ {
-		if cfg.CI {
-			panic("Service principal is not configured. AZD_TEST_* variables are required to be set for live testing.")
-		}
-
-		t.Skip("Skipping test because service principal is not configured. " +
-			"Set the relevant AZD_TEST_* variables to run this test.")
-		return
-	}
-
-	loginState := loginStatus(t, ctx, cli)
-	require.Equal(t, contracts.LoginStatusUnauthenticated, loginState.Status)
-
-	_, err := cli.RunCommand(ctx,
-		"auth", "login",
-		"--client-id", cfg.ClientID,
-		//		"--client-secret", cfg.ClientSecret,
-		"--tenant-id", cfg.TenantID)
-	require.NoError(t, err)
-
-	loginState = loginStatus(t, ctx, cli)
-	require.Equal(t, contracts.LoginStatusSuccess, loginState.Status)
-
-	_, err = cli.RunCommand(ctx, "auth", "logout")
-	require.NoError(t, err)
-
-	loginState = loginStatus(t, ctx, cli)
-	require.Equal(t, contracts.LoginStatusUnauthenticated, loginState.Status)
-}
-
 func loginStatus(t *testing.T, ctx context.Context, cli *azdcli.CLI) contracts.LoginResult {
 	result, err := cli.RunCommand(ctx, "auth", "login", "--check-status", "--output", "json")
 	require.NoError(t, err)


### PR DESCRIPTION
We should be able to re-enable the tests now. The one exception is the `azd login` test that validated login with a long lived client secret, since we no longer have a service principal with a long lived client secret.

We'll have to make due without the end to end coverage here - but in practice we have good coverage at the unit test level of much of the code here, so we should be okay.