### PR TITLE
set-secrets: Add shortcuts for using the Key Vault created by `azd add`

### DIFF
--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -8,9 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -302,20 +300,26 @@ func (e *envSetSecretAction) Run(ctx context.Context) (*actions.ActionResult, er
 			}
 			kvName := resId.Name
 			kvSubId := resId.SubscriptionID
-			if v, err := strconv.ParseBool(os.Getenv("AZD_DEMO_MODE")); err == nil && v {
-				e.console.Message(ctx, fmt.Sprintf("\nExisting project Key Vault found with name %s.\n",
-					output.WithHighLightFormat(kvName)))
-			} else {
-				e.console.Message(ctx, fmt.Sprintf("\nExisting project Key Vault found with name %s:\n%s\n",
-					output.WithHighLightFormat(kvName), output.WithGrayFormat(kvId)))
-			}
+			// if v, err := strconv.ParseBool(os.Getenv("AZD_DEMO_MODE")); err == nil && v {
+			// 	e.console.Message(ctx, fmt.Sprintf("\nExisting project Key Vault found with name %s.\n",
+			// 		output.WithHighLightFormat(kvName)))
+			// } else {
+			// 	e.console.Message(ctx, fmt.Sprintf("\nExisting project Key Vault found with name %s:\n%s\n",
+			// 		output.WithHighLightFormat(kvName), output.WithGrayFormat(kvId)))
+			// }
 			subscriptionOptions := []string{"Yes", "No, use a different Key Vault"}
