### PR TITLE
Use `log/slog` instead of `log`

### DIFF
--- a/cli/azd/cmd/auth_login.go
+++ b/cli/azd/cmd/auth_login.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -350,7 +350,7 @@ func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		if err := la.accountSubManager.RefreshSubscriptions(ctx); err != nil {
 			// If this fails, the subscriptions will still be loaded on-demand.
 			// erroring out when the user interacts with subscriptions is much more user-friendly.
-			log.Printf("failed retrieving subscriptions: %v", err)
+			slog.InfoContext(ctx, "failed retrieving subscriptions", "err", err)
 		}
 	}
 
@@ -405,7 +405,7 @@ func runningOnCodespacesBrowser(ctx context.Context, commandRunner exec.CommandR
 	if err != nil {
 		// An error here means VSCode is not installed or found, or something else.
 		// At any case, we know VSCode is not within a webBrowser
-		log.Printf("error running code --status: %s", err.Error())
+		slog.InfoContext(ctx, "error running code --status", "err", err)
 		return false
 	}
 
@@ -415,12 +415,14 @@ func runningOnCodespacesBrowser(ctx context.Context, commandRunner exec.CommandR
 func (la *loginAction) login(ctx context.Context) error {
 	if la.flags.federatedTokenProvider == azurePipelinesProvider {
 		if la.flags.clientID == "" {
-			log.Printf("setting client id from environment variable %s", azurePipelinesClientIDEnvVarName)
+			slog.InfoContext(ctx,
+				fmt.Sprintf("setting client id from environment variable %s", azurePipelinesClientIDEnvVarName))
 			la.flags.clientID = os.Getenv(azurePipelinesClientIDEnvVarName)
 		}
 
 		if la.flags.tenantID == "" {
-			log.Printf("setting tenant id from environment variable %s", azurePipelinesClientIDEnvVarName)
+			slog.InfoContext(ctx,
+				fmt.Sprintf("setting tenant id from environment variable %s", azurePipelinesClientIDEnvVarName))
 			la.flags.tenantID = os.Getenv(azurePipelinesTenantIDEnvVarName)
 		}
 	}

--- a/cli/azd/cmd/cobra_builder.go
+++ b/cli/azd/cmd/cobra_builder.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"slices"
 	"strconv"
 	"strings"
@@ -175,7 +174,7 @@ func (df *docsFlag) Set(value string) error {
 	// Setting help to true will make cobra to stop and call the HelpFunc
 	if err = df.command.Flag("help").Value.Set("true"); err != nil {
 		// dev-issue: help flag should be already been added when
-		log.Panic("tried to set help after docs parameter: %w", err)
+		panic(fmt.Sprintf("tried to set help after docs parameter: %v", err))
 	}
 
 	// keeping the default help function allows to set --help with higher priority and use it
@@ -213,7 +212,7 @@ func (cb *CobraBuilder) bindCommand(cmd *cobra.Command, descriptor *actions.Acti
 		consoleFn: func() input.Console {
 			var console input.Console
 			if err := cb.container.Resolve(&console); err != nil {
-				log.Panic("creating docs flag: %w", err)
+				panic(fmt.Sprintf("creating docs flag: %v", err))
 			}
 			return console
 		},

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -171,7 +171,8 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		// semantics to follow.
 		envValue, err := cmd.Flags().GetString(internal.EnvironmentNameFlagName)
 		if err != nil {
-			log.Printf("'%s'command asked for envFlag, but envFlag was not included in cmd.Flags().", cmd.CommandPath())
+			slog.InfoContext(context.TODO(), "command asked for envFlag, but envFlag was not included in cmd.Flags().",
+				"cmd", cmd.CommandPath())
 			envValue = ""
 		}
 

--- a/cli/azd/cmd/infra_synth.go
+++ b/cli/azd/cmd/infra_synth.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -162,10 +162,9 @@ func (a *infraSynthAction) Run(ctx context.Context) (*actions.ActionResult, erro
 
 func (a *infraSynthAction) promptForDuplicates(
 	ctx context.Context, staging string, target string) (skipSourceFiles map[string]struct{}, err error) {
-	log.Printf(
-		"infrastructure synth, checking for duplicates. source: %s target: %s",
-		staging,
-		target,
+	slog.InfoContext(ctx, "infrastructure synth, checking for duplicates",
+		"source", staging,
+		"target", target,
 	)
 
 	duplicateFiles, err := determineDuplicates(staging, target)

--- a/cli/azd/cmd/middleware/debug.go
+++ b/cli/azd/cmd/middleware/debug.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -50,7 +50,7 @@ func (m *DebugMiddleware) Run(ctx context.Context, next NextFn) (*actions.Action
 
 	debug, err := strconv.ParseBool(debugStr)
 	if err != nil {
-		log.Printf("failed converting AZD_DEBUG to boolean: %s", err.Error())
+		slog.InfoContext(ctx, "failed converting AZD_DEBUG to boolean", "err", err)
 	}
 
 	if !debug {

--- a/cli/azd/cmd/middleware/hooks.go
+++ b/cli/azd/cmd/middleware/hooks.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"context"
 	"fmt"
-	"log"
 	"log/slog"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
@@ -141,7 +140,7 @@ func (m *HooksMiddleware) registerServiceHooks(
 		serviceName := service.Name
 		// If the service hasn't configured any hooks we can continue on.
 		if len(service.Hooks) == 0 {
-			log.Printf("service '%s' does not require any command hooks.\n", serviceName)
+			slog.InfoContext(ctx, "service does not require any command hooks.", "service", serviceName)
 			continue
 		}
 

--- a/cli/azd/cmd/middleware/hooks.go
+++ b/cli/azd/cmd/middleware/hooks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
@@ -49,13 +50,13 @@ func NewHooksMiddleware(
 func (m *HooksMiddleware) Run(ctx context.Context, next NextFn) (*actions.ActionResult, error) {
 	env, err := m.lazyEnv.GetValue()
 	if err != nil {
-		log.Println("azd environment is not available, skipping all hook registrations.")
+		slog.InfoContext(ctx, "azd environment is not available, skipping all hook registrations.")
 		return next(ctx)
 	}
 
 	projectConfig, err := m.lazyProjectConfig.GetValue()
 	if err != nil || projectConfig == nil {
-		log.Println("azd project is not available, skipping all hook registrations.")
+		slog.InfoContext(ctx, "azd project is not available, skipping all hook registrations.")
 		return next(ctx)
 	}
 
@@ -75,7 +76,7 @@ func (m *HooksMiddleware) registerCommandHooks(
 	next NextFn,
 ) (*actions.ActionResult, error) {
 	if len(projectConfig.Hooks) == 0 {
-		log.Println(
+		slog.InfoContext(ctx,
 			"azd project is not available or does not contain any command hooks, skipping command hook registrations.",
 		)
 		return next(ctx)

--- a/cli/azd/cmd/middleware/middleware.go
+++ b/cli/azd/cmd/middleware/middleware.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"slices"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
@@ -95,7 +95,7 @@ func (r *MiddlewareRunner) RunAction(
 
 			var middleware Middleware
 			if err := actionContainer.ResolveNamed(middlewareName, &middleware); err != nil {
-				log.Printf("failed resolving middleware '%s' : %s\n", middlewareName, err.Error())
+				slog.InfoContext(ctx, "failed resolving middleware", "name", middlewareName, "err", err)
 			}
 
 			// It is an expected scenario that the middleware cannot be resolved
@@ -105,7 +105,7 @@ func (r *MiddlewareRunner) RunAction(
 				return nextFn(ctx)
 			}
 
-			log.Printf("running middleware '%s'\n", middlewareName)
+			slog.InfoContext(ctx, "running middleware", "name", middlewareName)
 			return middleware.Run(ctx, nextFn)
 		} else {
 			var action actions.Action

--- a/cli/azd/cmd/middleware/telemetry.go
+++ b/cli/azd/cmd/middleware/telemetry.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
@@ -40,7 +40,7 @@ func (m *TelemetryMiddleware) Run(ctx context.Context, next NextFn) (*actions.Ac
 	cmdPath := events.GetCommandEventName(m.options.CommandPath)
 	spanCtx, span := tracing.Start(ctx, cmdPath)
 
-	log.Printf("TraceID: %s", span.SpanContext().TraceID())
+	slog.InfoContext(spanCtx, "started tracing span", "traceId", span.SpanContext().TraceID())
 
 	if !m.options.IsChildAction(ctx) {
 		// Set the command name as a baggage item on the span context.

--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -4,9 +4,10 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -236,7 +237,7 @@ func NewRootCmd(
 		}).
 		UseMiddlewareWhen("hooks", middleware.NewHooksMiddleware, func(descriptor *actions.ActionDescriptor) bool {
 			if onPreview, _ := descriptor.Options.Command.Flags().GetBool("preview"); onPreview {
-				log.Println("Skipping provision hooks due to preview flag.")
+				slog.InfoContext(context.TODO(), "Skipping provision hooks due to preview flag.")
 				return false
 			}
 			return true

--- a/cli/azd/cmd/util.go
+++ b/cli/azd/cmd/util.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -125,9 +125,9 @@ func openWithDefaultBrowser(ctx context.Context, console input.Console, url stri
 		if err == nil {
 			return
 		}
-		log.Printf(
-			"warning: failed to open browser configured by $BROWSER: %s\nTrying with default browser.\n",
-			err.Error(),
+		slog.InfoContext(ctx,
+			"warning: failed to open browser configured by $BROWSER. Trying with default browser",
+			"err", err,
 		)
 	}
 
@@ -136,9 +136,7 @@ func openWithDefaultBrowser(ctx context.Context, console input.Console, url stri
 		return
 	}
 
-	log.Printf(
-		"warning: failed to open default browser: %s\nTrying manual launch.", err.Error(),
-	)
+	slog.InfoContext(ctx, "warning: failed to open default browser. Trying manual launch.", "err", err)
 
 	// wsl manual launch. Trying cmd first, and pwsh second
 	_, err = cmdRunner.Run(ctx, azdExec.RunArgs{
@@ -154,9 +152,7 @@ func openWithDefaultBrowser(ctx context.Context, console input.Console, url stri
 	if err == nil {
 		return
 	}
-	log.Printf(
-		"warning: failed to open browser with cmd: %s\nTrying powershell.", err.Error(),
-	)
+	slog.InfoContext(ctx, "warning: failed to open browser with cmd. Trying powershell.", "err", err)
 
 	_, err = cmdRunner.Run(ctx, azdExec.RunArgs{
 		Cmd: "powershell.exe",
@@ -168,7 +164,7 @@ func openWithDefaultBrowser(ctx context.Context, console input.Console, url stri
 		return
 	}
 
-	log.Printf("warning: failed to use manual launch: %s\n", err.Error())
+	slog.InfoContext(ctx, "warning: failed to use manual launch", "err", err)
 	console.Message(ctx, fmt.Sprintf("Azd was unable to open the next url. Please try it manually: %s", url))
 }
 

--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -254,7 +254,7 @@ func detectUnder(ctx context.Context, root string, config detectConfig) ([]Proje
 
 // Detects if a directory belongs to any projects.
 func detectAny(ctx context.Context, detectors []projectDetector, path string, entries []fs.DirEntry) (*Project, error) {
-	log.Printf("Detecting projects in directory: %s", path)
+	slog.InfoContext(ctx, "Detecting projects in directory", "path", path)
 	for _, detector := range detectors {
 		project, err := detector.DetectProject(ctx, path, entries)
 		if err != nil {
@@ -262,7 +262,7 @@ func detectAny(ctx context.Context, detectors []projectDetector, path string, en
 		}
 
 		if project != nil {
-			log.Printf("Found project %s at %s", project.Language, path)
+			slog.InfoContext(ctx, "Found project", "language", project.Language, "path", path)
 
 			// docker is an optional property of a project, and thus is different than other detectors
 			docker, err := detectDockerInDirectory(path, entries)

--- a/cli/azd/internal/appdetect/docker.go
+++ b/cli/azd/internal/appdetect/docker.go
@@ -2,9 +2,10 @@ package appdetect
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -37,7 +38,7 @@ func AnalyzeDocker(dockerFilePath string) (*Docker, error) {
 		if strings.HasPrefix(line, "EXPOSE") {
 			parsedPorts, err := parsePortsInLine(line[len("EXPOSE"):])
 			if err != nil {
-				log.Printf("parsing Dockerfile at %s: %v", dockerFilePath, err)
+				slog.InfoContext(context.TODO(), "error parsing expose line", "path", dockerFilePath, "err", err)
 			}
 			ports = append(ports, parsedPorts...)
 		}

--- a/cli/azd/internal/appdetect/dotnet.go
+++ b/cli/azd/internal/appdetect/dotnet.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"strings"
 
@@ -48,7 +48,7 @@ func (dd *dotNetDetector) DetectProject(ctx context.Context, path string, entrie
 	if hasProjectFile && hasStartupFile {
 		projectPath := filepath.Join(path, projFileName)
 		if isWasm, err := dd.isWasmProject(ctx, projectPath); err != nil {
-			log.Printf("error checking if %s is a browser-wasm project: %v", projectPath, err)
+			slog.InfoContext(ctx, "error checking if project is a browser-wasm project", "path", projectPath, "err", err)
 		} else if isWasm { // Web assembly projects currently not supported as a hosted application project
 			return nil, filepath.SkipDir
 		}

--- a/cli/azd/internal/appdetect/dotnet_apphost.go
+++ b/cli/azd/internal/appdetect/dotnet_apphost.go
@@ -3,7 +3,7 @@ package appdetect
 import (
 	"context"
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
@@ -26,7 +26,7 @@ func (ad *dotNetAppHostDetector) DetectProject(ctx context.Context, path string,
 		case ".csproj", ".fsproj", ".vbproj":
 			projectPath := filepath.Join(path, name)
 			if isAppHost, err := ad.dotnetCli.IsAspireHostProject(ctx, filepath.Join(projectPath)); err != nil {
-				log.Printf("error checking if %s is an app host project: %v", projectPath, err)
+				slog.InfoContext(ctx, "error checking if project is an app host project", "path", projectPath, "err", err)
 			} else if isAppHost {
 				return &Project{
 					Language:      DotNetAppHost,

--- a/cli/azd/internal/cmd/add/add.go
+++ b/cli/azd/internal/cmd/add/add.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -192,7 +193,7 @@ func (a *AddAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	diffString, diffErr := DiffBlocks(prjConfig.Resources, newCfg.Resources)
 	if diffErr != nil {
 		a.console.Message(ctx, "Preview unavailable. Pass --debug for more details.\n")
-		log.Printf("add-diff: preview failed: %v", diffErr)
+		slog.InfoContext(ctx, "add-diff: preview failed", "err", diffErr)
 	} else {
 		a.console.Message(ctx, diffString)
 	}

--- a/cli/azd/internal/cmd/add/add.go
+++ b/cli/azd/internal/cmd/add/add.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -123,12 +122,12 @@ func (a *AddAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	}
 
 	if _, exists := prjConfig.Resources[resourceToAdd.Name]; exists {
-		log.Panicf("unhandled validation: resource with name %s already exists", resourceToAdd.Name)
+		panic(fmt.Sprintf("unhandled validation: resource with name %s already exists", resourceToAdd.Name))
 	}
 
 	if serviceToAdd != nil {
 		if _, exists := prjConfig.Services[serviceToAdd.Name]; exists {
-			log.Panicf("unhandled validation: service with name %s already exists", serviceToAdd.Name)
+			panic(fmt.Sprintf("unhandled validation: service with name %s already exists", serviceToAdd.Name))
 		}
 	}
 

--- a/cli/azd/internal/cmd/add/add_preview.go
+++ b/cli/azd/internal/cmd/add/add_preview.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"strings"
 	"text/tabwriter"
 
@@ -82,7 +82,7 @@ func (a *AddAction) previewProvision(
 
 	environmentDetails, err := getEnvDetails(ctx, a.env, a.subManager)
 	if err != nil {
-		log.Printf("failed getting environment details: %s", err)
+		slog.InfoContext(ctx, "failed getting environment details:", "err", err)
 	}
 
 	a.console.Message(ctx, fmt.Sprintf("\n%s\n", output.WithBold("Previewing Azure resource changes")))

--- a/cli/azd/internal/cmd/errors.go
+++ b/cli/azd/internal/cmd/errors.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"strings"
 
@@ -70,7 +71,7 @@ func MapError(err error, span tracing.Span) {
 		collect([]*azapi.DeploymentErrorLine{armDeployErr.Details}, 0)
 		if len(codes) > 0 {
 			if codesJson, err := json.Marshal(codes); err != nil {
-				log.Println("telemetry: failed to marshal arm error codes", err)
+				slog.InfoContext(context.TODO(), "telemetry: failed to marshal arm error codes", "err", err)
 			} else {
 				errDetails = append(errDetails, fields.ServiceErrorCode.String(string(codesJson)))
 			}

--- a/cli/azd/internal/cmd/provision.go
+++ b/cli/azd/internal/cmd/provision.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -211,7 +211,7 @@ func (p *ProvisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 		location, err := p.subManager.GetLocation(ctx, p.env.GetSubscriptionId(), p.env.GetLocation())
 		var locationDisplay string
 		if err != nil {
-			log.Printf("failed getting location: %v", err)
+			slog.InfoContext(ctx, "failed getting location", "err", err)
 		} else {
 			locationDisplay = location.DisplayName
 		}
@@ -229,7 +229,7 @@ func (p *ProvisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 		})
 
 	} else {
-		log.Printf("failed getting subscriptions. Skip displaying sub and location: %v", subErr)
+		slog.InfoContext(ctx, "failed getting subscriptions. Skip displaying sub and location", "err", subErr)
 	}
 
 	var deployResult *provisioning.DeployResult

--- a/cli/azd/internal/repository/detect_confirm.go
+++ b/cli/azd/internal/repository/detect_confirm.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"maps"
 	"os"
 	"path/filepath"
@@ -401,7 +400,7 @@ func (d *detectConfirm) add(ctx context.Context) error {
 		d.modified = true
 		return nil
 	default:
-		log.Panic("unhandled entry type")
+		panic("unhandled entry type")
 	}
 
 	msg := fmt.Sprintf("Enter file path of the directory that uses '%s'", projectDisplayName(s))

--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -165,11 +165,7 @@ func (i *Initializer) fetchCode(
 // The list of absolute source file paths to skip are returned.
 func (i *Initializer) promptForDuplicates(
 	ctx context.Context, staging string, target string) (skipSourceFiles map[string]struct{}, err error) {
-	log.Printf(
-		"template init, checking for duplicates. source: %s target: %s",
-		staging,
-		target,
-	)
+	slog.InfoContext(ctx, "template init, checking for duplicates.", "source", staging, "target", target)
 
 	duplicateFiles, err := determineDuplicates(staging, target)
 	if err != nil {

--- a/cli/azd/internal/runcontext/cloudshell.go
+++ b/cli/azd/internal/runcontext/cloudshell.go
@@ -1,7 +1,8 @@
 package runcontext
 
 import (
-	"log"
+	"context"
+	"log/slog"
 	"os"
 	"strconv"
 )
@@ -15,7 +16,7 @@ const AzdInCloudShellEnvVar = "AZD_IN_CLOUDSHELL"
 func IsRunningInCloudShell() bool {
 	if azdInCloudShell, has := os.LookupEnv(AzdInCloudShellEnvVar); has {
 		if use, err := strconv.ParseBool(azdInCloudShell); err == nil && use {
-			log.Printf("running in Cloud Shell")
+			slog.InfoContext(context.TODO(), "running in Cloud Shell")
 			return true
 		}
 	}

--- a/cli/azd/internal/telemetry/notice.go
+++ b/cli/azd/internal/telemetry/notice.go
@@ -1,9 +1,10 @@
 package telemetry
 
 import (
+	"context"
 	"errors"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -24,7 +25,7 @@ func FirstNotice() string {
 	if runcontext.IsRunningInCloudShell() && !noticeShown() {
 		err := SetupFirstRun()
 		if err != nil {
-			log.Printf("failed to setup first run: %v", err)
+			slog.InfoContext(context.TODO(), "failed to setup first run", "err", err)
 		}
 
 		//nolint:lll
@@ -41,7 +42,7 @@ Read more about Azure Developer CLI telemetry: https://github.com/Azure/azure-de
 func noticeShown() bool {
 	firstRunFilePath, err := getFirstRunFilePath()
 	if err != nil {
-		log.Printf("failed to get first run file path: %v", err)
+		slog.InfoContext(context.TODO(), "failed to get first run file path", "err", err)
 		// Assume no notice has been show
 		return false
 	}
@@ -53,7 +54,7 @@ func noticeShown() bool {
 		// The file does not exist, this is the first run
 		return false
 	} else {
-		log.Printf("failed to stat first run file: %v", err)
+		slog.InfoContext(context.TODO(), "failed to stat first run file", "err", err)
 		// If the first run file can't be read assume notice hasn't been shown
 		return false
 	}
@@ -62,7 +63,7 @@ func noticeShown() bool {
 func getFirstRunFilePath() (string, error) {
 	configDir, err := config.GetUserConfigDir()
 	if err != nil {
-		log.Printf("failed to get user config dir: %v", err)
+		slog.InfoContext(context.TODO(), "failed to get user config dir", "err", err)
 		return "", err
 	}
 

--- a/cli/azd/internal/telemetry/storage.go
+++ b/cli/azd/internal/telemetry/storage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -228,7 +228,7 @@ func (stg *StorageQueue) checkFileForCleanup(file fs.DirEntry) {
 func (stg *StorageQueue) checkTempFileForCleanup(file fs.DirEntry) {
 	info, err := file.Info()
 	if err != nil {
-		log.Printf("failed to retrieve old tmp file info for %s: %s", file.Name(), err)
+		slog.InfoContext(context.TODO(), "failed to retrieve old tmp file info", "name", file.Name(), "err", err)
 		return
 	}
 
@@ -254,7 +254,7 @@ func (stg *StorageQueue) cleanupItem(file fs.DirEntry, itemType string) {
 	err := removeIfExists(filepath.Join(stg.folder, file.Name()))
 
 	if err != nil {
-		log.Printf("failed to remove %s file: %s", itemType, err)
+		slog.InfoContext(context.TODO(), "failed to remove file", "type", itemType, "err", err)
 	}
 }
 

--- a/cli/azd/internal/telemetry/telemetry.go
+++ b/cli/azd/internal/telemetry/telemetry.go
@@ -7,7 +7,6 @@ package telemetry
 import (
 	"context"
 	"fmt"
-	"log"
 	"log/slog"
 	"net/url"
 	"os"
@@ -86,7 +85,7 @@ func GetTelemetrySystem() *TelemetrySystem {
 	once.Do(func() {
 		telemetrySystem, err := initialize()
 		if err != nil {
-			log.Printf("failed to initialize telemetry: %v\n", err)
+			slog.InfoContext(context.TODO(), "failed to initialize telemetry", "err", err)
 		} else {
 			instance = telemetrySystem
 		}
@@ -259,7 +258,7 @@ func (ts *TelemetrySystem) RunBackgroundUpload(ctx context.Context, enableDebugL
 		cancelCleanup()
 
 		if err != nil {
-			log.Printf("failed to upload telemetry: %v", err)
+			slog.InfoContext(ctx, "failed to upload telemetry", "err", err)
 		}
 		return err
 	}
@@ -295,7 +294,7 @@ func getTraceFlags() (logFile string, logUrl string) {
 	flags.BoolVarP(&help, "help", "h", false, "")
 
 	if err := flags.Parse(os.Args[1:]); err != nil {
-		log.Printf("could not parse flags: %v", err)
+		slog.InfoContext(context.TODO(), "could not parse flags", "err", err)
 	}
 
 	return

--- a/cli/azd/internal/telemetry/telemetry.go
+++ b/cli/azd/internal/telemetry/telemetry.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -96,12 +97,12 @@ func GetTelemetrySystem() *TelemetrySystem {
 
 func initialize() (*TelemetrySystem, error) {
 	if !IsTelemetryEnabled() {
-		log.Println("telemetry is disabled by user and will not be initialized.")
+		slog.InfoContext(context.TODO(), "telemetry is disabled by user and will not be initialized.")
 		return nil, nil
 	}
 
 	appinsightsexporter.SetListener(func(msg string) {
-		log.Println(msg)
+		slog.InfoContext(context.TODO(), msg)
 	})
 
 	telemetryDir, err := getTelemetryDirectory()
@@ -263,7 +264,7 @@ func (ts *TelemetrySystem) RunBackgroundUpload(ctx context.Context, enableDebugL
 		return err
 	}
 
-	log.Println("Upload already in progress. Exiting.")
+	slog.InfoContext(ctx, "Upload already in progress. Exiting.")
 	return nil
 }
 

--- a/cli/azd/internal/tracing/resource/machine_id.go
+++ b/cli/azd/internal/tracing/resource/machine_id.go
@@ -5,7 +5,6 @@ package resource
 
 import (
 	"context"
-	"log"
 	"log/slog"
 	"net"
 	"os"
@@ -60,7 +59,7 @@ func calculateMachineId() string {
 func loadOrCalculate(calc func() string, cacheFileName string) string {
 	configDir, err := config.GetUserConfigDir()
 	if err != nil {
-		log.Printf("could not load machineId from cache. returning calculated value: %s", err)
+		slog.InfoContext(context.TODO(), "could not load machineId from cache. returning calculated value", "err", err)
 		return calc()
 	}
 
@@ -72,7 +71,7 @@ func loadOrCalculate(calc func() string, cacheFileName string) string {
 
 	err = os.WriteFile(cacheFile, []byte(calc()), osutil.PermissionFile)
 	if err != nil {
-		log.Printf("could not write machineId to cache. returning calculated value: %s", err)
+		slog.InfoContext(context.TODO(), "could not write machineId to cache. returning calculated value", "err", err)
 	}
 
 	return calc()

--- a/cli/azd/internal/tracing/resource/machine_id.go
+++ b/cli/azd/internal/tracing/resource/machine_id.go
@@ -4,7 +4,9 @@
 package resource
 
 import (
+	"context"
 	"log"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -30,7 +32,7 @@ func DevDeviceId() string {
 	deviceId, err := deviceid.Get()
 
 	if err != nil {
-		log.Println("could not get device id, returning empty: ", err)
+		slog.InfoContext(context.TODO(), "could not get device id, returning empty", "err", err)
 		return ""
 	}
 

--- a/cli/azd/internal/vsrpc/environment_service_refresh.go
+++ b/cli/azd/internal/vsrpc/environment_service_refresh.go
@@ -6,7 +6,7 @@ package vsrpc
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/azure/azure-dev/cli/azd/internal"
@@ -94,7 +94,7 @@ func (s *environmentService) refreshEnvironmentAsync(
 
 	deployment, err := bicepProvider.LastDeployment(ctx)
 	if err != nil {
-		log.Printf("failed to get latest deployment result: %v", err)
+		slog.InfoContext(ctx, "failed to get latest deployment result", "err", err)
 	} else {
 		env.LastDeployment = &DeploymentResult{
 			DeploymentId: deployment.Id,
@@ -146,7 +146,7 @@ func (s *environmentService) refreshEnvironmentAsync(
 					))
 				}
 			} else {
-				log.Printf("ignoring error determining resource id for service %s: %v", svcName, err)
+				slog.InfoContext(ctx, "ignoring error determining resource id for service", "service", svcName, "err", err)
 			}
 		}
 
@@ -160,13 +160,13 @@ func (s *environmentService) refreshEnvironmentAsync(
 				})
 			}
 		} else {
-			log.Printf("ignoring error loading resources for environment %s: %v", envName, err)
+			slog.InfoContext(ctx, "ignoring error loading resources for environment", "environment", envName, "err", err)
 		}
 	} else {
-		log.Printf(
-			"ignoring error determining resource group for environment %s, resources will not be available: %v",
-			env.Name,
-			err)
+		slog.InfoContext(ctx,
+			"ignoring error determining resource group for environment, resources will not be available",
+			"environment", env.Name,
+			"err", err)
 	}
 
 	return env, nil
@@ -181,19 +181,19 @@ func (s *environmentService) serviceEndpoint(
 ) string {
 	targetResource, err := resourceManager.GetTargetResource(ctx, subId, serviceConfig)
 	if err != nil {
-		log.Printf("error: getting target-resource. Endpoints will be empty: %v", err)
+		slog.InfoContext(ctx, "error: getting target-resource. Endpoints will be empty", "err", err)
 		return ""
 	}
 
 	st, err := serviceManager.GetServiceTarget(ctx, serviceConfig)
 	if err != nil {
-		log.Printf("error: getting service target. Endpoints will be empty: %v", err)
+		slog.InfoContext(ctx, "error: getting service target. Endpoints will be empty", "err", err)
 		return ""
 	}
 
 	endpoints, err := st.Endpoints(ctx, serviceConfig, targetResource)
 	if err != nil {
-		log.Printf("error: getting service endpoints. Endpoints might be empty: %v", err)
+		slog.InfoContext(ctx, "error: getting service endpoints. Endpoints might be empty", "err", err)
 	}
 
 	if len(endpoints) == 0 {

--- a/cli/azd/internal/vsrpc/server.go
+++ b/cli/azd/internal/vsrpc/server.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"net"
 	"net/http"
@@ -96,7 +95,7 @@ func (s *Server) Serve(l net.Listener) error {
 func serveRpc(w http.ResponseWriter, r *http.Request, handlers map[string]Handler) {
 	c, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.Print("upgrade:", err)
+		slog.InfoContext(r.Context(), "error upgrading connect", "err", err)
 		return
 	}
 	defer c.Close()

--- a/cli/azd/internal/vsrpc/server_service.go
+++ b/cli/azd/internal/vsrpc/server_service.go
@@ -6,7 +6,7 @@ package vsrpc
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -98,7 +98,7 @@ func (s *serverService) StopAsync(ctx context.Context) error {
 	// Flush all in-memory telemetry data before stopping.
 	err := ts.Shutdown(ctx)
 	if err != nil {
-		log.Printf("error shutting down telemetry: %v", err)
+		slog.InfoContext(ctx, "error shutting down telemetry", "err", err)
 	}
 
 	// Graceful telemetry cancellation.
@@ -120,7 +120,7 @@ func (s *serverService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func newWriter(prefix string) *writerMultiplexer {
 	wm := &writerMultiplexer{}
 	wm.AddWriter(writerFunc(func(p []byte) (n int, err error) {
-		log.Printf("%s%s", prefix, string(p))
+		slog.InfoContext(context.TODO(), fmt.Sprintf("%s%s", prefix, string(p)))
 		return n, nil
 	}))
 

--- a/cli/azd/internal/vsrpc/utils.go
+++ b/cli/azd/internal/vsrpc/utils.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/apphost"
@@ -21,7 +21,7 @@ func appHostForProject(
 		if service.Language == project.ServiceLanguageDotNet {
 			isAppHost, err := dotnetCli.IsAspireHostProject(ctx, service.Path())
 			if err != nil {
-				log.Printf("error checking if %s is an app host project: %v", service.Path(), err)
+				slog.InfoContext(ctx, "error checking if project is an app host project", "path", service.Path(), "err", err)
 			}
 			if isAppHost {
 				return service, nil
@@ -77,7 +77,11 @@ func azdContext(hostProjectPath string) (*azdcontext.AzdContext, error) {
 	for _, svc := range prjConfig.Services {
 		if svc.Language == project.ServiceLanguageDotNet && svc.Host == project.ContainerAppTarget {
 			if svc.Path() != hostProjectPath {
-				log.Printf("ignoring %s due to mismatch, using app host directory", azdCtx.ProjectPath())
+				slog.InfoContext(context.TODO(),
+					"ignoring azd context project path due to mismatch, using ap host directory",
+					"contextProjectPath", azdCtx.ProjectPath(),
+					"appHostProjectPath", hostProjectDir,
+				)
 				return azdcontext.NewAzdContextWithDirectory(hostProjectDir), nil
 			}
 		}
@@ -86,6 +90,6 @@ func azdContext(hostProjectPath string) (*azdcontext.AzdContext, error) {
 		break
 	}
 
-	log.Printf("use nearest directory: %s", azdCtx.ProjectDirectory())
+	slog.InfoContext(context.TODO(), "use nearest directory", "path", azdCtx.ProjectDirectory())
 	return azdCtx, nil
 }

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -237,7 +237,7 @@ func fetchLatestVersion(version chan<- semver.Version) {
 
 	// If we don't have a cached version we can use, fetch one (and cache it)
 	if cachedLatestVersion == nil {
-		log.Print("fetching latest version information for update check")
+		slog.InfoContext(context.TODO(), "fetching latest version information for update check")
 		req, err := http.NewRequest(http.MethodGet, "https://aka.ms/azure-dev/versions/cli/latest", nil)
 		if err != nil {
 			slog.InfoContext(context.TODO(), "failed to create request object, skipping update check", "err", err)

--- a/cli/azd/pkg/account/manager.go
+++ b/cli/azd/pkg/account/manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"slices"
 
@@ -82,7 +83,7 @@ func (m *manager) GetAccountDefaults(ctx context.Context) (*Account, error) {
 	if err != nil {
 		// logging the error, but we don't want to fail, as this could only
 		// means an account change
-		log.Println(fmt.Errorf("failed retrieving default subscription: %w", err).Error())
+		slog.InfoContext(ctx, "failed retrieving default subscription", "err", err)
 	}
 
 	var location *Location

--- a/cli/azd/pkg/account/manager.go
+++ b/cli/azd/pkg/account/manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"os"
 	"slices"
@@ -60,7 +59,8 @@ func NewManager(
 	azdConfig, err := configManager.Load(filePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			log.Printf("configuration file '%s' does not exist. Creating new empty config.", filePath)
+			slog.InfoContext(context.TODO(), "configuration file does not exist. Creating new empty config.",
+				"path", filePath)
 			azdConfig = config.NewEmptyConfig()
 		} else {
 			return nil, err

--- a/cli/azd/pkg/account/subscriptions_cache.go
+++ b/cli/azd/pkg/account/subscriptions_cache.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -92,7 +92,8 @@ func (s *subscriptionsCache) Save(ctx context.Context, key string, subscriptions
 	if cacheFile != nil {
 		err = json.Unmarshal(cacheFile, &cache)
 		if err != nil {
-			log.Printf("failed to unmarshal %s, ignoring: %v", subscriptionsCacheFile, err)
+			slog.InfoContext(ctx, "failed to unmarshal subscription cache, ignoring cached data",
+				"path", subscriptionsCacheFile, "err", err)
 		}
 	}
 

--- a/cli/azd/pkg/account/subscriptions_manager.go
+++ b/cli/azd/pkg/account/subscriptions_manager.go
@@ -3,7 +3,7 @@ package account
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"math"
 	"os"
 	"sort"
@@ -330,7 +330,7 @@ func (m *SubscriptionsManager) ListSubscriptions(ctx context.Context) ([]Subscri
 
 	// If at least one was successful, log errors and continue
 	for _, err := range errors {
-		log.Println(err.Error())
+		slog.InfoContext(ctx, "error fetching subscription info", "err", err)
 	}
 
 	return allSubscriptions, nil

--- a/cli/azd/pkg/alpha/alpha_feature.go
+++ b/cli/azd/pkg/alpha/alpha_feature.go
@@ -2,7 +2,6 @@ package alpha
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/resources"
@@ -35,7 +34,7 @@ var allFeatures []Feature
 func init() {
 	err := yaml.Unmarshal(resources.AlphaFeatures, &allFeatures)
 	if err != nil {
-		log.Panic("Can't marshall alpha features!! %w", err)
+		panic(fmt.Sprintf("Can't marshall alpha features!! %v", err))
 	}
 }
 

--- a/cli/azd/pkg/alpha/alpha_feature_manager.go
+++ b/cli/azd/pkg/alpha/alpha_feature_manager.go
@@ -3,7 +3,6 @@ package alpha
 import (
 	"context"
 	"fmt"
-	"log"
 	"log/slog"
 	"os"
 	"strconv"
@@ -70,7 +69,7 @@ func (m *FeatureManager) initConfigCache() {
 	if m.userConfigCache == nil {
 		config, err := m.configManager.Load()
 		if err != nil {
-			log.Panic("Can't load user config!! %w", err)
+			panic(fmt.Sprintf("Can't load user config!! %v", err))
 		}
 		m.userConfigCache = config
 	}
@@ -146,18 +145,17 @@ func isEnabled(config config.Config, id FeatureId) bool {
 	// need to check the cast here in case the config is manually updated
 	stringValue, castResult := value.(string)
 	if !castResult {
-		log.Panicf("Invalid configuration value for '%s': %s", longKey, value)
+		panic(fmt.Sprintf("Invalid configuration value for '%s': %s", longKey, value))
 	}
 	stringValue = strings.ToLower(stringValue)
 
 	if stringValue != disabledValue && stringValue != enabledValue {
-		log.Panicf(
-			"invalid configuration value for '%s': %s. Valid options are '%s' or '%s'.",
+		panic(fmt.Sprintf("invalid configuration value for '%s': %s. Valid options are '%s' or '%s'.",
 			longKey,
 			stringValue,
 			enabledValue,
 			disabledValue,
-		)
+		))
 	}
 
 	// previous condition ensured that stringValue is either `enabledValue` or `disabledValue`

--- a/cli/azd/pkg/alpha/alpha_feature_manager.go
+++ b/cli/azd/pkg/alpha/alpha_feature_manager.go
@@ -1,8 +1,10 @@
 package alpha
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -97,7 +99,8 @@ func (m *FeatureManager) IsEnabled(featureId FeatureId) bool {
 				foundEnvVar = true
 				break
 			} else {
-				log.Printf("could not parse %s as a bool when considering %s", value, envName)
+				slog.InfoContext(context.TODO(), "could not parse env var value as a bool",
+					"value", value, "envName", envName)
 			}
 		}
 	}

--- a/cli/azd/pkg/apphost/aca_ingress.go
+++ b/cli/azd/pkg/apphost/aca_ingress.go
@@ -1,8 +1,9 @@
 package apphost
 
 import (
+	"context"
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/custommaps"
 )
@@ -30,7 +31,7 @@ func buildAcaIngress(
 		additionalPortsCount--
 	}
 	if additionalPortsCount > 5 {
-		log.Println("More than 5 additional ports are not supported. " +
+		slog.InfoContext(context.TODO(), "More than 5 additional ports are not supported. "+
 			"See https://learn.microsoft.com/azure/container-apps/ingress-overview#tcp for more details.")
 	}
 

--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io/fs"
-	"log"
+	"log/slog"
 	"maps"
 	"os"
 	"path/filepath"
@@ -681,9 +681,9 @@ func (b *infraGenerator) LoadManifest(m *Manifest) error {
 		default:
 			ignore, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES"))
 			if err == nil && ignore {
-				log.Printf(
-					"ignoring resource of type %s since AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES is set",
-					comp.Type)
+				slog.InfoContext(context.TODO(),
+					"ignoring unknown resource since AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES is set",
+					"type", comp.Type)
 				continue
 			}
 			return fmt.Errorf("unsupported resource type: %s", comp.Type)
@@ -1626,8 +1626,9 @@ func (b infraGenerator) evalBindingRef(v string, emitType inputEmitType) (string
 	default:
 		ignore, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES"))
 		if err == nil && ignore {
-			log.Printf("ignoring binding reference to resource of type %s since "+
-				"AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES is set", targetType)
+			slog.InfoContext(context.TODO(),
+				"ignoring binding reference to resource of unknown type since "+
+					"AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES is set", "type", targetType)
 
 			return fmt.Sprintf("!!! expression '%s' to type '%s' unsupported by azd !!!", v, targetType), nil
 		}

--- a/cli/azd/pkg/auth/azd_credential.go
+++ b/cli/azd/pkg/auth/azd_credential.go
@@ -6,7 +6,7 @@ package auth
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -34,7 +34,7 @@ func (c *azdCredential) GetToken(ctx context.Context, options policy.TokenReques
 		var authFailed *AuthFailedError
 		if errors.As(err, &authFailed) {
 			if loginErr, ok := newReLoginRequiredError(authFailed.Parsed, options.Scopes, c.cloud); ok {
-				log.Println(authFailed.httpErrorDetails())
+				slog.InfoContext(ctx, authFailed.httpErrorDetails())
 				return azcore.AccessToken{}, loginErr
 			}
 

--- a/cli/azd/pkg/auth/cache.go
+++ b/cli/azd/pkg/auth/cache.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
+	"log/slog"
 	"strings"
 	"unicode"
 
@@ -61,7 +61,7 @@ func (a *msalCacheAdapter) Replace(ctx context.Context, cache cache.Unmarshaler,
 
 				err := json.Unmarshal(msg, &inner)
 				if err != nil {
-					log.Printf("msal-upgrade: failed to unmarshal inner: %v", err)
+					slog.InfoContext(ctx, "msal-upgrade: failed to unmarshal inner", "err", err)
 					continue
 				}
 
@@ -72,7 +72,7 @@ func (a *msalCacheAdapter) Replace(ctx context.Context, cache cache.Unmarshaler,
 
 				newMsg, err := json.Marshal(inner)
 				if err != nil {
-					log.Printf("msal-upgrade: failed to remarshal inner: %v", err)
+					slog.InfoContext(ctx, "msal-upgrade: failed to remarshal inner", "err", err)
 					continue
 				}
 
@@ -83,10 +83,10 @@ func (a *msalCacheAdapter) Replace(ctx context.Context, cache cache.Unmarshaler,
 		if newVal, err := json.Marshal(c); err == nil {
 			val = newVal
 		} else {
-			log.Printf("msal-upgrade: failed to remarshal msal cache: %v", err)
+			slog.InfoContext(ctx, "msal-upgrade: failed to remarshal msal cache", "err", err)
 		}
 	} else {
-		log.Printf("msal-upgrade: failed to unmarshal msal cache: %v", err)
+		slog.InfoContext(ctx, "msal-upgrade: failed to unmarshal msal cache", "err", err)
 	}
 
 	// Replace the msal cache contents with the new value retrieved.

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -2,11 +2,12 @@ package auth
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"slices"
 
@@ -154,14 +155,14 @@ func (e *AuthFailedError) parseResponse() {
 	body, err := io.ReadAll(e.RawResp.Body)
 	e.RawResp.Body.Close()
 	if err != nil {
-		log.Printf("error reading aad response body: %v", err)
+		slog.InfoContext(context.TODO(), "error reading aad response body", "err", err)
 		return
 	}
 	e.RawResp.Body = io.NopCloser(bytes.NewReader(body))
 
 	var er AadErrorResponse
 	if err := json.Unmarshal(body, &er); err != nil {
-		log.Printf("parsing aad response body: %v", err)
+		slog.InfoContext(context.TODO(), "parsing aad response body", "err", err)
 		return
 	}
 

--- a/cli/azd/pkg/auth/file_cache.go
+++ b/cli/azd/pkg/auth/file_cache.go
@@ -4,9 +4,10 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -35,7 +36,7 @@ func (c *fileCache) Read(key string) ([]byte, error) {
 	}
 	defer func() {
 		if err := fl.Unlock(); err != nil {
-			log.Printf("failed to release file lock: %v", err)
+			slog.InfoContext(context.TODO(), "failed to release file lock", "err", err)
 		}
 	}()
 
@@ -58,7 +59,7 @@ func (c *fileCache) Set(key string, value []byte) error {
 	}
 	defer func() {
 		if err := fl.Unlock(); err != nil {
-			log.Printf("failed to release file lock: %v", err)
+			slog.InfoContext(context.TODO(), "failed to release file lock", "err", err)
 		}
 	}()
 

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -210,7 +209,7 @@ func (m *Manager) CredentialForCurrentUser(
 	}
 
 	if m.UseExternalAuth() {
-		log.Printf("delegating auth to external process")
+		slog.InfoContext(ctx, "delegating auth to external process")
 		return newRemoteCredential(
 			m.externalAuthCfg.Endpoint,
 			m.externalAuthCfg.Key,
@@ -224,7 +223,7 @@ func (m *Manager) CredentialForCurrentUser(
 	}
 
 	if shouldUseLegacyAuth(userConfig) {
-		log.Printf("delegating auth to az since %s is set to true", useAzCliAuthKey)
+		slog.InfoContext(ctx, fmt.Sprintf("delegating auth to az since %s is set to true", useAzCliAuthKey))
 		cred, err := azidentity.NewAzureCLICredential(&azidentity.AzureCLICredentialOptions{
 			TenantID: options.TenantID,
 		})

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -705,7 +706,7 @@ func (m *Manager) LoginWithDeviceCode(
 		m.console.Message(ctx, fmt.Sprintf("Start by copying the next code: %s", output.WithBold("%s", code.UserCode())))
 
 		if err := withOpenUrl(url); err != nil {
-			log.Println("error launching browser: ", err.Error())
+			slog.InfoContext(ctx, "error launching browser", "err", err)
 			m.console.Message(ctx, fmt.Sprintf("Error launching browser. Manually go to: %s", url))
 		}
 		m.console.Message(ctx, "Waiting for you to complete authentication in the browser...")

--- a/cli/azd/pkg/azapi/container_registry.go
+++ b/cli/azd/pkg/azapi/container_registry.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"slices"
@@ -131,7 +131,7 @@ func (crs *containerRegistryService) Credentials(
 			}
 		}
 
-		log.Printf("failed getting ACR token credentials: %s\n", tokenErr.Error())
+		slog.InfoContext(ctx, "failed getting ACR token credentials", "err", tokenErr)
 		// If that fails, attempt to get ACR credentials from the admin user
 		adminCreds, adminErr := crs.getAdminUserCredentials(ctx, subscriptionId, loginServer)
 		if adminErr != nil {

--- a/cli/azd/pkg/azapi/stack_deployments.go
+++ b/cli/azd/pkg/azapi/stack_deployments.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"maps"
 	"net/url"
 	"os"
@@ -562,10 +562,11 @@ func parseDeploymentStackOptions(options map[string]any) (*deploymentStackOption
 	if hasBypassStackOutOfSyncError {
 		byPassOutOfSyncError, err := strconv.ParseBool(bypassStackOutOfSyncErrorVal)
 		if err != nil {
-			log.Printf(
-				"Failed to parse environment variable '%s' value '%s' as a boolean. Defaulting to false.",
-				bypassOutOfSyncErrorEnvVarName,
-				bypassStackOutOfSyncErrorVal,
+			slog.InfoContext(context.TODO(),
+				fmt.Sprintf(
+					"Failed to parse environment variable '%s' as a boolean. Defaulting to false.",
+					bypassOutOfSyncErrorEnvVarName),
+				"value", bypassStackOutOfSyncErrorVal,
 			)
 		} else {
 			deploymentStackOptions.BypassStackOutOfSyncError = &byPassOutOfSyncError

--- a/cli/azd/pkg/config/user_config_manager.go
+++ b/cli/azd/pkg/config/user_config_manager.go
@@ -1,9 +1,10 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 )
@@ -36,7 +37,8 @@ func (m *userConfigManager) Load() (Config, error) {
 		// Ignore missing file errors
 		// File will automatically be created on first `set` operation
 		if errors.Is(err, os.ErrNotExist) {
-			log.Printf("creating empty config since '%s' did not exist.", configFilePath)
+			slog.InfoContext(context.TODO(), "creating empty config since it did not exist.",
+				"path", configFilePath)
 			return NewConfig(nil), nil
 		}
 

--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"slices"
 
@@ -145,7 +145,7 @@ func (cas *containerAppService) persistSettings(
 
 	aca, err := cas.getContainerApp(ctx, subscriptionId, resourceGroupName, appName, options)
 	if err != nil {
-		log.Printf("failed getting current aca settings: %v. No settings will be persisted.", err)
+		slog.InfoContext(ctx, "failed getting current aca settings. No settings will be persisted.", "err", err)
 		// if the container app doesn't exist, there's nothing for us to update in the desired state,
 		// so we can just return the existing state as is.
 		return obj, nil
@@ -570,7 +570,7 @@ type containerAppCustomApiVersionAndBodyPolicy struct {
 
 func (p *containerAppCustomApiVersionAndBodyPolicy) Do(req *policy.Request) (*http.Response, error) {
 	if p.apiVersion != "" {
-		log.Printf("setting api-version to %s", p.apiVersion)
+		slog.InfoContext(req.Raw().Context(), "setting api-version", "api-version", p.apiVersion)
 
 		reqQP := req.Raw().URL.Query()
 		reqQP.Set("api-version", p.apiVersion)
@@ -578,7 +578,7 @@ func (p *containerAppCustomApiVersionAndBodyPolicy) Do(req *policy.Request) (*ht
 	}
 
 	if p.body != nil {
-		log.Printf("setting body to %s", string(*p.body))
+		slog.InfoContext(req.Raw().Context(), "setting body", "body", string(*p.body))
 
 		if err := req.SetBody(streaming.NopCloser(bytes.NewReader(*p.body)), "application/json"); err != nil {
 			return nil, fmt.Errorf("updating request body: %w", err)

--- a/cli/azd/pkg/devcenter/provision_provider.go
+++ b/cli/azd/pkg/devcenter/provision_provider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"maps"
 	"os"
@@ -491,7 +490,7 @@ func (p *ProvisionProvider) pollForProgress(ctx context.Context, deployment infr
 		case <-timer.C:
 			if err := progressDisplay.ReportProgress(ctx, &queryStartTime); err != nil {
 				// We don't want to fail the whole deployment if a progress reporting error occurs
-				log.Printf("error while reporting progress: %s", err.Error())
+				slog.InfoContext(ctx, "error while reporting progress", "err", err)
 			}
 
 			timer.Reset(regularDelay)

--- a/cli/azd/pkg/devcenter/provision_provider.go
+++ b/cli/azd/pkg/devcenter/provision_provider.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"maps"
 	"os"
 	"slices"
@@ -410,7 +411,7 @@ func (p *ProvisionProvider) EnsureEnv(ctx context.Context) error {
 func (p *ProvisionProvider) pollForEnvironment(ctx context.Context, envName string) {
 	// Disable reporting progress if needed
 	if use, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_PROVISION_PROGRESS_DISABLE")); err == nil && use {
-		log.Println("Disabling progress reporting since AZD_DEBUG_PROVISION_PROGRESS_DISABLE was set")
+		slog.InfoContext(ctx, "Disabling progress reporting since AZD_DEBUG_PROVISION_PROGRESS_DISABLE was set")
 		return
 	}
 
@@ -470,7 +471,7 @@ func (p *ProvisionProvider) pollForEnvironment(ctx context.Context, envName stri
 func (p *ProvisionProvider) pollForProgress(ctx context.Context, deployment infra.Deployment) {
 	// Disable reporting progress if needed
 	if use, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_PROVISION_PROGRESS_DISABLE")); err == nil && use {
-		log.Println("Disabling progress reporting since AZD_DEBUG_PROVISION_PROGRESS_DISABLE was set")
+		slog.InfoContext(ctx, "Disabling progress reporting since AZD_DEBUG_PROVISION_PROGRESS_DISABLE was set")
 		return
 	}
 

--- a/cli/azd/pkg/entraid/entraid.go
+++ b/cli/azd/pkg/entraid/entraid.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -413,10 +413,10 @@ func (ad *entraIdService) ensureFederatedCredential(
 	// If a federated credential already exists for the same subject then nothing to do.
 	for _, existing := range existingCredentials {
 		if existing.Subject == repoCredential.Subject {
-			log.Printf(
-				"federated credential with subject '%s' already exists on application '%s'",
-				repoCredential.Subject,
-				*application.Id,
+			slog.InfoContext(ctx,
+				"federated credential with subject already exists on application'",
+				"subject", repoCredential.Subject,
+				"app", *application.Id,
 			)
 			return nil, nil
 		}

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"regexp"
 	"strings"
@@ -86,7 +86,7 @@ func getInitialConfig() config.Config {
 
 	var initConfig map[string]any
 	if err := json.Unmarshal([]byte(initialConfig), &initConfig); err != nil {
-		log.Println("Failed to unmarshal initial config", err, "Using empty config.")
+		slog.InfoContext(context.TODO(), "Failed to unmarshal initial config. Using empty config", "err", err)
 		return config.NewEmptyConfig()
 	}
 

--- a/cli/azd/pkg/exec/cmdtree_windows.go
+++ b/cli/azd/pkg/exec/cmdtree_windows.go
@@ -7,8 +7,9 @@
 package exec
 
 import (
+	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os/exec"
 	"syscall"
 	"unsafe"
@@ -64,7 +65,7 @@ func (o *CmdTree) Start() error {
 	defer func() {
 		err := windows.CloseHandle(process)
 		if err != nil {
-			log.Printf("failed to close process handle: %s\n", err)
+			slog.InfoContext(context.TODO(), "failed to close process handle", "err", err)
 		}
 	}()
 
@@ -80,6 +81,6 @@ func (o *CmdTree) Start() error {
 func (o *CmdTree) Kill() {
 	err := windows.TerminateJobObject(o.jobObject, 0)
 	if err != nil {
-		log.Printf("failed to terminate job object %d: %s\n", o.jobObject, err)
+		slog.InfoContext(context.TODO(), "failed to terminate job object", "job", o.jobObject, "err", err)
 	}
 }

--- a/cli/azd/pkg/exec/command_runner.go
+++ b/cli/azd/pkg/exec/command_runner.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -304,7 +304,7 @@ func (l *logBuilder) Write(debug bool, sensitiveArgsData []string) {
 		}
 	}
 
-	log.Print(msg.String())
+	slog.InfoContext(context.TODO(), msg.String())
 }
 
 // newCmdTree creates a `CmdTree`, optionally using a shell appropriate for windows

--- a/cli/azd/pkg/experimentation/assignment.go
+++ b/cli/azd/pkg/experimentation/assignment.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
@@ -85,7 +85,7 @@ type AssignmentConfig struct {
 func (am *AssignmentsManager) Assignment(ctx context.Context) (*Assignment, error) {
 	cachedAssignment, err := am.readResponseFromCache()
 	if err != nil {
-		log.Printf("could not read assignment from cache: %v", err)
+		slog.InfoContext(ctx, "could not read assignment from cache", "err", err)
 	}
 
 	if cachedAssignment == nil {
@@ -101,7 +101,7 @@ func (am *AssignmentsManager) Assignment(ctx context.Context) (*Assignment, erro
 			return nil, err
 		}
 		if err := am.cacheResponse(assignment); err != nil {
-			log.Printf("failed to cache assignment response: %v", err)
+			slog.InfoContext(ctx, "failed to cache assignment response", "err", err)
 		}
 
 		cachedAssignment = assignment

--- a/cli/azd/pkg/ext/hooks_manager.go
+++ b/cli/azd/pkg/ext/hooks_manager.go
@@ -1,8 +1,9 @@
 package ext
 
 import (
+	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"runtime"
 	"strings"
@@ -83,7 +84,7 @@ func (h *HooksManager) filterConfigs(
 
 		for _, hook := range hooks {
 			if hook == nil {
-				log.Printf("hook configuration for '%s' is missing", scriptName)
+				slog.InfoContext(context.TODO(), "hook configuration for script is missing", "script", scriptName)
 				continue
 			}
 

--- a/cli/azd/pkg/ext/hooks_runner.go
+++ b/cli/azd/pkg/ext/hooks_runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -177,7 +178,7 @@ func (h *HooksRunner) execHook(ctx context.Context, hookConfig *HookConfig, opti
 				ctx,
 				output.WithWarningFormat("Execution will continue since ContinueOnError has been set to true."),
 			)
-			log.Println(execErr.Error())
+			slog.InfoContext(ctx, "hook execution error, continuing due to ContinueOnError", "err", execErr)
 		} else {
 			return execErr
 		}

--- a/cli/azd/pkg/ext/hooks_runner.go
+++ b/cli/azd/pkg/ext/hooks_runner.go
@@ -3,7 +3,6 @@ package ext
 import (
 	"context"
 	"fmt"
-	"log"
 	"log/slog"
 	"os"
 	"strings"
@@ -160,7 +159,7 @@ func (h *HooksRunner) execHook(ctx context.Context, hookConfig *HookConfig, opti
 		defer h.console.StopPreviewer(ctx, false)
 	}
 
-	log.Printf("Executing script '%s'\n", hookConfig.path)
+	slog.InfoContext(ctx, "Executing script", "path", hookConfig.path)
 	res, err := script.Execute(ctx, hookConfig.path, *options)
 	if err != nil {
 		execErr := fmt.Errorf(

--- a/cli/azd/pkg/helm/cli.go
+++ b/cli/azd/pkg/helm/cli.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
@@ -41,9 +41,9 @@ func (cli *Cli) CheckInstalled(ctx context.Context) error {
 	// for diagnostics purposes, let's fetch and log the version of helm
 	// we're using.
 	if ver, err := cli.getClientVersion(ctx); err != nil {
-		log.Printf("error fetching helm version: %s", err)
+		slog.InfoContext(ctx, "error fetching helm version", "err", err)
 	} else {
-		log.Printf("helm version: %s", ver)
+		slog.InfoContext(ctx, "detected helm version", "version", ver)
 	}
 
 	return nil

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -512,7 +512,7 @@ func prevDeploymentEqualToCurrent(prev *azapi.ResourceDeployment, templateHash, 
 }
 
 func logDS(msg string, v ...any) {
-	log.Printf("%s : %s", "deployment-state: ", fmt.Sprintf(msg, v...))
+	slog.InfoContext(context.TODO(), fmt.Sprintf("%s : %s", "deployment-state: ", fmt.Sprintf(msg, v...)))
 }
 
 // Provisioning the infrastructure within the specified template
@@ -582,7 +582,7 @@ func (p *BicepProvider) Deploy(ctx context.Context) (*provisioning.DeployResult,
 			case <-timer.C:
 				if err := progressDisplay.ReportProgress(ctx, &queryStartTime); err != nil {
 					// We don't want to fail the whole deployment if a progress reporting error occurs
-					log.Printf("error while reporting progress: %s", err.Error())
+					slog.InfoContext(ctx, "error while reporting progress", "err", err)
 				}
 
 				timer.Reset(regularDelay)
@@ -1573,13 +1573,13 @@ func (p *BicepProvider) compileBicep(
 
 		var bicepParamOutput compiledBicepParamResult
 		if err := json.Unmarshal([]byte(compiled), &bicepParamOutput); err != nil {
-			log.Printf("failed unmarshalling compiled bicepparam (err: %v), template contents:\n%s", err, compiled)
+			slog.InfoContext(ctx, "failed unmarshalling compiled bicepparam", "err", err, "template", compiled)
 			return nil, fmt.Errorf("failed unmarshalling arm template from json: %w", err)
 		}
 		compiled = bicepParamOutput.TemplateJson
 		var params azure.ArmParameterFile
 		if err := json.Unmarshal([]byte(bicepParamOutput.ParametersJson), &params); err != nil {
-			log.Printf("failed unmarshalling compiled bicepparam parameters(err: %v), template contents:\n%s", err, compiled)
+			slog.InfoContext(ctx, "failed unmarshalling compiled bicepparam parameters", "err", err, "template", compiled)
 			return nil, fmt.Errorf("failed unmarshalling arm parameters template from json: %w", err)
 		}
 		parameters = params.Parameters
@@ -1595,7 +1595,7 @@ func (p *BicepProvider) compileBicep(
 
 	var template azure.ArmTemplate
 	if err := json.Unmarshal(rawTemplate, &template); err != nil {
-		log.Printf("failed unmarshalling compiled arm template to JSON (err: %v), template contents:\n%s", err, compiled)
+		slog.InfoContext(ctx, "failed unmarshalling compiled arm template to JSONs", "err", err, "template", compiled)
 		return nil, fmt.Errorf("failed unmarshalling arm template from json: %w", err)
 	}
 

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"maps"
 	"math"
 	"os"
@@ -560,7 +561,7 @@ func (p *BicepProvider) Deploy(ctx context.Context) (*provisioning.DeployResult,
 	go func() {
 		// Disable reporting progress if needed
 		if use, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_PROVISION_PROGRESS_DISABLE")); err == nil && use {
-			log.Println("Disabling progress reporting since AZD_DEBUG_PROVISION_PROGRESS_DISABLE was set")
+			slog.InfoContext(ctx, "Disabling progress reporting since AZD_DEBUG_PROVISION_PROGRESS_DISABLE was set")
 			<-cancelProgress
 			return
 		}

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"maps"
 	"math"
@@ -1061,7 +1060,7 @@ func (p *BicepProvider) destroyDeploymentWithConfirmation(
 func itemsCountAsText(items []itemToPurge) string {
 	count := len(items)
 	if count < 1 {
-		log.Panic("calling itemsCountAsText() with empty list.")
+		panic("calling itemsCountAsText() with empty list.")
 	}
 
 	var tokens []string
@@ -1968,17 +1967,17 @@ func mustSetParamAsConfig(key string, value any, config config.Config, isSecured
 
 	if !isSecured {
 		if err := config.Set(configKey, value); err != nil {
-			log.Panicf("failed setting config value: %v", err)
+			panic(fmt.Sprintf("failed setting config value: %v", err))
 		}
 		return
 	}
 
 	secretString, castOk := value.(string)
 	if !castOk {
-		log.Panic("tried to set a non-string as secret. This is not supported.")
+		panic("tried to set a non-string as secret. This is not supported.")
 	}
 	if err := config.SetSecret(configKey, secretString); err != nil {
-		log.Panicf("failed setting a secret in config: %v", err)
+		panic(fmt.Sprintf("failed setting a secret in config: %v", err))
 	}
 }
 

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"maps"
 	"os"
 	"path/filepath"
@@ -485,7 +485,7 @@ func (t *TerraformProvider) createDeployment(ctx context.Context) (*provisioning
 	parametersFilePath := t.parametersFilePath()
 
 	// check if the file does not exist to create it --> for shared env scenario
-	log.Printf("Reading parameters template file from: %s", parametersFilePath)
+	slog.InfoContext(ctx, "Reading parameters template file", "path", parametersFilePath)
 	if err := t.ensureParametersFile(ctx); err != nil {
 		return nil, err
 	}
@@ -526,7 +526,7 @@ func (t *TerraformProvider) collectAzureResources(rootModule terraformRootModule
 	visitResource := func(r terraformResource) {
 		if r.Mode == terraformModeManaged && r.ProviderName == "registry.terraform.io/hashicorp/azurerm" {
 			if id, err := t.getIdForManagedResource(r); err != nil {
-				log.Printf("error determining id for resource: %v, ignoring...", err)
+				slog.InfoContext(context.TODO(), "error determining id for resource ignoring...", "err", err)
 			} else {
 				azureResources[id] = struct{}{}
 			}
@@ -681,7 +681,7 @@ func (t *TerraformProvider) createInputParametersFile(
 	}
 
 	// Copy the parameter template file to the environment working directory and do substitutions.
-	log.Printf("Reading parameters template file from: %s", templateFilePath)
+	slog.InfoContext(ctx, "Reading parameters template file", "path", templateFilePath)
 	parametersBytes, err := os.ReadFile(templateFilePath)
 	if err != nil {
 		return fmt.Errorf("reading parameter file template: %w", err)
@@ -703,7 +703,7 @@ func (t *TerraformProvider) createInputParametersFile(
 		return fmt.Errorf("creating directory structure: %w", err)
 	}
 
-	log.Printf("Writing parameters file to: %s", inputFilePath)
+	slog.InfoContext(ctx, "Writing parameters file", "path", inputFilePath)
 	err = os.WriteFile(inputFilePath, []byte(replaced), 0600)
 	if err != nil {
 		return fmt.Errorf("writing parameter file: %w", err)

--- a/cli/azd/pkg/infra/provisioning_progress_display.go
+++ b/cli/azd/pkg/infra/provisioning_progress_display.go
@@ -6,7 +6,7 @@ package infra
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"sort"
 	"strconv"
@@ -53,7 +53,7 @@ func (display *ProvisioningProgressDisplay) ReportProgress(
 		_, err := display.deployment.Get(ctx)
 		if err != nil {
 			// Return default progress
-			log.Printf("error while reporting progress: %s", err.Error())
+			slog.InfoContext(ctx, "error while reporting progress", "err", err)
 			return nil
 		}
 
@@ -165,12 +165,11 @@ func (display *ProvisioningProgressDisplay) logNewlyCreatedResources(
 			resourceTypeName = resourceTypeDisplayName
 		}
 
-		log.Printf(
-			"%s - %s %s: %s",
-			resource.Properties.Timestamp.Local().Format("2006-01-02 15:04:05"),
-			*resource.Properties.ProvisioningState,
-			resourceTypeName,
-			*resource.Properties.TargetResource.ResourceName)
+		slog.InfoContext(ctx, "resource created/updated",
+			"time", resource.Properties.Timestamp.Local().Format("2006-01-02 15:04:05"),
+			"provisioningState", *resource.Properties.ProvisioningState,
+			"resourceType", resourceTypeName,
+			"name", *resource.Properties.TargetResource.ResourceName)
 
 		display.displayedResources[*resource.Properties.TargetResource.ResourceName] = true
 	}

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"os"
 	"os/signal"
 	"runtime"
@@ -223,7 +224,7 @@ func (c *AskerConsole) Message(ctx context.Context, message string) {
 	} else if c.formatter != nil {
 		c.println(ctx, message)
 	} else {
-		log.Println(message)
+		slog.InfoContext(ctx, message)
 	}
 	// Adding "\n" b/c calling Fprintln is adding one new line at the end to the msg
 	c.updateLastBytes(message + "\n")

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -870,7 +869,7 @@ func (c *AskerConsole) WaitForEnter() {
 	inputScanner := bufio.NewScanner(c.handles.Stdin)
 	if scan := inputScanner.Scan(); !scan {
 		if err := inputScanner.Err(); err != nil {
-			log.Printf("error while waiting for enter: %v", err)
+			slog.InfoContext(context.TODO(), "error while waiting for enter", "err", err)
 		}
 	}
 }

--- a/cli/azd/pkg/input/console_previewer_writer.go
+++ b/cli/azd/pkg/input/console_previewer_writer.go
@@ -3,8 +3,6 @@
 
 package input
 
-import "log"
-
 // ConsolePreviewerWriter implements io.Writer and is used to wrap a progress log
 // and panic if the writer is used after the previewer is stopped.
 type consolePreviewerWriter struct {
@@ -17,7 +15,7 @@ func (cp *consolePreviewerWriter) Write(logBytes []byte) (int, error) {
 	writer := *cp.previewer
 	if writer == nil {
 		//dev-bug - tried to write to a closed console previewer
-		log.Panic("tried to write to a closed console previewer.")
+		panic("tried to write to a closed console previewer.")
 	}
 
 	return writer.Write(logBytes)

--- a/cli/azd/pkg/input/progress_log.go
+++ b/cli/azd/pkg/input/progress_log.go
@@ -5,7 +5,8 @@ package input
 
 import (
 	"bufio"
-	"log"
+	"context"
+	"log/slog"
 	"strings"
 	"sync"
 
@@ -145,7 +146,7 @@ func (p *progressLog) Stop(keepLogs bool) {
 	p.output = nil
 }
 
-// Write implements oi.Writer and updates the internal buffer before flushing it into the screen.
+// Write implements io.Writer and updates the internal buffer before flushing it into the screen.
 // Calling Write() before Start() or after Stop() is a no-op
 func (p *progressLog) Write(logBytes []byte) (int, error) {
 	if p.output == nil {
@@ -202,7 +203,7 @@ func (p *progressLog) Write(logBytes []byte) (int, error) {
 	}
 
 	if err := logsScanner.Err(); err != nil {
-		log.Printf("error while reading logs for previewer: %v", err)
+		slog.InfoContext(context.TODO(), "error while reading logs for previewer", "err", err)
 	}
 
 	// .Scan() won't add a line break for a line which ends in `\n`

--- a/cli/azd/pkg/input/progress_log_test.go
+++ b/cli/azd/pkg/input/progress_log_test.go
@@ -6,7 +6,6 @@ package input
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"regexp"
 	"strconv"
 	"strings"
@@ -228,7 +227,7 @@ func offset(src, regex string) int {
 		var qty int
 		qty, err := strconv.Atoi(string(match[1]))
 		if err != nil {
-			log.Panic("converting string to int: %w", err)
+			panic(fmt.Sprintf("converting string to int: %v", err))
 		}
 		return qty
 	}

--- a/cli/azd/pkg/keyvault/keyvault.go
+++ b/cli/azd/pkg/keyvault/keyvault.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -143,7 +143,7 @@ func (kvs *keyVaultService) PurgeKeyVault(
 		var httpErr *azcore.ResponseError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
 			// no need to purge if the vault is already deleted (not found)
-			log.Printf("key vault '%s' was not found. No need to purge.", vaultName)
+			slog.InfoContext(ctx, "key vault was not found. No need to purge.", "name", vaultName)
 			return nil
 		}
 		return fmt.Errorf("starting purging key vault: %w", err)

--- a/cli/azd/pkg/kustomize/cli.go
+++ b/cli/azd/pkg/kustomize/cli.go
@@ -3,7 +3,7 @@ package kustomize
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
@@ -41,9 +41,9 @@ func (cli *Cli) CheckInstalled(ctx context.Context) error {
 	// for diagnostics purposes, let's fetch and log the version of kustomize
 	// we're using.
 	if ver, err := cli.getClientVersion(ctx); err != nil {
-		log.Printf("error fetching kustomize version: %s", err)
+		slog.InfoContext(ctx, "error fetching kustomize version", "err", err)
 	} else {
-		log.Printf("kustomize version: %s", ver)
+		slog.InfoContext(ctx, "detected kustomize version", "version", ver)
 	}
 
 	return nil

--- a/cli/azd/pkg/oneauth/oneauth_windows.go
+++ b/cli/azd/pkg/oneauth/oneauth_windows.go
@@ -38,7 +38,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,7 +54,7 @@ import (
 
 //export goLog
 func goLog(s *C.char) {
-	log.Print(C.GoString(s))
+	slog.InfoContext(context.TODO(), C.GoString(s))
 }
 
 // Supported indicates whether this build includes OneAuth integration.

--- a/cli/azd/pkg/osutil/rename_windows.go
+++ b/cli/azd/pkg/osutil/rename_windows.go
@@ -9,7 +9,7 @@ package osutil
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
 	"os"
 	"time"
 
@@ -25,11 +25,11 @@ func Rename(ctx context.Context, old, new string) error {
 		err := os.Rename(old, new)
 		if errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
 			// If some other process has a open handle to the source file, Rename can fail with ERROR_SHARING_VIOLATION.
-			log.Printf("rename of %s to %s failed due to ERROR_SHARING_VIOLATION, allowing retry", old, new)
+			slog.InfoContext(ctx, "rename failed due to ERROR_SHARING_VIOLATION, allowing retry", "old", old, "new", new)
 			return retry.RetryableError(err)
 		} else if errors.Is(err, windows.ERROR_ACCESS_DENIED) {
 			// If the target file has already exists and is in use, Rename can fail with ERROR_ACCESS_DENIED.
-			log.Printf("rename of %s to %s failed due to ERROR_ACCESS_DENIED, allowing retry", old, new)
+			slog.InfoContext(ctx, "rename failed due to ERROR_ACCESS_DENIED, allowing retry", "old", old, "new", new)
 			return retry.RetryableError(err)
 		}
 		return err

--- a/cli/azd/pkg/output/ux/list_as_text.go
+++ b/cli/azd/pkg/output/ux/list_as_text.go
@@ -5,7 +5,6 @@ package ux
 
 import (
 	"fmt"
-	"log"
 	"strings"
 )
 
@@ -17,7 +16,7 @@ import (
 func ListAsText(items []string) string {
 	count := len(items)
 	if count < 1 {
-		log.Panic("calling ListAsText() with empty list.")
+		panic("calling ListAsText() with empty list.")
 	}
 
 	if count == 1 {

--- a/cli/azd/pkg/pipeline/azdo_provider.go
+++ b/cli/azd/pkg/pipeline/azdo_provider.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -564,7 +564,7 @@ func (p *AzdoScmProvider) preventGitPush(
 func azdoPat(ctx context.Context, env *environment.Environment, console input.Console) string {
 	pat, _, err := azdo.EnsurePatExists(ctx, env, console)
 	if err != nil {
-		log.Printf("Error getting PAT when it should be found: %s", err.Error())
+		slog.InfoContext(ctx, "Error getting PAT when it should be found", "err", err)
 	}
 	return pat
 }
@@ -609,7 +609,7 @@ func (p *AzdoScmProvider) GitPush(
 	).WithInteractive(true)
 	if _, err := p.commandRunner.Run(ctx, runArgs); err != nil {
 		// this error should not fail the operation
-		log.Printf("Error setting git config: insteadOf url: %s", err.Error())
+		slog.InfoContext(ctx, "Error setting git config: insteadOf url", "err", err.Error())
 	}
 
 	// *** Queue pipeline

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"html/template"
 	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -829,10 +830,10 @@ func (pm *PipelineManager) checkAndPromptForProviderFiles(ctx context.Context, p
 	if !hasPipelineFile(props.CiProvider, props.RepoRoot) {
 		log.Printf("%s YAML not found, prompting for creation", props.CiProvider)
 		if err := pm.promptForCiFiles(ctx, props); err != nil {
-			log.Println("Error prompting for CI files:", err)
+			slog.InfoContext(ctx, "Error prompting for CI files", "err", err)
 			return err
 		}
-		log.Println("Prompt for CI files completed successfully.")
+		slog.InfoContext(ctx, "Prompt for CI files completed successfully.")
 	}
 
 	var dirPaths []string
@@ -844,7 +845,7 @@ func (pm *PipelineManager) checkAndPromptForProviderFiles(ctx context.Context, p
 		log.Printf("Checking if directory %s is empty", dirPath)
 		isEmpty, err := osutil.IsDirEmpty(dirPath, true)
 		if err != nil {
-			log.Println("Error checking if directory is empty:", err)
+			slog.InfoContext(ctx, "Error checking if directory is empty", "err", err)
 			return fmt.Errorf("error checking if directory is empty: %w", err)
 		}
 		if !isEmpty {
@@ -865,11 +866,11 @@ func (pm *PipelineManager) checkAndPromptForProviderFiles(ctx context.Context, p
 				"Please add pipeline files and try again.",
 			pipelineProviderFiles[props.CiProvider].DisplayName,
 			strings.Join(pipelineProviderFiles[props.CiProvider].PipelineDirectories, "\n"))
-		log.Println("Error:", message)
+		slog.InfoContext(ctx, message)
 		return errors.New(message)
 	}
 
-	log.Println("Info:", message)
+	slog.InfoContext(ctx, message)
 	pm.console.Message(ctx, message)
 	pm.console.Message(ctx, "")
 

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -91,7 +92,7 @@ func (ch *ContainerHelper) RegistryName(ctx context.Context, serviceConfig *Serv
 	if registryName == "" {
 		yamlRegistryName, err := serviceConfig.Docker.Registry.Envsubst(ch.env.Getenv)
 		if err != nil {
-			log.Println("Failed expanding 'docker.registry'")
+			slog.InfoContext(ctx, "Failed expanding 'docker.registry'", "err", err)
 		}
 
 		registryName = yamlRegistryName

--- a/cli/azd/pkg/project/dotnet_importer.go
+++ b/cli/azd/pkg/project/dotnet_importer.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -449,7 +449,8 @@ func evaluateSingleExpressionMatch(
 	}
 	fromEnvVar := strings.TrimSuffix(scaffold.EnvFormat(resourceName)[2:], "}")
 	if valueInEnv := os.Getenv(fromEnvVar); valueInEnv != "" {
-		log.Println("Using value from environment variable", fromEnvVar, "for parameter", resourceName)
+		slog.InfoContext(context.TODO(), "Using value from environment variable for parameter",
+			"envVar", fromEnvVar, "parameter", resourceName)
 		return valueInEnv, nil
 	}
 	// can't resolve the parameter here yet, best we can do is resolve the name of the parameter, removing the path

--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path"
 	"path/filepath"
@@ -257,14 +257,12 @@ func (p *dockerProject) Build(
 		buildArgs = append(buildArgs, exec.RedactSensitiveData(arg))
 	}
 
-	log.Printf(
-		"building image for service %s, cwd: %s, path: %s, context: %s, buildArgs: %s)",
-		serviceConfig.Name,
-		serviceConfig.Path(),
-		dockerOptions.Path,
-		dockerOptions.Context,
-		buildArgs,
-	)
+	slog.InfoContext(ctx, "building image for service",
+		"service", serviceConfig.Name,
+		"cwd", serviceConfig.Path(),
+		"path", dockerOptions.Path,
+		"context", dockerOptions.Context,
+		"buildArgs", buildArgs)
 
 	imageName := fmt.Sprintf(
 		"%s-%s",
@@ -327,7 +325,7 @@ func (p *dockerProject) Build(
 		return nil, fmt.Errorf("building container: %s at %s: %w", serviceConfig.Name, dockerOptions.Context, err)
 	}
 
-	log.Printf("built image %s for %s", imageId, serviceConfig.Name)
+	slog.InfoContext(ctx, "built image", "id", imageId, "service", serviceConfig.Name)
 	return &ServiceBuildResult{
 		Restore:         restoreOutput,
 		BuildOutputPath: imageId,
@@ -418,7 +416,7 @@ func (p *dockerProject) Package(
 	}
 
 	// Tag image.
-	log.Printf("tagging image %s as %s", imageId, imageWithTag)
+	slog.InfoContext(ctx, "tagging image", "source", imageId, "tagged", imageWithTag)
 	progress.SetProgress(NewServiceProgress("Tagging container image"))
 	if err := p.docker.Tag(ctx, serviceConfig.Path(), imageId, imageWithTag); err != nil {
 		return nil, fmt.Errorf("tagging image: %w", err)

--- a/cli/azd/pkg/project/framework_service_dotnet.go
+++ b/cli/azd/pkg/project/framework_service_dotnet.go
@@ -6,7 +6,7 @@ package project
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -193,7 +193,8 @@ func (dp *dotnetProject) setUserSecretsFromOutputs(
 ) error {
 	bicepOutputArgs := args.Args["bicepOutput"]
 	if bicepOutputArgs == nil {
-		log.Println("no bicep outputs set as secrets to dotnet project, map args.Args doesn't contain key \"bicepOutput\"")
+		slog.InfoContext(ctx,
+			"no bicep outputs set as secrets to dotnet project, map args.Args doesn't contain key \"bicepOutput\"")
 		return nil
 	}
 

--- a/cli/azd/pkg/project/importer.go
+++ b/cli/azd/pkg/project/importer.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -80,7 +80,8 @@ func (im *ImportManager) ServiceStable(ctx context.Context, projectConfig *Proje
 
 				continue
 			} else if err != nil {
-				log.Printf("error checking if %s is an app host project: %v", svcConfig.Path(), err)
+				slog.InfoContext(ctx, "error checking if project is an app host project",
+					"path", svcConfig.Path(), "err", err)
 			}
 		}
 
@@ -107,7 +108,8 @@ func (im *ImportManager) HasAppHost(ctx context.Context, projectConfig *ProjectC
 			if canImport, err := im.dotNetImporter.CanImport(ctx, svcConfig.Path()); canImport {
 				return true
 			} else if err != nil {
-				log.Printf("error checking if %s is an app host project: %v", svcConfig.Path(), err)
+				slog.InfoContext(ctx, "error checking if project is an app host project",
+					"path", svcConfig.Path(), "err", err)
 			}
 		}
 	}
@@ -141,7 +143,7 @@ func (im *ImportManager) ProjectInfrastructure(ctx context.Context, projectConfi
 
 	// Allow overriding the infrastructure only when path and module exists.
 	if moduleExists, err := pathHasModule(infraRoot, projectConfig.Infra.Module); err == nil && moduleExists {
-		log.Printf("using infrastructure from %s directory", infraRoot)
+		slog.InfoContext(ctx, "using infrastructure from directory", "path", infraRoot)
 		return &Infra{
 			Options: projectConfig.Infra,
 		}, nil
@@ -160,7 +162,8 @@ func (im *ImportManager) ProjectInfrastructure(ctx context.Context, projectConfi
 
 				return im.dotNetImporter.ProjectInfrastructure(ctx, svcConfig)
 			} else if err != nil {
-				log.Printf("error checking if %s is an app host project: %v", svcConfig.Path(), err)
+				slog.InfoContext(ctx, "error checking if project is an app host project",
+					"path", svcConfig.Path(), "err", err)
 			}
 		}
 	}

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -145,7 +145,7 @@ func Parse(ctx context.Context, yamlContent string) (*ProjectConfig, error) {
 // Load hydrates the azure.yaml configuring into an viewable structure
 // This does not evaluate any tooling
 func Load(ctx context.Context, projectFilePath string) (*ProjectConfig, error) {
-	log.Printf("Reading project from file '%s'\n", projectFilePath)
+	slog.InfoContext(ctx, "Reading project from file", "path", projectFilePath)
 	bytes, err := os.ReadFile(projectFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("reading project file: %w", err)
@@ -220,7 +220,7 @@ func Load(ctx context.Context, projectFilePath string) (*ProjectConfig, error) {
 }
 
 func LoadConfig(ctx context.Context, projectFilePath string) (config.Config, error) {
-	log.Printf("Reading project from file '%s'\n", projectFilePath)
+	slog.InfoContext(ctx, "Reading project from file", "path", projectFilePath)
 	bytes, err := os.ReadFile(projectFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("reading project file: %w", err)

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -570,7 +571,8 @@ func (sm *serviceManager) GetFrameworkService(ctx context.Context, serviceConfig
 					err,
 				)
 			}
-			log.Println("Using swa-cli for build and deploy because swa-cli.config.json was found in the service path")
+			slog.InfoContext(ctx,
+				"Using swa-cli for build and deploy because swa-cli.config.json was found in the service path")
 		}
 	}
 	if compositeFramework != nil {

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -591,10 +590,10 @@ func OverriddenEndpoints(ctx context.Context, serviceConfig *ServiceConfig, env 
 		if err != nil {
 			// This can only happen if the environment output was not a valid JSON array, which would be due to an authoring
 			// error. For typical infra provider output passthrough, the infra provider would guarantee well-formed syntax
-			log.Printf(
-				"failed to unmarshal endpoints override for service '%s' as JSON array of strings: %v, skipping override",
-				serviceConfig.Name,
-				err)
+			slog.InfoContext(ctx,
+				"failed to unmarshal endpoints override for service as JSON array of strings, skipping override",
+				"service", serviceConfig.Name,
+				"err", err)
 		}
 
 		return endpoints

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"net/url"
 	"os"
@@ -537,7 +536,7 @@ func (t *aksTarget) ensureClusterContext(
 		return "", err
 	}
 
-	log.Printf("getting AKS credentials for cluster '%s'\n", clusterName)
+	slog.InfoContext(ctx, "getting AKS credentials for cluster", "custer", clusterName)
 	clusterCreds, err := t.managedClustersService.GetUserCredentials(
 		ctx,
 		targetResource.SubscriptionId(),
@@ -871,7 +870,8 @@ func (t *aksTarget) resolveClusterName(
 	// Resolve cluster name
 	clusterName, found := t.env.LookupEnv(environment.AksClusterEnvVarName)
 	if !found {
-		log.Printf("'%s' environment variable not found\n", environment.AksClusterEnvVarName)
+		slog.InfoContext(context.TODO(),
+			fmt.Sprintf("'%s' environment variable not found", environment.AksClusterEnvVarName))
 	}
 
 	if clusterName == "" {

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -876,7 +877,7 @@ func (t *aksTarget) resolveClusterName(
 	if clusterName == "" {
 		yamlClusterName, err := serviceConfig.ResourceName.Envsubst(t.env.Getenv)
 		if err != nil {
-			log.Println("failed resolving cluster name from `resourceName` in azure.yaml", err)
+			slog.InfoContext(context.TODO(), "failed resolving cluster name from `resourceName` in azure.yaml", "err", err)
 		}
 
 		clusterName = yamlClusterName

--- a/cli/azd/pkg/project/service_target_staticwebapp.go
+++ b/cli/azd/pkg/project/service_target_staticwebapp.go
@@ -6,7 +6,7 @@ package project
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -131,7 +131,7 @@ func (at *staticWebAppTarget) Deploy(
 		*deploymentToken,
 		dOptions)
 
-	log.Println(res)
+	slog.InfoContext(ctx, res)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed deploying static web app: %w", err)

--- a/cli/azd/pkg/prompt/prompter.go
+++ b/cli/azd/pkg/prompt/prompter.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"slices"
 	"strconv"
@@ -84,7 +84,7 @@ func (p *DefaultPrompter) PromptSubscription(ctx context.Context, msg string) (s
 
 	if !p.accountManager.HasDefaultSubscription() {
 		if _, err := p.accountManager.SetDefaultSubscription(ctx, subscriptionId); err != nil {
-			log.Printf("failed setting default subscription. %s\n", err.Error())
+			slog.InfoContext(ctx, "failed setting default subscription", "err", err)
 		}
 	}
 
@@ -104,7 +104,7 @@ func (p *DefaultPrompter) PromptLocation(
 
 	if !p.accountManager.HasDefaultLocation() {
 		if _, err := p.accountManager.SetDefaultLocation(ctx, subId, loc); err != nil {
-			log.Printf("failed setting default location. %s\n", err.Error())
+			slog.InfoContext(ctx, "failed setting default location", "err", err)
 		}
 	}
 

--- a/cli/azd/pkg/templates/awesome_source.go
+++ b/cli/azd/pkg/templates/awesome_source.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -58,7 +58,7 @@ func newAwesomeAzdTemplateSource(
 	awesomeAzdTemplates := []*Template{}
 	for _, template := range rawAwesomeAzdTemplates {
 		if template.Title == "" || template.Source == "" {
-			log.Println("skipping template. missing required attributes")
+			slog.InfoContext(ctx, "skipping template. missing required attributes")
 			continue
 		}
 

--- a/cli/azd/pkg/templates/path.go
+++ b/cli/azd/pkg/templates/path.go
@@ -1,8 +1,9 @@
 package templates
 
 import (
+	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -37,7 +38,7 @@ func Absolute(path string) (string, error) {
 func Hyperlink(path string) string {
 	url, err := Absolute(path)
 	if err != nil {
-		log.Printf("error: getting absolute url from template: %v", err)
+		slog.InfoContext(context.TODO(), "error: getting absolute url from template", "err", err)
 		return path
 	}
 	return output.WithHyperlink(url, path)

--- a/cli/azd/pkg/templates/source.go
+++ b/cli/azd/pkg/templates/source.go
@@ -3,7 +3,7 @@ package templates
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"slices"
 )
 
@@ -73,7 +73,9 @@ func (ts *templateSource) GetTemplate(ctx context.Context, path string) (*Templa
 	matchingIndex := slices.IndexFunc(allTemplates, func(template *Template) bool {
 		absPath, err := Absolute(template.RepositoryPath)
 		if err != nil {
-			log.Printf("failed to get absolute path for template '%s': %s", template.RepositoryPath, err.Error())
+			slog.InfoContext(ctx, "failed to get absolute path for template",
+				"template", template.RepositoryPath,
+				"err", err.Error())
 			return false
 		}
 

--- a/cli/azd/pkg/templates/template_manager.go
+++ b/cli/azd/pkg/templates/template_manager.go
@@ -3,7 +3,7 @@ package templates
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"slices"
 	"strings"
 
@@ -170,7 +170,7 @@ func (tm *TemplateManager) createSourcesFromConfig(
 
 		source, err := tm.sourceManager.CreateSource(ctx, config)
 		if err != nil {
-			log.Printf("failed to create source: %s", err.Error())
+			slog.InfoContext(ctx, "failed to create source", "err", err.Error())
 			continue
 		}
 
@@ -244,7 +244,8 @@ func PromptTemplate(
 	}
 
 	template := templates[selected]
-	log.Printf("Selected template: %s", fmt.Sprint(template.RepositoryPath))
+	slog.InfoContext(ctx, "Selected template",
+		"template", fmt.Sprint(template.RepositoryPath))
 
 	return *template, nil
 }

--- a/cli/azd/pkg/tools/docker/docker.go
+++ b/cli/azd/pkg/tools/docker/docker.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -186,7 +186,8 @@ var dockerVersionMasterBuildRegexp = regexp.MustCompile(`^master-dockerproject-(
 // isSupportedDockerVersion returns true if the version string appears to be for a docker version
 // of 17.09 or later and false if it does not.
 func isSupportedDockerVersion(cliOutput string) (bool, error) {
-	log.Printf("determining version from docker --version string: %s", cliOutput)
+	slog.InfoContext(context.TODO(), "determining version from docker --version string",
+		"versionString", cliOutput)
 
 	matches := dockerVersionStringRegexp.FindStringSubmatch(cliOutput)
 
@@ -198,7 +199,8 @@ func isSupportedDockerVersion(cliOutput string) (bool, error) {
 	version := matches[1]
 	build := matches[2]
 
-	log.Printf("extracted docker version: %s, build: %s from version string", version, build)
+	slog.InfoContext(context.TODO(), "extracted docker version and build from version string",
+		"version", version, "build", build)
 
 	// For official release builds, the version number looks something like:
 	//
@@ -256,7 +258,7 @@ func (d *Cli) CheckInstalled(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("checking %s version: %w", toolName, err)
 	}
-	log.Printf("docker version: %s", dockerRes)
+	slog.InfoContext(ctx, "detected docker version", "version", dockerRes)
 	supported, err := isSupportedDockerVersion(dockerRes)
 	if err != nil {
 		return err

--- a/cli/azd/pkg/tools/dotnet/dotnet.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -66,7 +66,7 @@ func (cli *Cli) CheckInstalled(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("checking %s version: %w", cli.Name(), err)
 	}
-	log.Printf("dotnet version: %s", dotnetRes.Stdout)
+	slog.InfoContext(ctx, "detected dotnet version", "version", dotnetRes.Stdout)
 	dotnetSemver, err := tools.ExtractVersion(dotnetRes.Stdout)
 	if err != nil {
 		return fmt.Errorf("converting to semver version fails: %w", err)

--- a/cli/azd/pkg/tools/ensure.go
+++ b/cli/azd/pkg/tools/ensure.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	osexec "os/exec"
 )
 
@@ -44,7 +44,8 @@ func EnsureInstalled(ctx context.Context, tools ...ExternalTool) error {
 	for _, tool := range tools {
 		_, ok := confirmedTools[tool.Name()]
 		if ok {
-			log.Printf("Skipping install check for '%s'. It was previously confirmed.", tool.Name())
+			slog.InfoContext(ctx, "Skipping install check for tool. It was previously confirmed.",
+				"tool", tool.Name())
 			continue
 		}
 

--- a/cli/azd/pkg/tools/git/git.go
+++ b/cli/azd/pkg/tools/git/git.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"regexp"
 	"runtime"
 	"strings"
@@ -52,7 +52,7 @@ func (cli *Cli) CheckInstalled(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("checking %s version: %w", cli.Name(), err)
 	}
-	log.Printf("git version: %s", gitRes)
+	slog.InfoContext(ctx, "detected git version", "version", gitRes)
 	gitSemver, err := tools.ExtractVersion(gitRes)
 	if err != nil {
 		return fmt.Errorf("converting to semver version fails: %w", err)

--- a/cli/azd/pkg/tools/javac/javac.go
+++ b/cli/azd/pkg/tools/javac/javac.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	osexec "os/exec"
 	"path/filepath"
@@ -58,13 +58,13 @@ func (j *Cli) CheckInstalled(ctx context.Context) error {
 		})
 
 		if err == nil {
-			log.Printf("javac version: %s", runResult.Stdout)
+			slog.InfoContext(ctx, "detected javac version from -version", "version", runResult.Stdout)
 			return &tools.ErrSemver{ToolName: j.Name(), VersionInfo: j.VersionInfo()}
 		}
 
 		return fmt.Errorf("checking javac version: %w", err)
 	}
-	log.Printf("javac version: %s", runResult.Stdout)
+	slog.InfoContext(ctx, "detected javac version from --version", "version", runResult.Stdout)
 
 	jdkVer, err := tools.ExtractVersion(runResult.Stdout)
 	if err != nil {

--- a/cli/azd/pkg/tools/kubectl/kubectl.go
+++ b/cli/azd/pkg/tools/kubectl/kubectl.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -74,9 +74,10 @@ func (cli *Cli) CheckInstalled(ctx context.Context) error {
 	// for diagnostics purposes, let's fetch and log the version of kubectl
 	// we're using.
 	if ver, err := cli.getClientVersion(ctx); err != nil {
-		log.Printf("error fetching kubectl version: %s", err)
+		slog.InfoContext(ctx, "error fetching kubectl version", "err", err)
 	} else {
-		log.Printf("kubectl version: %s", ver)
+		slog.InfoContext(ctx, "detected kubectl version",
+			"version", ver)
 	}
 
 	return nil

--- a/cli/azd/pkg/tools/maven/maven.go
+++ b/cli/azd/pkg/tools/maven/maven.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -45,7 +45,7 @@ func (m *Cli) CheckInstalled(ctx context.Context) error {
 	}
 
 	if ver, err := m.extractVersion(ctx); err == nil {
-		log.Printf("maven version: %s", ver)
+		slog.InfoContext(ctx, "determined maven version", "version", ver)
 	}
 
 	return nil
@@ -110,18 +110,20 @@ func getMavenWrapperPath(projectPath string, rootProjectPath string) (string, er
 	}
 
 	root, err := filepath.Abs(rootProjectPath)
-	log.Printf("root: %s\n", root)
+	slog.InfoContext(context.TODO(), "searching for maven wrapper", "root", root)
 
 	if err != nil {
 		return "", err
 	}
 
 	for {
-		log.Printf("searchDir: %s\n", searchDir)
+		slog.InfoContext(context.TODO(), "checking directory for mvnw",
+			"path", searchDir)
 
 		mvnw, err := osexec.LookPath(filepath.Join(searchDir, "mvnw"))
 		if err == nil {
-			log.Printf("found mvnw as: %s\n", mvnw)
+			slog.InfoContext(context.TODO(), "found mvnw",
+				"path", mvnw)
 			return mvnw, nil
 		}
 

--- a/cli/azd/pkg/tools/maven/maven_test.go
+++ b/cli/azd/pkg/tools/maven/maven_test.go
@@ -2,7 +2,6 @@ package maven
 
 import (
 	"context"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -94,7 +93,7 @@ func Test_getMavenPath(t *testing.T) {
 
 			wd, err := os.Getwd()
 			require.NoError(t, err)
-			log.Printf("rootPath: %s, cwd: %s, getMavenPath(%s, %s)\n", rootPath, wd, args.projectPath, args.rootProjectPath)
+			t.Logf("rootPath: %s, cwd: %s, getMavenPath(%s, %s)\n", rootPath, wd, args.projectPath, args.rootProjectPath)
 			actual, err := getMavenPath(args.projectPath, args.rootProjectPath)
 
 			if tt.wantErr {

--- a/cli/azd/pkg/tools/python/python.go
+++ b/cli/azd/pkg/tools/python/python.go
@@ -6,7 +6,7 @@ package python
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -46,7 +46,7 @@ func (cli *Cli) CheckInstalled(ctx context.Context) error {
 		return fmt.Errorf("checking %s version: %w", cli.Name(), err)
 	}
 
-	log.Printf("python version: %s", pythonRes)
+	slog.InfoContext(ctx, "detected python version", "version", pythonRes)
 
 	pythonSemver, err := tools.ExtractVersion(pythonRes)
 	if err != nil {

--- a/cli/azd/pkg/tools/swa/swa.go
+++ b/cli/azd/pkg/tools/swa/swa.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,14 +69,12 @@ func (cli *Cli) Deploy(
 	deploymentToken string,
 	options DeployOptions,
 ) (string, error) {
-	log.Printf(
-		"SWA Deploy: TenantId: %s, SubscriptionId: %s, ResourceGroup: %s, ResourceName: %s, Environment: %s",
-		tenantId,
-		subscriptionId,
-		resourceGroup,
-		appName,
-		environment,
-	)
+	slog.InfoContext(ctx, "SWA Deploy",
+		"tenantId", tenantId,
+		"subscriptionId", subscriptionId,
+		"resourceGroup", resourceGroup,
+		"resourceName", appName,
+		"environment", environment)
 
 	args := []string{"deploy",
 		"--tenant-id", tenantId,

--- a/cli/azd/pkg/tools/terraform/terraform.go
+++ b/cli/azd/pkg/tools/terraform/terraform.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
@@ -56,7 +56,7 @@ func (cli *Cli) CheckInstalled(ctx context.Context) error {
 		return fmt.Errorf("checking %s version:  %w", cli.Name(), err)
 	}
 
-	log.Printf("terraform version: %s", tfVer)
+	slog.InfoContext(ctx, "detected terraform version", "version", tfVer)
 
 	tfSemver, err := semver.Parse(tfVer)
 	if err != nil {

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -108,7 +108,7 @@ func TestMain(m *testing.M) {
 
 	shortFlag := flag.Lookup("test.short")
 	if shortFlag != nil && shortFlag.Value.String() == "true" {
-		log.Println("Skipping tests in short mode")
+		fmt.Println("Skipping tests in short mode")
 		os.Exit(0)
 	}
 

--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -13,7 +13,7 @@ import (
 	"flag"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	osexec "os/exec"
@@ -98,7 +98,7 @@ func (c *cliConfig) init() {
 		}
 
 		if err != nil {
-			log.Printf("could not load user config to provide default test values: %v", err)
+			slog.InfoContext(context.Background(), "could not load user config to provide default test values", "err", err)
 		}
 	}
 }


### PR DESCRIPTION
Go added [`log/slog`](https://pkg.go.dev/log/slog) to the standard library in Go 1.21.  It provides a leveled logging API that allows for structured logging. If this package had existed in the standard library when we started `azd`, we would have used it over `log`.

This change moves us from `log` to `log/slog`.

To do so, I've replaced all the calls to `log.Print`, `log.Printf` and `log.Println` with calls to `slog.InfoContext`.  If a `context.Context` object was available in the method, I used it, otherwise I used `context.TODO()` so we can go back and thread the context parameter.  Passing the context object like this should allow us to tie these log messages to tracing spans at some point.  In practice, `slog.InfoContext(context.TODO, ....)` behaves `slog.Info(...)` (since `context.TODO()` is like `context.Background()` and `slog.Info` calls `slog.InfoContext` with `context.Background()`.

While `slog` does have levels, for the first pass, I chose to always use `slog.InfoContext` even if `slog.ErrorContext` or `slog.WarningContext` may have made more sense based on the log message.  We can evolve this over time.
 
Since `slog` does structured logging, it is expected that insead of intermixing the logging message with the data to be logged, that you pass these as separate values, I did light editing of the logging messages when it made sense.
 
Calls to `log.Panic` and `log.Panicf` were replaced with direct calls to `panic` (perhaps with a call to `fmt.Sprintf` to produce the message to pass to panic) since `slog` doesn't have helpers like `Panic` or `Fatal`.  This does mean we no longer log a message in these cases, but from inspection it felt like this would be OK.

The `--debug` output of `azd` is slightly different after this change, since we now have a level printed for the log message and the data is printed after the message:

Before:

```
matell@Matts-Work-MacBook azd % azd version --debug 
2024/12/16 20:20:55 main.go:56: azd version: 0.0.0-dev.0 (commit 0000000000000000000000000000000000000000)
2024/12/16 20:20:55 main.go:214: using cached latest version: 1.11.0 (expires on: 2024-12-18T02:28:37Z)
2024/12/16 20:20:55 middleware.go:108: running middleware 'debug'
2024/12/16 20:20:55 middleware.go:108: running middleware 'ux'
azd version 0.0.0-dev.0 (commit 0000000000000000000000000000000000000000)
2024/12/16 20:20:55 main.go:88: eliding update message for dev build
```

After:

```
matell@Matts-Work-MacBook azd % azd version --debug              
2024/12/16 20:21:24 main.go:57: INFO azd version version="0.0.0-dev.0 (commit 0000000000000000000000000000000000000000)"
2024/12/16 20:21:24 main.go:215: INFO using cached latest version version=1.11.0 expiresOn=2024-12-18T02:28:37Z
2024/12/16 20:21:24 middleware.go:108: INFO running middleware name=debug
2024/12/16 20:21:24 middleware.go:108: INFO running middleware name=ux
azd version 0.0.0-dev.0 (commit 0000000000000000000000000000000000000000)
2024/12/16 20:21:24 main.go:89: INFO eliding update message for dev build
```