### PR TITLE
compose: `azd add` support for Azure AI Search

### DIFF
--- a/cli/azd/internal/cmd/add/add_configure.go
+++ b/cli/azd/internal/cmd/add/add_configure.go
@@ -67,6 +67,13 @@ func Configure(
 		return fillStorageDetails(ctx, r, console, p)
 	case project.ResourceTypeAiProject:
 		return fillAiProjectName(ctx, r, console, p)
+	case project.ResourceTypeAiSearch:
+		if _, exists := p.PrjConfig.Resources["search"]; exists {
+			return nil, fmt.Errorf("only one AI Search resource is allowed at this time")
+		}
+
+		r.Name = "search"
+		return r, nil
 	case project.ResourceTypeKeyVault:
 		if _, exists := p.PrjConfig.Resources["vault"]; exists {
 			return nil, fmt.Errorf(

--- a/cli/azd/internal/cmd/add/add_select.go
+++ b/cli/azd/internal/cmd/add/add_select.go
@@ -5,6 +5,7 @@ package add
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"slices"
 	"strings"
@@ -31,7 +32,7 @@ func (a *AddAction) selectMenu() []Menu {
 	return []Menu{
 		{Namespace: "db", Label: "Database", SelectResource: selectDatabase},
 		{Namespace: "host", Label: "Host service"},
-		{Namespace: "ai", Label: "AI models", SelectResource: a.selectAiType},
+		{Namespace: "ai", Label: "AI", SelectResource: a.selectAiType},
 		{Namespace: "messaging", Label: "Messaging", SelectResource: selectMessaging},
 		{Namespace: "storage", Label: "Storage account", SelectResource: selectStorage},
 		{Namespace: "keyvault", Label: "Key Vault", SelectResource: selectKeyVault},
@@ -42,12 +43,14 @@ func (a *AddAction) selectAiType(
 	console input.Console, ctx context.Context, p PromptOptions) (*project.ResourceConfig, error) {
 	openAiOption := "Azure OpenAI model"
 	otherAiModels := "Azure AI services model"
+	aiSearch := "Azure AI Search"
 	options := []string{
 		openAiOption,
 		otherAiModels,
+		aiSearch,
 	}
 	aiOptionIndex, err := console.Select(ctx, input.ConsoleOptions{
-		Message:      "Which type of AI model?",
+		Message:      "Which type of AI resource?",
 		DefaultValue: openAiOption,
 		Options:      options,
 	})
@@ -55,10 +58,16 @@ func (a *AddAction) selectAiType(
 		return nil, err
 	}
 	selectedOption := options[aiOptionIndex]
-	if selectedOption == openAiOption {
+	switch selectedOption {
+	case openAiOption:
 		return a.selectOpenAi(console, ctx, p)
+	case aiSearch:
+		return a.selectSearch(console, ctx, p)
+	case otherAiModels: // otherAiModels
+		return a.selectAiModel(console, ctx, p)
+	default:
+		return nil, fmt.Errorf("invalid option %q", selectedOption)
 	}
-	return a.selectAiModel(console, ctx, p)
 }
 
 func selectDatabase(

--- a/cli/azd/internal/cmd/add/add_select.go
+++ b/cli/azd/internal/cmd/add/add_select.go
@@ -61,10 +61,10 @@ func (a *AddAction) selectAiType(
 	switch selectedOption {
 	case openAiOption:
 		return a.selectOpenAi(console, ctx, p)
+	case otherAiModels:
+		return a.selectAiModel(console, ctx, p)
 	case aiSearch:
 		return a.selectSearch(console, ctx, p)
-	case otherAiModels: // otherAiModels
-		return a.selectAiModel(console, ctx, p)
 	default:
 		return nil, fmt.Errorf("invalid option %q", selectedOption)
 	}

--- a/cli/azd/internal/cmd/add/add_select_ai.go
+++ b/cli/azd/internal/cmd/add/add_select_ai.go
@@ -22,6 +22,15 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 )
 
+func (a *AddAction) selectSearch(
+	console input.Console,
+	ctx context.Context,
+	_ PromptOptions) (*project.ResourceConfig, error) {
+	r := &project.ResourceConfig{}
+	r.Type = project.ResourceTypeAiSearch
+	return r, nil
+}
+
 func (a *AddAction) selectOpenAi(
 	console input.Console,
 	ctx context.Context,

--- a/cli/azd/internal/scaffold/resource_meta.go
+++ b/cli/azd/internal/scaffold/resource_meta.go
@@ -156,6 +156,14 @@ var Resources = []ResourceMeta{
 			"connectionString": "${aiProjectConnectionString .id .properties.discoveryUrl}",
 		},
 	},
+	{
+		ResourceType:      "Microsoft.Search/searchServices",
+		ApiVersion:        "2024-06-01-preview",
+		StandardVarPrefix: "AZURE_SEARCH",
+		Variables: map[string]string{
+			"endpoint": "https://${.name}.search.windows.net",
+		},
+	},
 }
 
 // EnvVars creates a map of environment variables with the given prefix and variable names.

--- a/cli/azd/internal/scaffold/resource_meta.go
+++ b/cli/azd/internal/scaffold/resource_meta.go
@@ -160,7 +160,7 @@ var Resources = []ResourceMeta{
 		ResourceType: "Microsoft.Search/searchServices",
 		// TODO: Switch to 2025-02-01-preview once available, which has a new 'endpoint' property
 		ApiVersion:        "2024-06-01-preview",
-		StandardVarPrefix: "AZURE_SEARCH",
+		StandardVarPrefix: "AZURE_AI_SEARCH",
 		Variables: map[string]string{
 			"endpoint": "https://${.name}.search.windows.net",
 		},

--- a/cli/azd/internal/scaffold/resource_meta.go
+++ b/cli/azd/internal/scaffold/resource_meta.go
@@ -157,7 +157,8 @@ var Resources = []ResourceMeta{
 		},
 	},
 	{
-		ResourceType:      "Microsoft.Search/searchServices",
+		ResourceType: "Microsoft.Search/searchServices",
+		// TODO: Switch to 2025-02-01-preview once available, which has a new 'endpoint' property
 		ApiVersion:        "2024-06-01-preview",
 		StandardVarPrefix: "AZURE_SEARCH",
 		Variables: map[string]string{

--- a/cli/azd/internal/scaffold/scaffold.go
+++ b/cli/azd/internal/scaffold/scaffold.go
@@ -154,6 +154,13 @@ func ExecInfraFs(
 		if err != nil {
 			return nil, fmt.Errorf("scaffolding ai-foundry-models.bicep: %w", err)
 		}
+
+		if spec.AISearch != nil {
+			err = executeToFS(fs, t, "ai-search-conn.bicep", "ai-search-conn.bicep", spec)
+			if err != nil {
+				return nil, fmt.Errorf("scaffolding ai-search-conn.bicep: %w", err)
+			}
+		}
 	}
 
 	return fs, nil

--- a/cli/azd/internal/scaffold/scaffold.go
+++ b/cli/azd/internal/scaffold/scaffold.go
@@ -75,6 +75,10 @@ func supportingFiles(spec InfraSpec) []string {
 		files = append(files, "/modules/fetch-container-image.bicep")
 	}
 
+	if spec.AiFoundryProject != nil && spec.AISearch != nil {
+		files = append(files, "/modules/ai-search-conn.bicep")
+	}
+
 	return files
 }
 
@@ -153,13 +157,6 @@ func ExecInfraFs(
 		err = executeToFS(fs, t, "ai-project.bicep", "ai-project.bicep", spec)
 		if err != nil {
 			return nil, fmt.Errorf("scaffolding ai-foundry-models.bicep: %w", err)
-		}
-
-		if spec.AISearch != nil {
-			err = executeToFS(fs, t, "ai-search-conn.bicep", "ai-search-conn.bicep", spec)
-			if err != nil {
-				return nil, fmt.Errorf("scaffolding ai-search-conn.bicep: %w", err)
-			}
 		}
 	}
 

--- a/cli/azd/internal/scaffold/scaffold_test.go
+++ b/cli/azd/internal/scaffold/scaffold_test.go
@@ -147,6 +147,7 @@ func TestExecInfra(t *testing.T) {
 						EventHubs:      &EventHubs{},
 						StorageAccount: &StorageReference{},
 						KeyVault:       &KeyVaultReference{},
+						AISearch:       &AISearchReference{},
 					},
 					{
 						Name: "web",

--- a/cli/azd/internal/scaffold/spec.go
+++ b/cli/azd/internal/scaffold/spec.go
@@ -34,6 +34,8 @@ type InfraSpec struct {
 
 	// ai foundry models
 	AiFoundryProject *AiFoundrySpec
+
+	AISearch *AISearch
 }
 
 type Parameter struct {
@@ -100,6 +102,9 @@ type AIModelModel struct {
 	Version string
 }
 
+type AISearch struct {
+}
+
 type ServiceBus struct {
 	Queues []string
 	Topics []string
@@ -148,6 +153,8 @@ type ServiceSpec struct {
 	EventHubs  *EventHubs
 
 	HasAiFoundryProject *AiFoundrySpec
+
+	AISearch *AISearchReference
 }
 
 type Frontend struct {
@@ -171,6 +178,9 @@ type AIModelReference struct {
 }
 
 type StorageReference struct {
+}
+
+type AISearchReference struct {
 }
 
 type KeyVaultReference struct {

--- a/cli/azd/pkg/project/resources.go
+++ b/cli/azd/pkg/project/resources.go
@@ -110,6 +110,8 @@ func (r ResourceType) AzureResourceType() string {
 		return "Microsoft.KeyVault/vaults"
 	case ResourceTypeAiProject:
 		return "Microsoft.MachineLearningServices/workspaces"
+	case ResourceTypeAiSearch:
+		return "Microsoft.Search/searchServices"
 	}
 
 	return ""

--- a/cli/azd/pkg/project/resources.go
+++ b/cli/azd/pkg/project/resources.go
@@ -23,6 +23,8 @@ func AllResourceTypes() []ResourceType {
 		ResourceTypeMessagingEventHubs,
 		ResourceTypeMessagingServiceBus,
 		ResourceTypeStorage,
+		ResourceTypeAiProject,
+		ResourceTypeAiSearch,
 		ResourceTypeKeyVault,
 	}
 }
@@ -39,6 +41,7 @@ const (
 	ResourceTypeMessagingServiceBus ResourceType = "messaging.servicebus"
 	ResourceTypeStorage             ResourceType = "storage"
 	ResourceTypeAiProject           ResourceType = "ai.project"
+	ResourceTypeAiSearch            ResourceType = "ai.search"
 	ResourceTypeKeyVault            ResourceType = "keyvault"
 )
 
@@ -66,6 +69,8 @@ func (r ResourceType) String() string {
 		return "Storage Account"
 	case ResourceTypeAiProject:
 		return "AI Foundry"
+	case ResourceTypeAiSearch:
+		return "AI Search"
 	case ResourceTypeKeyVault:
 		return "Key Vault"
 	}

--- a/cli/azd/pkg/project/scaffold_gen.go
+++ b/cli/azd/pkg/project/scaffold_gen.go
@@ -265,6 +265,8 @@ func infraSpec(projectConfig *ProjectConfig) (*scaffold.InfraSpec, error) {
 			infraSpec.AiFoundryProject = &foundrySpec
 		case ResourceTypeKeyVault:
 			infraSpec.KeyVault = &scaffold.KeyVault{}
+		case ResourceTypeAiSearch:
+			infraSpec.AISearch = &scaffold.AISearch{}
 		}
 	}
 
@@ -368,6 +370,8 @@ func mapHostUses(
 			svcSpec.StorageAccount = &scaffold.StorageReference{}
 		case ResourceTypeAiProject:
 			svcSpec.HasAiFoundryProject = &scaffold.AiFoundrySpec{}
+		case ResourceTypeAiSearch:
+			svcSpec.AISearch = &scaffold.AISearchReference{}
 		case ResourceTypeKeyVault:
 			svcSpec.KeyVault = &scaffold.KeyVaultReference{}
 		}

--- a/cli/azd/resources/scaffold/base/modules/ai-search-conn.bicep
+++ b/cli/azd/resources/scaffold/base/modules/ai-search-conn.bicep
@@ -1,5 +1,3 @@
-{{define "ai-search-conn.bicep" -}}
-
 @description('The name of the AI Hub')
 param aiHubName string
 
@@ -30,5 +28,3 @@ resource hub 'Microsoft.MachineLearningServices/workspaces@2024-10-01' existing 
     }
   }
 }
-
-{{ end}}

--- a/cli/azd/resources/scaffold/templates/ai-project.bicept
+++ b/cli/azd/resources/scaffold/templates/ai-project.bicept
@@ -190,6 +190,7 @@ resource mlServiceRoleSecretsReader 'Microsoft.Authorization/roleAssignments@202
   }
 }
 
+output hubName string = hub.name
 output projectDiscoveryUrl string = project.properties.discoveryUrl
 output projectId string = project.id
 output projectName string = project.name

--- a/cli/azd/resources/scaffold/templates/ai-search-conn.bicept
+++ b/cli/azd/resources/scaffold/templates/ai-search-conn.bicept
@@ -1,0 +1,34 @@
+{{define "ai-search-conn.bicep" -}}
+
+@description('The name of the AI Hub')
+param aiHubName string
+
+@description('The name of the AI Search')
+param aiSearchName string
+
+resource search 'Microsoft.Search/searchServices@2024-06-01-preview' existing = {
+  name: aiSearchName
+}
+
+resource hub 'Microsoft.MachineLearningServices/workspaces@2024-10-01' existing = {
+  name: aiHubName
+
+  resource AzureAISearch 'connections@2024-10-01' = {
+    name: 'AzureAISearch-connection'
+    properties: {
+      category: 'CognitiveSearch'
+      target: 'https://${search.name}.search.windows.net'
+      authType: 'ApiKey'
+      isSharedToAll: true
+      credentials: {
+        key: search.listAdminKeys().primaryKey
+      }
+      metadata: {
+        ApiType: 'Azure'
+        ResourceId: search.id
+      }
+    }
+  }
+}
+
+{{ end}}

--- a/cli/azd/resources/scaffold/templates/main.bicept
+++ b/cli/azd/resources/scaffold/templates/main.bicept
@@ -132,6 +132,6 @@ output AZURE_AIPROJECT_CONNECTION_STRING string = aiModelsDeploy.outputs.aiFound
 output AZURE_RESOURCE_AI_PROJECT_ID string = aiModelsDeploy.outputs.projectId
 {{- end}}
 {{- if .AISearch }}
-output AZURE_RESOURCE_SEARCH_ID string = resources.outputs.aiSearchName
+output AZURE_RESOURCE_SEARCH_ID string = resources.outputs.AZURE_RESOURCE_SEARCH_ID
 {{- end}}
 {{ end}}

--- a/cli/azd/resources/scaffold/templates/main.bicept
+++ b/cli/azd/resources/scaffold/templates/main.bicept
@@ -132,6 +132,7 @@ output AZURE_AIPROJECT_CONNECTION_STRING string = aiModelsDeploy.outputs.aiFound
 output AZURE_RESOURCE_AI_PROJECT_ID string = aiModelsDeploy.outputs.projectId
 {{- end}}
 {{- if .AISearch }}
+output AZURE_AI_SEARCH_ENDPOINT string = resources.outputs.AZURE_AI_SEARCH_ENDPOINT
 output AZURE_RESOURCE_SEARCH_ID string = resources.outputs.AZURE_RESOURCE_SEARCH_ID
 {{- end}}
 {{ end}}

--- a/cli/azd/resources/scaffold/templates/main.bicept
+++ b/cli/azd/resources/scaffold/templates/main.bicept
@@ -76,6 +76,17 @@ module aiModelsDeploy 'ai-project.bicep' = {
     envName: environmentName
   }
 }
+
+{{- if .AISearch }}
+module aiSearchConnection 'ai-search-conn.bicep' = {
+  scope: rg
+  name: 'ai-search-connection'
+  params: {
+    aiHubName: aiModelsDeploy.outputs.hubName
+    aiSearchName: resources.outputs.aiSearchName
+  }
+}
+{{- end}}
 {{- end}}
 
 {{- if .Services}}
@@ -119,5 +130,8 @@ output AZURE_RESOURCE_SERVICE_BUS_ID string = resources.outputs.AZURE_RESOURCE_S
 {{- if .AiFoundryProject }}
 output AZURE_AIPROJECT_CONNECTION_STRING string = aiModelsDeploy.outputs.aiFoundryProjectConnectionString
 output AZURE_RESOURCE_AI_PROJECT_ID string = aiModelsDeploy.outputs.projectId
+{{- end}}
+{{- if .AISearch }}
+output AZURE_RESOURCE_SEARCH_ID string = resources.outputs.aiSearchName
 {{- end}}
 {{ end}}

--- a/cli/azd/resources/scaffold/templates/main.bicept
+++ b/cli/azd/resources/scaffold/templates/main.bicept
@@ -78,7 +78,7 @@ module aiModelsDeploy 'ai-project.bicep' = {
 }
 
 {{- if .AISearch }}
-module aiSearchConnection 'ai-search-conn.bicep' = {
+module aiSearchConnection 'modules/ai-search-conn.bicep' = {
   scope: rg
   name: 'ai-search-connection'
   params: {

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -299,11 +299,12 @@ resource localUserOpenAIIdentity 'Microsoft.Authorization/roleAssignments@2022-0
 {{- end}}
 
 {{- if .AISearch}}
-module searchService 'br/public:avm/res/search/search-service:0.9.1' = {
+module search 'br/public:avm/res/search/search-service:0.9.1' = {
   name: 'aiSearch'
   params: {
     name: '${abbrs.storageStorageAccounts}${resourceToken}'
     location: location
+    tags: tags
     sku: 'basic'
     replicaCount: 1
     managedIdentities: {
@@ -333,7 +334,12 @@ module searchService 'br/public:avm/res/search/search-service:0.9.1' = {
       }
       {{- end}}
     ]
-    disableLocalAuth: true
+    disableLocalAuth: false
+    authOptions: {
+      aadOrApiKey: {
+        aadAuthFailureMode: 'http401WithBearerChallenge'
+      }
+    }
     publicNetworkAccess: 'Enabled'
   }
 }
@@ -668,6 +674,12 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
             value: account.outputs.endpoint
           }
           {{- end}}
+          {{- if .AISearch}}
+          {
+            name: 'AZURE_SEARCH_ENDPOINT'
+            value: 'https://${search.outputs.name}.search.windows.net'
+          }
+          {{- end}}
           {{- if .HasAiFoundryProject }}
           {
             name: 'AZURE_AIPROJECT_CONNECTION_STRING'
@@ -828,5 +840,9 @@ output AZURE_RESOURCE_EVENT_HUBS_ID string = eventHubNamespace.outputs.resourceI
 {{- end}}
 {{- if .ServiceBus}}
 output AZURE_RESOURCE_SERVICE_BUS_ID string = serviceBusNamespace.outputs.resourceId
+{{- end}}
+{{- if .AISearch}}
+output AZURE_RESOURCE_SEARCH_ID string = search.outputs.resourceId
+output aiSearchName string = search.outputs.name
 {{- end}}
 {{ end}}

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -298,6 +298,47 @@ resource localUserOpenAIIdentity 'Microsoft.Authorization/roleAssignments@2022-0
 }
 {{- end}}
 
+{{- if .AISearch}}
+module searchService 'br/public:avm/res/search/search-service:0.9.1' = {
+  name: 'aiSearch'
+  params: {
+    name: '${abbrs.storageStorageAccounts}${resourceToken}'
+    location: location
+    sku: 'basic'
+    replicaCount: 1
+    managedIdentities: {
+      systemAssigned: true
+    }
+    roleAssignments: [
+      {  
+        principalId: principalId
+        principalType: 'User'
+        roleDefinitionIdOrName: 'Search Index Data Contributor'  
+      }
+      {  
+        principalId: principalId
+        principalType: 'User'
+        roleDefinitionIdOrName: 'Search Service Contributor'  
+      }
+      {{- range .Services}}
+      {
+        principalId: {{bicepName .Name}}Identity.outputs.principalId
+        principalType: 'ServicePrincipal'
+        roleDefinitionIdOrName: 'Search Index Data Contributor'
+      }
+      {
+        principalId: {{bicepName .Name}}Identity.outputs.principalId
+        principalType: 'ServicePrincipal'
+        roleDefinitionIdOrName: 'Search Service Contributor'
+      }
+      {{- end}}
+    ]
+    disableLocalAuth: true
+    publicNetworkAccess: 'Enabled'
+  }
+}
+{{- end}}
+
 {{- if .EventHubs }}
 module eventHubNamespace 'br/public:avm/res/event-hub/namespace:0.8.0' = {
   name: 'eventHubNamespace'

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -302,7 +302,7 @@ resource localUserOpenAIIdentity 'Microsoft.Authorization/roleAssignments@2022-0
 module search 'br/public:avm/res/search/search-service:0.9.1' = {
   name: 'ai-search'
   params: {
-    name: '${abbrs.storageStorageAccounts}${resourceToken}'
+    name: '${abbrs.searchSearchServices}${resourceToken}'
     location: location
     tags: tags
     sku: 'basic'

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -300,7 +300,7 @@ resource localUserOpenAIIdentity 'Microsoft.Authorization/roleAssignments@2022-0
 
 {{- if .AISearch}}
 module search 'br/public:avm/res/search/search-service:0.9.1' = {
-  name: 'aiSearch'
+  name: 'ai-search'
   params: {
     name: '${abbrs.storageStorageAccounts}${resourceToken}'
     location: location

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -676,7 +676,7 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
           {{- end}}
           {{- if .AISearch}}
           {
-            name: 'AZURE_SEARCH_ENDPOINT'
+            name: 'AZURE_AI_SEARCH_ENDPOINT'
             value: 'https://${search.outputs.name}.search.windows.net'
           }
           {{- end}}
@@ -842,6 +842,7 @@ output AZURE_RESOURCE_EVENT_HUBS_ID string = eventHubNamespace.outputs.resourceI
 output AZURE_RESOURCE_SERVICE_BUS_ID string = serviceBusNamespace.outputs.resourceId
 {{- end}}
 {{- if .AISearch}}
+output AZURE_AI_SEARCH_ENDPOINT string = 'https://${search.outputs.name}.search.windows.net'
 output AZURE_RESOURCE_SEARCH_ID string = search.outputs.resourceId
 output aiSearchName string = search.outputs.name
 {{- end}}

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -372,6 +372,7 @@
                             "db.mongo",
                             "db.cosmos",
                             "ai.openai.model",
+                            "ai.search",
                             "host.containerapp",
                             "messaging.eventhubs",
                             "messaging.servicebus",
@@ -391,6 +392,7 @@
                 "allOf": [
                     { "if": { "properties": { "type": { "const": "host.containerapp" }}}, "then": { "$ref": "#/definitions/containerAppResource" } },
                     { "if": { "properties": { "type": { "const": "ai.openai.model" }}}, "then": { "$ref": "#/definitions/aiModelResource" } },
+                    { "if": { "properties": { "type": { "const": "ai.search" }}}, "then": { "$ref": "#/definitions/resource" } },
                     { "if": { "properties": { "type": { "const": "db.postgres"  }}}, "then": { "$ref": "#/definitions/resource"} },
                     { "if": { "properties": { "type": { "const": "db.mysql"  }}}, "then": { "$ref": "#/definitions/resource"} },
                     { "if": { "properties": { "type": { "const": "db.redis"  }}}, "then": { "$ref": "#/definitions/resource"} },
@@ -1243,6 +1245,7 @@
                         "db.cosmos",
                         "host.containerapp",
                         "ai.openai.model",
+                        "ai.search",
                         "keyvault"
                     ]
                 },


### PR DESCRIPTION
Closes #4889 

This PR adds `azd add` support for Azure AI Search (aka Azure Cognitive Search). **Azure AI Search** now appears as an option under the **AI** group (previously **AI models**) in the `azd add` menu:

![image](https://github.com/user-attachments/assets/dba1150e-544b-41d7-b3c2-1771f06eee45)

Support for dataplane resources (indexes, index aliases, indexers, data sources, skillsets, debug sessions) are out of scope of this PR.

### Auth
The AI Search resource is configured with a "hybrid" authentication configuration, allowing access via API keys and Entra/RBAC. The [**Search Service Contributor** and  **Search Index Data Contributor** roles](https://learn.microsoft.com/en-us/azure/search/search-security-rbac#built-in-roles-used-in-search) are assigned to the user and host identity (if host **uses** `search`). 

![image](https://github.com/user-attachments/assets/2b63d4df-a70a-443e-baec-167a8067ab91)

If both an Azure AI Search resource and a Foundry model are present in `azure.yaml`, the generated Bicep azd additionally creates an API key-based connection between the AI hub and AI Search as a "Connected resource". This connection currently uses API key authentication due to limited support for key-less/Entra auth. Issue #4879 tracks moving to Entra-based authentication.

![image](https://github.com/user-attachments/assets/02507529-295d-47a4-baf1-912183c798f8)

### Connecting to resource

Users can connect to the resource directly using the `AZURE_AI_SEARCH_ENDPOINT` environment variable with an AI Search client library.

If Foundry resources are present, they can also connect to the resource through the Foundry SDK using the AI project connection string: [example](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/sdk-overview?tabs=sync&pivots=programming-language-python#azure-ai-search).

## azure.yaml schema

```yaml
resources:
  search:
    type: ai.search
```

## Binding variables

`AZURE_AI_SEARCH_ENDPOINT` - Azure AI Search endpoint

## Testing
Validated using sample app https://github.com/JeffreyCA/azd-compose-search-demo
