### PR TITLE
Export database secrets only when there's a service to bind to

### DIFF
--- a/cli/azd/internal/scaffold/scaffold.go
+++ b/cli/azd/internal/scaffold/scaffold.go
@@ -68,11 +68,10 @@ func Execute(
 func supportingFiles(spec InfraSpec) []string {
 	files := []string{"/abbreviations.json"}
 
-	if spec.DbRedis != nil {
-		files = append(files, "/modules/set-redis-conn.bicep")
-	}
-
 	if len(spec.Services) > 0 {
+		if spec.DbRedis != nil {
+			files = append(files, "/modules/set-redis-conn.bicep")
+		}
 		files = append(files, "/modules/fetch-container-image.bicep")
 	}
 

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -91,10 +91,12 @@ module cosmos 'br/public:avm/res/document-db/database-account:0.8.1' = {
       }
     ]
     {{- end}}
+    {{- if .Services}}
     secretsExportConfiguration: {
       keyVaultResourceId: keyVault.outputs.resourceId
       primaryWriteConnectionStringSecretName: 'MONGODB-URL'
     }
+    {{- end}}
     capabilitiesToAdd: [ 'EnableServerless' ]
   }
 }
@@ -398,6 +400,7 @@ module redis 'br/public:avm/res/cache/redis:0.3.2' = {
   }
 }
 
+{{- if .Services}}
 module redisConn './modules/set-redis-conn.bicep' = {
   name: 'redisConn'
   params: {
@@ -407,6 +410,7 @@ module redisConn './modules/set-redis-conn.bicep' = {
     keyVaultName: keyVault.outputs.name
   }
 }
+{{- end}}
 {{- end}}
 
 {{- if .Services}}


### PR DESCRIPTION
Fixes #4574 

These changes are based on [prior discussion here](https://github.com/Azure/azure-dev/pull/4473#discussion_r1913915088) to only export database secrets to AKV when there is a service to bind to. We export Redis access keys using a custom Bicep module, hence the additional change to `scaffold.go`.