### PR TITLE
lint with current bicep version

### DIFF
--- a/.github/workflows/lint-bicep.yml
+++ b/.github/workflows/lint-bicep.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Upgrade bicep
         run: |
           which bicep
-          sudo curl -o $(which bicep) -L https://github.com/Azure/bicep/releases/download/v0.31.92/bicep-linux-x64
+          sudo curl -o $(which bicep) -L https://github.com/Azure/bicep/releases/download/v0.33.93/bicep-linux-x64
           sudo chmod +x $(which bicep)
       - name: Lint .bicep files
         run: $ErrorActionPreference='Continue'; eng/scripts/Test-BicepLint.ps1 -Verbose


### PR DESCRIPTION
Update Bicep CLI version in CI/CD for linting to match the current version used by AZD.