### PR TITLE
tests: Use OIDC for Terraform in template-tests

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -116,6 +116,11 @@ overrides:
   - filename: internal/vsrpc/handler.go
     words:
       - arity
+  - filename: test/internal/tfoidc/main.go
+    words:
+      - tfoidc
+      - OIDCREQUESTURI
+      - oidctoken
 ignorePaths:
   - "**/*_test.go"
   - "**/mock*.go"

--- a/cli/azd/test/internal/tfoidc/main.go
+++ b/cli/azd/test/internal/tfoidc/main.go
@@ -1,0 +1,197 @@
+// Program tfoidc is a simple adapter that presents a GitHub Actions style OIDC token endpoint backed by an Azure
+// DevOps service connection. It can also be used to continuously refresh the Azure CLI federated token, as the
+// AzureCLI task would.
+//
+// It requires the following environment variables to be set:
+//
+// - AZURESUBSCRIPTION_SERVICE_CONNECTION_ID: the Azure DevOps service connection ID
+// - SYSTEM_ACCESSTOKEN: the Azure DevOps system access token
+// - SYSTEM_OIDCREQUESTURI: the Azure DevOps OIDC request URI
+//
+// When the -refresh-az flag is passed, it also requires the following environment variables to be set, which should
+// correspond to the configured Azure service connection:
+//
+// - AZURESUBSCRIPTION_SUBSCRIPTION_ID: the Azure subscription ID
+// - AZURESUBSCRIPTION_CLIENT_ID: the Azure service principal client ID
+// - AZURESUBSCRIPTION_TENANT_ID: the Azure service principal tenant ID
+//
+// The adapter listens on http://127.0.0.1:27838 and is secured by using SYSTEM_ACCESSTOKEN as a bearer token.
+//
+// Configure the Azure TF provider to use this endpoint by setting the following environment variables:
+//
+// ARM_USE_OIDC=true
+// ARM_OIDC_REQUEST_URL=http://localhost:27838/oidctoken
+// ARM_OIDC_REQUEST_TOKEN=$(System.AccessToken)
+//
+// When `-refresh-az` is set, the adapter will refresh the Azure CLI federated token every 8 minutes, calling
+// `az login` and `az account set` each time. This is useful for long-running Terraform operations that require
+// Azure CLI authentication.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+var refreshAz = flag.Bool("refresh-az", false, "Refresh the Azure CLI federated token")
+
+func main() {
+	flag.Parse()
+
+	if os.Getenv("AZURESUBSCRIPTION_SERVICE_CONNECTION_ID") == "" {
+		log.Fatal("AZURESUBSCRIPTION_SERVICE_CONNECTION_ID is not set")
+	}
+
+	if os.Getenv("SYSTEM_ACCESSTOKEN") == "" {
+		log.Fatal("SYSTEM_ACCESSTOKEN is not set")
+	}
+
+	if os.Getenv("SYSTEM_OIDCREQUESTURI") == "" {
+		log.Fatal("SYSTEM_OIDCREQUESTURI is not set")
+	}
+
+	if *refreshAz {
+		if os.Getenv("AZURESUBSCRIPTION_SUBSCRIPTION_ID") == "" {
+			log.Fatal("AZURESUBSCRIPTION_SUBSCRIPTION_ID is not set")
+		}
+
+		if os.Getenv("AZURESUBSCRIPTION_CLIENT_ID") == "" {
+			log.Fatal("AZURESUBSCRIPTION_CLIENT_ID is not set")
+		}
+
+		if os.Getenv("AZURESUBSCRIPTION_TENANT_ID") == "" {
+			log.Fatal("AZURESUBSCRIPTION_TENANT_ID is not set")
+		}
+
+		go refreshAzFederatedToken()
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:27838")
+	if err != nil {
+		log.Fatalf("Failed to listen on a port: %v", err)
+	}
+	defer listener.Close()
+
+	http.HandleFunc("/oidctoken", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+os.Getenv("SYSTEM_ACCESSTOKEN") {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		tokenResponse, err := fetchOIDCToken(r.Context())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Value string `json:"value"`
+			Count int    `json:"count"`
+		}{tokenResponse, 0})
+	})
+
+	log.Fatal(
+		// nolint:gosec
+		http.Serve(listener, nil),
+	)
+}
+
+const refreshTimeout = 8 * time.Minute
+
+func refreshAzFederatedToken() {
+	_, err := exec.LookPath("az")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tfoidc: az CLI is not installed\n")
+		return
+	}
+
+	first := true
+
+	for {
+		if !first {
+			time.Sleep(refreshTimeout)
+			first = false
+		}
+
+		token, err := fetchOIDCToken(context.Background())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "tfoidc: failed to fetch OIDC token: %v\n", err)
+			continue
+		}
+
+		// nolint:gosec
+		loginCmd := exec.Command("az",
+			"login",
+			"--service-principal",
+			"--username", os.Getenv("AZURESUBSCRIPTION_CLIENT_ID"),
+			"--tenant", os.Getenv("AZURESUBSCRIPTION_TENANT_ID"),
+			"--allow-no-subscriptions",
+			"--federated-token", token,
+			"--output", "none",
+		)
+		if err := loginCmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "tfoidc: failed to run az login: %v\n", err)
+			continue
+		}
+
+		// nolint:gosec
+		subSelectCmd := exec.Command("az",
+			"account",
+			"set",
+			"--subscription", os.Getenv("AZURESUBSCRIPTION_SUBSCRIPTION_ID"),
+		)
+		if err := subSelectCmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "tfoidc: failed to run az account set: %v\n", err)
+			continue
+		}
+	}
+}
+
+func fetchOIDCToken(ctx context.Context) (string, error) {
+	url := fmt.Sprintf("%s?api-version=7.1&serviceConnectionId=%s",
+		os.Getenv("SYSTEM_OIDCREQUESTURI"),
+		os.Getenv("AZURESUBSCRIPTION_SERVICE_CONNECTION_ID"))
+	url, err := runtime.EncodeQueryParams(url)
+	if err != nil {
+		return "", err
+	}
+
+	tokenReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	tokenReq.Header.Set("Authorization", "Bearer "+os.Getenv("SYSTEM_ACCESSTOKEN"))
+	tokenRes, err := http.DefaultClient.Do(tokenReq)
+	if err != nil {
+		return "", err
+	}
+	if tokenRes.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%s response from the OIDC endpoint. Check service connection ID and Pipeline configuration",
+			tokenRes.Status)
+	}
+	b, err := runtime.Payload(tokenRes)
+	if err != nil {
+		return "", err
+	}
+	var tokenResponse struct {
+		OIDCToken string `json:"oidcToken"`
+	}
+	err = json.Unmarshal(b, &tokenResponse)
+	if err != nil {
+		return "", err
+	}
+
+	return tokenResponse.OIDCToken, nil
+}

