### PR TITLE
down: idempotent delete on resource groups

### DIFF
--- a/cli/azd/pkg/azapi/resource_service.go
+++ b/cli/azd/pkg/azapi/resource_service.go
@@ -2,8 +2,10 @@ package azapi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
@@ -194,6 +196,11 @@ func (rs *ResourceService) DeleteResourceGroup(ctx context.Context, subscription
 	}
 
 	poller, err := client.BeginDelete(ctx, resourceGroupName, nil)
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) && respErr.StatusCode == 404 { // Resource group is already deleted
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("beginning resource group deletion: %w", err)
 	}


### PR DESCRIPTION
This addresses the incorrect behavior of: when deleting a resource group in `azd down`, azd currently fails.

A delete on a resource group that does not exist should result in a no-opt.

Fixes #4628