### PR TITLE
Fix vscode publishing

### DIFF
--- a/eng/pipelines/templates/steps/publish-vscode.yml
+++ b/eng/pipelines/templates/steps/publish-vscode.yml
@@ -81,4 +81,4 @@ steps:
             --azure-credential `
             --packagePath "$($baseName).vsix" `
             --manifestPath "$($baseName).manifest" `
-            --signaturePath "$($baseName).p7s"
+            --signaturePath "$($baseName).signature.p7s"


### PR DESCRIPTION
The error seen is happening when the path to the signature file is incorrect. 

```
$ npx @vscode/vsce verify-signature -i azure-dev-0.9.0.vsix -m azure-dev-0.9.0.manifest -s azure-dev-0.9.0.p7s
 ERROR  ExtensionSignatureVerificationResult {
  code: 'SignatureIsUnreadable',
  internalCode: 10,
  didExecute: true,
  output: undefined
}
```

In this case, the `-s` parameter needs `azure-dev-0.9.0.signature.p7s` instead of `azure-dev-0.9.0.p7s`.