### PR TITLE
Fix: missing support for entrypoint in container.v0

### DIFF
--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -1235,6 +1235,7 @@ func (b *infraGenerator) Compile() error {
 			Volumes:         bc.Volumes,
 			DeploySource:    bc.DeploymentSource,
 			BindMounts:      bMounts,
+			Entrypoint:      bc.Entrypoint,
 		}
 
 		if err := b.buildEnvBlock(bc.Env, &projectTemplateCtx); err != nil {

--- a/cli/azd/pkg/apphost/generate_types.go
+++ b/cli/azd/pkg/apphost/generate_types.go
@@ -153,6 +153,7 @@ type genBicepTemplateContext struct {
 
 type genContainerAppManifestTemplateContext struct {
 	Name            string
+	Entrypoint      string
 	Ingress         *genContainerAppIngress
 	Env             map[string]string
 	Secrets         map[string]string

--- a/cli/azd/pkg/apphost/testdata/TestAspireContainerArgs-container0.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireContainerArgs-container0.snap
@@ -30,6 +30,7 @@ properties:
         args:
           - arg1
           - https://project.internal.{{ .Env.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN }}
+        command: [entrypoint.sh]
         env:
           - name: AZURE_CLIENT_ID
             value: {{ .Env.MANAGED_IDENTITY_CLIENT_ID }}

--- a/cli/azd/pkg/apphost/testdata/aspire-container-args.json
+++ b/cli/azd/pkg/apphost/testdata/aspire-container-args.json
@@ -24,6 +24,7 @@
       "type": "container.v0",
       "image": "mysql:latest",
       "args": [ "arg1", "{project.bindings.https.url}" ],
+      "entrypoint": "entrypoint.sh",
       "bindings": {
         "tcp": {
           "scheme": "tcp",

--- a/cli/azd/resources/apphost/templates/containerApp.tmpl.yamlt
+++ b/cli/azd/resources/apphost/templates/containerApp.tmpl.yamlt
@@ -90,6 +90,9 @@ properties:
 {{- range $arg := .Args}}
           - {{$arg}}
 {{- end}}
+{{- if ne .Entrypoint "" }}
+        command: [{{ .Entrypoint }}]
+{{- end}}
 {{- end}}
         env:
           - name: AZURE_CLIENT_ID


### PR DESCRIPTION
Fix: https://github.com/Azure/azure-dev/issues/4786

### Summary

This PR addresses an oversight in the `container.v0` schema support. While `container.v1` was introduced with support for `entrypoint`, the corresponding update for `container.v0` to handle `entrypoint` in the `yaml` deployment file was not implemented. This PR rectifies that by adding the necessary support for `entrypoint` in `container.v0`.

### Details

- **Background**: When `container.v1` was added, `container.v0` was also updated to support `entrypoint` as defined in the schema manifest.
- **Issue**: The deployment files generated by Aspire for `container.v1` included `entrypoint` support, but this was missing for `container.v0`.
- **Fix**: This PR implements the missing `entrypoint` support for `container.v0` in the `yaml` deployment file.

### Related Issue

Fixes: [Azure/azure-dev#4786](https://github.com/Azure/azure-dev/issues/4786)

### Testing

- Verified that `container.v0` now correctly handles `entrypoint` in the `yaml` deployment file.
- Added unit tests to ensure future changes do not break this functionality.

### Notes

This change ensures consistency between `container.v0` and `container.v1`, providing a seamless experience for users relying on `entrypoint` in their deployment configurations.