### PR TITLE
bicep: Support `@sealed()` decorator on user defined types

### DIFF
--- a/cli/azd/pkg/azure/arm_template.go
+++ b/cli/azd/pkg/azure/arm_template.go
@@ -57,7 +57,7 @@ type ArmTemplateParameterDefinitions map[string]ArmTemplateParameterDefinition
 
 type ArmTemplateOutputs map[string]ArmTemplateOutput
 
-type ArmTemplateParameterAdditionalProperties struct {
+type ArmTemplateParameterAdditionalPropertiesProperties struct {
 	Type      string                     `json:"type"`
 	MinValue  *int                       `json:"minValue,omitempty"`
 	MaxValue  *int                       `json:"maxValue,omitempty"`
@@ -66,18 +66,52 @@ type ArmTemplateParameterAdditionalProperties struct {
 	Metadata  map[string]json.RawMessage `json:"metadata"`
 }
 
+type ArmTemplateParameterAdditionalPropertiesValue struct {
+	props *ArmTemplateParameterAdditionalPropertiesProperties
+}
+
+func (v ArmTemplateParameterAdditionalPropertiesValue) HasAdditionalProperties() bool {
+	return v.props != nil
+}
+
+func (v ArmTemplateParameterAdditionalPropertiesValue) Properties() ArmTemplateParameterAdditionalPropertiesProperties {
+	return *v.props
+}
+
+func (v *ArmTemplateParameterAdditionalPropertiesValue) UnmarshalJSON(data []byte) error {
+	if string(data) == "false" {
+		return nil
+	}
+
+	var props ArmTemplateParameterAdditionalPropertiesProperties
+	if err := json.Unmarshal(data, &props); err != nil {
+		return err
+	}
+
+	v.props = &props
+	return nil
+}
+
+func (v *ArmTemplateParameterAdditionalPropertiesValue) MarshalJSON() ([]byte, error) {
+	if v.props == nil {
+		return []byte("false"), nil
+	}
+
+	return json.Marshal(v.props)
+}
+
 type ArmTemplateParameterDefinition struct {
-	Type                 string                                   `json:"type"`
-	DefaultValue         any                                      `json:"defaultValue"`
-	AllowedValues        *[]any                                   `json:"allowedValues,omitempty"`
-	MinValue             *int                                     `json:"minValue,omitempty"`
-	MaxValue             *int                                     `json:"maxValue,omitempty"`
-	MinLength            *int                                     `json:"minLength,omitempty"`
-	MaxLength            *int                                     `json:"maxLength,omitempty"`
-	Metadata             map[string]json.RawMessage               `json:"metadata"`
-	Ref                  string                                   `json:"$ref"`
-	Properties           ArmTemplateParameterDefinitions          `json:"properties,omitempty"`
-	AdditionalProperties ArmTemplateParameterAdditionalProperties `json:"additionalProperties,omitempty"`
+	Type                 string                                         `json:"type"`
+	DefaultValue         any                                            `json:"defaultValue"`
+	AllowedValues        *[]any                                         `json:"allowedValues,omitempty"`
+	MinValue             *int                                           `json:"minValue,omitempty"`
+	MaxValue             *int                                           `json:"maxValue,omitempty"`
+	MinLength            *int                                           `json:"minLength,omitempty"`
+	MaxLength            *int                                           `json:"maxLength,omitempty"`
+	Metadata             map[string]json.RawMessage                     `json:"metadata"`
+	Ref                  string                                         `json:"$ref"`
+	Properties           ArmTemplateParameterDefinitions                `json:"properties,omitempty"`
+	AdditionalProperties *ArmTemplateParameterAdditionalPropertiesValue `json:"additionalProperties,omitempty"`
 }
 
 func (d *ArmTemplateParameterDefinition) Secure() bool {


### PR DESCRIPTION
When the `@sealed()` decorator is applied on user defined types, it causes an `additionalProperties: false` property to be added to the type defintition in the generated arm deployment. Our unmarshalling logic did not understand this pattern and so it would cause an error when trying to unmarshall this, since it expected if `additionalProperties` was set, it would be to set to an object that described information about the additional properties.

I've updated the marshalling code to support `false` as a valid value for the additional properties node when parsing an ARM template. Since Go doesn't have great support for modeling descrimited unions, the new `ArmTemplateParameterAdditionalPropertiesValue` type is used to provide the logcal descrimited union of `false` or a object like value.

Fixes #4659