### PR TITLE
 ci: Update bicep in lint-bicep to v0.31.92

### DIFF
--- a/.github/workflows/lint-bicep.yml
+++ b/.github/workflows/lint-bicep.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Upgrade bicep
+        run: |
+          which bicep
+          sudo curl -o $(which bicep) -L https://github.com/Azure/bicep/releases/download/v0.31.92/bicep-linux-x64
+          sudo chmod +x $(which bicep)
       - name: Lint .bicep files
         run: $ErrorActionPreference='Continue'; eng/scripts/Test-BicepLint.ps1 -Verbose
         shell: pwsh


### PR DESCRIPTION
The current version that is installed on the runners (0.31.34) has some bugs around linting and causes lint warnings during our legs. These errors are not present on the latest Bicep CLI.
    
Force an upgrade of the binary that is installed as part of the test runner to latest version. We should be able to remove this step once new image is built with an upgraded bicep (the `README.md` at https://github.com/actions/runner-images/tree/main/images/ubuntu has information about what is on the runner.)