### PR TITLE
fix: resolves #5074

### DIFF
--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -606,6 +606,7 @@ func (t *aksTarget) ensureClusterContext(
 		convertOptions := &kubelogin.ConvertOptions{
 			Login:      "azd",
 			KubeConfig: kubeConfigPath,
+			TenantId:   t.env.GetTenantId(),
 		}
 
 		if err := tools.EnsureInstalled(ctx, t.kubeLoginCli); err != nil {


### PR DESCRIPTION
Resolves #5074 by adding tenant id to kubeconfig convert options when cluster is Azure RBAC enabled or local account is disabled.