### PR TITLE
compose: `existing` support

### DIFF
--- a/cli/azd/internal/cmd/add/add.go
+++ b/cli/azd/internal/cmd/add/add.go
@@ -119,6 +119,11 @@ func (a *AddAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		resourceToAdd = r
 	}
 
+	resourceToAdd, err = a.ConfigureLive(ctx, resourceToAdd, a.console, promptOpts)
+	if err != nil {
+		return nil, err
+	}
+
 	resourceToAdd, err = Configure(ctx, resourceToAdd, a.console, promptOpts)
 	if err != nil {
 		return nil, err

--- a/cli/azd/internal/cmd/add/add_configure.go
+++ b/cli/azd/internal/cmd/add/add_configure.go
@@ -34,6 +34,36 @@ type PromptOptions struct {
 	ExistingId string
 }
 
+// ConfigureLive fills in the fields for a resource by first querying live Azure for information.
+//
+// This is used in addition to Configure currently.
+func (a *AddAction) ConfigureLive(
+	ctx context.Context,
+	r *project.ResourceConfig,
+	console input.Console,
+	p PromptOptions) (*project.ResourceConfig, error) {
+	if r.Existing {
+		return r, nil
+	}
+
+	var resourceToAdd *project.ResourceConfig
+	var err error
+
+	switch r.Type {
+	case project.ResourceTypeAiProject:
+		resourceToAdd, err = a.promptAiModel(console, ctx, r, p)
+	case project.ResourceTypeOpenAiModel:
+		resourceToAdd, err = a.promptOpenAi(console, ctx, r, p)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	r = resourceToAdd
+	return r, nil
+}
+
 // Configure fills in the fields for a resource.
 func Configure(
 	ctx context.Context,

--- a/cli/azd/internal/cmd/add/add_configure.go
+++ b/cli/azd/internal/cmd/add/add_configure.go
@@ -46,21 +46,19 @@ func (a *AddAction) ConfigureLive(
 		return r, nil
 	}
 
-	var resourceToAdd *project.ResourceConfig
 	var err error
 
 	switch r.Type {
 	case project.ResourceTypeAiProject:
-		resourceToAdd, err = a.promptAiModel(console, ctx, r, p)
+		r, err = a.promptAiModel(console, ctx, r, p)
 	case project.ResourceTypeOpenAiModel:
-		resourceToAdd, err = a.promptOpenAi(console, ctx, r, p)
+		r, err = a.promptOpenAi(console, ctx, r, p)
 	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	r = resourceToAdd
 	return r, nil
 }
 

--- a/cli/azd/internal/cmd/add/add_configure.go
+++ b/cli/azd/internal/cmd/add/add_configure.go
@@ -28,6 +28,10 @@ var DbMap = map[appdetect.DatabaseDep]project.ResourceType{
 type PromptOptions struct {
 	// PrjConfig is the current project configuration.
 	PrjConfig *project.ProjectConfig
+
+	// ExistingId is the ID of an existing resource.
+	// This is only used to configure the resource with an existing resource.
+	ExistingId string
 }
 
 // Configure fills in the fields for a resource.
@@ -36,6 +40,10 @@ func Configure(
 	r *project.ResourceConfig,
 	console input.Console,
 	p PromptOptions) (*project.ResourceConfig, error) {
+	if r.Existing {
+		return ConfigureExisting(ctx, r, console, p)
+	}
+
 	switch r.Type {
 	case project.ResourceTypeHostContainerApp:
 		return fillUses(ctx, r, console, p)

--- a/cli/azd/internal/cmd/add/add_configure_existing.go
+++ b/cli/azd/internal/cmd/add/add_configure_existing.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package add
 
 import (
@@ -5,11 +8,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/azure/azure-dev/cli/azd/internal/names"
-	"github.com/azure/azure-dev/cli/azd/internal/scaffold"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 )
 
+// ConfigureExisting prompts the user to configure details for an existing resource.
 func ConfigureExisting(
 	ctx context.Context,
 	r *project.ResourceConfig,
@@ -42,8 +45,6 @@ func ConfigureExisting(
 		}
 	}
 
-	_ = getResourceMeta(r.Type.AzureResourceType())
-
 	return r, nil
 }
 
@@ -57,14 +58,4 @@ func resourceType(azureResourceType string) project.ResourceType {
 	}
 
 	return project.ResourceType("")
-}
-
-func getResourceMeta(resourceType string) scaffold.ResourceMeta {
-	for _, res := range scaffold.Resources {
-		if res.ResourceType == resourceType {
-			return res
-		}
-	}
-
-	return scaffold.ResourceMeta{}
 }

--- a/cli/azd/internal/cmd/add/add_configure_existing.go
+++ b/cli/azd/internal/cmd/add/add_configure_existing.go
@@ -1,0 +1,70 @@
+package add
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/azure/azure-dev/cli/azd/internal/names"
+	"github.com/azure/azure-dev/cli/azd/internal/scaffold"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
+)
+
+func ConfigureExisting(
+	ctx context.Context,
+	r *project.ResourceConfig,
+	console input.Console,
+	p PromptOptions) (*project.ResourceConfig, error) {
+	if r.Name == "" {
+		resourceId, err := arm.ParseResourceID(r.ResourceId)
+		if err != nil {
+			return nil, err
+		}
+
+		for {
+			name, err := console.Prompt(ctx, input.ConsoleOptions{
+				Message: "What should we call this resource?",
+				Help: "This name will be used to identify the resource in your project. " +
+					"It will also be used to prefix environment variables by default.",
+				DefaultValue: names.LabelName(resourceId.Name),
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			if err := names.ValidateLabelName(name); err != nil {
+				console.Message(ctx, err.Error())
+				continue
+			}
+
+			r.Name = name
+			break
+		}
+	}
+
+	_ = getResourceMeta(r.Type.AzureResourceType())
+
+	return r, nil
+}
+
+// resourceType returns the resource type for the given Azure resource type.
+func resourceType(azureResourceType string) project.ResourceType {
+	resourceTypes := project.AllResourceTypes()
+	for _, resourceType := range resourceTypes {
+		if resourceType.AzureResourceType() == azureResourceType {
+			return resourceType
+		}
+	}
+
+	return project.ResourceType("")
+}
+
+func getResourceMeta(resourceType string) scaffold.ResourceMeta {
+	for _, res := range scaffold.Resources {
+		if res.ResourceType == resourceType {
+			return res
+		}
+	}
+
+	return scaffold.ResourceMeta{}
+}

--- a/cli/azd/internal/cmd/add/add_preview.go
+++ b/cli/azd/internal/cmd/add/add_preview.go
@@ -15,6 +15,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/azure/azure-dev/cli/azd/internal/scaffold"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
@@ -34,6 +35,10 @@ func Metadata(r *project.ResourceConfig) metaDisplay {
 		if res.ResourceType == azureResType {
 			// transform to standard variables
 			prefix := res.StandardVarPrefix
+
+			if r.Existing {
+				prefix += "_" + environment.Key(r.Name)
+			}
 
 			// host resources are special and prefixed with the name
 			if strings.HasPrefix(string(r.Type), "host.") {
@@ -90,7 +95,12 @@ func (a *AddAction) previewProvision(
 	fmt.Fprintln(w, "b  Name\tResource type")
 	for _, res := range resourcesToAdd {
 		meta := Metadata(res)
-		fmt.Fprintf(w, "+  %s\t%s\n", res.Name, meta.ResourceType)
+		status := ""
+		if res.Existing {
+			status = " (existing)"
+		}
+
+		fmt.Fprintf(w, "+  %s\t%s%s\n", res.Name, meta.ResourceType, status)
 	}
 
 	w.Flush()

--- a/cli/azd/internal/cmd/add/add_select.go
+++ b/cli/azd/internal/cmd/add/add_select.go
@@ -159,7 +159,6 @@ func (a *AddAction) selectExistingResource(
 			}
 
 			if menu.Namespace == "host" || // host resources are not yet supported
-				menu.Namespace == "keyvault" || // keyvault (RBAC) is not yet supported
 				menu.Namespace == "db" { // db resources are not yet supported
 				continue
 			}

--- a/cli/azd/internal/cmd/add/add_select.go
+++ b/cli/azd/internal/cmd/add/add_select.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 )
@@ -36,6 +38,7 @@ func (a *AddAction) selectMenu() []Menu {
 		{Namespace: "messaging", Label: "Messaging", SelectResource: selectMessaging},
 		{Namespace: "storage", Label: "Storage account", SelectResource: selectStorage},
 		{Namespace: "keyvault", Label: "Key Vault", SelectResource: selectKeyVault},
+		{Namespace: "existing", Label: "~Existing resource", SelectResource: a.selectExistingResource},
 	}
 }
 
@@ -134,4 +137,112 @@ func selectKeyVault(console input.Console, ctx context.Context, p PromptOptions)
 	r := &project.ResourceConfig{}
 	r.Type = project.ResourceTypeKeyVault
 	return r, nil
+}
+
+func (a *AddAction) selectExistingResource(
+	console input.Console,
+	ctx context.Context,
+	p PromptOptions) (*project.ResourceConfig, error) {
+	res := &project.ResourceConfig{}
+	res.Existing = true
+
+	if p.ExistingId == "" {
+		all := a.selectMenu()
+		selectMenu := make([]Menu, 0, len(all))
+		for _, menu := range all {
+			if menu.Namespace != "existing" {
+				selectMenu = append(selectMenu, menu)
+			}
+		}
+		slices.SortFunc(selectMenu, func(a, b Menu) int {
+			return strings.Compare(a.Label, b.Label)
+		})
+
+		selections := make([]string, 0, len(selectMenu))
+		for _, menu := range selectMenu {
+			selections = append(selections, menu.Label)
+		}
+		idx, err := a.console.Select(ctx, input.ConsoleOptions{
+			Message: "Which type of existing resource?",
+			Options: selections,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		selected := selectMenu[idx]
+
+		r, err := selected.SelectResource(a.console, ctx, p)
+		if err != nil {
+			return nil, err
+		}
+
+		azureResourceType := r.Type.AzureResourceType()
+		resourceId, err := a.promptResource(ctx, "Which resource?", azureResourceType)
+		if err != nil {
+			return nil, fmt.Errorf("prompting for resource: %w", err)
+		}
+
+		if resourceId == "" {
+			return nil, fmt.Errorf("no resources of type '%s' were found", azureResourceType)
+		}
+
+		res.Type = r.Type
+		res.ResourceId = resourceId
+	} else {
+		resourceId, err := arm.ParseResourceID(p.ExistingId)
+		if err != nil {
+			return nil, err
+		}
+
+		azureResourceType := resourceId.ResourceType.String()
+		resourceType := resourceType(azureResourceType)
+		if resourceType == "" {
+			return nil, fmt.Errorf("resource type '%s' is not currently supported", azureResourceType)
+		}
+
+		res.Type = resourceType
+		res.ResourceId = resourceId.String()
+	}
+
+	return res, nil
+}
+
+func (a *AddAction) promptResource(
+	ctx context.Context,
+	msg string,
+	resourceType string,
+) (string, error) {
+	options := azapi.ListResourcesOptions{
+		ResourceType: resourceType,
+	}
+
+	a.console.ShowSpinner(ctx, "Listing resources...", input.Step)
+	resources, err := a.resourceService.ListResources(ctx, a.env.GetSubscriptionId(), &options)
+	if err != nil {
+		return "", fmt.Errorf("listing resources: %w", err)
+	}
+	if len(resources) == 0 {
+		return "", nil
+	}
+	a.console.StopSpinner(ctx, "", input.StepDone)
+
+	slices.SortFunc(resources, func(a, b *azapi.Resource) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	choices := make([]string, len(resources))
+	for idx, resource := range resources {
+		choices[idx] = fmt.Sprintf("%d. %s (%s)", idx+1, resource.Name, resource.Location)
+	}
+
+	choice, err := a.console.Select(ctx, input.ConsoleOptions{
+		Message: msg,
+		Options: choices,
+	})
+	if err != nil {
+		return "", fmt.Errorf("selecting resource: %w", err)
+	}
+
+	return resources[choice].Id, nil
 }

--- a/cli/azd/internal/cmd/add/add_select_ai.go
+++ b/cli/azd/internal/cmd/add/add_select_ai.go
@@ -34,8 +34,17 @@ func (a *AddAction) selectSearch(
 func (a *AddAction) selectOpenAi(
 	console input.Console,
 	ctx context.Context,
-	_ PromptOptions) (r *project.ResourceConfig, err error) {
-	resourceToAdd := &project.ResourceConfig{}
+	_ PromptOptions) (*project.ResourceConfig, error) {
+	r := &project.ResourceConfig{}
+	r.Type = project.ResourceTypeOpenAiModel
+	return r, nil
+}
+
+func (a *AddAction) promptOpenAi(
+	console input.Console,
+	ctx context.Context,
+	r *project.ResourceConfig,
+	_ PromptOptions) (*project.ResourceConfig, error) {
 	aiOption, err := console.Select(ctx, input.ConsoleOptions{
 		Message: "Which type of Azure OpenAI service?",
 		Options: []string{
@@ -45,8 +54,6 @@ func (a *AddAction) selectOpenAi(
 	if err != nil {
 		return nil, err
 	}
-
-	resourceToAdd.Type = project.ResourceTypeOpenAiModel
 
 	var allModels []ModelList
 	for {
@@ -138,14 +145,14 @@ func (a *AddAction) selectOpenAi(
 		return nil, err
 	}
 
-	resourceToAdd.Props = project.AIModelProps{
+	r.Props = project.AIModelProps{
 		Model: project.AIModelPropsModel{
 			Name:    models[sel].Name,
 			Version: models[sel].Version,
 		},
 	}
 
-	return resourceToAdd, nil
+	return r, nil
 }
 
 func (a *AddAction) supportedModelsInLocation(ctx context.Context, subId, location string) ([]ModelList, error) {
@@ -227,11 +234,18 @@ func (a *AddAction) selectAiModel(
 	p PromptOptions) (*project.ResourceConfig, error) {
 	r := &project.ResourceConfig{}
 	r.Type = project.ResourceTypeAiProject
+	return r, nil
+}
 
+func (a *AddAction) promptAiModel(
+	console input.Console,
+	ctx context.Context,
+	r *project.ResourceConfig,
+	p PromptOptions) (*project.ResourceConfig, error) {
 	// check if there are models in the project already
 	aiProject := project.AiFoundryModelProps{}
 	for _, resource := range p.PrjConfig.Resources {
-		if resource.Type == project.ResourceTypeAiProject {
+		if resource.Type == project.ResourceTypeAiProject && resource.Name == "ai-project" {
 			em, castOk := resource.Props.(project.AiFoundryModelProps)
 			if !castOk {
 				return nil, fmt.Errorf("invalid resource properties")

--- a/cli/azd/internal/cmd/show/show_resource.go
+++ b/cli/azd/internal/cmd/show/show_resource.go
@@ -86,7 +86,11 @@ func (s *showResource) showResourceGeneric(
 	}
 
 	// Convert to environment variables
-	envValues := scaffold.EnvVars(resourceMeta.StandardVarPrefix, values)
+	prefix := resourceMeta.StandardVarPrefix
+	if opts.resourceSpec != nil && opts.resourceSpec.Existing {
+		prefix += "_" + environment.Key(id.Name)
+	}
+	envValues := scaffold.EnvVars(prefix, values)
 
 	display := id.ResourceType.String()
 	if translated := azapi.GetResourceTypeDisplayName(azapi.AzureResourceType(display)); translated != "" {

--- a/cli/azd/internal/scaffold/funcs.go
+++ b/cli/azd/internal/scaffold/funcs.go
@@ -251,3 +251,32 @@ func aiProjectConnectionString(resourceId string, projectUrl string) (string, er
 
 	return fmt.Sprintf("%s;%s;%s;%s", hostName, resId.SubscriptionID, resId.ResourceGroupName, resId.Name), nil
 }
+
+func emitAiProjectConnectionString(resourceIdVar string, projectUrlVar string) (string, error) {
+	return fmt.Sprintf(
+		"${split(%s, '/')[2]};${split(%s, '/')[2]}};${split(%s, '/')[4]};${split(%s, '/')[8]}",
+		projectUrlVar,
+		resourceIdVar,
+		resourceIdVar,
+		resourceIdVar), nil
+}
+
+func emitHostFromEndpoint(endpointVar string) (string, error) {
+	// example: https://{your-namespace}.servicebus.windows.net:443
+	return fmt.Sprintf("split(split('%s', '//')[1], ':')[0]", endpointVar), nil
+
+}
+
+func bicepFuncCall(funcName string) func(name string) string {
+	// example: toLower(foo)
+	return func(name string) string {
+		return fmt.Sprintf("%s(%s)", funcName, name)
+	}
+}
+
+func bicepFuncCallThree(funcName string) func(a string, b string, c string) string {
+	// example: replace(foo, bar, baz)
+	return func(a string, b string, c string) string {
+		return fmt.Sprintf("%s(%s, %s, %s)", funcName, a, b, c)
+	}
+}

--- a/cli/azd/internal/scaffold/funcs.go
+++ b/cli/azd/internal/scaffold/funcs.go
@@ -53,6 +53,19 @@ func BicepName(name string) string {
 	return sb.String()
 }
 
+// BicepNameInfix is like BicepName, except that the first character is upper-cased for infix use.
+func BicepNameInfix(name string) string {
+	bicepName := BicepName(name)
+	return capitalizeFirst(bicepName)
+}
+
+func capitalizeFirst(s string) string {
+	if s == "" {
+		return ""
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
 func RemoveDotAndDash(name string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(name, ".", ""), "-", "")
 }

--- a/cli/azd/internal/scaffold/funcs.go
+++ b/cli/azd/internal/scaffold/funcs.go
@@ -263,7 +263,7 @@ func emitAiProjectConnectionString(resourceIdVar string, projectUrlVar string) (
 
 func emitHostFromEndpoint(endpointVar string) (string, error) {
 	// example: https://{your-namespace}.servicebus.windows.net:443
-	return fmt.Sprintf("split(split('%s', '//')[1], ':')[0]", endpointVar), nil
+	return fmt.Sprintf("split(split(%s, '//')[1], ':')[0]", endpointVar), nil
 
 }
 

--- a/cli/azd/internal/scaffold/resource_expr.go
+++ b/cli/azd/internal/scaffold/resource_expr.go
@@ -269,7 +269,7 @@ type tmpl struct {
 	// rawOffset is the offset of the raw string due to replacements from expressions
 	rawOffset int
 	// expressions are the parsed expressions in the template
-	expressions []Expression
+	expressions []*Expression
 }
 
 func (t *tmpl) Replace(expr *Expression, val string) {
@@ -280,7 +280,7 @@ func (t *tmpl) Replace(expr *Expression, val string) {
 	t.rawOffset += len(val) - (expr.end - expr.start)
 }
 
-func Parse(s *string) ([]Expression, error) {
+func Parse(s *string) ([]*Expression, error) {
 	var t *tmpl
 	prev := rune(0)
 	val := *s
@@ -309,7 +309,7 @@ func Parse(s *string) ([]Expression, error) {
 				expr.end = (i + 1) + p.cursor + 1 // end of '}'
 				expr.t = t
 
-				t.expressions = append(t.expressions, *expr)
+				t.expressions = append(t.expressions, expr)
 			}
 		}
 

--- a/cli/azd/internal/scaffold/resource_expr.go
+++ b/cli/azd/internal/scaffold/resource_expr.go
@@ -74,8 +74,8 @@ type Expression struct {
 	t *tmpl
 
 	// The start and end positions of the expression in the template.
-	start int
-	end   int
+	Start int
+	End   int
 }
 
 func (e *Expression) Replace(val string) {
@@ -274,10 +274,10 @@ type tmpl struct {
 
 func (t *tmpl) Replace(expr *Expression, val string) {
 	raw := *t.raw
-	raw = raw[:expr.start+t.rawOffset] + val + raw[expr.end+t.rawOffset:]
+	raw = raw[:expr.Start+t.rawOffset] + val + raw[expr.End+t.rawOffset:]
 
 	*t.raw = raw
-	t.rawOffset += len(val) - (expr.end - expr.start)
+	t.rawOffset += len(val) - (expr.End - expr.Start)
 }
 
 func Parse(s *string) ([]*Expression, error) {
@@ -305,8 +305,8 @@ func Parse(s *string) ([]*Expression, error) {
 					}
 				}
 
-				expr.start = i - 1                // start of '${'
-				expr.end = (i + 1) + p.cursor + 1 // end of '}'
+				expr.Start = i - 1                // start of '${'
+				expr.End = (i + 1) + p.cursor + 1 // end of '}'
 				expr.t = t
 
 				t.expressions = append(t.expressions, expr)

--- a/cli/azd/internal/scaffold/resource_expr_eval.go
+++ b/cli/azd/internal/scaffold/resource_expr_eval.go
@@ -37,7 +37,10 @@ type EvalEnv struct {
 // execution terminates and Eval returns that error.
 type FuncMap map[string]any
 
-func BaseFuncMap() FuncMap {
+// BaseEvalFuncMap returns a map of functions that can be used for evaluation purposes.
+//
+// The functions are evaluated at runtime against live Azure resources.
+func BaseEvalFuncMap() FuncMap {
 	return FuncMap{
 		"lower":                     strings.ToLower,
 		"upper":                     strings.ToUpper,
@@ -47,6 +50,11 @@ func BaseFuncMap() FuncMap {
 	}
 }
 
+// BaseEmitFuncMap returns a map of functions that can be used for bicep emitting purposes.
+//
+// The functions are similar to the base function map, except they are compile-time expressions that operate
+// on the string symbols of the variables, rather than their resolved values.
+// The functions are not evaluated at runtime, but rather emitted as part of the Bicep template.
 func BaseEmitBicepFuncMap() FuncMap {
 	return FuncMap{
 		"lower":                     bicepFuncCall("toLower"),
@@ -83,7 +91,7 @@ func Eval(values map[string]string, env EvalEnv) (map[string]string, error) {
 		return values, fmt.Errorf("missing vault secret resolver")
 	}
 
-	defaultFuncMap := BaseFuncMap()
+	defaultFuncMap := BaseEvalFuncMap()
 	if env.FuncMap == nil {
 		env.FuncMap = make(FuncMap, len(defaultFuncMap))
 	}

--- a/cli/azd/internal/scaffold/resource_meta.go
+++ b/cli/azd/internal/scaffold/resource_meta.go
@@ -227,7 +227,7 @@ var Resources = []ResourceMeta{
 		ResourceType:      "Microsoft.MachineLearningServices/workspaces",
 		ResourceKind:      "Project",
 		ApiVersion:        "2024-10-01",
-		StandardVarPrefix: "AZURE_AI_PROJECT",
+		StandardVarPrefix: "AZURE_AIPROJECT",
 		Variables: map[string]string{
 			"connectionString": "${aiProjectConnectionString .id .properties.discoveryUrl}",
 		},
@@ -249,6 +249,20 @@ var Resources = []ResourceMeta{
 		StandardVarPrefix: "AZURE_AI_SEARCH",
 		Variables: map[string]string{
 			"endpoint": "https://${.name}.search.windows.net",
+		},
+		RoleAssignments: RoleAssignments{
+			Write: []RoleAssignment{
+				{
+					Name:               "IdxContributor",
+					RoleDefinitionName: "Search Index Data Contributor",
+					RoleDefinitionId:   "8ebe5a00-799e-43f5-93ac-243d3dce84a7",
+				},
+				{
+					Name:               "SvcContributor",
+					RoleDefinitionName: "Search Service Contributor",
+					RoleDefinitionId:   "7ca78c08-252a-4471-8644-bb5ff32d4ba0",
+				},
+			},
 		},
 	},
 }

--- a/cli/azd/internal/scaffold/resource_meta.go
+++ b/cli/azd/internal/scaffold/resource_meta.go
@@ -236,7 +236,7 @@ var Resources = []ResourceMeta{
 		ResourceType:      "Microsoft.MachineLearningServices/workspaces",
 		ResourceKind:      "Project",
 		ApiVersion:        "2024-10-01",
-		StandardVarPrefix: "AZURE_AIPROJECT",
+		StandardVarPrefix: "AZURE_AI_PROJECT",
 		Variables: map[string]string{
 			"connectionString": "${aiProjectConnectionString .id .properties.discoveryUrl}",
 		},

--- a/cli/azd/internal/scaffold/resource_meta.go
+++ b/cli/azd/internal/scaffold/resource_meta.go
@@ -157,6 +157,15 @@ var Resources = []ResourceMeta{
 			"name": "${.name}",
 			"host": "${host .properties.serviceBusEndpoint}",
 		},
+		RoleAssignments: RoleAssignments{
+			Write: []RoleAssignment{
+				{
+					Name:               "HubDataOwner",
+					RoleDefinitionName: "Azure Event Hubs Data Owner",
+					RoleDefinitionId:   "f526a384-b230-433a-b45c-95f59c4a2dec",
+				},
+			},
+		},
 	},
 	{
 		ResourceType:      "Microsoft.KeyVault/vaults",
@@ -178,6 +187,15 @@ var Resources = []ResourceMeta{
 		Variables: map[string]string{
 			"name": "${.name}",
 			"host": "${host .properties.serviceBusEndpoint}",
+		},
+		RoleAssignments: RoleAssignments{
+			Write: []RoleAssignment{
+				{
+					Name:               "BusDataOwner",
+					RoleDefinitionName: "Azure Service Bus Data Owner",
+					RoleDefinitionId:   "090c5cfd-751d-490a-894a-3ce6f1109419",
+				},
+			},
 		},
 	},
 	{

--- a/cli/azd/internal/scaffold/resource_meta.go
+++ b/cli/azd/internal/scaffold/resource_meta.go
@@ -175,6 +175,15 @@ var Resources = []ResourceMeta{
 			"name":     "${.name}",
 			"endpoint": "${.properties.vaultUri}",
 		},
+		RoleAssignments: RoleAssignments{
+			Read: []RoleAssignment{
+				{
+					Name:               "Reader",
+					RoleDefinitionName: "Key Vault Secrets User",
+					RoleDefinitionId:   "4633458b-17de-408a-b874-0445c86b69e6",
+				},
+			},
+		},
 	},
 	{
 		ResourceType: "Microsoft.ManagedIdentity/userAssignedIdentities",

--- a/cli/azd/internal/scaffold/scaffold.go
+++ b/cli/azd/internal/scaffold/scaffold.go
@@ -75,6 +75,12 @@ func supportingFiles(spec InfraSpec) []string {
 		files = append(files, "/modules/fetch-container-image.bicep")
 	}
 
+	if len(spec.Existing) > 0 {
+		files = append(files,
+			"/modules/role-assignment.bicep",
+			"/modules/role-assignment.json")
+	}
+
 	if spec.AiFoundryProject != nil && spec.AISearch != nil {
 		files = append(files, "/modules/ai-search-conn.bicep")
 	}
@@ -236,4 +242,15 @@ func preExecExpand(spec *InfraSpec) {
 		spec.Parameters = append(spec.Parameters,
 			containerAppExistsParameter(svc.Name))
 	}
+
+	for _, res := range spec.Existing {
+		// each existing resource adds a parameter declaration input for its resource id
+		spec.Parameters = append(spec.Parameters,
+			Parameter{
+				Name:  res.Name + "Id",
+				Value: fmt.Sprintf("${%s}", res.ResourceIdEnvVar),
+				Type:  "string",
+			})
+	}
+
 }

--- a/cli/azd/internal/scaffold/spec.go
+++ b/cli/azd/internal/scaffold/spec.go
@@ -10,7 +10,13 @@ import (
 
 type InfraSpec struct {
 	Parameters []Parameter
-	Services   []ServiceSpec
+
+	Services []ServiceSpec
+
+	// Existing resources for declaration purposes.
+	// These are resources that are already created and should be used by the
+	// current deployment for referencing
+	Existing []ExistingResource
 
 	// Databases to create
 	DbPostgres    *DatabasePostgres
@@ -155,6 +161,9 @@ type ServiceSpec struct {
 	AiFoundryProject *AiFoundrySpec
 
 	AISearch *AISearchReference
+
+	// Existing resource bindings
+	Existing []*ExistingResource
 }
 
 type Frontend struct {
@@ -184,6 +193,19 @@ type AISearchReference struct {
 }
 
 type KeyVaultReference struct {
+}
+
+type ExistingResource struct {
+	// The unique logical name of the existing resource in the infra scope.
+	Name string
+	// The resource ID of the resource.
+	ResourceIdEnvVar string
+	// The resource type of the resource. This should match the type contained in the resource ID.
+	ResourceType string
+	// The API version of the resource to look up values.
+	ApiVersion string
+	// Role assignment
+	RoleAssignments []RoleAssignment
 }
 
 func containerAppExistsParameter(serviceName string) Parameter {

--- a/cli/azd/pkg/azapi/resource_service.go
+++ b/cli/azd/pkg/azapi/resource_service.go
@@ -255,45 +255,6 @@ func (rs *ResourceService) ListSubscriptionResources(
 	return resources, nil
 }
 
-// ListResources returns a slice of resources - optionally filtered on fields in `ListResourcesOptions` - including the
-// ID, Name, Type, and Location of each resource.
-func (rs *ResourceService) ListResources(
-	ctx context.Context,
-	subscriptionId string,
-	listOptions *ListResourcesOptions,
-) ([]*Resource, error) {
-	client, err := rs.createResourcesClient(ctx, subscriptionId)
-	if err != nil {
-		return nil, err
-	}
-
-	options := armresources.ClientListOptions{}
-	if listOptions != nil && listOptions.ResourceType != "" {
-		filter := fmt.Sprintf("resourceType eq '%s'", listOptions.ResourceType)
-		options.Filter = &filter
-	}
-
-	resources := []*Resource{}
-	pager := client.NewListPager(&options)
-
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, resource := range page.ResourceListResult.Value {
-			resources = append(resources, &Resource{
-				Id:       *resource.ID,
-				Name:     *resource.Name,
-				Type:     *resource.Type,
-				Location: *resource.Location,
-			})
-		}
-	}
-	return resources, nil
-}
-
 func (rs *ResourceService) CreateOrUpdateResourceGroup(
 	ctx context.Context,
 	subscriptionId string,

--- a/cli/azd/pkg/azapi/resource_service.go
+++ b/cli/azd/pkg/azapi/resource_service.go
@@ -58,10 +58,6 @@ type ListResourceGroupResourcesOptions struct {
 	Filter *string
 }
 
-type ListResourcesOptions struct {
-	ResourceType string
-}
-
 type ResourceService struct {
 	credentialProvider account.SubscriptionCredentialProvider
 	armClientOptions   *arm.ClientOptions

--- a/cli/azd/pkg/azapi/resource_service.go
+++ b/cli/azd/pkg/azapi/resource_service.go
@@ -58,6 +58,10 @@ type ListResourceGroupResourcesOptions struct {
 	Filter *string
 }
 
+type ListResourcesOptions struct {
+	ResourceType string
+}
+
 type ResourceService struct {
 	credentialProvider account.SubscriptionCredentialProvider
 	armClientOptions   *arm.ClientOptions
@@ -248,6 +252,45 @@ func (rs *ResourceService) ListSubscriptionResources(
 		}
 	}
 
+	return resources, nil
+}
+
+// ListResources returns a slice of resources - optionally filtered on fields in `ListResourcesOptions` - including the
+// ID, Name, Type, and Location of each resource.
+func (rs *ResourceService) ListResources(
+	ctx context.Context,
+	subscriptionId string,
+	listOptions *ListResourcesOptions,
+) ([]*Resource, error) {
+	client, err := rs.createResourcesClient(ctx, subscriptionId)
+	if err != nil {
+		return nil, err
+	}
+
+	options := armresources.ClientListOptions{}
+	if listOptions != nil && listOptions.ResourceType != "" {
+		filter := fmt.Sprintf("resourceType eq '%s'", listOptions.ResourceType)
+		options.Filter = &filter
+	}
+
+	resources := []*Resource{}
+	pager := client.NewListPager(&options)
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, resource := range page.ResourceListResult.Value {
+			resources = append(resources, &Resource{
+				Id:       *resource.ID,
+				Name:     *resource.Name,
+				Type:     *resource.Type,
+				Location: *resource.Location,
+			})
+		}
+	}
 	return resources, nil
 }
 

--- a/cli/azd/pkg/infra/util.go
+++ b/cli/azd/pkg/infra/util.go
@@ -19,7 +19,7 @@ func ResourceId(name string, env *environment.Environment) (resId *arm.ResourceI
 		return resId, nil
 	}
 
-	key := fmt.Sprintf("AZURE_RESOURCE_%s_ID", environment.Key(name))
+	key := ResourceIdName(name)
 	resourceId, ok := env.LookupEnv(key)
 	if !ok {
 		return resId, fmt.Errorf("%s is not set as an output variable", key)
@@ -35,6 +35,11 @@ func ResourceId(name string, env *environment.Environment) (resId *arm.ResourceI
 	}
 
 	return resId, nil
+}
+
+// ResourceIdName returns the environment variable name for the resource ID of the given name.
+func ResourceIdName(name string) string {
+	return fmt.Sprintf("AZURE_RESOURCE_%s_ID", environment.Key(name))
 }
 
 // KeyVaultName returns the name of the "canonical" key vault to use for secrets.

--- a/cli/azd/pkg/project/resources.go
+++ b/cli/azd/pkg/project/resources.go
@@ -129,6 +129,11 @@ type ResourceConfig struct {
 	Props    interface{}          `yaml:"-"`
 	// Relationships to other resources
 	Uses []string `yaml:"uses,omitempty"`
+	// Existing indicates whether the resource is an existing resource.
+	Existing bool `yaml:"existing,omitempty"`
+	// Resource ID in the project.
+	// This is a virtual field. It is stored as environment state.
+	ResourceId string `yaml:"-"`
 
 	// IncludeName indicates whether the `name` field should be included upon serialization.
 	IncludeName bool `yaml:"-"`
@@ -156,26 +161,28 @@ func (r *ResourceConfig) MarshalYAML() (interface{}, error) {
 		return nil
 	}
 
-	var errMarshal error
-	switch raw.Type {
-	case ResourceTypeOpenAiModel:
-		errMarshal = marshalRawProps(raw.Props.(AIModelProps))
-	case ResourceTypeHostContainerApp:
-		errMarshal = marshalRawProps(raw.Props.(ContainerAppProps))
-	case ResourceTypeDbCosmos:
-		errMarshal = marshalRawProps(raw.Props.(CosmosDBProps))
-	case ResourceTypeMessagingEventHubs:
-		errMarshal = marshalRawProps(raw.Props.(EventHubsProps))
-	case ResourceTypeMessagingServiceBus:
-		errMarshal = marshalRawProps(raw.Props.(ServiceBusProps))
-	case ResourceTypeStorage:
-		errMarshal = marshalRawProps(raw.Props.(StorageProps))
-	case ResourceTypeAiProject:
-		errMarshal = marshalRawProps(raw.Props.(AiFoundryModelProps))
-	}
+	if raw.Props != nil {
+		var errMarshal error
+		switch raw.Type {
+		case ResourceTypeOpenAiModel:
+			errMarshal = marshalRawProps(raw.Props.(AIModelProps))
+		case ResourceTypeHostContainerApp:
+			errMarshal = marshalRawProps(raw.Props.(ContainerAppProps))
+		case ResourceTypeDbCosmos:
+			errMarshal = marshalRawProps(raw.Props.(CosmosDBProps))
+		case ResourceTypeMessagingEventHubs:
+			errMarshal = marshalRawProps(raw.Props.(EventHubsProps))
+		case ResourceTypeMessagingServiceBus:
+			errMarshal = marshalRawProps(raw.Props.(ServiceBusProps))
+		case ResourceTypeStorage:
+			errMarshal = marshalRawProps(raw.Props.(StorageProps))
+		case ResourceTypeAiProject:
+			errMarshal = marshalRawProps(raw.Props.(AiFoundryModelProps))
+		}
 
-	if errMarshal != nil {
-		return nil, errMarshal
+		if errMarshal != nil {
+			return nil, errMarshal
+		}
 	}
 
 	return raw, nil

--- a/cli/azd/pkg/project/scaffold_gen.go
+++ b/cli/azd/pkg/project/scaffold_gen.go
@@ -158,7 +158,7 @@ func infraSpec(projectConfig *ProjectConfig) (*scaffold.InfraSpec, error) {
 		if res.Existing { // handle existing flow
 			resourceMeta, ok := scaffold.ResourceMetaFromType(res.Type.AzureResourceType())
 			if !ok {
-				return nil, fmt.Errorf("resource type '%s' is not currently supported for existing", res.Type)
+				return nil, fmt.Errorf("resource type '%s' is not currently supported for existing", string(res.Type))
 			}
 
 			existing := scaffold.ExistingResource{
@@ -167,6 +167,10 @@ func infraSpec(projectConfig *ProjectConfig) (*scaffold.InfraSpec, error) {
 				ResourceIdEnvVar: infra.ResourceIdName(res.Name),
 				ResourceType:     resourceMeta.ResourceType,
 				RoleAssignments:  resourceMeta.RoleAssignments.Write,
+			}
+
+			if resourceMeta.ParentForEval != "" {
+				existing.ResourceType = resourceMeta.ParentForEval
 			}
 
 			infraSpec.Existing = append(infraSpec.Existing, existing)
@@ -376,7 +380,7 @@ func mapHostUses(
 		if useRes.Existing {
 			resourceMeta, ok := scaffold.ResourceMetaFromType(useRes.Type.AzureResourceType())
 			if !ok {
-				return fmt.Errorf("resource type '%s' is not currently supported for existing", res.Type)
+				return fmt.Errorf("resource type '%s' is not currently supported for existing", string(res.Type))
 			}
 
 			existingDecl := existingMap[use]
@@ -388,7 +392,7 @@ func mapHostUses(
 
 			results, err := scaffold.EmitBicep(resourceMeta.Variables, emitter)
 			if err != nil {
-				return fmt.Errorf("emitting bicep bindings: %w", err)
+				return fmt.Errorf("emitting bicep bindings for '%s': %w", useRes.Name, err)
 			}
 
 			for key, value := range results {

--- a/cli/azd/pkg/project/scaffold_gen.go
+++ b/cli/azd/pkg/project/scaffold_gen.go
@@ -461,14 +461,16 @@ func emitVariable(emitEnv EmitEnv, val *scaffold.ExpressionVar, results map[stri
 		return nil
 	}
 
-	// if there are multiple expressions, we need to surround each expression with ${}
-	// to make it a Bicep interpolated string
-	interpolationMode := len(val.Expressions) > 1
+	// surround each expression with ${} in a Bicep interpolated string
 	surround := func(s string) string {
-		if interpolationMode {
-			return fmt.Sprintf("${%s}", s)
+		return fmt.Sprintf("${%s}", s)
+	}
+
+	if len(val.Expressions) == 1 && val.Expressions[0].Start == 0 && val.Expressions[0].End == len(val.Value) {
+		// if there is only one expression and it covers the entire value, we don't need to surround it
+		surround = func(s string) string {
+			return s
 		}
-		return s
 	}
 
 	for _, expr := range val.Expressions {

--- a/cli/azd/pkg/project/scaffold_gen.go
+++ b/cli/azd/pkg/project/scaffold_gen.go
@@ -141,15 +141,17 @@ func infraSpec(projectConfig *ProjectConfig) (*scaffold.InfraSpec, error) {
 
 	// Create a "virtual" copy since we're adding any implicitly dependent resources
 	// that are unrepresented by the current user-provided schema
-	resources := maps.Clone(projectConfig.Resources)
+	resMap := maps.Clone(projectConfig.Resources)
+	resources := slices.Sorted(maps.Keys(resMap))
 
 	// First pass
 	for _, res := range resources {
+		res := resMap[res]
 		// Add any implicit dependencies
 		dependencies := DependentResourcesOf(res)
 		for _, dep := range dependencies {
-			if _, exists := resources[dep.Name]; !exists {
-				resources[dep.Name] = dep
+			if _, exists := resMap[dep.Name]; !exists {
+				resMap[dep.Name] = dep
 			}
 		}
 
@@ -174,9 +176,11 @@ func infraSpec(projectConfig *ProjectConfig) (*scaffold.InfraSpec, error) {
 	}
 
 	for _, res := range resources {
+		res := resMap[res]
 		if res.Existing {
 			continue
 		}
+
 		switch res.Type {
 		case ResourceTypeDbRedis:
 			infraSpec.DbRedis = &scaffold.DatabaseRedis{}

--- a/cli/azd/resources/scaffold/base/modules/role-assignment.bicep
+++ b/cli/azd/resources/scaffold/base/modules/role-assignment.bicep
@@ -1,0 +1,35 @@
+param resourceId string
+param roleDefinitionId string
+param principalId string
+param principalType string = ''
+
+#disable-next-line no-deployments-resources
+resource roleAssignment 'Microsoft.Resources/deployments@2021-04-01' = {
+    name: guid(resourceId, principalId, roleDefinitionId)
+    properties: {
+        mode: 'Incremental'
+        expressionEvaluationOptions: {
+            scope: 'Outer'
+        }
+        template: json(loadTextContent('./role-assignment.json'))
+        parameters: {
+            scope: {
+                value: resourceId
+            }
+            name: {
+                value: guid(resourceId, principalId, roleDefinitionId)
+            }
+            roleDefinitionId: {
+                value: roleDefinitionId
+            }
+            principalId: {
+                value: principalId
+            }
+            principalType: {
+                value: principalType
+            }
+        }
+    }
+}
+
+output roleAssignmentId string = roleAssignment.properties.outputs.roleAssignmentId.value

--- a/cli/azd/resources/scaffold/base/modules/role-assignment.bicep
+++ b/cli/azd/resources/scaffold/base/modules/role-assignment.bicep
@@ -3,9 +3,11 @@ param roleDefinitionId string
 param principalId string
 param principalType string = ''
 
+var fullRoleDefinitionId = az.subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleDefinitionId)
+
 #disable-next-line no-deployments-resources
 resource roleAssignment 'Microsoft.Resources/deployments@2021-04-01' = {
-    name: guid(resourceId, principalId, roleDefinitionId)
+    name: guid(resourceId, principalId, fullRoleDefinitionId)
     properties: {
         mode: 'Incremental'
         expressionEvaluationOptions: {
@@ -17,10 +19,10 @@ resource roleAssignment 'Microsoft.Resources/deployments@2021-04-01' = {
                 value: resourceId
             }
             name: {
-                value: guid(resourceId, principalId, roleDefinitionId)
+                value: guid(resourceId, principalId, fullRoleDefinitionId)
             }
             roleDefinitionId: {
-                value: roleDefinitionId
+                value: fullRoleDefinitionId
             }
             principalId: {
                 value: principalId

--- a/cli/azd/resources/scaffold/base/modules/role-assignment.bicep
+++ b/cli/azd/resources/scaffold/base/modules/role-assignment.bicep
@@ -1,4 +1,4 @@
-param resourceId string
+param resourceId string = ''
 param roleDefinitionId string
 param principalId string
 param principalType string = ''

--- a/cli/azd/resources/scaffold/base/modules/role-assignment.json
+++ b/cli/azd/resources/scaffold/base/modules/role-assignment.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "scope": {
+        "type": "string"
+      },
+      "name": {
+        "type": "string"
+      },
+      "roleDefinitionId": {
+        "type": "string"
+      },
+      "principalId": {
+        "type": "string"
+      },
+      "principalType": {
+        "type": "string"
+      }
+    },
+    "resources": [
+      {
+        "type": "Microsoft.Authorization/roleAssignments",
+        "apiVersion": "2022-04-01",
+        "scope": "[parameters('scope')]",
+        "name": "[parameters('name')]",
+        "properties": {
+          "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]",
+          "principalId": "[parameters('principalId')]",
+          "principalType": "[parameters('principalType')]"
+        }
+      }
+    ],
+    "outputs": {
+      "roleAssignmentId": {
+        "type": "string",
+        "value": "[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]"
+      }
+    }
+  }

--- a/cli/azd/resources/scaffold/base/modules/role-assignment.json
+++ b/cli/azd/resources/scaffold/base/modules/role-assignment.json
@@ -25,7 +25,7 @@
         "scope": "[parameters('scope')]",
         "name": "[parameters('name')]",
         "properties": {
-          "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]",
+          "roleDefinitionId": "[parameters('roleDefinitionId')]",
           "principalId": "[parameters('principalId')]",
           "principalType": "[parameters('principalType')]"
         }

--- a/cli/azd/resources/scaffold/base/modules/role-assignment.json
+++ b/cli/azd/resources/scaffold/base/modules/role-assignment.json
@@ -34,7 +34,7 @@
     "outputs": {
       "roleAssignmentId": {
         "type": "string",
-        "value": "[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]"
+        "value": "[if(empty(parameters('scope')), resourceId('Microsoft.Authorization/roleAssignments', parameters('name')), extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name')))]"
       }
     }
   }

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -38,7 +38,7 @@ module local_{{$existing.Name}}_{{.Name}} 'modules/role-assignment.bicep' = {
     {{- if eq .Scope 0}}
     resourceId: {{$existing.Name}}Id
     {{- end}}
-    roleDefinitionId: '{{.RoleDefinitionId}}'
+    roleDefinitionId: '{{.RoleDefinitionId}}' // {{.RoleDefinitionName}}
     principalId: principalId
     principalType: 'User'
   }
@@ -475,7 +475,7 @@ module {{bicepName $svc.Name}}_{{$existing.Name}}_{{.Name}} 'modules/role-assign
   scope: resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4])
   params: {
     {{ if eq .Scope 0 -}}resourceId: {{$existing.Name}}Id{{- end}}
-    roleDefinitionId: '{{.RoleDefinitionId}}'
+    roleDefinitionId: '{{.RoleDefinitionId}}' // {{.RoleDefinitionName}}
     principalId: {{bicepName $svc.Name}}Identity.outputs.principalId
     principalType: 'ServicePrincipal'
   }

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -37,7 +37,7 @@ module local_{{$existing.Name}}_{{.Name}}_RoleAssignment 'modules/role-assignmen
   scope: resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4])
   params: {
     resourceId: {{if eq .Scope 1 -}}
-      resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4])
+      string(resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4]))
     {{- else -}}
       {{$existing.Name}}Id
     {{- end}}
@@ -478,7 +478,7 @@ module {{bicepName $svc.Name}}_{{$existing.Name}}_{{.Name}}_RoleAssignment 'modu
   scope: resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4])
   params: {
     resourceId: {{if eq .Scope 1 -}}
-      resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4])
+      string(resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4]))
     {{- else -}}
       {{$existing.Name}}Id
     {{- end}}

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -22,6 +22,34 @@ param principalId string
 var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = uniqueString(subscription().id, resourceGroup().id, location)
 
+{{if .Existing -}}
+{{- range .Existing }}
+var {{.Name}}IdSegments = split({{.Name}}Id, '/')
+resource {{.Name}} '{{.ResourceType}}@{{.ApiVersion}}' existing = {
+  scope: resourceGroup({{.Name}}IdSegments[2], {{.Name}}IdSegments[4])
+  name: {{.Name}}IdSegments[8]
+}
+
+{{- $existing := . -}}
+{{- range .RoleAssignments}}
+module local_{{$existing.Name}}_{{.Name}}_RoleAssignment 'modules/role-assignment.bicep' = {
+  name: 'local_{{$existing.Name}}_{{.Name}}_RoleAssignment'
+  scope: resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4])
+  params: {
+    resourceId: {{if eq .Scope 1 -}}
+      resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4])
+    {{- else -}}
+      {{$existing.Name}}Id
+    {{- end}}
+    roleDefinitionId: '{{.RoleDefinitionId}}'
+    principalId: principalId
+    principalType: 'User'
+  }
+}
+{{- end}}
+{{- end}}
+{{- end -}}
+
 {{- if .Services }}
 
 // Monitor application with Azure Monitor
@@ -439,6 +467,28 @@ resource {{bicepName .Name}}OpenAIIdentity 'Microsoft.Authorization/roleAssignme
     roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd')
   }
 }
+{{- end}}
+
+{{- $svc := . -}}
+{{- if .Existing }}
+{{- range $index, $existing := .Existing}}
+{{- range .RoleAssignments}}
+module {{bicepName $svc.Name}}_{{$existing.Name}}_{{.Name}}_RoleAssignment 'modules/role-assignment.bicep' = {
+  name: '{{bicepName $svc.Name}}_{{$existing.Name}}_{{.Name}}_RoleAssignment'
+  scope: resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4])
+  params: {
+    resourceId: {{if eq .Scope 1 -}}
+      resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4])
+    {{- else -}}
+      {{$existing.Name}}Id
+    {{- end}}
+    roleDefinitionId: '{{.RoleDefinitionId}}'
+    principalId: {{bicepName $svc.Name}}Identity.outputs.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+{{- end}}
+{{- end}}
 {{- end}}
 
 module {{bicepName .Name}}FetchLatestImage './modules/fetch-container-image.bicep' = {

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -31,8 +31,8 @@ resource {{.Name}} '{{.ResourceType}}@{{.ApiVersion}}' existing = {
 }
 
 {{- $existing := .}}{{- range .RoleAssignments}}
-module local_{{$existing.Name}}_{{.Name}}_RoleAssignment 'modules/role-assignment.bicep' = {
-  name: 'local_{{$existing.Name}}_{{.Name}}_RoleAssignment'
+module local_{{$existing.Name}}_{{.Name}} 'modules/role-assignment.bicep' = {
+  name: 'local_{{$existing.Name}}_{{.Name}}'
   scope: resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4])
   params: {
     {{- if eq .Scope 0}}
@@ -470,8 +470,8 @@ resource {{bicepName .Name}}OpenAIIdentity 'Microsoft.Authorization/roleAssignme
 {{- if .Existing }}
 {{- range $index, $existing := .Existing}}
 {{- range .RoleAssignments}}
-module {{bicepName $svc.Name}}_{{$existing.Name}}_{{.Name}}_RoleAssignment 'modules/role-assignment.bicep' = {
-  name: '{{bicepName $svc.Name}}_{{$existing.Name}}_{{.Name}}_RoleAssignment'
+module {{bicepName $svc.Name}}_{{$existing.Name}}_{{.Name}} 'modules/role-assignment.bicep' = {
+  name: '{{bicepName $svc.Name}}_{{$existing.Name}}_{{.Name}}'
   scope: resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4])
   params: {
     {{ if eq .Scope 0 -}}resourceId: {{$existing.Name}}Id{{- end}}

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -22,30 +22,14 @@ param principalId string
 var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = uniqueString(subscription().id, resourceGroup().id, location)
 
-{{if .Existing}}
 {{- range .Existing }}
+
 var {{.Name}}IdSegments = split({{.Name}}Id, '/')
 resource {{.Name}} '{{.ResourceType}}@{{.ApiVersion}}' existing = {
   scope: resourceGroup({{.Name}}IdSegments[2], {{.Name}}IdSegments[4])
   name: {{.Name}}IdSegments[8]
 }
-
-{{- $existing := .}}{{- range .RoleAssignments}}
-module local_{{$existing.Name}}_{{.Name}} 'modules/role-assignment.bicep' = {
-  name: 'local_{{$existing.Name}}_{{.Name}}'
-  scope: resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4])
-  params: {
-    {{- if eq .Scope 0}}
-    resourceId: {{$existing.Name}}Id
-    {{- end}}
-    roleDefinitionId: '{{.RoleDefinitionId}}' // {{.RoleDefinitionName}}
-    principalId: principalId
-    principalType: 'User'
-  }
-}
-{{end}}
 {{- end}}
-{{- end -}}
 
 {{- if .Services }}
 
@@ -467,9 +451,9 @@ resource {{bicepName .Name}}OpenAIIdentity 'Microsoft.Authorization/roleAssignme
 {{- end}}
 
 {{- $svc := . -}}
-{{- if .Existing }}
 {{- range $index, $existing := .Existing}}
 {{- range .RoleAssignments}}
+
 module {{bicepName $svc.Name}}_{{$existing.Name}}_{{.Name}} 'modules/role-assignment.bicep' = {
   name: '{{bicepName $svc.Name}}_{{$existing.Name}}_{{.Name}}'
   scope: resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4])
@@ -480,7 +464,6 @@ module {{bicepName $svc.Name}}_{{$existing.Name}}_{{.Name}} 'modules/role-assign
     principalType: 'ServicePrincipal'
   }
 }
-{{- end}}
 {{- end}}
 {{- end}}
 

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -22,7 +22,7 @@ param principalId string
 var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = uniqueString(subscription().id, resourceGroup().id, location)
 
-{{if .Existing -}}
+{{if .Existing}}
 {{- range .Existing }}
 var {{.Name}}IdSegments = split({{.Name}}Id, '/')
 resource {{.Name}} '{{.ResourceType}}@{{.ApiVersion}}' existing = {
@@ -30,23 +30,20 @@ resource {{.Name}} '{{.ResourceType}}@{{.ApiVersion}}' existing = {
   name: {{.Name}}IdSegments[8]
 }
 
-{{- $existing := . -}}
-{{- range .RoleAssignments}}
+{{- $existing := .}}{{- range .RoleAssignments}}
 module local_{{$existing.Name}}_{{.Name}}_RoleAssignment 'modules/role-assignment.bicep' = {
   name: 'local_{{$existing.Name}}_{{.Name}}_RoleAssignment'
   scope: resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4])
   params: {
-    resourceId: {{if eq .Scope 1 -}}
-      string(resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4]))
-    {{- else -}}
-      {{$existing.Name}}Id
+    {{- if eq .Scope 0}}
+    resourceId: {{$existing.Name}}Id
     {{- end}}
     roleDefinitionId: '{{.RoleDefinitionId}}'
     principalId: principalId
     principalType: 'User'
   }
 }
-{{- end}}
+{{end}}
 {{- end}}
 {{- end -}}
 
@@ -477,11 +474,7 @@ module {{bicepName $svc.Name}}_{{$existing.Name}}_{{.Name}}_RoleAssignment 'modu
   name: '{{bicepName $svc.Name}}_{{$existing.Name}}_{{.Name}}_RoleAssignment'
   scope: resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4])
   params: {
-    resourceId: {{if eq .Scope 1 -}}
-      string(resourceGroup({{$existing.Name}}IdSegments[2], {{$existing.Name}}IdSegments[4]))
-    {{- else -}}
-      {{$existing.Name}}Id
-    {{- end}}
+    {{ if eq .Scope 0 -}}resourceId: {{$existing.Name}}Id{{- end}}
     roleDefinitionId: '{{.RoleDefinitionId}}'
     principalId: {{bicepName $svc.Name}}Identity.outputs.principalId
     principalType: 'ServicePrincipal'

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -388,6 +388,11 @@
                             "type": "string"
                         },
                         "uniqueItems": true
+                    },
+                    "existing": {
+                        "type": "boolean",
+                        "title": "An existing resource for referencing purposes",
+                        "description": "Optional. When set to true, this resource will not be created and instead be used for referencing purposes. (Default: false)"
                     }
                 },
                 "allOf": [
@@ -1272,6 +1277,11 @@
                         "type": "string"
                     },
                     "uniqueItems": true
+                },
+                "existing": {
+                    "type": "boolean",
+                    "title": "An existing resource for referencing purposes",
+                    "description": "Optional. When set to true, this resource will not be created and instead be used for referencing purposes. (Default: false)"
                 }
             }
         },
@@ -1392,6 +1402,7 @@
             "properties": {
                 "type": true,
                 "uses": true,
+                "existing": true,
                 "hubs": {
                     "type": "array",
                     "title": "Hubs to create in the Event Hubs namespace",
@@ -1410,6 +1421,7 @@
             "properties": {
                 "type": true,
                 "uses": true,
+                "existing": true,
                 "queues": {
                     "type": "array",
                     "title": "Queues to create in the Service Bus namespace",
@@ -1437,6 +1449,7 @@
             "properties": {
                 "type": true,
                 "uses": true,
+                "existing": true,
                 "containers": {
                     "type": "array",
                     "title": "Azure Storage Account container names.",
@@ -1456,6 +1469,7 @@
             "properties": {
                 "type": true,
                 "uses": true,
+                "existing": true,
                 "models": {
                     "type": "array",
                     "title": "AI models to deploy",


### PR DESCRIPTION
This change adds support for referencing `existing` resources.

## User-facing changes

`azd add` now supports adding existing resources by listing resources interactively. In the schema, a new `existing` keyword is added.

An example resulting schema looks like:

```yaml
  shared:
    type: storage
    existing: true
```

The resource ID, in the format of, `AZURE_RESOURCE_SHARED_STORAGE_ID` is stored in azd's `.env` file to support cross environment.

Existing resources support `uses` linking, just as before:

```yaml
  stg-exist:
    type: host.containerapp
    port: 80
    uses:
      - shared # Adds env variables `AZURE_STORAGE_SHARED_ACCOUNT_NAME`,  `AZURE_STORAGE_SHARED_ACCOUNT_BLOB_ENDPOINT`
```

`azd show <resource>`, i.e. `azd show shared` also works to display the environment variables for existing resources.

### Backend Bicep implementation

1. The resource is added as an `existing` resource to fetch properties.
2. The resource is assumed to be using managed identity, role permissions are assigned to the appropriate service identity when `uses` is added.

## Demo: 

https://github.com/user-attachments/assets/3254fbd2-9938-498e-8bc2-78084a9dde14

Completes #4577