### PR TITLE
docs: Add documentation for `azd infra synth`

### DIFF
--- a/cli/azd/cmd/infra.go
+++ b/cli/azd/cmd/infra.go
@@ -11,11 +11,9 @@ import (
 )
 
 func infraActions(root *actions.ActionDescriptor) *actions.ActionDescriptor {
-	//deprecate:cmd hide infra
 	group := root.Add("infra", &actions.ActionDescriptorOptions{
 		Command: &cobra.Command{
-			Short:  "Manage your Azure infrastructure.",
-			Hidden: true,
+			Short: "Manage your Azure infrastructure.",
 		},
 	})
 

--- a/cli/azd/cmd/infra_synth.go
+++ b/cli/azd/cmd/infra_synth.go
@@ -47,7 +47,8 @@ func newInfraSynthCmd() *cobra.Command {
 	return &cobra.Command{
 		Use: "synth",
 		Short: fmt.Sprintf(
-			"Write IaC for your project to disk, allowing you to manage it by hand. %s", output.WithWarningFormat("(Beta)")),
+			"Write IaC for your project to disk, allowing you to manage it by hand. %s",
+			output.WithWarningFormat("(Alpha)")),
 	}
 }
 

--- a/cli/azd/cmd/testdata/TestUsage-azd-infra-synth.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-infra-synth.snap
@@ -1,0 +1,20 @@
+
+Write IaC for your project to disk, allowing you to manage it by hand. (Alpha)
+
+Usage
+  azd infra synth [flags]
+
+Flags
+    -e, --environment string 	: The name of the environment to use.
+        --force              	: Overwrite any existing files without prompting
+
+Global Flags
+    -C, --cwd string 	: Sets the current working directory.
+        --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd infra synth in your web browser.
+    -h, --help       	: Gets help for synth.
+        --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
+
+Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.
+
+

--- a/cli/azd/cmd/testdata/TestUsage-azd-infra.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-infra.snap
@@ -1,0 +1,21 @@
+
+Manage your Azure infrastructure.
+
+Usage
+  azd infra [command]
+
+Available Commands
+  synth	: Write IaC for your project to disk, allowing you to manage it by hand. (Alpha)
+
+Global Flags
+    -C, --cwd string 	: Sets the current working directory.
+        --debug      	: Enables debugging and diagnostics logging.
+        --docs       	: Opens the documentation for azd infra in your web browser.
+    -h, --help       	: Gets help for infra.
+        --no-prompt  	: Accepts the default value instead of prompting, or it fails if there is no default.
+
+Use azd infra [command] --help to view examples and more information about a specific command.
+
+Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.
+
+


### PR DESCRIPTION
We added `azd infra synth` as an alpha command which can be used for Aspire and composibility based project to write the generated infrastructure that is normally managed by `azd` to disk so it can be tweaked by an end user.

This command was not showing up in our documentation, since we hide the entire `infra` tree, since previous to `infra synth` the only other two commands under the `infra` command where `create` and `delete` and we had deprecated these commands (in favor of `provision` and `down`).

This change adjusts things such that `infra synth` correctly shows up in the help text from Cobra (so `docgen` will include it in the generated documentation we ship to learn.microsoft.com) and correctly marks it as "(Alpha)" instead of "(Beta)".

Fixes #4590