### PR TITLE
Support generate CI definition for composability mode as alpha

### DIFF
--- a/cli/azd/pkg/pipeline/pipeline.go
+++ b/cli/azd/pkg/pipeline/pipeline.go
@@ -245,12 +245,13 @@ func toInfraProviderType(provider string) (infraProviderType, error) {
 }
 
 type projectProperties struct {
-	CiProvider    ciProviderType
-	InfraProvider infraProviderType
-	RepoRoot      string
-	HasAppHost    bool
-	BranchName    string
-	AuthType      PipelineAuthType
-	Variables     []string
-	Secrets       []string
+	CiProvider            ciProviderType
+	InfraProvider         infraProviderType
+	RepoRoot              string
+	HasAppHost            bool
+	BranchName            string
+	AuthType              PipelineAuthType
+	Variables             []string
+	Secrets               []string
+	RequiredAlphaFeatures []string
 }

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -810,6 +810,10 @@ func (pm *PipelineManager) initialize(ctx context.Context, override string) erro
 		return err
 	}
 
+	var requiredAlphaFeatures []string
+	if infra.IsCompose {
+		requiredAlphaFeatures = append(requiredAlphaFeatures, "compose")
+	}
 	// There are 2 possible options, for the git branch name, when running azd pipeline config:
 	// - There is not a git repo, so the branch name is empty. In this case, we default to "main".
 	// - There is a git repo and we can get the name of the current branch.
@@ -830,14 +834,15 @@ func (pm *PipelineManager) initialize(ctx context.Context, override string) erro
 	// Check and prompt for missing CI/CD files
 	if err := pm.checkAndPromptForProviderFiles(
 		ctx, projectProperties{
-			CiProvider:    pipelineProvider,
-			RepoRoot:      repoRoot,
-			InfraProvider: infraProvider,
-			HasAppHost:    hasAppHost,
-			BranchName:    branchName,
-			AuthType:      authType,
-			Variables:     prjConfig.Pipeline.Variables,
-			Secrets:       prjConfig.Pipeline.Secrets,
+			CiProvider:            pipelineProvider,
+			RepoRoot:              repoRoot,
+			InfraProvider:         infraProvider,
+			HasAppHost:            hasAppHost,
+			BranchName:            branchName,
+			AuthType:              authType,
+			Variables:             prjConfig.Pipeline.Variables,
+			Secrets:               prjConfig.Pipeline.Secrets,
+			RequiredAlphaFeatures: requiredAlphaFeatures,
 		}); err != nil {
 		return err
 	}
