### PR TITLE
Demo Extension: Adds colors command to display the list of standard colors

### DIFF
--- a/cli/azd/extensions/microsoft.azd.demo/extension.yaml
+++ b/cli/azd/extensions/microsoft.azd.demo/extension.yaml
@@ -4,7 +4,7 @@ namespace: demo
 displayName: Demo Extension
 description: This extension provides examples of the AZD extension framework.
 usage: azd demo <command> [options]
-version: 0.1.0
+version: 0.2.0
 capabilities:
   - custom-commands
   - lifecycle-events

--- a/cli/azd/extensions/microsoft.azd.demo/internal/cmd/colors.go
+++ b/cli/azd/extensions/microsoft.azd.demo/internal/cmd/colors.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/cli/azd/extensions/microsoft.azd.demo/internal/cmd/colors.go
+++ b/cli/azd/extensions/microsoft.azd.demo/internal/cmd/colors.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+func newColorsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "colors",
+		Short: "Displays all ASCII colors with their standard and high-intensity variants.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Create a tab writer for proper column alignment
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w)
+			fmt.Fprintln(w, "Standard          High Intensity")
+
+			// Define color names and their corresponding fatih/color styles
+			colors := []struct {
+				name     string
+				standard *color.Color
+				hiColor  *color.Color
+			}{
+				{"Black", color.New(color.FgBlack), color.New(color.FgHiBlack)},
+				{"Red", color.New(color.FgRed), color.New(color.FgHiRed)},
+				{"Green", color.New(color.FgGreen), color.New(color.FgHiGreen)},
+				{"Yellow", color.New(color.FgYellow), color.New(color.FgHiYellow)},
+				{"Blue", color.New(color.FgBlue), color.New(color.FgHiBlue)},
+				{"Magenta", color.New(color.FgMagenta), color.New(color.FgHiMagenta)},
+				{"Cyan", color.New(color.FgCyan), color.New(color.FgHiCyan)},
+				{"White", color.New(color.FgWhite), color.New(color.FgHiWhite)},
+			}
+
+			// Print each color row
+			for _, c := range colors {
+				standard := c.standard.Sprintf("██████ %s", c.name)
+				hi := c.hiColor.Sprintf("██████ %s", c.name)
+				fmt.Fprintf(w, "%s\t\t%s\n", standard, hi)
+			}
+
+			fmt.Fprintln(w)
+
+			// Flush the writer
+			w.Flush()
+
+			return nil
+		},
+	}
+}

--- a/cli/azd/extensions/microsoft.azd.demo/internal/cmd/root.go
+++ b/cli/azd/extensions/microsoft.azd.demo/internal/cmd/root.go
@@ -24,6 +24,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.AddCommand(newListenCommand())
 	rootCmd.AddCommand(newContextCommand())
 	rootCmd.AddCommand(newPromptCommand())
+	rootCmd.AddCommand(newColorsCommand())
 	rootCmd.AddCommand(newVersionCommand())
 
 	return rootCmd


### PR DESCRIPTION
Adds colors command to display the list of standard colors

![image](https://github.com/user-attachments/assets/8168c79f-fe72-4681-a5ba-1e1f9fecb2bc)
