### PR TITLE
Enhance `azd init` to auto-detect Dockerfile ARGS and update azure.yaml

### DIFF
--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
 	"github.com/bmatcuk/doublestar/v4"
 )
@@ -167,8 +168,9 @@ type Port struct {
 }
 
 type Docker struct {
-	Path  string
-	Ports []Port
+	Path      string
+	Ports     []Port
+	BuildArgs []osutil.ExpandableString
 }
 
 type projectDetector interface {

--- a/cli/azd/internal/repository/app_init_test.go
+++ b/cli/azd/internal/repository/app_init_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/appdetect"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/stretchr/testify/require"
 )
@@ -93,7 +94,13 @@ func TestInitializer_prjConfigFromDetect(t *testing.T) {
 					{
 						Language: appdetect.DotNet,
 						Path:     "dotnet",
-						Docker:   &appdetect.Docker{Path: "Dockerfile"},
+						Docker: &appdetect.Docker{
+							Path: "Dockerfile",
+							BuildArgs: []osutil.ExpandableString{
+								osutil.NewExpandableString("ARG1"),
+								osutil.NewExpandableString("ARG2"),
+							},
+						},
 					},
 				},
 			},
@@ -112,6 +119,10 @@ func TestInitializer_prjConfigFromDetect(t *testing.T) {
 						RelativePath: "dotnet",
 						Docker: project.DockerProjectOptions{
 							Path: "Dockerfile",
+							BuildArgs: []osutil.ExpandableString{
+								osutil.NewExpandableString("ARG1"),
+								osutil.NewExpandableString("ARG2"),
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Fix issue https://github.com/Azure/azure-dev/issues/4606, this PR adds automatic detection of ARG parameters in Dockerfiles during `azd init`.

When a user runs `azd init` to initialize an existing application as an azd project, the command will now scan the Dockerfile, identify all defined ARG parameters, and automatically populate them into the `buildArgs` section of the generated `azure.yaml` file.

@rajeshkamal5050 for notification.