### PR TITLE
aspire secrets impl change

### DIFF
--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -1728,7 +1728,7 @@ func (b infraGenerator) evalBindingRef(v string, emitType inputEmitType) (string
 				}
 				if parts[0] != resource {
 					return "", fmt.Errorf(
-						"expecting to find connectionString for resource %s to auto-referencd itself"+
+						"expecting to find connectionString for resource %s to auto-referenced itself"+
 							", like %s.outputs.name. But found: %s",
 						resource,
 						resource,


### PR DESCRIPTION
Adding support for a bicep.v0 expressing secrets.

For any resource referencing secrets, like

```json
"cosmos": {
      "type": "azure.bicep.v0",
      "connectionString": "{cosmos-kv.secrets.connectionstrings--cosmos}",
      "path": "cosmos.module.bicep",
      "params": {
        "keyVaultName": "{cosmos-kv.outputs.name}"
      }
    },
```

a resource `cosmos-kv` is expected to provide a connectionString which reference itselft's outputs and a name. like:

```json
"cosmos-kv": {
      "type": "azure.bicep.v0",
      "connectionString": "{cosmos-kv.outputs.vaultUri}",
      "path": "cosmos-kv.module.bicep"
    },
```

The output `vaultUri` represents the bicep output where the KV URL is defined and AZD uses to write the expression for YAML, like:

```yaml
 secrets:
      - name: connectionstrings--db
        keyVaultUrl: '{{ .Env.COSMOS_KV_VAULTURI }}secrets/connectionstrings--db'
        identity: {{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}
      - name: connectionstrings--entries
        keyVaultUrl: '{{ .Env.COSMOS_KV_VAULTURI }}secrets/connectionstrings--entries'
        identity: {{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}
```
