### PR TITLE
Extensions: Adds sample extension pack

### DIFF
--- a/cli/azd/extensions/azd.internal.pack/extension.yaml
+++ b/cli/azd/extensions/azd.internal.pack/extension.yaml
@@ -1,0 +1,7 @@
+id: azd.internal.pack
+displayName: The AZD internal extension pack
+description: Includes AZD internal extensions
+version: 0.0.1
+dependencies:
+  - id: azd.internal.registry
+    version: latest


### PR DESCRIPTION
This is an example extension that is an extension pack.  An extension pack by itself does not contain any executable artifacts but includes dependencies for other extensions.

## Sample

```yaml
# extension.yaml

id: azd.internal.pack
displayName: The AZD internal extension pack
description: Includes AZD internal extensions
version: 0.0.1
dependencies:
  - id: azd.internal.registry
    version: latest
```

## Build the extension

Update the registry
`azd registry package -p azd.internal.pack`

> [!NOTE]
> Generates registry updates with the following:

```jsonc
// registry.json

{
    "id": "azd.internal.pack",
    "displayName": "The AZD internal extension pack",
    "description": "Includes AZD internal extensions",
    "versions": [
      {
        "version": "0.0.1",
        "dependencies": [
          {
            "id": "azd.internal.registry",
            "version": "latest"
          }
        ]
      }
    ]
  }
```

## Install extension pack

```bash
azd ext install azd.internal.pack
```

> [!NOTE]
> Installs all dependent extensions referenced in the pack