### PR TITLE
Allow Linux App Service deployments to resume on 500 deployment status response

### DIFF
--- a/cli/azd/pkg/azapi/azure_client_linuxwebapp_test.go
+++ b/cli/azd/pkg/azapi/azure_client_linuxwebapp_test.go
@@ -69,7 +69,32 @@ func Test_DeployTrackLinuxWebAppStatus(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("Error", func(t *testing.T) {
+	t.Run("InternalServerError", func(t *testing.T) {
+		ran := false
+		mockContext := mocks.NewMockContext(context.Background())
+		azCli := newAzureClientFromMockContext(mockContext)
+
+		registerIsLinuxWebAppMocks(mockContext, &ran)
+		registerLinuxWebAppZipDeployMocks(mockContext, &ran)
+		registerLinuxWebAppDeploy500SuccessfulMocks(mockContext, &ran)
+
+		zipFile := bytes.NewReader([]byte{})
+
+		res, err := azCli.DeployAppServiceZip(
+			*mockContext.Context,
+			"SUBSCRIPTION_ID",
+			"RESOURCE_GROUP_ID",
+			"LINUX_WEB_APP_NAME",
+			zipFile,
+			func(s string) {},
+		)
+
+		require.NoError(t, err)
+		require.True(t, ran)
+		require.NotNil(t, res)
+	})
+
+	t.Run("Logic App Success", func(t *testing.T) {
 		ran := false
 		mockContext := mocks.NewMockContext(context.Background())
 		azCli := newAzureClientFromMockContext(mockContext)
@@ -242,6 +267,70 @@ func registerLinuxWebAppDeployRuntimeFailedMocks(mockContext *mocks.MockContext,
 		)
 
 		return response, nil
+	})
+}
+
+func registerLinuxWebAppDeploy500SuccessfulMocks(mockContext *mocks.MockContext, ran *bool) {
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		//nolint:lll
+		return request.Method == http.MethodGet &&
+			strings.Contains(
+				request.URL.Path,
+				"/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_ID/providers/Microsoft.Web/sites/LINUX_WEB_APP_NAME/deploymentStatus/00000000-0000-0000-0000-000000000000",
+			)
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*ran = true
+		response, _ := mocks.CreateHttpResponseWithBody(
+			request,
+			int(http.StatusInternalServerError),
+			map[string]any{
+				"code": "InternalServerError",
+				"details": []any{
+					map[string]any{"message": nil},
+					map[string]any{"code": "InternalServerError"},
+					map[string]any{
+						"errorEntity": map[string]any{
+							"code":    "InternalServerError",
+							"message": nil,
+						},
+					},
+				},
+			},
+		)
+		return response, nil
+	})
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodPost &&
+			request.URL.Host == "LINUX_WEB_APP_NAME_SCM_HOST" &&
+			strings.Contains(request.URL.Path, "/api/zipdeploy")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*ran = true
+		response, _ := mocks.CreateEmptyHttpResponse(request, http.StatusAccepted)
+		response.Header.Set("Location", "https://LINUX_WEB_APP_NAME_SCM_HOST/deployments/latest")
+		return response, nil
+	})
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.Method == http.MethodGet && request.URL.Host == "LINUX_WEB_APP_NAME_SCM_HOST" &&
+			strings.Contains(request.URL.Path, "/deployments/latest")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		*ran = true
+		completeStatus := azsdk.DeployStatusResponse{
+			DeployStatus: azsdk.DeployStatus{
+				Id:         "ID",
+				Status:     http.StatusOK,
+				StatusText: "OK",
+				Message:    "Deployment Complete",
+				Progress:   nil,
+				Complete:   true,
+				Active:     true,
+				SiteName:   "LINUX_WEB_APP_NAME",
+				LogUrl:     "https://log.url",
+			},
+		}
+
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, completeStatus)
 	})
 }
 

--- a/cli/azd/pkg/azapi/webapp.go
+++ b/cli/azd/pkg/azapi/webapp.go
@@ -115,6 +115,12 @@ func resumeDeployment(err error, progressLog func(msg string)) bool {
 			"Resuming deployment without tracking status.")
 		return true
 	}
+
+	if errors.As(err, &httpErr) && httpErr.StatusCode == 500 {
+		progressLog("Internal server error. Failed to enable tracking runtime status. " +
+			"Resuming deployment without tracking status.")
+		return true
+	}
 	return false
 }
 

--- a/cli/azd/pkg/azapi/webapp.go
+++ b/cli/azd/pkg/azapi/webapp.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -110,13 +111,13 @@ func resumeDeployment(err error, progressLog func(msg string)) bool {
 	}
 
 	var httpErr *azcore.ResponseError
-	if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
 		progressLog("Resource not found. Failed to enable tracking runtime status." +
 			"Resuming deployment without tracking status.")
 		return true
 	}
 
-	if errors.As(err, &httpErr) && httpErr.StatusCode == 500 {
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusInternalServerError {
 		progressLog("Internal server error. Failed to enable tracking runtime status. " +
 			"Resuming deployment without tracking status.")
 		return true

--- a/cli/azd/pkg/azsdk/zip_deploy_client.go
+++ b/cli/azd/pkg/azsdk/zip_deploy_client.go
@@ -281,6 +281,10 @@ func (c *ZipDeployClient) DeployTrackStatus(
 			return err
 		}
 
+		if resp.StatusCode == http.StatusInternalServerError {
+			return runtime.NewResponseError(resp)
+		}
+
 		if err := runtime.UnmarshalAsJSON(resp, &response); err != nil {
 			return err
 		}


### PR DESCRIPTION
Contributes to #4844

This PR makes a change to allow Linux App Service deployments to continue and not fail when it encounters a 500 Internal Server Error response from polling the [deploymentStatus API](https://learn.microsoft.com/en-us/rest/api/appservice/web-apps/get-production-site-deployment-status?view=rest-appservice-2024-04-01&tabs=HTTP).

I'm using the existing `progressLog` to log the 500 error, which, as seen in the video below, disappears after the operation completes. If we want to have a persisted warning message, I'm not sure how straightforward it is to add that to the `deploy` flow and would need some guidance there.

## Demo

https://github.com/user-attachments/assets/8851b4f7-4b24-4cb5-bcf4-2ecb0c732621

