### PR TITLE
Extensions: Auto install extensions during `azd init` command

### DIFF
--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -146,6 +146,7 @@ func newExtensionListFlags(cmd *cobra.Command) *extensionListFlags {
 type extensionListAction struct {
 	flags            *extensionListFlags
 	formatter        output.Formatter
+	console          input.Console
 	writer           io.Writer
 	sourceManager    *extensions.SourceManager
 	extensionManager *extensions.Manager
@@ -154,6 +155,7 @@ type extensionListAction struct {
 func newExtensionListAction(
 	flags *extensionListFlags,
 	formatter output.Formatter,
+	console input.Console,
 	writer io.Writer,
 	sourceManager *extensions.SourceManager,
 	extensionManager *extensions.Manager,
@@ -161,6 +163,7 @@ func newExtensionListAction(
 	return &extensionListAction{
 		flags:            flags,
 		formatter:        formatter,
+		console:          console,
 		writer:           writer,
 		sourceManager:    sourceManager,
 		extensionManager: extensionManager,
@@ -225,17 +228,17 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 
 	if len(extensionRows) == 0 {
 		if a.flags.installed {
-			fmt.Println(output.WithWarningFormat("WARNING: No extensions installed.\n"))
-			fmt.Printf(
-				"Run %s to install extensions.\n",
+			a.console.Message(ctx, output.WithWarningFormat("WARNING: No extensions installed.\n"))
+			a.console.Message(ctx, fmt.Sprintf(
+				"Run %s to install extensions.",
 				output.WithHighLightFormat("azd extension install <extension-name>"),
-			)
+			))
 		} else {
-			fmt.Println(output.WithWarningFormat("WARNING: No extensions found in configured sources.\n"))
-			fmt.Printf(
-				"Run %s to add a new extension source.\n",
+			a.console.Message(ctx, output.WithWarningFormat("WARNING: No extensions found in configured sources.\n"))
+			a.console.Message(ctx, fmt.Sprintf(
+				"Run %s to add a new extension source.",
 				output.WithHighLightFormat("azd extension source add [flags]"),
-			)
+			))
 		}
 
 		return nil, nil

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -168,11 +168,12 @@ func newExtensionListAction(
 }
 
 type extensionListItem struct {
-	Id        string
-	Name      string
-	Namespace string
-	Version   string
-	Installed bool
+	Id        string `json:"id"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Version   string `json:"version"`
+	Installed bool   `json:"installed"`
+	Source    string `json:"source"`
 }
 
 func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, error) {
@@ -217,8 +218,27 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 			Name:      extension.DisplayName,
 			Namespace: extension.Namespace,
 			Version:   version,
+			Source:    extension.Source,
 			Installed: installedExtensions[extension.Id] != nil,
 		})
+	}
+
+	if len(extensionRows) == 0 {
+		if a.flags.installed {
+			fmt.Println(output.WithWarningFormat("WARNING: No extensions installed.\n"))
+			fmt.Printf(
+				"Run %s to install extensions.\n",
+				output.WithHighLightFormat("azd extension install <extension-name>"),
+			)
+		} else {
+			fmt.Println(output.WithWarningFormat("WARNING: No extensions found in configured sources.\n"))
+			fmt.Printf(
+				"Run %s to add a new extension source.\n",
+				output.WithHighLightFormat("azd extension source add [flags]"),
+			)
+		}
+
+		return nil, nil
 	}
 
 	var formatErr error
@@ -236,6 +256,10 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 			{
 				Heading:       "Version",
 				ValueTemplate: `{{.Version}}`,
+			},
+			{
+				Heading:       "Source",
+				ValueTemplate: `{{.Source}}`,
 			},
 			{
 				Heading:       "Installed",
@@ -276,8 +300,10 @@ func newExtensionShowAction(
 }
 
 type extensionShowItem struct {
-	Name             string
+	Id               string
+	Namespace        string
 	Description      string
+	Tags             []string
 	LatestVersion    string
 	InstalledVersion string
 	Usage            string
@@ -293,10 +319,12 @@ func (t *extensionShowItem) Display(writer io.Writer) error {
 		output.TablePadCharacter,
 		output.TableFlags)
 	text := [][]string{
-		{"Name", ":", t.Name},
+		{"Id", ":", t.Id},
+		{"Namespace", ":", t.Namespace},
 		{"Description", ":", t.Description},
 		{"Latest Version", ":", t.LatestVersion},
 		{"Installed Version", ":", t.InstalledVersion},
+		{"Tags", ":", strings.Join(t.Tags, ", ")},
 		{"", "", ""},
 		{"Usage", ":", t.Usage},
 		{"Examples", ":", ""},
@@ -326,8 +354,10 @@ func (a *extensionShowAction) Run(ctx context.Context) (*actions.ActionResult, e
 	latestVersion := registryExtension.Versions[len(registryExtension.Versions)-1]
 
 	extensionDetails := extensionShowItem{
-		Name:             registryExtension.Id,
+		Id:               registryExtension.Id,
+		Namespace:        registryExtension.Namespace,
 		Description:      registryExtension.DisplayName,
+		Tags:             registryExtension.Tags,
 		LatestVersion:    latestVersion.Version,
 		Usage:            latestVersion.Usage,
 		Examples:         latestVersion.Examples,
@@ -715,9 +745,10 @@ type extensionSourceAddFlags struct {
 
 func newExtensionSourceAddFlags(cmd *cobra.Command) *extensionSourceAddFlags {
 	flags := &extensionSourceAddFlags{}
-	cmd.Flags().StringVar(&flags.name, "name", "", "The name of the extension source")
-	cmd.Flags().StringVar(&flags.location, "location", "", "The location of the extension source")
-	cmd.Flags().StringVar(&flags.kind, "king", "", "The type of the extension source")
+	cmd.Flags().StringVarP(&flags.name, "name", "n", "", "The name of the extension source")
+	cmd.Flags().StringVarP(&flags.location, "location", "l", "", "The location of the extension source")
+	cmd.Flags().StringVarP(&flags.kind,
+		"type", "t", "", "The type of the extension source. Supported types are 'file' and 'url'")
 
 	return flags
 }
@@ -726,7 +757,6 @@ type extensionSourceAddAction struct {
 	flags         *extensionSourceAddFlags
 	console       input.Console
 	sourceManager *extensions.SourceManager
-	args          []string
 }
 
 func newExtensionSourceAddAction(
@@ -739,7 +769,6 @@ func newExtensionSourceAddAction(
 		flags:         flags,
 		console:       console,
 		sourceManager: sourceManager,
-		args:          args,
 	}
 }
 
@@ -747,8 +776,6 @@ func (a *extensionSourceAddAction) Run(ctx context.Context) (*actions.ActionResu
 	a.console.MessageUxItem(ctx, &ux.MessageTitle{
 		Title: "Add extension source (azd extension source add)",
 	})
-
-	var name = strings.ToLower(a.args[0])
 
 	spinnerMessage := "Validating extension source"
 	a.console.ShowSpinner(ctx, spinnerMessage, input.Step)
@@ -777,7 +804,7 @@ func (a *extensionSourceAddAction) Run(ctx context.Context) (*actions.ActionResu
 	spinnerMessage = "Saving extension source"
 	a.console.ShowSpinner(ctx, spinnerMessage, input.Step)
 
-	err = a.sourceManager.Add(ctx, name, sourceConfig)
+	err = a.sourceManager.Add(ctx, a.flags.name, sourceConfig)
 	a.console.StopSpinner(ctx, spinnerMessage, input.GetStepResultFormat(err))
 	if err != nil {
 		return nil, fmt.Errorf("failed adding extension source: %w", err)
@@ -785,7 +812,7 @@ func (a *extensionSourceAddAction) Run(ctx context.Context) (*actions.ActionResu
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header:   fmt.Sprintf("Added azd extension source %s", name),
+			Header:   fmt.Sprintf("Added azd extension source %s", a.flags.name),
 			FollowUp: "Run `azd extension list` to see the available set of azd extensions.",
 		},
 	}, nil

--- a/cli/azd/extensions/registry.schema.json
+++ b/cli/azd/extensions/registry.schema.json
@@ -174,8 +174,7 @@
                 },
                 "version": {
                     "type": "string",
-                    "description": "Required version of the dependency. Must follow semantic versioning.",
-                    "pattern": "^\\d+\\.\\d+\\.\\d+$"
+                    "description": "Required version of the dependency. Supports semantic versioning constraints."
                 }
             },
             "required": [

--- a/cli/azd/pkg/extensions/manager.go
+++ b/cli/azd/pkg/extensions/manager.go
@@ -18,10 +18,12 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Masterminds/semver/v3"
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/rzip"
@@ -229,7 +231,7 @@ func (m *Manager) ListFromRegistry(ctx context.Context, options *ListOptions) ([
 // Install an extension by name and optional version
 // If no version is provided, the latest version is installed
 // Latest version is determined by the last element in the Versions slice
-func (m *Manager) Install(ctx context.Context, id string, version string) (*ExtensionVersion, error) {
+func (m *Manager) Install(ctx context.Context, id string, versionConstraint string) (*ExtensionVersion, error) {
 	installed, err := m.GetInstalled(GetInstalledOptions{Id: id})
 	if err == nil && installed != nil {
 		return nil, fmt.Errorf("%s %w", id, ErrExtensionInstalled)
@@ -244,26 +246,50 @@ func (m *Manager) Install(ctx context.Context, id string, version string) (*Exte
 	// Step 2: Determine the version to install
 	var selectedVersion *ExtensionVersion
 
-	if version == "" {
-		// Default to the latest version (last in the slice)
-		versions := extension.Versions
-		if len(versions) == 0 {
-			return nil, fmt.Errorf("no versions available for extension: %s", id)
+	availableVersions := []*semver.Version{}
+	availableVersionMap := map[*semver.Version]*ExtensionVersion{}
+
+	// Create a map of available versions and sort them
+	// This sorts the version from lowest to highest
+	for _, extensionVersion := range extension.Versions {
+		version, err := semver.NewVersion(extensionVersion.Version)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse version: %w", err)
 		}
 
-		selectedVersion = &versions[len(versions)-1]
+		availableVersionMap[version] = &extensionVersion
+		availableVersions = append(availableVersions, version)
+	}
+
+	sort.Sort(semver.Collection(availableVersions))
+
+	if versionConstraint == "" || versionConstraint == "latest" {
+		latestVersion := availableVersions[len(availableVersions)-1]
+		selectedVersion = availableVersionMap[latestVersion]
 	} else {
-		// Find the specific version
-		for _, v := range extension.Versions {
-			if v.Version == version {
-				selectedVersion = &v
-				break
+		// Find the best match for the version constraint
+		constraint, err := semver.NewConstraint(versionConstraint)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse version constraint: %w", err)
+		}
+
+		var bestMatch *semver.Version
+		for _, v := range availableVersions {
+			// Find the highest version that satisfies the constraint
+			if constraint.Check(v) {
+				bestMatch = v
 			}
 		}
 
-		if selectedVersion == nil {
-			return nil, fmt.Errorf("version %s not found for extension: %s", version, id)
+		if bestMatch == nil {
+			return nil, fmt.Errorf("no matching version found for extension: %s and constraint: %s", id, versionConstraint)
 		}
+
+		selectedVersion = availableVersionMap[bestMatch]
+	}
+
+	if selectedVersion == nil {
+		return nil, fmt.Errorf("no compatible version found for extension: %s", id)
 	}
 
 	// Binaries are optional as long as dependencies are provided
@@ -456,18 +482,23 @@ func findArtifactForCurrentOS(version *ExtensionVersion) (*ExtensionArtifact, er
 		return nil, fmt.Errorf("no binaries available for this version")
 	}
 
-	artifactVersion := fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
-	artifact, exists := version.Artifacts[artifactVersion]
-
-	if !exists {
-		return nil, fmt.Errorf("no artifact available for platform: %s", artifactVersion)
+	artifactVersions := []string{
+		fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		runtime.GOOS,
 	}
 
-	if artifact.URL == "" {
-		return nil, fmt.Errorf("artifact URL is missing for platform: %s", artifactVersion)
+	for _, artifactVersion := range artifactVersions {
+		artifact, exists := version.Artifacts[artifactVersion]
+		if exists {
+			if artifact.URL == "" {
+				return nil, fmt.Errorf("artifact URL is missing for platform: %s", artifactVersion)
+			}
+
+			return &artifact, nil
+		}
 	}
 
-	return &artifact, nil
+	return nil, fmt.Errorf("no artifact available for platform: %s", artifactVersions)
 }
 
 // downloadFile downloads a file from the given URL and saves it to a temporary directory using the filename from the URL.

--- a/cli/azd/pkg/extensions/manager_test.go
+++ b/cli/azd/pkg/extensions/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
@@ -142,10 +143,11 @@ func Test_ValidateChecksum_Failure_InvalidChecksumData(t *testing.T) {
 func Test_List_Install_Uninstall_Flow(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 
-	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
-	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, http.DefaultClient)
+	createRegistryMocks(mockContext)
 
-	manager, err := NewManager(userConfigManager, sourceManager, http.DefaultClient)
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	manager, err := NewManager(userConfigManager, sourceManager, mockContext.HttpClient)
 	require.NoError(t, err)
 
 	// List installed extensions (expect 0)
@@ -180,4 +182,179 @@ func Test_List_Install_Uninstall_Flow(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, installed)
 	require.Equal(t, 0, len(installed))
+}
+
+func Test_Install_With_SemverConstraints(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+
+	createRegistryMocks(mockContext)
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	manager, err := NewManager(userConfigManager, sourceManager, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	// Generate a list of tests cases to validate the semver constraints of the Install function.
+	testCases := []struct {
+		Constraint string
+		Expected   string
+	}{
+		{
+			Constraint: "latest",
+			Expected:   "3.1.0",
+		},
+		{
+			Constraint: "*",
+			Expected:   "3.1.0",
+		},
+		{
+			Constraint: "2.x",
+			Expected:   "2.1.1",
+		},
+		{
+			Constraint: "1.0.0",
+			Expected:   "1.0.0",
+		},
+		{
+			Constraint: "=2.1.1",
+			Expected:   "2.1.1",
+		},
+		{
+			Constraint: ">=1.0.0",
+			Expected:   "3.1.0",
+		},
+		{
+			Constraint: ">=1.0.0 <2.0.0",
+			Expected:   "1.3.0",
+		},
+		{
+			Constraint: ">=1.0.0 <1.2.0",
+			Expected:   "1.1.0",
+		},
+		{
+			Constraint: ">=1.0.0 <1.1.0",
+			Expected:   "1.0.0",
+		},
+		{
+			Constraint: ">=1.0.0 <2.0.0",
+			Expected:   "1.3.0",
+		},
+		{
+			Constraint: ">=1.0.0 <1.0.0 || >=2.0.0 <3.0.0",
+			Expected:   "2.1.1",
+		},
+		{
+			Constraint: "~2.1.0",
+			Expected:   "2.1.1",
+		},
+		{
+			Constraint: "^1.0.0",
+			Expected:   "1.3.0",
+		},
+		{
+			Constraint: "^1.1.0",
+			Expected:   "1.3.0",
+		},
+		{
+			Constraint: "invalid",
+			Expected:   "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Constraint, func(t *testing.T) {
+			extensionVersion, err := manager.Install(*mockContext.Context, "test.extension", tc.Constraint)
+			if tc.Expected == "" {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, extensionVersion)
+				require.Equal(t, tc.Expected, extensionVersion.Version)
+
+				err = manager.Uninstall("test.extension")
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func createRegistryMocks(mockContext *mocks.MockContext) {
+	// Create a mock source
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, testRegistry)
+	})
+
+	// Return some mock file
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/test.extension")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+}
+
+var sampleArtifacts = map[string]ExtensionArtifact{
+	"darwin": {
+		//nolint:lll
+		URL: "https://aka.ms/azd/extensions/registry/test.extension/azd-ext-test-darwin-amd64",
+	},
+	"windows": {
+		//nolint:lll
+		URL: "https://aka.ms/azd/extensions/registry/test.extension/azd-ext-test-windows-amd64.exe",
+	},
+	"linux": {
+		//nolint:lll
+		URL: "https://aka.ms/azd/extensions/registry/test.extension/azd-ext-test-linux-amd64",
+	},
+}
+
+var testRegistry = Registry{
+	Extensions: []*ExtensionMetadata{
+		{
+			Id:          "test.extension",
+			Namespace:   "test",
+			DisplayName: "Test Extension",
+			Description: "Test extension description",
+			Tags:        []string{"test"},
+			Versions: []ExtensionVersion{
+				{
+					Version:   "1.0.0",
+					Artifacts: sampleArtifacts,
+				},
+				{
+					Version:   "1.1.0",
+					Artifacts: sampleArtifacts,
+				},
+				{
+					Version:   "1.2.0",
+					Artifacts: sampleArtifacts,
+				},
+				{
+					Version:   "1.3.0",
+					Artifacts: sampleArtifacts,
+				},
+				{
+					Version:   "2.0.0",
+					Artifacts: sampleArtifacts,
+				},
+				{
+					Version:   "2.1.0",
+					Artifacts: sampleArtifacts,
+				},
+				{
+					Version:   "2.1.1",
+					Artifacts: sampleArtifacts,
+				},
+				{
+					Version:   "3.0.0",
+					Artifacts: sampleArtifacts,
+				},
+				{
+					Version:   "3.1.0",
+					Artifacts: sampleArtifacts,
+				},
+			},
+		},
+	},
 }

--- a/cli/azd/pkg/extensions/source_manager.go
+++ b/cli/azd/pkg/extensions/source_manager.go
@@ -174,6 +174,14 @@ func (sm *SourceManager) CreateSource(ctx context.Context, config *SourceConfig)
 	var source Source
 	var err error
 
+	if config.Name == "" {
+		return nil, errors.New("extension source name is required")
+	}
+
+	if config.Location == "" {
+		return nil, errors.New("extension source location is required")
+	}
+
 	switch config.Type {
 	case SourceKindFile:
 		source, err = newFileSource(config.Name, config.Location)

--- a/cli/azd/pkg/project/project_config.go
+++ b/cli/azd/pkg/project/project_config.go
@@ -48,7 +48,8 @@ type ProjectConfig struct {
 // If a value is nil, it is treated as if there is no constraint.
 type RequiredVersions struct {
 	// When non nil, a semver range (in the format expected by semver.ParseRange).
-	Azd *string `yaml:"azd,omitempty"`
+	Azd        *string            `yaml:"azd,omitempty"`
+	Extensions map[string]*string `yaml:"extensions,omitempty"`
 }
 
 // options supported in azure.yaml

--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/Azure/azure-pipeline-go v0.2.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.1.0 // indirect
+	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203 // indirect

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZYIR/J6A=
 github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8 h1:xzYJEypr/85nBpB11F9br+3HUrpgb+fcm5iADzXXYEw=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -508,11 +508,12 @@
                 },
                 "extensions": {
                     "type": "object",
-                    "title": "A range of supported versions of extensions for this project",
-                    "description": "A range of supported versions of extensions for this project. Supports semver constraints. Optional (allows all versions if absent).",
+                    "title": "A map of required extensions and version constraints for this project.",
+                    "description": "A map of required extensions and version constraints for this project. Supports semver constraints. If version is omitted the latest version will be installed.",
                     "additionalProperties": {
                         "type": "string",
                         "examples": [
+                            "latest",
                             ">=1.0.0",
                             "~2.0.0",
                             "=3.1.2",

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -496,6 +496,7 @@
         "requiredVersions": {
             "type": "object",
             "additionalProperties": false,
+            "description": "Optional. Provides additional configuration for required versions of `azd` and extensions.",
             "properties": {
                 "azd": {
                     "type": "string",
@@ -504,6 +505,20 @@
                     "examples": [
                         ">= 0.6.0-beta.3"
                     ]
+                },
+                "extensions": {
+                    "type": "object",
+                    "title": "A range of supported versions of extensions for this project",
+                    "description": "A range of supported versions of extensions for this project. Supports semver constraints. Optional (allows all versions if absent).",
+                    "additionalProperties": {
+                        "type": "string",
+                        "examples": [
+                            ">=1.0.0",
+                            "~2.0.0",
+                            "=3.1.2",
+                            ">= 1.0.0 < 2.0.0"
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
# New features:
- Extensions can now be referenced directly within `azure.yaml` under the `requiredVersions.extensions` configuration element.
- Referenced extensions are automatically installed during `azd init` command when the extensions alpha feature is enabled.
- Extension dependencies now support semver constraints
- Minor updates on `azd extension` commands

## Why?
When a users project is dependent on `azd` extensions and another team member onboards or a new machine/workstation is used users will need to manually install the required extensions otherwise downstream failure will occur when those extensions are expected to be invoked.  With this feature, any time a template is initialized `azd` will ensure that any referenced extensions are installed with based on the required version constraints.

## Example 
```yaml
#azure.yaml

name: todo-nodejs-mongo-aca
metadata:
  template: todo-nodejs-mongo-aca@0.0.1-beta
requiredVersions:
  extensions:
    microsoft.azd.ai: ">=0.2.0" # Supports semver constraints
services:
  web:
    project: ./src/web
    language: js
    host: containerapp
  api:
    project: ./src/api
    language: js
    host: containerapp
 ```
 
 ### Usage: Runing `azd init`
 When running `azd init` the required extensions will automatically be inspected and install the latest version matching the project constraint.
 
<img width="366" alt="image" src="https://github.com/user-attachments/assets/d9bd0ed1-24a8-415f-a7d7-3d2f1cec70a5" />

## Potential Issues

A potential complication arises when different azd projects require conflicting extension versions. Since azd currently supports only global extension installations rather than per-project installations, a version mismatch could occur.
