### PR TITLE
yamlnode: fix nested create operations

### DIFF
--- a/cli/azd/pkg/yamlnode/yamlnode.go
+++ b/cli/azd/pkg/yamlnode/yamlnode.go
@@ -220,7 +220,11 @@ func find(current *yaml.Node, parts []pathElem, findOnly bool) (*yaml.Node, erro
 		current.Content[part.idx] = node
 	}
 
-	return node, nil
+	if len(parts) == 0 {
+		return node, nil
+	}
+
+	return find(node, parts[1:], findOnly)
 }
 
 // parsePath parses a dotted-path into a slice of yaml path elements.

--- a/cli/azd/pkg/yamlnode/yamlnode_test.go
+++ b/cli/azd/pkg/yamlnode/yamlnode_test.go
@@ -87,6 +87,7 @@ func TestSet(t *testing.T) {
 		{"Create array", "root.new_array", []string{"first_item"}, false},
 		{"Create object", "root.nested.new_object", map[string]string{"key": "value"}, false},
 		{"Create nested array object", "root.mixedArray[1].nestedObj.newKey", "new_deep_value", false},
+		{"Create layers", "root.new?.new2?.new3", "new_deep_value", false},
 		{"Create missing key", "root.nonexistent?.key", "value", false},
 
 		{"Invalid path", "root.nonexistent.key", "value", true},
@@ -141,6 +142,7 @@ func TestAppend(t *testing.T) {
 		{"Append object to mixed array", "root.mixedArray", map[string]string{"key": "value"}, false, 4},
 		{"Append to nested array", "root.mixedArray[2].nestedArr", "item3", false, 3},
 		{"Append to non-existent array", "root.nonexistent[]?", "item1", false, 1},
+		{"Append layers", "root.new?.new2?.arr[]?", "item1", false, 1},
 		{"Invalid path (not an array)", "root.nested.key", "invalid", true, 0},
 		{"Non-existent path", "root.nonexistent", "value", true, 0},
 		{"Invalid path format", "root.array.[1]", "invalid", true, 0},


### PR DESCRIPTION
Fix node creation terminating after the first optional node.

In `find`, if a node was created, we terminated the recursion instead of iterating until `parts` is empty.

This was discovered while prototyping an `application.yaml` binding generation for Java.