### PR TITLE
[Aspire] Promote ACE domain from outputs

### DIFF
--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -575,6 +575,14 @@ func evaluateForOutputs(value string, appHostOwnsCompute bool) (map[string]genOu
 				Value: noBrackets,
 			}
 		}
+		// Same for AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN as it is required to display the Aspire Dashboard link
+		// at the end of the deployment.
+		if strings.Contains(outputName, environment.ContainerEnvironmentEndpointEnvVarName) && appHostOwnsCompute {
+			outputs[environment.ContainerEnvironmentEndpointEnvVarName] = genOutputParameter{
+				Type:  "string",
+				Value: noBrackets,
+			}
+		}
 		name := fmt.Sprintf("%s_%s", strings.ToUpper(resourceName), strings.ToUpper(outputName))
 		outputs[name] = genOutputParameter{
 			Type:  "string",

--- a/cli/azd/pkg/apphost/testdata/TestAspireBicepGenerationAppHostOwnsCompute-frontend.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireBicepGenerationAppHostOwnsCompute-frontend.snap
@@ -36,6 +36,10 @@ properties:
         env:
           - name: AZURE_CLIENT_ID
             value: {{ .Env.MANAGED_IDENTITY_CLIENT_ID }}
+          - name: ACE
+            value: '{{ .Env.TEST_AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN }}'
+          - name: ACR
+            value: '{{ .Env.TEST_AZURE_CONTAINER_REGISTRY_ENDPOINT }}'
           - name: OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES
             value: "true"
           - name: OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES

--- a/cli/azd/pkg/apphost/testdata/TestAspireBicepGenerationAppHostOwnsCompute-main.bicep.snap
+++ b/cli/azd/pkg/apphost/testdata/TestAspireBicepGenerationAppHostOwnsCompute-main.bicep.snap
@@ -92,8 +92,12 @@ module test 'test/test.bicep' = {
   }
 }
 output AI_APPINSIGHTSCONNECTIONSTRING string = ai.outputs.appInsightsConnectionString
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = test.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = test.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT
 output S_B_SERVICEBUSENDPOINT string = s_b.outputs.serviceBusEndpoint
 output SQL_SQLSERVERFQDN string = sql.outputs.sqlServerFqdn
+output TEST_AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = test.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN
+output TEST_AZURE_CONTAINER_REGISTRY_ENDPOINT string = test.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT
 output TEST_TEST string = test.outputs.test
 output TEST_VAL0 string = test.outputs.val0
 

--- a/cli/azd/pkg/apphost/testdata/aspire-apphost-owns-compute.json
+++ b/cli/azd/pkg/apphost/testdata/aspire-apphost-owns-compute.json
@@ -136,7 +136,9 @@
           "bicepValue0": "{test.outputs.val0}",
           "ConnectionStrings__s-b": "{s-b.connectionString}",
           "APPLICATIONINSIGHTS_CONNECTION_STRING": "{ai.connectionString}",
-          "ConnectionStrings__db": "{db.connectionString}"
+          "ConnectionStrings__db": "{db.connectionString}",
+          "ACR": "{test.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+          "ACE": "{test.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}"
         },
         "bindings": {
           "http": {

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -37,6 +37,8 @@ const TenantIdEnvVarName = "AZURE_TENANT_ID"
 // to.
 const ContainerRegistryEndpointEnvVarName = "AZURE_CONTAINER_REGISTRY_ENDPOINT"
 
+const ContainerEnvironmentEndpointEnvVarName = "AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"
+
 // AksClusterEnvVarName is the name of they key used to store the endpoint of the AKS cluster to push to.
 const AksClusterEnvVarName = "AZURE_AKS_CLUSTER_NAME"
 

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -37,6 +37,8 @@ const TenantIdEnvVarName = "AZURE_TENANT_ID"
 // to.
 const ContainerRegistryEndpointEnvVarName = "AZURE_CONTAINER_REGISTRY_ENDPOINT"
 
+// ContainerEnvironmentEndpointEnvVarName is the name of the environment variable
+// that specifies the default domain for Azure Container Apps environments.
 const ContainerEnvironmentEndpointEnvVarName = "AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"
 
 // AksClusterEnvVarName is the name of they key used to store the endpoint of the AKS cluster to push to.


### PR DESCRIPTION
This PR updates AZD to utilize the `AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN` variable for determining when to display the link to the Aspire dashboard. The change ensures that output references from any resource in the manifest are elevated to a top-level output.

These updates are specifically designed for scenarios where Aspire owns the compute resources.

fix: https://github.com/Azure/azure-dev/issues/4998