--- a/eng/pipelines/templates/steps/template-test-run-job.yml
+++ b/eng/pipelines/templates/steps/template-test-run-job.yml
@@ -62,6 +62,10 @@ steps:
           TargetFolder: "$(Build.SourcesDirectory)/temp"
       displayName: Copy test-templates.sh
 
+    - bash: |
+        go build -o ./temp/tfoidc ./cli/azd/test/internal/tfoidc 
+      displayName: Build tfoidc
+
     - task: DevcontainersCI@0
       inputs:
           env: |
@@ -69,8 +73,13 @@ steps:
               AZURESUBSCRIPTION_CLIENT_ID=$(AzureSubscriptionClientId)
               AZURESUBSCRIPTION_TENANT_ID=$(AzureSubscriptionTenantId)
               AZURESUBSCRIPTION_SERVICE_CONNECTION_ID=$(AzureSubscriptionServiceConnectionId)
+              AZURESUBSCRIPTION_SUBSCRIPTION_ID=$(SubscriptionId)
               SYSTEM_ACCESSTOKEN=$(System.AccessToken)
               SYSTEM_OIDCREQUESTURI=$(System.OidcRequestUri)
+
+              # Terraform Configuration
+              ARM_CLIENT_ID=$(AzureSubscriptionClientId)
+              ARM_TENANT_ID=$(AzureSubscriptionTenantId)
 
               # Pass in TemplateRunEnvironmentVariables
               $(VARIABLE_LIST)
@@ -91,7 +100,7 @@ steps:
               fi
 
               RUN_VALIDATION=true
-              if [[ $TEMPLATE_NAME == *aks* ]]; then
+              if [[ "$(TemplateName)" == *aks* ]]; then
                 RUN_VALIDATION=false
               fi
 
@@ -105,6 +114,13 @@ steps:
               sudo apt-get update
               sudo apt-get install -y gstreamer1.0*
               sudo apt-get install -y gstreamer1.0-libav libnss3-tools libatk-bridge2.0-0 libcups2-dev libxkbcommon-x11-0 libxcomposite-dev libxrandr2 libgbm-dev libgtk-3-0
+
+              # Run tfoidc in background and configure Terraform to use OIDC via it.
+              ./tfoidc -refresh-az &
+
+              export ARM_USE_OIDC=true
+              export ARM_OIDC_REQUEST_URL=http://localhost:27838/oidctoken
+              export ARM_OIDC_REQUEST_TOKEN=$(System.AccessToken)
 
               # Run template test bash script
               chmod u+x test-templates.sh


### PR DESCRIPTION
The terraform legs in our template test pipelines have been broken since we moved to ODIC and this change gets them working again. Because we run the template tests inside a dev container, we can't leverage the AzureCLI task to configure OIDC for `az`, so we have to do things the hard way.

The AzureRM Terraform Provider does support OIDC auth an even has knobs to configure the URL and token used when fetching the federated token used to do the ODIC dance, but it expects a slightly different protocol than what Azure Pipelines provides, so we now have a small adapter program `tfoidc` which exposes the endpoint in the format that the provider expects (it's the format spoken by GitHub Actions) which proxies to the Azure Pipelines version.

In addition, to support local-exec scenarios where `az` is invoked, `tfoidc` can manage calling `az login` and `az account set` as the AzureCLI task would (refreshing as needed).

The template-test pipelines have been updated to build this binary and place it in the root of the folder that is mounted into the dev container when the template-test script is run and to launch `tfoidc` and configure things as needed before running the `template-test.sh` script.

Contributes To: #4564