### PR TITLE
Extension Framework: Fixes event handling issues

### DIFF
--- a/cli/azd/cmd/middleware/extensions.go
+++ b/cli/azd/cmd/middleware/extensions.go
@@ -116,7 +116,7 @@ func (m *ExtensionsMiddleware) Run(ctx context.Context, next NextFn) (*actions.A
 			}()
 
 			// Wait for the extension to signal readiness or failure.
-			readyCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			readyCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 			defer cancel()
 			if err := extension.WaitUntilReady(readyCtx); err != nil {
 				log.Printf("extension '%s' failed to become ready: %s\n", extension.Id, err.Error())

--- a/cli/azd/cmd/middleware/extensions.go
+++ b/cli/azd/cmd/middleware/extensions.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal/grpcserver"
@@ -115,7 +116,9 @@ func (m *ExtensionsMiddleware) Run(ctx context.Context, next NextFn) (*actions.A
 			}()
 
 			// Wait for the extension to signal readiness or failure.
-			if err := extension.WaitUntilReady(ctx); err != nil {
+			readyCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+			if err := extension.WaitUntilReady(readyCtx); err != nil {
 				log.Printf("extension '%s' failed to become ready: %s\n", extension.Id, err.Error())
 			}
 		}(extension, jwtToken)

--- a/cli/azd/internal/grpcserver/event_service.go
+++ b/cli/azd/internal/grpcserver/event_service.go
@@ -309,7 +309,10 @@ func (s *eventService) waitForServiceStatus(
 
 // ----- Dispatch Handlers -----
 
-func (s *eventService) handleProjectHandlerStatus(extension *extensions.Extension, statusMessage *azdext.ProjectHandlerStatus) {
+func (s *eventService) handleProjectHandlerStatus(
+	extension *extensions.Extension,
+	statusMessage *azdext.ProjectHandlerStatus,
+) {
 	fullEventName := fmt.Sprintf("%s.%s", extension.Id, statusMessage.EventName)
 	if val, ok := s.projectEvents.Load(fullEventName); ok {
 		ch := val.(chan *azdext.ProjectHandlerStatus)
@@ -317,7 +320,10 @@ func (s *eventService) handleProjectHandlerStatus(extension *extensions.Extensio
 	}
 }
 
-func (s *eventService) handleServiceHandlerStatus(extension *extensions.Extension, statusMessage *azdext.ServiceHandlerStatus) {
+func (s *eventService) handleServiceHandlerStatus(
+	extension *extensions.Extension,
+	statusMessage *azdext.ServiceHandlerStatus,
+) {
 	fullEventName := fmt.Sprintf("%s.%s.%s", extension.Id, statusMessage.ServiceName, statusMessage.EventName)
 	if val, ok := s.serviceEvents.Load(fullEventName); ok {
 		ch := val.(chan *azdext.ServiceHandlerStatus)


### PR DESCRIPTION
- Adds 2 second timeout for extension initialization for lifecycle events
- Fixes event namespacing when multiple extensions are handling the same lifecycle events.

If timeout occurs the extension cannot participate in lifecycle events.  This avoids extension initialization to perform and blocking or long running operations which should not be happening at this point.