### PR TITLE
Fix error: failed to get effective pom for multiple module pom

### DIFF
--- a/cli/azd/internal/appdetect/java_test.go
+++ b/cli/azd/internal/appdetect/java_test.go
@@ -174,7 +174,95 @@ func TestToMavenProject(t *testing.T) {
 			},
 		},
 		{
-			name: "Test pom with multi modules",
+			name: "Test pom with multi modules: root pom build first when run help:effective-pom",
+			testPoms: []testPom{
+				{
+					pomFilePath: "pom.xml",
+					pomContentString: `
+						<project>
+							<modelVersion>4.0.0</modelVersion>
+							<parent>
+								<groupId>org.springframework.boot</groupId>
+								<artifactId>spring-boot-starter-parent</artifactId>
+								<version>3.2.7</version>
+							</parent>
+							<groupId>org.springframework</groupId>
+							<artifactId>gs-multi-module</artifactId>
+							<version>0.1.0</version>
+							<packaging>pom</packaging>
+							<modules>
+								<module>library</module>
+								<module>application</module>
+							</modules>
+						</project>
+						`,
+				},
+				{
+					pomFilePath: filepath.Join("application", "pom.xml"),
+					pomContentString: `
+						<project>
+							<modelVersion>4.0.0</modelVersion>
+							<parent>
+								<groupId>org.springframework</groupId>
+								<artifactId>gs-multi-module</artifactId>
+								<version>0.1.0</version>
+							</parent>
+							<groupId>com.example</groupId>
+							<artifactId>application</artifactId>
+							<version>0.0.1-SNAPSHOT</version>
+							<name>application</name>
+							<description>Demo project for Spring Boot</description>
+							<dependencies>
+								<dependency>
+									<groupId>org.slf4j</groupId>
+									<artifactId>slf4j-api</artifactId>
+								</dependency>
+							</dependencies>
+							<build>
+								<plugins>
+									<plugin>
+										<groupId>org.springframework.boot</groupId>
+										<artifactId>spring-boot-maven-plugin</artifactId>
+									</plugin>
+								</plugins>
+							</build>
+						</project>
+						`,
+				},
+				{
+					pomFilePath: filepath.Join("library", "pom.xml"),
+					pomContentString: `
+						<project>
+							<modelVersion>4.0.0</modelVersion>
+							<parent>
+								<groupId>org.springframework</groupId>
+								<artifactId>gs-multi-module</artifactId>
+								<version>0.1.0</version>
+							</parent>
+							<groupId>com.example</groupId>
+							<artifactId>library</artifactId>
+							<version>0.0.1-SNAPSHOT</version>
+							<name>library</name>
+							<description>Demo project for Spring Boot</description>
+							<dependencies>
+								<dependency>
+									<groupId>org.springframework.boot</groupId>
+									<artifactId>spring-boot</artifactId>
+								</dependency>
+								<dependency>
+									<groupId>org.springframework.boot</groupId>
+									<artifactId>spring-boot-starter-test</artifactId>
+									<scope>test</scope>
+								</dependency>
+							</dependencies>
+						</project>
+						`,
+				},
+			},
+			expected: []dependency{},
+		},
+		{
+			name: "Test pom with multi modules: root pom build last when run help:effective-pom",
 			testPoms: []testPom{
 				{
 					pomFilePath: "pom.xml",
@@ -209,6 +297,10 @@ func TestToMavenProject(t *testing.T) {
 							<name>application</name>
 							<description>Demo project for Spring Boot</description>
 							<dependencies>
+								<dependency>
+									<groupId>org.slf4j</groupId>
+									<artifactId>slf4j-api</artifactId>
+								</dependency>
 							</dependencies>
 							<build>
 								<plugins>

--- a/cli/azd/pkg/tools/maven/maven.go
+++ b/cli/azd/pkg/tools/maven/maven.go
@@ -247,6 +247,7 @@ func (cli *Cli) EffectivePom(ctx context.Context, pomPath string) (string, error
 		return "", err
 	}
 	pomDir := filepath.Dir(pomPath)
+	// Link to "-pl" related doc: https://maven.apache.org/ref/3.1.0/maven-embedder/cli.html
 	runArgs := exec.NewRunArgs(mvnCmd, "help:effective-pom", "-f", pomPath, "-pl", filepath.Base(pomPath)).WithCwd(pomDir)
 	result, err := cli.commandRunner.Run(ctx, runArgs)
 	if err != nil {


### PR DESCRIPTION
### Fix error: failed to get effective pom for multiple module pom

For a pom which contains multiple modules:
1. Before current PR, the `mvn help:effective-pom -f xxx/pom.xml` will output effective pom for both root pom and child poms. The `getEffectivePomFromConsoleOutput` func will always return the last one. But the actually, the effective pom of root pom is not always appear at last.
2. After current PR, the `mvn help:effective0pom -f xxx/pom.xml -pl pom.xml` will only output effective pom for root pom. Link to "-pl" related doc: https://maven.apache.org/ref/3.1.0/maven-embedder/cli.html