### PR TITLE
azd init with env file

### DIFF
--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -30,6 +30,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/git"
 	"github.com/fatih/color"
+	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -164,6 +165,24 @@ func (i *initAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	i.console.MessageUxItem(ctx, &ux.MessageTitle{
 		Title: "Initializing an app to run on Azure (azd init)",
 	})
+
+	// AZD supports having .env at the root of the project directory as the initial environment file.
+	// godotenv.Load() -> add all the values from the .env file in the process environment
+	// If AZURE_ENV_NAME is set in the .env file, it will be used to name the environment during env initialize.
+	if err := godotenv.Overload(); err != nil {
+		// ignore the error if the file does not exist
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("reading .env file: %w", err)
+		}
+	}
+	if i.flags.EnvFlag.EnvironmentName == "" ||
+		(i.flags.EnvFlag.EnvironmentName != "" && !i.flags.EnvFlag.FromArg()) {
+		// only azd init supports using .env to influence the command. The `-e` flag is linked to the
+		// env var AZURE_ENV_NAME, which means it could've be set either from ENV or from arg.
+		// re-setting the value here after loading the .env file overrides any value coming from the system env but
+		// doest not override the value coming from the arg.
+		i.flags.EnvFlag.EnvironmentName = os.Getenv(environment.EnvNameEnvVarName)
+	}
 
 	var existingProject bool
 	if _, err := os.Stat(azdCtx.ProjectPath()); err == nil {
@@ -453,6 +472,14 @@ func (i *initAction) initializeEnv(
 		if err := env.Config.Set(key, value); err != nil {
 			return nil, fmt.Errorf("setting environment config: %w", err)
 		}
+	}
+
+	initialValuesFromEnv, err := repository.InitEnvFileValues()
+	if err != nil {
+		return nil, fmt.Errorf("loading initial env file values: %w", err)
+	}
+	for key, value := range initialValuesFromEnv {
+		env.DotenvSet(key, value)
 	}
 
 	if err := envManager.Save(ctx, env); err != nil {

--- a/cli/azd/internal/env_flag.go
+++ b/cli/azd/internal/env_flag.go
@@ -13,6 +13,7 @@ import (
 // so the user can control what environment is loaded in a uniform way across all our commands.
 type EnvFlag struct {
 	EnvironmentName string
+	fromEnvVarValue string
 }
 
 // EnvironmentNameFlagName is the full name of the flag as it appears on the command line.
@@ -22,11 +23,17 @@ const EnvironmentNameFlagName string = "environment"
 const envNameEnvVarName = "AZURE_ENV_NAME"
 
 func (e *EnvFlag) Bind(local *pflag.FlagSet, global *GlobalCommandOptions) {
+	e.fromEnvVarValue = os.Getenv(envNameEnvVarName)
 	local.StringVarP(
 		&e.EnvironmentName,
 		EnvironmentNameFlagName,
 		"e",
 		// Set the default value to AZURE_ENV_NAME value if available
-		os.Getenv(envNameEnvVarName),
+		e.fromEnvVarValue,
 		"The name of the environment to use.")
+}
+
+// checks if the environment name was set from the command line
+func (e *EnvFlag) FromArg() bool {
+	return e.EnvironmentName != "" && e.EnvironmentName != e.fromEnvVarValue
 }


### PR DESCRIPTION
Fix: [Issue #4935](https://github.com/Azure/azure-dev/issues/4935)

This PR enhances the `azd init` command to utilize an initial `.env` file, allowing it to influence the initial state of the environment created during initialization. 

With this feature, users can run `azd init -t some-template` from a directory containing a pre-configured `.env` file with the necessary values for the environment's starting state. This is particularly useful for connecting to existing resources when initializing a template.

Additionally, users can set the key `AZD_ALLOW_NON_EMPTY_FOLDER=` in the `.env` file to bypass the warning about initializing a template in a non-empty directory. This assumes that the `.env` file and the current directory are pre-configured and ready for `azd init -t template-name`.

After this PR, users can define the name of the environment with any of the next alternatives:
- 1. Setting AZURE_ENV_VAR as system environment. AZD takes the value (if not empty) w/o asking or confirming the name to create the environment as part of `azd init`
- 2. Using argument `-e name`.  AZD overrides any value from the system environment and takes the value defined as argument during the call to `azd init -e name`.
- 3. Using `.env` file.  Set `AZURE_ENV_VAR=name` inside the .env file and run `azd init` in the folder where the .env file is. AZD overrides the System Environment with the values from the .env file. However, arguments are not overridden and are the highest priority