### PR TITLE
set default for apphost confirmation

### DIFF
--- a/cli/azd/internal/repository/detect_confirm_apphost.go
+++ b/cli/azd/internal/repository/detect_confirm_apphost.go
@@ -52,12 +52,14 @@ func (d *detectConfirmAppHost) Confirm(ctx context.Context) error {
 			return err
 		}
 
+		defaultConfirmation := "Confirm and continue initializing my app"
 		continueOption, err := d.console.Select(ctx, input.ConsoleOptions{
 			Message: "Select an option",
 			Options: []string{
-				"Confirm and continue initializing my app",
+				defaultConfirmation,
 				"Cancel and exit",
 			},
+			DefaultValue: defaultConfirmation,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
fix: https://github.com/Azure/azure-dev/issues/3093

Allow running `azd init --from-code --no-prompt` in CI to initialize and deploy Aspire Applications.

This should remove the need of running `azd init` like: 

```sh
yes "Confirm and continue initializing my app" | azd init --from-code
```
