### PR TITLE
ci: Disable tests against azure/azure-dev#4612

### DIFF
--- a/cli/azd/test/functional/restore_test.go
+++ b/cli/azd/test/functional/restore_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
@@ -14,6 +15,10 @@ import (
 
 // test for errors when running restore in invalid working directories
 func Test_CLI_Restore_Err_WorkingDirectory(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("azure/azure-dev#4612")
+	}
+
 	t.Parallel()
 	ctx, cancel := newTestContext(t)
 	defer cancel()
@@ -79,6 +84,10 @@ func Test_CLI_Restore_Err_WorkingDirectory(t *testing.T) {
 
 // test restore in a service directory
 func Test_CLI_Restore_InServiceDirectory(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("azure/azure-dev#4612")
+	}
+
 	t.Parallel()
 	ctx, cancel := newTestContext(t)
 	defer cancel()
@@ -111,6 +120,10 @@ func Test_CLI_Restore_InServiceDirectory(t *testing.T) {
 
 // test restore using a service name passed explicitly
 func Test_CLI_Restore_UsingServiceName(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("azure/azure-dev#4612")
+	}
+
 	t.Parallel()
 	ctx, cancel := newTestContext(t)
 	defer cancel()
@@ -142,6 +155,10 @@ func Test_CLI_Restore_UsingServiceName(t *testing.T) {
 
 // test restore all in the project directory
 func Test_CLI_RestoreAll_InProjectDir(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("azure/azure-dev#4612")
+	}
+
 	t.Parallel()
 	ctx, cancel := newTestContext(t)
 	defer cancel()
@@ -176,6 +193,10 @@ func Test_CLI_RestoreAll_InProjectDir(t *testing.T) {
 
 // test restore --all
 func Test_CLI_RestoreAll_UsingFlags(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("azure/azure-dev#4612")
+	}
+
 	// running this test in parallel is ok as it uses a t.TempDir()
 	t.Parallel()
 	ctx, cancel := newTestContext(t)

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -133,6 +134,10 @@ func Test_CLI_Telemetry_UsageData_Simple_Command(t *testing.T) {
 
 // Verifies telemetry usage data generated when environments and projects are loaded.
 func Test_CLI_Telemetry_UsageData_EnvProjectLoad(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("azure/azure-dev#4612")
+	}
+
 	// CLI process and working directory are isolated
 	ctx, cancel := newTestContext(t)
 	defer cancel()


### PR DESCRIPTION
These tests are failing on macOS in CI due to the docker daemon not being configured correctly. Disable them against #4612 which tracks fixing the issue.