### PR TITLE
Fix publishing issue: exit 0

### DIFF
--- a/eng/pipelines/templates/steps/publish-cli.yml
+++ b/eng/pipelines/templates/steps/publish-cli.yml
@@ -13,19 +13,23 @@ steps:
         Write-Host "Release tag: $tag"
 
         # Check for tag using gh API
-        $existingTag = gh api /repos/Azure/azure-dev/tags | ConvertFrom-Json | Where-Object { $_.name -eq $tag }
+        $existingTag = gh api /repos/$(Build.Repository.Name)/tags | ConvertFrom-Json | Where-Object { $_.name -eq $tag }
         if ($existingTag) {
             Write-Host "Tag $tag already exists. Exiting."
             exit 1
         }
 
-        gh release view $tag --repo Azure/azure-dev
+        gh release view $tag --repo $(Build.Repository.Name)
         if ($LASTEXITCODE -eq 0) {
           Write-Host "Release ($tag) already exists. Exiting."
           exit 1
         }
 
         Write-Host "##vso[task.setvariable variable=GH_RELEASE_TAG;]$tag"
+
+        # Exit with 0 (otherwise $LASTEXITCODE will not be 0 and the pipeline
+        # will fail)
+        exit 0
       displayName: Check for existing GitHub release
       env:
         GH_TOKEN: $(azuresdk-github-pat)
@@ -35,9 +39,9 @@ steps:
           "$(GH_RELEASE_TAG)" `
           --title "$(GH_RELEASE_TAG)" `
           --notes-file changelog/CHANGELOG.md `
-          --repo Azure/azure-dev
+          --repo $(Build.Repository.Name)
 
-        gh release upload $(GH_RELEASE_TAG) release/* --repo Azure/azure-dev
+        gh release upload $(GH_RELEASE_TAG) release/* --repo $(Build.Repository.Name)
       displayName: Create GitHub Release and upload artifacts
       env:
         GH_TOKEN: $(azuresdk-github-pat)


### PR DESCRIPTION
* Exit 0 so the job continues. `gh release view...` is the last thing to set `$LASTEXITCODE` and it is expected to return a nonzero exit code (meaning that the tag is not found and can therefore be created).
* Replace direct references of `Azure/azure-dev` repo with `$(Build.Repository.Name)` 