### PR TITLE
compose: fix AI project connection string binding value when added as existing resource

### DIFF
--- a/cli/azd/internal/scaffold/funcs.go
+++ b/cli/azd/internal/scaffold/funcs.go
@@ -254,7 +254,7 @@ func aiProjectConnectionString(resourceId string, projectUrl string) (string, er
 
 func emitAiProjectConnectionString(resourceIdVar string, projectUrlVar string) (string, error) {
 	return fmt.Sprintf(
-		"${split(%s, '/')[2]};${split(%s, '/')[2]}};${split(%s, '/')[4]};${split(%s, '/')[8]}",
+		"${split(%s, '/')[2]};${split(%s, '/')[2]};${split(%s, '/')[4]};${split(%s, '/')[8]}",
 		projectUrlVar,
 		resourceIdVar,
 		resourceIdVar,


### PR DESCRIPTION
Copilot caught this when working on a different part of `funcs.go` 😅

There's an extra right curly brace that's present in the binding value for AI project connection strings:
![image](https://github.com/user-attachments/assets/df556438-4770-4aea-9e2d-79be277c72e6)
