### PR TITLE
Update `azd template source` help text

### DIFF
--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -545,6 +545,9 @@ func getCmdTemplateSourceHelpFooter(*cobra.Command) string {
 		"Add a new url template source.": output.WithHighLightFormat(
 			"azd template source add <key> --type url --location <url>",
 		),
+		"Add a new GitHub template source.": output.WithHighLightFormat(
+			"azd template source add <key> --type gh --location <GitHub URL>",
+		),
 		"Remove a previously registered template source.": output.WithHighLightFormat(
 			"azd template source remove <key>",
 		),

--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -234,11 +234,11 @@ func getCmdTemplateSourceAddHelpFooter(*cobra.Command) string {
 		"Add default azd templates source.": output.WithHighLightFormat(
 			"azd template source add default",
 		),
-		"Add templates form a GitHub repository": output.WithHighLightFormat(
-			"azd template source add --type gh --location <GitHub URL>",
+		"Add templates from a GitHub repository": output.WithHighLightFormat(
+			"azd template source add <key> --type gh --location <GitHub URL>",
 		),
 		"Add templates from a public url": output.WithHighLightFormat(
-			"azd template source add --type url --location https://example.com/templates.json",
+			"azd template source add <key> --type url --location https://example.com/templates.json",
 		),
 	})
 }

--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -240,6 +240,9 @@ func getCmdTemplateSourceAddHelpFooter(*cobra.Command) string {
 		"Add templates from a public url": output.WithHighLightFormat(
 			"azd template source add <key> --type url --location https://example.com/templates.json",
 		),
+		"Add templates from a file path": output.WithHighLightFormat(
+			"azd template source add <key> --type file --location /path/to/templates.json",
+		),
 	})
 }
 

--- a/cli/azd/cmd/testdata/TestUsage-azd-template-source-add.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-template-source-add.snap
@@ -24,11 +24,11 @@ Examples
   Add default azd templates source.
     azd template source add default
 
-  Add templates form a GitHub repository
-    azd template source add --type gh --location <GitHub URL>
+  Add templates from a GitHub repository
+    azd template source add <key> --type gh --location <GitHub URL>
 
   Add templates from a public url
-    azd template source add --type url --location https://example.com/templates.json
+    azd template source add <key> --type url --location https://example.com/templates.json
 
   Add templates from awesome-azd source
     azd template source add awesome-azd

--- a/cli/azd/cmd/testdata/TestUsage-azd-template-source-add.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-template-source-add.snap
@@ -27,6 +27,9 @@ Examples
   Add templates from a GitHub repository
     azd template source add <key> --type gh --location <GitHub URL>
 
+  Add templates from a file path
+    azd template source add <key> --type file --location /path/to/templates.json
+
   Add templates from a public url
     azd template source add <key> --type url --location https://example.com/templates.json
 

--- a/cli/azd/cmd/testdata/TestUsage-azd-template-source.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-template-source.snap
@@ -22,6 +22,9 @@ Global Flags
 Use azd template source [command] --help to view examples and more information about a specific command.
 
 Examples
+  Add a new GitHub template source.
+    azd template source add <key> --type gh --location <GitHub URL>
+
   Add a new file template source.
     azd template source add <key> --type file --location <path>
 


### PR DESCRIPTION
Fixes #4608
I also added some missing examples, but if people think there are too many examples, I'm fine with reverting them as well.

### `azd template source --help`:
![image](https://github.com/user-attachments/assets/8c15c0bd-cae9-41d6-b56c-3963b784b859)

### `azd template source add --help`:
![image](https://github.com/user-attachments/assets/88397adf-6ce7-4710-b06b-35968e63be0a)
