### PR TITLE
Update Java dependencies and fix failing template tests

### DIFF
--- a/cli/azd/internal/appdetect/testdata/java-multimodules/application/pom.xml
+++ b/cli/azd/internal/appdetect/testdata/java-multimodules/application/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.0</version>
+		<version>3.4.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/cli/azd/internal/appdetect/testdata/java-multimodules/library/pom.xml
+++ b/cli/azd/internal/appdetect/testdata/java-multimodules/library/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.2</version>
+		<version>3.4.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/cli/azd/internal/appdetect/testdata/java-multimodules/module2/pom.xml
+++ b/cli/azd/internal/appdetect/testdata/java-multimodules/module2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.2</version>
+        <version>3.4.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/cli/azd/internal/appdetect/testdata/java-multimodules/module2/submodule1/pom.xml
+++ b/cli/azd/internal/appdetect/testdata/java-multimodules/module2/submodule1/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.2</version>
+        <version>3.4.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/cli/azd/internal/appdetect/testdata/java-multimodules/notmodule/pom.xml
+++ b/cli/azd/internal/appdetect/testdata/java-multimodules/notmodule/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.2</version>
+        <version>3.4.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/cli/azd/test/functional/testdata/samples/springapp/pom.xml
+++ b/cli/azd/test/functional/testdata/samples/springapp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.4</version>
+		<version>3.4.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.microsoft.azure</groupId>

--- a/eng/pipelines/templates/steps/template-test-run-job.yml
+++ b/eng/pipelines/templates/steps/template-test-run-job.yml
@@ -65,6 +65,8 @@ steps:
     - bash: |
         go build -o ./temp/tfoidc ./cli/azd/test/internal/tfoidc 
       displayName: Build tfoidc
+      env:
+        CGO_ENABLED: 0
 
     - task: DevcontainersCI@0
       inputs:

--- a/templates/todo/api/java-postgresql/pom.xml
+++ b/templates/todo/api/java-postgresql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.4</version>
+    <version>3.4.5</version>
     <relativePath/>
     <!-- lookup parent from repository -->
   </parent>

--- a/templates/todo/api/java/pom.xml
+++ b/templates/todo/api/java/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.4</version>
+    <version>3.4.5</version>
     <relativePath/>
     <!-- lookup parent from repository -->
   </parent>

--- a/templates/todo/projects/nodejs-mongo-aks/.repo/bicep/infra/main.bicep
+++ b/templates/todo/projects/nodejs-mongo-aks/.repo/bicep/infra/main.bicep
@@ -50,7 +50,7 @@ resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
 }
 
 // The AKS cluster to host applications
-module aks 'br/public:avm/ptn/azd/aks:0.1.2' = {
+module aks 'br/public:avm/ptn/azd/aks:0.2.0' = {
   scope: rg
   name: 'aks'
   params: {
@@ -128,6 +128,6 @@ output AZURE_KEY_VAULT_NAME string = keyVault.outputs.name
 output AZURE_LOCATION string = location
 output AZURE_TENANT_ID string = tenant().tenantId
 output AZURE_AKS_CLUSTER_NAME string = aks.outputs.managedClusterName
-output AZURE_AKS_IDENTITY_CLIENT_ID string = aks.outputs.managedClusterClientId
+output AZURE_AKS_IDENTITY_CLIENT_ID string? = aks.outputs.?managedClusterClientId
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = aks.outputs.containerRegistryLoginServer
 output AZURE_CONTAINER_REGISTRY_NAME string = aks.outputs.containerRegistryName


### PR DESCRIPTION
This should hopefully address the remaining Maven CG security vulnerability alerts.

This PR also fixes several failing template tests due to:

- Unsupported/retired Kubernetes version in the AKS TODO templates:
  ```
  K8sVersionNotSupported: Preflight validation check for resource(s) for container service aks-eqlqwhy6oyc4a in resource group rg-azd-template-test-todo-nodejs-mongo-aks-4820260-3 failed. Message: Managed cluster aks-eqlqwhy6oyc4a is on version 1.29.15, which is only available for Long-Term Support (LTS).
  ```
- `tfoidc` binary failing to run causing Terraform templates to fail in test pipeline:
  ```
  ./tfoidc: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./tfoidc)
  ./tfoidc: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./tfoidc)
  ```
