### PR TITLE
Fix: bindMounts in Windows and adding support for single file binding

### DIFF
--- a/cli/azd/pkg/apphost/manifest.go
+++ b/cli/azd/pkg/apphost/manifest.go
@@ -309,7 +309,9 @@ func ManifestFromAppHost(
 		}
 		if res.BindMounts != nil {
 			for _, bindMount := range res.BindMounts {
-				bindMount.Source = filepath.Join(manifestDir, bindMount.Source)
+				if !filepath.IsAbs(bindMount.Source) {
+					bindMount.Source = filepath.Join(manifestDir, bindMount.Source)
+				}
 			}
 		}
 		if res.Type == "container.v1" {

--- a/cli/azd/pkg/azsdk/storage/storage_file_share_service.go
+++ b/cli/azd/pkg/azsdk/storage/storage_file_share_service.go
@@ -45,6 +45,19 @@ func (f *fileShareClient) UploadPath(ctx context.Context, subId, shareUrl, sourc
 		return err
 	}
 
+	info, err := os.Stat(source)
+	if err != nil {
+		return err
+	}
+
+	if !info.IsDir() {
+		// If the source is a file, upload it directly to the root of the file share
+		if err := f.uploadFile(ctx, shareUrl, source, filepath.Base(source), credential); err != nil {
+			return fmt.Errorf("uploading single file to file share: %w", err)
+		}
+		return nil
+	}
+
 	return filepath.WalkDir(source, func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -52,7 +65,7 @@ func (f *fileShareClient) UploadPath(ctx context.Context, subId, shareUrl, sourc
 		if !info.IsDir() {
 			destination := strings.TrimPrefix(path, source+string(filepath.Separator))
 			if err := f.uploadFile(ctx, shareUrl, path, destination, credential); err != nil {
-				return fmt.Errorf("error uploading file to file share: %w", err)
+				return fmt.Errorf("uploading folder to file share: %w", err)
 			}
 		}
 		return nil


### PR DESCRIPTION
Fix: https://github.com/Azure/azure-dev/issues/4413

### Summary
This PR addresses issues with the `bindMount` implementation on Windows and adds support for binding single files.

### Fixes
- Corrects the source path creation when the workspace is not on the `C:\` drive.
- Adds support for binding a single file, in addition to the previously supported folder binding.
