### PR TITLE
support for default location

### DIFF
--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -307,7 +307,8 @@ func (e *envSetSecretAction) Run(ctx context.Context) (*actions.ActionResult, er
 	}
 
 	if willCreateNewKvAccount {
-		location, err := e.prompter.PromptLocation(ctx, subId, "Select the location to create the Key Vault", nil)
+		location, err := e.prompter.PromptLocation(
+			ctx, subId, "Select the location to create the Key Vault", nil, nil)
 		if err != nil {
 			return nil, fmt.Errorf("prompting for Key Vault location: %w", err)
 		}
@@ -788,7 +789,7 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 	if errors.Is(err, bicep.ErrEnsureEnvPreReqBicepCompileFailed) {
 		// If bicep is not available, we continue to prompt for subscription and location unfiltered
 		err = provisioning.EnsureSubscriptionAndLocation(ctx, ef.envManager, ef.env, ef.prompters,
-			func(_ account.Location) bool { return true })
+			provisioning.EnsureSubscriptionAndLocationOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/cli/azd/cmd/up.go
+++ b/cli/azd/cmd/up.go
@@ -116,7 +116,8 @@ func (u *upAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	err = u.provisioningManager.Initialize(ctx, u.projectConfig.Path, infra.Options)
 	if errors.Is(err, bicep.ErrEnsureEnvPreReqBicepCompileFailed) {
 		// If bicep is not available, we continue to prompt for subscription and location unfiltered
-		err = provisioning.EnsureSubscriptionAndLocation(ctx, u.envManager, u.env, u.prompters, nil)
+		err = provisioning.EnsureSubscriptionAndLocation(
+			ctx, u.envManager, u.env, u.prompters, provisioning.EnsureSubscriptionAndLocationOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/cli/azd/internal/cmd/add/add_preview.go
+++ b/cli/azd/internal/cmd/add/add_preview.go
@@ -78,7 +78,8 @@ func (a *AddAction) previewProvision(
 	usedBy []string,
 ) error {
 	a.console.ShowSpinner(ctx, "Previewing changes....", input.Step)
-	err := provisioning.EnsureSubscriptionAndLocation(ctx, a.envManager, a.env, a.prompter, nil)
+	err := provisioning.EnsureSubscriptionAndLocation(
+		ctx, a.envManager, a.env, a.prompter, provisioning.EnsureSubscriptionAndLocationOptions{})
 	if err != nil {
 		return err
 	}

--- a/cli/azd/internal/cmd/add/add_select_ai.go
+++ b/cli/azd/internal/cmd/add/add_select_ai.go
@@ -41,7 +41,8 @@ func (a *AddAction) selectOpenAi(
 
 	var allModels []ModelList
 	for {
-		err = provisioning.EnsureSubscriptionAndLocation(ctx, a.envManager, a.env, a.prompter, nil)
+		err = provisioning.EnsureSubscriptionAndLocation(
+			ctx, a.envManager, a.env, a.prompter, provisioning.EnsureSubscriptionAndLocationOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/cli/azd/pkg/azure/arm_template.go
+++ b/cli/azd/pkg/azure/arm_template.go
@@ -143,7 +143,7 @@ type AzdMetadata struct {
 	Type               *AzdMetadataType `json:"type,omitempty"`
 	AutoGenerateConfig *AutoGenInput    `json:"config,omitempty"`
 	DefaultValueExpr   *string          `json:"defaultValueExpr,omitempty"`
-	DefaultLocation    *string          `json:"defaultLocation,omitempty"`
+	Default            *string          `json:"default,omitempty"`
 }
 
 // Description returns the value of the "Description" string metadata for this parameter or empty if it can not be found.

--- a/cli/azd/pkg/azure/arm_template.go
+++ b/cli/azd/pkg/azure/arm_template.go
@@ -143,6 +143,7 @@ type AzdMetadata struct {
 	Type               *AzdMetadataType `json:"type,omitempty"`
 	AutoGenerateConfig *AutoGenInput    `json:"config,omitempty"`
 	DefaultValueExpr   *string          `json:"defaultValueExpr,omitempty"`
+	DefaultLocation    *string          `json:"defaultLocation,omitempty"`
 }
 
 // Description returns the value of the "Description" string metadata for this parameter or empty if it can not be found.

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -199,9 +199,9 @@ func defaultLocationToSelectFn(locationParam azure.ArmTemplateParameterDefinitio
 	azdMetadata, has := locationParam.AzdMetadata()
 	if has &&
 		azdMetadata.Type != nil && *azdMetadata.Type == azure.AzdMetadataTypeLocation &&
-		azdMetadata.DefaultLocation != nil {
+		azdMetadata.Default != nil {
 		// Metadata using location type and a default location. This is the highest priority.
-		return azdMetadata.DefaultLocation
+		return azdMetadata.Default
 	}
 
 	if locationParam.AllowedValues != nil {

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -140,7 +140,7 @@ func (p *BicepProvider) EnsureEnv(ctx context.Context) error {
 		}
 		var defaultLocationToSelect *string
 		if locationParamDefined {
-			defaultLocationToSelect = defaultLocationToSelectFn(locationParam)
+			defaultLocationToSelect = defaultPromptValue(locationParam)
 		}
 
 		err := provisioning.EnsureSubscriptionAndLocation(
@@ -190,12 +190,12 @@ func locationParameterFilterImpl(param azure.ArmTemplateParameterDefinition, loc
 	}) != -1
 }
 
-// defaultLocationToSelectFn resolves if there is an intention from a location parameter to use a default location.
-// If the parameter has the @allowedValues set, it will return the first value from the array as the default.
-// If the parameter has the location azd metadata, it will check if there is configuration to set a default location.
-// If both @allowedValues and azd location metadata config are set, the metadata config will take precedence.
-// If nothing is set, it will return nil.
-func defaultLocationToSelectFn(locationParam azure.ArmTemplateParameterDefinition) *string {
+// defaultPromptValue resolves if there is an intention from a location parameter to use a default location.
+//
+// If the parameter has AzdMetadataTypeLocation, with a default location set, the default location is returned.
+// If the parameter has AllowedValues, the first option value is returned.
+// Otherwise, nil is returned to indicate no user-provided default value.
+func defaultPromptValue(locationParam azure.ArmTemplateParameterDefinition) *string {
 	azdMetadata, has := locationParam.AzdMetadata()
 	if has &&
 		azdMetadata.Type != nil && *azdMetadata.Type == azure.AzdMetadataTypeLocation &&

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -1358,7 +1358,7 @@ func TestInputsParameter(t *testing.T) {
 func TestDefaultLocationToSelectFn(t *testing.T) {
 	t.Run("NoAllowedValuesOrMetadata", func(t *testing.T) {
 		param := azure.ArmTemplateParameterDefinition{}
-		result := defaultLocationToSelectFn(param)
+		result := defaultPromptValue(param)
 		require.Nil(t, result)
 	})
 
@@ -1366,7 +1366,7 @@ func TestDefaultLocationToSelectFn(t *testing.T) {
 		param := azure.ArmTemplateParameterDefinition{
 			AllowedValues: &[]any{"eastus", "westus"},
 		}
-		result := defaultLocationToSelectFn(param)
+		result := defaultPromptValue(param)
 		require.NotNil(t, result)
 		require.Equal(t, "eastus", *result)
 	})
@@ -1378,7 +1378,7 @@ func TestDefaultLocationToSelectFn(t *testing.T) {
 				"azd": json.RawMessage(`{"type": "location", "default": "centralus"}`),
 			},
 		}
-		result := defaultLocationToSelectFn(param)
+		result := defaultPromptValue(param)
 		require.NotNil(t, result)
 		require.Equal(t, defaultLocation, *result)
 	})
@@ -1391,7 +1391,7 @@ func TestDefaultLocationToSelectFn(t *testing.T) {
 				"azd": json.RawMessage(`{"type": "location", "default": "centralus"}`),
 			},
 		}
-		result := defaultLocationToSelectFn(param)
+		result := defaultPromptValue(param)
 		require.NotNil(t, result)
 		require.Equal(t, defaultLocation, *result)
 	})
@@ -1402,7 +1402,7 @@ func TestDefaultLocationToSelectFn(t *testing.T) {
 				"azd": json.RawMessage(`{"type": "location"}`),
 			},
 		}
-		result := defaultLocationToSelectFn(param)
+		result := defaultPromptValue(param)
 		require.Nil(t, result)
 	})
 }

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -1355,3 +1355,54 @@ func TestInputsParameter(t *testing.T) {
 
 	require.Equal(t, expectedInputsUpdated, inputsUpdated)
 }
+func TestDefaultLocationToSelectFn(t *testing.T) {
+	t.Run("NoAllowedValuesOrMetadata", func(t *testing.T) {
+		param := azure.ArmTemplateParameterDefinition{}
+		result := defaultLocationToSelectFn(param)
+		require.Nil(t, result)
+	})
+
+	t.Run("AllowedValuesOnly", func(t *testing.T) {
+		param := azure.ArmTemplateParameterDefinition{
+			AllowedValues: &[]any{"eastus", "westus"},
+		}
+		result := defaultLocationToSelectFn(param)
+		require.NotNil(t, result)
+		require.Equal(t, "eastus", *result)
+	})
+
+	t.Run("MetadataOnly", func(t *testing.T) {
+		defaultLocation := "centralus"
+		param := azure.ArmTemplateParameterDefinition{
+			Metadata: map[string]json.RawMessage{
+				"azd": json.RawMessage(`{"type": "location", "default": "centralus"}`),
+			},
+		}
+		result := defaultLocationToSelectFn(param)
+		require.NotNil(t, result)
+		require.Equal(t, defaultLocation, *result)
+	})
+
+	t.Run("AllowedValuesAndMetadata", func(t *testing.T) {
+		defaultLocation := "centralus"
+		param := azure.ArmTemplateParameterDefinition{
+			AllowedValues: &[]any{"eastus", "westus"},
+			Metadata: map[string]json.RawMessage{
+				"azd": json.RawMessage(`{"type": "location", "default": "centralus"}`),
+			},
+		}
+		result := defaultLocationToSelectFn(param)
+		require.NotNil(t, result)
+		require.Equal(t, defaultLocation, *result)
+	})
+
+	t.Run("InvalidMetadata", func(t *testing.T) {
+		param := azure.ArmTemplateParameterDefinition{
+			Metadata: map[string]json.RawMessage{
+				"azd": json.RawMessage(`{"type": "location"}`),
+			},
+		}
+		result := defaultLocationToSelectFn(param)
+		require.Nil(t, result)
+	})
+}

--- a/cli/azd/pkg/infra/provisioning/bicep/prompt.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"slices"
 	"strconv"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -97,14 +96,7 @@ func (p *BicepProvider) promptForParameter(
 		*azdMetadata.Type == azure.AzdMetadataTypeLocation {
 
 		location, err := p.prompters.PromptLocation(ctx, p.env.GetSubscriptionId(), msg, func(loc account.Location) bool {
-			if param.AllowedValues == nil {
-				return true
-			}
-
-			return slices.IndexFunc(*param.AllowedValues, func(v any) bool {
-				s, ok := v.(string)
-				return ok && loc.Name == s
-			}) != -1
+			return locationParameterFilterImpl(param, loc)
 		}, defaultLocationToSelectFn(param))
 		if err != nil {
 			return nil, err

--- a/cli/azd/pkg/infra/provisioning/bicep/prompt.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt.go
@@ -105,8 +105,7 @@ func (p *BicepProvider) promptForParameter(
 				s, ok := v.(string)
 				return ok && loc.Name == s
 			}) != -1
-		},
-		)
+		}, defaultLocationToSelectFn(param))
 		if err != nil {
 			return nil, err
 		}

--- a/cli/azd/pkg/infra/provisioning/bicep/prompt.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt.go
@@ -97,7 +97,7 @@ func (p *BicepProvider) promptForParameter(
 
 		location, err := p.prompters.PromptLocation(ctx, p.env.GetSubscriptionId(), msg, func(loc account.Location) bool {
 			return locationParameterFilterImpl(param, loc)
-		}, defaultLocationToSelectFn(param))
+		}, defaultPromptValue(param))
 		if err != nil {
 			return nil, err
 		}

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -332,6 +332,13 @@ func (m *Manager) UpdateEnvironment(
 	return nil
 }
 
+type EnsureSubscriptionAndLocationOptions struct {
+	// LocationFilterPredicate is a function to filter the locations being displayed if prompting the user for the location.
+	LocationFiler prompt.LocationFilterPredicate
+	// SelectDefaultLocation is the default location that azd mark as selected when prompting the user for the location.
+	SelectDefaultLocation *string
+}
+
 // EnsureSubscriptionAndLocation ensures that that that subscription (AZURE_SUBSCRIPTION_ID) and location (AZURE_LOCATION)
 // variables are set in the environment, prompting the user for the values if they do not exist.
 // locationFilter, when non-nil, filters the locations being displayed.
@@ -340,7 +347,7 @@ func EnsureSubscriptionAndLocation(
 	envManager environment.Manager,
 	env *environment.Environment,
 	prompter prompt.Prompter,
-	locationFiler prompt.LocationFilterPredicate,
+	options EnsureSubscriptionAndLocationOptions,
 ) error {
 	subId := env.GetSubscriptionId()
 	if subId == "" {
@@ -366,7 +373,8 @@ func EnsureSubscriptionAndLocation(
 			ctx,
 			env.GetSubscriptionId(),
 			"Select an Azure location to use:",
-			locationFiler,
+			options.LocationFiler,
+			options.SelectDefaultLocation,
 		)
 		if err != nil {
 			return err

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -130,7 +130,7 @@ func (t *TerraformProvider) EnsureEnv(ctx context.Context) error {
 		t.envManager,
 		t.env,
 		t.prompters,
-		nil,
+		provisioning.EnsureSubscriptionAndLocationOptions{},
 	)
 }
 

--- a/cli/azd/pkg/infra/provisioning/test/test_provider.go
+++ b/cli/azd/pkg/infra/provisioning/test/test_provider.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -54,7 +53,7 @@ func (t *TestProvider) EnsureEnv(ctx context.Context) error {
 		t.envManager,
 		t.env,
 		t.prompters,
-		func(_ account.Location) bool { return true },
+		provisioning.EnsureSubscriptionAndLocationOptions{},
 	)
 }
 

--- a/cli/azd/pkg/prompt/prompter.go
+++ b/cli/azd/pkg/prompt/prompter.go
@@ -28,7 +28,12 @@ type LocationFilterPredicate func(loc account.Location) bool
 
 type Prompter interface {
 	PromptSubscription(ctx context.Context, msg string) (subscriptionId string, err error)
-	PromptLocation(ctx context.Context, subId string, msg string, filter LocationFilterPredicate) (string, error)
+	PromptLocation(
+		ctx context.Context,
+		subId string,
+		msg string,
+		filter LocationFilterPredicate,
+		defaultLocation *string) (string, error)
 	PromptResourceGroup(ctx context.Context) (string, error)
 	PromptResourceGroupFrom(
 		ctx context.Context, subscriptionId string, location string, options PromptResourceGroupFromOptions) (string, error)
@@ -101,8 +106,9 @@ func (p *DefaultPrompter) PromptLocation(
 	subId string,
 	msg string,
 	filter LocationFilterPredicate,
+	defaultLocation *string,
 ) (string, error) {
-	loc, err := azureutil.PromptLocationWithFilter(ctx, subId, msg, "", p.console, p.accountManager, filter)
+	loc, err := azureutil.PromptLocationWithFilter(ctx, subId, msg, "", p.console, p.accountManager, filter, defaultLocation)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR adds the ability to set a default location, as part of the bicep definition, to be selected by azd during user prompt.

This feature works with priority levels. The default location setting priority is as follows, from highest to lowest:
- 1. Set AZURE_LOCATION in system environment for the main project `location`.  Azd skips the location prompt for main location and uses the value from the system environment when set.
- 2. Use azd metadata for bicep parameter like:

```bicep
@metadata({azd: { 
  type: 'location'
  defaultLocation: 'southcentralus'
}})
param foo string
```

   When using metadata type `location` plus `defaultLocation`, azd will list all locations and select the `defaultLocation` from the list.
    
- Use the `@allowed` tag in the bicep parameter like

```bicep
@allowed([
  'westus3'
  'southcentralus'
  'eastus'
  'eastus2'
  'westus2'
  'centralus'
])
param foo string
```

     Azd will use the fist location in the list as the default location.  Note that azd will not display the values with `location` style but only as a simple list.  Adding the metadata `@location` makes azd to display the location style. Like:

```bicep
@metadata({azd: { 
  type: 'location'
}})
@allowed([
  'westus3'
  'southcentralus'
  'eastus'
  'eastus2'
  'westus2'
  'centralus'
])
param foo string
```

   The `default location` in this case is the first location from the allowed array.  You can also add the `defaultLocation` to the metadata to set a specific location as the default, like:

```bicep
@metadata({azd: { 
  type: 'location'
  defaultLocation: 'southcentralus'
}})
@allowed([
  'westus3'
  'southcentralus'
  'eastus'
  'eastus2'
  'westus2'
  'centralus'
])
param foo string
```

   The metadata `defaultLocation` takes higher priority then the allowed array and is used.

- 3. When neither `defaultLocation`  (metadata) or allowed array is set, azd check if there is a default location saved in the azd local config for the user (~/.azd/config.json) and use that value as the default.  This is the lowest priority and the current behavior before this PR.

fix: https://github.com/Azure/azure-dev/issues/4749