### PR TITLE
Show full Entra error description on auth failure

### DIFF
--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -77,8 +77,8 @@ func (e *ReLoginRequiredError) Error() string {
 }
 
 func (e *ReLoginRequiredError) ErrorWithSuggestion() internal.ErrorWithSuggestion {
-	return internal.ErrorWithSuggestion {
-		Err: e,
+	return internal.ErrorWithSuggestion{
+		Err:        e,
 		Suggestion: fmt.Sprintf("Suggestion: %s, run `%s` to acquire a new token", e.scenario, e.loginCmd),
 	}
 }

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -29,7 +29,7 @@ type ReLoginRequiredError struct {
 	// The scenario in which the login is required
 	scenario string
 
-	description string
+	errText string
 
 	helpLink string
 }
@@ -66,7 +66,7 @@ func newReLoginRequiredError(
 }
 
 func (e *ReLoginRequiredError) init(response *AadErrorResponse, scopes []string, cloud *cloud.Cloud) {
-	e.description = response.ErrorDescription
+	e.errText = response.ErrorDescription
 	e.scenario = "reauthentication required"
 	e.loginCmd = "azd auth login"
 	if !matchesLoginScopes(scopes, cloud) { // if matching default login scopes, no scopes need to be specified
@@ -81,7 +81,7 @@ func (e *ReLoginRequiredError) init(response *AadErrorResponse, scopes []string,
 	}
 
 	// User tried to sign in to a device from a platform not currently supported through Conditional Access policy
-	if slices.Contains((response.ErrorCodes), 50005) {
+	if slices.Contains(response.ErrorCodes, 50005) {
 		e.loginCmd += " --use-device-code=false"
 		// TODO: Use aka.ms short link
 		//nolint:lll
@@ -90,7 +90,7 @@ func (e *ReLoginRequiredError) init(response *AadErrorResponse, scopes []string,
 }
 
 func (e *ReLoginRequiredError) Error() string {
-	return e.description
+	return e.errText
 }
 
 // matchesLoginScopes checks if the elements contained in the slice match the scopes acquired during login.

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -80,12 +80,11 @@ func (e *ReLoginRequiredError) init(response *AadErrorResponse, scopes []string,
 		e.scenario = "login expired"
 	}
 
-	// User tried to sign in to a device from a platform not currently supported through Conditional Access policy
+	// In a Codespaces environment, `azd auth login` defaults to device code flow, which can cause issues getting tokens if the
+	// the Entra tenant has Conditional Access Policies set.
 	if slices.Contains(response.ErrorCodes, 50005) {
 		e.loginCmd += " --use-device-code=false"
-		// TODO: Use aka.ms short link
-		//nolint:lll
-		e.helpLink = "https://learn.microsoft.com/azure/developer/azure-developer-cli/troubleshoot#azd-pipeline-config-failure-due-to-conditional-access-policy"
+		e.helpLink = "https://aka.ms/azd/troubleshoot/conditional-access-policy"
 	}
 }
 

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -50,8 +50,10 @@ func newReLoginRequiredError(
 		"interaction_required":
 		err := ReLoginRequiredError{}
 		err.init(response, scopes, cloud)
-		errWithSuggestion := err.ErrorWithSuggestion()
-		return &errWithSuggestion, true
+		return &internal.ErrorWithSuggestion{
+			Err:        &err,
+			Suggestion: fmt.Sprintf("Suggestion: %s, run `%s` to acquire a new token", err.scenario, err.loginCmd),
+		}, true
 	}
 
 	return nil, false
@@ -74,13 +76,6 @@ func (e *ReLoginRequiredError) init(response *AadErrorResponse, scopes []string,
 
 func (e *ReLoginRequiredError) Error() string {
 	return e.description
-}
-
-func (e *ReLoginRequiredError) ErrorWithSuggestion() internal.ErrorWithSuggestion {
-	return internal.ErrorWithSuggestion{
-		Err:        e,
-		Suggestion: fmt.Sprintf("Suggestion: %s, run `%s` to acquire a new token", e.scenario, e.loginCmd),
-	}
 }
 
 // matchesLoginScopes checks if the elements contained in the slice match the scopes acquired during login.

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -75,15 +75,16 @@ func (e *ReLoginRequiredError) init(response *AadErrorResponse, scopes []string,
 		}
 	}
 
-	// BadTokenDueToSignInFrequency - The refresh token has expired or is invalid due to sign-in frequency checks by Conditional Access.
+	// The refresh token has expired or is invalid due to sign-in frequency checks by Conditional Access.
 	if slices.Contains(response.ErrorCodes, 70043) {
 		e.scenario = "login expired"
 	}
 
-	// DevicePolicyError - User tried to sign in to a device from a platform not currently supported through Conditional Access policy
+	// User tried to sign in to a device from a platform not currently supported through Conditional Access policy
 	if slices.Contains((response.ErrorCodes), 50005) {
 		e.loginCmd += " --use-device-code=false"
 		// TODO: Use aka.ms short link
+		//nolint:lll
 		e.helpLink = "https://learn.microsoft.com/azure/developer/azure-developer-cli/troubleshoot#azd-pipeline-config-failure-due-to-conditional-access-policy"
 	}
 }

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -80,8 +80,8 @@ func (e *ReLoginRequiredError) init(response *AadErrorResponse, scopes []string,
 		e.scenario = "login expired"
 	}
 
-	// In a Codespaces environment, `azd auth login` defaults to device code flow, which can cause issues getting tokens if the
-	// the Entra tenant has Conditional Access Policies set.
+	// In a Codespaces environment, `azd auth login` defaults to device code flow, which can cause issues
+	// getting tokens if the Entra tenant has Conditional Access Policies set.
 	if slices.Contains(response.ErrorCodes, 50005) {
 		e.loginCmd += " --use-device-code=false"
 		e.helpLink = "https://aka.ms/azd/troubleshoot/conditional-access-policy"

--- a/cli/azd/pkg/auth/errors_test.go
+++ b/cli/azd/pkg/auth/errors_test.go
@@ -101,7 +101,7 @@ func TestReLoginRequired(t *testing.T) {
 	}
 }
 
-func TestReLoginRequiredDescription(t *testing.T) {
+func TestReLoginRequiredError(t *testing.T) {
 	tests := []struct {
 		name string
 		resp *AadErrorResponse
@@ -111,17 +111,17 @@ func TestReLoginRequiredDescription(t *testing.T) {
 			"invalid_grant",
 			&AadErrorResponse{
 				Error:            "invalid_grant",
-				ErrorDescription: "AADSTS50005",
+				ErrorDescription: "description 1",
 			},
-			"AADSTS50005",
+			"description 1",
 		},
 		{
 			"interaction_required",
 			&AadErrorResponse{
 				Error:            "interaction_required",
-				ErrorDescription: "AADSTS50076",
+				ErrorDescription: "description 2",
 			},
-			"AADSTS50076",
+			"description 2",
 		},
 	}
 	for _, tt := range tests {

--- a/cli/azd/pkg/auth/errors_test.go
+++ b/cli/azd/pkg/auth/errors_test.go
@@ -100,3 +100,21 @@ func TestReLoginRequired(t *testing.T) {
 		})
 	}
 }
+
+func TestReLoginRequiredDescription(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *AadErrorResponse
+		want string
+	}{
+		{"invalid_grant", &AadErrorResponse{Error: "invalid_grant", ErrorDescription: "AADSTS50005"}, "AADSTS50005"},
+		{"interaction_required", &AadErrorResponse{Error: "interaction_required", ErrorDescription: "AADSTS50076"}, "AADSTS50076"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err, _ := newReLoginRequiredError(tt.resp, LoginScopes(cloud.AzurePublic()), cloud.AzurePublic())
+			got := err.Error()
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/cli/azd/pkg/auth/errors_test.go
+++ b/cli/azd/pkg/auth/errors_test.go
@@ -107,8 +107,22 @@ func TestReLoginRequiredDescription(t *testing.T) {
 		resp *AadErrorResponse
 		want string
 	}{
-		{"invalid_grant", &AadErrorResponse{Error: "invalid_grant", ErrorDescription: "AADSTS50005"}, "AADSTS50005"},
-		{"interaction_required", &AadErrorResponse{Error: "interaction_required", ErrorDescription: "AADSTS50076"}, "AADSTS50076"},
+		{
+			"invalid_grant",
+			&AadErrorResponse{
+				Error:            "invalid_grant",
+				ErrorDescription: "AADSTS50005",
+			},
+			"AADSTS50005",
+		},
+		{
+			"interaction_required",
+			&AadErrorResponse{
+				Error:            "interaction_required",
+				ErrorDescription: "AADSTS50076",
+			},
+			"AADSTS50076",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #4559 so that the full Entra error description is shown to the user when there's an auth failure. In addition, the instruction text to reauthenticate is now wrapped in a suggestion.

**Existing behaviour:**
![image](https://github.com/user-attachments/assets/ea47e25c-7ab1-4775-8f32-772bde927239)

**New behaviour:**
![image](https://github.com/user-attachments/assets/91677600-ebf2-4d56-8ba9-bfac0d170932)
