### PR TITLE
compose: show resources

### DIFF
--- a/.vscode/cspell-github-user-aliases.txt
+++ b/.vscode/cspell-github-user-aliases.txt
@@ -33,6 +33,7 @@ sebastianmattar
 sergi
 sethvargo
 stretchr
+tidwall
 theckman
 TheEskhaton
 tonybaloney

--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -31,6 +31,7 @@ aspnet
 aspnetcore
 asyncmy
 asyncpg
+avmres
 azapi
 azblob
 AZCLI
@@ -57,6 +58,7 @@ azuretools
 azureutil
 azureyaml
 Backticks
+bicept
 bicepparam
 blockblob
 BOOLSLICE
@@ -111,6 +113,7 @@ Frontends
 funcapp
 functestapp
 functionapp
+gjson
 go-imath
 GOARCH
 GOCOVERDIR

--- a/cli/azd/internal/cmd/show/show_resource.go
+++ b/cli/azd/internal/cmd/show/show_resource.go
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package show
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/braydonk/yaml"
+
+	"github.com/azure/azure-dev/cli/azd/internal/scaffold"
+	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/keyvault"
+	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
+	"github.com/azure/azure-dev/cli/azd/pkg/yamlnode"
+)
+
+type showResource struct {
+	env             *environment.Environment
+	kvService       keyvault.KeyVaultService
+	resourceService *azapi.ResourceService
+	console         input.Console
+}
+
+func (s *showResource) showResourceGeneric(
+	ctx context.Context,
+	id arm.ResourceID,
+	opts showResourceOptions) (*ux.ShowResource, error) {
+	resourceMeta, resourceId := getResourceMeta(id)
+	if resourceMeta == nil {
+		return nil, fmt.Errorf("resource type '%s' is not currently supported", id.ResourceType)
+	}
+
+	spec, err := s.resourceService.GetRawResource(ctx, resourceId, resourceMeta.ApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get resource %s: %w", id.String(), err)
+	}
+
+	var resolveSecret func(name string) (string, error)
+	if opts.showSecrets {
+		vault := infra.KeyVaultName(s.env)
+
+		resolveSecret = func(name string) (string, error) {
+			kvSecret, err := s.kvService.GetKeyVaultSecret(ctx, id.SubscriptionID, vault, name)
+			if err != nil {
+				return "", fmt.Errorf("failed to get secret %s: %w", name, err)
+			}
+			return kvSecret.Value, nil
+		}
+	} else {
+		resolveSecret = func(name string) (string, error) {
+			return "<secret>", nil
+		}
+	}
+
+	var resourceNode *yaml.Node
+	if opts.resourceSpec == nil {
+		resourceNode = &yaml.Node{}
+	} else {
+		// include 'name' in the yaml
+		opts.resourceSpec.IncludeName = true
+
+		node, err := yamlnode.Encode(opts.resourceSpec)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode resource spec: %w", err)
+		}
+
+		resourceNode = node
+	}
+
+	context := scaffold.EvalCtx{
+		ResourceSpec: resourceNode,
+		ArmResource:  spec,
+		VaultSecret:  resolveSecret,
+	}
+	values, err := scaffold.Eval(resourceMeta.Variables, context)
+	if err != nil {
+		return nil, fmt.Errorf("expanding variables: %w", err)
+	}
+
+	display := id.ResourceType.String()
+	if translated := azapi.GetResourceTypeDisplayName(azapi.AzureResourceType(display)); translated != "" {
+		display = translated
+	}
+
+	showRes := ux.ShowResource{
+		Name:        id.Name,
+		TypeDisplay: display,
+		Variables:   values,
+	}
+
+	return &showRes, nil
+}
+
+func getResourceMeta(id arm.ResourceID) (*scaffold.ResourceMeta, arm.ResourceID) {
+	resourceType := id.ResourceType.String()
+	resources := scaffold.Resources
+
+	for _, res := range resources {
+		if res.ResourceType == resourceType { // exact match
+			return &res, id
+		}
+	}
+
+	var matched *scaffold.ResourceMeta
+	parentLevels := 0
+	for _, res := range resources {
+		// find longest prefix match
+		if strings.HasPrefix(resourceType, res.ResourceType) {
+			if matched == nil || len(res.ResourceType) > len(matched.ResourceType) {
+				matched = &res
+				parentLevels = strings.Count(resourceType[len(res.ResourceType):], "/")
+			}
+		}
+	}
+
+	parentId := &id
+	for i := 0; i < parentLevels; i++ {
+		if parentId.Parent != nil {
+			parentId = parentId.Parent
+		}
+	}
+
+	return matched, *parentId
+}

--- a/cli/azd/internal/cmd/show/show_resource.go
+++ b/cli/azd/internal/cmd/show/show_resource.go
@@ -85,7 +85,7 @@ func (s *showResource) showResourceGeneric(
 		return nil, fmt.Errorf("expanding variables: %w", err)
 	}
 
-	// Display environment variables
+	// Convert to environment variables
 	envValues := scaffold.EnvVars(resourceMeta.StandardVarPrefix, values)
 
 	display := id.ResourceType.String()
@@ -128,10 +128,10 @@ func getResourceMeta(id arm.ResourceID) (*scaffold.ResourceMeta, arm.ResourceID)
 		}
 	}
 
