### PR TITLE
Extensions: Pass console width to extensions when invoked

### DIFF
--- a/cli/azd/cmd/extensions.go
+++ b/cli/azd/cmd/extensions.go
@@ -18,6 +18,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
+	"github.com/azure/azure-dev/cli/azd/pkg/ux"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -126,6 +127,13 @@ func (a *extensionAction) Run(ctx context.Context) (*actions.ActionResult, error
 	forceColor := !color.NoColor
 	if forceColor {
 		allEnv = append(allEnv, "FORCE_COLOR=1")
+	}
+
+	// Pass the console width down to the child process
+	// COLUMNS is a semi-standard environment variable used by many Unix programs to determine the width of the terminal.
+	width := ux.ConsoleWidth()
+	if width > 0 {
+		allEnv = append(allEnv, fmt.Sprintf("COLUMNS=%d", width))
 	}
 
 	env, err := a.lazyEnv.GetValue()

--- a/cli/azd/pkg/ux/printer.go
+++ b/cli/azd/pkg/ux/printer.go
@@ -44,10 +44,7 @@ func NewPrinter(writer io.Writer) Printer {
 		writer = os.Stdout
 	}
 
-	width, _ := consolesize.GetConsoleSize()
-	if width == 0 {
-		width = 150
-	}
+	width := ConsoleWidth()
 
 	printer := &printer{
 		Cursor: internal.NewCursor(writer),

--- a/cli/azd/pkg/ux/ux.go
+++ b/cli/azd/pkg/ux/ux.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/ux/internal"
 	"github.com/fatih/color"
+	"github.com/nathan-fiscaletti/consolesize-go"
 )
 
 var ErrCancelled = internal.ErrCancelled
@@ -71,4 +73,24 @@ func VisibleLength(s string) int {
 	cleaned := specialTextRegex.ReplaceAllString(s, "")
 	// Count actual visible characters
 	return utf8.RuneCountInString(cleaned)
+}
+
+// ConsoleWidth returns the width of the console in characters.
+// It uses the consolesize package to get the size and falls back to check the COLUMNS environment variable
+// Defaults to 120 if the console size cannot be determined.
+func ConsoleWidth() int {
+	width, _ := consolesize.GetConsoleSize()
+	if width <= 0 {
+		// Default to 120 if console size cannot be determined
+		width = 120
+
+		consoleWidth := os.Getenv("COLUMNS")
+		if consoleWidth != "" {
+			if parsedWidth, err := strconv.Atoi(consoleWidth); err == nil {
+				width = parsedWidth
+			}
+		}
+	}
+
+	return width
 }


### PR DESCRIPTION
When a command is invoked through a sub process/shell, the called extension is unable to determine the correct console width using the `consolesize.GetConsoleSize()` that is used within `azd`.

To work around this issue, the currently detected console width will be set in a `COLUMNS` environment variable and then read by the extensions if unable to detect the size using standard libraries.

The `COLUMNS` environment variable is a semi-standard used in some Mac/unix based terminals.  If a console width is still unable to be detected we fallback to a default of `120`.