### PR TITLE
chore: `init` to depend on `add.Configure`

### DIFF
--- a/cli/azd/internal/cmd/add/add.go
+++ b/cli/azd/internal/cmd/add/add.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
-	"github.com/azure/azure-dev/cli/azd/internal/repository"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
@@ -50,7 +49,6 @@ type AddAction struct {
 	alphaManager     *alpha.FeatureManager
 	creds            account.SubscriptionCredentialProvider
 	rm               infra.ResourceManager
-	appInit          *repository.Initializer
 	armClientOptions *arm.ClientOptions
 	prompter         prompt.Prompter
 	console          input.Console
@@ -93,7 +91,7 @@ func (a *AddAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	resourceToAdd := &project.ResourceConfig{}
 	var serviceToAdd *project.ServiceConfig
 
-	promptOpts := promptOptions{prj: prjConfig}
+	promptOpts := PromptOptions{PrjConfig: prjConfig}
 	if strings.EqualFold(selected.Namespace, "host") {
 		svc, r, err := a.configureHost(a.console, ctx, promptOpts)
 		if err != nil {
@@ -111,7 +109,7 @@ func (a *AddAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		resourceToAdd = r
 	}
 
-	resourceToAdd, err = configure(ctx, resourceToAdd, a.console, promptOpts)
+	resourceToAdd, err = Configure(ctx, resourceToAdd, a.console, promptOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -368,7 +366,6 @@ func NewAddAction(
 	prompter prompt.Prompter,
 	rm infra.ResourceManager,
 	armClientOptions *arm.ClientOptions,
-	appInit *repository.Initializer,
 	azd workflow.AzdCommandRunner,
 	console input.Console) actions.Action {
 	return &AddAction{
@@ -381,7 +378,6 @@ func NewAddAction(
 		prompter:         prompter,
 		rm:               rm,
 		armClientOptions: armClientOptions,
-		appInit:          appInit,
 		creds:            creds,
 		azd:              azd,
 	}

--- a/cli/azd/internal/cmd/add/add_configure_host.go
+++ b/cli/azd/internal/cmd/add/add_configure_host.go
@@ -8,11 +8,12 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/appdetect"
-	"github.com/azure/azure-dev/cli/azd/internal/repository"
+	"github.com/azure/azure-dev/cli/azd/internal/names"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -21,10 +22,19 @@ import (
 	"github.com/fatih/color"
 )
 
+// LanguageMap is a map of supported languages.
+var LanguageMap = map[appdetect.Language]project.ServiceLanguageKind{
+	appdetect.DotNet:     project.ServiceLanguageDotNet,
+	appdetect.Java:       project.ServiceLanguageJava,
+	appdetect.JavaScript: project.ServiceLanguageJavaScript,
+	appdetect.TypeScript: project.ServiceLanguageTypeScript,
+	appdetect.Python:     project.ServiceLanguagePython,
+}
+
 func (a *AddAction) configureHost(
 	console input.Console,
 	ctx context.Context,
-	p promptOptions) (*project.ServiceConfig, *project.ResourceConfig, error) {
+	p PromptOptions) (*project.ServiceConfig, *project.ResourceConfig, error) {
 	prj, err := a.promptCodeProject(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -62,7 +72,7 @@ func (a *AddAction) promptCodeProject(ctx context.Context) (*appdetect.Project, 
 	if prj == nil {
 		// fallback, prompt for language
 		a.console.MessageUxItem(ctx, &ux.WarningMessage{Description: "Could not automatically detect language"})
-		languages := slices.SortedFunc(maps.Keys(repository.LanguageMap),
+		languages := slices.SortedFunc(maps.Keys(LanguageMap),
 			func(a, b appdetect.Language) int {
 				return strings.Compare(a.Display(), b.Display())
 			})
@@ -136,10 +146,10 @@ func (a *AddAction) promptCodeProject(ctx context.Context) (*appdetect.Project, 
 // projectAsService prompts the user for enough information to create a service.
 func (a *AddAction) projectAsService(
 	ctx context.Context,
-	p promptOptions,
+	p PromptOptions,
 	prj *appdetect.Project,
 ) (*project.ServiceConfig, error) {
-	_, supported := repository.LanguageMap[prj.Language]
+	_, supported := LanguageMap[prj.Language]
 	if !supported {
 		return nil, fmt.Errorf("unsupported language: %s", prj.Language)
 	}
@@ -155,12 +165,12 @@ func (a *AddAction) projectAsService(
 			return nil, err
 		}
 
-		if err := validateServiceName(name, p.prj); err != nil {
+		if err := validateServiceName(name, p.PrjConfig); err != nil {
 			a.console.Message(ctx, err.Error())
 			continue
 		}
 
-		if err := validateResourceName(name, p.prj); err != nil {
+		if err := validateResourceName(name, p.PrjConfig); err != nil {
 			a.console.Message(ctx, err.Error())
 			continue
 		}
@@ -203,7 +213,7 @@ func (a *AddAction) projectAsService(
 		}
 	}
 
-	svc, err := repository.ServiceFromDetect(
+	svc, err := ServiceFromDetect(
 		a.azdCtx.ProjectDirectory(),
 		svcName,
 		*prj)
@@ -245,7 +255,7 @@ func addServiceAsResource(
 	}
 
 	if props.Port == -1 {
-		port, err := repository.PromptPort(console, ctx, svc.Name, prj)
+		port, err := PromptPort(console, ctx, svc.Name, prj)
 		if err != nil {
 			return nil, err
 		}
@@ -255,4 +265,158 @@ func addServiceAsResource(
 
 	resSpec.Props = props
 	return &resSpec, nil
+}
+
+// ServiceFromDetect creates a ServiceConfig from an appdetect project.
+func ServiceFromDetect(
+	root string,
+	svcName string,
+	prj appdetect.Project) (project.ServiceConfig, error) {
+	svc := project.ServiceConfig{
+		Name: svcName,
+	}
+	rel, err := filepath.Rel(root, prj.Path)
+	if err != nil {
+		return svc, err
+	}
+
+	if svc.Name == "" {
+		dirName := filepath.Base(rel)
+		if dirName == "." {
+			dirName = filepath.Base(root)
+		}
+
+		svc.Name = names.LabelName(dirName)
+	}
+
+	svc.Host = project.ContainerAppTarget
+	svc.RelativePath = rel
+
+	language, supported := LanguageMap[prj.Language]
+	if !supported {
+		return svc, fmt.Errorf("unsupported language: %s", prj.Language)
+	}
+
+	svc.Language = language
+
+	if prj.Docker != nil {
+		relDocker, err := filepath.Rel(prj.Path, prj.Docker.Path)
+		if err != nil {
+			return svc, err
+		}
+
+		svc.Docker = project.DockerProjectOptions{
+			Path: relDocker,
+		}
+	}
+
+	if prj.HasWebUIFramework() {
+		// By default, use 'dist'. This is common for frameworks such as:
+		// - TypeScript
+		// - Vite
+		svc.OutputPath = "dist"
+
+	loop:
+		for _, dep := range prj.Dependencies {
+			switch dep {
+			case appdetect.JsNext:
+				// next.js works as SSR with default node configuration without static build output
+				svc.OutputPath = ""
+				break loop
+			case appdetect.JsVite:
+				svc.OutputPath = "dist"
+				break loop
+			case appdetect.JsReact:
+				// react from create-react-app uses 'build' when used, but this can be overridden
+				// by choice of build tool, such as when using Vite.
+				svc.OutputPath = "build"
+			case appdetect.JsAngular:
+				// angular uses dist/<project name>
+				svc.OutputPath = "dist/" + filepath.Base(rel)
+				break loop
+			}
+		}
+	}
+
+	return svc, nil
+}
+
+// PromptPort prompts for port selection from an appdetect project.
+func PromptPort(
+	console input.Console,
+	ctx context.Context,
+	name string,
+	svc appdetect.Project) (int, error) {
+	if svc.Docker == nil || svc.Docker.Path == "" { // using default builder from azd
+		if svc.Language == appdetect.Java || svc.Language == appdetect.DotNet {
+			return 8080, nil
+		}
+		return 80, nil
+	}
+
+	// a custom Dockerfile is provided
+	ports := svc.Docker.Ports
+	switch len(ports) {
+	case 1: // only one port was exposed, that's the one
+		return ports[0].Number, nil
+	case 0: // no ports exposed, prompt for port
+		port, err := promptPortNumber(console, ctx, "What port does '"+name+"' listen on?")
+		if err != nil {
+			return -1, err
+		}
+		return port, nil
+	}
+
+	// multiple ports exposed, prompt for selection
+	var portOptions []string
+	for _, port := range ports {
+		portOptions = append(portOptions, strconv.Itoa(port.Number))
+	}
+	portOptions = append(portOptions, "Other")
+
+	selection, err := console.Select(ctx, input.ConsoleOptions{
+		Message: "What port does '" + name + "' listen on?",
+		Options: portOptions,
+	})
+	if err != nil {
+		return -1, err
+	}
+
+	if selection < len(ports) { // user selected a port
+		return ports[selection].Number, nil
+	}
+
+	// user selected 'Other', prompt for port
+	port, err := promptPortNumber(console, ctx, "Provide the port number for '"+name+"':")
+	if err != nil {
+		return -1, err
+	}
+
+	return port, nil
+}
+
+func promptPortNumber(console input.Console, ctx context.Context, promptMessage string) (int, error) {
+	var port int
+	for {
+		val, err := console.Prompt(ctx, input.ConsoleOptions{
+			Message: promptMessage,
+		})
+		if err != nil {
+			return -1, err
+		}
+
+		port, err = strconv.Atoi(val)
+		if err != nil {
+			console.Message(ctx, "Port must be an integer.")
+			continue
+		}
+
+		if port < 1 || port > 65535 {
+			console.Message(ctx, "Port must be a value between 1 and 65535.")
+			continue
+		}
+
+		break
+	}
+	return port, nil
 }

--- a/cli/azd/internal/cmd/add/add_select.go
+++ b/cli/azd/internal/cmd/add/add_select.go
@@ -11,7 +11,7 @@ import (
 )
 
 // resourceSelection prompts the user to select a given resource type, returning the resulting resource configuration.
-type resourceSelection func(console input.Console, ctx context.Context, p promptOptions) (*project.ResourceConfig, error)
+type resourceSelection func(console input.Console, ctx context.Context, p PromptOptions) (*project.ResourceConfig, error)
 
 // A menu to be displayed.
 type Menu struct {
@@ -35,7 +35,7 @@ func (a *AddAction) selectMenu() []Menu {
 func selectDatabase(
 	console input.Console,
 	ctx context.Context,
-	p promptOptions) (*project.ResourceConfig, error) {
+	p PromptOptions) (*project.ResourceConfig, error) {
 	resourceTypesDisplayMap := make(map[string]project.ResourceType)
 	for _, resourceType := range project.AllResourceTypes() {
 		if strings.HasPrefix(string(resourceType), "db.") {

--- a/cli/azd/internal/cmd/add/add_select_ai.go
+++ b/cli/azd/internal/cmd/add/add_select_ai.go
@@ -22,7 +22,7 @@ import (
 func (a *AddAction) selectOpenAi(
 	console input.Console,
 	ctx context.Context,
-	p promptOptions) (r *project.ResourceConfig, err error) {
+	p PromptOptions) (r *project.ResourceConfig, err error) {
 	resourceToAdd := &project.ResourceConfig{}
 	aiOption, err := console.Select(ctx, input.ConsoleOptions{
 		Message: "Which type of Azure OpenAI service?",

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/appdetect"
-	"github.com/azure/azure-dev/cli/azd/internal/names"
+	"github.com/azure/azure-dev/cli/azd/internal/cmd/add"
 	"github.com/azure/azure-dev/cli/azd/internal/scaffold"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
@@ -27,20 +27,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/otiai10/copy"
 )
-
-var LanguageMap = map[appdetect.Language]project.ServiceLanguageKind{
-	appdetect.DotNet:     project.ServiceLanguageDotNet,
-	appdetect.Java:       project.ServiceLanguageJava,
-	appdetect.JavaScript: project.ServiceLanguageJavaScript,
-	appdetect.TypeScript: project.ServiceLanguageTypeScript,
-	appdetect.Python:     project.ServiceLanguagePython,
-}
-
-var dbMap = map[appdetect.DatabaseDep]struct{}{
-	appdetect.DbMongo:    {},
-	appdetect.DbPostgres: {},
-	appdetect.DbRedis:    {},
-}
 
 var featureCompose = alpha.MustFeatureKey("compose")
 
@@ -395,7 +381,7 @@ func (i *Initializer) prjConfigFromDetect(
 
 	svcMapping := map[string]string{}
 	for _, prj := range detect.Services {
-		svc, err := ServiceFromDetect(root, "", prj)
+		svc, err := add.ServiceFromDetect(root, "", prj)
 		if err != nil {
 			return config, err
 		}
@@ -413,46 +399,20 @@ func (i *Initializer) prjConfigFromDetect(
 				return strings.Compare(string(a), string(b))
 			})
 
+		promptOpts := add.PromptOptions{PrjConfig: &config}
+
 		for _, database := range databases {
-			if database == appdetect.DbRedis {
-				redis := project.ResourceConfig{
-					Type: project.ResourceTypeDbRedis,
-					Name: "redis",
-				}
-				config.Resources[redis.Name] = &redis
-				dbNames[database] = redis.Name
-				continue
-			}
-
-			var dbType project.ResourceType
-			switch database {
-			case appdetect.DbMongo:
-				dbType = project.ResourceTypeDbMongo
-			case appdetect.DbPostgres:
-				dbType = project.ResourceTypeDbPostgres
-			}
-
 			db := project.ResourceConfig{
-				Type: dbType,
+				Type: add.DbMap[database],
 			}
 
-			for {
-				dbName, err := promptDbName(i.console, ctx, database)
-				if err != nil {
-					return config, err
-				}
-
-				if dbName == "" {
-					i.console.Message(ctx, "Database name is required.")
-					continue
-				}
-
-				db.Name = dbName
-				break
+			configured, err := add.Configure(ctx, &db, i.console, promptOpts)
+			if err != nil {
+				return config, err
 			}
 
-			config.Resources[db.Name] = &db
-			dbNames[database] = db.Name
+			config.Resources[configured.Name] = &db
+			dbNames[database] = configured.Name
 		}
 
 		backends := []*project.ResourceConfig{}
@@ -468,7 +428,7 @@ func (i *Initializer) prjConfigFromDetect(
 				Port: -1,
 			}
 
-			port, err := PromptPort(i.console, ctx, name, svc)
+			port, err := add.PromptPort(i.console, ctx, name, svc)
 			if err != nil {
 				return config, err
 			}
@@ -503,78 +463,4 @@ func (i *Initializer) prjConfigFromDetect(
 	}
 
 	return config, nil
-}
-
-// ServiceFromDetect creates a ServiceConfig from an appdetect project.
-func ServiceFromDetect(
-	root string,
-	svcName string,
-	prj appdetect.Project) (project.ServiceConfig, error) {
-	svc := project.ServiceConfig{
-		Name: svcName,
-	}
-	rel, err := filepath.Rel(root, prj.Path)
-	if err != nil {
-		return svc, err
-	}
-
-	if svc.Name == "" {
-		dirName := filepath.Base(rel)
-		if dirName == "." {
-			dirName = filepath.Base(root)
-		}
-
-		svc.Name = names.LabelName(dirName)
-	}
-
-	svc.Host = project.ContainerAppTarget
-	svc.RelativePath = rel
-
-	language, supported := LanguageMap[prj.Language]
-	if !supported {
-		return svc, fmt.Errorf("unsupported language: %s", prj.Language)
-	}
-
-	svc.Language = language
-
-	if prj.Docker != nil {
-		relDocker, err := filepath.Rel(prj.Path, prj.Docker.Path)
-		if err != nil {
-			return svc, err
-		}
-
-		svc.Docker = project.DockerProjectOptions{
-			Path: relDocker,
-		}
-	}
-
-	if prj.HasWebUIFramework() {
-		// By default, use 'dist'. This is common for frameworks such as:
-		// - TypeScript
-		// - Vite
-		svc.OutputPath = "dist"
-
-	loop:
-		for _, dep := range prj.Dependencies {
-			switch dep {
-			case appdetect.JsNext:
-				// next.js works as SSR with default node configuration without static build output
-				svc.OutputPath = ""
-				break loop
-			case appdetect.JsVite:
-				svc.OutputPath = "dist"
-				break loop
-			case appdetect.JsReact:
-				// react from create-react-app uses 'build' when used, but this can be overridden
-				// by choice of build tool, such as when using Vite.
-				svc.OutputPath = "build"
-			case appdetect.JsAngular:
-				// angular uses dist/<project name>
-				svc.OutputPath = "dist/" + filepath.Base(rel)
-				break loop
-			}
-		}
-	}
-
-	return svc, nil
 }

--- a/cli/azd/internal/repository/detect_confirm.go
+++ b/cli/azd/internal/repository/detect_confirm.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/azure/azure-dev/cli/azd/internal/appdetect"
+	"github.com/azure/azure-dev/cli/azd/internal/cmd/add"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -64,12 +65,12 @@ func (d *detectConfirm) Init(projects []appdetect.Project, root string) {
 	d.root = root
 
 	for _, project := range projects {
-		if _, supported := LanguageMap[project.Language]; supported {
+		if _, supported := add.LanguageMap[project.Language]; supported {
 			d.Services = append(d.Services, project)
 		}
 
 		for _, dbType := range project.DatabaseDeps {
-			if _, supported := dbMap[dbType]; supported {
+			if _, supported := add.DbMap[dbType]; supported {
 				d.Databases[dbType] = EntryKindDetected
 			}
 		}
@@ -310,7 +311,7 @@ func (d *detectConfirm) remove(ctx context.Context) error {
 }
 
 func (d *detectConfirm) add(ctx context.Context) error {
-	languages := slices.SortedFunc(maps.Keys(LanguageMap),
+	languages := slices.SortedFunc(maps.Keys(add.LanguageMap),
 		func(a, b appdetect.Language) int {
 			return strings.Compare(a.Display(), b.Display())
 		})
@@ -321,7 +322,7 @@ func (d *detectConfirm) add(ctx context.Context) error {
 		})
 
 	// only include databases not already added
-	allDbs := slices.Collect(maps.Keys(dbMap))
+	allDbs := slices.Collect(maps.Keys(add.DbMap))
 	databases := make([]appdetect.DatabaseDep, 0, len(allDbs))
 	for _, db := range allDbs {
 		if _, ok := d.Databases[db]; !ok {

--- a/cli/azd/internal/repository/infra_confirm.go
+++ b/cli/azd/internal/repository/infra_confirm.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/internal/appdetect"
+	"github.com/azure/azure-dev/cli/azd/internal/cmd/add"
 	"github.com/azure/azure-dev/cli/azd/internal/names"
 	"github.com/azure/azure-dev/cli/azd/internal/scaffold"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -65,7 +65,7 @@ func (i *Initializer) infraSpecFromDetect(
 			Port: -1,
 		}
 
-		port, err := PromptPort(i.console, ctx, name, svc)
+		port, err := add.PromptPort(i.console, ctx, name, svc)
 		if err != nil {
 			return scaffold.InfraSpec{}, err
 		}
@@ -131,32 +131,6 @@ func (i *Initializer) infraSpecFromDetect(
 	return spec, nil
 }
 
-func promptPortNumber(console input.Console, ctx context.Context, promptMessage string) (int, error) {
-	var port int
-	for {
-		val, err := console.Prompt(ctx, input.ConsoleOptions{
-			Message: promptMessage,
-		})
-		if err != nil {
-			return -1, err
-		}
-
-		port, err = strconv.Atoi(val)
-		if err != nil {
-			console.Message(ctx, "Port must be an integer.")
-			continue
-		}
-
-		if port < 1 || port > 65535 {
-			console.Message(ctx, "Port must be a value between 1 and 65535.")
-			continue
-		}
-
-		break
-	}
-	return port, nil
-}
-
 func promptDbName(console input.Console, ctx context.Context, database appdetect.DatabaseDep) (string, error) {
 	for {
 		dbName, err := console.Prompt(ctx, input.ConsoleOptions{
@@ -203,58 +177,4 @@ func promptDbName(console input.Console, ctx context.Context, database appdetect
 
 		return dbName, nil
 	}
-}
-
-// PromptPort prompts for port selection from an appdetect project.
-func PromptPort(
-	console input.Console,
-	ctx context.Context,
-	name string,
-	svc appdetect.Project) (int, error) {
-	if svc.Docker == nil || svc.Docker.Path == "" { // using default builder from azd
-		if svc.Language == appdetect.Java || svc.Language == appdetect.DotNet {
-			return 8080, nil
-		}
-		return 80, nil
-	}
-
-	// a custom Dockerfile is provided
-	ports := svc.Docker.Ports
-	switch len(ports) {
-	case 1: // only one port was exposed, that's the one
-		return ports[0].Number, nil
-	case 0: // no ports exposed, prompt for port
-		port, err := promptPortNumber(console, ctx, "What port does '"+name+"' listen on?")
-		if err != nil {
-			return -1, err
-		}
-		return port, nil
-	}
-
-	// multiple ports exposed, prompt for selection
-	var portOptions []string
-	for _, port := range ports {
-		portOptions = append(portOptions, strconv.Itoa(port.Number))
-	}
-	portOptions = append(portOptions, "Other")
-
-	selection, err := console.Select(ctx, input.ConsoleOptions{
-		Message: "What port does '" + name + "' listen on?",
-		Options: portOptions,
-	})
-	if err != nil {
-		return -1, err
-	}
-
-	if selection < len(ports) { // user selected a port
-		return ports[selection].Number, nil
-	}
-
-	// user selected 'Other', prompt for port
-	port, err := promptPortNumber(console, ctx, "Provide the port number for '"+name+"':")
-	if err != nil {
-		return -1, err
-	}
-
-	return port, nil
 }


### PR DESCRIPTION
This change reshares UI prompting logic between `init` and `add`.

**Context**
`init` logically depends on `add` since it is essentially a quick wizard that ends up prompting attributes for each resource. In the limit, `init` can be thought of as a series of `add` calls, though this is not reflected in practice due to difference in UX design considerations.

This is a pure refactor and does not introduce any functional changes. The UI prompting is covered by existing tests.

