### PR TITLE
Ensure copyright header in source files

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -40,6 +40,11 @@ jobs:
       - run: npm install -g cspell@8.13.1
       - name: Spell check for go and docs
         run: cspell lint '**/*.{go,md}' --config ./cli/azd/.vscode/cspell.yaml --root ./cli/azd --no-progress
+
+  Copyright-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - name: Copyright check
         run: ./eng/scripts/copyright-check.sh ./cli/azd
 

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -40,6 +40,8 @@ jobs:
       - run: npm install -g cspell@8.13.1
       - name: Spell check for go and docs
         run: cspell lint '**/*.{go,md}' --config ./cli/azd/.vscode/cspell.yaml --root ./cli/azd --no-progress
+      - name: Copyright check
+        run: ./eng/scripts/copyright-check.sh ./cli/azd
 
   bicep-lint:
     uses: ./.github/workflows/lint-bicep.yml

--- a/cli/azd/appdetect/main.go
+++ b/cli/azd/appdetect/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package main
 
 import (

--- a/cli/azd/cmd/actions/action.go
+++ b/cli/azd/cmd/actions/action.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 // Package actions contains the application logic that handles azd CLI commands.
 package actions
 

--- a/cli/azd/cmd/actions/action_descriptor.go
+++ b/cli/azd/cmd/actions/action_descriptor.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package actions
 
 import (

--- a/cli/azd/cmd/actions/action_descriptor_test.go
+++ b/cli/azd/cmd/actions/action_descriptor_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package actions_test
 
 import (

--- a/cli/azd/cmd/auth.go
+++ b/cli/azd/cmd/auth.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/cmd/build.go
+++ b/cli/azd/cmd/build.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/cmd/cobra_builder.go
+++ b/cli/azd/cmd/cobra_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/cmd/cobra_builder_test.go
+++ b/cli/azd/cmd/cobra_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/cmd/container_test.go
+++ b/cli/azd/cmd/container_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/cmd/down.go
+++ b/cli/azd/cmd/down.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/cmd/hooks.go
+++ b/cli/azd/cmd/hooks.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/cmd/infra_create.go
+++ b/cli/azd/cmd/infra_create.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/cmd/infra_delete.go
+++ b/cli/azd/cmd/infra_delete.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/cmd/infra_synth.go
+++ b/cli/azd/cmd/infra_synth.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/cmd/middleware/debug.go
+++ b/cli/azd/cmd/middleware/debug.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package middleware
 
 import (

--- a/cli/azd/cmd/middleware/experimentation.go
+++ b/cli/azd/cmd/middleware/experimentation.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package middleware
 
 import (

--- a/cli/azd/cmd/middleware/hooks.go
+++ b/cli/azd/cmd/middleware/hooks.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package middleware
 
 import (

--- a/cli/azd/cmd/middleware/hooks_test.go
+++ b/cli/azd/cmd/middleware/hooks_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package middleware
 
 import (

--- a/cli/azd/cmd/middleware/middleware.go
+++ b/cli/azd/cmd/middleware/middleware.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package middleware
 
 import (

--- a/cli/azd/cmd/middleware/middleware_test.go
+++ b/cli/azd/cmd/middleware/middleware_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package middleware
 
 import (

--- a/cli/azd/cmd/middleware/telemetry.go
+++ b/cli/azd/cmd/middleware/telemetry.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package middleware
 
 import (

--- a/cli/azd/cmd/middleware/telemetry_test.go
+++ b/cli/azd/cmd/middleware/telemetry_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package middleware
 
 import (

--- a/cli/azd/cmd/middleware/ux.go
+++ b/cli/azd/cmd/middleware/ux.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package middleware
 
 import (

--- a/cli/azd/cmd/package.go
+++ b/cli/azd/cmd/package.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/cmd/show.go
+++ b/cli/azd/cmd/show.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/cmd/usage_test.go
+++ b/cli/azd/cmd/usage_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/internal/appdetect/appdetect_test.go
+++ b/cli/azd/internal/appdetect/appdetect_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appdetect
 
 import (

--- a/cli/azd/internal/appdetect/config.go
+++ b/cli/azd/internal/appdetect/config.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appdetect
 
 func newConfig(options ...DetectOption) detectConfig {

--- a/cli/azd/internal/appdetect/docker.go
+++ b/cli/azd/internal/appdetect/docker.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appdetect
 
 import (

--- a/cli/azd/internal/appdetect/docker_test.go
+++ b/cli/azd/internal/appdetect/docker_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appdetect
 
 import (

--- a/cli/azd/internal/appdetect/dotnet.go
+++ b/cli/azd/internal/appdetect/dotnet.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appdetect
 
 import (

--- a/cli/azd/internal/appdetect/dotnet_apphost.go
+++ b/cli/azd/internal/appdetect/dotnet_apphost.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appdetect
 
 import (

--- a/cli/azd/internal/appdetect/java.go
+++ b/cli/azd/internal/appdetect/java.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appdetect
 
 import (

--- a/cli/azd/internal/appdetect/javascript.go
+++ b/cli/azd/internal/appdetect/javascript.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appdetect
 
 import (

--- a/cli/azd/internal/appdetect/python.go
+++ b/cli/azd/internal/appdetect/python.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appdetect
 
 import (

--- a/cli/azd/internal/appdetect/python_test.go
+++ b/cli/azd/internal/appdetect/python_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appdetect
 
 import (

--- a/cli/azd/internal/cmd/add/add_configure.go
+++ b/cli/azd/internal/cmd/add/add_configure.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package add
 
 import (

--- a/cli/azd/internal/cmd/add/add_configure_host.go
+++ b/cli/azd/internal/cmd/add/add_configure_host.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package add
 
 import (

--- a/cli/azd/internal/cmd/add/add_preview.go
+++ b/cli/azd/internal/cmd/add/add_preview.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package add
 
 import (

--- a/cli/azd/internal/cmd/add/add_select.go
+++ b/cli/azd/internal/cmd/add/add_select.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package add
 
 import (

--- a/cli/azd/internal/cmd/add/add_select_ai.go
+++ b/cli/azd/internal/cmd/add/add_select_ai.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package add
 
 import (

--- a/cli/azd/internal/cmd/add/diff.go
+++ b/cli/azd/internal/cmd/add/diff.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package add
 
 import (

--- a/cli/azd/internal/cmd/cmd_help.go
+++ b/cli/azd/internal/cmd/cmd_help.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/internal/cmd/errors.go
+++ b/cli/azd/internal/cmd/errors.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/internal/cmd/errors_test.go
+++ b/cli/azd/internal/cmd/errors_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/internal/cmd/provision.go
+++ b/cli/azd/internal/cmd/provision.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/internal/cmd/util.go
+++ b/cli/azd/internal/cmd/util.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/internal/env_flag.go
+++ b/cli/azd/internal/env_flag.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package internal
 
 import (

--- a/cli/azd/internal/errors.go
+++ b/cli/azd/internal/errors.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package internal
 
 // ErrorWithSuggestion is a custom error type that includes a suggestion for the user

--- a/cli/azd/internal/global_command_options.go
+++ b/cli/azd/internal/global_command_options.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package internal
 
 type GlobalCommandOptions struct {

--- a/cli/azd/internal/names/label_test.go
+++ b/cli/azd/internal/names/label_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package names
 
 import (

--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package repository
 
 import (

--- a/cli/azd/internal/repository/app_init_test.go
+++ b/cli/azd/internal/repository/app_init_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package repository
 
 import (

--- a/cli/azd/internal/repository/detect_confirm.go
+++ b/cli/azd/internal/repository/detect_confirm.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package repository
 
 import (

--- a/cli/azd/internal/repository/detect_confirm_apphost.go
+++ b/cli/azd/internal/repository/detect_confirm_apphost.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package repository
 
 import (

--- a/cli/azd/internal/repository/detect_confirm_test.go
+++ b/cli/azd/internal/repository/detect_confirm_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package repository
 
 import (

--- a/cli/azd/internal/repository/infra_confirm.go
+++ b/cli/azd/internal/repository/infra_confirm.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package repository
 
 import (

--- a/cli/azd/internal/repository/infra_confirm_test.go
+++ b/cli/azd/internal/repository/infra_confirm_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package repository
 
 import (

--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 // Package repository provides handling of files in the user's code repository.
 package repository
 

--- a/cli/azd/internal/repository/initializer_test.go
+++ b/cli/azd/internal/repository/initializer_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package repository
 
 import (

--- a/cli/azd/internal/repository/prompt_util.go
+++ b/cli/azd/internal/repository/prompt_util.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package repository
 
 import (

--- a/cli/azd/internal/runcontext/cloudshell.go
+++ b/cli/azd/internal/runcontext/cloudshell.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package runcontext
 
 import (

--- a/cli/azd/internal/runcontext/cloudshell_test.go
+++ b/cli/azd/internal/runcontext/cloudshell_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package runcontext
 
 import (

--- a/cli/azd/internal/scaffold/funcs.go
+++ b/cli/azd/internal/scaffold/funcs.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package scaffold
 
 import (

--- a/cli/azd/internal/scaffold/funcs_test.go
+++ b/cli/azd/internal/scaffold/funcs_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package scaffold
 
 import (

--- a/cli/azd/internal/scaffold/scaffold.go
+++ b/cli/azd/internal/scaffold/scaffold.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package scaffold
 
 import (

--- a/cli/azd/internal/scaffold/scaffold_test.go
+++ b/cli/azd/internal/scaffold/scaffold_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package scaffold
 
 import (

--- a/cli/azd/internal/scaffold/spec.go
+++ b/cli/azd/internal/scaffold/spec.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package scaffold
 
 import (

--- a/cli/azd/internal/telemetry/appinsights-exporter/endpoint_config.go
+++ b/cli/azd/internal/telemetry/appinsights-exporter/endpoint_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appinsightsexporter
 
 import (

--- a/cli/azd/internal/telemetry/appinsights-exporter/endpoint_config_test.go
+++ b/cli/azd/internal/telemetry/appinsights-exporter/endpoint_config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appinsightsexporter
 
 import (

--- a/cli/azd/internal/telemetry/appinsights-exporter/span_to_envelope.go
+++ b/cli/azd/internal/telemetry/appinsights-exporter/span_to_envelope.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appinsightsexporter
 
 import (

--- a/cli/azd/internal/telemetry/appinsights-exporter/span_to_envelope_test.go
+++ b/cli/azd/internal/telemetry/appinsights-exporter/span_to_envelope_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appinsightsexporter
 
 import (

--- a/cli/azd/internal/telemetry/appinsights-exporter/transmit_payload.go
+++ b/cli/azd/internal/telemetry/appinsights-exporter/transmit_payload.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appinsightsexporter
 
 import (

--- a/cli/azd/internal/telemetry/appinsights-exporter/transmitter.go
+++ b/cli/azd/internal/telemetry/appinsights-exporter/transmitter.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appinsightsexporter
 
 // Forked implementation from github.com/microsoft/ApplicationInsights-Go

--- a/cli/azd/internal/telemetry/appinsights-exporter/transmitter_test.go
+++ b/cli/azd/internal/telemetry/appinsights-exporter/transmitter_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package appinsightsexporter
 
 import (

--- a/cli/azd/internal/telemetry/notice.go
+++ b/cli/azd/internal/telemetry/notice.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package telemetry
 
 import (

--- a/cli/azd/internal/telemetry/notice_test.go
+++ b/cli/azd/internal/telemetry/notice_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package telemetry
 
 import (

--- a/cli/azd/internal/telemetry/storage.go
+++ b/cli/azd/internal/telemetry/storage.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package telemetry
 
 import (

--- a/cli/azd/internal/telemetry/storage_exporter.go
+++ b/cli/azd/internal/telemetry/storage_exporter.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package telemetry
 
 import (

--- a/cli/azd/internal/telemetry/storage_exporter_test.go
+++ b/cli/azd/internal/telemetry/storage_exporter_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package telemetry
 
 import (

--- a/cli/azd/internal/telemetry/storage_test.go
+++ b/cli/azd/internal/telemetry/storage_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package telemetry
 
 import (

--- a/cli/azd/internal/telemetry/telemetry_test.go
+++ b/cli/azd/internal/telemetry/telemetry_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package telemetry
 
 import (

--- a/cli/azd/internal/telemetry/uploader.go
+++ b/cli/azd/internal/telemetry/uploader.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package telemetry
 
 import (

--- a/cli/azd/internal/telemetry/uploader_test.go
+++ b/cli/azd/internal/telemetry/uploader_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package telemetry
 
 import (

--- a/cli/azd/internal/tracing/attributes.go
+++ b/cli/azd/internal/tracing/attributes.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package tracing
 
 import (

--- a/cli/azd/internal/tracing/attributes_test.go
+++ b/cli/azd/internal/tracing/attributes_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package tracing
 
 import (

--- a/cli/azd/internal/tracing/events/format_test.go
+++ b/cli/azd/internal/tracing/events/format_test.go
@@ -1,4 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
 
 // Licensed under the MIT License.
 

--- a/cli/azd/internal/tracing/fields/domains.go
+++ b/cli/azd/internal/tracing/fields/domains.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package fields
 
 type Domain struct {

--- a/cli/azd/internal/tracing/fields/key.go
+++ b/cli/azd/internal/tracing/fields/key.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package fields
 
 import (

--- a/cli/azd/internal/tracing/resource/ci.go
+++ b/cli/azd/internal/tracing/resource/ci.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package resource
 
 import (

--- a/cli/azd/internal/useragent.go
+++ b/cli/azd/internal/useragent.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package internal
 
 import (

--- a/cli/azd/internal/useragent_test.go
+++ b/cli/azd/internal/useragent_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package internal
 
 import (

--- a/cli/azd/internal/vsrpc/environment_service_create.go
+++ b/cli/azd/internal/vsrpc/environment_service_create.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package vsrpc
 
 import (

--- a/cli/azd/internal/vsrpc/handler_test.go
+++ b/cli/azd/internal/vsrpc/handler_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package vsrpc
 
 import (

--- a/cli/azd/internal/vsrpc/observer_test.go
+++ b/cli/azd/internal/vsrpc/observer_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package vsrpc
 
 import (

--- a/cli/azd/internal/vsrpc/server_session.go
+++ b/cli/azd/internal/vsrpc/server_session.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package vsrpc
 
 import (

--- a/cli/azd/internal/vsrpc/server_test.go
+++ b/cli/azd/internal/vsrpc/server_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package vsrpc
 
 import (

--- a/cli/azd/internal/vsrpc/utils.go
+++ b/cli/azd/internal/vsrpc/utils.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package vsrpc
 
 import (

--- a/cli/azd/internal/vsrpc/utils_test.go
+++ b/cli/azd/internal/vsrpc/utils_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package vsrpc
 
 import (

--- a/cli/azd/internal/vsrpc/writer_multiplexer.go
+++ b/cli/azd/internal/vsrpc/writer_multiplexer.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package vsrpc
 
 import (

--- a/cli/azd/internal/vsrpc/writer_multiplexer_test.go
+++ b/cli/azd/internal/vsrpc/writer_multiplexer_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package vsrpc
 
 import (

--- a/cli/azd/pkg/account/manager.go
+++ b/cli/azd/pkg/account/manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package account
 
 import (

--- a/cli/azd/pkg/account/manager_test.go
+++ b/cli/azd/pkg/account/manager_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package account
 
 import (

--- a/cli/azd/pkg/account/models.go
+++ b/cli/azd/pkg/account/models.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package account
 
 // AZD Account configuration

--- a/cli/azd/pkg/account/subscriptions.go
+++ b/cli/azd/pkg/account/subscriptions.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package account
 
 import (

--- a/cli/azd/pkg/account/subscriptions_cache.go
+++ b/cli/azd/pkg/account/subscriptions_cache.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package account
 
 import (

--- a/cli/azd/pkg/account/subscriptions_cache_test.go
+++ b/cli/azd/pkg/account/subscriptions_cache_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package account
 
 import (

--- a/cli/azd/pkg/account/subscriptions_manager.go
+++ b/cli/azd/pkg/account/subscriptions_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package account
 
 import (

--- a/cli/azd/pkg/account/subscriptions_manager_test.go
+++ b/cli/azd/pkg/account/subscriptions_manager_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package account
 
 import (

--- a/cli/azd/pkg/ai/config.go
+++ b/cli/azd/pkg/ai/config.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ai
 
 import (

--- a/cli/azd/pkg/ai/config_test.go
+++ b/cli/azd/pkg/ai/config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ai
 
 import (

--- a/cli/azd/pkg/ai/python_bridge.go
+++ b/cli/azd/pkg/ai/python_bridge.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ai
 
 import (

--- a/cli/azd/pkg/ai/python_bridge_test.go
+++ b/cli/azd/pkg/ai/python_bridge_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ai
 
 import (

--- a/cli/azd/pkg/ai/util.go
+++ b/cli/azd/pkg/ai/util.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ai
 
 import (

--- a/cli/azd/pkg/ai/util_test.go
+++ b/cli/azd/pkg/ai/util_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ai
 
 import (

--- a/cli/azd/pkg/alpha/alpha_feature.go
+++ b/cli/azd/pkg/alpha/alpha_feature.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package alpha
 
 import (

--- a/cli/azd/pkg/alpha/alpha_feature_manager.go
+++ b/cli/azd/pkg/alpha/alpha_feature_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package alpha
 
 import (

--- a/cli/azd/pkg/alpha/alpha_feature_test.go
+++ b/cli/azd/pkg/alpha/alpha_feature_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package alpha
 
 import (

--- a/cli/azd/pkg/apphost/aca_ingress.go
+++ b/cli/azd/pkg/apphost/aca_ingress.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package apphost
 
 import (

--- a/cli/azd/pkg/apphost/aca_ingress_test.go
+++ b/cli/azd/pkg/apphost/aca_ingress_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package apphost
 
 import (

--- a/cli/azd/pkg/apphost/eval.go
+++ b/cli/azd/pkg/apphost/eval.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package apphost
 
 import (

--- a/cli/azd/pkg/apphost/eval_test.go
+++ b/cli/azd/pkg/apphost/eval_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package apphost
 
 import (

--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package apphost
 
 import (

--- a/cli/azd/pkg/apphost/generate_test.go
+++ b/cli/azd/pkg/apphost/generate_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package apphost
 
 import (

--- a/cli/azd/pkg/apphost/generate_types.go
+++ b/cli/azd/pkg/apphost/generate_types.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package apphost
 
 import "github.com/azure/azure-dev/cli/azd/pkg/custommaps"

--- a/cli/azd/pkg/apphost/manifest.go
+++ b/cli/azd/pkg/apphost/manifest.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package apphost
 
 import (

--- a/cli/azd/pkg/async/progress.go
+++ b/cli/azd/pkg/async/progress.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package async
 
 // Progress is a wrapper around a channel which can be used to report progress of an operation. The zero value of Progress

--- a/cli/azd/pkg/auth/cloudshell_credential.go
+++ b/cli/azd/pkg/auth/cloudshell_credential.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package auth
 
 import (

--- a/cli/azd/pkg/auth/cloudshell_credential_test.go
+++ b/cli/azd/pkg/auth/cloudshell_credential_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package auth
 
 import (

--- a/cli/azd/pkg/auth/credential_providers.go
+++ b/cli/azd/pkg/auth/credential_providers.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package auth
 
 import (

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package auth
 
 import (

--- a/cli/azd/pkg/auth/errors_test.go
+++ b/cli/azd/pkg/auth/errors_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package auth
 
 import (

--- a/cli/azd/pkg/auth/remote_credential.go
+++ b/cli/azd/pkg/auth/remote_credential.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package auth
 
 import (

--- a/cli/azd/pkg/auth/token.go
+++ b/cli/azd/pkg/auth/token.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package auth
 
 import (

--- a/cli/azd/pkg/auth/token_test.go
+++ b/cli/azd/pkg/auth/token_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package auth
 
 import (

--- a/cli/azd/pkg/azapi/account.go
+++ b/cli/azd/pkg/azapi/account.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/apim.go
+++ b/cli/azd/pkg/azapi/apim.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/appconfig.go
+++ b/cli/azd/pkg/azapi/appconfig.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/cognitive_service.go
+++ b/cli/azd/pkg/azapi/cognitive_service.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/cognitive_service_test.go
+++ b/cli/azd/pkg/azapi/cognitive_service_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/container_registry.go
+++ b/cli/azd/pkg/azapi/container_registry.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/function_app.go
+++ b/cli/azd/pkg/azapi/function_app.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/managed_clusters.go
+++ b/cli/azd/pkg/azapi/managed_clusters.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/managed_hsm.go
+++ b/cli/azd/pkg/azapi/managed_hsm.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/resource_service.go
+++ b/cli/azd/pkg/azapi/resource_service.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/spring_app.go
+++ b/cli/azd/pkg/azapi/spring_app.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/stack_deployments.go
+++ b/cli/azd/pkg/azapi/stack_deployments.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/stack_deployments_test.go
+++ b/cli/azd/pkg/azapi/stack_deployments_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/standard_deployments.go
+++ b/cli/azd/pkg/azapi/standard_deployments.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/standard_deployments_test.go
+++ b/cli/azd/pkg/azapi/standard_deployments_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/static_webapp.go
+++ b/cli/azd/pkg/azapi/static_webapp.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/user_profile.go
+++ b/cli/azd/pkg/azapi/user_profile.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/user_profile_test.go
+++ b/cli/azd/pkg/azapi/user_profile_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azapi/webapp.go
+++ b/cli/azd/pkg/azapi/webapp.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azapi
 
 import (

--- a/cli/azd/pkg/azd/default.go
+++ b/cli/azd/pkg/azd/default.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azd
 
 import (

--- a/cli/azd/pkg/azd/default_test.go
+++ b/cli/azd/pkg/azd/default_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azd
 
 import (

--- a/cli/azd/pkg/azsdk/correlation_policy.go
+++ b/cli/azd/pkg/azsdk/correlation_policy.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azsdk
 
 import (

--- a/cli/azd/pkg/azsdk/correlation_policy_test.go
+++ b/cli/azd/pkg/azsdk/correlation_policy_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azsdk
 
 import (

--- a/cli/azd/pkg/azsdk/funcapp_host_client.go
+++ b/cli/azd/pkg/azsdk/funcapp_host_client.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azsdk
 
 import (

--- a/cli/azd/pkg/azsdk/storage/storage_blob_client.go
+++ b/cli/azd/pkg/azsdk/storage/storage_blob_client.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package storage
 
 import (

--- a/cli/azd/pkg/azsdk/storage/storage_file_share_service.go
+++ b/cli/azd/pkg/azsdk/storage/storage_file_share_service.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package storage
 
 import (

--- a/cli/azd/pkg/azsdk/user_agent_policy.go
+++ b/cli/azd/pkg/azsdk/user_agent_policy.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azsdk
 
 import (

--- a/cli/azd/pkg/azsdk/user_agent_policy_test.go
+++ b/cli/azd/pkg/azsdk/user_agent_policy_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azsdk
 
 import (

--- a/cli/azd/pkg/azsdk/zip_deploy_client.go
+++ b/cli/azd/pkg/azsdk/zip_deploy_client.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azsdk
 
 import (

--- a/cli/azd/pkg/azsdk/zip_deploy_client_test.go
+++ b/cli/azd/pkg/azsdk/zip_deploy_client_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azsdk
 
 import (

--- a/cli/azd/pkg/azure/resource_ids_test.go
+++ b/cli/azd/pkg/azure/resource_ids_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azure
 
 import (

--- a/cli/azd/pkg/cloud/cloud.go
+++ b/cli/azd/pkg/cloud/cloud.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cloud
 
 import (

--- a/cli/azd/pkg/compare/compare.go
+++ b/cli/azd/pkg/compare/compare.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package compare
 
 import "strings"

--- a/cli/azd/pkg/compare/compare_test.go
+++ b/cli/azd/pkg/compare/compare_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package compare
 
 import (

--- a/cli/azd/pkg/config/config_test.go
+++ b/cli/azd/pkg/config/config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package config
 
 import (

--- a/cli/azd/pkg/config/file_config_manager.go
+++ b/cli/azd/pkg/config/file_config_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package config
 
 import (

--- a/cli/azd/pkg/config/file_config_manager_test.go
+++ b/cli/azd/pkg/config/file_config_manager_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package config
 
 import (

--- a/cli/azd/pkg/config/manager.go
+++ b/cli/azd/pkg/config/manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package config
 
 import (

--- a/cli/azd/pkg/config/manager_test.go
+++ b/cli/azd/pkg/config/manager_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package config
 
 import (

--- a/cli/azd/pkg/config/user_config_manager.go
+++ b/cli/azd/pkg/config/user_config_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package config
 
 import (

--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package containerapps
 
 import (

--- a/cli/azd/pkg/containerapps/container_app_test.go
+++ b/cli/azd/pkg/containerapps/container_app_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package containerapps
 
 import (

--- a/cli/azd/pkg/contracts/auth_token_test.go
+++ b/cli/azd/pkg/contracts/auth_token_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package contracts
 
 import (

--- a/cli/azd/pkg/contracts/env_list.go
+++ b/cli/azd/pkg/contracts/env_list.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package contracts
 
 type EnvListEnvironment struct {

--- a/cli/azd/pkg/contracts/vs_server.go
+++ b/cli/azd/pkg/contracts/vs_server.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package contracts
 
 type VsServerResult struct {

--- a/cli/azd/pkg/convert/util.go
+++ b/cli/azd/pkg/convert/util.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package convert
 
 import (

--- a/cli/azd/pkg/convert/util_test.go
+++ b/cli/azd/pkg/convert/util_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package convert
 
 import (

--- a/cli/azd/pkg/cosmosdb/cosmosdb.go
+++ b/cli/azd/pkg/cosmosdb/cosmosdb.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cosmosdb
 
 import (

--- a/cli/azd/pkg/custommaps/with_order_map.go
+++ b/cli/azd/pkg/custommaps/with_order_map.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package custommaps
 
 import (

--- a/cli/azd/pkg/custommaps/with_order_map_test.go
+++ b/cli/azd/pkg/custommaps/with_order_map_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package custommaps
 
 import (

--- a/cli/azd/pkg/devcenter/config.go
+++ b/cli/azd/pkg/devcenter/config.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcenter
 
 import (

--- a/cli/azd/pkg/devcenter/devcenter.go
+++ b/cli/azd/pkg/devcenter/devcenter.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcenter
 
 import (

--- a/cli/azd/pkg/devcenter/devcenter_test.go
+++ b/cli/azd/pkg/devcenter/devcenter_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcenter
 
 import (

--- a/cli/azd/pkg/devcenter/environment_store.go
+++ b/cli/azd/pkg/devcenter/environment_store.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcenter
 
 import (

--- a/cli/azd/pkg/devcenter/environment_store_test.go
+++ b/cli/azd/pkg/devcenter/environment_store_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcenter
 
 import (

--- a/cli/azd/pkg/devcenter/manager.go
+++ b/cli/azd/pkg/devcenter/manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcenter
 
 import (

--- a/cli/azd/pkg/devcenter/manager_test.go
+++ b/cli/azd/pkg/devcenter/manager_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcenter
 
 import (

--- a/cli/azd/pkg/devcenter/platform.go
+++ b/cli/azd/pkg/devcenter/platform.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcenter
 
 import (

--- a/cli/azd/pkg/devcenter/platform_test.go
+++ b/cli/azd/pkg/devcenter/platform_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcenter
 
 import (

--- a/cli/azd/pkg/devcenter/prompter.go
+++ b/cli/azd/pkg/devcenter/prompter.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcenter
 
 import (

--- a/cli/azd/pkg/devcenter/prompter_test.go
+++ b/cli/azd/pkg/devcenter/prompter_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcenter
 
 import (

--- a/cli/azd/pkg/devcenter/provision_provider.go
+++ b/cli/azd/pkg/devcenter/provision_provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcenter
 
 import (

--- a/cli/azd/pkg/devcenter/provision_provider_test.go
+++ b/cli/azd/pkg/devcenter/provision_provider_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcenter
 
 import (

--- a/cli/azd/pkg/devcenter/template_source.go
+++ b/cli/azd/pkg/devcenter/template_source.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcenter
 
 import (

--- a/cli/azd/pkg/devcenter/template_source_test.go
+++ b/cli/azd/pkg/devcenter/template_source_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcenter
 
 import (

--- a/cli/azd/pkg/devcentersdk/api_version_policy.go
+++ b/cli/azd/pkg/devcentersdk/api_version_policy.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/devcentersdk/catalog_request_builders.go
+++ b/cli/azd/pkg/devcentersdk/catalog_request_builders.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/devcentersdk/devcenter_request_builders.go
+++ b/cli/azd/pkg/devcentersdk/devcenter_request_builders.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/devcentersdk/devcentersdk.go
+++ b/cli/azd/pkg/devcentersdk/devcentersdk.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/devcentersdk/developer_client.go
+++ b/cli/azd/pkg/devcentersdk/developer_client.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/devcentersdk/developer_client_test.go
+++ b/cli/azd/pkg/devcentersdk/developer_client_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/devcentersdk/entity_item_request_builder.go
+++ b/cli/azd/pkg/devcentersdk/entity_item_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/devcentersdk/entity_list_request_builder.go
+++ b/cli/azd/pkg/devcentersdk/entity_list_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/devcentersdk/environment_definition_request_builders.go
+++ b/cli/azd/pkg/devcentersdk/environment_definition_request_builders.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/devcentersdk/environment_request_builders.go
+++ b/cli/azd/pkg/devcentersdk/environment_request_builders.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/devcentersdk/environment_type_request_builders.go
+++ b/cli/azd/pkg/devcentersdk/environment_type_request_builders.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/devcentersdk/models.go
+++ b/cli/azd/pkg/devcentersdk/models.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/devcentersdk/outputs_request_builder.go
+++ b/cli/azd/pkg/devcentersdk/outputs_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/devcentersdk/permissions_request_builder.go
+++ b/cli/azd/pkg/devcentersdk/permissions_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/devcentersdk/project_request_builders.go
+++ b/cli/azd/pkg/devcentersdk/project_request_builders.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/devcentersdk/util.go
+++ b/cli/azd/pkg/devcentersdk/util.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/devcentersdk/util.go
+++ b/cli/azd/pkg/devcentersdk/util.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package devcentersdk
 
 import (

--- a/cli/azd/pkg/entraid/entraid.go
+++ b/cli/azd/pkg/entraid/entraid.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package entraid
 
 import (

--- a/cli/azd/pkg/entraid/entraid_test.go
+++ b/cli/azd/pkg/entraid/entraid_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package entraid
 
 import (

--- a/cli/azd/pkg/environment/azdcontext/azdcontext.go
+++ b/cli/azd/pkg/environment/azdcontext/azdcontext.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azdcontext
 
 import (

--- a/cli/azd/pkg/environment/data_store.go
+++ b/cli/azd/pkg/environment/data_store.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package environment
 
 import (

--- a/cli/azd/pkg/environment/environment_init_error.go
+++ b/cli/azd/pkg/environment/environment_init_error.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package environment
 
 import "fmt"

--- a/cli/azd/pkg/environment/local_file_data_store.go
+++ b/cli/azd/pkg/environment/local_file_data_store.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package environment
 
 import (

--- a/cli/azd/pkg/environment/local_file_data_store_test.go
+++ b/cli/azd/pkg/environment/local_file_data_store_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package environment
 
 import (

--- a/cli/azd/pkg/environment/manager.go
+++ b/cli/azd/pkg/environment/manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package environment
 
 import (

--- a/cli/azd/pkg/environment/manager_test.go
+++ b/cli/azd/pkg/environment/manager_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package environment
 
 import (

--- a/cli/azd/pkg/environment/storage_blob_data_store.go
+++ b/cli/azd/pkg/environment/storage_blob_data_store.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package environment
 
 import (

--- a/cli/azd/pkg/environment/storage_blob_data_store_test.go
+++ b/cli/azd/pkg/environment/storage_blob_data_store_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package environment
 
 import (

--- a/cli/azd/pkg/environment/target_resource.go
+++ b/cli/azd/pkg/environment/target_resource.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package environment
 
 type TargetResource struct {

--- a/cli/azd/pkg/exec/command_runner.go
+++ b/cli/azd/pkg/exec/command_runner.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package exec
 
 import (

--- a/cli/azd/pkg/exec/command_runner_test_unix.go
+++ b/cli/azd/pkg/exec/command_runner_test_unix.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 //go:build unix
 
 package exec

--- a/cli/azd/pkg/exec/runargs.go
+++ b/cli/azd/pkg/exec/runargs.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package exec
 
 import (

--- a/cli/azd/pkg/exec/runargs_test.go
+++ b/cli/azd/pkg/exec/runargs_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package exec
 
 import (

--- a/cli/azd/pkg/exec/runresult.go
+++ b/cli/azd/pkg/exec/runresult.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package exec
 
 import (

--- a/cli/azd/pkg/exec/sanitizer.go
+++ b/cli/azd/pkg/exec/sanitizer.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package exec
 
 import (

--- a/cli/azd/pkg/experimentation/assignment.go
+++ b/cli/azd/pkg/experimentation/assignment.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package experimentation
 
 import (

--- a/cli/azd/pkg/experimentation/assignment_test.go
+++ b/cli/azd/pkg/experimentation/assignment_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package experimentation
 
 import (

--- a/cli/azd/pkg/experimentation/client.go
+++ b/cli/azd/pkg/experimentation/client.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package experimentation
 
 import (

--- a/cli/azd/pkg/experimentation/client_test.go
+++ b/cli/azd/pkg/experimentation/client_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package experimentation
 
 import (

--- a/cli/azd/pkg/experimentation/doc.go
+++ b/cli/azd/pkg/experimentation/doc.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 // Package experimentation provides functionality for experimentation in azd. The [AssignmentsManager] can
 // be used to retrieve the current assignment for the current machine.
 package experimentation

--- a/cli/azd/pkg/ext/event_dispatcher.go
+++ b/cli/azd/pkg/ext/event_dispatcher.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ext
 
 import (

--- a/cli/azd/pkg/ext/event_dispatcher_test.go
+++ b/cli/azd/pkg/ext/event_dispatcher_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ext
 
 import (

--- a/cli/azd/pkg/ext/hooks_manager.go
+++ b/cli/azd/pkg/ext/hooks_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ext
 
 import (

--- a/cli/azd/pkg/ext/hooks_manager_test.go
+++ b/cli/azd/pkg/ext/hooks_manager_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ext
 
 import (

--- a/cli/azd/pkg/ext/hooks_runner.go
+++ b/cli/azd/pkg/ext/hooks_runner.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ext
 
 import (

--- a/cli/azd/pkg/ext/hooks_runner_test.go
+++ b/cli/azd/pkg/ext/hooks_runner_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ext
 
 import (

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ext
 
 import (

--- a/cli/azd/pkg/github/remote.go
+++ b/cli/azd/pkg/github/remote.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package github
 
 import (

--- a/cli/azd/pkg/github/remote_test.go
+++ b/cli/azd/pkg/github/remote_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package github
 
 import (

--- a/cli/azd/pkg/graphsdk/application_request_builders.go
+++ b/cli/azd/pkg/graphsdk/application_request_builders.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk
 
 import (

--- a/cli/azd/pkg/graphsdk/application_request_builders_test.go
+++ b/cli/azd/pkg/graphsdk/application_request_builders_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk_test
 
 import (

--- a/cli/azd/pkg/graphsdk/applications_models.go
+++ b/cli/azd/pkg/graphsdk/applications_models.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk
 
 import "time"

--- a/cli/azd/pkg/graphsdk/entity_item_request_builder.go
+++ b/cli/azd/pkg/graphsdk/entity_item_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk
 
 import (

--- a/cli/azd/pkg/graphsdk/entity_list_request_builder.go
+++ b/cli/azd/pkg/graphsdk/entity_list_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk
 
 import (

--- a/cli/azd/pkg/graphsdk/entity_list_request_builder_test.go
+++ b/cli/azd/pkg/graphsdk/entity_list_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk_test
 
 import (

--- a/cli/azd/pkg/graphsdk/fic_models.go
+++ b/cli/azd/pkg/graphsdk/fic_models.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk
 
 type FederatedIdentityCredentialListResponse struct {

--- a/cli/azd/pkg/graphsdk/fic_request_builders.go
+++ b/cli/azd/pkg/graphsdk/fic_request_builders.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk
 
 import (

--- a/cli/azd/pkg/graphsdk/fic_request_builders_test.go
+++ b/cli/azd/pkg/graphsdk/fic_request_builders_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk_test
 
 import (

--- a/cli/azd/pkg/graphsdk/graph_client.go
+++ b/cli/azd/pkg/graphsdk/graph_client.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk
 
 import (

--- a/cli/azd/pkg/graphsdk/graph_client_test.go
+++ b/cli/azd/pkg/graphsdk/graph_client_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk_test
 
 import (

--- a/cli/azd/pkg/graphsdk/graphsdk.go
+++ b/cli/azd/pkg/graphsdk/graphsdk.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk
 
 import (

--- a/cli/azd/pkg/graphsdk/me_request_builder.go
+++ b/cli/azd/pkg/graphsdk/me_request_builder.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk
 
 import (

--- a/cli/azd/pkg/graphsdk/me_request_builder_test.go
+++ b/cli/azd/pkg/graphsdk/me_request_builder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk_test
 
 import (

--- a/cli/azd/pkg/graphsdk/service_principal_models.go
+++ b/cli/azd/pkg/graphsdk/service_principal_models.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk
 
 // A Microsoft Graph Service Principal entity.

--- a/cli/azd/pkg/graphsdk/service_principal_request_builders.go
+++ b/cli/azd/pkg/graphsdk/service_principal_request_builders.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk
 
 import (

--- a/cli/azd/pkg/graphsdk/service_principal_request_builders_test.go
+++ b/cli/azd/pkg/graphsdk/service_principal_request_builders_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk_test
 
 import (

--- a/cli/azd/pkg/graphsdk/user_models.go
+++ b/cli/azd/pkg/graphsdk/user_models.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk
 
 // A Microsoft Graph UserProfile entity.

--- a/cli/azd/pkg/graphsdk/util.go
+++ b/cli/azd/pkg/graphsdk/util.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk
 
 import (

--- a/cli/azd/pkg/graphsdk/util_test.go
+++ b/cli/azd/pkg/graphsdk/util_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package graphsdk_test
 
 import (

--- a/cli/azd/pkg/helm/cli.go
+++ b/cli/azd/pkg/helm/cli.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package helm
 
 import (

--- a/cli/azd/pkg/helm/cli_test.go
+++ b/cli/azd/pkg/helm/cli_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package helm
 
 import (

--- a/cli/azd/pkg/helm/config.go
+++ b/cli/azd/pkg/helm/config.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package helm
 
 type Config struct {

--- a/cli/azd/pkg/httputil/util.go
+++ b/cli/azd/pkg/httputil/util.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package httputil
 
 import (

--- a/cli/azd/pkg/httputil/util_test.go
+++ b/cli/azd/pkg/httputil/util_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package httputil
 
 import (

--- a/cli/azd/pkg/infra/deployment_manager.go
+++ b/cli/azd/pkg/infra/deployment_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package infra
 
 import (

--- a/cli/azd/pkg/infra/provisioning/bicep/prompt.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package bicep
 
 import (

--- a/cli/azd/pkg/infra/provisioning/bicep/prompt_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package bicep
 
 import (

--- a/cli/azd/pkg/infra/provisioning/current_principal_id_provider.go
+++ b/cli/azd/pkg/infra/provisioning/current_principal_id_provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package provisioning
 
 import (

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package terraform
 
 import (

--- a/cli/azd/pkg/infra/scope_test.go
+++ b/cli/azd/pkg/infra/scope_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package infra
 
 import (

--- a/cli/azd/pkg/input/external_prompt_client.go
+++ b/cli/azd/pkg/input/external_prompt_client.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package input
 
 import (

--- a/cli/azd/pkg/installer/installed_by.go
+++ b/cli/azd/pkg/installer/installed_by.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package installer
 
 import (

--- a/cli/azd/pkg/ioc/binding.go
+++ b/cli/azd/pkg/ioc/binding.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ioc
 
 // binding represents the metadata used for an IoC registration consisting of a optional name and resolver.

--- a/cli/azd/pkg/ioc/container.go
+++ b/cli/azd/pkg/ioc/container.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 // This package wraps the golobby/container package to provide support for the following:
 // 1. Easier usage of lazy type resolvers and ability to register specific type instances
 // 2. Support for hierarchical/nested containers to resolve types from parent containers

--- a/cli/azd/pkg/ioc/container_test.go
+++ b/cli/azd/pkg/ioc/container_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ioc
 
 import (

--- a/cli/azd/pkg/ioc/service_locator.go
+++ b/cli/azd/pkg/ioc/service_locator.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ioc
 
 type ServiceLocator interface {

--- a/cli/azd/pkg/keyvault/keyvault.go
+++ b/cli/azd/pkg/keyvault/keyvault.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package keyvault
 
 import (

--- a/cli/azd/pkg/kubelogin/cli.go
+++ b/cli/azd/pkg/kubelogin/cli.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package kubelogin
 
 import (

--- a/cli/azd/pkg/kustomize/cli.go
+++ b/cli/azd/pkg/kustomize/cli.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package kustomize
 
 import (

--- a/cli/azd/pkg/kustomize/cli_test.go
+++ b/cli/azd/pkg/kustomize/cli_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package kustomize
 
 import (

--- a/cli/azd/pkg/kustomize/config.go
+++ b/cli/azd/pkg/kustomize/config.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package kustomize
 
 import "github.com/azure/azure-dev/cli/azd/pkg/osutil"

--- a/cli/azd/pkg/lazy/lazy.go
+++ b/cli/azd/pkg/lazy/lazy.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package lazy
 
 import "sync"

--- a/cli/azd/pkg/lazy/lazy_test.go
+++ b/cli/azd/pkg/lazy/lazy_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package lazy
 
 import (

--- a/cli/azd/pkg/osutil/osversion/osversion.go
+++ b/cli/azd/pkg/osutil/osversion/osversion.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 //go:build !windows && !linux && !darwin
 
 package osversion

--- a/cli/azd/pkg/osutil/osversion/osversion_darwin.go
+++ b/cli/azd/pkg/osutil/osversion/osversion_darwin.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package osversion
 
 /*

--- a/cli/azd/pkg/osutil/osversion/osversion_linux.go
+++ b/cli/azd/pkg/osutil/osversion/osversion_linux.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package osversion
 
 import (

--- a/cli/azd/pkg/osutil/osversion/osversion_test.go
+++ b/cli/azd/pkg/osutil/osversion/osversion_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package osversion
 
 import (

--- a/cli/azd/pkg/osutil/osversion/osversion_windows.go
+++ b/cli/azd/pkg/osutil/osversion/osversion_windows.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package osversion
 
 import (

--- a/cli/azd/pkg/osutil/permissions.go
+++ b/cli/azd/pkg/osutil/permissions.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package osutil
 
 import "os"

--- a/cli/azd/pkg/osutil/retry_strategy.go
+++ b/cli/azd/pkg/osutil/retry_strategy.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package osutil
 
 import (

--- a/cli/azd/pkg/output/colors.go
+++ b/cli/azd/pkg/output/colors.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package output
 
 import (

--- a/cli/azd/pkg/output/links.go
+++ b/cli/azd/pkg/output/links.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package output
 
 type Link struct {

--- a/cli/azd/pkg/platform/platform.go
+++ b/cli/azd/pkg/platform/platform.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package platform
 
 import (

--- a/cli/azd/pkg/platform/platform_test.go
+++ b/cli/azd/pkg/platform/platform_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package platform
 
 import (

--- a/cli/azd/pkg/platform/provider.go
+++ b/cli/azd/pkg/platform/provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package platform
 
 import "github.com/azure/azure-dev/cli/azd/pkg/ioc"

--- a/cli/azd/pkg/project/ai_helper.go
+++ b/cli/azd/pkg/project/ai_helper.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/ai_helper_test.go
+++ b/cli/azd/pkg/project/ai_helper_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/container_helper_test.go
+++ b/cli/azd/pkg/project/container_helper_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/dotnet_importer.go
+++ b/cli/azd/pkg/project/dotnet_importer.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/dotnet_importer_test.go
+++ b/cli/azd/pkg/project/dotnet_importer_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/framework_service_maven.go
+++ b/cli/azd/pkg/project/framework_service_maven.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/framework_service_maven_test.go
+++ b/cli/azd/pkg/project/framework_service_maven_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/framework_service_noop.go
+++ b/cli/azd/pkg/project/framework_service_noop.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/framework_service_npm_test.go
+++ b/cli/azd/pkg/project/framework_service_npm_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/project.go
+++ b/cli/azd/pkg/project/project.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/project_config.go
+++ b/cli/azd/pkg/project/project_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/project_config_test.go
+++ b/cli/azd/pkg/project/project_config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/resource_manager.go
+++ b/cli/azd/pkg/project/resource_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/resource_manager_test.go
+++ b/cli/azd/pkg/project/resource_manager_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/service_config_test.go
+++ b/cli/azd/pkg/project/service_config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/service_manager_test.go
+++ b/cli/azd/pkg/project/service_manager_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/service_models.go
+++ b/cli/azd/pkg/project/service_models.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/service_models_test.go
+++ b/cli/azd/pkg/project/service_models_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/service_target_ai_endpoint.go
+++ b/cli/azd/pkg/project/service_target_ai_endpoint.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/service_target_ai_endpoint_test.go
+++ b/cli/azd/pkg/project/service_target_ai_endpoint_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package project
 
 import (

--- a/cli/azd/pkg/prompt/prompter.go
+++ b/cli/azd/pkg/prompt/prompter.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package prompt
 
 import (

--- a/cli/azd/pkg/sqldb/sqldb.go
+++ b/cli/azd/pkg/sqldb/sqldb.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package sqldb
 
 import (

--- a/cli/azd/pkg/state/config.go
+++ b/cli/azd/pkg/state/config.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package state
 
 // Config is the state configuration for an azd project

--- a/cli/azd/pkg/templates/awesome_source.go
+++ b/cli/azd/pkg/templates/awesome_source.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/templates/awesome_source_test.go
+++ b/cli/azd/pkg/templates/awesome_source_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/templates/file_source.go
+++ b/cli/azd/pkg/templates/file_source.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/templates/file_source_test.go
+++ b/cli/azd/pkg/templates/file_source_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/templates/gh_source.go
+++ b/cli/azd/pkg/templates/gh_source.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/templates/gh_source_test.go
+++ b/cli/azd/pkg/templates/gh_source_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/templates/json_source.go
+++ b/cli/azd/pkg/templates/json_source.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/templates/json_source_test.go
+++ b/cli/azd/pkg/templates/json_source_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/templates/path.go
+++ b/cli/azd/pkg/templates/path.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/templates/source.go
+++ b/cli/azd/pkg/templates/source.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/templates/source_manager.go
+++ b/cli/azd/pkg/templates/source_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/templates/source_manager_test.go
+++ b/cli/azd/pkg/templates/source_manager_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/templates/template.go
+++ b/cli/azd/pkg/templates/template.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/templates/template_manager.go
+++ b/cli/azd/pkg/templates/template_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/templates/template_manager_test.go
+++ b/cli/azd/pkg/templates/template_manager_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/templates/url_source.go
+++ b/cli/azd/pkg/templates/url_source.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/templates/url_source_test.go
+++ b/cli/azd/pkg/templates/url_source_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package templates
 
 import (

--- a/cli/azd/pkg/tools/bash/bash.go
+++ b/cli/azd/pkg/tools/bash/bash.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package bash
 
 import (

--- a/cli/azd/pkg/tools/bash/bash_test.go
+++ b/cli/azd/pkg/tools/bash/bash_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package bash
 
 import (

--- a/cli/azd/pkg/tools/bicep/bicep_test.go
+++ b/cli/azd/pkg/tools/bicep/bicep_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package bicep
 
 import (

--- a/cli/azd/pkg/tools/docker/container_image.go
+++ b/cli/azd/pkg/tools/docker/container_image.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package docker
 
 import (

--- a/cli/azd/pkg/tools/docker/container_image_test.go
+++ b/cli/azd/pkg/tools/docker/container_image_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package docker
 
 import (

--- a/cli/azd/pkg/tools/docker/docker.go
+++ b/cli/azd/pkg/tools/docker/docker.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package docker
 
 import (

--- a/cli/azd/pkg/tools/docker/docker_test.go
+++ b/cli/azd/pkg/tools/docker/docker_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package docker
 
 import (

--- a/cli/azd/pkg/tools/dotnet/dotnet_test.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package dotnet
 
 import (

--- a/cli/azd/pkg/tools/ensure.go
+++ b/cli/azd/pkg/tools/ensure.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package tools
 
 import (

--- a/cli/azd/pkg/tools/ensure_test.go
+++ b/cli/azd/pkg/tools/ensure_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package tools
 
 import (

--- a/cli/azd/pkg/tools/github/github_test.go
+++ b/cli/azd/pkg/tools/github/github_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package github
 
 import (

--- a/cli/azd/pkg/tools/javac/javac.go
+++ b/cli/azd/pkg/tools/javac/javac.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package javac
 
 import (

--- a/cli/azd/pkg/tools/javac/javac_test.go
+++ b/cli/azd/pkg/tools/javac/javac_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package javac
 
 import (

--- a/cli/azd/pkg/tools/kubectl/kube_config.go
+++ b/cli/azd/pkg/tools/kubectl/kube_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package kubectl
 
 import (

--- a/cli/azd/pkg/tools/kubectl/kube_config_test.go
+++ b/cli/azd/pkg/tools/kubectl/kube_config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package kubectl
 
 import (

--- a/cli/azd/pkg/tools/kubectl/kubectl.go
+++ b/cli/azd/pkg/tools/kubectl/kubectl.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package kubectl
 
 import (

--- a/cli/azd/pkg/tools/kubectl/kubectl_test.go
+++ b/cli/azd/pkg/tools/kubectl/kubectl_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package kubectl
 
 import (

--- a/cli/azd/pkg/tools/kubectl/models.go
+++ b/cli/azd/pkg/tools/kubectl/models.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package kubectl
 
 import (

--- a/cli/azd/pkg/tools/kubectl/models_test.go
+++ b/cli/azd/pkg/tools/kubectl/models_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package kubectl
 
 import (

--- a/cli/azd/pkg/tools/kubectl/util.go
+++ b/cli/azd/pkg/tools/kubectl/util.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package kubectl
 
 import (

--- a/cli/azd/pkg/tools/maven/maven.go
+++ b/cli/azd/pkg/tools/maven/maven.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package maven
 
 import (

--- a/cli/azd/pkg/tools/maven/maven_test.go
+++ b/cli/azd/pkg/tools/maven/maven_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package maven
 
 import (

--- a/cli/azd/pkg/tools/pack/pack.go
+++ b/cli/azd/pkg/tools/pack/pack.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package pack
 
 import (

--- a/cli/azd/pkg/tools/pack/pack_test.go
+++ b/cli/azd/pkg/tools/pack/pack_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package pack
 
 import (

--- a/cli/azd/pkg/tools/powershell/powershell.go
+++ b/cli/azd/pkg/tools/powershell/powershell.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package powershell
 
 import (

--- a/cli/azd/pkg/tools/powershell/powershell_test.go
+++ b/cli/azd/pkg/tools/powershell/powershell_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package powershell
 
 import (

--- a/cli/azd/pkg/tools/python/python_test.go
+++ b/cli/azd/pkg/tools/python/python_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package python
 
 import (

--- a/cli/azd/pkg/tools/script.go
+++ b/cli/azd/pkg/tools/script.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package tools
 
 import (

--- a/cli/azd/pkg/tools/terraform/terraform_test.go
+++ b/cli/azd/pkg/tools/terraform/terraform_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package terraform
 
 import (

--- a/cli/azd/pkg/workflow/config.go
+++ b/cli/azd/pkg/workflow/config.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package workflow
 
 // Stores a map of workflows configured for an azd project

--- a/cli/azd/pkg/workflow/config_test.go
+++ b/cli/azd/pkg/workflow/config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package workflow
 
 import (

--- a/cli/azd/pkg/workflow/runner.go
+++ b/cli/azd/pkg/workflow/runner.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package workflow
 
 import (

--- a/cli/azd/pkg/workflow/workflow.go
+++ b/cli/azd/pkg/workflow/workflow.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package workflow
 
 import (

--- a/cli/azd/resources/resources.go
+++ b/cli/azd/resources/resources.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package resources
 
 import (

--- a/cli/azd/test/azdcli/cli.go
+++ b/cli/azd/test/azdcli/cli.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 // ------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.

--- a/cli/azd/test/azdcli/util.go
+++ b/cli/azd/test/azdcli/util.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package azdcli
 
 // GetOutputFlagValue returns the value specified by --output.

--- a/cli/azd/test/cmdrecord/proxy/main.go
+++ b/cli/azd/test/cmdrecord/proxy/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package main
 
 import (

--- a/cli/azd/test/functional/deploy_test.go
+++ b/cli/azd/test/functional/deploy_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cli_test
 
 import (

--- a/cli/azd/test/functional/deployment_stacks_test.go
+++ b/cli/azd/test/functional/deployment_stacks_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cli_test
 
 import (

--- a/cli/azd/test/functional/experiment_test.go
+++ b/cli/azd/test/functional/experiment_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cli_test
 
 import (

--- a/cli/azd/test/functional/initialize_test.go
+++ b/cli/azd/test/functional/initialize_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cli_test
 
 import (

--- a/cli/azd/test/functional/login_test.go
+++ b/cli/azd/test/functional/login_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cli_test
 
 import (

--- a/cli/azd/test/functional/package_test.go
+++ b/cli/azd/test/functional/package_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cli_test
 
 import (

--- a/cli/azd/test/functional/remote_state_test.go
+++ b/cli/azd/test/functional/remote_state_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cli_test
 
 import (

--- a/cli/azd/test/functional/restore_test.go
+++ b/cli/azd/test/functional/restore_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cli_test
 
 import (

--- a/cli/azd/test/internal/tfoidc/main.go
+++ b/cli/azd/test/internal/tfoidc/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 // Program tfoidc is a simple adapter that presents a GitHub Actions style OIDC token endpoint backed by an Azure
 // DevOps service connection. It can also be used to continuously refresh the Azure CLI federated token, as the
 // AzureCLI task would.

--- a/cli/azd/test/mocks/mock_context.go
+++ b/cli/azd/test/mocks/mock_context.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mocks
 
 import (

--- a/cli/azd/test/mocks/mock_credentials.go
+++ b/cli/azd/test/mocks/mock_credentials.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mocks
 
 import (

--- a/cli/azd/test/mocks/mock_user_agent_policy.go
+++ b/cli/azd/test/mocks/mock_user_agent_policy.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mocks
 
 import (

--- a/cli/azd/test/mocks/mockaccount/mock_manager.go
+++ b/cli/azd/test/mocks/mockaccount/mock_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockaccount
 
 import (

--- a/cli/azd/test/mocks/mockai/deployments.go
+++ b/cli/azd/test/mocks/mockai/deployments.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockai
 
 import (

--- a/cli/azd/test/mocks/mockai/endpoints.go
+++ b/cli/azd/test/mocks/mockai/endpoints.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockai
 
 import (

--- a/cli/azd/test/mocks/mockai/environments.go
+++ b/cli/azd/test/mocks/mockai/environments.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockai
 
 import (

--- a/cli/azd/test/mocks/mockai/models.go
+++ b/cli/azd/test/mocks/mockai/models.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockai
 
 import (

--- a/cli/azd/test/mocks/mockai/workspaces.go
+++ b/cli/azd/test/mocks/mockai/workspaces.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockai
 
 import (

--- a/cli/azd/test/mocks/mockarmresources/mockarmresources.go
+++ b/cli/azd/test/mocks/mockarmresources/mockarmresources.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockarmresources
 
 import (

--- a/cli/azd/test/mocks/mockarmresources/subscriptions.go
+++ b/cli/azd/test/mocks/mockarmresources/subscriptions.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockarmresources
 
 import (

--- a/cli/azd/test/mocks/mockazapi/mocks.go
+++ b/cli/azd/test/mocks/mockazapi/mocks.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockazapi
 
 import (

--- a/cli/azd/test/mocks/mockazsdk/container_apps.go
+++ b/cli/azd/test/mocks/mockazsdk/container_apps.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockazsdk
 
 import (

--- a/cli/azd/test/mocks/mockazsdk/container_registry.go
+++ b/cli/azd/test/mocks/mockazsdk/container_registry.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockazsdk
 
 import (

--- a/cli/azd/test/mocks/mockconfig/mock_config.go
+++ b/cli/azd/test/mocks/mockconfig/mock_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockconfig
 
 import "github.com/azure/azure-dev/cli/azd/pkg/config"

--- a/cli/azd/test/mocks/mockdevcentersdk/mocks.go
+++ b/cli/azd/test/mocks/mockdevcentersdk/mocks.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockdevcentersdk
 
 import (

--- a/cli/azd/test/mocks/mockenv/mock_manager.go
+++ b/cli/azd/test/mocks/mockenv/mock_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockenv
 
 import (

--- a/cli/azd/test/mocks/mockexec/mock_runner.go
+++ b/cli/azd/test/mocks/mockexec/mock_runner.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockexec
 
 import (

--- a/cli/azd/test/mocks/mockgraphsdk/mocks.go
+++ b/cli/azd/test/mocks/mockgraphsdk/mocks.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockgraphsdk
 
 import (

--- a/cli/azd/test/mocks/mockhttp/mock_http_client.go
+++ b/cli/azd/test/mocks/mockhttp/mock_http_client.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockhttp
 
 import (

--- a/cli/azd/test/mocks/mockinput/mock_console.go
+++ b/cli/azd/test/mocks/mockinput/mock_console.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockinput
 
 import (

--- a/cli/azd/test/mocks/mockzip/mockzip.go
+++ b/cli/azd/test/mocks/mockzip/mockzip.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mockzip
 
 import (

--- a/cli/azd/test/mocks/util.go
+++ b/cli/azd/test/mocks/util.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package mocks
 
 import (

--- a/cli/azd/test/ostest/ostest.go
+++ b/cli/azd/test/ostest/ostest.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package ostest
 
 import (

--- a/cli/azd/test/recording/proxy_test.go
+++ b/cli/azd/test/recording/proxy_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package recording
 
 import (

--- a/cli/azd/test/recording/sanitize.go
+++ b/cli/azd/test/recording/sanitize.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package recording
 
 import (

--- a/eng/scripts/copyright-check.sh
+++ b/eng/scripts/copyright-check.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+HEADER1="// Copyright (c) Microsoft Corporation. All rights reserved."
+HEADER2="// Licensed under the MIT License."
+
+check_header() {
+    local file=$1
+    if ! head -n 1 "$file" | grep -q "$HEADER1"; then
+        echo "Missing or incorrect first line of header in $file"
+        return 1
+    fi
+    if ! head -n 2 "$file" | tail -n 1 | grep -q "$HEADER2"; then
+        echo "Missing or incorrect second line of header in $file"
+        return 1
+    fi
+    return 0
+}
+
+insert_header() {
+    local file=$1
+    echo "Inserting header in $file"
+    (echo "$HEADER1"; echo "$HEADER2"; echo ""; cat "$file") > "$file.tmp" && mv "$file.tmp" "$file"
+}
+
+validate_headers() {
+    local directory=$1
+    local insert_missing=$2
+    local all_files_valid=0
+    for file in $(find "$directory" -name '*.go'); do
+        if ! check_header "$file"; then
+            all_files_valid=1
+            if [ "$insert_missing" = true ]; then
+                insert_header "$file"
+            fi
+        fi
+    done
+    return $all_files_valid
+}
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+    echo "Usage: $0 <directory> [--fix]"
+    exit 1
+fi
+
+DIRECTORY=$1
+INSERT_MISSING=false
+
+if [ "$#" -eq 2 ] && [ "$2" = "--fix" ]; then
+    INSERT_MISSING=true
+fi
+
+validate_headers "$DIRECTORY" "$INSERT_MISSING"


### PR DESCRIPTION
The open source code in the Azure open source GitHub organization must include a copyright header at the top of every source file. According to the Microsoft Open Source Guidelines.

Adding script to check and optionally fix.
To fix files, run:

```sh
./eng/scripts/copyright-check.sh ./cli/azd --fix
```

