### PR TITLE
compose: force alpha flag

### DIFF
--- a/cli/azd/internal/repository/app_init.go
+++ b/cli/azd/internal/repository/app_init.go
@@ -351,11 +351,16 @@ func (i *Initializer) genProjectFile(
 	ctx context.Context,
 	azdCtx *azdcontext.AzdContext,
 	detect detectConfirm,
-	addResources bool) error {
-	config, err := i.prjConfigFromDetect(ctx, azdCtx.ProjectDirectory(), detect, addResources)
+	composeEnabled bool) error {
+	config, err := i.prjConfigFromDetect(ctx, azdCtx.ProjectDirectory(), detect, composeEnabled)
 	if err != nil {
 		return fmt.Errorf("converting config: %w", err)
 	}
+
+	if composeEnabled {
+		config.MetaSchemaVersion = "alpha"
+	}
+
 	err = project.Save(
 		ctx,
 		&config,

--- a/cli/azd/resources/scaffold/templates/main.bicept
+++ b/cli/azd/resources/scaffold/templates/main.bicept
@@ -128,7 +128,7 @@ output AZURE_RESOURCE_EVENT_HUBS_ID string = resources.outputs.AZURE_RESOURCE_EV
 output AZURE_RESOURCE_SERVICE_BUS_ID string = resources.outputs.AZURE_RESOURCE_SERVICE_BUS_ID
 {{- end}}
 {{- if .AiFoundryProject }}
-output AZURE_AIPROJECT_CONNECTION_STRING string = aiModelsDeploy.outputs.aiFoundryProjectConnectionString
+output AZURE_AI_PROJECT_CONNECTION_STRING string = aiModelsDeploy.outputs.aiFoundryProjectConnectionString
 output AZURE_RESOURCE_AI_PROJECT_ID string = aiModelsDeploy.outputs.projectId
 {{- end}}
 {{- if .AISearch }}

--- a/cli/azd/resources/scaffold/templates/resources.bicept
+++ b/cli/azd/resources/scaffold/templates/resources.bicept
@@ -696,7 +696,7 @@ module {{bicepName .Name}} 'br/public:avm/res/app/container-app:0.8.0' = {
           {{- end}}
           {{- if .AiFoundryProject }}
           {
-            name: 'AZURE_AIPROJECT_CONNECTION_STRING'
+            name: 'AZURE_AI_PROJECT_CONNECTION_STRING'
             value: aiFoundryProjectConnectionString
           }
           {{- end}}


### PR DESCRIPTION
This change forces the schema version to `alpha` when `azd init` runs with compose enabled. This avoids the `resources` node from showing up as unrecognized.

Also, including a small fix to rename `AZURE_AIPROJECT` -> `AZURE_AI_PROJECT`.

Fixes #4572