### PR TITLE
dotnet: Support `dotnet publish` to produce container image

### DIFF
--- a/cli/azd/internal/cmd/add/add_configure_host.go
+++ b/cli/azd/internal/cmd/add/add_configure_host.go
@@ -238,7 +238,7 @@ func addServiceAsResource(
 		if _, err := os.Stat(filepath.Join(svc.RelativePath, "Dockerfile")); errors.Is(err, os.ErrNotExist) {
 			// default builder always specifies port 80
 			props.Port = 80
-			if svc.Language == project.ServiceLanguageJava {
+			if svc.Language == project.ServiceLanguageJava || svc.Language.IsDotNet() {
 				props.Port = 8080
 			}
 		}

--- a/cli/azd/internal/repository/app_init_test.go
+++ b/cli/azd/internal/repository/app_init_test.go
@@ -46,7 +46,7 @@ func TestInitializer_prjConfigFromDetect(t *testing.T) {
 						Type: project.ResourceTypeHostContainerApp,
 						Name: "dotnet",
 						Props: project.ContainerAppProps{
-							Port: 80,
+							Port: 8080,
 						},
 					},
 				},

--- a/cli/azd/internal/repository/infra_confirm.go
+++ b/cli/azd/internal/repository/infra_confirm.go
@@ -212,7 +212,7 @@ func PromptPort(
 	name string,
 	svc appdetect.Project) (int, error) {
 	if svc.Docker == nil || svc.Docker.Path == "" { // using default builder from azd
-		if svc.Language == appdetect.Java {
+		if svc.Language == appdetect.Java || svc.Language == appdetect.DotNet {
 			return 8080, nil
 		}
 		return 80, nil

--- a/cli/azd/internal/repository/infra_confirm_test.go
+++ b/cli/azd/internal/repository/infra_confirm_test.go
@@ -35,7 +35,7 @@ func TestInitializer_infraSpecFromDetect(t *testing.T) {
 				Services: []scaffold.ServiceSpec{
 					{
 						Name:    "dotnet",
-						Port:    80,
+						Port:    8080,
 						Backend: &scaffold.Backend{},
 					},
 				},

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
 	"github.com/benbjohnson/clock"
 	"github.com/sethvargo/go-retry"
 )
@@ -32,6 +33,7 @@ type ContainerHelper struct {
 	remoteBuildManager       *containerregistry.RemoteBuildManager
 	containerRegistryService azcli.ContainerRegistryService
 	docker                   *docker.Cli
+	dotNetCli                *dotnet.Cli
 	clock                    clock.Clock
 	console                  input.Console
 	cloud                    *cloud.Cloud
@@ -44,6 +46,7 @@ func NewContainerHelper(
 	containerRegistryService azcli.ContainerRegistryService,
 	remoteBuildManager *containerregistry.RemoteBuildManager,
 	docker *docker.Cli,
+	dotNetCli *dotnet.Cli,
 	console input.Console,
 	cloud *cloud.Cloud,
 ) *ContainerHelper {
@@ -53,6 +56,7 @@ func NewContainerHelper(
 		remoteBuildManager:       remoteBuildManager,
 		containerRegistryService: containerRegistryService,
 		docker:                   docker,
+		dotNetCli:                dotNetCli,
 		clock:                    clock,
 		console:                  console,
 		cloud:                    cloud,
@@ -194,6 +198,10 @@ func (ch *ContainerHelper) RequiredExternalTools(ctx context.Context, serviceCon
 		return []tools.ExternalTool{}
 	}
 
+	if useDotnetPublishForDockerBuild(serviceConfig) {
+		return []tools.ExternalTool{ch.dotNetCli}
+	}
+
 	return []tools.ExternalTool{ch.docker}
 }
 
@@ -270,6 +278,8 @@ func (ch *ContainerHelper) Deploy(
 
 	if serviceConfig.Docker.RemoteBuild {
 		remoteImage, err = ch.runRemoteBuild(ctx, serviceConfig, targetResource, progress)
+	} else if useDotnetPublishForDockerBuild(serviceConfig) {
+		remoteImage, err = ch.runDotnetPublish(ctx, serviceConfig, targetResource, progress)
 	} else {
 		remoteImage, err = ch.runLocalBuild(ctx, serviceConfig, packageOutput, progress)
 	}
@@ -382,7 +392,8 @@ func (ch *ContainerHelper) runLocalBuild(
 	return remoteImage, nil
 }
 
-// runLocalBuild builds the image using a remote azure container registry and tags it. It returns the full remote image name.
+// runRemoteBuild builds the image using a remote azure container registry and tags it.
+// It returns the full remote image name.
 func (ch *ContainerHelper) runRemoteBuild(
 	ctx context.Context,
 	serviceConfig *ServiceConfig,
@@ -471,6 +482,41 @@ func (ch *ContainerHelper) runRemoteBuild(
 	}
 
 	return imageName, nil
+}
+
+// runDotnetPublish builds and publishes the container image using `dotnet publish`. It returns the full remote image name.
+func (ch *ContainerHelper) runDotnetPublish(
+	ctx context.Context,
+	serviceConfig *ServiceConfig,
+	target *environment.TargetResource,
+	progress *async.Progress[ServiceProgress],
+) (string, error) {
+	progress.SetProgress(NewServiceProgress("Logging into registry"))
+
+	dockerCreds, err := ch.Credentials(ctx, serviceConfig, target)
+	if err != nil {
+		return "", fmt.Errorf("logging in to registry: %w", err)
+	}
+
+	progress.SetProgress(NewServiceProgress("Publishing container image"))
+
+	imageName := fmt.Sprintf("%s:%s",
+		ch.DefaultImageName(serviceConfig),
+		ch.DefaultImageTag())
+
+	_, err = ch.dotNetCli.PublishContainer(
+		ctx,
+		serviceConfig.Path(),
+		"Release",
+		imageName,
+		dockerCreds.LoginServer,
+		dockerCreds.Username,
+		dockerCreds.Password)
+	if err != nil {
+		return "", fmt.Errorf("publishing container: %w", err)
+	}
+
+	return fmt.Sprintf("%s/%s", dockerCreds.LoginServer, imageName), nil
 }
 
 type dockerDeployResult struct {

--- a/cli/azd/pkg/project/framework_service.go
+++ b/cli/azd/pkg/project/framework_service.go
@@ -121,3 +121,7 @@ func validatePackageOutput(packagePath string) error {
 
 	return nil
 }
+
+func (slk ServiceLanguageKind) IsDotNet() bool {
+	return slk == ServiceLanguageDotNet || slk == ServiceLanguageCsharp || slk == ServiceLanguageFsharp
+}

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/npm"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockarmresources"
@@ -100,6 +101,7 @@ services:
 
 	npmCli := npm.NewCli(mockContext.CommandRunner)
 	docker := docker.NewCli(mockContext.CommandRunner)
+	dotnetCli := dotnet.NewCli(mockContext.CommandRunner)
 
 	internalFramework := NewNpmProject(npmCli, env)
 	progressMessages := []string{}
@@ -107,7 +109,8 @@ services:
 	framework := NewDockerProject(
 		env,
 		docker,
-		NewContainerHelper(env, envManager, clock.NewMock(), nil, nil, docker, mockContext.Console, cloud.AzurePublic()),
+		NewContainerHelper(
+			env, envManager, clock.NewMock(), nil, nil, docker, dotnetCli, mockContext.Console, cloud.AzurePublic()),
 		mockinput.NewMockConsole(),
 		mockContext.AlphaFeaturesManager,
 		mockContext.CommandRunner)
@@ -194,6 +197,7 @@ services:
 
 	npmCli := npm.NewCli(mockContext.CommandRunner)
 	docker := docker.NewCli(mockContext.CommandRunner)
+	dotnetCli := dotnet.NewCli(mockContext.CommandRunner)
 
 	projectConfig, err := Parse(*mockContext.Context, testProj)
 	require.NoError(t, err)
@@ -211,7 +215,8 @@ services:
 	framework := NewDockerProject(
 		env,
 		docker,
-		NewContainerHelper(env, envManager, clock.NewMock(), nil, nil, docker, mockContext.Console, cloud.AzurePublic()),
+		NewContainerHelper(
+			env, envManager, clock.NewMock(), nil, nil, docker, dotnetCli, mockContext.Console, cloud.AzurePublic()),
 		mockinput.NewMockConsole(),
 		mockContext.AlphaFeaturesManager,
 		mockContext.CommandRunner)
@@ -444,6 +449,7 @@ func Test_DockerProject_Build(t *testing.T) {
 			}
 
 			dockerCli := docker.NewCli(mockContext.CommandRunner)
+			dotnetCli := dotnet.NewCli(mockContext.CommandRunner)
 			serviceConfig := createTestServiceConfig(tt.project, ContainerAppTarget, tt.language)
 			serviceConfig.Project.Path = temp
 			serviceConfig.Docker = tt.dockerOptions
@@ -466,7 +472,8 @@ func Test_DockerProject_Build(t *testing.T) {
 				env,
 				dockerCli,
 				NewContainerHelper(
-					env, envManager, clock.NewMock(), nil, nil, dockerCli, mockContext.Console, cloud.AzurePublic()),
+					env, envManager, clock.NewMock(), nil, nil, dockerCli, dotnetCli, mockContext.Console,
+					cloud.AzurePublic()),
 				mockinput.NewMockConsole(),
 				mockContext.AlphaFeaturesManager,
 				mockContext.CommandRunner)
@@ -582,13 +589,15 @@ func Test_DockerProject_Package(t *testing.T) {
 
 			env := environment.NewWithValues("test", map[string]string{})
 			dockerCli := docker.NewCli(mockContext.CommandRunner)
+			dotnetCli := dotnet.NewCli(mockContext.CommandRunner)
 			serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
 
 			dockerProject := NewDockerProject(
 				env,
 				dockerCli,
 				NewContainerHelper(
-					env, envManager, clock.NewMock(), nil, nil, dockerCli, mockContext.Console, cloud.AzurePublic()),
+					env, envManager, clock.NewMock(), nil, nil, dockerCli, dotnetCli, mockContext.Console,
+					cloud.AzurePublic()),
 				mockinput.NewMockConsole(),
 				mockContext.AlphaFeaturesManager,
 				mockContext.CommandRunner)

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -45,6 +45,9 @@ type ServiceConfig struct {
 	DotNetContainerApp *DotNetContainerAppOptions `yaml:"-,omitempty"`
 	// Custom configuration for the service target
 	Config map[string]any `yaml:"config,omitempty"`
+	// Computed lazily by useDotnetPublishForDockerBuild and cached. This is true when the project
+	// is a dotnet project and there is not an explicit Dockerfile in the project directory.
+	useDotNetPublishForDockerBuild *bool
 
 	*ext.EventDispatcher[ServiceLifecycleEventArgs] `yaml:"-"`
 }

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/kubectl"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockaccount"
@@ -811,6 +812,7 @@ func createAksServiceTarget(
 	helmCli := helm.NewCli(mockContext.CommandRunner)
 	kustomizeCli := kustomize.NewCli(mockContext.CommandRunner)
 	dockerCli := docker.NewCli(mockContext.CommandRunner)
+	dotnetCli := dotnet.NewCli(mockContext.CommandRunner)
 	kubeLoginCli := kubelogin.NewCli(mockContext.CommandRunner)
 	credentialProvider := mockaccount.SubscriptionCredentialProviderFunc(
 		func(_ context.Context, _ string) (azcore.TokenCredential, error) {
@@ -849,6 +851,7 @@ func createAksServiceTarget(
 		containerRegistryService,
 		remoteBuildManager,
 		dockerCli,
+		dotnetCli,
 		mockContext.Console,
 		cloud.AzurePublic(),
 	)

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/azcli"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockaccount"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazcli"
@@ -132,6 +133,7 @@ func createContainerAppServiceTarget(
 	env *environment.Environment,
 ) ServiceTarget {
 	dockerCli := docker.NewCli(mockContext.CommandRunner)
+	dotnetCli := dotnet.NewCli(mockContext.CommandRunner)
 	credentialProvider := mockaccount.SubscriptionCredentialProviderFunc(
 		func(_ context.Context, _ string) (azcore.TokenCredential, error) {
 			return mockContext.Credentials, nil
@@ -163,6 +165,7 @@ func createContainerAppServiceTarget(
 		containerRegistryService,
 		remoteBuildManager,
 		dockerCli,
+		dotnetCli,
 		mockContext.Console,
 		cloud.AzurePublic(),
 	)

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_Up_Down_ContainerAppDotNetPublish.dotnet.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_Up_Down_ContainerAppDotNetPublish.dotnet.yaml
@@ -1,0 +1,20 @@
+version: "1.0"
+tool: dotnet
+interactions:
+    - id: 0
+      args:
+        - publish
+        - /private/var/folders/6n/sxbj12js5ksg6ztn0kslqp400000gn/T/Test_CLI_Up_Down_ContainerAppDotNetPublish3940537069/001/src/dotnet
+        - -r
+        - linux-x64
+        - -c
+        - Release
+        - /t:PublishContainer
+        - -p:ContainerRepository=containerapp/web-azdtest-de207ca
+        - -p:ContainerImageTag=azd-deploy-1732146560
+        - -p:ContainerRegistry=crtf5bjllihraai.azurecr.io
+        - --getProperty:GeneratedContainerConfiguration
+      exitCode: 0
+      stdout: |
+        {"config":{"ExposedPorts":{"8080/tcp":{}},"Labels":{"org.opencontainers.image.created":"2024-11-20T23:52:02.8460760Z","org.opencontainers.artifact.created":"2024-11-20T23:52:02.8460760Z","org.opencontainers.image.authors":"webapp","org.opencontainers.image.version":"1.0.0","org.opencontainers.image.base.name":"mcr.microsoft.com/dotnet/aspnet:8.0","net.dot.runtime.majorminor":"8.0","net.dot.sdk.version":"9.0.100-rc.2.24474.11","org.opencontainers.image.base.digest":"sha256:3e2d76f7d3310b31e6400154e8f718600138db5d5ec9c37748bbda6922182ead"},"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","APP_UID=1654","ASPNETCORE_HTTP_PORTS=8080","DOTNET_RUNNING_IN_CONTAINER=true","DOTNET_VERSION=8.0.11","ASPNET_VERSION=8.0.11"],"WorkingDir":"/app/","Entrypoint":["dotnet","/app/webapp.dll"],"User":"1654"},"created":"2024-11-20T23:52:04.0532130Z","rootfs":{"type":"layers","diff_ids":["sha256:c3548211b8264f8bfa47a6727043a64f1791b82ac965a284a7ea187e971a95e2","sha256:24716a9c28f5c0fcc7713347708e93e9531a58629fc22b47bd45f19b591c7453","sha256:2ffebcb9c50a8e37858d22d39df5e8a8004b2e12923ee60c6344162427424960","sha256:dec72eb2a8b47bbe9e0ffc56fb9c1a9e577e1b9febb385e836ee0977254b7c0d","sha256:20c9409270c12ce0c1bb3271d534508956fdc68f489365ffbb40a14532f86e88","sha256:9e43e3f4b30f02815d600b02af454c449b59d5c4dd5f3afa4e49c3ffd6ecd025","sha256:1f45fbd6c62e42e4da992eaf73808abd3b9fbf40cd08e7cebf3a33cf3eee0c10"]},"architecture":"amd64","os":"linux","history":[{"comment":"buildkit.dockerfile.v0","created":"2024-11-11T00:00:00.0000000Z","created_by":"ADD rootfs.tar.xz / # buildkit"},{"comment":"buildkit.dockerfile.v0","created":"2024-11-11T00:00:00.0000000Z","created_by":"CMD [\u0022bash\u0022]","empty_layer":true},{"comment":"buildkit.dockerfile.v0","created":"2024-11-12T18:41:09.3239341Z","created_by":"ENV APP_UID=1654 ASPNETCORE_HTTP_PORTS=8080 DOTNET_RUNNING_IN_CONTAINER=true","empty_layer":true},{"comment":"buildkit.dockerfile.v0","created":"2024-11-12T18:41:09.3239341Z","created_by":"RUN /bin/sh -c apt-get update     \u0026\u0026 apt-get install -y --no-install-recommends         ca-certificates                 libc6         libgcc-s1         libicu72         libssl3         libstdc\u002B\u002B6         tzdata         zlib1g     \u0026\u0026 rm -rf /var/lib/apt/lists/* # buildkit"},{"comment":"buildkit.dockerfile.v0","created":"2024-11-12T18:41:10.7740643Z","created_by":"RUN /bin/sh -c groupadd         --gid=$APP_UID         app     \u0026\u0026 useradd -l         --uid=$APP_UID         --gid=$APP_UID         --create-home         app # buildkit"},{"comment":"buildkit.dockerfile.v0","created":"2024-11-12T18:41:16.8668835Z","created_by":"ENV DOTNET_VERSION=8.0.11","empty_layer":true},{"comment":"buildkit.dockerfile.v0","created":"2024-11-12T18:41:16.8668835Z","created_by":"COPY /dotnet /usr/share/dotnet # buildkit"},{"comment":"buildkit.dockerfile.v0","created":"2024-11-12T18:41:17.7626695Z","created_by":"RUN /bin/sh -c ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet # buildkit"},{"comment":"buildkit.dockerfile.v0","created":"2024-11-12T18:41:23.2518218Z","created_by":"ENV ASPNET_VERSION=8.0.11","empty_layer":true},{"comment":"buildkit.dockerfile.v0","created":"2024-11-12T18:41:23.2518218Z","created_by":"COPY /shared/Microsoft.AspNetCore.App /usr/share/dotnet/shared/Microsoft.AspNetCore.App # buildkit"},{"author":".NET SDK","created":"2024-11-20T23:52:04.0531950Z","created_by":".NET SDK Container Tooling, version 9.0.100-rc.2.24474.11\u002B315e1305dbe1a5ef5870faab5dc12d3a375f61eb"}]}
+      stderr: ""

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_Up_Down_ContainerAppDotNetPublish.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_Up_Down_ContainerAppDotNetPublish.yaml
@@ -1,0 +1,2298 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armsubscriptions/v1.0.0 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 49df2a253364c7faf47cfcf104e3c1ad
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations?api-version=2021-01-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 35781
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastus","name":"eastus","type":"Region","displayName":"East US","regionalDisplayName":"(US) East US","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"US","longitude":"-79.8164","latitude":"37.3719","physicalLocation":"Virginia","pairedRegion":[{"name":"westus","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westus"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southcentralus","name":"southcentralus","type":"Region","displayName":"South Central US","regionalDisplayName":"(US) South Central US","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"US","longitude":"-98.5","latitude":"29.4167","physicalLocation":"Texas","pairedRegion":[{"name":"northcentralus","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/northcentralus"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westus2","name":"westus2","type":"Region","displayName":"West US 2","regionalDisplayName":"(US) West US 2","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"US","longitude":"-119.852","latitude":"47.233","physicalLocation":"Washington","pairedRegion":[{"name":"westcentralus","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westcentralus"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westus3","name":"westus3","type":"Region","displayName":"West US 3","regionalDisplayName":"(US) West US 3","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"US","longitude":"-112.074036","latitude":"33.448376","physicalLocation":"Phoenix","pairedRegion":[{"name":"eastus","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastus"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australiaeast","name":"australiaeast","type":"Region","displayName":"Australia East","regionalDisplayName":"(Asia Pacific) Australia East","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Asia Pacific","longitude":"151.2094","latitude":"-33.86","physicalLocation":"New South Wales","pairedRegion":[{"name":"australiasoutheast","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australiasoutheast"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southeastasia","name":"southeastasia","type":"Region","displayName":"Southeast Asia","regionalDisplayName":"(Asia Pacific) Southeast Asia","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Asia Pacific","longitude":"103.833","latitude":"1.283","physicalLocation":"Singapore","pairedRegion":[{"name":"eastasia","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastasia"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/northeurope","name":"northeurope","type":"Region","displayName":"North Europe","regionalDisplayName":"(Europe) North Europe","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"-6.2597","latitude":"53.3478","physicalLocation":"Ireland","pairedRegion":[{"name":"westeurope","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westeurope"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/swedencentral","name":"swedencentral","type":"Region","displayName":"Sweden Central","regionalDisplayName":"(Europe) Sweden Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"17.14127","latitude":"60.67488","physicalLocation":"Gävle","pairedRegion":[{"name":"swedensouth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/swedensouth"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/uksouth","name":"uksouth","type":"Region","displayName":"UK South","regionalDisplayName":"(Europe) UK South","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"-0.799","latitude":"50.941","physicalLocation":"London","pairedRegion":[{"name":"ukwest","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/ukwest"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westeurope","name":"westeurope","type":"Region","displayName":"West Europe","regionalDisplayName":"(Europe) West Europe","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"4.9","latitude":"52.3667","physicalLocation":"Netherlands","pairedRegion":[{"name":"northeurope","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/northeurope"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/centralus","name":"centralus","type":"Region","displayName":"Central US","regionalDisplayName":"(US) Central US","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"US","longitude":"-93.6208","latitude":"41.5908","physicalLocation":"Iowa","pairedRegion":[{"name":"eastus2","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastus2"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southafricanorth","name":"southafricanorth","type":"Region","displayName":"South Africa North","regionalDisplayName":"(Africa) South Africa North","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Africa","longitude":"28.21837","latitude":"-25.73134","physicalLocation":"Johannesburg","pairedRegion":[{"name":"southafricawest","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southafricawest"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/centralindia","name":"centralindia","type":"Region","displayName":"Central India","regionalDisplayName":"(Asia Pacific) Central India","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Asia Pacific","longitude":"73.9197","latitude":"18.5822","physicalLocation":"Pune","pairedRegion":[{"name":"southindia","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southindia"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastasia","name":"eastasia","type":"Region","displayName":"East Asia","regionalDisplayName":"(Asia Pacific) East Asia","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Asia Pacific","longitude":"114.188","latitude":"22.267","physicalLocation":"Hong Kong","pairedRegion":[{"name":"southeastasia","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southeastasia"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/japaneast","name":"japaneast","type":"Region","displayName":"Japan East","regionalDisplayName":"(Asia Pacific) Japan East","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Asia Pacific","longitude":"139.77","latitude":"35.68","physicalLocation":"Tokyo, Saitama","pairedRegion":[{"name":"japanwest","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/japanwest"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/koreacentral","name":"koreacentral","type":"Region","displayName":"Korea Central","regionalDisplayName":"(Asia Pacific) Korea Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Asia Pacific","longitude":"126.978","latitude":"37.5665","physicalLocation":"Seoul","pairedRegion":[{"name":"koreasouth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/koreasouth"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/newzealandnorth","name":"newzealandnorth","type":"Region","displayName":"New Zealand North","regionalDisplayName":"(Asia Pacific) New Zealand North","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Asia Pacific","longitude":"174.76349","latitude":"-36.84853","physicalLocation":"Auckland","pairedRegion":[]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/canadacentral","name":"canadacentral","type":"Region","displayName":"Canada Central","regionalDisplayName":"(Canada) Canada Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Canada","longitude":"-79.383","latitude":"43.653","physicalLocation":"Toronto","pairedRegion":[{"name":"canadaeast","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/canadaeast"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/francecentral","name":"francecentral","type":"Region","displayName":"France Central","regionalDisplayName":"(Europe) France Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"2.373","latitude":"46.3772","physicalLocation":"Paris","pairedRegion":[{"name":"francesouth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/francesouth"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/germanywestcentral","name":"germanywestcentral","type":"Region","displayName":"Germany West Central","regionalDisplayName":"(Europe) Germany West Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"8.682127","latitude":"50.110924","physicalLocation":"Frankfurt","pairedRegion":[{"name":"germanynorth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/germanynorth"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/italynorth","name":"italynorth","type":"Region","displayName":"Italy North","regionalDisplayName":"(Europe) Italy North","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"9.18109","latitude":"45.46888","physicalLocation":"Milan","pairedRegion":[]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/norwayeast","name":"norwayeast","type":"Region","displayName":"Norway East","regionalDisplayName":"(Europe) Norway East","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"10.752245","latitude":"59.913868","physicalLocation":"Norway","pairedRegion":[{"name":"norwaywest","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/norwaywest"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/polandcentral","name":"polandcentral","type":"Region","displayName":"Poland Central","regionalDisplayName":"(Europe) Poland Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"21.01666","latitude":"52.23334","physicalLocation":"Warsaw","pairedRegion":[]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/spaincentral","name":"spaincentral","type":"Region","displayName":"Spain Central","regionalDisplayName":"(Europe) Spain Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"3.4209","latitude":"40.4259","physicalLocation":"Madrid","pairedRegion":[]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/switzerlandnorth","name":"switzerlandnorth","type":"Region","displayName":"Switzerland North","regionalDisplayName":"(Europe) Switzerland North","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Europe","longitude":"8.564572","latitude":"47.451542","physicalLocation":"Zurich","pairedRegion":[{"name":"switzerlandwest","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/switzerlandwest"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/mexicocentral","name":"mexicocentral","type":"Region","displayName":"Mexico Central","regionalDisplayName":"(Mexico) Mexico Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Mexico","longitude":"-100.389888","latitude":"20.588818","physicalLocation":"Querétaro State","pairedRegion":[]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/uaenorth","name":"uaenorth","type":"Region","displayName":"UAE North","regionalDisplayName":"(Middle East) UAE North","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Middle East","longitude":"55.316666","latitude":"25.266666","physicalLocation":"Dubai","pairedRegion":[{"name":"uaecentral","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/uaecentral"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/brazilsouth","name":"brazilsouth","type":"Region","displayName":"Brazil South","regionalDisplayName":"(South America) Brazil South","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"South America","longitude":"-46.633","latitude":"-23.55","physicalLocation":"Sao Paulo State","pairedRegion":[{"name":"southcentralus","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southcentralus"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/israelcentral","name":"israelcentral","type":"Region","displayName":"Israel Central","regionalDisplayName":"(Middle East) Israel Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Middle East","longitude":"33.4506633","latitude":"31.2655698","physicalLocation":"Israel","pairedRegion":[]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/qatarcentral","name":"qatarcentral","type":"Region","displayName":"Qatar Central","regionalDisplayName":"(Middle East) Qatar Central","metadata":{"regionType":"Physical","regionCategory":"Recommended","geographyGroup":"Middle East","longitude":"51.439327","latitude":"25.551462","physicalLocation":"Doha","pairedRegion":[]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/centralusstage","name":"centralusstage","type":"Region","displayName":"Central US (Stage)","regionalDisplayName":"(US) Central US (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"US"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastusstage","name":"eastusstage","type":"Region","displayName":"East US (Stage)","regionalDisplayName":"(US) East US (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"US"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastus2stage","name":"eastus2stage","type":"Region","displayName":"East US 2 (Stage)","regionalDisplayName":"(US) East US 2 (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"US"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/northcentralusstage","name":"northcentralusstage","type":"Region","displayName":"North Central US (Stage)","regionalDisplayName":"(US) North Central US (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"US"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southcentralusstage","name":"southcentralusstage","type":"Region","displayName":"South Central US (Stage)","regionalDisplayName":"(US) South Central US (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"US"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westusstage","name":"westusstage","type":"Region","displayName":"West US (Stage)","regionalDisplayName":"(US) West US (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"US"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westus2stage","name":"westus2stage","type":"Region","displayName":"West US 2 (Stage)","regionalDisplayName":"(US) West US 2 (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"US"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/asia","name":"asia","type":"Region","displayName":"Asia","regionalDisplayName":"Asia","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/asiapacific","name":"asiapacific","type":"Region","displayName":"Asia Pacific","regionalDisplayName":"Asia Pacific","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australia","name":"australia","type":"Region","displayName":"Australia","regionalDisplayName":"Australia","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/brazil","name":"brazil","type":"Region","displayName":"Brazil","regionalDisplayName":"Brazil","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/canada","name":"canada","type":"Region","displayName":"Canada","regionalDisplayName":"Canada","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/europe","name":"europe","type":"Region","displayName":"Europe","regionalDisplayName":"Europe","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/france","name":"france","type":"Region","displayName":"France","regionalDisplayName":"France","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/germany","name":"germany","type":"Region","displayName":"Germany","regionalDisplayName":"Germany","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/global","name":"global","type":"Region","displayName":"Global","regionalDisplayName":"Global","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/india","name":"india","type":"Region","displayName":"India","regionalDisplayName":"India","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/israel","name":"israel","type":"Region","displayName":"Israel","regionalDisplayName":"Israel","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/italy","name":"italy","type":"Region","displayName":"Italy","regionalDisplayName":"Italy","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/japan","name":"japan","type":"Region","displayName":"Japan","regionalDisplayName":"Japan","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/korea","name":"korea","type":"Region","displayName":"Korea","regionalDisplayName":"Korea","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/newzealand","name":"newzealand","type":"Region","displayName":"New Zealand","regionalDisplayName":"New Zealand","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/norway","name":"norway","type":"Region","displayName":"Norway","regionalDisplayName":"Norway","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/poland","name":"poland","type":"Region","displayName":"Poland","regionalDisplayName":"Poland","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/qatar","name":"qatar","type":"Region","displayName":"Qatar","regionalDisplayName":"Qatar","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/singapore","name":"singapore","type":"Region","displayName":"Singapore","regionalDisplayName":"Singapore","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southafrica","name":"southafrica","type":"Region","displayName":"South Africa","regionalDisplayName":"South Africa","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/sweden","name":"sweden","type":"Region","displayName":"Sweden","regionalDisplayName":"Sweden","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/switzerland","name":"switzerland","type":"Region","displayName":"Switzerland","regionalDisplayName":"Switzerland","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/uae","name":"uae","type":"Region","displayName":"United Arab Emirates","regionalDisplayName":"United Arab Emirates","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/uk","name":"uk","type":"Region","displayName":"United Kingdom","regionalDisplayName":"United Kingdom","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/unitedstates","name":"unitedstates","type":"Region","displayName":"United States","regionalDisplayName":"United States","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/unitedstateseuap","name":"unitedstateseuap","type":"Region","displayName":"United States EUAP","regionalDisplayName":"United States EUAP","metadata":{"regionType":"Logical","regionCategory":"Other"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastasiastage","name":"eastasiastage","type":"Region","displayName":"East Asia (Stage)","regionalDisplayName":"(Asia Pacific) East Asia (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"Asia Pacific"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southeastasiastage","name":"southeastasiastage","type":"Region","displayName":"Southeast Asia (Stage)","regionalDisplayName":"(Asia Pacific) Southeast Asia (Stage)","metadata":{"regionType":"Logical","regionCategory":"Other","geographyGroup":"Asia Pacific"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/brazilus","name":"brazilus","type":"Region","displayName":"Brazil US","regionalDisplayName":"(South America) Brazil US","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"South America","longitude":"0","latitude":"0","physicalLocation":"","pairedRegion":[{"name":"brazilsoutheast","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/brazilsoutheast"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastus2","name":"eastus2","type":"Region","displayName":"East US 2","regionalDisplayName":"(US) East US 2","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"US","longitude":"-78.3889","latitude":"36.6681","physicalLocation":"Virginia","pairedRegion":[{"name":"centralus","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/centralus"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastusstg","name":"eastusstg","type":"Region","displayName":"East US STG","regionalDisplayName":"(US) East US STG","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"US","longitude":"-79.8164","latitude":"37.3719","physicalLocation":"Virginia","pairedRegion":[{"name":"southcentralusstg","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southcentralusstg"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/northcentralus","name":"northcentralus","type":"Region","displayName":"North Central US","regionalDisplayName":"(US) North Central US","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"US","longitude":"-87.6278","latitude":"41.8819","physicalLocation":"Illinois","pairedRegion":[{"name":"southcentralus","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southcentralus"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westus","name":"westus","type":"Region","displayName":"West US","regionalDisplayName":"(US) West US","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"US","longitude":"-122.417","latitude":"37.783","physicalLocation":"California","pairedRegion":[{"name":"eastus","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastus"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/japanwest","name":"japanwest","type":"Region","displayName":"Japan West","regionalDisplayName":"(Asia Pacific) Japan West","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"135.5022","latitude":"34.6939","physicalLocation":"Osaka","pairedRegion":[{"name":"japaneast","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/japaneast"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/jioindiawest","name":"jioindiawest","type":"Region","displayName":"Jio India West","regionalDisplayName":"(Asia Pacific) Jio India West","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"70.05773","latitude":"22.470701","physicalLocation":"Jamnagar","pairedRegion":[{"name":"jioindiacentral","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/jioindiacentral"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/centraluseuap","name":"centraluseuap","type":"Region","displayName":"Central US EUAP","regionalDisplayName":"(US) Central US EUAP","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"US","longitude":"-93.6208","latitude":"41.5908","physicalLocation":"","pairedRegion":[{"name":"eastus2euap","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastus2euap"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastus2euap","name":"eastus2euap","type":"Region","displayName":"East US 2 EUAP","regionalDisplayName":"(US) East US 2 EUAP","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"US","longitude":"-78.3889","latitude":"36.6681","physicalLocation":"","pairedRegion":[{"name":"centraluseuap","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/centraluseuap"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southcentralusstg","name":"southcentralusstg","type":"Region","displayName":"South Central US STG","regionalDisplayName":"(US) South Central US STG","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"US","longitude":"-98.5","latitude":"29.4167","physicalLocation":"Texas","pairedRegion":[{"name":"eastusstg","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/eastusstg"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westcentralus","name":"westcentralus","type":"Region","displayName":"West Central US","regionalDisplayName":"(US) West Central US","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"US","longitude":"-110.234","latitude":"40.89","physicalLocation":"Wyoming","pairedRegion":[{"name":"westus2","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westus2"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southafricawest","name":"southafricawest","type":"Region","displayName":"South Africa West","regionalDisplayName":"(Africa) South Africa West","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Africa","longitude":"18.843266","latitude":"-34.075691","physicalLocation":"Cape Town","pairedRegion":[{"name":"southafricanorth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southafricanorth"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australiacentral","name":"australiacentral","type":"Region","displayName":"Australia Central","regionalDisplayName":"(Asia Pacific) Australia Central","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"149.1244","latitude":"-35.3075","physicalLocation":"Canberra","pairedRegion":[{"name":"australiacentral2","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australiacentral2"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australiacentral2","name":"australiacentral2","type":"Region","displayName":"Australia Central 2","regionalDisplayName":"(Asia Pacific) Australia Central 2","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"149.1244","latitude":"-35.3075","physicalLocation":"Canberra","pairedRegion":[{"name":"australiacentral","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australiacentral"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australiasoutheast","name":"australiasoutheast","type":"Region","displayName":"Australia Southeast","regionalDisplayName":"(Asia Pacific) Australia Southeast","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"144.9631","latitude":"-37.8136","physicalLocation":"Victoria","pairedRegion":[{"name":"australiaeast","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/australiaeast"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/jioindiacentral","name":"jioindiacentral","type":"Region","displayName":"Jio India Central","regionalDisplayName":"(Asia Pacific) Jio India Central","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"79.08886","latitude":"21.146633","physicalLocation":"Nagpur","pairedRegion":[{"name":"jioindiawest","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/jioindiawest"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/koreasouth","name":"koreasouth","type":"Region","displayName":"Korea South","regionalDisplayName":"(Asia Pacific) Korea South","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"129.0756","latitude":"35.1796","physicalLocation":"Busan","pairedRegion":[{"name":"koreacentral","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/koreacentral"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southindia","name":"southindia","type":"Region","displayName":"South India","regionalDisplayName":"(Asia Pacific) South India","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"80.1636","latitude":"12.9822","physicalLocation":"Chennai","pairedRegion":[{"name":"centralindia","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/centralindia"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/westindia","name":"westindia","type":"Region","displayName":"West India","regionalDisplayName":"(Asia Pacific) West India","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Asia Pacific","longitude":"72.868","latitude":"19.088","physicalLocation":"Mumbai","pairedRegion":[{"name":"southindia","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/southindia"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/canadaeast","name":"canadaeast","type":"Region","displayName":"Canada East","regionalDisplayName":"(Canada) Canada East","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Canada","longitude":"-71.217","latitude":"46.817","physicalLocation":"Quebec","pairedRegion":[{"name":"canadacentral","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/canadacentral"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/francesouth","name":"francesouth","type":"Region","displayName":"France South","regionalDisplayName":"(Europe) France South","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Europe","longitude":"2.1972","latitude":"43.8345","physicalLocation":"Marseille","pairedRegion":[{"name":"francecentral","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/francecentral"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/germanynorth","name":"germanynorth","type":"Region","displayName":"Germany North","regionalDisplayName":"(Europe) Germany North","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Europe","longitude":"8.806422","latitude":"53.073635","physicalLocation":"Berlin","pairedRegion":[{"name":"germanywestcentral","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/germanywestcentral"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/norwaywest","name":"norwaywest","type":"Region","displayName":"Norway West","regionalDisplayName":"(Europe) Norway West","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Europe","longitude":"5.733107","latitude":"58.969975","physicalLocation":"Norway","pairedRegion":[{"name":"norwayeast","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/norwayeast"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/switzerlandwest","name":"switzerlandwest","type":"Region","displayName":"Switzerland West","regionalDisplayName":"(Europe) Switzerland West","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Europe","longitude":"6.143158","latitude":"46.204391","physicalLocation":"Geneva","pairedRegion":[{"name":"switzerlandnorth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/switzerlandnorth"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/ukwest","name":"ukwest","type":"Region","displayName":"UK West","regionalDisplayName":"(Europe) UK West","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Europe","longitude":"-3.084","latitude":"53.427","physicalLocation":"Cardiff","pairedRegion":[{"name":"uksouth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/uksouth"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/uaecentral","name":"uaecentral","type":"Region","displayName":"UAE Central","regionalDisplayName":"(Middle East) UAE Central","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"Middle East","longitude":"54.366669","latitude":"24.466667","physicalLocation":"Abu Dhabi","pairedRegion":[{"name":"uaenorth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/uaenorth"}]}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/brazilsoutheast","name":"brazilsoutheast","type":"Region","displayName":"Brazil Southeast","regionalDisplayName":"(South America) Brazil Southeast","metadata":{"regionType":"Physical","regionCategory":"Other","geographyGroup":"South America","longitude":"-43.2075","latitude":"-22.90278","physicalLocation":"Rio","pairedRegion":[{"name":"brazilsouth","id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/locations/brazilsouth"}]}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "35781"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:49:42 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 49df2a253364c7faf47cfcf104e3c1ad
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 9e351a18-9a61-4c59-b2c8-a9d858178852
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T234942Z:9e351a18-9a61-4c59-b2c8-a9d858178852
+            X-Msedge-Ref:
+                - 'Ref A: 439B8584B8D04A659DB2336C142889B9 Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:49:39Z'
+        status: 200 OK
+        code: 200
+        duration: 3.30844375s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 49df2a253364c7faf47cfcf104e3c1ad
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-de207ca%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 12
+        uncompressed: false
+        body: '{"value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "12"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:49:42 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 49df2a253364c7faf47cfcf104e3c1ad
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 55496832-5078-4046-94f5-62069767ad08
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T234943Z:55496832-5078-4046-94f5-62069767ad08
+            X-Msedge-Ref:
+                - 'Ref A: 08646722FF5A4457A3D7296DFB86D03A Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:49:43Z'
+        status: 200 OK
+        code: 200
+        duration: 69.813ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 49df2a253364c7faf47cfcf104e3c1ad
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 40404
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/dataproduct48702-HostedResources-32E47270","name":"dataproduct48702-HostedResources-32E47270","type":"Microsoft.Resources/resourceGroups","location":"centraluseuap","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg73273/providers/Microsoft.NetworkAnalytics/dataProducts/dataproduct48702","tags":{},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/dataproduct72706-HostedResources-6BE50C22","name":"dataproduct72706-HostedResources-6BE50C22","type":"Microsoft.Resources/resourceGroups","location":"centraluseuap","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg39104/providers/Microsoft.NetworkAnalytics/dataProducts/dataproduct72706","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/product89683-HostedResources-6EFC6FE2","name":"product89683-HostedResources-6EFC6FE2","type":"Microsoft.Resources/resourceGroups","location":"centraluseuap","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg98573/providers/Microsoft.NetworkAnalytics/dataProducts/product89683","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/product56057-HostedResources-081D2AD1","name":"product56057-HostedResources-081D2AD1","type":"Microsoft.Resources/resourceGroups","location":"centraluseuap","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg31226/providers/Microsoft.NetworkAnalytics/dataProducts/product56057","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/product52308-HostedResources-5D5C105C","name":"product52308-HostedResources-5D5C105C","type":"Microsoft.Resources/resourceGroups","location":"centraluseuap","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg22243/providers/Microsoft.NetworkAnalytics/dataProducts/product52308","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/product09392-HostedResources-6F71BABB","name":"product09392-HostedResources-6F71BABB","type":"Microsoft.Resources/resourceGroups","location":"centraluseuap","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg70288/providers/Microsoft.NetworkAnalytics/dataProducts/product09392","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/product4lh001-HostedResources-20AFF06E","name":"product4lh001-HostedResources-20AFF06E","type":"Microsoft.Resources/resourceGroups","location":"centraluseuap","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/v-tongMonthlyReleaseTest02/providers/Microsoft.NetworkAnalytics/dataProducts/product4lh001","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/xiaofeitest-HostedResources-38FAB8A0","name":"xiaofeitest-HostedResources-38FAB8A0","type":"Microsoft.Resources/resourceGroups","location":"centraluseuap","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-xiaofei/providers/Microsoft.NetworkAnalytics/dataProducts/xiaofeitest","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/zed5311dwmin001-rg","name":"zed5311dwmin001-rg","type":"Microsoft.Resources/resourceGroups","location":"uksouth","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/dep-zed5311-databricks.workspaces-dwmin-rg/providers/Microsoft.Databricks/workspaces/zed5311dwmin001","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/openai-shared","name":"openai-shared","type":"Microsoft.Resources/resourceGroups","location":"swedencentral","tags":{"DoNotDelete":""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/wenjiefu","name":"wenjiefu","type":"Microsoft.Resources/resourceGroups","location":"southcentralus","tags":{"DeleteAfter":"07/12/2024 17:23:01"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/chriss","name":"chriss","type":"Microsoft.Resources/resourceGroups","location":"southcentralus","tags":{"DoNotDelete":""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/ResourceMoverRG-eastus-centralus-eus2","name":"ResourceMoverRG-eastus-centralus-eus2","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"DeleteAfter":"09/09/2023 21:30:48"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-mdwgecko","name":"rg-mdwgecko","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"DeleteAfter":"09/09/2023 21:31:22"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/NI_nc-platEng-Dev_eastus2","name":"NI_nc-platEng-Dev_eastus2","type":"Microsoft.Resources/resourceGroups","location":"eastus2","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/PlatEng-Dev/providers/Microsoft.DevCenter/networkconnections/nc-platEng-Dev","tags":{},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-contoso-i34nhebbt3526","name":"rg-contoso-i34nhebbt3526","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"devcenter4lh003","DeleteAfter":"11/08/2023 08:09:14"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/azdux","name":"azdux","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"Owners":"rajeshkamal,hemarina,matell,vivazqu,wabrez,weilim","DoNotDelete":""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-devcenter","name":"rg-wabrez-devcenter","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"wabrez-devcenter","DoNotDelete":""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/ResourceMoverRG-eastus-westus2-eus2","name":"ResourceMoverRG-eastus-westus2-eus2","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"DeleteAfter":"05/11/2024 19:17:16"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/AzSecPackAutoConfigRG","name":"AzSecPackAutoConfigRG","type":"Microsoft.Resources/resourceGroups","location":"eastus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-raychen-test-wus","name":"rg-raychen-test-wus","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"DeleteAfter ":"2024-12-30T12:30:00.000Z","owner":"raychen","DoNotDelete":""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg40370","name":"rg40370","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"DeleteAfter":"09/09/2023 21:33:47"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg16812","name":"rg16812","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"DeleteAfter":"09/09/2023 21:33:48"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/msolomon-testing","name":"msolomon-testing","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"DoNotDelete":"\"\""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/senyangrg","name":"senyangrg","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"DeleteAfter":"03/08/2024 00:08:48"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/v-tongMonthlyReleaseTest02","name":"v-tongMonthlyReleaseTest02","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"DeleteAfter":"11/27/2024 08:17:25"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/azsdk-pm-ai","name":"azsdk-pm-ai","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"azd-env-name":"TypeSpecChannelBot-dev"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/bterlson-cadl","name":"bterlson-cadl","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DoNotDelete":""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-shrejaappconfiguration","name":"rg-shrejaappconfiguration","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DeleteAfter":"2025-12-24T05:11:17.9627286Z","Owners":"shreja","ServiceDirectory":"appconfiguration"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rgloc88170fa","name":"rgloc88170fa","type":"Microsoft.Resources/resourceGroups","location":"westus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rgloc0890584","name":"rgloc0890584","type":"Microsoft.Resources/resourceGroups","location":"westus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-riparkaznamespaces","name":"rg-riparkaznamespaces","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DoNotDelete":"Service team has setup special things on this resource","DeleteAfter":"2024-12-20T21:46:59.4955367Z","ServiceDirectory":"messaging/eventgrid/aznamespaces","Owners":"ripark"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-riparkazservicebus","name":"rg-riparkazservicebus","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DeleteAfter":"2024-12-20T21:46:28.6292946Z","Owners":"ripark","ServiceDirectory":"messaging/azservicebus"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-riparkaztables","name":"rg-riparkaztables","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"ServiceDirectory":"data/aztables","DeleteAfter":"2024-12-20T21:45:38.9682135Z","Owners":"ripark"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/anuchan-poi","name":"anuchan-poi","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DeleteAfter":"11/30/2024 19:14:22"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-gearamatables","name":"rg-gearamatables","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"ServiceDirectory":"tables","Owners":"gearama","DeleteAfter":"2024-11-27T20:57:08.3261941Z"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-larryoeventhubs","name":"rg-larryoeventhubs","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"Owners":"larryo","DeleteAfter":"2024-11-24T19:25:57.7637691Z","ServiceDirectory":"eventhubs"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-vigera-4394_ai","name":"rg-vigera-4394_ai","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DeleteAfter":"11/22/2024 20:22:29"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/llawrence-eventgridtesting","name":"llawrence-eventgridtesting","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DeleteAfter":"11/23/2024 00:21:43"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/llawrence-rg","name":"llawrence-rg","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DeleteAfter":"11/23/2024 00:21:43"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-maorlegerkeyvault","name":"rg-maorlegerkeyvault","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DeleteAfter":"2024-11-23T18:10:58.1637018Z","ServiceDirectory":"keyvault","Owners":"maorleger"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-chrisstables","name":"rg-chrisstables","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"ServiceDirectory":"tables","Owners":"chriss","DeleteAfter":"2024-11-24T22:44:48.058547+00:00"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-llawrenceeventhub","name":"rg-llawrenceeventhub","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"ServiceDirectory":"eventhub","Owners":"llawrence","DeleteAfter":"2024-11-20T22:05:29.1416683Z"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-mlegermihsm","name":"rg-mlegermihsm","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DeleteAfter":"2024-11-23T18:11:15.1193293Z","ServiceDirectory":"keyvault","Owners":"maorleger"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-mlegerhsm","name":"rg-mlegerhsm","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DeleteAfter":"2024-11-23T18:31:23.5436544Z","ServiceDirectory":"keyvault","Owners":"maorleger"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-mlegerhsm2","name":"rg-mlegerhsm2","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DeleteAfter":"2024-11-23T18:46:57.9046341Z","ServiceDirectory":"keyvault","Owners":"maorleger"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-mlegerhsm3","name":"rg-mlegerhsm3","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DeleteAfter":"2024-11-23T19:03:35.9283306Z","ServiceDirectory":"keyvault","Owners":"maorleger"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-kashifkhanservicebus","name":"rg-kashifkhanservicebus","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"Owners":"kashifkhan","DeleteAfter":"2024-11-23T19:12:19.1602043Z","ServiceDirectory":"servicebus"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-mlegerhsm4","name":"rg-mlegerhsm4","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DeleteAfter":"2024-11-23T19:31:20.3464467Z","ServiceDirectory":"keyvault","Owners":"maorleger"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-llawrenceeventgrid","name":"rg-llawrenceeventgrid","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"ServiceDirectory":"eventgrid","Owners":"llawrence","DeleteAfter":"2024-11-24T16:27:28.8179650Z"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-llawrenceservicebus","name":"rg-llawrenceservicebus","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"ServiceDirectory":"servicebus","DeleteAfter":"2024-11-24T20:37:51.4654117Z","Owners":"llawrence"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-yalltbtests","name":"rg-yalltbtests","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DeleteAfter":"2024-11-25T01:47:36.8949743Z","Owners":"yall","ServiceDirectory":"tables"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-mlegerhsm6","name":"rg-mlegerhsm6","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DeleteAfter":"2024-11-25T17:57:29.9514805Z","ServiceDirectory":"keyvault","Owners":"maorleger"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-mlegerhsm7","name":"rg-mlegerhsm7","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"ServiceDirectory":"keyvault","DeleteAfter":"2024-11-25T18:59:23.5310302Z","Owners":"maorleger"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-mlegerhsm8","name":"rg-mlegerhsm8","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"ServiceDirectory":"keyvault","DeleteAfter":"2024-11-25T19:13:28.0885286Z","Owners":"maorleger"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-alzimmerstorage","name":"rg-alzimmerstorage","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"Owners":"alzimmer","DeleteAfter":"2024-11-25T20:17:08.9497402Z","ServiceDirectory":"storage"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-yallappconfigtests","name":"rg-yallappconfigtests","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"DeleteAfter":"2024-11-25T23:22:35.9390130Z","Owners":"yall","ServiceDirectory":"appconfiguration"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/NetworkWatcherRG","name":"NetworkWatcherRG","type":"Microsoft.Resources/resourceGroups","location":"westus2","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-stress-secrets-pg","name":"rg-stress-secrets-pg","type":"Microsoft.Resources/resourceGroups","location":"westus3","tags":{"environment":"pg","owners":"bebroder, albertcheng","DoNotDelete":""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-stress-cluster-pg","name":"rg-stress-cluster-pg","type":"Microsoft.Resources/resourceGroups","location":"westus3","tags":{"environment":"pg","owners":"bebroder, albertcheng","DoNotDelete":""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-nodes-s1-stress-pg-pg","name":"rg-nodes-s1-stress-pg-pg","type":"Microsoft.Resources/resourceGroups","location":"westus3","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-stress-cluster-pg/providers/Microsoft.ContainerService/managedClusters/stress-pg","tags":{"DoNotDelete":"","aks-managed-cluster-name":"stress-pg","aks-managed-cluster-rg":"rg-stress-cluster-pg","environment":"pg","owners":"bebroder, albertcheng"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdev-dev","name":"rg-azdev-dev","type":"Microsoft.Resources/resourceGroups","location":"westus2","tags":{"Owners":"rajeshkamal,hemarina,matell,vivazqu,wabrez,weilim","product":"azdev","DoNotDelete":""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/xiangyan-search","name":"xiangyan-search","type":"Microsoft.Resources/resourceGroups","location":"westus2","tags":{"DoNotDelete":""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/xiangyan-apiview-gpt","name":"xiangyan-apiview-gpt","type":"Microsoft.Resources/resourceGroups","location":"westus3","tags":{"DoNotDelete":""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/maorleger-mi","name":"maorleger-mi","type":"Microsoft.Resources/resourceGroups","location":"westus2","tags":{"DeleteAfter":"07/12/2025 17:23:02"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/MC_maorleger-mi_maorleger-mi_westus2","name":"MC_maorleger-mi_maorleger-mi_westus2","type":"Microsoft.Resources/resourceGroups","location":"westus2","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/maorleger-mi/providers/Microsoft.ContainerService/managedClusters/maorleger-mi","tags":{"aks-managed-cluster-name":"maorleger-mi","aks-managed-cluster-rg":"maorleger-mi"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/MA_defaultazuremonitorworkspace-wus2_westus2_managed","name":"MA_defaultazuremonitorworkspace-wus2_westus2_managed","type":"Microsoft.Resources/resourceGroups","location":"westus2","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/maorleger-mi/providers/microsoft.monitor/accounts/defaultazuremonitorworkspace-wus2","tags":{},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/gh-issue-labeler","name":"gh-issue-labeler","type":"Microsoft.Resources/resourceGroups","location":"westus2","tags":{"DoNotDelete":"\"\""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/jsquire-sdk-dotnet","name":"jsquire-sdk-dotnet","type":"Microsoft.Resources/resourceGroups","location":"westus2","tags":{"purpose":"local development","owner":"Jesse Squire","DoNotDelete":""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-weilim-as","name":"rg-weilim-as","type":"Microsoft.Resources/resourceGroups","location":"westus3","tags":{"azd-env-name":"weilim-as","DeleteAfter":"11/23/2024 00:21:44"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/vigera-databricks","name":"vigera-databricks","type":"Microsoft.Resources/resourceGroups","location":"westus2","tags":{"DeleteAfter":"11/23/2024 00:21:45"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/databricks-rg-vigera-databricks-qvxupqsado3le","name":"databricks-rg-vigera-databricks-qvxupqsado3le","type":"Microsoft.Resources/resourceGroups","location":"westus2","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/vigera-databricks/providers/Microsoft.Databricks/workspaces/vigera-databricks","tags":{},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/joheredi-rg","name":"joheredi-rg","type":"Microsoft.Resources/resourceGroups","location":"westus2","tags":{"DeleteAfter":"11/23/2024 00:21:46"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/antisch-cm","name":"antisch-cm","type":"Microsoft.Resources/resourceGroups","location":"westus2","tags":{"DeleteAfter":"11/23/2024 04:29:32"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/mcpatino-rg","name":"mcpatino-rg","type":"Microsoft.Resources/resourceGroups","location":"westus3","tags":{"DeleteAfter":"11/23/2024 04:29:33"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/antischquhldk34smp4c","name":"antischquhldk34smp4c","type":"Microsoft.Resources/resourceGroups","location":"westus2","tags":{"azd-env-name":"cloudmachine-searchopenaidemo-local","abc":"def","cloudmachine-friendlyname":"searchopenaidemo","DoNotDelete":"true"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/jeffreychen","name":"jeffreychen","type":"Microsoft.Resources/resourceGroups","location":"westus2","tags":{"DeleteAfter":"11/29/2024 20:25:44"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/javacsmrg073113ac","name":"javacsmrg073113ac","type":"Microsoft.Resources/resourceGroups","location":"westus3","tags":{"DeleteAfter":"11/21/2024 08:15:09"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/cppinttest-rg","name":"cppinttest-rg","type":"Microsoft.Resources/resourceGroups","location":"westus2","tags":{},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/dep-cntso-network.virtualHub-nvhwaf-rg","name":"dep-cntso-network.virtualHub-nvhwaf-rg","type":"Microsoft.Resources/resourceGroups","location":"eastasia","tags":{"DeleteAfter":"07/09/2024 07:20:37"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/typespec-service-adoption-mariog","name":"typespec-service-adoption-mariog","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"DoNotDelete":""," Owners":"marioguerra"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/jinlongshiAZD","name":"jinlongshiAZD","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"DeleteAfter":"11/27/2024 08:17:25"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rohitganguly-pycon-demo","name":"rohitganguly-pycon-demo","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{" Owners":"rohitganguly","DoNotDelete":""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-hemarina-test2","name":"rg-hemarina-test2","type":"Microsoft.Resources/resourceGroups","location":"australiacentral","tags":{"azd-env-name":"hemarina-test2"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-hemarina-test3","name":"rg-hemarina-test3","type":"Microsoft.Resources/resourceGroups","location":"australiacentral","tags":{"azd-env-name":"hemarina-test3"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-shrejasearchservice","name":"rg-shrejasearchservice","type":"Microsoft.Resources/resourceGroups","location":"westcentralus","tags":{"ServiceDirectory":"search","DeleteAfter":"2025-10-23T04:00:14.3477795Z","Owners":"shreja","DoNotDelete":"AI Chat Protocol Demo"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/jsquire-labeler","name":"jsquire-labeler","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"DoNotDelete":"","owner":"Jesse Squire","purpose":"Spring Grove testing"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-o12r-max","name":"rg-o12r-max","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wb-devcenter","name":"rg-wb-devcenter","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"wb-devcenter","DeleteAfter":"09/05/2024 23:19:06"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-jinlong-1121","name":"rg-jinlong-1121","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"Environment":"Dev","Owner":"AI Team","Project":"GPTBot","Toolkit":"Bicep","DeleteAfter":"10/09/2024 12:06:59"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-test-tc-final","name":"rg-test-tc-final","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"Environment":"Dev","Owner":"AI Team","Project":"GPTBot","Toolkit":"Bicep","DeleteAfter":"10/10/2024 11:13:37"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-bicep-registry","name":"rg-wabrez-bicep-registry","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"DoNotDelete":""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-ai-hoolis","name":"rg-wabrez-ai-hoolis","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"wabrez-ai-hoolis","DeleteAfter":"11/25/2024 00:28:08"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/vivazqu-testai-backend","name":"vivazqu-testai-backend","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"vivazqu-test-ai-full","DeleteAfter":"11/22/2024 00:21:58"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-vigera-app","name":"rg-vigera-app","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"vigera-app","DeleteAfter":"11/22/2024 20:22:30"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-hemarina-helloazd","name":"rg-hemarina-helloazd","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"DeleteAfter":"11/23/2024 00:21:46"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-wabrez-azd-search-demo","name":"rg-wabrez-azd-search-demo","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"wabrez-azd-search-demo","DeleteAfter":"11/24/2024 21:36:42"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/samvaity-rg","name":"samvaity-rg","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"DeleteAfter":"11/28/2024 20:26:50"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/alzimmer-rg","name":"alzimmer-rg","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"DeleteAfter":"11/29/2024 20:25:45"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-vision-chat-demo","name":"rg-vision-chat-demo","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"vision-chat-demo","DeleteAfter":"11/20/2024 20:25:43"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-demo-vision-chat-ignite","name":"rg-demo-vision-chat-ignite","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"demo-vision-chat-ignite","DeleteAfter":"11/20/2024 21:29:50"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azd-template-test-todo-nodejs-mongo-aks-4341647-2","name":"rg-azd-template-test-todo-nodejs-mongo-aks-4341647-2","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azd-template-test-todo-nodejs-mongo-aks-4341647-2","DeleteAfter":"11/21/2024 04:20:49"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg_aks_node","name":"rg_aks_node","type":"Microsoft.Resources/resourceGroups","location":"eastus2","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azd-template-test-todo-nodejs-mongo-aks-4341647-2/providers/Microsoft.ContainerService/managedClusters/aks-g2mjerqqp2mfi","tags":{"aks-managed-cluster-name":"aks-g2mjerqqp2mfi","aks-managed-cluster-rg":"rg-azd-template-test-todo-nodejs-mongo-aks-4341647-2"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-fenglongdev","name":"rg-fenglongdev","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"fenglongdev","DeleteAfter":"11/21/2024 08:15:11"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-mh111","name":"rg-mh111","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"mh111","DeleteAfter":"11/21/2024 12:19:51"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-mc-aks-fky3cgyrwgnzu","name":"rg-mc-aks-fky3cgyrwgnzu","type":"Microsoft.Resources/resourceGroups","location":"eastus2","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-mh111/providers/Microsoft.ContainerService/managedClusters/aks-fky3cgyrwgnzu","tags":{"aks-managed-cluster-name":"aks-fky3cgyrwgnzu","aks-managed-cluster-rg":"rg-mh111"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-mh214","name":"rg-mh214","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"mh214","DeleteAfter":"11/21/2024 12:19:52"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-mc-aks-wjknbjzhrk33q","name":"rg-mc-aks-wjknbjzhrk33q","type":"Microsoft.Resources/resourceGroups","location":"eastus2","managedBy":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-mh214/providers/Microsoft.ContainerService/managedClusters/aks-wjknbjzhrk33q","tags":{"aks-managed-cluster-name":"aks-wjknbjzhrk33q","aks-managed-cluster-rg":"rg-mh214"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/ignite-demo-2-env-rg","name":"ignite-demo-2-env-rg","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"ignite-demo-2-env","DeleteAfter":"11/21/2024 16:14:51"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/ignite-demo-3-rg","name":"ignite-demo-3-rg","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"ignite-demo-3","DeleteAfter":"11/21/2024 20:16:20"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-matell-dotnet-ca","name":"rg-matell-dotnet-ca","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"matell-dotnet-ca","DeleteAfter":"2024-11-20T23:37:39Z"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/DefaultResourceGroup-EUS2","name":"DefaultResourceGroup-EUS2","type":"Microsoft.Resources/resourceGroups","location":"eastus2","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-tdsn1120","name":"rg-tdsn1120","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"tdsn1120"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-kz34-max","name":"rg-kz34-max","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-nlkm-pe-mng","name":"rg-nlkm-pe-mng","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-ip60-pe-umg","name":"rg-ip60-pe-umg","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/dep-xsh-virtualmachineimages.imagetemplates-vmiitmax-rg","name":"dep-xsh-virtualmachineimages.imagetemplates-vmiitmax-rg","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"DeleteAfter":"09/11/2024 19:25:43"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/matthewp-rg","name":"matthewp-rg","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"DeleteAfter":"11/24/2024 21:36:43"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/ahkha-keyvault-rg","name":"ahkha-keyvault-rg","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"DeleteAfter":"11/25/2024 04:21:32"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-llaw","name":"rg-llaw","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"ServiceDirectory":"eventgrid","Owners":"llawrence","DeleteAfter":"2024-11-24T16:48:35.8173060Z"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/limolkova","name":"limolkova","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"DeleteAfter":"11/29/2024 21:29:51"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/DefaultResourceGroup-EUS","name":"DefaultResourceGroup-EUS","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"DeleteAfter":"11/21/2024 08:15:13"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/cmec4615e3fdfa44e","name":"cmec4615e3fdfa44e","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"DeleteAfter":"11/21/2024 16:14:52"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/cmec4615e3fdfa44g","name":"cmec4615e3fdfa44g","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"DeleteAfter":"11/21/2024 20:16:21"},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/xiangyan","name":"xiangyan","type":"Microsoft.Resources/resourceGroups","location":"westus2","tags":{"DoNotDelete":""},"properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/krpratic-rg","name":"krpratic-rg","type":"Microsoft.Resources/resourceGroups","location":"centralus","tags":{"DoNotDelete":""},"properties":{"provisioningState":"Succeeded"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "40404"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:49:43 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 49df2a253364c7faf47cfcf104e3c1ad
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 6a18ef1b-d8f1-487e-8421-c17ae70a2d7b
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T234943Z:6a18ef1b-d8f1-487e-8421-c17ae70a2d7b
+            X-Msedge-Ref:
+                - 'Ref A: 994E78D1453E4F5493B1F2E4D5596740 Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:49:43Z'
+        status: 200 OK
+        code: 200
+        duration: 93.254833ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 49df2a253364c7faf47cfcf104e3c1ad
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 284026
+        uncompressed: false
+        body: '{"value":[]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "284026"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:49:45 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 49df2a253364c7faf47cfcf104e3c1ad
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - cab940ef-2e84-4865-9b06-27deabef236f
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T234945Z:cab940ef-2e84-4865-9b06-27deabef236f
+            X-Msedge-Ref:
+                - 'Ref A: 85B2171BFAF74396840A78A2CC8AC61C Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:49:43Z'
+        status: 200 OK
+        code: 200
+        duration: 2.111639542s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 9515
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"location":"eastus2","properties":{"mode":"Incremental","parameters":{"environmentName":{"value":"azdtest-de207ca"},"location":{"value":"eastus2"}},"template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","metadata":{"_generator":{"name":"bicep","version":"0.29.47.4906","templateHash":"12856671344366107312"}},"parameters":{"environmentName":{"type":"string","minLength":1,"maxLength":64,"metadata":{"description":"Name of the the environment which is used to generate a short unique hash used in all resources."}},"location":{"type":"string","metadata":{"description":"Primary location for all resources"}},"deleteAfterTime":{"type":"string","defaultValue":"[dateTimeAdd(utcNow(''o''), ''PT1H'')]","metadata":{"description":"A time to mark on created resource groups, so they can be cleaned up via an automated process."}}},"variables":{"tags":{"azd-env-name":"[parameters(''environmentName'')]","DeleteAfter":"[parameters(''deleteAfterTime'')]"}},"resources":[{"type":"Microsoft.Resources/resourceGroups","apiVersion":"2021-04-01","name":"[format(''rg-{0}'', parameters(''environmentName''))]","location":"[parameters(''location'')]","tags":"[variables(''tags'')]"},{"type":"Microsoft.Resources/deployments","apiVersion":"2022-09-01","name":"resources","resourceGroup":"[format(''rg-{0}'', parameters(''environmentName''))]","properties":{"expressionEvaluationOptions":{"scope":"inner"},"mode":"Incremental","parameters":{"environmentName":{"value":"[parameters(''environmentName'')]"},"location":{"value":"[parameters(''location'')]"}},"template":{"$schema":"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","metadata":{"_generator":{"name":"bicep","version":"0.29.47.4906","templateHash":"11220754103571024397"}},"parameters":{"environmentName":{"type":"string"},"location":{"type":"string","defaultValue":"[resourceGroup().location]"},"adminUserEnabled":{"type":"bool","defaultValue":true},"anonymousPullEnabled":{"type":"bool","defaultValue":false},"dataEndpointEnabled":{"type":"bool","defaultValue":false},"encryption":{"type":"object","defaultValue":{"status":"disabled"}},"networkRuleBypassOptions":{"type":"string","defaultValue":"AzureServices"},"publicNetworkAccess":{"type":"string","defaultValue":"Enabled"},"sku":{"type":"object","defaultValue":{"name":"Basic"}},"zoneRedundancy":{"type":"string","defaultValue":"Disabled"}},"variables":{"tags":{"azd-env-name":"[parameters(''environmentName'')]"},"resourceToken":"[toLower(uniqueString(subscription().id, parameters(''environmentName''), parameters(''location'')))]"},"resources":[{"type":"Microsoft.ContainerRegistry/registries","apiVersion":"2023-01-01-preview","name":"[format(''cr{0}'', variables(''resourceToken''))]","location":"[parameters(''location'')]","tags":"[variables(''tags'')]","sku":"[parameters(''sku'')]","properties":{"adminUserEnabled":"[parameters(''adminUserEnabled'')]","anonymousPullEnabled":"[parameters(''anonymousPullEnabled'')]","dataEndpointEnabled":"[parameters(''dataEndpointEnabled'')]","encryption":"[parameters(''encryption'')]","networkRuleBypassOptions":"[parameters(''networkRuleBypassOptions'')]","publicNetworkAccess":"[parameters(''publicNetworkAccess'')]","zoneRedundancy":"[parameters(''zoneRedundancy'')]"}},{"type":"Microsoft.App/managedEnvironments","apiVersion":"2022-03-01","name":"[format(''cae-{0}'', variables(''resourceToken''))]","location":"[parameters(''location'')]","tags":"[variables(''tags'')]","properties":{"appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"[reference(resourceId(''Microsoft.OperationalInsights/workspaces'', format(''log-{0}'', variables(''resourceToken''))), ''2022-10-01'').customerId]","sharedKey":"[listKeys(resourceId(''Microsoft.OperationalInsights/workspaces'', format(''log-{0}'', variables(''resourceToken''))), ''2022-10-01'').primarySharedKey]"}}},"dependsOn":["[resourceId(''Microsoft.OperationalInsights/workspaces'', format(''log-{0}'', variables(''resourceToken'')))]"]},{"type":"Microsoft.OperationalInsights/workspaces","apiVersion":"2022-10-01","name":"[format(''log-{0}'', variables(''resourceToken''))]","location":"[parameters(''location'')]","tags":"[variables(''tags'')]","properties":{"retentionInDays":30,"features":{"searchVersion":1},"sku":{"name":"PerGB2018"}}}],"outputs":{"containerRegistryName":{"type":"string","value":"[format(''cr{0}'', variables(''resourceToken''))]"},"containerAppsEnvironmentName":{"type":"string","value":"[format(''cae-{0}'', variables(''resourceToken''))]"},"containerRegistryloginServer":{"type":"string","value":"[reference(resourceId(''Microsoft.ContainerRegistry/registries'', format(''cr{0}'', variables(''resourceToken''))), ''2023-01-01-preview'').loginServer]"}}}},"dependsOn":["[subscriptionResourceId(''Microsoft.Resources/resourceGroups'', format(''rg-{0}'', parameters(''environmentName'')))]"]},{"type":"Microsoft.Resources/deployments","apiVersion":"2022-09-01","name":"web","resourceGroup":"[format(''rg-{0}'', parameters(''environmentName''))]","properties":{"expressionEvaluationOptions":{"scope":"inner"},"mode":"Incremental","parameters":{"containerRegistryName":{"value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.containerRegistryName.value]"},"containerAppsEnvironmentName":{"value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.containerAppsEnvironmentName.value]"},"environmentName":{"value":"[parameters(''environmentName'')]"},"location":{"value":"[parameters(''location'')]"},"imageName":{"value":"nginx:latest"}},"template":{"$schema":"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","metadata":{"_generator":{"name":"bicep","version":"0.29.47.4906","templateHash":"9857249991022820150"}},"parameters":{"environmentName":{"type":"string"},"location":{"type":"string","defaultValue":"[resourceGroup().location]"},"imageName":{"type":"string"},"containerRegistryName":{"type":"string"},"containerAppsEnvironmentName":{"type":"string"}},"variables":{"tags":{"azd-env-name":"[parameters(''environmentName'')]"},"resourceToken":"[toLower(uniqueString(subscription().id, parameters(''environmentName''), parameters(''location'')))]"},"resources":[{"type":"Microsoft.App/containerApps","apiVersion":"2023-05-02-preview","name":"[format(''ca-{0}'', variables(''resourceToken''))]","location":"[parameters(''location'')]","tags":"[union(variables(''tags''), createObject(''azd-service-name'', ''web''))]","properties":{"managedEnvironmentId":"[resourceId(''Microsoft.App/managedEnvironments'', parameters(''containerAppsEnvironmentName''))]","configuration":{"activeRevisionsMode":"single","ingress":{"external":true,"targetPort":8080,"transport":"auto"},"secrets":[{"name":"registry-password","value":"[listCredentials(resourceId(''Microsoft.ContainerRegistry/registries'', parameters(''containerRegistryName'')), ''2023-01-01-preview'').passwords[0].value]"}],"registries":[{"server":"[format(''{0}.azurecr.io'', parameters(''containerRegistryName''))]","username":"[parameters(''containerRegistryName'')]","passwordSecretRef":"registry-password"}]},"template":{"containers":[{"image":"[parameters(''imageName'')]","name":"main","env":[]}]}}}],"outputs":{"WEBSITE_URL":{"type":"string","value":"[format(''https://{0}'', reference(resourceId(''Microsoft.App/containerApps'', format(''ca-{0}'', variables(''resourceToken''))), ''2023-05-02-preview'').configuration.ingress.fqdn)]"}}}},"dependsOn":["[extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources'')]","[subscriptionResourceId(''Microsoft.Resources/resourceGroups'', format(''rg-{0}'', parameters(''environmentName'')))]"]}],"outputs":{"AZURE_CONTAINER_REGISTRY_NAME":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.containerRegistryName.value]"},"AZURE_CONTAINER_ENVIRONMENT_NAME":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.containerAppsEnvironmentName.value]"},"AZURE_CONTAINER_REGISTRY_ENDPOINT":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''resources''), ''2022-09-01'').outputs.containerRegistryloginServer.value]"},"WEBSITE_URL":{"type":"string","value":"[reference(extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'', subscription().subscriptionId, format(''rg-{0}'', parameters(''environmentName''))), ''Microsoft.Resources/deployments'', ''web''), ''2022-09-01'').outputs.WEBSITE_URL.value]"}}}},"tags":{"azd-env-name":"azdtest-de207ca","azd-provision-param-hash":"d03c3e46ae91b9352a9b20036d26adfe205cb3040af103c2d61b737993f1672b"}}'
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Length:
+                - "9515"
+            Content-Type:
+                - application/json
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 49df2a253364c7faf47cfcf104e3c1ad
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560?api-version=2021-04-01
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2271
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560","name":"azdtest-de207ca-1732146560","type":"Microsoft.Resources/deployments","location":"eastus2","tags":{"azd-env-name":"azdtest-de207ca","azd-provision-param-hash":"d03c3e46ae91b9352a9b20036d26adfe205cb3040af103c2d61b737993f1672b"},"properties":{"templateHash":"12856671344366107312","parameters":{"environmentName":{"type":"String","value":"azdtest-de207ca"},"location":{"type":"String","value":"eastus2"},"deleteAfterTime":{"type":"String","value":"2024-11-21T00:49:45Z"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2024-11-20T23:49:48.474839Z","duration":"PT0.0001742S","correlationId":"49df2a253364c7faf47cfcf104e3c1ad","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["eastus2"]},{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","resourceType":"Microsoft.Resources/resourceGroups","resourceName":"rg-azdtest-de207ca"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","resourceType":"Microsoft.Resources/resourceGroups","resourceName":"rg-azdtest-de207ca"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources","apiVersion":"2022-09-01"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/web","resourceType":"Microsoft.Resources/deployments","resourceName":"web"}]}}'
+        headers:
+            Azure-Asyncoperation:
+                - https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560/operationStatuses/08584694602995920570?api-version=2021-04-01
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2271"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:49:49 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 49df2a253364c7faf47cfcf104e3c1ad
+            X-Ms-Deployment-Engine-Version:
+                - 1.158.0
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Writes:
+                - "11999"
+            X-Ms-Ratelimit-Remaining-Subscription-Writes:
+                - "799"
+            X-Ms-Request-Id:
+                - b300b799-893f-499a-9a55-6a1eec1dbc8d
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T234949Z:b300b799-893f-499a-9a55-6a1eec1dbc8d
+            X-Msedge-Ref:
+                - 'Ref A: 1628AD85EBED4FA9BAA7DCBA679930FB Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:49:45Z'
+        status: 201 Created
+        code: 201
+        duration: 4.218506666s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 49df2a253364c7faf47cfcf104e3c1ad
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560/operationStatuses/08584694602995920570?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 22
+        uncompressed: false
+        body: '{"status":"Succeeded"}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "22"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:51:51 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 49df2a253364c7faf47cfcf104e3c1ad
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 2ab2e078-7b6b-4b30-8dec-13fc2d357630
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235151Z:2ab2e078-7b6b-4b30-8dec-13fc2d357630
+            X-Msedge-Ref:
+                - 'Ref A: 910AFF890F9F49B797E044939FD5D9D8 Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:51:51Z'
+        status: 200 OK
+        code: 200
+        duration: 438.36525ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 49df2a253364c7faf47cfcf104e3c1ad
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3399
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560","name":"azdtest-de207ca-1732146560","type":"Microsoft.Resources/deployments","location":"eastus2","tags":{"azd-env-name":"azdtest-de207ca","azd-provision-param-hash":"d03c3e46ae91b9352a9b20036d26adfe205cb3040af103c2d61b737993f1672b"},"properties":{"templateHash":"12856671344366107312","parameters":{"environmentName":{"type":"String","value":"azdtest-de207ca"},"location":{"type":"String","value":"eastus2"},"deleteAfterTime":{"type":"String","value":"2024-11-21T00:49:45Z"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-11-20T23:51:43.4063381Z","duration":"PT1M54.9316733S","correlationId":"49df2a253364c7faf47cfcf104e3c1ad","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["eastus2"]},{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","resourceType":"Microsoft.Resources/resourceGroups","resourceName":"rg-azdtest-de207ca"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","resourceType":"Microsoft.Resources/resourceGroups","resourceName":"rg-azdtest-de207ca"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources","apiVersion":"2022-09-01"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/web","resourceType":"Microsoft.Resources/deployments","resourceName":"web"}],"outputs":{"azurE_CONTAINER_REGISTRY_NAME":{"type":"String","value":"crtf5bjllihraai"},"azurE_CONTAINER_ENVIRONMENT_NAME":{"type":"String","value":"cae-tf5bjllihraai"},"azurE_CONTAINER_REGISTRY_ENDPOINT":{"type":"String","value":"crtf5bjllihraai.azurecr.io"},"websitE_URL":{"type":"String","value":"https://ca-tf5bjllihraai.greencoast-e664163f.eastus2.azurecontainerapps.io"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerApps/ca-tf5bjllihraai"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/managedEnvironments/cae-tf5bjllihraai"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.ContainerRegistry/registries/crtf5bjllihraai"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.OperationalInsights/workspaces/log-tf5bjllihraai"}]}}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3399"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:51:51 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 49df2a253364c7faf47cfcf104e3c1ad
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - e98ecb8e-69f6-4771-bee3-0ee58350d396
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235151Z:e98ecb8e-69f6-4771-bee3-0ee58350d396
+            X-Msedge-Ref:
+                - 'Ref A: 2A0AFC0CE828466DB43116304536982A Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:51:51Z'
+        status: 200 OK
+        code: 200
+        duration: 393.631ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 49df2a253364c7faf47cfcf104e3c1ad
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-de207ca%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 325
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","name":"rg-azdtest-de207ca","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-de207ca","DeleteAfter":"2024-11-21T00:49:45Z"},"properties":{"provisioningState":"Succeeded"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:51:54 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 49df2a253364c7faf47cfcf104e3c1ad
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 6676204e-5e69-400c-9464-f18667c53fe6
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235154Z:6676204e-5e69-400c-9464-f18667c53fe6
+            X-Msedge-Ref:
+                - 'Ref A: B8174DD33E3F4E5880CF35AC6C34AAF1 Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:51:54Z'
+        status: 200 OK
+        code: 200
+        duration: 181.266625ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-de207ca%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 325
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","name":"rg-azdtest-de207ca","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-de207ca","DeleteAfter":"2024-11-21T00:49:45Z"},"properties":{"provisioningState":"Succeeded"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:51:55 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 73d6b651-1961-4d40-92a2-b9ec4bad6e2b
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235155Z:73d6b651-1961-4d40-92a2-b9ec4bad6e2b
+            X-Msedge-Ref:
+                - 'Ref A: C8B14722CAB44AE194C8397F95C27D9F Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:51:55Z'
+        status: 200 OK
+        code: 200
+        duration: 65.187166ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.Client/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/resources?%24filter=tagName+eq+%27azd-service-name%27+and+tagValue+eq+%27web%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 364
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerApps/ca-tf5bjllihraai","name":"ca-tf5bjllihraai","type":"Microsoft.App/containerApps","kind":"","managedBy":"","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-de207ca","azd-service-name":"web"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "364"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:51:55 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 0fd96cbb-475c-44df-bd0b-0cd9504060f7
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235155Z:0fd96cbb-475c-44df-bd0b-0cd9504060f7
+            X-Msedge-Ref:
+                - 'Ref A: 4478A45C02194DC285C4F3740E0C677F Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:51:55Z'
+        status: 200 OK
+        code: 200
+        duration: 402.500834ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        transfer_encoding:
+            - chunked
+        trailer: {}
+        host: crtf5bjllihraai.azurecr.io
+        remote_addr: ""
+        request_uri: ""
+        body: access_token=SANITIZED&grant_type=access_token&service=crtf5bjllihraai.azurecr.io
+        form:
+            access_token:
+                - SANITIZED
+            grant_type:
+                - access_token
+            service:
+                - crtf5bjllihraai.azurecr.io
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Type:
+                - application/x-www-form-urlencoded
+            User-Agent:
+                - azsdk-go-azd-acr/0.0.0-dev.0 (commit 0000000000000000000000000000000000000000) (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+        url: https://crtf5bjllihraai.azurecr.io:443/oauth2/exchange
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding:
+            - chunked
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"refresh_token":"SANITIZED"}'
+        headers:
+            Connection:
+                - keep-alive
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:51:56 GMT
+            Server:
+                - AzureContainerRegistry
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+            X-Ms-Ratelimit-Remaining-Calls-Per-Second:
+                - "166.65"
+        status: 200 OK
+        code: 200
+        duration: 421.016708ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armappcontainers/v3.0.0-beta.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerApps/ca-tf5bjllihraai?api-version=2023-11-02-preview
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2543
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerapps/ca-tf5bjllihraai","name":"ca-tf5bjllihraai","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"azd-env-name":"azdtest-de207ca","azd-service-name":"web"},"systemData":{"createdBy":"matell@microsoft.com","createdByType":"User","createdAt":"2024-11-20T23:51:19.2800391","lastModifiedBy":"matell@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-11-20T23:51:19.2800391"},"properties":{"provisioningState":"Succeeded","runningStatus":"Running","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/managedEnvironments/cae-tf5bjllihraai","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/managedEnvironments/cae-tf5bjllihraai","workloadProfileName":null,"outboundIpAddresses":["48.214.9.178"],"latestRevisionName":"ca-tf5bjllihraai--rbfti59","latestReadyRevisionName":"ca-tf5bjllihraai--rbfti59","latestRevisionFqdn":"ca-tf5bjllihraai--rbfti59.greencoast-e664163f.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"registry-password"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"ca-tf5bjllihraai.greencoast-e664163f.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Auto","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null,"additionalPortMappings":null,"targetPortHttpScheme":null},"registries":[{"server":"crtf5bjllihraai.azurecr.io","username":"crtf5bjllihraai","passwordSecretRef":"registry-password","identity":""}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"","terminationGracePeriodSeconds":null,"containers":[{"image":"nginx:latest","name":"main","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"}}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/containerApps/ca-tf5bjllihraai/eventstream","delegatedIdentities":[]},"identity":{"type":"None"}}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01, 2024-08-02-preview, 2024-10-02-preview
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2543"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:52:13 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 8ac96bdc-2548-4f4f-b9e6-add724a89d89
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235213Z:8ac96bdc-2548-4f4f-b9e6-add724a89d89
+            X-Msedge-Ref:
+                - 'Ref A: E0FAD946B60941E18C99C5A804DE98B1 Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:52:13Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 656.742459ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armappcontainers/v3.0.0-beta.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerApps/ca-tf5bjllihraai/revisions/ca-tf5bjllihraai--rbfti59?api-version=2023-11-02-preview
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 916
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerApps/ca-tf5bjllihraai/revisions/ca-tf5bjllihraai--rbfti59","name":"ca-tf5bjllihraai--rbfti59","type":"Microsoft.App/containerapps/revisions","properties":{"createdTime":"2024-11-20T23:51:25+00:00","fqdn":"ca-tf5bjllihraai--rbfti59.greencoast-e664163f.eastus2.azurecontainerapps.io","template":{"revisionSuffix":null,"terminationGracePeriodSeconds":null,"containers":[{"image":"nginx:latest","name":"main","resources":{"cpu":0.500,"memory":"1Gi"},"probes":[]}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"active":true,"replicas":1,"trafficWeight":100,"healthState":"None","provisioningState":"Provisioned","runningState":"Activating","runningStateDetails":"The TargetPort 8080 does not match the listening port 80."}}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01, 2024-08-02-preview, 2024-10-02-preview
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "916"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:52:14 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 13192a73-e7a5-46b3-afbb-2094e54c1bbf
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235214Z:13192a73-e7a5-46b3-afbb-2094e54c1bbf
+            X-Msedge-Ref:
+                - 'Ref A: F37A3EE3899C41AA8265D48755FE9550 Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:52:13Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 1.2030055s
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Length:
+                - "0"
+            User-Agent:
+                - azsdk-go-armappcontainers/v3.0.0-beta.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerApps/ca-tf5bjllihraai/listSecrets?api-version=2023-11-02-preview
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 103
+        uncompressed: false
+        body: '{"value":[{"name":"registry-password","value":"SANITIZED"}]}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01, 2024-08-02-preview, 2024-10-02-preview
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "103"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:52:15 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Writes:
+                - "11999"
+            X-Ms-Ratelimit-Remaining-Subscription-Writes:
+                - "799"
+            X-Ms-Request-Id:
+                - ef877d1e-41bb-4261-bd4d-d0a887aeb276
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235215Z:ef877d1e-41bb-4261-bd4d-d0a887aeb276
+            X-Msedge-Ref:
+                - 'Ref A: 4174B8A2BBEE429FB52A088D39FFB9A8 Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:52:14Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 691.44625ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2269
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerapps/ca-tf5bjllihraai","identity":{"type":"None"},"location":"East US 2","name":"ca-tf5bjllihraai","properties":{"configuration":{"activeRevisionsMode":"Single","ingress":{"allowInsecure":false,"exposedPort":0,"external":true,"fqdn":"ca-tf5bjllihraai.greencoast-e664163f.eastus2.azurecontainerapps.io","targetPort":8080,"traffic":[{"latestRevision":true,"weight":100}],"transport":"Auto"},"maxInactiveRevisions":100,"registries":[{"identity":"","passwordSecretRef":"registry-password","server":"crtf5bjllihraai.azurecr.io","username":"crtf5bjllihraai"}],"secrets":[{"name":"registry-password","value":"SANITIZED"}]},"customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/managedEnvironments/cae-tf5bjllihraai","eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/containerApps/ca-tf5bjllihraai/eventstream","latestReadyRevisionName":"ca-tf5bjllihraai--rbfti59","latestRevisionFqdn":"ca-tf5bjllihraai--rbfti59.greencoast-e664163f.eastus2.azurecontainerapps.io","latestRevisionName":"ca-tf5bjllihraai--rbfti59","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/managedEnvironments/cae-tf5bjllihraai","outboundIpAddresses":["48.214.9.178"],"provisioningState":"Succeeded","template":{"containers":[{"image":"crtf5bjllihraai.azurecr.io/containerapp/web-azdtest-de207ca:azd-deploy-1732146560","name":"main","probes":[],"resources":{"cpu":0.5,"memory":"1Gi"}}],"revisionSuffix":"azd-1732146560","scale":{"maxReplicas":10}}},"systemData":{"createdAt":"2024-11-20T23:51:19.2800391Z","createdBy":"matell@microsoft.com","createdByType":"User","lastModifiedAt":"2024-11-20T23:51:19.2800391Z","lastModifiedBy":"matell@microsoft.com","lastModifiedByType":"User"},"tags":{"azd-env-name":"azdtest-de207ca","azd-service-name":"web"},"type":"Microsoft.App/containerApps"}'
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Length:
+                - "2269"
+            Content-Type:
+                - application/json
+            User-Agent:
+                - azsdk-go-armappcontainers/v3.0.0-beta.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerApps/ca-tf5bjllihraai?api-version=2023-11-02-preview
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01, 2024-08-02-preview, 2024-10-02-preview
+            Azure-Asyncoperation:
+                - https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/11b998db-7857-4084-9137-c21d729c6db8?api-version=2023-11-02-preview&azureAsyncOperation=true&t=638677435365856741&c=MIIHpTCCBo2gAwIBAgITOgM6dTLGpzYZpvPtgQAEAzp1MjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSU5GUkEgQ0EgMDEwHhcNMjQwNjI2MDEzMjIxWhcNMjUwNjIxMDEzMjIxWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPPPKY5bDN03KptFFhiyLIyn86BlrXYFIZWYXA-hY7_WbLyWN0IxcLIUBW_I-9u-YsXOHk9WPMlUYHIFPgHW7A3FsSGfl9dd6YGapKoSSw0NkTpNXM58R54BBgLp7AhiWzK15D9T-XELNSU4Wq9sEeA5T24kazcgS2MUkzELH0I9dwu7g0dwJIuIJkoJjEzg1b1Q3Ie5HKHHNbjottJn7Q5LBS-9QtQyruuwaNTgSJpCoi4PBKVIOTBYL_Nv1wecmKmfWcT0mnhQE9zjhJTbcoN9hKSvAMqsDHtxWUFZosiw3JKIY0zb59CrVGSuOhfN3qaarwN9EAlXLqc4ZyKpsTkCAwEAAaOCBJIwggSOMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQlkyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMElORlJBJTIwQ0ElMjAwMSg0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JZMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CWTJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSU5GUkElMjBDQSUyMDAxKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQlkyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMElORlJBJTIwQ0ElMjAwMSg0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JZMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3J0MB0GA1UdDgQWBBRk_38CqdKjPVylWUR4uuqhbFGeHTAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwEwDAYKKwYBBAGCN3sEATAfBgNVHSMEGDAWgBTl2Ztn_PjsurvwwKidileIud8-YzAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAFsx7FtYAzSo98T5ydNFa0ukjPZ6XCQc9zo7ldqy235P_zJAUkaNgCU4EGOzbZJDoMa8mAfhyukL_0GfPeApUaY2e44ZOzoYAkeEuDiwcs-9zoQ1fCyXhn0pCumGFXRilX9KjAPaYTzDvQMEllTy_ZViwTahuKaGtFVamZguBPdaeYC_0oybtTVNQCs8hGnffhNZOMASB-5pFs35MNxsDWTVIQksDee419jqpsbWLkh6rnanILO1O_ihwb-WpvRQByQ5NGpG1-z0MQ6nRpr9wWxUi-DsrVsD38NTMIPc2uei4Ivf6qnGRvOOj0fmsciWuTTEXMaD-5a81mGlzhZc09Q&s=RmGC8qaSRyDXG16thsEDbdrFiT8NZYP0iOQGbBQ-OYezNCD0kOog91gYsEzO9W1XRwTM6MG9tVbcd_jjJd5tK5aTEST9oyotqivakobYYvSi06TYXqIcdyKqTikJ79gOUl7U4d4uBAFfoxThqNpCoM5yQBw9HP-p_tchi1gvkLYpv3OL6BI7FzlXkHxIcoMS97jWXl8UjmvsrrEHqawKjvFSF6JUFuKbb1WH6Akv2TYSUh6fCKOCqGA12SUrZ2Sm9CSTeX0QcCFCthgDjYWSR_RPcSBzouNFdUelq5nJJyhbwkoNm2aFa8wcd7wHiAh2L0PKiMGFpr1S-voo3BUpLw&h=1zF-0QaHGPg9-ZVxK9lgqS5RDY6klvrY4c0l6VqkYT4
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "0"
+            Date:
+                - Wed, 20 Nov 2024 23:52:16 GMT
+            Expires:
+                - "-1"
+            Location:
+                - https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationResults/11b998db-7857-4084-9137-c21d729c6db8?api-version=2023-11-02-preview&t=638677435365856741&c=MIIHpTCCBo2gAwIBAgITOgM6dTLGpzYZpvPtgQAEAzp1MjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSU5GUkEgQ0EgMDEwHhcNMjQwNjI2MDEzMjIxWhcNMjUwNjIxMDEzMjIxWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPPPKY5bDN03KptFFhiyLIyn86BlrXYFIZWYXA-hY7_WbLyWN0IxcLIUBW_I-9u-YsXOHk9WPMlUYHIFPgHW7A3FsSGfl9dd6YGapKoSSw0NkTpNXM58R54BBgLp7AhiWzK15D9T-XELNSU4Wq9sEeA5T24kazcgS2MUkzELH0I9dwu7g0dwJIuIJkoJjEzg1b1Q3Ie5HKHHNbjottJn7Q5LBS-9QtQyruuwaNTgSJpCoi4PBKVIOTBYL_Nv1wecmKmfWcT0mnhQE9zjhJTbcoN9hKSvAMqsDHtxWUFZosiw3JKIY0zb59CrVGSuOhfN3qaarwN9EAlXLqc4ZyKpsTkCAwEAAaOCBJIwggSOMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQlkyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMElORlJBJTIwQ0ElMjAwMSg0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JZMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CWTJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSU5GUkElMjBDQSUyMDAxKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQlkyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMElORlJBJTIwQ0ElMjAwMSg0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JZMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3J0MB0GA1UdDgQWBBRk_38CqdKjPVylWUR4uuqhbFGeHTAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwEwDAYKKwYBBAGCN3sEATAfBgNVHSMEGDAWgBTl2Ztn_PjsurvwwKidileIud8-YzAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAFsx7FtYAzSo98T5ydNFa0ukjPZ6XCQc9zo7ldqy235P_zJAUkaNgCU4EGOzbZJDoMa8mAfhyukL_0GfPeApUaY2e44ZOzoYAkeEuDiwcs-9zoQ1fCyXhn0pCumGFXRilX9KjAPaYTzDvQMEllTy_ZViwTahuKaGtFVamZguBPdaeYC_0oybtTVNQCs8hGnffhNZOMASB-5pFs35MNxsDWTVIQksDee419jqpsbWLkh6rnanILO1O_ihwb-WpvRQByQ5NGpG1-z0MQ6nRpr9wWxUi-DsrVsD38NTMIPc2uei4Ivf6qnGRvOOj0fmsciWuTTEXMaD-5a81mGlzhZc09Q&s=O3lR53p2igDZzPQY5_3WeifyAQ0vR44fNwW0Rf1Dum20ml6PFJTE_1a3PNXIihd93yUpK6c17uY3v-UopPWbKuQmASiUzamWgnQI9Kl1Wux74ffB840DSkK1ZpisSC_mz6LXYaQrsuxFBKHXblgW3_fHsoG79N8LfC180N-Jx5O9pOHHi1q_fOrhdrGkgUTZ_uPE5u6aVU79A8PHDpcW1QcOgqrC97TcSPJDx5RSubOmf5yktHiF5msXy8eypxyE54_S1tm3yPU-rBfcc4PKD65lv787pwZ2a5OjtRIrgLnX6vID6g3V7Fi-uW6SPDV9mE0BmmUwPaOm8XfeukXqjQ&h=pMDewDnDCgiVdyVZ5zOscTzZBEMpF55Wh9fh_upGbQU
+            Pragma:
+                - no-cache
+            Retry-After:
+                - "0"
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+            X-Ms-Ratelimit-Remaining-Subscription-Resource-Requests:
+                - "699"
+            X-Ms-Request-Id:
+                - 14aa2535-454e-4566-8c3a-465dd1f7b7bc
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235216Z:14aa2535-454e-4566-8c3a-465dd1f7b7bc
+            X-Msedge-Ref:
+                - 'Ref A: 4827066D0D654FB9B7AC19DEEEACE51A Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:52:15Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 202 Accepted
+        code: 202
+        duration: 999.49225ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armappcontainers/v3.0.0-beta.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/11b998db-7857-4084-9137-c21d729c6db8?api-version=2023-11-02-preview&azureAsyncOperation=true&t=638677435365856741&c=MIIHpTCCBo2gAwIBAgITOgM6dTLGpzYZpvPtgQAEAzp1MjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSU5GUkEgQ0EgMDEwHhcNMjQwNjI2MDEzMjIxWhcNMjUwNjIxMDEzMjIxWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPPPKY5bDN03KptFFhiyLIyn86BlrXYFIZWYXA-hY7_WbLyWN0IxcLIUBW_I-9u-YsXOHk9WPMlUYHIFPgHW7A3FsSGfl9dd6YGapKoSSw0NkTpNXM58R54BBgLp7AhiWzK15D9T-XELNSU4Wq9sEeA5T24kazcgS2MUkzELH0I9dwu7g0dwJIuIJkoJjEzg1b1Q3Ie5HKHHNbjottJn7Q5LBS-9QtQyruuwaNTgSJpCoi4PBKVIOTBYL_Nv1wecmKmfWcT0mnhQE9zjhJTbcoN9hKSvAMqsDHtxWUFZosiw3JKIY0zb59CrVGSuOhfN3qaarwN9EAlXLqc4ZyKpsTkCAwEAAaOCBJIwggSOMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQlkyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMElORlJBJTIwQ0ElMjAwMSg0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JZMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CWTJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSU5GUkElMjBDQSUyMDAxKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQlkyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMElORlJBJTIwQ0ElMjAwMSg0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JZMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3J0MB0GA1UdDgQWBBRk_38CqdKjPVylWUR4uuqhbFGeHTAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwEwDAYKKwYBBAGCN3sEATAfBgNVHSMEGDAWgBTl2Ztn_PjsurvwwKidileIud8-YzAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAFsx7FtYAzSo98T5ydNFa0ukjPZ6XCQc9zo7ldqy235P_zJAUkaNgCU4EGOzbZJDoMa8mAfhyukL_0GfPeApUaY2e44ZOzoYAkeEuDiwcs-9zoQ1fCyXhn0pCumGFXRilX9KjAPaYTzDvQMEllTy_ZViwTahuKaGtFVamZguBPdaeYC_0oybtTVNQCs8hGnffhNZOMASB-5pFs35MNxsDWTVIQksDee419jqpsbWLkh6rnanILO1O_ihwb-WpvRQByQ5NGpG1-z0MQ6nRpr9wWxUi-DsrVsD38NTMIPc2uei4Ivf6qnGRvOOj0fmsciWuTTEXMaD-5a81mGlzhZc09Q&s=RmGC8qaSRyDXG16thsEDbdrFiT8NZYP0iOQGbBQ-OYezNCD0kOog91gYsEzO9W1XRwTM6MG9tVbcd_jjJd5tK5aTEST9oyotqivakobYYvSi06TYXqIcdyKqTikJ79gOUl7U4d4uBAFfoxThqNpCoM5yQBw9HP-p_tchi1gvkLYpv3OL6BI7FzlXkHxIcoMS97jWXl8UjmvsrrEHqawKjvFSF6JUFuKbb1WH6Akv2TYSUh6fCKOCqGA12SUrZ2Sm9CSTeX0QcCFCthgDjYWSR_RPcSBzouNFdUelq5nJJyhbwkoNm2aFa8wcd7wHiAh2L0PKiMGFpr1S-voo3BUpLw&h=1zF-0QaHGPg9-ZVxK9lgqS5RDY6klvrY4c0l6VqkYT4
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 278
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.App/locations/eastus2/containerappOperationStatuses/11b998db-7857-4084-9137-c21d729c6db8","name":"11b998db-7857-4084-9137-c21d729c6db8","status":"Succeeded","startTime":"2024-11-20T23:52:16.5148894"}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01, 2024-08-02-preview, 2024-10-02-preview
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "278"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:52:31 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 0f5e36cc-7234-4348-b477-85601b3ee659
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235232Z:0f5e36cc-7234-4348-b477-85601b3ee659
+            X-Msedge-Ref:
+                - 'Ref A: A71EC925F5964AF8A6244457A2910F26 Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:52:31Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 442.951208ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armappcontainers/v3.0.0-beta.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerApps/ca-tf5bjllihraai?api-version=2023-11-02-preview
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2652
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerapps/ca-tf5bjllihraai","name":"ca-tf5bjllihraai","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"azd-env-name":"azdtest-de207ca","azd-service-name":"web"},"systemData":{"createdBy":"matell@microsoft.com","createdByType":"User","createdAt":"2024-11-20T23:51:19.2800391","lastModifiedBy":"matell@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-11-20T23:52:16.2263043"},"properties":{"provisioningState":"Succeeded","runningStatus":"Running","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/managedEnvironments/cae-tf5bjllihraai","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/managedEnvironments/cae-tf5bjllihraai","workloadProfileName":null,"outboundIpAddresses":["48.214.9.178"],"latestRevisionName":"ca-tf5bjllihraai--azd-1732146560","latestReadyRevisionName":"ca-tf5bjllihraai--rbfti59","latestRevisionFqdn":"ca-tf5bjllihraai--azd-1732146560.greencoast-e664163f.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"registry-password"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"ca-tf5bjllihraai.greencoast-e664163f.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Auto","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null,"additionalPortMappings":null,"targetPortHttpScheme":null},"registries":[{"server":"crtf5bjllihraai.azurecr.io","username":"crtf5bjllihraai","passwordSecretRef":"registry-password","identity":""}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"azd-1732146560","terminationGracePeriodSeconds":null,"containers":[{"image":"crtf5bjllihraai.azurecr.io/containerapp/web-azdtest-de207ca:azd-deploy-1732146560","name":"main","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"},"probes":[]}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/containerApps/ca-tf5bjllihraai/eventstream","delegatedIdentities":[]},"identity":{"type":"None"}}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01, 2024-08-02-preview, 2024-10-02-preview
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2652"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:52:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16498"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1098"
+            X-Ms-Request-Id:
+                - bb9a61f4-2672-4b36-948b-e2cd176a528c
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235232Z:bb9a61f4-2672-4b36-948b-e2cd176a528c
+            X-Msedge-Ref:
+                - 'Ref A: 398C619BD1254D4D974A28210D48A84F Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:52:32Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 289.675084ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armappcontainers/v3.0.0-beta.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerApps/ca-tf5bjllihraai?api-version=2023-11-02-preview
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2652
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerapps/ca-tf5bjllihraai","name":"ca-tf5bjllihraai","type":"Microsoft.App/containerApps","location":"East US 2","tags":{"azd-env-name":"azdtest-de207ca","azd-service-name":"web"},"systemData":{"createdBy":"matell@microsoft.com","createdByType":"User","createdAt":"2024-11-20T23:51:19.2800391","lastModifiedBy":"matell@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-11-20T23:52:16.2263043"},"properties":{"provisioningState":"Succeeded","runningStatus":"Running","managedEnvironmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/managedEnvironments/cae-tf5bjllihraai","environmentId":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/managedEnvironments/cae-tf5bjllihraai","workloadProfileName":null,"outboundIpAddresses":["48.214.9.178"],"latestRevisionName":"ca-tf5bjllihraai--azd-1732146560","latestReadyRevisionName":"ca-tf5bjllihraai--rbfti59","latestRevisionFqdn":"ca-tf5bjllihraai--azd-1732146560.greencoast-e664163f.eastus2.azurecontainerapps.io","customDomainVerificationId":"952E2B5B449FE1809E86B56F4189627111A065213A56FF099BE2E8782C9EB920","configuration":{"secrets":[{"name":"registry-password"}],"activeRevisionsMode":"Single","ingress":{"fqdn":"ca-tf5bjllihraai.greencoast-e664163f.eastus2.azurecontainerapps.io","external":true,"targetPort":8080,"exposedPort":0,"transport":"Auto","traffic":[{"weight":100,"latestRevision":true}],"customDomains":null,"allowInsecure":false,"ipSecurityRestrictions":null,"corsPolicy":null,"clientCertificateMode":null,"stickySessions":null,"additionalPortMappings":null,"targetPortHttpScheme":null},"registries":[{"server":"crtf5bjllihraai.azurecr.io","username":"crtf5bjllihraai","passwordSecretRef":"registry-password","identity":""}],"dapr":null,"maxInactiveRevisions":100,"service":null},"template":{"revisionSuffix":"azd-1732146560","terminationGracePeriodSeconds":null,"containers":[{"image":"crtf5bjllihraai.azurecr.io/containerapp/web-azdtest-de207ca:azd-deploy-1732146560","name":"main","resources":{"cpu":0.5,"memory":"1Gi","ephemeralStorage":"2Gi"},"probes":[]}],"initContainers":null,"scale":{"minReplicas":null,"maxReplicas":10,"rules":null},"volumes":null,"serviceBinds":null},"eventStreamEndpoint":"https://eastus2.azurecontainerapps.dev/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/containerApps/ca-tf5bjllihraai/eventstream","delegatedIdentities":[]},"identity":{"type":"None"}}'
+        headers:
+            Api-Supported-Versions:
+                - 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01, 2024-08-02-preview, 2024-10-02-preview
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "2652"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:52:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            Vary:
+                - Accept-Encoding
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 445e3fbf-3051-493f-9491-d24922e07285
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235232Z:445e3fbf-3051-493f-9491-d24922e07285
+            X-Msedge-Ref:
+                - 'Ref A: DDB18BBE240645698965AAA249A435A3 Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:52:32Z'
+            X-Powered-By:
+                - ASP.NET
+        status: 200 OK
+        code: 200
+        duration: 487.33725ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-de207ca%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 325
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","name":"rg-azdtest-de207ca","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-de207ca","DeleteAfter":"2024-11-21T00:49:45Z"},"properties":{"provisioningState":"Succeeded"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:52:32 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 9f992d232f9d54b736d89693f7e044a6
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 9b6d990d-5fe5-4e27-b08b-f5bfac4c37cd
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235233Z:9b6d990d-5fe5-4e27-b08b-f5bfac4c37cd
+            X-Msedge-Ref:
+                - 'Ref A: 8153972D4ED647429D1442305DC851EE Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:52:32Z'
+        status: 200 OK
+        code: 200
+        duration: 84.099ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: ca-tf5bjllihraai.greencoast-e664163f.eastus2.azurecontainerapps.io
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - Go-http-client/1.1
+        url: https://ca-tf5bjllihraai.greencoast-e664163f.eastus2.azurecontainerapps.io:443/
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: Hello, `azd`.
+        headers:
+            Content-Type:
+                - text/plain; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:52:32 GMT
+            Server:
+                - Kestrel
+        status: 200 OK
+        code: 200
+        duration: 385.660584ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 287426
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560","location":"eastus2","name":"azdtest-de207ca-1732146560","properties":{"correlationId":"49df2a253364c7faf47cfcf104e3c1ad","dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","resourceName":"rg-azdtest-de207ca","resourceType":"Microsoft.Resources/resourceGroups"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceName":"resources","resourceType":"Microsoft.Resources/deployments"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceName":"resources","resourceType":"Microsoft.Resources/deployments"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","resourceName":"rg-azdtest-de207ca","resourceType":"Microsoft.Resources/resourceGroups"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceName":"resources","resourceType":"Microsoft.Resources/deployments"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/web","resourceName":"web","resourceType":"Microsoft.Resources/deployments"}],"duration":"PT1M54.9316733S","mode":"Incremental","outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerApps/ca-tf5bjllihraai"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/managedEnvironments/cae-tf5bjllihraai"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.ContainerRegistry/registries/crtf5bjllihraai"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.OperationalInsights/workspaces/log-tf5bjllihraai"}],"outputs":{"azurE_CONTAINER_ENVIRONMENT_NAME":{"type":"String","value":"cae-tf5bjllihraai"},"azurE_CONTAINER_REGISTRY_ENDPOINT":{"type":"String","value":"crtf5bjllihraai.azurecr.io"},"azurE_CONTAINER_REGISTRY_NAME":{"type":"String","value":"crtf5bjllihraai"},"websitE_URL":{"type":"String","value":"https://ca-tf5bjllihraai.greencoast-e664163f.eastus2.azurecontainerapps.io"}},"parameters":{"deleteAfterTime":{"type":"String","value":"2024-11-21T00:49:45Z"},"environmentName":{"type":"String","value":"azdtest-de207ca"},"location":{"type":"String","value":"eastus2"}},"providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"locations":["eastus2"],"resourceType":"resourceGroups"},{"locations":[null],"resourceType":"deployments"}]}],"provisioningState":"Succeeded","templateHash":"12856671344366107312","timestamp":"2024-11-20T23:51:43.4063381Z"},"tags":{"azd-env-name":"azdtest-de207ca","azd-provision-param-hash":"d03c3e46ae91b9352a9b20036d26adfe205cb3040af103c2d61b737993f1672b"},"type":"Microsoft.Resources/deployments"}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "287426"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:52:37 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 70b0e9fa-f46e-44ac-b5b6-55ab0ff5af2c
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235237Z:70b0e9fa-f46e-44ac-b5b6-55ab0ff5af2c
+            X-Msedge-Ref:
+                - 'Ref A: 0AC2529CA5B84D8F8C61D1DB0B60AF1D Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:52:35Z'
+        status: 200 OK
+        code: 200
+        duration: 2.219065292s
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3399
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560","name":"azdtest-de207ca-1732146560","type":"Microsoft.Resources/deployments","location":"eastus2","tags":{"azd-env-name":"azdtest-de207ca","azd-provision-param-hash":"d03c3e46ae91b9352a9b20036d26adfe205cb3040af103c2d61b737993f1672b"},"properties":{"templateHash":"12856671344366107312","parameters":{"environmentName":{"type":"String","value":"azdtest-de207ca"},"location":{"type":"String","value":"eastus2"},"deleteAfterTime":{"type":"String","value":"2024-11-21T00:49:45Z"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-11-20T23:51:43.4063381Z","duration":"PT1M54.9316733S","correlationId":"49df2a253364c7faf47cfcf104e3c1ad","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["eastus2"]},{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","resourceType":"Microsoft.Resources/resourceGroups","resourceName":"rg-azdtest-de207ca"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","resourceType":"Microsoft.Resources/resourceGroups","resourceName":"rg-azdtest-de207ca"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources","apiVersion":"2022-09-01"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/web","resourceType":"Microsoft.Resources/deployments","resourceName":"web"}],"outputs":{"azurE_CONTAINER_REGISTRY_NAME":{"type":"String","value":"crtf5bjllihraai"},"azurE_CONTAINER_ENVIRONMENT_NAME":{"type":"String","value":"cae-tf5bjllihraai"},"azurE_CONTAINER_REGISTRY_ENDPOINT":{"type":"String","value":"crtf5bjllihraai.azurecr.io"},"websitE_URL":{"type":"String","value":"https://ca-tf5bjllihraai.greencoast-e664163f.eastus2.azurecontainerapps.io"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerApps/ca-tf5bjllihraai"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/managedEnvironments/cae-tf5bjllihraai"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.ContainerRegistry/registries/crtf5bjllihraai"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.OperationalInsights/workspaces/log-tf5bjllihraai"}]}}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3399"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:52:38 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 3b166904-48c6-4bd6-b7d9-e92e669a08a8
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235238Z:3b166904-48c6-4bd6-b7d9-e92e669a08a8
+            X-Msedge-Ref:
+                - 'Ref A: B28C2E691F1C42FB8E80B8BB2602DA02 Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:52:37Z'
+        status: 200 OK
+        code: 200
+        duration: 448.776792ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-de207ca%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 325
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","name":"rg-azdtest-de207ca","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-de207ca","DeleteAfter":"2024-11-21T00:49:45Z"},"properties":{"provisioningState":"Succeeded"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:52:38 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 636fe258-eb2d-4ddd-bef9-7d80eb1324e3
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235238Z:636fe258-eb2d-4ddd-bef9-7d80eb1324e3
+            X-Msedge-Ref:
+                - 'Ref A: 41945602006D4D54BD9CA98858970C46 Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:52:38Z'
+        status: 200 OK
+        code: 200
+        duration: 74.123459ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.Client/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/resources?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1961
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.ContainerRegistry/registries/crtf5bjllihraai","name":"crtf5bjllihraai","type":"Microsoft.ContainerRegistry/registries","sku":{"name":"Basic","tier":"Basic"},"location":"eastus2","tags":{"azd-env-name":"azdtest-de207ca"},"systemData":{"createdBy":"matell@microsoft.com","createdByType":"User","createdAt":"2024-11-20T23:49:52.9788616Z","lastModifiedBy":"matell@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-11-20T23:49:52.9788616Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.OperationalInsights/workspaces/log-tf5bjllihraai","name":"log-tf5bjllihraai","type":"Microsoft.OperationalInsights/workspaces","location":"eastus2","tags":{"azd-env-name":"azdtest-de207ca"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/managedEnvironments/cae-tf5bjllihraai","name":"cae-tf5bjllihraai","type":"Microsoft.App/managedEnvironments","location":"eastus2","tags":{"azd-env-name":"azdtest-de207ca"},"systemData":{"createdBy":"matell@microsoft.com","createdByType":"User","createdAt":"2024-11-20T23:50:40.743519Z","lastModifiedBy":"matell@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-11-20T23:50:40.743519Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerApps/ca-tf5bjllihraai","name":"ca-tf5bjllihraai","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-de207ca","azd-service-name":"web"},"systemData":{"createdBy":"matell@microsoft.com","createdByType":"User","createdAt":"2024-11-20T23:51:19.2800391Z","lastModifiedBy":"matell@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-11-20T23:52:16.2263043Z"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "1961"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:52:38 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - f1eccd06-58d3-4323-9eea-5139aca4facc
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235238Z:f1eccd06-58d3-4323-9eea-5139aca4facc
+            X-Msedge-Ref:
+                - 'Ref A: 6FBF6218621144599DB16F1AC62E5DB5 Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:52:38Z'
+        status: 200 OK
+        code: 200
+        duration: 185.743666ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3399
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560","name":"azdtest-de207ca-1732146560","type":"Microsoft.Resources/deployments","location":"eastus2","tags":{"azd-env-name":"azdtest-de207ca","azd-provision-param-hash":"d03c3e46ae91b9352a9b20036d26adfe205cb3040af103c2d61b737993f1672b"},"properties":{"templateHash":"12856671344366107312","parameters":{"environmentName":{"type":"String","value":"azdtest-de207ca"},"location":{"type":"String","value":"eastus2"},"deleteAfterTime":{"type":"String","value":"2024-11-21T00:49:45Z"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-11-20T23:51:43.4063381Z","duration":"PT1M54.9316733S","correlationId":"49df2a253364c7faf47cfcf104e3c1ad","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["eastus2"]},{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","resourceType":"Microsoft.Resources/resourceGroups","resourceName":"rg-azdtest-de207ca"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","resourceType":"Microsoft.Resources/resourceGroups","resourceName":"rg-azdtest-de207ca"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources","apiVersion":"2022-09-01"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/web","resourceType":"Microsoft.Resources/deployments","resourceName":"web"}],"outputs":{"azurE_CONTAINER_REGISTRY_NAME":{"type":"String","value":"crtf5bjllihraai"},"azurE_CONTAINER_ENVIRONMENT_NAME":{"type":"String","value":"cae-tf5bjllihraai"},"azurE_CONTAINER_REGISTRY_ENDPOINT":{"type":"String","value":"crtf5bjllihraai.azurecr.io"},"websitE_URL":{"type":"String","value":"https://ca-tf5bjllihraai.greencoast-e664163f.eastus2.azurecontainerapps.io"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerApps/ca-tf5bjllihraai"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/managedEnvironments/cae-tf5bjllihraai"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.ContainerRegistry/registries/crtf5bjllihraai"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.OperationalInsights/workspaces/log-tf5bjllihraai"}]}}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3399"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:52:38 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 2682cb52-2a19-44d8-bbb7-f54555cd33c3
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235238Z:2682cb52-2a19-44d8-bbb7-f54555cd33c3
+            X-Msedge-Ref:
+                - 'Ref A: BC056C03C1CC4F4EA303223CD5B1204E Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:52:38Z'
+        status: 200 OK
+        code: 200
+        duration: 213.315334ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups?%24filter=tagName+eq+%27azd-env-name%27+and+tagValue+eq+%27azdtest-de207ca%27&api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 325
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","name":"rg-azdtest-de207ca","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"azd-env-name":"azdtest-de207ca","DeleteAfter":"2024-11-21T00:49:45Z"},"properties":{"provisioningState":"Succeeded"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "325"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:52:38 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - a5204f5c-d97f-415b-bc6e-2915f8cb29f3
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235239Z:a5204f5c-d97f-415b-bc6e-2915f8cb29f3
+            X-Msedge-Ref:
+                - 'Ref A: 6E95951448D4442E934FCC965FF2ED2E Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:52:38Z'
+        status: 200 OK
+        code: 200
+        duration: 92.853333ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.Client/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/resources?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1961
+        uncompressed: false
+        body: '{"value":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.ContainerRegistry/registries/crtf5bjllihraai","name":"crtf5bjllihraai","type":"Microsoft.ContainerRegistry/registries","sku":{"name":"Basic","tier":"Basic"},"location":"eastus2","tags":{"azd-env-name":"azdtest-de207ca"},"systemData":{"createdBy":"matell@microsoft.com","createdByType":"User","createdAt":"2024-11-20T23:49:52.9788616Z","lastModifiedBy":"matell@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-11-20T23:49:52.9788616Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.OperationalInsights/workspaces/log-tf5bjllihraai","name":"log-tf5bjllihraai","type":"Microsoft.OperationalInsights/workspaces","location":"eastus2","tags":{"azd-env-name":"azdtest-de207ca"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/managedEnvironments/cae-tf5bjllihraai","name":"cae-tf5bjllihraai","type":"Microsoft.App/managedEnvironments","location":"eastus2","tags":{"azd-env-name":"azdtest-de207ca"},"systemData":{"createdBy":"matell@microsoft.com","createdByType":"User","createdAt":"2024-11-20T23:50:40.743519Z","lastModifiedBy":"matell@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-11-20T23:50:40.743519Z"}},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerApps/ca-tf5bjllihraai","name":"ca-tf5bjllihraai","type":"Microsoft.App/containerApps","location":"eastus2","identity":{"type":"None"},"tags":{"azd-env-name":"azdtest-de207ca","azd-service-name":"web"},"systemData":{"createdBy":"matell@microsoft.com","createdByType":"User","createdAt":"2024-11-20T23:51:19.2800391Z","lastModifiedBy":"matell@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2024-11-20T23:52:16.2263043Z"}}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "1961"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 20 Nov 2024 23:52:39 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 35a39033-829c-4e9d-8f1d-158e8c8e9269
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235239Z:35a39033-829c-4e9d-8f1d-158e8c8e9269
+            X-Msedge-Ref:
+                - 'Ref A: 26DFAE48DB154101ABA9FA0C83CE839A Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:52:39Z'
+        status: 200 OK
+        code: 200
+        duration: 190.776708ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourcegroups/rg-azdtest-de207ca?api-version=2021-04-01
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "0"
+            Date:
+                - Wed, 20 Nov 2024 23:52:40 GMT
+            Expires:
+                - "-1"
+            Location:
+                - https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SRzoyREFaRFRFU1Q6MkRERTIwN0NBLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2021-04-01&t=638677440995710693&c=MIIHpTCCBo2gAwIBAgITOgM6dTLGpzYZpvPtgQAEAzp1MjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSU5GUkEgQ0EgMDEwHhcNMjQwNjI2MDEzMjIxWhcNMjUwNjIxMDEzMjIxWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPPPKY5bDN03KptFFhiyLIyn86BlrXYFIZWYXA-hY7_WbLyWN0IxcLIUBW_I-9u-YsXOHk9WPMlUYHIFPgHW7A3FsSGfl9dd6YGapKoSSw0NkTpNXM58R54BBgLp7AhiWzK15D9T-XELNSU4Wq9sEeA5T24kazcgS2MUkzELH0I9dwu7g0dwJIuIJkoJjEzg1b1Q3Ie5HKHHNbjottJn7Q5LBS-9QtQyruuwaNTgSJpCoi4PBKVIOTBYL_Nv1wecmKmfWcT0mnhQE9zjhJTbcoN9hKSvAMqsDHtxWUFZosiw3JKIY0zb59CrVGSuOhfN3qaarwN9EAlXLqc4ZyKpsTkCAwEAAaOCBJIwggSOMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQlkyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMElORlJBJTIwQ0ElMjAwMSg0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JZMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CWTJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSU5GUkElMjBDQSUyMDAxKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQlkyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMElORlJBJTIwQ0ElMjAwMSg0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JZMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3J0MB0GA1UdDgQWBBRk_38CqdKjPVylWUR4uuqhbFGeHTAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwEwDAYKKwYBBAGCN3sEATAfBgNVHSMEGDAWgBTl2Ztn_PjsurvwwKidileIud8-YzAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAFsx7FtYAzSo98T5ydNFa0ukjPZ6XCQc9zo7ldqy235P_zJAUkaNgCU4EGOzbZJDoMa8mAfhyukL_0GfPeApUaY2e44ZOzoYAkeEuDiwcs-9zoQ1fCyXhn0pCumGFXRilX9KjAPaYTzDvQMEllTy_ZViwTahuKaGtFVamZguBPdaeYC_0oybtTVNQCs8hGnffhNZOMASB-5pFs35MNxsDWTVIQksDee419jqpsbWLkh6rnanILO1O_ihwb-WpvRQByQ5NGpG1-z0MQ6nRpr9wWxUi-DsrVsD38NTMIPc2uei4Ivf6qnGRvOOj0fmsciWuTTEXMaD-5a81mGlzhZc09Q&s=BUYLqZZPtd9xWn5B7rKKPoqohrE_HX7NW_CSmFPGzSKOYQ7t-ZqXzdcy5RUYbjlGFEDhsABA5TkTsb_cz_4s6y0oTba6hmGa4pzsRvpTjw0LjHf9AsVVT__6urDBjy6QpaS-HFc06mchwRyT57jfmhGn_m1Gw6N-quHQsmudlCU2RzjluEIQ8LvlXygUxbVjAW0MelEVPPuUj2hKdA77q8kAa2DaDd-HJ7aW6Z-b2LWVRXh_i6hmqbcf2sTGk5OWpZlyfhy2DkZfqmH2QsZpXkz4G6fgCiKCkY2QIh7fJsuFoIWZVkivsaN6xExf7ZYjC60K9QtSyqzGxjIbytYWZQ&h=kGSCES3FvNRWHsMZFLpN7AN97qO8y7pUHLx6cBYJpBc
+            Pragma:
+                - no-cache
+            Retry-After:
+                - "0"
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+            X-Ms-Ratelimit-Remaining-Subscription-Deletes:
+                - "799"
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Deletes:
+                - "11999"
+            X-Ms-Request-Id:
+                - ec9b5290-b6a3-4ef1-a977-0ed4108d1ec3
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241120T235240Z:ec9b5290-b6a3-4ef1-a977-0ed4108d1ec3
+            X-Msedge-Ref:
+                - 'Ref A: 24BB8530A40148008AEEC2862A6F4886 Ref B: CO6AA3150217021 Ref C: 2024-11-20T23:52:39Z'
+        status: 202 Accepted
+        code: 202
+        duration: 1.056469458s
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.ResourceGroupsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SRzoyREFaRFRFU1Q6MkRERTIwN0NBLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2021-04-01&t=638677440995710693&c=MIIHpTCCBo2gAwIBAgITOgM6dTLGpzYZpvPtgQAEAzp1MjANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSU5GUkEgQ0EgMDEwHhcNMjQwNjI2MDEzMjIxWhcNMjUwNjIxMDEzMjIxWjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPPPKY5bDN03KptFFhiyLIyn86BlrXYFIZWYXA-hY7_WbLyWN0IxcLIUBW_I-9u-YsXOHk9WPMlUYHIFPgHW7A3FsSGfl9dd6YGapKoSSw0NkTpNXM58R54BBgLp7AhiWzK15D9T-XELNSU4Wq9sEeA5T24kazcgS2MUkzELH0I9dwu7g0dwJIuIJkoJjEzg1b1Q3Ie5HKHHNbjottJn7Q5LBS-9QtQyruuwaNTgSJpCoi4PBKVIOTBYL_Nv1wecmKmfWcT0mnhQE9zjhJTbcoN9hKSvAMqsDHtxWUFZosiw3JKIY0zb59CrVGSuOhfN3qaarwN9EAlXLqc4ZyKpsTkCAwEAAaOCBJIwggSOMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwEwCgYIKwYBBQUHAwIwPQYJKwYBBAGCNxUHBDAwLgYmKwYBBAGCNxUIhpDjDYTVtHiE8Ys-hZvdFs6dEoFggvX2K4Py0SACAWQCAQowggHaBggrBgEFBQcBAQSCAcwwggHIMGYGCCsGAQUFBzAChlpodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpaW5mcmEvQ2VydHMvQlkyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMElORlJBJTIwQ0ElMjAwMSg0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmwxLmFtZS5nYmwvYWlhL0JZMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3J0MFYGCCsGAQUFBzAChkpodHRwOi8vY3JsMi5hbWUuZ2JsL2FpYS9CWTJQS0lJTlRDQTAxLkFNRS5HQkxfQU1FJTIwSU5GUkElMjBDQSUyMDAxKDQpLmNydDBWBggrBgEFBQcwAoZKaHR0cDovL2NybDMuYW1lLmdibC9haWEvQlkyUEtJSU5UQ0EwMS5BTUUuR0JMX0FNRSUyMElORlJBJTIwQ0ElMjAwMSg0KS5jcnQwVgYIKwYBBQUHMAKGSmh0dHA6Ly9jcmw0LmFtZS5nYmwvYWlhL0JZMlBLSUlOVENBMDEuQU1FLkdCTF9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3J0MB0GA1UdDgQWBBRk_38CqdKjPVylWUR4uuqhbFGeHTAOBgNVHQ8BAf8EBAMCBaAwggE1BgNVHR8EggEsMIIBKDCCASSgggEgoIIBHIZCaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3BraWluZnJhL0NSTC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsMS5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsMi5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsMy5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JshjRodHRwOi8vY3JsNC5hbWUuZ2JsL2NybC9BTUUlMjBJTkZSQSUyMENBJTIwMDEoNCkuY3JsMIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwEwDAYKKwYBBAGCN3sEATAfBgNVHSMEGDAWgBTl2Ztn_PjsurvwwKidileIud8-YzAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAFsx7FtYAzSo98T5ydNFa0ukjPZ6XCQc9zo7ldqy235P_zJAUkaNgCU4EGOzbZJDoMa8mAfhyukL_0GfPeApUaY2e44ZOzoYAkeEuDiwcs-9zoQ1fCyXhn0pCumGFXRilX9KjAPaYTzDvQMEllTy_ZViwTahuKaGtFVamZguBPdaeYC_0oybtTVNQCs8hGnffhNZOMASB-5pFs35MNxsDWTVIQksDee419jqpsbWLkh6rnanILO1O_ihwb-WpvRQByQ5NGpG1-z0MQ6nRpr9wWxUi-DsrVsD38NTMIPc2uei4Ivf6qnGRvOOj0fmsciWuTTEXMaD-5a81mGlzhZc09Q&s=BUYLqZZPtd9xWn5B7rKKPoqohrE_HX7NW_CSmFPGzSKOYQ7t-ZqXzdcy5RUYbjlGFEDhsABA5TkTsb_cz_4s6y0oTba6hmGa4pzsRvpTjw0LjHf9AsVVT__6urDBjy6QpaS-HFc06mchwRyT57jfmhGn_m1Gw6N-quHQsmudlCU2RzjluEIQ8LvlXygUxbVjAW0MelEVPPuUj2hKdA77q8kAa2DaDd-HJ7aW6Z-b2LWVRXh_i6hmqbcf2sTGk5OWpZlyfhy2DkZfqmH2QsZpXkz4G6fgCiKCkY2QIh7fJsuFoIWZVkivsaN6xExf7ZYjC60K9QtSyqzGxjIbytYWZQ&h=kGSCES3FvNRWHsMZFLpN7AN97qO8y7pUHLx6cBYJpBc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "0"
+            Date:
+                - Thu, 21 Nov 2024 00:01:54 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 0c9b606d-62c0-4f6d-8a02-1ac4830b2546
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241121T000154Z:0c9b606d-62c0-4f6d-8a02-1ac4830b2546
+            X-Msedge-Ref:
+                - 'Ref A: 4965FFDC2D8543A490DBFAF69C6552B1 Ref B: CO6AA3150217021 Ref C: 2024-11-21T00:01:54Z'
+        status: 200 OK
+        code: 200
+        duration: 177.694583ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3399
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560","name":"azdtest-de207ca-1732146560","type":"Microsoft.Resources/deployments","location":"eastus2","tags":{"azd-env-name":"azdtest-de207ca","azd-provision-param-hash":"d03c3e46ae91b9352a9b20036d26adfe205cb3040af103c2d61b737993f1672b"},"properties":{"templateHash":"12856671344366107312","parameters":{"environmentName":{"type":"String","value":"azdtest-de207ca"},"location":{"type":"String","value":"eastus2"},"deleteAfterTime":{"type":"String","value":"2024-11-21T00:49:45Z"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-11-20T23:51:43.4063381Z","duration":"PT1M54.9316733S","correlationId":"49df2a253364c7faf47cfcf104e3c1ad","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["eastus2"]},{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","resourceType":"Microsoft.Resources/resourceGroups","resourceName":"rg-azdtest-de207ca"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources"},{"dependsOn":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca","resourceType":"Microsoft.Resources/resourceGroups","resourceName":"rg-azdtest-de207ca"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/resources","resourceType":"Microsoft.Resources/deployments","resourceName":"resources","apiVersion":"2022-09-01"}],"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.Resources/deployments/web","resourceType":"Microsoft.Resources/deployments","resourceName":"web"}],"outputs":{"azurE_CONTAINER_REGISTRY_NAME":{"type":"String","value":"crtf5bjllihraai"},"azurE_CONTAINER_ENVIRONMENT_NAME":{"type":"String","value":"cae-tf5bjllihraai"},"azurE_CONTAINER_REGISTRY_ENDPOINT":{"type":"String","value":"crtf5bjllihraai.azurecr.io"},"websitE_URL":{"type":"String","value":"https://ca-tf5bjllihraai.greencoast-e664163f.eastus2.azurecontainerapps.io"}},"outputResources":[{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/containerApps/ca-tf5bjllihraai"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.App/managedEnvironments/cae-tf5bjllihraai"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.ContainerRegistry/registries/crtf5bjllihraai"},{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/rg-azdtest-de207ca/providers/Microsoft.OperationalInsights/workspaces/log-tf5bjllihraai"}]}}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "3399"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Thu, 21 Nov 2024 00:01:54 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 6a995bbb-c3e9-45d4-9284-f013eb0247a8
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241121T000155Z:6a995bbb-c3e9-45d4-9284-f013eb0247a8
+            X-Msedge-Ref:
+                - 'Ref A: 8A94B1051BC9461BA38850790947303A Ref B: CO6AA3150217021 Ref C: 2024-11-21T00:01:54Z'
+        status: 200 OK
+        code: 200
+        duration: 212.268834ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 346
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"location":"eastus2","properties":{"mode":"Incremental","parameters":{},"template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{},"variables":{},"resources":[],"outputs":{}}},"tags":{"azd-deploy-reason":"down","azd-env-name":"azdtest-de207ca"}}'
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            Content-Length:
+                - "346"
+            Content-Type:
+                - application/json
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560?api-version=2021-04-01
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 569
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560","name":"azdtest-de207ca-1732146560","type":"Microsoft.Resources/deployments","location":"eastus2","tags":{"azd-deploy-reason":"down","azd-env-name":"azdtest-de207ca"},"properties":{"templateHash":"14737569621737367585","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2024-11-21T00:01:58.5092559Z","duration":"PT0.000898S","correlationId":"7301e414171db9aa93a2e586de7c9796","providers":[],"dependencies":[]}}'
+        headers:
+            Azure-Asyncoperation:
+                - https://management.azure.com/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560/operationStatuses/08584694595699913261?api-version=2021-04-01
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "569"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Thu, 21 Nov 2024 00:01:58 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+            X-Ms-Deployment-Engine-Version:
+                - 1.158.0
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Writes:
+                - "11999"
+            X-Ms-Ratelimit-Remaining-Subscription-Writes:
+                - "799"
+            X-Ms-Request-Id:
+                - 4d3ec4c0-ae2c-42b1-9c31-2c9e90af6794
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241121T000159Z:4d3ec4c0-ae2c-42b1-9c31-2c9e90af6794
+            X-Msedge-Ref:
+                - 'Ref A: A35F93BE8B8D4E278D9614D4D4AA2CE9 Ref B: CO6AA3150217021 Ref C: 2024-11-21T00:01:55Z'
+        status: 200 OK
+        code: 200
+        duration: 4.096975708s
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560/operationStatuses/08584694595699913261?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 22
+        uncompressed: false
+        body: '{"status":"Succeeded"}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "22"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Thu, 21 Nov 2024 00:01:58 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 088e9aef-769c-449d-86e9-f31c4e7584ff
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241121T000159Z:088e9aef-769c-449d-86e9-f31c4e7584ff
+            X-Msedge-Ref:
+                - 'Ref A: 59E6114A20004047932BBC60C9D9C08F Ref B: CO6AA3150217021 Ref C: 2024-11-21T00:01:59Z'
+        status: 200 OK
+        code: 200
+        duration: 392.228125ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: management.azure.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Authorization:
+                - SANITIZED
+            User-Agent:
+                - azsdk-go-armresources.DeploymentsClient/v1.1.1 (go1.23.0; darwin),azdev/0.0.0-dev.0 (Go go1.23.0; darwin/arm64)
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+        url: https://management.azure.com:443/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560?api-version=2021-04-01
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 604
+        uncompressed: false
+        body: '{"id":"/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/providers/Microsoft.Resources/deployments/azdtest-de207ca-1732146560","name":"azdtest-de207ca-1732146560","type":"Microsoft.Resources/deployments","location":"eastus2","tags":{"azd-deploy-reason":"down","azd-env-name":"azdtest-de207ca"},"properties":{"templateHash":"14737569621737367585","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2024-11-21T00:01:59.2484269Z","duration":"PT0.740069S","correlationId":"7301e414171db9aa93a2e586de7c9796","providers":[],"dependencies":[],"outputs":{},"outputResources":[]}}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "604"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Thu, 21 Nov 2024 00:01:59 GMT
+            Expires:
+                - "-1"
+            Pragma:
+                - no-cache
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains
+            X-Cache:
+                - CONFIG_NOCACHE
+            X-Content-Type-Options:
+                - nosniff
+            X-Ms-Correlation-Request-Id:
+                - 7301e414171db9aa93a2e586de7c9796
+            X-Ms-Ratelimit-Remaining-Subscription-Global-Reads:
+                - "16499"
+            X-Ms-Ratelimit-Remaining-Subscription-Reads:
+                - "1099"
+            X-Ms-Request-Id:
+                - 62e21152-9af8-4e36-9cda-eab2617c1a67
+            X-Ms-Routing-Request-Id:
+                - WESTUS2:20241121T000159Z:62e21152-9af8-4e36-9cda-eab2617c1a67
+            X-Msedge-Ref:
+                - 'Ref A: DD568D386B79486BB3358A8820508C3E Ref B: CO6AA3150217021 Ref C: 2024-11-21T00:01:59Z'
+        status: 200 OK
+        code: 200
+        duration: 193.259292ms
+---
+env_name: azdtest-de207ca
+subscription_id: faa080af-c1d8-40ad-9cce-e1a450ca5b57
+time: "1732146560"

--- a/cli/azd/test/functional/testdata/samples/containerapp/infra/web.bicep
+++ b/cli/azd/test/functional/testdata/samples/containerapp/infra/web.bicep
@@ -24,7 +24,7 @@ resource app 'Microsoft.App/containerApps@2023-05-02-preview' = {
       activeRevisionsMode: 'single'
       ingress: {
         external: true
-        targetPort: 3100
+        targetPort: 8080
         transport: 'auto'
       }
       secrets: [

--- a/cli/azd/test/functional/testdata/samples/containerapp/src/dotnet/Dockerfile
+++ b/cli/azd/test/functional/testdata/samples/containerapp/src/dotnet/Dockerfile
@@ -12,7 +12,7 @@ RUN dotnet publish -c Release -o out
 FROM mcr.microsoft.com/dotnet/aspnet:8.0
 WORKDIR /app
 COPY --from=build-env /app/out .
-EXPOSE 3100
-ENV ASPNETCORE_URLS=http://+:3100
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://+:8080
 
 ENTRYPOINT ["dotnet", "webapp.dll"]

--- a/cli/azd/test/recording/sanitize.go
+++ b/cli/azd/test/recording/sanitize.go
@@ -56,8 +56,8 @@ func sanitizeContainerAppListSecrets(i *cassette.Interaction) error {
 					// Redis requirepass. Sanitize the password, remove other config.
 					if strings.Contains(val, "requirepass ") {
 						body.Value[i].Value = to.Ptr("requirepass SANITIZED")
+						continue
 					}
-					continue
 				}
 
 				body.Value[i].Value = to.Ptr("SANITIZED")


### PR DESCRIPTION
The `dotnet` tool has native support for producing (and pushing) a container image. This does not require a local docker daemon and in general "does the right thing" and is the prefered way for .NET customers to produce container
images. https://learn.microsoft.com/dotnet/core/docker/publish-as-container gives a good overview of how this support works and we've been using it to build and push container images for Aspire apps.

This change updates things such that we can use this support when building a non Aspire based .NET app. If a `Dockerfile` exists, we respect it, but otherwise instead of trying to use Oryx to produce a container image, we will use `dotnet publish`.

A new recorded test was added - it builds on top of the existing `containerapp` sample, and the test aranges to remove the `Dockerfile` file from the template before running `up`.

Fixes #2632