### PR TITLE
compose: update service-bus sku, remove api passing

### DIFF
--- a/cli/azd/ci-test.ps1
+++ b/cli/azd/ci-test.ps1
@@ -56,12 +56,11 @@ $oldGOEXPERIMENT = $env:GOEXPERIMENT
 # GOCOVERDIR enables any binaries (in this case, azd.exe) built with '-cover',
 # to write out coverage output to the specific directory.
 $env:GOCOVERDIR = $intCoverDir.FullName
-# Enable the loopvar experiment, which makes the loop variaible for go loops like `range` behave as most folks would expect.
-# the go team is exploring making this default in the future, and we'd like to opt into the behavior now.
-$env:GOEXPERIMENT="loopvar"
+# Set any experiment flags that are needed for the tests.
+$env:GOEXPERIMENT=""
 
 try {
-    & $gotestsum -- ./test/... -v -timeout $IntegrationTestTimeout
+    & $gotestsum -- ./... -v -timeout $IntegrationTestTimeout
     if ($LASTEXITCODE) {
         exit $LASTEXITCODE
     }    

--- a/cli/azd/internal/repository/infra_confirm.go
+++ b/cli/azd/internal/repository/infra_confirm.go
@@ -27,7 +27,10 @@ func (i *Initializer) infraSpecFromDetect(
 	ctx context.Context,
 	detect detectConfirm) (scaffold.InfraSpec, error) {
 	spec := scaffold.InfraSpec{}
+
+	hasDb := false
 	for database := range detect.Databases {
+		hasDb = true
 		if database == appdetect.DbRedis {
 			spec.DbRedis = &scaffold.DatabaseRedis{}
 			// no further configuration needed for redis
@@ -59,6 +62,10 @@ func (i *Initializer) infraSpecFromDetect(
 			}
 			break dbPrompt
 		}
+	}
+
+	if hasDb {
+		spec.KeyVault = &scaffold.KeyVault{}
 	}
 
 	for _, svc := range detect.Services {

--- a/cli/azd/internal/repository/infra_confirm_test.go
+++ b/cli/azd/internal/repository/infra_confirm_test.go
@@ -175,6 +175,7 @@ func TestInitializer_infraSpecFromDetect(t *testing.T) {
 				DbPostgres: &scaffold.DatabasePostgres{
 					DatabaseName: "myappdb",
 				},
+				KeyVault: &scaffold.KeyVault{},
 				Services: []scaffold.ServiceSpec{
 					{
 						Name: "py",

--- a/cli/azd/internal/scaffold/scaffold.go
+++ b/cli/azd/internal/scaffold/scaffold.go
@@ -235,7 +235,5 @@ func preExecExpand(spec *InfraSpec) {
 		// containerapp requires a global '_exist' parameter for each service
 		spec.Parameters = append(spec.Parameters,
 			containerAppExistsParameter(svc.Name))
-		spec.Parameters = append(spec.Parameters,
-			serviceDefPlaceholder(svc.Name))
 	}
 }

--- a/cli/azd/internal/scaffold/scaffold_test.go
+++ b/cli/azd/internal/scaffold/scaffold_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/bicep"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
 	"github.com/otiai10/copy"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -117,6 +118,7 @@ func TestExecInfra(t *testing.T) {
 				EventHubs:      &EventHubs{},
 				StorageAccount: &StorageAccount{},
 				KeyVault:       &KeyVault{},
+				AISearch:       &AISearch{},
 				Services: []ServiceSpec{
 					{
 						Name: "api",
@@ -143,11 +145,12 @@ func TestExecInfra(t *testing.T) {
 						DbMySql: &DatabaseReference{
 							DatabaseName: "mysqldb",
 						},
-						ServiceBus:     &ServiceBus{},
-						EventHubs:      &EventHubs{},
-						StorageAccount: &StorageReference{},
-						KeyVault:       &KeyVaultReference{},
-						AISearch:       &AISearchReference{},
+						ServiceBus:       &ServiceBus{},
+						EventHubs:        &EventHubs{},
+						StorageAccount:   &StorageReference{},
+						KeyVault:         &KeyVaultReference{},
+						AISearch:         &AISearchReference{},
+						AiFoundryProject: &AiFoundrySpec{},
 					},
 					{
 						Name: "web",
@@ -169,76 +172,13 @@ func TestExecInfra(t *testing.T) {
 				DbPostgres: &DatabasePostgres{
 					DatabaseName: "appdb",
 				},
+				KeyVault: &KeyVault{},
 				Services: []ServiceSpec{
 					{
 						Name: "api",
 						Port: 3100,
 						DbPostgres: &DatabaseReference{
 							DatabaseName: "appdb",
-						},
-					},
-				},
-			},
-		},
-		{
-			"API with MySQL",
-			InfraSpec{
-				DbMySql: &DatabaseMysql{
-					DatabaseName: "appdb",
-				},
-				Services: []ServiceSpec{
-					{
-						Name: "api",
-						Port: 3100,
-						DbMySql: &DatabaseReference{
-							DatabaseName: "appdb",
-						},
-					},
-				},
-			},
-		},
-		{
-			"API with MongoDB",
-			InfraSpec{
-				DbCosmosMongo: &DatabaseCosmosMongo{
-					DatabaseName: "appdb",
-				},
-				Services: []ServiceSpec{
-					{
-						Name: "api",
-						Port: 3100,
-						DbCosmosMongo: &DatabaseReference{
-							DatabaseName: "appdb",
-						},
-					},
-				},
-			},
-		},
-		{
-			"API with Redis",
-			InfraSpec{
-				DbRedis: &DatabaseRedis{},
-				Services: []ServiceSpec{
-					{
-						Name: "api",
-						Port: 3100,
-						DbRedis: &DatabaseReference{
-							DatabaseName: "redis",
-						},
-					},
-				},
-			},
-		},
-		{
-			"API with Cosmos",
-			InfraSpec{
-				DbCosmos: &DatabaseCosmos{},
-				Services: []ServiceSpec{
-					{
-						Name: "api",
-						Port: 3100,
-						DbCosmos: &DatabaseReference{
-							DatabaseName: "cosmos",
 						},
 					},
 				},
@@ -273,7 +213,21 @@ func TestExecInfra(t *testing.T) {
 
 			res, err := cli.Build(ctx, filepath.Join(dir, "main.bicep"))
 			require.NoError(t, err)
-			require.Empty(t, res.LintErr, "lint errors occurred")
+
+			lintErrs := strings.Split(res.LintErr, "\n")
+			for _, lintErr := range lintErrs {
+				if lintErr == "" {
+					continue
+				}
+
+				if strings.Contains(lintErr, "no-unused-params: Parameter \"principalId\" ") { // suppress this error
+					// we always set principalId regardless of whether it's used
+					// in the current implementation
+					continue
+				}
+
+				assert.Failf(t, "found bicep lint error", "lint: %s", lintErr)
+			}
 		})
 	}
 }

--- a/cli/azd/internal/scaffold/spec.go
+++ b/cli/azd/internal/scaffold/spec.go
@@ -152,7 +152,7 @@ type ServiceSpec struct {
 	ServiceBus *ServiceBus
 	EventHubs  *EventHubs
 
-	HasAiFoundryProject *AiFoundrySpec
+	AiFoundryProject *AiFoundrySpec
 
 	AISearch *AISearchReference
 }
@@ -192,45 +192,5 @@ func containerAppExistsParameter(serviceName string) Parameter {
 		Value: fmt.Sprintf("${SERVICE_%s_RESOURCE_EXISTS=false}",
 			strings.ReplaceAll(strings.ToUpper(serviceName), "-", "_")),
 		Type: "bool",
-	}
-}
-
-type serviceDef struct {
-	Settings []serviceDefSettings `json:"settings"`
-}
-
-type serviceDefSettings struct {
-	Name         string `json:"name"`
-	Value        string `json:"value"`
-	Secret       bool   `json:"secret,omitempty"`
-	SecretRef    string `json:"secretRef,omitempty"`
-	CommentName  string `json:"_comment_name,omitempty"`
-	CommentValue string `json:"_comment_value,omitempty"`
-}
-
-func serviceDefPlaceholder(serviceName string) Parameter {
-	return Parameter{
-		Name: BicepName(serviceName) + "Definition",
-		Value: serviceDef{
-			Settings: []serviceDefSettings{
-				{
-					Name:        "",
-					Value:       "${VAR}",
-					CommentName: "The name of the environment variable when running in Azure. If empty, ignored.",
-					//nolint:lll
-					CommentValue: "The value to provide. This can be a fixed literal, or an expression like ${VAR} to use the value of 'VAR' from the current environment.",
-				},
-				{
-					Name:        "",
-					Value:       "${VAR_S}",
-					Secret:      true,
-					CommentName: "The name of the environment variable when running in Azure. If empty, ignored.",
-					//nolint:lll
-					CommentValue: "The value to provide. This can be a fixed literal, or an expression like ${VAR_S} to use the value of 'VAR_S' from the current environment.",
-				},
-			},
-		},
-		Type:   "object",
-		Secret: true,
 	}
 }

--- a/cli/azd/pkg/project/scaffold_gen.go
+++ b/cli/azd/pkg/project/scaffold_gen.go
@@ -369,7 +369,7 @@ func mapHostUses(
 		case ResourceTypeStorage:
 			svcSpec.StorageAccount = &scaffold.StorageReference{}
 		case ResourceTypeAiProject:
-			svcSpec.HasAiFoundryProject = &scaffold.AiFoundrySpec{}
+			svcSpec.AiFoundryProject = &scaffold.AiFoundrySpec{}
 		case ResourceTypeAiSearch:
 			svcSpec.AISearch = &scaffold.AISearchReference{}
 		case ResourceTypeKeyVault:

--- a/cli/azd/resources/scaffold/templates/next-steps-alpha.mdt
+++ b/cli/azd/resources/scaffold/templates/next-steps-alpha.mdt
@@ -34,6 +34,7 @@ If you do this, some additional directories will be created:
 - infra/            # Infrastructure as Code (bicep) files
   - main.bicep      # main deployment module
   - resources.bicep # resources shared across your application's services
+  - modules/        # Library modules
 ```
 
 *Note*: Once you have synthesized your infrastructure to disk, changes made to `azure.yaml` will not be reflected in the infrastructure. You can re-generate the infrastructure by running `azd infra synth` again. It will prompt you before overwriting files. You can pass `--force` to force `azd infra synth` to overwrite the files without prompting.

--- a/cli/azd/resources/scaffold/templates/next-steps.mdt
+++ b/cli/azd/resources/scaffold/templates/next-steps.mdt
@@ -18,7 +18,8 @@ To troubleshoot any issues, see [troubleshooting](#troubleshooting).
 
 ### Configure environment variables for running services
 
-Configure environment variables for running services by updating `settings` in [main.parameters.json](./infra/main.parameters.json).
+Environment variables can be configured by modifying the `env` settings in [resources.bicep](./infra/resources.bicep).
+To define a secret, add the variable as a `secretRef` pointing to a `secrets` entry or a stored KeyVault secret.
 
 {{- range .Services}}
 {{- if or .DbPostgres .DbCosmosMongo .DbRedis }}

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -383,6 +383,9 @@ module serviceBusNamespace 'br/public:avm/res/service-bus/namespace:0.11.2' = {
   params: {
     name: '${abbrs.serviceBusNamespaces}${resourceToken}'
     location: location
+    skuObject: {
+      name: 'Standard'
+    }
     roleAssignments: [
       {{- range .Services}}
       {
@@ -446,17 +449,6 @@ module {{bicepName .Name}}FetchLatestImage './modules/fetch-container-image.bice
   }
 }
 
-var {{bicepName .Name}}AppSettingsArray = filter(array({{bicepName .Name}}Definition.settings), i => i.name != '')
-var {{bicepName .Name}}Secrets = map(filter({{bicepName .Name}}AppSettingsArray, i => i.?secret != null), i => {
-  name: i.name
-  value: i.value
-  secretRef: i.?secretRef ?? take(replace(replace(toLower(i.name), '_', '-'), '.', '-'), 32)
-})
-var {{bicepName .Name}}Env = map(filter({{bicepName .Name}}AppSettingsArray, i => i.?secret == null), i => {
-  name: i.name
-  value: i.value
-})
-
 module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
   name: '{{bicepName .Name}}'
   params: {
@@ -479,7 +471,7 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
     scaleMinReplicas: 1
     scaleMaxReplicas: 10
     secrets: {
-      secureList:  union([
+      secureList:  [
         {{- if .DbCosmosMongo}}
         {
           name: 'mongodb-url'
@@ -519,11 +511,7 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
           keyVaultUrl: '${keyVault.outputs.uri}secrets/redis-url'
         }
         {{- end}}
-      ],
-      map({{bicepName .Name}}Secrets, secret => {
-        name: secret.secretRef
-        value: secret.value
-      }))
+      ]
     }
     containers: [
       {
@@ -533,7 +521,7 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
           cpu: json('0.5')
           memory: '1.0Gi'
         }
-        env: union([
+        env: [
           {
             name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
             value: monitoring.outputs.applicationInsightsConnectionString
@@ -680,7 +668,7 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
             value: 'https://${search.outputs.name}.search.windows.net'
           }
           {{- end}}
-          {{- if .HasAiFoundryProject }}
+          {{- if .AiFoundryProject }}
           {
             name: 'AZURE_AIPROJECT_CONNECTION_STRING'
             value: aiFoundryProjectConnectionString
@@ -706,12 +694,7 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
             value: {{ $value }}
           }
           {{- end}}
-        ],
-        {{bicepName .Name}}Env,
-        map({{bicepName .Name}}Secrets, secret => {
-            name: secret.name
-            secretRef: secret.secretRef
-        }))
+        ]
       }
     ]
     managedIdentities:{
@@ -729,7 +712,7 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
     tags: union(tags, { 'azd-service-name': '{{.Name}}' })
   }
 }
-{{- if .HasAiFoundryProject}}
+{{- if .AiFoundryProject}}
 
 resource {{bicepName .Name}}backendRoleAzureAIDeveloperRG 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
   name: guid(subscription().id, resourceGroup().id, {{bicepName .Name}}Identity.name, '64702f94-c441-49e6-a78b-ef80e0188fee')

--- a/cli/azd/tools/avmres/main.go
+++ b/cli/azd/tools/avmres/main.go
@@ -13,8 +13,6 @@ import (
 	"slices"
 	"strings"
 
-	//nolint:ST1001
-
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	flag "github.com/spf13/pflag"
 )


### PR DESCRIPTION
This change updates the SKU for service bus to Standard, as opposed to the default value in AVM which is Premium. Premium sku was accounting for a cost total of 200+ per month.

It also includes the following the changes:

1. **Remove `main.parameters.json` setting passing**: Remove an old feature of passing host settings through main.parameters.json. This was previously introduced in #2875 for simplified init (`azd init` with `azd config set alpha.compose off`), that hasn't been widely adopted in real world usage. It is also unused when `alpha.compose` is enabled.

2. **Fix simplified init and tests**: Fixes simplified init not automatically setting a KeyVault and failing to provision in the process. This was caught by `TestExecInfra` in scaffold_test.go, but this test was not running in CI. This has also been fixed to be running with a change in `ci-test.ps1`.