### PR TITLE
Correct input for failing `env set-secret` functional test

### DIFF
--- a/cli/azd/test/functional/cli_test.go
+++ b/cli/azd/test/functional/cli_test.go
@@ -894,7 +894,7 @@ func stdinForCreateKvAccount(rg, kva, kvs, kvsv string) string {
 		"\n" + // "choose subscription" (we're choosing the default)
 		"\n" + // "Create new Key Vault
 		"\n" + // "choose location" (we're choosing the default)
-		"Create a new resource group\n" + // "Create new resource group"
+		"1. Create a new resource group\n" + // "1. Create new resource group"
 		rg + "\n" + // "resource group name"
 		kva + "\n" + // "key vault name"
 		kvs + "\n" + // "key vault secret name"


### PR DESCRIPTION
Functional tests are failing after merging #4874 because one of the inputs for a `set-secret` functional test is invalid:

```
    cli.go:244: 13.08s [stdout] ERROR: prompting for resource group: selecting resource group: 'Create a new resource group' is not an allowed choice. allowed choices: 1. Create a new resource group,2. AzSec...
    cli_test.go:409: 
        	Error Trace:	D:/a/_work/1/s/cli/azd/test/functional/cli_test.go:409
        	Error:      	Received unexpected error:
        	            	command 'azd env set-secret SEC_REF in C:\Users\CLOUDT~1\AppData\Local\Temp\Test_CLI_EnvironmentSecrets2416717770\001' had non-zero exit code: exit status 1
        	Test:       	Test_CLI_EnvironmentSecrets
```