+	// inexact match, find the longest prefix match
 	var matched *scaffold.ResourceMeta
 	parentLevels := 0
 	for _, res := range resources {
-		// find longest prefix match
 		if strings.HasPrefix(resourceType, res.ResourceType) {
 			if matched == nil || len(res.ResourceType) > len(matched.ResourceType) {
 				matched = &res
@@ -140,6 +140,7 @@ func getResourceMeta(id arm.ResourceID) (*scaffold.ResourceMeta, arm.ResourceID)
 		}
 	}
 
+	// level up the resource id to the parent
 	parentId := &id
 	for i := 0; i < parentLevels; i++ {
 		if parentId.Parent != nil {

--- a/cli/azd/internal/cmd/show/show_resource.go
+++ b/cli/azd/internal/cmd/show/show_resource.go
@@ -74,7 +74,7 @@ func (s *showResource) showResourceGeneric(
 		resourceNode = node
 	}
 
-	context := scaffold.EvalCtx{
+	context := scaffold.EvalEnv{
 		ResourceSpec: resourceNode,
 		ArmResource:  spec,
 		VaultSecret:  resolveSecret,

--- a/cli/azd/internal/cmd/show/show_resource.go
+++ b/cli/azd/internal/cmd/show/show_resource.go
@@ -104,6 +104,22 @@ func getResourceMeta(id arm.ResourceID) (*scaffold.ResourceMeta, arm.ResourceID)
 
 	for _, res := range resources {
 		if res.ResourceType == resourceType { // exact match
+			if res.ParentForEval != "" {
+				// find the parent resource
+				parentId := &id
+				for {
+					if parentId.Parent != nil {
+						parentId = parentId.Parent
+					}
+
+					if parentId.ResourceType.Type == res.ParentForEval {
+						break
+					}
+				}
+
+				return &res, *parentId
+			}
+
 			return &res, id
 		}
 	}

--- a/cli/azd/internal/scaffold/resource_expr.go
+++ b/cli/azd/internal/scaffold/resource_expr.go
@@ -70,7 +70,7 @@ type Expression struct {
 	Value string
 
 	// The template that this expression is a part of.
-	// Can be nil if the expression is not part of a template, and if so Value is the final value.
+	// Can be nil if the expression is not part of a template, and if so Value will store the final value.
 	t *tmpl
 
 	// The start and end positions of the expression in the template.
@@ -229,7 +229,7 @@ func (p *parser) parseExpression() (*Expression, error) {
 				wordStart := p.cursor
 				origTerminal := p.terminal
 
-				// lookahead for the next token
+				// lookahead for the next word token
 				p.untilOneOf(Space, p.terminal)
 				terminal := p.peek()
 
@@ -287,9 +287,9 @@ func Parse(s *string) ([]Expression, error) {
 	for i, c := range val {
 		switch c {
 		case '$':
-			prev = c
 			if prev == '$' { // escape character, reset prev to avoid parsing
 				prev = 0
+				continue
 			}
 		case '{':
 			if prev == '$' {

--- a/cli/azd/internal/scaffold/resource_expr.go
+++ b/cli/azd/internal/scaffold/resource_expr.go
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package scaffold
+
+import (
+	"bytes"
+	"fmt"
+)
+
+type Kind uint32
+
+const (
+	PropertyExpr Kind = 1 << iota
+	SpecExpr
+	VaultExpr
+	VarExpr
+)
+
+const (
+	DotToken   = ""
+	SpecToken  = "spec"
+	VaultToken = "vault"
+)
+
+type PropertyExprData struct {
+	// The dotted property path
+	PropertyPath string
+}
+
+type SpecExprData struct {
+	// The dotted property path
+	PropertyPath string
+}
+
+type VaultExprData struct {
+	// The vault secret path to the value of the expression
+	SecretPath string
+}
+
+type VarExprData struct {
+	// The name of the variable
+	Name string
+}
+
+type expression struct {
+	// The kind of expression.
+	Kind Kind
+
+	// The data associated with the kind of expression.
+	Data any
+
+	// The template that this expression is a part of.
+	t *tmpl
+	// The start and end positions of the expression in the template.
+	start int
+	end   int
+}
+
+func (e *expression) Replace(val string) {
+	e.t.Replace(e, val)
+}
+
+const (
+	DotChar      byte = '.'
+	DoubleQuotes byte = '"'
+)
+
+// parser for a dot-like expression.
+type parser struct {
+	// The string to parse.
+	s string
+
+	// The terminal byte that ends the expression.
+	terminal byte
+
+	// The current cursor position.
+	cursor int
+
+	// The seen buffer.
+	seen bytes.Buffer
+}
+
+func (p *parser) peek() byte {
+	if p.cursor >= len(p.s) {
+		return 0 // end of string
+	}
+
+	return p.s[p.cursor]
+}
+
+func (p *parser) next() byte {
+	p.cursor++
+	return p.peek()
+}
+
+func (p *parser) until(b byte) byte {
+	p.seen.Reset()
+
+	c := p.peek()
+	for {
+		if c == 0 || c == b {
+			break
+		}
+
+		p.seen.WriteByte(c)
+		c = p.next()
+	}
+
+	return c
+}
+
+func (p *parser) parseExpression() (*expression, error) {
+	seen := bytes.Buffer{}
+	var expr *expression
+	for c := p.peek(); c != 0; c = p.next() {
+		switch c {
+		case '.':
+			p.next() // skip the '.' character
+			switch seen.String() {
+			case VaultToken:
+				expr = &expression{Kind: VaultExpr}
+				p.until(p.terminal)
+
+				path := p.seen.String()
+				expr.Data = VaultExprData{
+					SecretPath: path,
+				}
+				return expr, nil
+			case SpecToken:
+				expr = &expression{Kind: SpecExpr}
+				p.until(p.terminal)
+
+				path := p.seen.String()
+				expr.Data = SpecExprData{
+					PropertyPath: path,
+				}
+				return expr, nil
+			case "":
+				expr = &expression{Kind: PropertyExpr}
+				p.until(p.terminal)
+
+				path := p.seen.String()
+				expr.Data = PropertyExprData{
+					PropertyPath: path,
+				}
+				return expr, nil
+			default:
+				return nil, fmt.Errorf("unknown expression: %s", seen.String())
+			}
+			// parse qualifier
+		case 0, p.terminal: // we're done
+			expr = &expression{Kind: VarExpr}
+			expr.Data = VarExprData{
+				Name: seen.String(),
+			}
+			return expr, nil
+		}
+
+		seen.WriteByte(byte(c))
+	}
+
+	return nil, nil
+}
+
+// tmpl represents a string with placeholders and their replacements
+type tmpl struct {
+	// raw is the pointer to the raw string with expressions
+	raw *string
+	// rawOffset is the offset of the raw string due to replacements from expressions
+	rawOffset int
+	// expressions are the parsed expressions in the template
+	expressions []expression
+}
+
+func (t *tmpl) Replace(expr *expression, val string) {
+	raw := *t.raw
+	raw = raw[:expr.start+t.rawOffset] + val + raw[expr.end+t.rawOffset:]
+
+	*t.raw = raw
+	t.rawOffset += len(val) - (expr.end - expr.start)
+}
+
+func parseExpressions(s *string) ([]expression, error) {
+	var t *tmpl
+	prev := rune(0)
+	val := *s
+	for i, c := range val {
+		switch c {
+		case '$':
+			prev = c
+			if prev == '$' { // escape character, reset prev to avoid parsing
+				prev = 0
+			}
+		case '{':
+			if prev == '$' {
+				p := parser{s: val[i+1:], terminal: '}'}
+				expr, err := p.parseExpression()
+				if err != nil || expr == nil {
+					return nil, err
+				}
+
+				if t == nil {
+					t = &tmpl{
+						raw: s,
+					}
+				}
+
+				expr.start = i - 1                // start of '${'
+				expr.end = (i + 1) + p.cursor + 1 // end of '}'
+				expr.t = t
+				t.expressions = append(t.expressions, *expr)
+			}
+		}
+
+		prev = c
+	}
+
+	if t == nil {
+		return nil, nil
+	}
+
+	return t.expressions, nil
+}

--- a/cli/azd/internal/scaffold/resource_expr_eval.go
+++ b/cli/azd/internal/scaffold/resource_expr_eval.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package scaffold
 
 import (

--- a/cli/azd/internal/scaffold/resource_expr_eval.go
+++ b/cli/azd/internal/scaffold/resource_expr_eval.go
@@ -191,14 +191,8 @@ func evalExpression(env EvalEnv, key string, expr *Expression, results map[strin
 		literal := expr.Data.(LiteralExprData).Value
 		expr.Replace(literal)
 	case VaultExpr:
-		// Vault expression ${vault.xxx} or ${vault.}
+		// Vault expression ${vault.xxx}
 		secretPath := expr.Data.(VaultExprData).SecretPath
-		if secretPath == "" {
-			// the canonical secret path is the key, but we need to replace _ with -
-			// to match the vault secret name
-			secretPath = strings.ReplaceAll(key, "_", "-")
-		}
-
 		secret, err := env.VaultSecret(secretPath)
 		if err != nil {
 			return fmt.Errorf("failed to get secret '%s': %w", secretPath, err)

--- a/cli/azd/internal/scaffold/resource_expr_eval.go
+++ b/cli/azd/internal/scaffold/resource_expr_eval.go
@@ -3,15 +3,18 @@ package scaffold
 import (
 	"errors"
 	"fmt"
+	"log"
 	"slices"
 	"strings"
+
+	"maps"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/yamlnode"
 	"github.com/braydonk/yaml"
 	"github.com/tidwall/gjson"
 )
 
-type EvalCtx struct {
+type EvalEnv struct {
 	// ResourceSpec is the azure.yaml resource spec.
 	ResourceSpec *yaml.Node
 
@@ -20,20 +23,80 @@ type EvalCtx struct {
 
 	// VaultSecret is a function that resolves a secret from the vault.
 	VaultSecret func(string) (string, error)
+
+	// FuncMap is a map of function names to their implementations.
+	FuncMap map[string]FunctionCall
 }
 
-func Eval(values map[string]string, context EvalCtx) (map[string]string, error) {
-	if context.ArmResource == "" {
+type FunctionCall func([]string) (string, error)
+
+func BaseFuncMap() map[string]FunctionCall {
+	return map[string]FunctionCall{
+		// Add basic string manipulation functions
+		"concat": func(args []string) (string, error) {
+			return strings.Join(args, ""), nil
+		},
+		"lower": func(args []string) (string, error) {
+			if len(args) != 1 {
+				return "", fmt.Errorf("lower function requires exactly 1 argument")
+			}
+			return strings.ToLower(args[0]), nil
+		},
+		"upper": func(args []string) (string, error) {
+			if len(args) != 1 {
+				return "", fmt.Errorf("upper function requires exactly 1 argument")
+			}
+			return strings.ToUpper(args[0]), nil
+		},
+		"replace": func(args []string) (string, error) {
+			if len(args) != 3 {
+				return "", fmt.Errorf("replace function requires exactly 3 arguments: string, old, new")
+			}
+			return strings.Replace(args[0], args[1], args[2], -1), nil
+		},
+		"host": func(args []string) (string, error) {
+			if len(args) != 1 {
+				return "", fmt.Errorf("host function requires exactly 1 argument")
+			}
+			endpoint := args[0]
+			// Extract the host from the endpoint
+			host := strings.Split(strings.ReplaceAll(endpoint, "/", ""), ":")[1]
+			return host, nil
+		},
+	}
+}
+
+// Eval evaluates the given values using the provided environment.
+// It replaces the expressions in the values with their resolved values.
+// It returns the resolved values as a map.
+//
+// The function supports the following types of expressions:
+// - Variable references, ${varName}
+// - ARM Property expressions, ${.property.path}
+// - Spec expressions, ${spec.property.path}
+// - Literal expressions, ${"literal"} (for use in function expressions)
+// - Vault expressions, ${vault.secretName} OR ${vault.} -- the latter will use the key as the secret name
+// - Function expressions (only a single-level of nesting), ${concat "management.azure.com/" spec.id}
+//
+// The function also supports nested expressions and circular dependencies.
+func Eval(values map[string]string, env EvalEnv) (map[string]string, error) {
+	if env.ArmResource == "" {
 		return values, fmt.Errorf("missing arm resource")
 	}
 
-	if context.ResourceSpec == nil {
+	if env.ResourceSpec == nil {
 		return values, fmt.Errorf("missing resource spec")
 	}
 
-	if context.VaultSecret == nil {
+	if env.VaultSecret == nil {
 		return values, fmt.Errorf("missing vault secret resolver")
 	}
+
+	defaultFuncMap := BaseFuncMap()
+	if env.FuncMap == nil {
+		env.FuncMap = make(map[string]FunctionCall, len(defaultFuncMap))
+	}
+	maps.Copy(env.FuncMap, defaultFuncMap)
 
 	// parse into map of expression values
 	evalValues := make([]*expressionVar, 0, len(values))
@@ -68,6 +131,18 @@ func Eval(values map[string]string, context EvalCtx) (map[string]string, error) 
 				}
 
 				exp.dependsOn = append(exp.dependsOn, dependOn)
+			case FuncExpr:
+				funcData := expr.Data.(FuncExprData)
+				for _, arg := range funcData.Args {
+					if arg.Kind == VarExpr {
+						dependOn := arg.Data.(VarExprData).Name
+						if _, ok := values[dependOn]; !ok {
+							return nil, fmt.Errorf("missing dependency for function argument: %s", dependOn)
+						}
+
+						exp.dependsOn = append(exp.dependsOn, dependOn)
+					}
+				}
 			}
 		}
 
@@ -92,35 +167,9 @@ func Eval(values map[string]string, context EvalCtx) (map[string]string, error) 
 		}
 
 		for _, expr := range val.expressions {
-			switch expr.Kind {
-			case VarExpr:
-				envVarName := expr.Data.(VarExprData).Name
-				expr.Replace(results[envVarName].value)
-			case SpecExpr:
-				path := expr.Data.(SpecExprData).PropertyPath
-				node, _ := yamlnode.Find(context.ResourceSpec, path)
-				if node != nil {
-					expr.Replace(node.Value)
-				}
-			case PropertyExpr:
-				path := expr.Data.(PropertyExprData).PropertyPath
-				result := gjson.Get(context.ArmResource, path)
-				if result.Exists() {
-					expr.Replace(result.String())
-				}
-			case VaultExpr:
-				secretPath := expr.Data.(VaultExprData).SecretPath
-				if secretPath == "" {
-					// the canonical secret path is the key, but we need to replace _ with -
-					// to match the vault secret name
-					secretPath = strings.ReplaceAll(val.key, "_", "-")
-				}
-
-				secret, err := context.VaultSecret(secretPath)
-				if err != nil {
-					return nil, fmt.Errorf("failed to get secret '%s': %w", secretPath, err)
-				}
-				expr.Replace(secret)
+			err := evalExpression(env, val.key, &expr, results)
+			if err != nil {
+				return nil, fmt.Errorf("evaluating key '%s': %w", val.key, err)
 			}
 
 			results[val.key] = val
@@ -133,6 +182,83 @@ func Eval(values map[string]string, context EvalCtx) (map[string]string, error) 
 	}
 
 	return values, nil
+}
+
+func evalExpression(env EvalEnv, key string, expr *expression, results map[string]*expressionVar) error {
+	switch expr.Kind {
+	case VarExpr:
+		// Variable reference
+		varName := expr.Data.(VarExprData).Name
+		expr.Replace(results[varName].value)
+	case PropertyExpr:
+		// Property expression ${.xxx}
+		path := expr.Data.(PropertyExprData).PropertyPath
+		result := gjson.Get(env.ArmResource, path)
+		if !result.Exists() {
+			return fmt.Errorf("arm property '%s' does not exist", path)
+		}
+
+		expr.Replace(result.String())
+	case SpecExpr:
+		// Spec expression ${spec.xxx}
+		path := expr.Data.(SpecExprData).PropertyPath
+		node, err := yamlnode.Find(env.ResourceSpec, path)
+		if err != nil {
+			return fmt.Errorf("spec property '%s' does not exist: %w", path, err)
+		}
+
+		expr.Replace(node.Value)
+	case LiteralExpr:
+		// Literal expression ${"xxx"}
+		literal := expr.Data.(LiteralExprData).Value
+		expr.Replace(literal)
+	case VaultExpr:
+		// Vault expression ${vault.xxx} or ${vault.}
+		secretPath := expr.Data.(VaultExprData).SecretPath
+		if secretPath == "" {
+			// the canonical secret path is the key, but we need to replace _ with -
+			// to match the vault secret name
+			secretPath = strings.ReplaceAll(key, "_", "-")
+		}
+
+		secret, err := env.VaultSecret(secretPath)
+		if err != nil {
+			return fmt.Errorf("failed to get secret '%s': %w", secretPath, err)
+		}
+
+		expr.Replace(secret)
+	case FuncExpr:
+		funcData := expr.Data.(FuncExprData)
+		funcName := funcData.FuncName
+
+		// Check if function exists
+		fn, ok := env.FuncMap[funcName]
+		if !ok {
+			return fmt.Errorf("unknown function: %s", funcName)
+		}
+
+		// Evaluate all arguments
+		args := make([]string, 0, len(funcData.Args))
+		for _, arg := range funcData.Args {
+			err := evalExpression(env, key, arg, results)
+			if err != nil {
+				return fmt.Errorf("evaluating arguments for '%s': %w", funcName, err)
+			}
+
+			args = append(args, arg.Value)
+		}
+
+		log.Println("evaluating function", funcName, "with args", args)
+		// Call the function
+		funcResult, err := fn(args)
+		if err != nil {
+			return fmt.Errorf("calling '%s' failed: %w", funcName, err)
+		}
+
+		expr.Replace(funcResult)
+	}
+
+	return nil
 }
 
 // expressionVar represents an expression variable to be resolved, and its final output value.

--- a/cli/azd/internal/scaffold/resource_expr_eval.go
+++ b/cli/azd/internal/scaffold/resource_expr_eval.go
@@ -108,7 +108,7 @@ func Eval(values map[string]string, env EvalEnv) (map[string]string, error) {
 			value: value,
 		}
 
-		expressions, err := parseExpressions(&exp.value)
+		expressions, err := Parse(&exp.value)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse expression '%s': %w", exp.value, err)
 		}
@@ -184,7 +184,7 @@ func Eval(values map[string]string, env EvalEnv) (map[string]string, error) {
 	return values, nil
 }
 
-func evalExpression(env EvalEnv, key string, expr *expression, results map[string]*expressionVar) error {
+func evalExpression(env EvalEnv, key string, expr *Expression, results map[string]*expressionVar) error {
 	switch expr.Kind {
 	case VarExpr:
 		// Variable reference
@@ -273,7 +273,7 @@ type expressionVar struct {
 	value string
 
 	// The expressions parsed from the value. Can be nil if the value does not contain any expressions.
-	expressions []expression
+	expressions []Expression
 
 	// Variables that this variable depends on.
 	dependsOn []string

--- a/cli/azd/internal/scaffold/resource_expr_eval.go
+++ b/cli/azd/internal/scaffold/resource_expr_eval.go
@@ -1,0 +1,184 @@
+package scaffold
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/yamlnode"
+	"github.com/braydonk/yaml"
+	"github.com/tidwall/gjson"
+)
+
+type EvalCtx struct {
+	// ResourceSpec is the azure.yaml resource spec.
+	ResourceSpec *yaml.Node
+
+	// ArmResource is the Azure resource representation.
+	ArmResource string
+
+	// VaultSecret is a function that resolves a secret from the vault.
+	VaultSecret func(string) (string, error)
+}
+
+func Eval(values map[string]string, context EvalCtx) (map[string]string, error) {
+	if context.ArmResource == "" {
+		return values, fmt.Errorf("missing arm resource")
+	}
+
+	if context.ResourceSpec == nil {
+		return values, fmt.Errorf("missing resource spec")
+	}
+
+	if context.VaultSecret == nil {
+		return values, fmt.Errorf("missing vault secret resolver")
+	}
+
+	// parse into map of expression values
+	evalValues := make([]*expressionVar, 0, len(values))
+	results := make(map[string]*expressionVar, len(values))
+
+	for key, value := range values {
+		exp := &expressionVar{
+			key:   key,
+			value: value,
+		}
+
+		expressions, err := parseExpressions(&exp.value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse expression '%s': %w", exp.value, err)
+		}
+
+		if len(expressions) == 0 {
+			results[key] = exp
+			continue
+		}
+
+		exp.expressions = expressions
+
+		// parse dependencies
+		for _, expr := range exp.expressions {
+			switch expr.Kind {
+			case VarExpr:
+				dependOn := expr.Data.(VarExprData).Name
+
+				if _, ok := values[dependOn]; !ok {
+					return nil, fmt.Errorf("missing dependency: %s", dependOn)
+				}
+
+				exp.dependsOn = append(exp.dependsOn, dependOn)
+			}
+		}
+
+		evalValues = append(evalValues, exp)
+	}
+
+	// sort for determinism
+	slices.SortFunc(evalValues, func(a, b *expressionVar) int {
+		return strings.Compare(a.key, b.key)
+	})
+
+	// evaluate expressions
+	for {
+		val, err := nextVal(evalValues, results)
+		if err != nil {
+			return nil, fmt.Errorf("evaluating values: %w", err)
+		}
+
+		if val == nil {
+			// done
+			break
+		}
+
+		for _, expr := range val.expressions {
+			switch expr.Kind {
+			case VarExpr:
+				envVarName := expr.Data.(VarExprData).Name
+				expr.Replace(results[envVarName].value)
+			case SpecExpr:
+				path := expr.Data.(SpecExprData).PropertyPath
+				node, _ := yamlnode.Find(context.ResourceSpec, path)
+				if node != nil {
+					expr.Replace(node.Value)
+				}
+			case PropertyExpr:
+				path := expr.Data.(PropertyExprData).PropertyPath
+				result := gjson.Get(context.ArmResource, path)
+				if result.Exists() {
+					expr.Replace(result.String())
+				}
+			case VaultExpr:
+				secretPath := expr.Data.(VaultExprData).SecretPath
+				if secretPath == "" {
+					// the canonical secret path is the key, but we need to replace _ with -
+					// to match the vault secret name
+					secretPath = strings.ReplaceAll(val.key, "_", "-")
+				}
+
+				secret, err := context.VaultSecret(secretPath)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get secret '%s': %w", secretPath, err)
+				}
+				expr.Replace(secret)
+			}
+
+			results[val.key] = val
+		}
+	}
+
+	// return resolved values as map
+	for key, val := range results {
+		values[key] = val.value
+	}
+
+	return values, nil
+}
+
+// expressionVar represents an expression variable to be resolved, and its final output value.
+type expressionVar struct {
+	// The name of the variable
+	key string
+
+	// The value of the expression
+	//
+	// When initially created, this is the raw value of the expression.
+	// When the expression is resolved, this is the resolved value.
+	value string
+
+	// The expressions parsed from the value. Can be nil if the value does not contain any expressions.
+	expressions []expression
+
+	// Variables that this variable depends on.
+	dependsOn []string
+}
+
+func nextVal(evalCtx []*expressionVar, results map[string]*expressionVar) (*expressionVar, error) {
+	allDone := true
+
+	for _, val := range evalCtx {
+		if results[val.key] != nil {
+			// already done
+			continue
+		}
+
+		allDone = false
+		allDependenciesMet := true
+		for _, key := range val.dependsOn {
+			if _, ok := results[key]; !ok {
+				allDependenciesMet = false
+				break
+			}
+		}
+
+		if allDependenciesMet {
+			return val, nil
+		}
+	}
+
+	if !allDone {
+		return nil, errors.New("circular dependencies detected")
+	}
+
+	return nil, nil
+}

--- a/cli/azd/internal/scaffold/resource_expr_eval_test.go
+++ b/cli/azd/internal/scaffold/resource_expr_eval_test.go
@@ -47,16 +47,12 @@ location: westus
 		expected map[string]string
 	}{
 		{
-			name: "Basic function test - concat",
+			name: "Basic function test - replace",
 			input: map[string]string{
-				"prefix":    "prefix-",
-				"suffix":    "-suffix",
-				"full_name": "${concat \"prefix-\" spec.name \"-suffix\"}",
+				"full_name": "${replace .id 'test' 'test-resource'}",
 			},
 			expected: map[string]string{
-				"prefix":    "prefix-",
-				"suffix":    "-suffix",
-				"full_name": "prefix-test-resource-suffix",
+				"full_name": "test-resource-id",
 			},
 		},
 		{
@@ -101,26 +97,6 @@ location: westus
 				"formatted": "TEST-NAME",
 			},
 		},
-		{
-			name: "Mixed argument types",
-			input: map[string]string{
-				"mixed": "${concat \"prefix-\" spec.name '-suffix'}",
-			},
-			expected: map[string]string{
-				"mixed": "prefix-test-resource-suffix",
-			},
-		},
-		{
-			name: "Vault secret",
-			input: map[string]string{
-				"secret":    "${vault.my-secret}",
-				"formatted": "${concat \"Secret: \" vault.my-secret}",
-			},
-			expected: map[string]string{
-				"secret":    "secret-my-secret",
-				"formatted": "Secret: secret-my-secret",
-			},
-		},
 	}
 
 	// Run the tests
@@ -135,12 +111,9 @@ location: westus
 
 func TestEvalAdvanced(t *testing.T) {
 	// Create custom function map
-	customFuncMap := map[string]FunctionCall{}
-	customFuncMap["prefix"] = func(args []string) (string, error) {
-		if len(args) != 2 {
-			return "", assert.AnError
-		}
-		return args[0] + "-" + args[1], nil
+	customFuncMap := map[string]any{}
+	customFuncMap["prefix"] = func(prefix string, suffix string) string {
+		return prefix + "-" + suffix
 	}
 
 	// Create test context
@@ -166,8 +139,8 @@ location: eastus
 		"base":       "base",
 		"app_id":     "${prefix \"app\" spec.name}",
 		"resource":   "${prefix \"res\" .name}",
-		"combined":   "${concat app_id \"-\" resource}",
-		"with_vault": "${concat vault.secretkey \"-\" \"custom\"}",
+		"combined":   "${prefix app_id resource}",
+		"with_vault": "${prefix vault.secretkey \"custom\"}",
 	}
 
 	expected := map[string]string{

--- a/cli/azd/internal/scaffold/resource_expr_eval_test.go
+++ b/cli/azd/internal/scaffold/resource_expr_eval_test.go
@@ -1,0 +1,184 @@
+package scaffold
+
+import (
+	"testing"
+
+	"github.com/braydonk/yaml"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvalSimple(t *testing.T) {
+	// Create a simple resource spec
+	resourceSpecYaml := `
+name: test-resource
+location: westus
+`
+	var resourceSpec yaml.Node
+	err := yaml.Unmarshal([]byte(resourceSpecYaml), &resourceSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a simple ARM resource
+	armResource := `{
+		"id": "test-id",
+		"properties": {
+			"name": "test-properties-name",
+			"hostName": "test-host-name"
+		}
+	}`
+
+	// Create a simple vault secret resolver
+	vaultSecret := func(path string) (string, error) {
+		return "secret-" + path, nil
+	}
+
+	// Create the evaluation context
+	EvalEnv := EvalEnv{
+		ResourceSpec: &resourceSpec,
+		ArmResource:  armResource,
+		VaultSecret:  vaultSecret,
+	}
+
+	// Test cases
+	testCases := []struct {
+		name     string
+		input    map[string]string
+		expected map[string]string
+	}{
+		{
+			name: "Basic function test - concat",
+			input: map[string]string{
+				"prefix":    "prefix-",
+				"suffix":    "-suffix",
+				"full_name": "${concat \"prefix-\" spec.name \"-suffix\"}",
+			},
+			expected: map[string]string{
+				"prefix":    "prefix-",
+				"suffix":    "-suffix",
+				"full_name": "prefix-test-resource-suffix",
+			},
+		},
+		{
+			name: "Function with property access - lower",
+			input: map[string]string{
+				"resource_id":   "${lower .id}",
+				"resource_name": "${upper spec.name}",
+			},
+			expected: map[string]string{
+				"resource_id":   "test-id",
+				"resource_name": "TEST-RESOURCE",
+			},
+		},
+		{
+			name: "Replace function with double quotes",
+			input: map[string]string{
+				"original": "${.properties.hostName}",
+				"modified": "${replace .properties.hostName \"test-\" \"modified-\"}",
+			},
+			expected: map[string]string{
+				"original": "test-host-name",
+				"modified": "modified-host-name",
+			},
+		},
+		{
+			name: "Replace function with single quotes",
+			input: map[string]string{
+				"modified": "${replace .properties.hostName 'test-' 'modified-'}",
+			},
+			expected: map[string]string{
+				"modified": "modified-host-name",
+			},
+		},
+		{
+			name: "Variable reference as argument",
+			input: map[string]string{
+				"name":      "test-name",
+				"formatted": "${upper name}",
+			},
+			expected: map[string]string{
+				"name":      "test-name",
+				"formatted": "TEST-NAME",
+			},
+		},
+		{
+			name: "Mixed argument types",
+			input: map[string]string{
+				"mixed": "${concat \"prefix-\" spec.name '-suffix'}",
+			},
+			expected: map[string]string{
+				"mixed": "prefix-test-resource-suffix",
+			},
+		},
+		{
+			name: "Vault secret",
+			input: map[string]string{
+				"secret":    "${vault.my-secret}",
+				"formatted": "${concat \"Secret: \" vault.my-secret}",
+			},
+			expected: map[string]string{
+				"secret":    "secret-my-secret",
+				"formatted": "Secret: secret-my-secret",
+			},
+		},
+	}
+
+	// Run the tests
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := Eval(tc.input, EvalEnv)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEvalAdvanced(t *testing.T) {
+	// Create custom function map
+	customFuncMap := map[string]FunctionCall{}
+	customFuncMap["prefix"] = func(args []string) (string, error) {
+		if len(args) != 2 {
+			return "", assert.AnError
+		}
+		return args[0] + "-" + args[1], nil
+	}
+
+	// Create test context
+	resourceSpecYaml := `
+name: myapp
+location: eastus
+`
+	var resourceSpec yaml.Node
+	err := yaml.Unmarshal([]byte(resourceSpecYaml), &resourceSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	env := EvalEnv{
+		ResourceSpec: &resourceSpec,
+		ArmResource:  `{"id": "resource-id", "name": "resource-name"}`,
+		VaultSecret:  func(s string) (string, error) { return "vault-" + s, nil },
+		FuncMap:      customFuncMap,
+	}
+
+	// Test custom functions
+	input := map[string]string{
+		"base":       "base",
+		"app_id":     "${prefix \"app\" spec.name}",
+		"resource":   "${prefix \"res\" .name}",
+		"combined":   "${concat app_id \"-\" resource}",
+		"with_vault": "${concat vault.secretkey \"-\" \"custom\"}",
+	}
+
+	expected := map[string]string{
+		"base":       "base",
+		"app_id":     "app-myapp",
+		"resource":   "res-resource-name",
+		"combined":   "app-myapp-res-resource-name",
+		"with_vault": "vault-secretkey-custom",
+	}
+
+	result, err := Eval(input, env)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+}

--- a/cli/azd/internal/scaffold/resource_expr_eval_test.go
+++ b/cli/azd/internal/scaffold/resource_expr_eval_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package scaffold
 
 import (

--- a/cli/azd/internal/scaffold/resource_expr_test.go
+++ b/cli/azd/internal/scaffold/resource_expr_test.go
@@ -10,13 +10,13 @@ func TestExpressionParsing(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
-		expected []expression
+		expected []Expression
 		wantErr  bool
 	}{
 		{
 			name:  "simple property reference",
 			input: "${.properties.host}",
-			expected: []expression{{
+			expected: []Expression{{
 				Kind: PropertyExpr,
 				Data: PropertyExprData{
 					PropertyPath: "properties.host",
@@ -26,7 +26,7 @@ func TestExpressionParsing(t *testing.T) {
 		{
 			name:  "simple spec reference",
 			input: "${spec.name}",
-			expected: []expression{{
+			expected: []Expression{{
 				Kind: SpecExpr,
 				Data: SpecExprData{
 					PropertyPath: "name",
@@ -36,7 +36,7 @@ func TestExpressionParsing(t *testing.T) {
 		{
 			name:  "vault reference",
 			input: "${vault.SECRET-KEY}",
-			expected: []expression{{
+			expected: []Expression{{
 				Kind: VaultExpr,
 				Data: VaultExprData{
 					SecretPath: "SECRET-KEY",
@@ -46,7 +46,7 @@ func TestExpressionParsing(t *testing.T) {
 		{
 			name:  "environment variable",
 			input: "${DATABASE_URL}",
-			expected: []expression{{
+			expected: []Expression{{
 				Kind: VarExpr,
 				Data: VarExprData{
 					Name: "DATABASE_URL",
@@ -56,11 +56,11 @@ func TestExpressionParsing(t *testing.T) {
 		{
 			name:  "func",
 			input: "${func .id spec.name name}",
-			expected: []expression{{
+			expected: []Expression{{
 				Kind: FuncExpr,
 				Data: FuncExprData{
 					FuncName: "func",
-					Args: []*expression{
+					Args: []*Expression{
 						{
 							Kind: PropertyExpr,
 							Data: PropertyExprData{PropertyPath: "id"},
@@ -80,7 +80,7 @@ func TestExpressionParsing(t *testing.T) {
 		{
 			name:  "complex nested expression",
 			input: "postgresql://${.properties.user}:${vault.}@${.properties.host}:${DB_PORT}/${spec.name}",
-			expected: []expression{
+			expected: []Expression{
 				{
 					Kind: PropertyExpr,
 					Data: PropertyExprData{PropertyPath: "properties.user"},
@@ -112,7 +112,7 @@ func TestExpressionParsing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			expressions, err := parseExpressions(&tt.input)
+			expressions, err := Parse(&tt.input)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/cli/azd/internal/scaffold/resource_expr_test.go
+++ b/cli/azd/internal/scaffold/resource_expr_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package scaffold
 
 import (

--- a/cli/azd/internal/scaffold/resource_expr_test.go
+++ b/cli/azd/internal/scaffold/resource_expr_test.go
@@ -1,0 +1,107 @@
+package scaffold
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpressionParsing(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []expression
+		wantErr  bool
+	}{
+		{
+			name:  "simple property reference",
+			input: "${.properties.host}",
+			expected: []expression{{
+				Kind: PropertyExpr,
+				Data: PropertyExprData{
+					PropertyPath: "properties.host",
+				},
+			}},
+		},
+		{
+			name:  "simple spec reference",
+			input: "${spec.name}",
+			expected: []expression{{
+				Kind: SpecExpr,
+				Data: SpecExprData{
+					PropertyPath: "name",
+				},
+			}},
+		},
+		{
+			name:  "vault reference",
+			input: "${vault.SECRET-KEY}",
+			expected: []expression{{
+				Kind: VaultExpr,
+				Data: VaultExprData{
+					SecretPath: "SECRET-KEY",
+				},
+			}},
+		},
+		{
+			name:  "environment variable",
+			input: "${DATABASE_URL}",
+			expected: []expression{{
+				Kind: VarExpr,
+				Data: VarExprData{
+					Name: "DATABASE_URL",
+				},
+			}},
+		},
+		{
+			name:  "complex nested expression",
+			input: "postgresql://${.properties.user}:${vault.}@${.properties.host}:${DB_PORT}/${spec.name}",
+			expected: []expression{
+				{
+					Kind: PropertyExpr,
+					Data: PropertyExprData{PropertyPath: "properties.user"},
+				},
+				{
+					Kind: VaultExpr,
+					Data: VaultExprData{SecretPath: ""},
+				},
+				{
+					Kind: PropertyExpr,
+					Data: PropertyExprData{PropertyPath: "properties.host"},
+				},
+				{
+					Kind: VarExpr,
+					Data: VarExprData{Name: "DB_PORT"},
+				},
+				{
+					Kind: SpecExpr,
+					Data: SpecExprData{PropertyPath: "name"},
+				},
+			},
+		},
+		{
+			name:    "invalid token type",
+			input:   "${invalid.key}",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expressions, err := parseExpressions(&tt.input)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, len(tt.expected), len(expressions))
+
+			for i, exp := range tt.expected {
+				assert.Equal(t, exp.Kind, expressions[i].Kind)
+				assert.Equal(t, exp.Data, expressions[i].Data)
+			}
+		})
+	}
+}

--- a/cli/azd/internal/scaffold/resource_meta.go
+++ b/cli/azd/internal/scaffold/resource_meta.go
@@ -8,11 +8,18 @@ type ResourceMeta struct {
 	// ResourceType is the resource type.
 	ResourceType string
 
-	//
-	ParentResourceType string
+	// ResourceKind is the resource kind.
+	ResourceKind string
+
+	// ParentForEval is the parent resource used for evaluation.
+	// This can be moved into the expression language later.
+	ParentForEval string
 
 	// ApiVersion is the api version for the resource.
 	ApiVersion string
+
+	// StandardVarPrefix is the standard variable prefix for the resource.
+	StandardVarPrefix string
 
 	// Variables are the variables for the resource.
 	// The key is the variable name and the value is the expression.
@@ -76,8 +83,12 @@ var Resources = []ResourceMeta{
 		},
 	},
 	{
-		ResourceType: "Microsoft.DocumentDB/databaseAccounts",
-		ApiVersion:   "2023-04-15",
+		ResourceType:  "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
+		ApiVersion:    "2023-04-15",
+		ParentForEval: "Microsoft.DocumentDB/databaseAccounts",
+		Variables: map[string]string{
+			"AZURE_COSMOS_ENDPOINT": "${.properties.documentEndpoint}",
+		},
 	},
 	{
 		ResourceType: "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases",
@@ -97,6 +108,10 @@ var Resources = []ResourceMeta{
 	{
 		ResourceType: "Microsoft.KeyVault/vaults",
 		ApiVersion:   "2022-07-01",
+		Variables: map[string]string{
+			"AZURE_KEY_VAULT_NAME":     "${.name}",
+			"AZURE_KEY_VAULT_ENDPOINT": "${.properties.vaultUri}",
+		},
 	},
 	{
 		ResourceType: "Microsoft.ManagedIdentity/userAssignedIdentities",
@@ -116,6 +131,14 @@ var Resources = []ResourceMeta{
 		Variables: map[string]string{
 			"AZURE_STORAGE_ACCOUNT_NAME":  "${.name}",
 			"AZURE_STORAGE_BLOB_ENDPOINT": "${.properties.primaryEndpoints.blob}",
+		},
+	},
+	{
+		ResourceType: "Microsoft.MachineLearningServices/workspaces",
+		ResourceKind: "Project",
+		ApiVersion:   "2024-10-01",
+		Variables: map[string]string{
+			"AZURE_AI_PROJECT_CONNECTION_STRING": "${aiProjectConnectionString .id .properties.discoveryUrl}",
 		},
 	},
 }

--- a/cli/azd/internal/scaffold/resource_meta.go
+++ b/cli/azd/internal/scaffold/resource_meta.go
@@ -21,14 +21,15 @@ type ResourceMeta struct {
 	// StandardVarPrefix is the standard variable prefix for the resource.
 	StandardVarPrefix string
 
-	// Variables are the variables for the resource.
-	// The key is the variable name and the value is the expression.
+	// Variables are the variables exposed by this resource for connecting to application code.
+	//
+	// To evaluate the actual values, see [Eval].
 	Variables map[string]string
 }
 
-// Resources that are supported by the scaffold.
+// List of resources that are supported by scaffold.
 var Resources = []ResourceMeta{
-	// To register a new resource from AVM modules in resources.bicept:
+	// To register a newly added resource, run the following command:
 	//    cd tools/avmres && go run main.go
 	// and add the new resource to this list.
 	{

--- a/cli/azd/internal/scaffold/resource_meta.go
+++ b/cli/azd/internal/scaffold/resource_meta.go
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package scaffold
+
+// ResourceMeta contains the metadata for a resource.
+type ResourceMeta struct {
+	// ResourceType is the resource type.
+	ResourceType string
+
+	//
+	ParentResourceType string
+
+	// ApiVersion is the api version for the resource.
+	ApiVersion string
+
+	// Variables are the variables for the resource.
+	// The key is the variable name and the value is the expression.
+	Variables map[string]string
+}
+
+// Resources that are supported by the scaffold.
+var Resources = []ResourceMeta{
+	// To register a new resource from AVM modules in resources.bicept:
+	//    cd tools/avmres && go run main.go
+	// and add the new resource to this list.
+	{
+		ResourceType: "Microsoft.App/containerApps",
+		ApiVersion:   "2023-05-01",
+	},
+	{
+		ResourceType: "Microsoft.App/managedEnvironments",
+		ApiVersion:   "2023-05-01",
+	},
+	{
+		ResourceType: "Microsoft.Cache/redis",
+		ApiVersion:   "2024-03-01",
+		Variables: map[string]string{
+			"REDIS_HOST":     "${.properties.hostName}",
+			"REDIS_PORT":     "6380",
+			"REDIS_PASSWORD": "${vault.}",
+			"REDIS_URL":      "redis://${REDIS_HOST}:${REDIS_PORT}",
+			"REDIS_ENDPOINT": "${REDIS_HOST}:${REDIS_PORT}",
+		},
+	},
+	{
+		ResourceType: "Microsoft.CognitiveServices/accounts",
+		ApiVersion:   "2023-05-01",
+	},
+	{
+		ResourceType: "Microsoft.ContainerRegistry/registries",
+		ApiVersion:   "2023-06-01-preview",
+	},
+	{
+		ResourceType: "Microsoft.DBforMySQL/flexibleServers",
+		ApiVersion:   "2023-12-30",
+		Variables: map[string]string{
+			"MYSQL_DATABASE": "${spec.name}",
+			"MYSQL_HOST":     "${.properties.fullyQualifiedDomainName}",
+			"MYSQL_USERNAME": "${.properties.administratorLogin}",
+			"MYSQL_PORT":     "3306",
+			"MYSQL_PASSWORD": "${vault.}",
+			"MYSQL_URL":      "mysql://${MYSQL_USERNAME}:${MYSQL_PASSWORD}@${MYSQL_HOST}:3306/${MYSQL_DATABASE}",
+		},
+	},
+	{
+		ResourceType: "Microsoft.DBforPostgreSQL/flexibleServers",
+		ApiVersion:   "2022-12-01",
+		Variables: map[string]string{
+			"POSTGRES_DATABASE": "${spec.name}",
+			"POSTGRES_HOST":     "${.properties.fullyQualifiedDomainName}",
+			"POSTGRES_USERNAME": "${.properties.administratorLogin}",
+			"POSTGRES_PORT":     "5432",
+			"POSTGRES_PASSWORD": "${vault.}",
+			"POSTGRES_URL":      "postgresql://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/${POSTGRES_DATABASE}",
+		},
+	},
+	{
+		ResourceType: "Microsoft.DocumentDB/databaseAccounts",
+		ApiVersion:   "2023-04-15",
+	},
+	{
+		ResourceType: "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases",
+		ApiVersion:   "2023-04-15",
+		Variables: map[string]string{
+			"MONGODB_URL": "${vault.}",
+		},
+	},
+	{
+		ResourceType: "Microsoft.EventHub/namespaces",
+		ApiVersion:   "2024-01-01",
+		Variables: map[string]string{
+			"AZURE_EVENT_HUBS_NAME": "${.name}",
+			"AZURE_EVENT_HUBS_HOST": "${.name}.servicebus.windows.net",
+		},
+	},
+	{
+		ResourceType: "Microsoft.KeyVault/vaults",
+		ApiVersion:   "2022-07-01",
+	},
+	{
+		ResourceType: "Microsoft.ManagedIdentity/userAssignedIdentities",
+		ApiVersion:   "2023-01-31",
+	},
+	{
+		ResourceType: "Microsoft.ServiceBus/namespaces",
+		ApiVersion:   "2022-10-01-preview",
+		Variables: map[string]string{
+			"AZURE_SERVICE_BUS_NAME": "${.name}",
+			"AZURE_SERVICE_BUS_HOST": "${.name}.servicebus.windows.net",
+		},
+	},
+	{
+		ResourceType: "Microsoft.Storage/storageAccounts",
+		ApiVersion:   "2023-05-01",
+		Variables: map[string]string{
+			"AZURE_STORAGE_ACCOUNT_NAME":  "${.name}",
+			"AZURE_STORAGE_BLOB_ENDPOINT": "${.properties.primaryEndpoints.blob}",
+		},
+	},
+}

--- a/cli/azd/internal/scaffold/resource_meta.go
+++ b/cli/azd/internal/scaffold/resource_meta.go
@@ -91,7 +91,7 @@ var Resources = []ResourceMeta{
 		ApiVersion:   "2024-01-01",
 		Variables: map[string]string{
 			"AZURE_EVENT_HUBS_NAME": "${.name}",
-			"AZURE_EVENT_HUBS_HOST": "${.name}.servicebus.windows.net",
+			"AZURE_EVENT_HUBS_HOST": "${host .properties.serviceBusEndpoint}",
 		},
 	},
 	{
@@ -107,7 +107,7 @@ var Resources = []ResourceMeta{
 		ApiVersion:   "2022-10-01-preview",
 		Variables: map[string]string{
 			"AZURE_SERVICE_BUS_NAME": "${.name}",
-			"AZURE_SERVICE_BUS_HOST": "${.name}.servicebus.windows.net",
+			"AZURE_SERVICE_BUS_HOST": "${host .properties.serviceBusEndpoint}",
 		},
 	},
 	{

--- a/cli/azd/pkg/infra/util.go
+++ b/cli/azd/pkg/infra/util.go
@@ -36,3 +36,8 @@ func ResourceId(name string, env *environment.Environment) (resId *arm.ResourceI
 
 	return resId, nil
 }
+
+// KeyVaultName returns the name of the "canonical" key vault to use for secrets.
+func KeyVaultName(env *environment.Environment) string {
+	return env.Getenv("AZURE_KEY_VAULT_NAME")
+}

--- a/cli/azd/pkg/output/ux/show.go
+++ b/cli/azd/pkg/output/ux/show.go
@@ -144,3 +144,21 @@ func environments(environments []*ShowEnvironment) string {
 func (s *Show) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("not implemented")
 }
+
+type ShowResource struct {
+	Name        string
+	TypeDisplay string
+	Variables   map[string]string
+}
+
+func (s *ShowResource) ToString(currentIndentation string) string {
+	return fmt.Sprintf(
+		"%s\n"+
+			"  Variables:\n"+
+			color.HiBlueString(formatEnv("    ", s.Variables)),
+		color.HiMagentaString("%s (%s)", s.Name, s.TypeDisplay))
+}
+
+func (s *ShowResource) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/cli/azd/pkg/project/resources.go
+++ b/cli/azd/pkg/project/resources.go
@@ -79,17 +79,24 @@ type ResourceConfig struct {
 	// Type of resource
 	Type ResourceType `yaml:"type"`
 	// The name of the resource
-	Name string `yaml:"-"`
+	Name string `yaml:"name,omitempty"`
 	// The properties for the resource
 	RawProps map[string]yaml.Node `yaml:",inline"`
 	Props    interface{}          `yaml:"-"`
 	// Relationships to other resources
 	Uses []string `yaml:"uses,omitempty"`
+
+	// IncludeName indicates whether the `name` field should be included upon serialization.
+	IncludeName bool `yaml:"-"`
 }
 
 func (r *ResourceConfig) MarshalYAML() (interface{}, error) {
 	type rawResourceConfig ResourceConfig
 	raw := rawResourceConfig(*r)
+
+	if !raw.IncludeName {
+		raw.Name = ""
+	}
 
 	var marshalRawProps = func(in interface{}) error {
 		marshaled, err := yaml.Marshal(in)

--- a/cli/azd/pkg/project/resources.go
+++ b/cli/azd/pkg/project/resources.go
@@ -73,6 +73,43 @@ func (r ResourceType) String() string {
 	return ""
 }
 
+func (r ResourceType) AzureResourceType() string {
+	// DEV note:
+	// This can be updated after the resource is fully generated in scaffold
+	// and well-tested.
+	//
+	// Alongside this, the resource type should be updated in the scaffold/resource_meta.go
+	// See notes there on how to easily obtain the resource type for new AVM modules.
+	switch r {
+	case ResourceTypeHostContainerApp:
+		return "Microsoft.App/containerApps"
+	case ResourceTypeDbRedis:
+		return "Microsoft.Cache/redis"
+	case ResourceTypeDbPostgres:
+		return "Microsoft.DBforPostgreSQL/flexibleServers/databases"
+	case ResourceTypeDbMySql:
+		return "Microsoft.DBforMySQL/flexibleServers/databases"
+	case ResourceTypeDbMongo:
+		return "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases"
+	case ResourceTypeOpenAiModel:
+		return "Microsoft.CognitiveServices/accounts/deployments"
+	case ResourceTypeDbCosmos:
+		return "Microsoft.DocumentDB/databaseAccounts/sqlDatabases"
+	case ResourceTypeMessagingEventHubs:
+		return "Microsoft.EventHub/namespaces"
+	case ResourceTypeMessagingServiceBus:
+		return "Microsoft.ServiceBus/namespaces"
+	case ResourceTypeStorage:
+		return "Microsoft.Storage/storageAccounts"
+	case ResourceTypeKeyVault:
+		return "Microsoft.KeyVault/vaults"
+	case ResourceTypeAiProject:
+		return "Microsoft.MachineLearningServices/workspaces"
+	}
+
+	return ""
+}
+
 type ResourceConfig struct {
 	// Reference to the parent project configuration
 	Project *ProjectConfig `yaml:"-"`

--- a/cli/azd/tools/avmres/main.go
+++ b/cli/azd/tools/avmres/main.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+
+	//nolint:ST1001
+
+	"github.com/azure/azure-dev/cli/azd/internal/scaffold"
+	flag "github.com/spf13/pflag"
+)
+
+var (
+	token      = flag.String("token", "", "GitHub token")
+	avmModule  = flag.String("module", "", "AVM module")
+	bicepFile  = flag.String("bicep-file", "../../resources/scaffold/templates/resources.bicept", "Bicep file")
+	emitSource = flag.Bool("emit-source", false, "Emit the fetched source documents to disk.")
+)
+
+var bicepAvmModuleRegex = regexp.MustCompile(`'br/public:(avm/res/.+?)'`)
+
+func run() error {
+	var avmModules []string
+
+	if avmModule == nil || *avmModule == "" {
+		bytes, err := os.ReadFile(*bicepFile)
+		if err != nil {
+			return fmt.Errorf("reading bicep file: %w", err)
+		}
+
+		matches := bicepAvmModuleRegex.FindAllStringSubmatch(string(bytes), -1)
+		for _, match := range matches {
+			if len(match) > 1 {
+				avmModules = append(avmModules, match[1])
+			}
+		}
+	} else {
+		avmModules = append(avmModules, *avmModule)
+	}
+
+	resources := []scaffold.ResourceMeta{}
+	for _, avmModule := range avmModules {
+		moduleVersion := strings.Split(avmModule, ":")
+		module, version := moduleVersion[0], moduleVersion[1]
+
+		readme, err := fetchGithub(
+			*token,
+			"Azure/bicep-registry-modules",
+			fmt.Sprintf("%s/README.md", module),
+			fmt.Sprintf("%s/%s", module, version))
+		if err != nil {
+			return fmt.Errorf("fetching README: %w", err)
+		}
+
+		brackets := regexp.MustCompile(`\[(.*?)\]`)
+
+		lines := strings.Split(string(readme), "\n")
+		resourceType := ""
+		apiVersion := ""
+		inSection := false
+		for i, line := range lines {
+			if i == 0 {
+				// Extract the resource type from something that looks like:
+				// # Storage Accounts `[Microsoft.Storage/storageAccounts]`
+				matches := brackets.FindStringSubmatch(line)
+				if len(matches) > 1 {
+					resourceType = matches[1]
+				}
+			}
+
+			if strings.HasPrefix(line, "## Resource Types") {
+				inSection = true
+			}
+
+			if inSection {
+				// Example input:
+				//nolint:lll
+				// | `Microsoft.Storage/storageAccounts` | [2023-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2023-05-01/storageAccounts) |
+				if strings.HasPrefix(line, "|") { // inside table
+					if strings.Contains(line, "`"+resourceType+"`") { // found the resource type
+						matches := brackets.FindStringSubmatch(line)
+						if len(matches) > 1 {
+							apiVersion = matches[1]
+							break
+						}
+					}
+				}
+			}
+		}
+
+		if resourceType == "" || apiVersion == "" {
+			return fmt.Errorf("unable to find resource type or API version, run with --emit-source to see the source")
+		}
+
+		resources = append(resources, scaffold.ResourceMeta{
+			ApiVersion:   apiVersion,
+			ResourceType: resourceType,
+		})
+	}
+
+	slices.SortFunc(resources, func(a, b scaffold.ResourceMeta) int {
+		return strings.Compare(a.ResourceType, b.ResourceType)
+	})
+
+	for _, res := range resources {
+		fmt.Println("{")
+		fmt.Printf("  ResourceType: \"%s\",\n", res.ResourceType)
+		fmt.Printf("  ApiVersion: \"%s\",\n", res.ApiVersion)
+		fmt.Println("},")
+	}
+
+	return nil
+}
+
+func main() {
+	flag.Parse()
+
+	err := run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+	}
+}
+
+// path example: specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2023-05-01/cognitiveservices.json
+// token example: GITHUB_TOKEN
+func fetchGithub(
+	token string,
+	repo string,
+	path string,
+	tag string) ([]byte, error) {
+	req, err := http.NewRequest("GET",
+		fmt.Sprintf("https://api.github.com/repos/%s/contents/%s?ref=%s", repo, path, tag), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github.raw")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	if token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("http status code: %d", resp.StatusCode)
+	}
+
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading body: %w", err)
+	}
+
+	if emitSource != nil && *emitSource {
+		lastSep := strings.LastIndex(path, "/")
+		fileName := path[lastSep+1:]
+		err = os.WriteFile(fileName, content, 0644)
+		if err != nil {
+			return nil, fmt.Errorf("writing file: %w", err)
+		}
+	}
+
+	_ = resp.Body.Close()
+	return content, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203
 	github.com/fatih/color v1.13.0
 	github.com/gofrs/flock v0.8.1
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golobby/container/v3 v3.3.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.1
@@ -64,6 +65,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.10.0
 	github.com/theckman/yacspin v0.13.12
+	github.com/tidwall/gjson v1.18.0
 	go.lsp.dev/jsonrpc2 v0.10.0
 	go.opentelemetry.io/otel v1.8.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.8.0
@@ -76,6 +78,7 @@ require (
 	google.golang.org/grpc v1.68.1
 	google.golang.org/protobuf v1.34.2
 	gopkg.in/dnaeon/go-vcr.v3 v3.1.2
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -86,7 +89,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
@@ -100,7 +102,6 @@ require (
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.3.4 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.8.0 // indirect
@@ -111,5 +112,4 @@ require (
 	golang.org/x/term v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/azure/azure-dev
 go 1.23
 
 require (
+	dario.cat/mergo v1.0.1
 	github.com/AlecAivazis/survey/v2 v2.3.2
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.0
@@ -30,6 +31,7 @@ require (
 	github.com/Azure/azure-storage-file-go v0.8.0
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/adam-lavrik/go-imath v0.0.0-20210910152346-265a42a96f0b
 	github.com/benbjohnson/clock v1.3.0
 	github.com/blang/semver/v4 v4.0.0
@@ -39,6 +41,7 @@ require (
 	github.com/buger/goterm v1.0.4
 	github.com/cli/browser v1.1.0
 	github.com/drone/envsubst v1.0.3
+	github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203
 	github.com/fatih/color v1.13.0
 	github.com/gofrs/flock v0.8.1
 	github.com/golobby/container/v3 v3.3.1
@@ -76,14 +79,11 @@ require (
 )
 
 require (
-	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/azure-pipeline-go v0.2.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.1.0 // indirect
-	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
@@ -100,6 +100,9 @@ require (
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.3.4 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.8.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.8.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -535,6 +535,12 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/theckman/yacspin v0.13.12 h1:CdZ57+n0U6JMuh2xqjnjRq5Haj6v1ner2djtLQRzJr4=
 github.com/theckman/yacspin v0.13.12/go.mod h1:Rd2+oG2LmQi5f3zC3yeZAOl245z8QOvrH4OPOJNZxLg=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Add ability to `azd show <name>` for all existing supported resources.

With this change, we add the ability to display fully-evaluated connection variables for resources without provisioning a `host` resource.

To do this, we create a generic mapping between ARM and the app representation. This mapping, which is comprised of simple templating-like expressions, are evaluated against live Azure in the `show` command. 

Example output:
<img width="687" alt="image" src="https://github.com/user-attachments/assets/ccf37eb3-5863-447a-ab01-1cc8addd9da6" />

## Forward-looking ideas

1. This contributes to #4577, in which `azd show <full resource ID>` could be used to display, or as a base layer, for obtaining connection information to an existing resource. The schema does not track managed identity vs key-based approaches, but I do see a somewhat straightforward pathway there.

2. This also contributes to #4747, as we are laying down a schema mapping that could be used to *emit* Bicep representation during generation. This may end up unifying the story between generation and evaluation for roundtripping.

3. This also contributes to #4747. we expect to use parts of the parsing logic in to support a similar expression-model at the app layer.

Closes #4727
Contributes to #4577, #4747, #4887 