### PR TITLE
Update the `Configure CI/CD pipeline` content in `next-steps.md`

### DIFF
--- a/cli/azd/resources/apphost/templates/next-steps.mdt
+++ b/cli/azd/resources/apphost/templates/next-steps.mdt
@@ -18,10 +18,11 @@ To troubleshoot any issues, see [troubleshooting](#troubleshooting).
 
 ### Configure CI/CD pipeline
 
-1. Create a workflow pipeline file locally. The following starters are available:
-   - [Deploy with GitHub Actions](https://github.com/Azure-Samples/azd-starter-bicep/blob/main/.github/workflows/azure-dev.yml)
-   - [Deploy with Azure Pipelines](https://github.com/Azure-Samples/azd-starter-bicep/blob/main/.azdo/pipelines/azure-dev.yml)
-2. Run `azd pipeline config -e <environment name>` to configure the deployment pipeline to connect securely to Azure. An environment name is specified here to configure the pipeline with a different environment for isolation purposes. Run `azd env list` and `azd env set` to reselect the default environment after this step.
+Run `azd pipeline config` to configure the deployment pipeline to connect securely to Azure. 
+
+- Deploying with `GitHub Actions`: Select `GitHub` when prompted for a provider. If your project lacks the `azure-dev.yml` file, accept the prompt to add it and proceed with pipeline configuration.
+
+- Deploying with `Azure DevOps Pipeline`: Select `Azure DevOps` when prompted for a provider. If your project lacks the `azure-dev.yml` file, accept the prompt to add it and proceed with pipeline configuration.
 
 ## What was added
 

--- a/cli/azd/resources/apphost/templates/next-steps.mdt
+++ b/cli/azd/resources/apphost/templates/next-steps.mdt
@@ -18,7 +18,7 @@ To troubleshoot any issues, see [troubleshooting](#troubleshooting).
 
 ### Configure CI/CD pipeline
 
-Run `azd pipeline config` to configure the deployment pipeline to connect securely to Azure. 
+Run `azd pipeline config -e <environment name>` to configure the deployment pipeline to connect securely to Azure. An environment name is specified here to configure the pipeline with a different environment for isolation purposes. Run `azd env list` and `azd env set` to reselect the default environment after this step.
 
 - Deploying with `GitHub Actions`: Select `GitHub` when prompted for a provider. If your project lacks the `azure-dev.yml` file, accept the prompt to add it and proceed with pipeline configuration.
 

--- a/cli/azd/resources/scaffold/templates/next-steps.mdt
+++ b/cli/azd/resources/scaffold/templates/next-steps.mdt
@@ -43,10 +43,11 @@ Individual components are also available as: `REDIS_HOST`, `REDIS_PASSWORD`, and
 
 ### Configure CI/CD pipeline
 
-1. Create a workflow pipeline file locally. The following starters are available:
-   - [Deploy with GitHub Actions](https://github.com/Azure-Samples/azd-starter-bicep/blob/main/.github/workflows/azure-dev.yml)
-   - [Deploy with Azure Pipelines](https://github.com/Azure-Samples/azd-starter-bicep/blob/main/.azdo/pipelines/azure-dev.yml)
-2. Run `azd pipeline config` to configure the deployment pipeline to connect securely to Azure.
+Run `azd pipeline config` to configure the deployment pipeline to connect securely to Azure. 
+
+- Deploying with `GitHub Actions`: Select `GitHub` when prompted for a provider. If your project lacks the `azure-dev.yml` file, accept the prompt to add it and proceed with pipeline configuration.
+
+- Deploying with `Azure DevOps Pipeline`: Select `Azure DevOps` when prompted for a provider. If your project lacks the `azure-dev.yml` file, accept the prompt to add it and proceed with pipeline configuration.
 
 ## What was added
 


### PR DESCRIPTION
Fix issue https://github.com/Azure/azure-dev/issues/4799.

This PR removes the link to the 404 error and provides a new guide on how to configure the deployment pipeline using the `azd pipeline config` command.

@rajeshkamal5050 for notification.