### PR TITLE
Extensions: Adds support for nested extension namespaces

### DIFF
--- a/cli/azd/cmd/extensions.go
+++ b/cli/azd/cmd/extensions.go
@@ -7,11 +7,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
+	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal/grpcserver"
-	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
@@ -29,18 +28,58 @@ func bindExtension(
 	root *actions.ActionDescriptor,
 	extension *extensions.Extension,
 ) error {
+	// Split the namespace by dots to support nested namespaces
+	namespaceParts := strings.Split(extension.Namespace, ".")
+
+	// Start with the root command
+	current := root
+
+	// For each part except the last one, create or find a command in the hierarchy
+	for i := 0; i < len(namespaceParts)-1; i++ {
+		part := namespaceParts[i]
+
+		// Check if a command with this name already exists
+		found := false
+		for _, child := range current.Children() {
+			if child.Name == part {
+				current = child
+				found = true
+				break
+			}
+		}
+
+		// If not found, create a new command
+		if !found {
+			cmd := &cobra.Command{
+				Use:   part,
+				Short: extension.Description,
+			}
+
+			current = current.Add(part, &actions.ActionDescriptorOptions{
+				Command: cmd,
+				GroupingOptions: actions.CommandGroupOptions{
+					RootLevelHelp: actions.CmdGroupExtensions,
+				},
+			})
+		}
+	}
+
+	// The last part of the namespace is the actual command
+	lastPart := namespaceParts[len(namespaceParts)-1]
+
 	cmd := &cobra.Command{
-		Use:                extension.Namespace,
+		Use:                lastPart,
 		Short:              extension.Description,
 		Long:               extension.Description,
 		DisableFlagParsing: true,
+		// Add extension metadata as annotations for faster lookup later during invocation.
+		Annotations: map[string]string{
+			"extension.id":        extension.Id,
+			"extension.namespace": extension.Namespace,
+		},
 	}
 
-	cmd.SetHelpFunc(func(c *cobra.Command, s []string) {
-		_ = serviceLocator.Invoke(invokeExtensionHelp)
-	})
-
-	root.Add(extension.Namespace, &actions.ActionDescriptorOptions{
+	current.Add(lastPart, &actions.ActionDescriptorOptions{
 		Command:        cmd,
 		ActionResolver: newExtensionAction,
 		GroupingOptions: actions.CommandGroupOptions{
@@ -49,35 +88,6 @@ func bindExtension(
 	})
 
 	return nil
-}
-
-// invokeExtensionHelp invokes the help for the extension
-func invokeExtensionHelp(console input.Console, commandRunner exec.CommandRunner, extensionManager *extensions.Manager) {
-	extensionNamespace := os.Args[1]
-	extension, err := extensionManager.GetInstalled(extensions.LookupOptions{
-		Namespace: extensionNamespace,
-	})
-	if err != nil {
-		fmt.Println("Failed running help")
-	}
-
-	homeDir, err := config.GetUserConfigDir()
-	if err != nil {
-		fmt.Println("Failed running help")
-	}
-
-	extensionPath := filepath.Join(homeDir, extension.Path)
-
-	runArgs := exec.
-		NewRunArgs(extensionPath, os.Args[2:]...).
-		WithStdIn(console.Handles().Stdin).
-		WithStdOut(console.Handles().Stdout).
-		WithStdErr(console.Handles().Stderr)
-
-	_, err = commandRunner.Run(context.Background(), runArgs)
-	if err != nil {
-		fmt.Println("Failed running help")
-	}
 }
 
 type extensionAction struct {
@@ -112,13 +122,16 @@ func newExtensionAction(
 }
 
 func (a *extensionAction) Run(ctx context.Context) (*actions.ActionResult, error) {
-	extensionNamespace := a.cmd.Use
+	extensionId, has := a.cmd.Annotations["extension.id"]
+	if !has {
+		return nil, fmt.Errorf("extension id not found")
+	}
 
 	extension, err := a.extensionManager.GetInstalled(extensions.LookupOptions{
-		Namespace: extensionNamespace,
+		Id: extensionId,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get extension %s: %w", extensionNamespace, err)
+		return nil, fmt.Errorf("failed to get extension %s: %w", extensionId, err)
 	}
 
 	allEnv := []string{}


### PR DESCRIPTION
This change adds support for nested extension namespaces.
`azd` will register the correct hierarchy of extensions regardless of the namespace.

## Example

Extension 1 can register namespace `ai.vision`
Extension 1 can be invoked by calling `azd ai vision <command> [options]`

Extension 2 can register namespace `ai.speech`
Extension 2 can be invoked by calling `azd ai speech <command> [options]`

### `azd --help` will show top level extension command groups

<img width="392" alt="image" src="https://github.com/user-attachments/assets/c8155990-3db0-42ee-b516-b8ae448de73e" />

### `azd ai --help` will show the extensions within the command group

<img width="376" alt="image" src="https://github.com/user-attachments/assets/463eab93-00a0-4040-bb3b-a5cd879d6854" />

### `azd ai <extension> --help` will continue to show specific help of the extension.

### TODO

- [ ] Tests
- [ ] Merge help at command group level?

