### PR TITLE
add test for aspire secrets support

### DIFF
--- a/cli/azd/pkg/apphost/generate_test.go
+++ b/cli/azd/pkg/apphost/generate_test.go
@@ -136,6 +136,7 @@ func TestAspireBicepGeneration(t *testing.T) {
 	filesFromManifest["aspire.hosting.azure.bicep.servicebus.bicep"] = ignoredBicepContent
 	filesFromManifest["aspire.hosting.azure.bicep.appinsights.bicep"] = ignoredBicepContent
 	filesFromManifest["aspire.hosting.azure.bicep.sql.bicep"] = ignoredBicepContent
+	filesFromManifest["kv.bicep"] = ignoredBicepContent
 	mockPublishManifest(mockCtx, aspireBicepManifest, filesFromManifest)
 	mockCli := dotnet.NewCli(mockCtx.CommandRunner)
 

--- a/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-frontend.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-frontend.snap
@@ -26,7 +26,7 @@ properties:
       - name: connectionstrings--db
         value: Server=tcp:{{ .Env.SQL_SQLSERVERFQDN }},1433;Encrypt=True;Authentication="Active Directory Default";Database=db
       - name: connectionstrings--db2
-        value: '{{ secretOutput "SERVICE_BINDING_KV854251F1_ENDPOINT" "connectionString" }};Database=db2;'
+        value: '{{ secretOutput "KV_KVURI" "connectionstrings--db" }};Database=db2;'
       - name: connectionstrings--s-b
         value: '{{ .Env.S_B_SERVICEBUSENDPOINT }}'
   template:

--- a/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-kv-kv.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-kv-kv.bicep.snap
@@ -1,0 +1,1 @@
+bicep file contents

--- a/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-main.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireBicepGeneration-main.bicep.snap
@@ -52,6 +52,13 @@ module ai 'ai/aspire.hosting.azure.bicep.appinsights.bicep' = {
     userPrincipalId: 'fixed-value-to-test-userPrincipalId-convention'
   }
 }
+module kv 'kv/kv.bicep' = {
+  name: 'kv'
+  scope: rg
+  params: {
+    location: location
+  }
+}
 module postgres_2 'postgres-2/aspire.hosting.azure.bicep.postgres.bicep' = {
   name: 'postgres-2'
   scope: rg
@@ -113,6 +120,7 @@ output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = resources.output
 output SERVICE_BINDING_KV854251F1_ENDPOINT string = resources.outputs.SERVICE_BINDING_KV854251F1_ENDPOINT
 output SERVICE_BINDING_KV854251F1_NAME string = resources.outputs.SERVICE_BINDING_KV854251F1_NAME
 output AI_APPINSIGHTSCONNECTIONSTRING string = ai.outputs.appInsightsConnectionString
+output KV_KVURI string = kv.outputs.kvUri
 output S_B_SERVICEBUSENDPOINT string = s_b.outputs.serviceBusEndpoint
 output SQL_SQLSERVERFQDN string = sql.outputs.sqlServerFqdn
 output TEST_TEST string = test.outputs.test

--- a/cli/azd/pkg/apphost/testdata/aspire-bicep.json
+++ b/cli/azd/pkg/apphost/testdata/aspire-bicep.json
@@ -49,9 +49,14 @@
           }
         }
       },
+      "kv": {
+        "type": "azure.bicep.v0",
+        "connectionString": "{kv.outputs.kvUri}",
+        "path": "kv.bicep"
+      },
       "postgres-2": {
         "type": "azure.bicep.v0",
-        "connectionString": "{postgres-2.secretOutputs.connectionString}",
+        "connectionString": "{kv.secrets.connectionstrings--db}",
         "path": "aspire.hosting.azure.bicep.postgres.bicep",
         "params": {
           "serverName": "postgres-2",


### PR DESCRIPTION
Missing tests for supporting the new `.secrets` field that replaces the previous `.secretOutputs` field for Aspire manifest