### PR TITLE
update bicep 33.93

### DIFF
--- a/cli/azd/pkg/tools/bicep/bicep.go
+++ b/cli/azd/pkg/tools/bicep/bicep.go
@@ -25,7 +25,7 @@ import (
 
 // Version is the minimum version of bicep that we require (and the one we fetch when we fetch bicep on behalf of a
 // user).
-var Version semver.Version = semver.MustParse("0.33.13")
+var Version semver.Version = semver.MustParse("0.33.93")
 
 // NewCli creates a new Bicep CLI. Azd manages its own copy of the bicep CLI, stored in `$AZD_CONFIG_DIR/bin`. If
 // bicep is not present at this location, or if it is present but is older than the minimum supported version, it is


### PR DESCRIPTION
update from bicep: https://github.com/Azure/bicep/releases/tag/v0.33.93

Highlights
•	Address v0.33.13 language server crash/stack overflow (#16235)
•	Address v0.33.13 deployment failures when depending on looped resources in non-symbolic name templates (#16236)
•	Release Deployment Pane as a non-experimental feature (#16173)

Other bugs and features
•	Offer code fix to fully qualify function call for shadowed decorator functions (#16116)
