### PR TITLE
Update `env set` to accept multiple key-value pairs

### DIFF
--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -116,9 +116,18 @@ func newEnvSetFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *
 
 func newEnvSetCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "set <key> <value>",
-		Short: "Manage your environment settings.",
-		Args:  cobra.ExactArgs(2),
+		Use:   "set <key> <value> [<key2> <value2> ...]",
+		Short: "Set one or more environment values.",
+		Long:  "Set one or more key-value pairs in the environment. Each key must be followed by its value.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 2 {
+				return fmt.Errorf("requires at least one key-value pair")
+			}
+			if len(args)%2 != 0 {
+				return fmt.Errorf("each key must be followed by a value")
+			}
+			return nil
+		},
 	}
 }
 
@@ -160,13 +169,15 @@ func newEnvSetAction(
 }
 
 func (e *envSetAction) Run(ctx context.Context) (*actions.ActionResult, error) {
-	key := e.args[0]
-	value := e.args[1]
-
 	dotEnv := e.env.Dotenv()
-	warnKeyCaseConflicts(ctx, e.console, dotEnv, key)
 
-	e.env.DotenvSet(key, value)
+	for i := 0; i < len(e.args); i += 2 {
+		key := e.args[i]
+		value := e.args[i+1]
+
+		warnKeyCaseConflicts(ctx, e.console, dotEnv, key)
+		e.env.DotenvSet(key, value)
+	}
 
 	if err := e.envManager.Save(ctx, e.env); err != nil {
 		return nil, fmt.Errorf("saving environment: %w", err)

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -169,6 +169,7 @@ func newEnvSetAction(
 }
 
 func (e *envSetAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	// To track case conflicts
 	dotEnv := e.env.Dotenv()
 
 	for i := 0; i < len(e.args); i += 2 {
@@ -177,6 +178,8 @@ func (e *envSetAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 		warnKeyCaseConflicts(ctx, e.console, dotEnv, key)
 		e.env.DotenvSet(key, value)
+		// Update to check case conflicts in subsequent keys
+		dotEnv[key] = value
 	}
 
 	if err := e.envManager.Save(ctx, e.env); err != nil {

--- a/cli/azd/cmd/testdata/TestUsage-azd-env-set.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env-set.snap
@@ -1,8 +1,8 @@
 
-Manage your environment settings.
+Set one or more environment values.
 
 Usage
-  azd env set <key> <value> [flags]
+  azd env set <key> <value> [<key2> <value2> ...] [flags]
 
 Flags
     -e, --environment string 	: The name of the environment to use.

--- a/cli/azd/cmd/testdata/TestUsage-azd-env.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-env.snap
@@ -16,7 +16,7 @@ Available Commands
   new       	: Create a new environment and set it as the default.
   refresh   	: Refresh environment settings by using information from a previous infrastructure provision.
   select    	: Set the default environment.
-  set       	: Manage your environment settings.
+  set       	: Set one or more environment values.
   set-secret	: Set a <name> as a reference to a Key Vault secret in the environment.
 
 Global Flags


### PR DESCRIPTION
Contributes to #4941

This PR updates the `env set` command so you can now set multiple environment key-value pairs, like:

```
azd set key1 val1 key2 val2
```


https://github.com/user-attachments/assets/604ef21c-66fc-408a-be1c-d9d1c68bd4da

