### PR TITLE
Fix bind mounts for Windows

### DIFF
--- a/cli/azd/pkg/azsdk/storage/storage_file_share_service.go
+++ b/cli/azd/pkg/azsdk/storage/storage_file_share_service.go
@@ -63,8 +63,12 @@ func (f *fileShareClient) UploadPath(ctx context.Context, subId, shareUrl, sourc
 			return err
 		}
 		if !info.IsDir() {
-			destination := strings.TrimPrefix(path, source+string(filepath.Separator))
-			if err := f.uploadFile(ctx, shareUrl, path, destination, credential); err != nil {
+			// since we are iterating source, path is always relative to source and this would be unlikely to fail
+			relativePath, err := filepath.Rel(source, path)
+			if err != nil {
+				return err
+			}
+			if err := f.uploadFile(ctx, shareUrl, path, relativePath, credential); err != nil {
 				return fmt.Errorf("uploading folder to file share: %w", err)
 			}
 		}


### PR DESCRIPTION
Fix: https://github.com/Azure/azure-dev/issues/4413

### Description

This PR updates the logic to obtain the relative path for file share uploads on Windows. The previous implementation worked correctly on Linux but encountered issues on Windows due to different backslash handling in paths. This change leverages `filepath.Rel()`, ensuring compatibility across all operating systems.

### Fixes

- Fixes [#4413](https://github.com/Azure/azure-dev/issues/4413)

### Changes

- Updated the path handling logic to use `filepath.Rel()` for cross-platform compatibility.

### Testing

- Verified the relative path calculation on both Windows and Linux environments.

### Notes

- This change should resolve the path handling discrepancies between different operating systems.
- 