### PR TITLE
compose: openai endpoint

### DIFF
--- a/cli/azd/internal/cmd/show/show.go
+++ b/cli/azd/internal/cmd/show/show.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/cmd"
@@ -35,7 +34,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -313,11 +311,6 @@ func (s *showAction) showResource(ctx context.Context, name string, env *environ
 		if err != nil {
 			return err
 		}
-	case strings.EqualFold(resType, "Microsoft.CognitiveServices/accounts/deployments"):
-		err = showModelDeployment(ctx, s.console, credential, id.Parent, resourceOptions)
-		if err != nil {
-			return err
-		}
 	default:
 		showRes := showResource{
 			env:             env,
@@ -422,43 +415,6 @@ func showContainerApp(
 	}
 
 	return service, nil
-}
-
-func showModelDeployment(
-	ctx context.Context,
-	console input.Console,
-	cred azcore.TokenCredential,
-	id *arm.ResourceID,
-	opts showResourceOptions) error {
-	client, err := armcognitiveservices.NewAccountsClient(id.SubscriptionID, cred, opts.clientOpts)
-	if err != nil {
-		return fmt.Errorf("creating accounts client: %w", err)
-	}
-
-	account, err := client.Get(ctx, id.ResourceGroupName, id.Name, nil)
-	if err != nil {
-		return fmt.Errorf("getting account: %w", err)
-	}
-
-	if account.Properties.Endpoint != nil {
-		console.Message(ctx, color.HiMagentaString("%s (Azure AI Services Model Deployment)", id.Name))
-		console.Message(ctx, "  Endpoint:")
-		console.Message(ctx,
-			output.WithHighLightFormat(fmt.Sprintf("    AZURE_OPENAI_ENDPOINT=%s", *account.Properties.Endpoint)))
-		console.Message(ctx, "  Access:")
-		console.Message(ctx, "    Keyless (Microsoft Entra ID)")
-		//nolint:lll
-		console.Message(
-			ctx,
-			output.WithGrayFormat(
-				"        Hint: To access locally, use DefaultAzureCredential. To learn more, visit https://learn.microsoft.com/en-us/azure/ai-services/openai/supported-languages",
-			),
-		)
-
-		console.Message(ctx, "")
-	}
-
-	return nil
 }
 
 func (s *showAction) serviceEndpoint(

--- a/cli/azd/internal/cmd/show/show_resource.go
+++ b/cli/azd/internal/cmd/show/show_resource.go
@@ -99,6 +99,10 @@ func (s *showResource) showResourceGeneric(
 		Variables:   envValues,
 	}
 
+	if opts.resourceSpec != nil {
+		showRes.Name = opts.resourceSpec.Name
+	}
+
 	return &showRes, nil
 }
 
@@ -112,13 +116,15 @@ func getResourceMeta(id arm.ResourceID) (*scaffold.ResourceMeta, arm.ResourceID)
 				// find the parent resource
 				parentId := &id
 				for {
-					if parentId.Parent != nil {
-						parentId = parentId.Parent
+					if parentId == nil {
+						panic(fmt.Sprintf("'%s' was not found as a parent of '%s'", res.ParentForEval, resourceType))
 					}
 
-					if parentId.ResourceType.Type == res.ParentForEval {
+					if parentId.ResourceType.String() == res.ParentForEval {
 						break
 					}
+
+					parentId = parentId.Parent
 				}
 
 				return &res, *parentId

--- a/cli/azd/internal/scaffold/resource_meta.go
+++ b/cli/azd/internal/scaffold/resource_meta.go
@@ -61,6 +61,15 @@ var Resources = []ResourceMeta{
 		ApiVersion:   "2023-05-01",
 	},
 	{
+		ResourceType:      "Microsoft.CognitiveServices/accounts/deployments",
+		ApiVersion:        "2023-05-01",
+		ParentForEval:     "Microsoft.CognitiveServices/accounts",
+		StandardVarPrefix: "AZURE_OPENAI",
+		Variables: map[string]string{
+			"endpoint": "${.properties.endpoint}",
+		},
+	},
+	{
 		ResourceType: "Microsoft.ContainerRegistry/registries",
 		ApiVersion:   "2023-06-01-preview",
 	},


### PR DESCRIPTION
Fix `AZURE_OPENAI_ENDPOINT` not showing in add preview.

In #4914, we shifted the preview to leverage the newly added resource metadata. Azure OpenAI models had a resource specific show implementation built that wasn't immediately refactored in the change. This change shifts the Azure OpenAI implementation and fixes the add preview

Contributes to #4933