### PR TITLE
build: fully enable ASLR with dynamicbase

### DIFF
--- a/cli/azd/ci-build.ps1
+++ b/cli/azd/ci-build.ps1
@@ -184,9 +184,9 @@ $oldGOEXPERIMENT = $env:GOEXPERIMENT
 $env:GOEXPERIMENT="loopvar"
 
 try {
-    Write-Host "Running: go build ``"
-    PrintFlags -flags $buildFlags
     if ($OneAuth) {
+        Write-Host "Running: go build (oneauth)``"
+        PrintFlags -flags $buildFlags
         # write the go build command line to a script because that's simpler than trying
         # to escape the build flags, which contain commas and both kinds of quotes
         Set-Content -Path build.sh -Value "go build $($buildFlags)"
@@ -217,6 +217,8 @@ try {
         go build @buildFlags
     } 
     else {
+        Write-Host "Running: go build ``"
+        PrintFlags -flags $buildFlags
         go build @buildFlags
     }
     

--- a/cli/azd/ci-build.ps1
+++ b/cli/azd/ci-build.ps1
@@ -129,7 +129,8 @@ if ($IsWindows) {
         "-trimpath",
         $tagsFlag,
         # -extldflags=-Wl,--high-entropy-va: Pass the high-entropy VA flag to the linker to enable high entropy virtual addresses
-        ($ldFlag + "-linkmode=auto -extldflags=-Wl,--high-entropy-va")
+        # --dynamicbase: Enable dynamic base address for the executable
+        ($ldFlag + "-linkmode=auto -extldflags=-Wl,--high-entropy-va,--dynamicbase")
     )
 }
 elseif ($IsLinux) {
@@ -192,10 +193,7 @@ try {
         Invoke-Expression "$($MSYS2Shell) -mingw64 -defterm -no-start -here -c 'bash ./build.sh'"
         Remove-Item -Path build.sh -ErrorAction Ignore
     }
-    else {
-        go build @buildFlags
-    }
-    if ($BuildRecordMode) {
+    else if ($BuildRecordMode) {
         $recordFlagPresent = $false
         for ($i = 0; $i -lt $buildFlags.Length; $i++) {
             if ($buildFlags[$i].StartsWith("-tags=")) {
@@ -216,6 +214,9 @@ try {
     
         Write-Host "Running: go build (record) ``"
         PrintFlags -flags $buildFlags
+        go build @buildFlags
+    } 
+    else {
         go build @buildFlags
     }
     


### PR DESCRIPTION
This enables [/DYNAMICBASE](https://learn.microsoft.com/en-us/cpp/build/reference/dynamicbase?view=msvc-170) which is a pre-requisite for --high-entropy-va.

Adjust go-build.ps1 slightly as it was building twice for record mode.