### PR TITLE
rpc: Support handlers of any arity

### DIFF
--- a/cli/azd/internal/vsrpc/aspire_service.go
+++ b/cli/azd/internal/vsrpc/aspire_service.go
@@ -28,7 +28,7 @@ func newAspireService(server *Server) *aspireService {
 // GetAspireHostAsync is the server implementation of:
 // ValueTask<AspireHost> GetAspireHostAsync(Session session, string aspireEnv, CancellationToken cancellationToken).
 func (s *aspireService) GetAspireHostAsync(
-	ctx context.Context, rc RequestContext, aspireEnv string, observer IObserver[ProgressMessage],
+	ctx context.Context, rc RequestContext, aspireEnv string, observer *Observer[ProgressMessage],
 ) (*AspireHost, error) {
 	session, err := s.server.validateSession(rc.Session)
 	if err != nil {
@@ -65,7 +65,7 @@ func (s *aspireService) GetAspireHostAsync(
 // RenameAspireHostAsync is the server implementation of:
 // ValueTask RenameAspireHostAsync(Session session, string newPath, CancellationToken cancellationToken).
 func (s *aspireService) RenameAspireHostAsync(
-	ctx context.Context, rc RequestContext, newPath string, observer IObserver[ProgressMessage],
+	ctx context.Context, rc RequestContext, newPath string, observer *Observer[ProgressMessage],
 ) error {
 	_, err := s.server.validateSession(rc.Session)
 	if err != nil {
@@ -79,7 +79,7 @@ func (s *aspireService) RenameAspireHostAsync(
 // ServeHTTP implements http.Handler.
 func (s *aspireService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	serveRpc(w, r, map[string]Handler{
-		"GetAspireHostAsync":    HandlerFunc3(s.GetAspireHostAsync),
-		"RenameAspireHostAsync": HandlerAction3(s.RenameAspireHostAsync),
+		"GetAspireHostAsync":    NewHandler(s.GetAspireHostAsync),
+		"RenameAspireHostAsync": NewHandler(s.RenameAspireHostAsync),
 	})
 }

--- a/cli/azd/internal/vsrpc/debug_service.go
+++ b/cli/azd/internal/vsrpc/debug_service.go
@@ -53,7 +53,7 @@ func (s *debugService) TestCancelAsync(ctx context.Context, timeoutMs int) (bool
 // ValueTask<bool> TestIObserverAsync(int, CancellationToken);
 //
 // It emits a sequence of integers to the observer, from 0 to max, and then completes the observer, before returning.
-func (s *debugService) TestIObserverAsync(ctx context.Context, max int, observer IObserver[int]) error {
+func (s *debugService) TestIObserverAsync(ctx context.Context, max int, observer *Observer[int]) error {
 	for i := 0; i < max; i++ {
 		_ = observer.OnNext(ctx, i)
 	}
@@ -107,9 +107,9 @@ func (s *debugService) FetchTokenAsync(ctx context.Context, sessionId Session) (
 // ServeHTTP implements http.Handler.
 func (s *debugService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	serveRpc(w, r, map[string]Handler{
-		"TestCancelAsync":    HandlerFunc1(s.TestCancelAsync),
-		"TestIObserverAsync": HandlerAction2(s.TestIObserverAsync),
-		"TestPanicAsync":     HandlerAction1(s.TestPanicAsync),
-		"FetchTokenAsync":    HandlerFunc1(s.FetchTokenAsync),
+		"TestCancelAsync":    NewHandler(s.TestCancelAsync),
+		"TestIObserverAsync": NewHandler(s.TestIObserverAsync),
+		"TestPanicAsync":     NewHandler(s.TestPanicAsync),
+		"FetchTokenAsync":    NewHandler(s.FetchTokenAsync),
 	})
 }

--- a/cli/azd/internal/vsrpc/environment_service.go
+++ b/cli/azd/internal/vsrpc/environment_service.go
@@ -32,7 +32,7 @@ func newEnvironmentService(server *Server) *environmentService {
 // ValueTask<IEnumerable<EnvironmentInfo>> GetEnvironmentsAsync(
 // RequestContext, IObserver<ProgressMessage>, CancellationToken);
 func (s *environmentService) GetEnvironmentsAsync(
-	ctx context.Context, rc RequestContext, observer IObserver[ProgressMessage],
+	ctx context.Context, rc RequestContext, observer *Observer[ProgressMessage],
 ) ([]*EnvironmentInfo, error) {
 	session, err := s.server.validateSession(rc.Session)
 	if err != nil {
@@ -71,7 +71,7 @@ func (s *environmentService) GetEnvironmentsAsync(
 // SetCurrentEnvironmentAsync is the server implementation of:
 // ValueTask<bool> SetCurrentEnvironmentAsync(RequestContext, string, IObserver<ProgressMessage>, CancellationToken);
 func (s *environmentService) SetCurrentEnvironmentAsync(
-	ctx context.Context, rc RequestContext, name string, observer IObserver[ProgressMessage],
+	ctx context.Context, rc RequestContext, name string, observer *Observer[ProgressMessage],
 ) (bool, error) {
 	session, err := s.server.validateSession(rc.Session)
 	if err != nil {
@@ -107,7 +107,7 @@ const (
 // DeleteEnvironmentAsync is the server implementation of:
 // ValueTask<bool> DeleteEnvironmentAsync(RequestContext, string, IObserver<ProgressMessage>, int, CancellationToken);
 func (s *environmentService) DeleteEnvironmentAsync(
-	ctx context.Context, rc RequestContext, name string, mode int, observer IObserver[ProgressMessage],
+	ctx context.Context, rc RequestContext, name string, mode int, observer *Observer[ProgressMessage],
 ) (bool, error) {
 	session, err := s.server.validateSession(rc.Session)
 	if err != nil {
@@ -196,13 +196,13 @@ func (s *environmentService) DeleteEnvironmentAsync(
 // ServeHTTP implements http.Handler.
 func (s *environmentService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	serveRpc(w, r, map[string]Handler{
-		"CreateEnvironmentAsync":     HandlerFunc3(s.CreateEnvironmentAsync),
-		"GetEnvironmentsAsync":       HandlerFunc2(s.GetEnvironmentsAsync),
-		"LoadEnvironmentAsync":       HandlerFunc3(s.LoadEnvironmentAsync),
-		"OpenEnvironmentAsync":       HandlerFunc3(s.OpenEnvironmentAsync),
-		"SetCurrentEnvironmentAsync": HandlerFunc3(s.SetCurrentEnvironmentAsync),
-		"DeleteEnvironmentAsync":     HandlerFunc4(s.DeleteEnvironmentAsync),
-		"RefreshEnvironmentAsync":    HandlerFunc3(s.RefreshEnvironmentAsync),
-		"DeployAsync":                HandlerFunc3(s.DeployAsync),
+		"CreateEnvironmentAsync":     NewHandler(s.CreateEnvironmentAsync),
+		"GetEnvironmentsAsync":       NewHandler(s.GetEnvironmentsAsync),
+		"LoadEnvironmentAsync":       NewHandler(s.LoadEnvironmentAsync),
+		"OpenEnvironmentAsync":       NewHandler(s.OpenEnvironmentAsync),
+		"SetCurrentEnvironmentAsync": NewHandler(s.SetCurrentEnvironmentAsync),
+		"DeleteEnvironmentAsync":     NewHandler(s.DeleteEnvironmentAsync),
+		"RefreshEnvironmentAsync":    NewHandler(s.RefreshEnvironmentAsync),
+		"DeployAsync":                NewHandler(s.DeployAsync),
 	})
 }

--- a/cli/azd/internal/vsrpc/environment_service_create.go
+++ b/cli/azd/internal/vsrpc/environment_service_create.go
@@ -18,7 +18,7 @@ import (
 // CreateEnvironmentAsync is the server implementation of:
 // ValueTask<bool> CreateEnvironmentAsync(RequestContext, Environment, IObserver<ProgressMessage>, CancellationToken);
 func (s *environmentService) CreateEnvironmentAsync(
-	ctx context.Context, rc RequestContext, newEnv Environment, observer IObserver[ProgressMessage],
+	ctx context.Context, rc RequestContext, newEnv Environment, observer *Observer[ProgressMessage],
 ) (bool, error) {
 	session, err := s.server.validateSession(rc.Session)
 	if err != nil {

--- a/cli/azd/internal/vsrpc/environment_service_deploy.go
+++ b/cli/azd/internal/vsrpc/environment_service_deploy.go
@@ -17,7 +17,7 @@ import (
 //
 // While it is named simply `DeployAsync`, it behaves as if the user had run `azd provision` and `azd deploy`.
 func (s *environmentService) DeployAsync(
-	ctx context.Context, rc RequestContext, name string, observer IObserver[ProgressMessage],
+	ctx context.Context, rc RequestContext, name string, observer *Observer[ProgressMessage],
 ) (*Environment, error) {
 	session, err := s.server.validateSession(rc.Session)
 	if err != nil {

--- a/cli/azd/internal/vsrpc/environment_service_load.go
+++ b/cli/azd/internal/vsrpc/environment_service_load.go
@@ -21,7 +21,7 @@ import (
 // already cached) and is faster than `LoadEnvironmentAsync` in cases where we have not cached the manifest. This means
 // the Services array of the returned environment may be empty.
 func (s *environmentService) OpenEnvironmentAsync(
-	ctx context.Context, rc RequestContext, name string, observer IObserver[ProgressMessage],
+	ctx context.Context, rc RequestContext, name string, observer *Observer[ProgressMessage],
 ) (*Environment, error) {
 	session, err := s.server.validateSession(rc.Session)
 	if err != nil {
@@ -43,7 +43,7 @@ func (s *environmentService) OpenEnvironmentAsync(
 // the environment (like service endpoints) may not be available. Use `RefreshEnvironmentAsync` to load the environment and
 // fetch information from Azure.
 func (s *environmentService) LoadEnvironmentAsync(
-	ctx context.Context, rc RequestContext, name string, observer IObserver[ProgressMessage],
+	ctx context.Context, rc RequestContext, name string, observer *Observer[ProgressMessage],
 ) (*Environment, error) {
 	session, err := s.server.validateSession(rc.Session)
 	if err != nil {

--- a/cli/azd/internal/vsrpc/environment_service_refresh.go
+++ b/cli/azd/internal/vsrpc/environment_service_refresh.go
@@ -25,7 +25,7 @@ import (
 // to accept some loss of information in favor of a faster load time, use `LoadEnvironmentAsync` instead, which does not
 // contact azure to compute service endpoints or last deployment information.
 func (s *environmentService) RefreshEnvironmentAsync(
-	ctx context.Context, rc RequestContext, name string, observer IObserver[ProgressMessage],
+	ctx context.Context, rc RequestContext, name string, observer *Observer[ProgressMessage],
 ) (*Environment, error) {
 	session, err := s.server.validateSession(rc.Session)
 	if err != nil {
@@ -41,7 +41,7 @@ func (s *environmentService) RefreshEnvironmentAsync(
 }
 
 func (s *environmentService) refreshEnvironmentAsync(
-	ctx context.Context, container *container, name string, observer IObserver[ProgressMessage],
+	ctx context.Context, container *container, name string, observer *Observer[ProgressMessage],
 ) (*Environment, error) {
 	env, err := s.loadEnvironmentAsync(ctx, container, name, true)
 	if err != nil {

--- a/cli/azd/internal/vsrpc/handler.go
+++ b/cli/azd/internal/vsrpc/handler.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"runtime"
 
 	"go.lsp.dev/jsonrpc2"
@@ -17,373 +18,137 @@ const (
 	// requestCanceledErrorCode is the error code that is used when a request is cancelled. StreamJsonRpc understands this
 	// error code and causes the Task to throw a TaskCanceledException instead of a normal RemoteInvocationException error.
 	requestCanceledErrorCode jsonrpc2.Code = -32800
-
-	// arityZero is the count of arguments in a zero argument function.
-	arityZero = 0
-	// arityOne is the count of arguments in an one argument function.
-	arityOne = 1
-	// arityTwo is the count of arguments in a two argument function.
-	arityTwo = 2
-	// arityThree is the count of arguments in a three argument function.
-	arityThree = 3
-	// arityFour is the count of arguments in a four argument function.
-	arityFour = 4
 )
 
 // Handler is the type of function that handles incoming RPC requests.
 type Handler func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error
 
-// HandlerAction0 is a helper for creating a Handler from a function that takes no arguments and returns an error.
-func HandlerAction0(f func(context.Context) error) Handler {
+// NewHandler is a generic helper for creating a Handler from an arbitrary function. The function must:
+//
+// - Take a context.Context as its first argument.
+// - Return either an error or a value and an error.
+//
+// If f does not meet these requirements, NewHandler will panic.
+func NewHandler(f any) Handler {
+	fnValue := reflect.ValueOf(f)
+	fnType := fnValue.Type()
+
+	if fnType.Kind() != reflect.Func {
+		panic(fmt.Sprintf("NewHandler: expected a function, got %s", fnType.Kind()))
+	}
+
+	if fnType.NumIn() == 0 {
+		panic("NewHandler: function must take at least one argument")
+	}
+
+	if fnType.In(0) != reflect.TypeOf((*context.Context)(nil)).Elem() {
+		panic(fmt.Sprintf("NewHandler: first argument must be a context.Context, got %s", fnType.In(0)))
+	}
+
+	if fnType.NumOut() != 1 && fnType.NumOut() != 2 {
+		panic(fmt.Sprintf("NewHandler: function must return either an error or a value and an error, got %d return values",
+			fnType.NumOut()))
+	}
+
+	if fnType.NumOut() == 1 && fnType.Out(0) != reflect.TypeOf((*error)(nil)).Elem() {
+		panic(fmt.Sprintf("NewHandler: single return value must be an error, got %s", fnType.Out(0)))
+	}
+
+	if fnType.NumOut() == 2 && fnType.Out(1) != reflect.TypeOf((*error)(nil)).Elem() {
+		panic(fmt.Sprintf("NewHandler: second return value must be an error, got %s", fnType.Out(1)))
+	}
+
 	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-		if err := verifyArity(req, arityZero); err != nil {
+		args, err := unmarshalArgs(conn, req, fnType)
+		if err != nil {
 			return reply(ctx, nil, err)
 		}
 
-		err := func() (err error) {
-			defer capturePanic(&err)
-			err = f(ctx)
-			return
+		var results []reflect.Value
+		func() {
+			defer func() {
+				if p := recover(); p != nil {
+					stackBuf := make([]byte, 4096)
+					stack := string(stackBuf[:runtime.Stack(stackBuf, false)])
+
+					rpcErr := &jsonrpc2.Error{
+						Code:    jsonrpc2.InternalError,
+						Message: fmt.Sprintf("panic: %v\n%v", p, stack),
+					}
+
+					if fnType.NumOut() == 1 {
+						results = []reflect.Value{reflect.ValueOf(rpcErr)}
+					} else if fnType.NumOut() == 2 {
+						results = []reflect.Value{reflect.Zero(fnType.Out(0)), reflect.ValueOf(rpcErr)}
+					}
+				}
+			}()
+
+			results = fnValue.Call(append([]reflect.Value{reflect.ValueOf(ctx)}, args...))
 		}()
 
-		if err != nil && errors.Is(err, ctx.Err()) {
-			err = &jsonrpc2.Error{
-				Code:    requestCanceledErrorCode,
-				Message: err.Error(),
+		if fnType.NumOut() == 1 {
+			// Function returns only an error
+			errResult := results[0].Interface()
+			if errResult != nil {
+				err = errResult.(error)
 			}
+			if err != nil && errors.Is(err, ctx.Err()) {
+				err = &jsonrpc2.Error{
+					Code:    requestCanceledErrorCode,
+					Message: err.Error(),
+				}
+			}
+			return reply(ctx, nil, err)
+		} else if fnType.NumOut() == 2 {
+			// Function returns a value and an error
+			ret := results[0].Interface()
+			errResult := results[1].Interface()
+			if errResult != nil {
+				err = errResult.(error)
+			}
+			if err != nil && errors.Is(err, ctx.Err()) {
+				err = &jsonrpc2.Error{
+					Code:    requestCanceledErrorCode,
+					Message: err.Error(),
+				}
+			}
+			return reply(ctx, ret, err)
 		}
-		return reply(ctx, nil, err)
+		return reply(ctx, nil, fmt.Errorf("unexpected number of return values"))
 	}
 }
 
-// HandlerAction1 is a helper for creating a Handler from a function that takes one argument and returns an error.
-func HandlerAction1[T1 any](f func(context.Context, T1) error) Handler {
-	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-		if err := verifyArity(req, arityOne); err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		t1, err := unmarshalArg[T1](conn, req, 0)
-		if err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		err = func() (err error) {
-			defer capturePanic(&err)
-			err = f(ctx, t1)
-			return
-		}()
-
-		if err != nil && errors.Is(err, ctx.Err()) {
-			err = &jsonrpc2.Error{
-				Code:    requestCanceledErrorCode,
-				Message: err.Error(),
-			}
-		}
-		return reply(ctx, nil, err)
-	}
-}
-
-// HandlerAction2 is a helper for creating a Handler from a function that takes two arguments and returns an error.
-func HandlerAction2[T1 any, T2 any](f func(context.Context, T1, T2) error) Handler {
-	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-		if err := verifyArity(req, arityTwo); err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		t1, err := unmarshalArg[T1](conn, req, 0)
-		if err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		t2, err := unmarshalArg[T2](conn, req, 1)
-		if err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		err = func() (err error) {
-			defer capturePanic(&err)
-			err = f(ctx, t1, t2)
-			return
-		}()
-
-		if err != nil && errors.Is(err, ctx.Err()) {
-			err = &jsonrpc2.Error{
-				Code:    requestCanceledErrorCode,
-				Message: err.Error(),
-			}
-		}
-		return reply(ctx, nil, err)
-	}
-}
-
-// HandlerAction3 is a helper for creating a Handler from a function that takes two arguments and returns an error.
-func HandlerAction3[T1 any, T2 any, T3 any](f func(context.Context, T1, T2, T3) error) Handler {
-	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-		if err := verifyArity(req, arityThree); err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		t1, err := unmarshalArg[T1](conn, req, 0)
-		if err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		t2, err := unmarshalArg[T2](conn, req, 1)
-		if err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		t3, err := unmarshalArg[T3](conn, req, 2)
-		if err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		err = func() (err error) {
-			defer capturePanic(&err)
-			err = f(ctx, t1, t2, t3)
-			return
-		}()
-
-		if err != nil && errors.Is(err, ctx.Err()) {
-			err = &jsonrpc2.Error{
-				Code:    requestCanceledErrorCode,
-				Message: err.Error(),
-			}
-		}
-		return reply(ctx, nil, err)
-	}
-}
-
-// HandlerFunc0 is a helper for creating a Handler from a function that takes no arguments and returns a value and an error.
-func HandlerFunc0[TRet any](f func(context.Context) (TRet, error)) Handler {
-	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-		if err := verifyArity(req, arityZero); err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		ret, err := func() (ret TRet, err error) {
-			defer capturePanic(&err)
-			ret, err = f(ctx)
-			return
-		}()
-
-		if err != nil && errors.Is(err, ctx.Err()) {
-			err = &jsonrpc2.Error{
-				Code:    requestCanceledErrorCode,
-				Message: err.Error(),
-			}
-		}
-		return reply(ctx, ret, err)
-	}
-}
-
-// HandlerFunc1 is a helper for creating a Handler from a function that takes one argument and returns a value and an error.
-func HandlerFunc1[T1 any, TRet any](f func(context.Context, T1) (TRet, error)) Handler {
-	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-		if err := verifyArity(req, arityOne); err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		t1, err := unmarshalArg[T1](conn, req, 0)
-		if err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		ret, err := func() (ret TRet, err error) {
-			defer capturePanic(&err)
-			ret, err = f(ctx, t1)
-			return
-		}()
-
-		if err != nil && errors.Is(err, ctx.Err()) {
-			err = &jsonrpc2.Error{
-				Code:    requestCanceledErrorCode,
-				Message: err.Error(),
-			}
-		}
-		return reply(ctx, ret, err)
-	}
-}
-
-// HandlerFunc2 is a helper for creating a Handler from a function that takes two arguments and returns a value and an error.
-func HandlerFunc2[T1 any, T2 any, TRet any](f func(context.Context, T1, T2) (TRet, error)) Handler {
-	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-		if err := verifyArity(req, arityTwo); err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		t1, err := unmarshalArg[T1](conn, req, 0)
-		if err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		t2, err := unmarshalArg[T2](conn, req, 1)
-		if err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		ret, err := func() (ret TRet, err error) {
-			defer capturePanic(&err)
-			ret, err = f(ctx, t1, t2)
-			return
-		}()
-
-		if err != nil && errors.Is(err, ctx.Err()) {
-			err = &jsonrpc2.Error{
-				Code:    requestCanceledErrorCode,
-				Message: err.Error(),
-			}
-		}
-		return reply(ctx, ret, err)
-	}
-}
-
-// HandlerFunc3 is a helper for creating a Handler from a function that takes three arguments and returns a value and an
-// error.
-func HandlerFunc3[T1 any, T2 any, T3 any, TRet any](f func(context.Context, T1, T2, T3) (TRet, error)) Handler {
-	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-		if err := verifyArity(req, arityThree); err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		t1, err := unmarshalArg[T1](conn, req, 0)
-		if err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		t2, err := unmarshalArg[T2](conn, req, 1)
-		if err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		t3, err := unmarshalArg[T3](conn, req, 2)
-		if err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		ret, err := func() (ret TRet, err error) {
-			defer capturePanic(&err)
-			ret, err = f(ctx, t1, t2, t3)
-			return
-		}()
-
-		if err != nil && errors.Is(err, ctx.Err()) {
-			err = &jsonrpc2.Error{
-				Code:    requestCanceledErrorCode,
-				Message: err.Error(),
-			}
-		}
-		return reply(ctx, ret, err)
-	}
-}
-
-// HandlerFunc4 is a helper for creating a Handler from a function that takes four arguments and returns a value and an
-// error.
-func HandlerFunc4[T1 any, T2 any, T3 any, T4 any, TRet any](f func(context.Context, T1, T2, T3, T4) (TRet, error)) Handler {
-	return func(ctx context.Context, conn jsonrpc2.Conn, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-		if err := verifyArity(req, arityFour); err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		t1, err := unmarshalArg[T1](conn, req, 0)
-		if err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		t2, err := unmarshalArg[T2](conn, req, 1)
-		if err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		t3, err := unmarshalArg[T3](conn, req, 2)
-		if err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		t4, err := unmarshalArg[T4](conn, req, 3)
-		if err != nil {
-			return reply(ctx, nil, err)
-		}
-
-		ret, err := func() (ret TRet, err error) {
-			defer capturePanic(&err)
-			ret, err = f(ctx, t1, t2, t3, t4)
-			return
-		}()
-
-		if err != nil && errors.Is(err, ctx.Err()) {
-			err = &jsonrpc2.Error{
-				Code:    requestCanceledErrorCode,
-				Message: err.Error(),
-			}
-		}
-		return reply(ctx, ret, err)
-	}
-}
-
-// unmarshalArg returns the i'th member of the Params property of a request, after JSON unmarshalling it as an instance of T.
-// If an error is returned, it is of type *jsonrpc.Error with a code of jsonrpc2.InvalidParams.
-func unmarshalArg[T any](conn jsonrpc2.Conn, req jsonrpc2.Request, index int) (T, error) {
+// unmarshalArgs unmarshals the request parameters into the expected argument types for the function.
+func unmarshalArgs(conn jsonrpc2.Conn, req jsonrpc2.Request, fnType reflect.Type) ([]reflect.Value, error) {
 	var args []json.RawMessage
 	if err := json.Unmarshal(req.Params(), &args); err != nil {
-		return *new(T), jsonrpc2.NewError(
+		return nil, jsonrpc2.NewError(
 			jsonrpc2.InvalidParams, fmt.Sprintf("unmarshalling params as array: %s", err.Error()))
 	}
 
-	if index >= len(args) {
-		return *new(T), jsonrpc2.NewError(
-			jsonrpc2.InvalidParams, fmt.Sprintf("param out of range, len: %d index: %d", len(args), index))
+	// The first argument in the go handler function is always a context, and that argument is not passed on the wire.
+	expectedArgs := fnType.NumIn() - 1
+
+	if len(args) != expectedArgs {
+		return nil, jsonrpc2.NewError(
+			jsonrpc2.InvalidParams, fmt.Sprintf("expected %d params for %s, got %d", expectedArgs, req.Method(), len(args)))
 	}
 
-	var arg T
-	if err := json.Unmarshal(args[index], &arg); err != nil {
-		return *new(T), jsonrpc2.NewError(
-			jsonrpc2.InvalidParams, fmt.Sprintf("unmarshalling param: %s", err.Error()))
-	}
+	fnArgs := make([]reflect.Value, expectedArgs)
+	for i := 0; i < len(args); i++ {
+		argType := fnType.In(i + 1)
+		argValue := reflect.New(argType).Interface()
+		if err := json.Unmarshal(args[i], argValue); err != nil {
+			return nil, jsonrpc2.NewError(
+				jsonrpc2.InvalidParams, fmt.Sprintf("unmarshalling param: %s", err.Error()))
+		}
+		fnArgs[i] = reflect.ValueOf(argValue).Elem()
 
-	if v, ok := (any(&arg)).(connectionObserver); ok {
-		v.attachConnection(conn)
-	}
-
-	return arg, nil
-}
-
-// verifyArity returns a error if the number of parameters in a request does not match the expected number. The error
-// is of type *jsonrpc2.Error with a code of jsonrpc2.InvalidParams.
-func verifyArity(req jsonrpc2.Request, expected int) error {
-	var args []json.RawMessage
-	if err := json.Unmarshal(req.Params(), &args); err != nil {
-		return jsonrpc2.NewError(
-			jsonrpc2.InvalidParams, fmt.Sprintf("unmarshalling params as array: %s", err.Error()))
-	}
-
-	if len(args) != expected {
-		return jsonrpc2.NewError(
-			jsonrpc2.InvalidParams, fmt.Sprintf("expected %d params for %s, got %d", expected, req.Method(), len(args)))
-	}
-
-	return nil
-}
-
-// capturePanic is a helper for capturing panics and converting them to an error. It is expected to be called via `defer`:
-//
-//	err := func() (err error) {
-//		defer capturePanic(&err)
-//		err = /* ... some call that might panic ... */
-//		return
-//	}()
-//
-// If a panic occurs, the error will be set to a new *jsonrpc2.Error instance with a code of jsonrpc2.InternalError and a
-// message that includes the panic value.
-func capturePanic(err *error) {
-	if p := recover(); p != nil {
-		stackBuf := make([]byte, 4096)
-		stack := string(stackBuf[:runtime.Stack(stackBuf, false)])
-
-		*err = &jsonrpc2.Error{
-			Code:    jsonrpc2.InternalError,
-			Message: fmt.Sprintf("panic: %v\n%v", p, stack),
+		if v, ok := (fnArgs[i].Interface()).(connectionObserver); ok {
+			v.attachConnection(conn)
 		}
 	}
+
+	return fnArgs, nil
 }

--- a/cli/azd/internal/vsrpc/handler_test.go
+++ b/cli/azd/internal/vsrpc/handler_test.go
@@ -84,7 +84,7 @@ func TestHandler(t *testing.T) {
 }
 
 func newHandlerAction0(t *testing.T, tc handlerTestCase) Handler {
-	return HandlerAction0(func(ctx context.Context) error {
+	return NewHandler(func(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -95,7 +95,7 @@ func newHandlerAction0(t *testing.T, tc handlerTestCase) Handler {
 }
 
 func newHandlerAction1(t *testing.T, tc handlerTestCase) Handler {
-	return HandlerAction1(func(ctx context.Context, arg0 string) error {
+	return NewHandler(func(ctx context.Context, arg0 string) error {
 		validateParam(t, tc.params, 0, arg0)
 
 		select {
@@ -108,7 +108,7 @@ func newHandlerAction1(t *testing.T, tc handlerTestCase) Handler {
 }
 
 func newHandlerAction2(t *testing.T, tc handlerTestCase) Handler {
-	return HandlerAction2(func(ctx context.Context, arg0, arg1 string) error {
+	return NewHandler(func(ctx context.Context, arg0, arg1 string) error {
 		validateParam(t, tc.params, 0, arg0)
 		validateParam(t, tc.params, 1, arg1)
 
@@ -122,7 +122,7 @@ func newHandlerAction2(t *testing.T, tc handlerTestCase) Handler {
 }
 
 func newHandlerAction3(t *testing.T, tc handlerTestCase) Handler {
-	return HandlerAction3(func(ctx context.Context, arg0, arg1, arg2 string) error {
+	return NewHandler(func(ctx context.Context, arg0, arg1, arg2 string) error {
 		validateParam(t, tc.params, 0, arg0)
 		validateParam(t, tc.params, 1, arg1)
 		validateParam(t, tc.params, 2, arg2)
@@ -137,7 +137,7 @@ func newHandlerAction3(t *testing.T, tc handlerTestCase) Handler {
 }
 
 func newHandlerFunc0(t *testing.T, tc handlerTestCase) Handler {
-	return HandlerFunc0(func(ctx context.Context) (any, error) {
+	return NewHandler(func(ctx context.Context) (any, error) {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -148,7 +148,7 @@ func newHandlerFunc0(t *testing.T, tc handlerTestCase) Handler {
 }
 
 func newHandlerFunc1(t *testing.T, tc handlerTestCase) Handler {
-	return HandlerFunc1(func(ctx context.Context, arg0 string) (any, error) {
+	return NewHandler(func(ctx context.Context, arg0 string) (any, error) {
 		validateParam(t, tc.params, 0, arg0)
 
 		select {
@@ -161,7 +161,7 @@ func newHandlerFunc1(t *testing.T, tc handlerTestCase) Handler {
 }
 
 func newHandlerFunc2(t *testing.T, tc handlerTestCase) Handler {
-	return HandlerFunc2(func(ctx context.Context, arg0, arg1 string) (any, error) {
+	return NewHandler(func(ctx context.Context, arg0, arg1 string) (any, error) {
 		validateParam(t, tc.params, 0, arg0)
 		validateParam(t, tc.params, 1, arg1)
 
@@ -175,7 +175,7 @@ func newHandlerFunc2(t *testing.T, tc handlerTestCase) Handler {
 }
 
 func newHandlerFunc3(t *testing.T, tc handlerTestCase) Handler {
-	return HandlerFunc3(func(ctx context.Context, arg0, arg1, arg2 string) (any, error) {
+	return NewHandler(func(ctx context.Context, arg0, arg1, arg2 string) (any, error) {
 		validateParam(t, tc.params, 0, arg0)
 		validateParam(t, tc.params, 1, arg1)
 		validateParam(t, tc.params, 2, arg2)

--- a/cli/azd/internal/vsrpc/message_writer.go
+++ b/cli/azd/internal/vsrpc/message_writer.go
@@ -13,7 +13,7 @@ import (
 // messageWriter is an io.Writer that writes to an IObserver[ProgressMessage], emitting a message for each write.
 type messageWriter struct {
 	ctx             context.Context
-	observer        IObserver[ProgressMessage]
+	observer        *Observer[ProgressMessage]
 	messageTemplate ProgressMessage
 }
 

--- a/cli/azd/internal/vsrpc/observer.go
+++ b/cli/azd/internal/vsrpc/observer.go
@@ -18,30 +18,30 @@ type connectionObserver interface {
 	attachConnection(c jsonrpc2.Conn)
 }
 
-// IObserver is treated special by our JSON-RPC implementation and plays nicely with StreamJsonRpc's ideas on how to
-// marshal an IObserver<T> in .NET.
+// Observer is treated special by our JSON-RPC implementation and plays nicely with StreamJsonRpc's ideas on how to
+// marshal an Observer<T> in .NET.
 //
 // The way this works is that that we can send a notification back to to the server with the method
-// `$/invokeProxy/{handle}/{onCompleted|onNext}`. When marshalled as an argument, the wire format of IObserver<T> is:
+// `$/invokeProxy/{handle}/{onCompleted|onNext}`. When marshalled as an argument, the wire format of Observer<T> is:
 //
 //	{
 //	  "__jsonrpc_marshaled": 1,
 //	  "handle": <some-integer>
 //	}
-type IObserver[T any] struct {
+type Observer[T any] struct {
 	handle int
 	c      jsonrpc2.Conn
 }
 
-func (o *IObserver[T]) OnNext(ctx context.Context, value T) error {
+func (o *Observer[T]) OnNext(ctx context.Context, value T) error {
 	return o.c.Notify(ctx, fmt.Sprintf("$/invokeProxy/%d/onNext", o.handle), []any{value})
 }
 
-func (o *IObserver[T]) OnCompleted(ctx context.Context) error {
+func (o *Observer[T]) OnCompleted(ctx context.Context) error {
 	return o.c.Notify(ctx, fmt.Sprintf("$/invokeProxy/%d/onCompleted", o.handle), nil)
 }
 
-func (o *IObserver[T]) UnmarshalJSON(data []byte) error {
+func (o *Observer[T]) UnmarshalJSON(data []byte) error {
 	var wire map[string]int
 	if err := json.Unmarshal(data, &wire); err != nil {
 		return err
@@ -60,6 +60,6 @@ func (o *IObserver[T]) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (o *IObserver[T]) attachConnection(c jsonrpc2.Conn) {
+func (o *Observer[T]) attachConnection(c jsonrpc2.Conn) {
 	o.c = c
 }

--- a/cli/azd/internal/vsrpc/server.go
+++ b/cli/azd/internal/vsrpc/server.go
@@ -57,7 +57,7 @@ func (s *Server) Serve(l net.Listener) error {
 	mux.Handle("/EnvironmentService/v1.0", newEnvironmentService(s))
 
 	// Expose a few special test endpoints that can be used to debug our special RPC behavior around cancellation and
-	// IObservers. This is useful for both developers unit testing in VS Code (where they can set this value in launch.json
+	// observers. This is useful for both developers unit testing in VS Code (where they can set this value in launch.json
 	// as well as tests where we can set this value with t.SetEnv()).
 	if on, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_SERVER_DEBUG_ENDPOINTS")); err == nil && on {
 		mux.Handle("/TestDebugService/v1.0", newDebugService(s))

--- a/cli/azd/internal/vsrpc/server_service.go
+++ b/cli/azd/internal/vsrpc/server_service.go
@@ -111,8 +111,8 @@ func (s *serverService) StopAsync(ctx context.Context) error {
 // ServeHTTP implements http.Handler.
 func (s *serverService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	serveRpc(w, r, map[string]Handler{
-		"InitializeAsync": HandlerFunc2(s.InitializeAsync),
-		"StopAsync":       HandlerAction0(s.StopAsync),
+		"InitializeAsync": NewHandler(s.InitializeAsync),
+		"StopAsync":       NewHandler(s.StopAsync),
 	})
 }
 

--- a/cli/azd/internal/vsrpc/server_test.go
+++ b/cli/azd/internal/vsrpc/server_test.go
@@ -116,7 +116,7 @@ func TestObserverable(t *testing.T) {
 	wsConn, _, err := websocket.DefaultDialer.Dial(serverUrl.String(), nil)
 	require.NoError(t, err)
 
-	// The IObserver machinary ends up sending RPCs back to the client, capture them so we can validate they are
+	// The Observer machinary ends up sending RPCs back to the client, capture them so we can validate they are
 	// correct later.
 	var onNextParams []json.RawMessage
 	var onCompletedParams []json.RawMessage


### PR DESCRIPTION
Previously, we had of hand written adapters that allowed exposing go functions over our JSON-RPC boundary.  Changes to the number of arguments or return values would require changes to the adapter used (or writing a new adapter by copy/pasting an existing one).

Now, we have a single `NewHandler` which allows exposing arbitrary go functions over the RPC boundary (as long as the follow some rules, like taking a `context.Context` as the first paremeter, and returning a value and `error` or just an `error`.

As part of this change, the `IObserver` type is now called `Observer` and it is passed by reference instead of value in signatures.