### PR TITLE
require min 2 capacity for s0 sku

### DIFF
--- a/cli/azd/pkg/infra/provisioning/bicep/prompt.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt.go
@@ -133,7 +133,8 @@ func (a *BicepProvider) locationsWithQuotaFor(
 	sharedResults.Range(func(key, value any) bool {
 		usages := value.([]*armcognitiveservices.Usage)
 		hasS0SkuQuota := slices.ContainsFunc(usages, func(q *armcognitiveservices.Usage) bool {
-			return *q.Name.Value == "OpenAI.S0.AccountCount" && *q.CurrentValue < *q.Limit
+			// The minimum quota for the S0 SKU in Microsoft.CognitiveServices/accounts is 2 capacity units
+			return *q.Name.Value == "OpenAI.S0.AccountCount" && (*q.Limit-*q.CurrentValue) >= 2
 		})
 		hasQuotaForModel := slices.ContainsFunc(usages, func(q *armcognitiveservices.Usage) bool {
 			hasQuota := *q.Name.Value == skuUsageName


### PR DESCRIPTION
fix: https://github.com/Azure/azure-dev/issues/4920

Current filter is only looking for locations where S0 sku capacity for cognitive accounts is greater than 0.
This can still lead to a failure b/c S0 requires at least 2 capacity units.