### PR TITLE
Do not hide `--output` Flag in help

### DIFF
--- a/cli/azd/pkg/output/parameter.go
+++ b/cli/azd/pkg/output/parameter.go
@@ -25,7 +25,7 @@ func AddOutputFlag(f *pflag.FlagSet, s *string, supportedFormats []Format, defau
 	description := fmt.Sprintf("The output format (the supported formats are %s).", strings.Join(formatNames, ", "))
 	f.StringVarP(s, outputFlagName, "o", string(defaultFormat), description)
 	//preview:flag hide --output
-	_ = f.MarkHidden(outputFlagName)
+	// _ = f.MarkHidden(outputFlagName)
 
 	// Only error that can occur is "flag not found", which is not possible given we just added the flag on the previous line
 	_ = f.SetAnnotation(outputFlagName, supportedFormatterAnnotation, formatNames)


### PR DESCRIPTION
Fix issue https://github.com/Azure/azure-dev/issues/4075.

Commented out the `_ = f.MarkHidden(outputFlagName)` line in the `AddOutputFlag` function to ensure the `-o` flag is no longer hidden.
The `-o` flag is now correctly listed in the command help, making it easier for users to discover and use it.

@rajeshkamal5050 for notification.