### PR TITLE
Adds support for `docker` language type

### DIFF
--- a/cli/azd/pkg/project/framework_service.go
+++ b/cli/azd/pkg/project/framework_service.go
@@ -43,7 +43,7 @@ func parseServiceLanguage(kind ServiceLanguageKind) (ServiceLanguageKind, error)
 		ServiceLanguagePython,
 		ServiceLanguageJava,
 		ServiceLanguageDocker:
-		// Excluding ServiceLanguageDocker and ServiceLanguageSwa since it is implicitly derived currently,
+		// Excluding ServiceLanguageSwa since it is implicitly derived currently,
 		// and not an actual language
 		return kind, nil
 	}

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -137,7 +137,8 @@
                             "python",
                             "js",
                             "ts",
-                            "java"
+                            "java",
+                            "docker"
                         ]
                     },
                     "module": {

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -108,7 +108,8 @@
                             "python",
                             "js",
                             "ts",
-                            "java"
+                            "java",
+                            "docker"
                         ]
                     },
                     "module": {


### PR DESCRIPTION
Enables `docker` to be a supported language for `azd` services.  This enables scenarios for developers to use languages like `Go` or others that don't have native built-in support in `azd` but can still but leverage in containerized applications.