### PR TITLE
Enable run azd init from a Maven project's pom file on right click

### DIFF
--- a/ext/vscode/package.json
+++ b/ext/vscode/package.json
@@ -185,11 +185,16 @@
             "explorer/context": [
                 {
                     "submenu": "azure-dev.explorer.submenu",
-                    "when": "resourceFilename =~ /azure.yaml/i",
+                    "when": "resourceFilename =~ /(azure.yaml|pom.xml)/i",
                     "group": "azure-dev"
                 }
             ],
             "azure-dev.explorer.submenu": [
+                {
+                    "when": "resourceFilename =~ /pom.xml/i",
+                    "command": "azure-dev.commands.cli.init",
+                    "group": "10provision@10"
+                },
                 {
                     "when": "resourceFilename =~ /azure.yaml/i",
                     "command": "azure-dev.commands.cli.provision",

--- a/ext/vscode/package.json
+++ b/ext/vscode/package.json
@@ -171,6 +171,10 @@
         "menus": {
             "commandPalette": [
                 {
+                    "command": "azure-dev.commands.cli.initFromPom",
+                    "when": "false"
+                },
+                {
                     "command": "azure-dev.commands.getDotEnvFilePath",
                     "when": "false"
                 },

--- a/ext/vscode/package.json
+++ b/ext/vscode/package.json
@@ -40,6 +40,11 @@
             },
             {
                 "category": "%azure-dev.commands_category%",
+                "command": "azure-dev.commands.cli.initFromPom",
+                "title": "%azure-dev.commands.cli.initFromPom.title%"
+            },
+            {
+                "category": "%azure-dev.commands_category%",
                 "command": "azure-dev.commands.cli.provision",
                 "title": "%azure-dev.commands.cli.provision.title%"
             },
@@ -192,7 +197,7 @@
             "azure-dev.explorer.submenu": [
                 {
                     "when": "resourceFilename =~ /pom.xml/i",
-                    "command": "azure-dev.commands.cli.init",
+                    "command": "azure-dev.commands.cli.initFromPom",
                     "group": "10provision@10"
                 },
                 {

--- a/ext/vscode/package.nls.json
+++ b/ext/vscode/package.nls.json
@@ -1,7 +1,7 @@
 {
     "azure-dev.commands_category": "Azure Developer CLI (azd)",
 
-    "azure-dev.commands.cli.init.title": "Initialize App (init)",
+    "azure-dev.commands.cli.init.title": "Generate Azure Deployment Script (init)",
     "azure-dev.commands.cli.provision.title": "Provision Azure Resources (provision)",
     "azure-dev.commands.cli.deploy.title": "Deploy to Azure (deploy)",
     "azure-dev.commands.cli.restore.title": "Restore App Dependencies (restore)",

--- a/ext/vscode/package.nls.json
+++ b/ext/vscode/package.nls.json
@@ -1,7 +1,8 @@
 {
     "azure-dev.commands_category": "Azure Developer CLI (azd)",
 
-    "azure-dev.commands.cli.init.title": "Generate Azure Deployment Script (init)",
+    "azure-dev.commands.cli.init.title": "Initialize App (init)",
+    "azure-dev.commands.cli.initFromPom.title": "Initialize for Azure (init)",
     "azure-dev.commands.cli.provision.title": "Provision Azure Resources (provision)",
     "azure-dev.commands.cli.deploy.title": "Deploy to Azure (deploy)",
     "azure-dev.commands.cli.restore.title": "Restore App Dependencies (restore)",

--- a/ext/vscode/src/commands/registerCommands.ts
+++ b/ext/vscode/src/commands/registerCommands.ts
@@ -22,6 +22,7 @@ import { disableDevCenterMode, enableDevCenterMode } from './devCenterMode';
 
 export function registerCommands(): void {
     registerActivityCommand('azure-dev.commands.cli.init', init);
+    registerActivityCommand('azure-dev.commands.cli.initFromPom', init);
     registerActivityCommand('azure-dev.commands.cli.provision', provision);
     registerActivityCommand('azure-dev.commands.cli.deploy', deploy);
     registerActivityCommand('azure-dev.commands.cli.restore', restore);


### PR DESCRIPTION
This PR is to enable running `azd init` on a Java Maven project, when right click on the pom file. The expected output is the `azure.yaml` after analyzing the project. This PR changes the title of running `azd init` from `Initialize App` to `Generate Azure Deployment Script`.

Below are the screenshots:

1. Initialize from a pom file

<img width="640" alt="image" src="https://github.com/user-attachments/assets/a95ebd63-e272-4bae-80ba-791617ceaa2f" />

2. Right click on `azure.yaml` (nothing changed)

<img width="819" alt="image" src="https://github.com/user-attachments/assets/98d03715-eee8-4a66-9b01-44f3495b3e48" />
