### PR TITLE
allow user to disable provision preflight

### DIFF
--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -46,6 +46,9 @@ const ResourceGroupEnvVarName = "AZURE_RESOURCE_GROUP"
 // PlatformTypeEnvVarName is the name of the key used to store the current azd platform type
 const PlatformTypeEnvVarName = "AZD_PLATFORM_TYPE"
 
+// DisablePreflightName is used to allow users to skip the preflight validation check
+const DisablePreflightName = "AZURE_PROVISION_SKIP_VALIDATE"
+
 // The zero value of an Environment is not valid. Use [New] to create one. When writing tests,
 // [Ephemeral] and [EphemeralWithValues] are useful to create environments which are not persisted to disk.
 type Environment struct {

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -637,7 +637,8 @@ func (p *BicepProvider) Deploy(ctx context.Context) (*provisioning.DeployResult,
 			}
 		}
 	} else {
-		warningMessage := fmt.Sprintf("WARNING: Provision validation is disabled. To enable it, please run `azd config set %s off`.\n",
+		warningMessage := fmt.Sprintf("WARNING: Provision validation is disabled. "+
+			"To enable it, please run `azd config set %s off`.\n",
 			preflightDisableVar)
 		p.console.Message(ctx, output.WithWarningFormat(warningMessage))
 	}

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
-	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
@@ -381,7 +380,6 @@ func createBicepProvider(t *testing.T, mockContext *mocks.MockContext) *BicepPro
 			},
 		},
 	}
-	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
 
 	provider := NewBicepProvider(
 		azCli,
@@ -405,7 +403,6 @@ func createBicepProvider(t *testing.T, mockContext *mocks.MockContext) *BicepPro
 		cloud.AzurePublic(),
 		nil,
 		nil,
-		userConfigManager,
 	)
 
 	err = provider.Initialize(*mockContext.Context, projectDir, options)
@@ -992,7 +989,6 @@ func TestUserDefinedTypes(t *testing.T) {
 			cloud.AzurePublic(),
 		),
 		cloud.AzurePublic(),
-		nil,
 		nil,
 		nil,
 	)

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
@@ -380,6 +381,7 @@ func createBicepProvider(t *testing.T, mockContext *mocks.MockContext) *BicepPro
 			},
 		},
 	}
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
 
 	provider := NewBicepProvider(
 		azCli,
@@ -403,6 +405,7 @@ func createBicepProvider(t *testing.T, mockContext *mocks.MockContext) *BicepPro
 		cloud.AzurePublic(),
 		nil,
 		nil,
+		userConfigManager,
 	)
 
 	err = provider.Initialize(*mockContext.Context, projectDir, options)
@@ -989,6 +992,7 @@ func TestUserDefinedTypes(t *testing.T) {
 			cloud.AzurePublic(),
 		),
 		cloud.AzurePublic(),
+		nil,
 		nil,
 		nil,
 	)


### PR DESCRIPTION
- fix #4932 
- Added opt out support for skipping preflight validation

Current method (set .env):
During the discussion on Monday, we went through three methods including set config, set .env, or add flag. It is clear to me that set config is not the way we want as this lets users to completely disable Preflight in all scenarios. We want the disabled functionality to be more project specific. I thought about the trades off between set .env vs add flag and discussed with @weikanglim. Considering our use case, we prefer to be environment/project-specific and speaks the same language that template authors want to speak to users. I believe set .env method is what we are looking for. 
If disable: 
<img width="573" alt="image" src="https://github.com/user-attachments/assets/fd880f57-03a3-4037-9cf9-d95b05413ab5" />

allow user to disable it when an error is blocking:
<img width="578" alt="image" src="https://github.com/user-attachments/assets/a8b2d896-84af-4320-8a04-a2b853117f70" />

Previous method (set config): 
I used the similar logic of alpha feature and added option out feature so that we could use it to option out other features in future. If folks think it is duplication of alpha feature, happy to migrate it under alpha feature support or just directly support config. 

After gathering folks feedback, update the method to directly support config:
Migrate to use `azd config set provision.disableValidation on`. Use `validation` since preflight is an internal word.
If disable, run provision directly:
<img width="547" alt="image" src="https://github.com/user-attachments/assets/1131db87-1a5f-49c8-a0e1-c4d60002e6bf" />

Allow user to disable it when an error is blocking:
<img width="674" alt="image" src="https://github.com/user-attachments/assets/c6a661e8-9310-4eb8-b9d0-7e900f22b5eb" />