+			var verb string
+			if willCreateNewSecret {
+				verb = "Set"
+			} else {
+				verb = "Select"
+			}
 
 			useProjectKvPrompt, err := e.console.Select(
 				ctx,
 				input.ConsoleOptions{
-					Message: fmt.Sprintf("Do you want to use the project Key Vault '%s'?",
-						output.WithHighLightFormat(kvName)),
+					Message: fmt.Sprintf("%s secret in the project %s?",
+						verb, output.WithHighLightFormat("vault")),
 					Options:      subscriptionOptions,
 					DefaultValue: subscriptionOptions[0],
 				})

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -506,7 +506,7 @@ func (e *envSetSecretAction) Run(ctx context.Context) (*actions.ActionResult, er
 
 	var kvSecretName string
 	if willCreateNewSecret {
-		kvSecretName, err = e.createNewKeyVaultSecret(ctx, subId, secretName, kvAccount.Name)
+		kvSecretName, err = e.createNewKeyVaultSecret(ctx, secretName, subId, kvAccount.Name)
 	} else {
 		kvSecretName, err = e.selectKeyVaultSecret(ctx, subId, kvAccount.Name)
 	}

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -8,7 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -300,9 +302,13 @@ func (e *envSetSecretAction) Run(ctx context.Context) (*actions.ActionResult, er
 			}
 			kvName := resId.Name
 			kvSubId := resId.SubscriptionID
-
-			e.console.Message(ctx, fmt.Sprintf("\nExisting project Key Vault found with name %s:\n%s\n",
-				output.WithHighLightFormat(kvName), output.WithGrayFormat(kvId)))
+			if v, err := strconv.ParseBool(os.Getenv("AZD_DEMO_MODE")); err == nil && v {
+				e.console.Message(ctx, fmt.Sprintf("\nExisting project Key Vault found with name %s.\n",
+					output.WithHighLightFormat(kvName)))
+			} else {
+				e.console.Message(ctx, fmt.Sprintf("\nExisting project Key Vault found with name %s:\n%s\n",
+					output.WithHighLightFormat(kvName), output.WithGrayFormat(kvId)))
+			}
 			subscriptionOptions := []string{"Yes", "No, use a different Key Vault"}
 
 			useProjectKvPrompt, err := e.console.Select(

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -303,7 +303,7 @@ func (e *envSetSecretAction) Run(ctx context.Context) (*actions.ActionResult, er
 
 			e.console.Message(ctx, fmt.Sprintf("\nExisting project Key Vault found with name %s:\n%s\n",
 				output.WithHighLightFormat(kvName), output.WithGrayFormat(kvId)))
-			subscriptionOptions := []string{"Use project Key Vault", "Use a different Key Vault"}
+			subscriptionOptions := []string{"Yes", "No, use a different Key Vault"}
 
 			useProjectKvPrompt, err := e.console.Select(
 				ctx,
@@ -344,13 +344,14 @@ func (e *envSetSecretAction) Run(ctx context.Context) (*actions.ActionResult, er
 				return createSuccessResult(secretName, kvSecretName, kvAccount.Name), nil
 			}
 		} else if _, hasProjectKv := e.projectConfig.Resources["vault"]; hasProjectKv { // KV defined but not provisioned yet
-			e.console.Message(ctx, fmt.Sprintf("\nAn existing project Key Vault exists but has not been provisioned yet."+
-				" Run '%s' first to use it\n", output.WithHighLightFormat("azd provision")))
+			e.console.Message(ctx,
+				output.WithWarningFormat("\nAn existing project Key Vault is defined but has not been provisioned yet. ")+
+					fmt.Sprintf("Run '%s' first to use it.\n", output.WithHighLightFormat("azd provision")))
 			options := []string{"Use a different key vault", "Cancel"}
 			useProjectKvPrompt, err := e.console.Select(
 				ctx,
 				input.ConsoleOptions{
-					Message:      "How would you like to proceed?",
+					Message:      "How do you want to proceed?",
 					Options:      options,
 					DefaultValue: options[0],
 				})

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -289,9 +289,9 @@ func TestPlanForResourceGroup(t *testing.T) {
 		return options.Message == "Pick a resource group to use:"
 	}).RespondFn(func(options input.ConsoleOptions) (any, error) {
 		require.Len(t, options.Options, 3)
-		require.Equal(t, "Create a new resource group", options.Options[0])
-		require.Equal(t, "1. existingGroup1", options.Options[1])
-		require.Equal(t, "2. existingGroup2", options.Options[2])
+		require.Equal(t, "1. Create a new resource group", options.Options[0])
+		require.Equal(t, "2. existingGroup1", options.Options[1])
+		require.Equal(t, "3. existingGroup2", options.Options[2])
 
 		return 0, nil
 	})

--- a/cli/azd/pkg/prompt/prompter.go
+++ b/cli/azd/pkg/prompt/prompter.go
@@ -166,11 +166,11 @@ func (p *DefaultPrompter) PromptResourceGroupFrom(
 	canCreateOverride := 0
 	if canCreateNeResourceGroup {
 		choices = make([]string, len(groups)+1)
-		choices[0] = "Create a new resource group"
+		choices[0] = "1. Create a new resource group"
 		canCreateOverride = 1
 	}
 	for idx, group := range groups {
-		choices[idx+canCreateOverride] = fmt.Sprintf("%d. %s", idx+1, group.Name)
+		choices[idx+canCreateOverride] = fmt.Sprintf("%d. %s", idx+canCreateOverride+1, group.Name)
 	}
 
 	choice, err := p.console.Select(ctx, input.ConsoleOptions{

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -721,7 +721,7 @@ module keyVault 'br/public:avm/res/key-vault/vault:0.12.0' = {
       {
         objectId: principalId
         permissions: {
-          secrets: [ 'get', 'list' ]
+          secrets: [ 'get', 'list', 'set' ]
         }
       }
       {{- range .Services}}

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -701,6 +701,19 @@
                     "description": "When specified overrides the hook configuration when executed in POSIX environments",
                     "default": null,
                     "$ref": "#/definitions/hook"
+                },
+                "secrets": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "title": "Optional. Map of azd environment variables to hook secrets.",
+                    "description": "If variable was set as a secret in the environment, the secret value will be passed to the hook.",
+                    "examples": [
+                        {
+                            "WITH_SECRET_VALUE": "ENV_VAR_WITH_SECRET"
+                        }
+                    ]
                 }
             },
             "if": {

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -640,14 +640,16 @@
                 },
                 "secrets": {
                     "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
                     "title": "Optional. Map of azd environment variables to hook secrets.",
                     "description": "If variable was set as a secret in the environment, the secret value will be passed to the hook.",
-                    "additionalProperties": {
-                            "type": "string"
-                        },
-                    "example": {
-                        "WITH_SECRET_VALUE": "ENV_VAR_WITH_SECRET"
-                    }
+                    "examples": [
+                        {
+                            "WITH_SECRET_VALUE": "ENV_VAR_WITH_SECRET"
+                        }
+                    ]
                 }
             },
             "if": {


### PR DESCRIPTION
Closes #4838

This PR adds "shortcuts" to `azd env set-secrets <name>` so that if a Key Vault added by `azd add` exists, the user can directly pick that one to use instead of having to go through the typical **Subscription > Resource Group > Key Vault** flow.

If a key vault resource is defined in `azure.yaml`, but hasn't been provisioned yet, the following warning message is displayed, and the user is asked if they want to pick another KV or cancel the operation.

![image](https://github.com/user-attachments/assets/d1201cb3-2daf-4d1c-91b4-09e9298537c0)

These changes do not touch the **Create a new Key Vault** flow, but in the future we could consider adding logic to detect if it's a compose project and ask if the user wants to add one to `azure.yaml` and provision it.

### Other changes

1. Update generated Bicep code for Key Vault to set the "set secret" permission on `principalId` so `azd env set-secret` can create new secrets in the project KV.
2. Add `secrets` to azure.yaml alpha schema and fix `examples` property so it auto-fills and shows up when you hover it in VS Code:
  ![image](https://github.com/user-attachments/assets/4e79f100-caee-4b55-9a6c-26d67789e66f)
3. The option to create a key vault or resource group in selection prompts are now numbered based on UX feedback:
  ![image](https://github.com/user-attachments/assets/0976a21d-0004-44a3-8fc1-65d8b930d073)

### Demo
https://github.com/user-attachments/assets/a047dee7-ee85-4cbb-8e4e-1d2776fec7dc

