### PR TITLE
compose: add `ai.project` resource type to alpha azure.yaml schema

### DIFF
--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -372,6 +372,7 @@
                             "db.mongo",
                             "db.cosmos",
                             "ai.openai.model",
+                            "ai.project",
                             "ai.search",
                             "host.containerapp",
                             "messaging.eventhubs",
@@ -392,6 +393,7 @@
                 "allOf": [
                     { "if": { "properties": { "type": { "const": "host.containerapp" }}}, "then": { "$ref": "#/definitions/containerAppResource" } },
                     { "if": { "properties": { "type": { "const": "ai.openai.model" }}}, "then": { "$ref": "#/definitions/aiModelResource" } },
+                    { "if": { "properties": { "type": { "const": "ai.project" }}}, "then": { "$ref": "#/definitions/aiProjectResource" } },
                     { "if": { "properties": { "type": { "const": "ai.search" }}}, "then": { "$ref": "#/definitions/resource" } },
                     { "if": { "properties": { "type": { "const": "db.postgres"  }}}, "then": { "$ref": "#/definitions/resource"} },
                     { "if": { "properties": { "type": { "const": "db.mysql"  }}}, "then": { "$ref": "#/definitions/resource"} },
@@ -1258,6 +1260,7 @@
                         "db.cosmos",
                         "host.containerapp",
                         "ai.openai.model",
+                        "ai.project",
                         "ai.search",
                         "keyvault"
                     ]
@@ -1442,6 +1445,67 @@
                         "type": "string",
                         "title": "Azure Storage Account container name",
                         "description": "The container name of Azure Storage Account."
+                    }
+                }
+            }
+        },
+        "aiProjectResource": {
+            "type": "object",
+            "description": "An Azure AI Foundry project with models.",
+            "additionalProperties": false,
+            "properties": {
+                "type": true,
+                "uses": true,
+                "models": {
+                    "type": "array",
+                    "title": "AI models to deploy",
+                    "description": "Optional. The AI models to be deployed as part of the AI project.",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["name", "version", "format", "sku"],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "title": "The name of the AI model.",
+                                "description": "Required. The name of the AI model."
+                            },
+                            "version": {
+                                "type": "string",
+                                "title": "The version of the AI model.",
+                                "description": "Required. The version of the AI model."
+                            },
+                            "format": {
+                                "type": "string",
+                                "title": "The format of the AI model.",
+                                "description": "Required. The format of the AI model. (Example: Microsoft, OpenAI)"
+                            },
+                            "sku": {
+                                "type": "object",
+                                "title": "The SKU configuration for the AI model.",
+                                "description": "Required. The SKU details for the AI model.",
+                                "additionalProperties": false,
+                                "required": ["name", "usageName", "capacity"],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "title": "The name of the SKU.",
+                                        "description": "Required. The name of the SKU. (Example: GlobalStandard)"
+                                    },
+                                    "usageName": {
+                                        "type": "string",
+                                        "title": "The usage name of the SKU.",
+                                        "description": "Required. The usage name of the SKU for billing purposes. (Example: AIServices.GlobalStandard.MaaS, OpenAI.GlobalStandard.gpt-4o-mini)"
+                                    },
+                                    "capacity": {
+                                        "type": "integer",
+                                        "title": "The capacity of the SKU.",
+                                        "description": "Required. The capacity of the SKU."
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR adds the `ai.project` resource type to the alpha azure.yaml schema

![image](https://github.com/user-attachments/assets/c4f8f1d3-e3f3-493b-8bfa-24e4cb8ba28f)