@@ -1049,12 +1054,14 @@ func generatePipelineDefinition(path string, props projectProperties) error {
 		InstallDotNetForAspire bool
 		Variables              []string
 		Secrets                []string
+		AlphaFeatures          []string
 	}{
 		BranchName:             props.BranchName,
 		FedCredLogIn:           props.AuthType == AuthTypeFederated,
 		InstallDotNetForAspire: props.HasAppHost,
 		Variables:              props.Variables,
 		Secrets:                props.Secrets,
+		AlphaFeatures:          props.RequiredAlphaFeatures,
 	})
 	if err != nil {
 		return fmt.Errorf("executing template: %w", err)

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_App_host_-_fed_Cred.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_App_host_-_fed_Cred.snap
@@ -6,10 +6,10 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  # setup-azd@0 needs to be manually installed in your organization
+  # setup-azd@1 needs to be manually installed in your organization
   # if you can't install it, you can use the below bash script to install azd
   # and remove this step
-  - task: setup-azd@0
+  - task: setup-azd@1
     displayName: Install azd
 
   # If you can't install above task in your organization, you can comment it and uncomment below task to install azd

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_branch_name.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_branch_name.snap
@@ -6,10 +6,10 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  # setup-azd@0 needs to be manually installed in your organization
+  # setup-azd@1 needs to be manually installed in your organization
   # if you can't install it, you can use the below bash script to install azd
   # and remove this step
-  - task: setup-azd@0
+  - task: setup-azd@1
     displayName: Install azd
 
   # If you can't install above task in your organization, you can comment it and uncomment below task to install azd

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_no_app_host_-_client_cred.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_no_app_host_-_client_cred.snap
@@ -6,10 +6,10 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  # setup-azd@0 needs to be manually installed in your organization
+  # setup-azd@1 needs to be manually installed in your organization
   # if you can't install it, you can use the below bash script to install azd
   # and remove this step
-  - task: setup-azd@0
+  - task: setup-azd@1
     displayName: Install azd
 
   # If you can't install above task in your organization, you can comment it and uncomment below task to install azd

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_no_app_host_-_fed_Cred.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_no_app_host_-_fed_Cred.snap
@@ -6,10 +6,10 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  # setup-azd@0 needs to be manually installed in your organization
+  # setup-azd@1 needs to be manually installed in your organization
   # if you can't install it, you can use the below bash script to install azd
   # and remove this step
-  - task: setup-azd@0
+  - task: setup-azd@1
     displayName: Install azd
 
   # If you can't install above task in your organization, you can comment it and uncomment below task to install azd

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_no_app_host_-_variables_and_secrets.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_no_app_host_-_variables_and_secrets.snap
@@ -6,10 +6,10 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  # setup-azd@0 needs to be manually installed in your organization
+  # setup-azd@1 needs to be manually installed in your organization
   # if you can't install it, you can use the below bash script to install azd
   # and remove this step
-  - task: setup-azd@0
+  - task: setup-azd@1
     displayName: Install azd
 
   # If you can't install above task in your organization, you can comment it and uncomment below task to install azd

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles_azureDevOpsDirectory-no_files_-_azdo_selected_-_azuredevops_dir_-_client_cred.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles_azureDevOpsDirectory-no_files_-_azdo_selected_-_azuredevops_dir_-_client_cred.snap
@@ -6,10 +6,10 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  # setup-azd@0 needs to be manually installed in your organization
+  # setup-azd@1 needs to be manually installed in your organization
   # if you can't install it, you can use the below bash script to install azd
   # and remove this step
-  - task: setup-azd@0
+  - task: setup-azd@1
     displayName: Install azd
 
   # If you can't install above task in your organization, you can comment it and uncomment below task to install azd

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles_azureDevOpsDirectory-no_files_-_azdo_selected_-_azuredevops_dir_-_fed_Cred.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles_azureDevOpsDirectory-no_files_-_azdo_selected_-_azuredevops_dir_-_fed_Cred.snap
@@ -6,10 +6,10 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  # setup-azd@0 needs to be manually installed in your organization
+  # setup-azd@1 needs to be manually installed in your organization
   # if you can't install it, you can use the below bash script to install azd
   # and remove this step
-  - task: setup-azd@0
+  - task: setup-azd@1
     displayName: Install azd
 
   # If you can't install above task in your organization, you can comment it and uncomment below task to install azd

--- a/cli/azd/pkg/project/importer.go
+++ b/cli/azd/pkg/project/importer.go
@@ -226,6 +226,7 @@ func (im *ImportManager) SynthAllInfrastructure(ctx context.Context, projectConf
 type Infra struct {
 	Options    provisioning.Options
 	cleanupDir string
+	IsCompose  bool
 }
 
 func (i *Infra) Cleanup() error {

--- a/cli/azd/pkg/project/scaffold_gen.go
+++ b/cli/azd/pkg/project/scaffold_gen.go
@@ -87,6 +87,7 @@ func tempInfra(
 			Module:   DefaultModule,
 		},
 		cleanupDir: tmpDir,
+		IsCompose:  true,
 	}, nil
 }
 

--- a/cli/azd/resources/pipeline/.azdo/azure-dev-tf.yml
+++ b/cli/azd/resources/pipeline/.azdo/azure-dev-tf.yml
@@ -13,7 +13,7 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  - task: setup-azd@0
+  - task: setup-azd@1
     displayName: Install azd
 
   # If you can't install above task in your organization, you can comment it and uncomment below task to install azd

--- a/cli/azd/resources/pipeline/.azdo/azure-dev.ymlt
+++ b/cli/azd/resources/pipeline/.azdo/azure-dev.ymlt
@@ -7,10 +7,10 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  # setup-azd@0 needs to be manually installed in your organization
+  # setup-azd@1 needs to be manually installed in your organization
   # if you can't install it, you can use the below bash script to install azd
   # and remove this step
-  - task: setup-azd@0
+  - task: setup-azd@1
     displayName: Install azd
 
   # If you can't install above task in your organization, you can comment it and uncomment below task to install azd
@@ -24,7 +24,14 @@ steps:
   # azd delegate auth to az to use service connection with AzureCLI@2
   - pwsh: |
       azd config set auth.useAzCliAuth "true"
-    displayName: Configure AZD to Use AZ CLI Authentication.  
+    displayName: Configure AZD to Use AZ CLI Authentication.
+{{- if .AlphaFeatures }}
+  - pwsh: |
+{{- range $feature := .AlphaFeatures }}
+      azd config set alpha.{{ $feature }} on
+{{- end }}
+    displayName: Enabled required alpha features
+{{ end }}    
 {{- if .InstallDotNetForAspire}}
   - task: UseDotNet@2
     inputs:

--- a/cli/azd/resources/pipeline/.github/azure-dev.ymlt
+++ b/cli/azd/resources/pipeline/.github/azure-dev.ymlt
@@ -51,6 +51,15 @@ jobs:
         shell: pwsh
 {{ end }}
 
+{{- if .AlphaFeatures }}
+      - name: Enabled required alpha features
+        run: |
+{{- range $feature := .AlphaFeatures }}
+          azd config set alpha.{{ $feature }} on
+{{- end }}
+        shell: pwsh
+{{ end }}
+
 {{- if not .FedCredLogIn }}
       - name: Log in with Azure (Client Credentials)
         run: |

--- a/templates/common/.azdo/pipelines/bicep/azure-dev.yml
+++ b/templates/common/.azdo/pipelines/bicep/azure-dev.yml
@@ -13,7 +13,7 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  - task: setup-azd@0 
+  - task: setup-azd@1 
     displayName: Install azd
 
   # If you can't install above task in your organization, you can comment it and uncomment below task to install azd

--- a/templates/common/.azdo/pipelines/java/azure-dev.yml
+++ b/templates/common/.azdo/pipelines/java/azure-dev.yml
@@ -13,7 +13,7 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  - task: setup-azd@0
+  - task: setup-azd@1
     displayName: Install azd
   
   # If you can't install above task in your organization, you can comment it and uncomment below task to install azd

--- a/templates/common/.azdo/pipelines/nodejs/aks/azure-dev.yml
+++ b/templates/common/.azdo/pipelines/nodejs/aks/azure-dev.yml
@@ -13,7 +13,7 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  - task: setup-azd@0 
+  - task: setup-azd@1 
     displayName: Install azd
 
   # If you can't install above task in your organization, you can comment it and uncomment below task to install azd

--- a/templates/common/.azdo/pipelines/terraform/azure-dev.yml
+++ b/templates/common/.azdo/pipelines/terraform/azure-dev.yml
@@ -13,7 +13,7 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  - task: setup-azd@0
+  - task: setup-azd@1
     displayName: Install azd
 
   # If you can't install above task in your organization, you can comment it and uncomment below task to install azd

--- a/templates/common/.azdo/pipelines/terraform/java/azure-dev.yml
+++ b/templates/common/.azdo/pipelines/terraform/java/azure-dev.yml
@@ -13,7 +13,7 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  - task: setup-azd@0
+  - task: setup-azd@1
     displayName: Install azd
 
   # If you can't install above task in your organization, you can comment it and uncomment below task to install azd


### PR DESCRIPTION
This changes make AZD pipeline config manager aware of what alpha features to turn on as part of the CI yaml definition.

After supporting turning alpha features ON as part of the pipeline, the pipeline manager includes `compose` when the infrastructure is detected as using composability.