### PR TITLE
Properly reading objects and arrays from parameter file

### DIFF
--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -1617,8 +1617,17 @@ func (p *BicepProvider) loadParameters(ctx context.Context) (loadParametersResul
 			resolvedParams[paramName] = resolvedParam
 			continue
 		}
+
+		// Check if the parameter has a valid type
 		stringValue, isString := resolvedParam.Value.(string)
-		if !isString {
+		mapValue, isMap := resolvedParam.Value.(map[string]any)
+		_, isArray := resolvedParam.Value.([]any)
+		if !isString && !isMap && !isArray {
+			continue
+		}
+
+		// Ensure that an object is not empty
+		if isMap && len(mapValue) == 0 {
 			continue
 		}
 

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -1618,24 +1618,15 @@ func (p *BicepProvider) loadParameters(ctx context.Context) (loadParametersResul
 			continue
 		}
 
-		// Check if the parameter has a valid type
-		stringValue, isString := resolvedParam.Value.(string)
-		mapValue, isMap := resolvedParam.Value.(map[string]any)
-		_, isArray := resolvedParam.Value.([]any)
-		if !isString && !isMap && !isArray {
-			continue
+		// Ignore string parameters which are empty b/c they are mapped to an undefined env var
+		if stringValue, isString := resolvedParam.Value.(string); isString {
+			// After previous checks, we know resolvedParam.Value is not nil
+			if stringValue == "" && hasUnsetEnvVar {
+				// parameter is empty and has an unset env var
+				continue
+			}
 		}
 
-		// Ensure that an object is not empty
-		if isMap && len(mapValue) == 0 {
-			continue
-		}
-
-		// After previous checks, we know resolvedParam.Value is not nil
-		if stringValue == "" && hasUnsetEnvVar {
-			// parameter is empty and has an unset env var
-			continue
-		}
 		// all other cases here represent a valid resolved parameter
 		resolvedParams[paramName] = resolvedParam
 	}

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -100,8 +100,7 @@ func TestBicepPlanParameterTypes(t *testing.T) {
 
 	require.NotEmpty(t, configuredParameters["regularObject"])
 	require.Equal(t, configuredParameters["regularObject"].Value, map[string]any{"test": "test"})
-	require.Empty(t, configuredParameters["emptyObject"])
-	require.Nil(t, configuredParameters["emptyObject"].Value)
+	require.Equal(t, configuredParameters["emptyObject"].Value, map[string]any{})
 
 	require.NotEmpty(t, configuredParameters["regularArray"])
 	require.Equal(t, configuredParameters["regularArray"].Value, []any{"test"})

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -81,6 +81,34 @@ func TestBicepPlanKeyVaultRef(t *testing.T) {
 	require.Equal(t, "secretName", configuredParameters["kvSecret"].KeyVaultReference.SecretName)
 }
 
+func TestBicepPlanParameterTypes(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+	prepareBicepMocks(mockContext)
+	infraProvider := createBicepProvider(t, mockContext)
+
+	deploymentPlan, err := infraProvider.plan(*mockContext.Context)
+
+	require.Nil(t, err)
+
+	require.IsType(t, &deploymentDetails{}, deploymentPlan)
+	configuredParameters := deploymentPlan.CompiledBicep.Parameters
+
+	require.NotEmpty(t, configuredParameters["regularString"])
+	require.Equal(t, configuredParameters["regularString"].Value, "test")
+	require.Empty(t, configuredParameters["emptyString"])
+	require.Nil(t, configuredParameters["emptyString"].Value)
+
+	require.NotEmpty(t, configuredParameters["regularObject"])
+	require.Equal(t, configuredParameters["regularObject"].Value, map[string]any{"test": "test"})
+	require.Empty(t, configuredParameters["emptyObject"])
+	require.Nil(t, configuredParameters["emptyObject"].Value)
+
+	require.NotEmpty(t, configuredParameters["regularArray"])
+	require.Equal(t, configuredParameters["regularArray"].Value, []any{"test"})
+	require.NotEmpty(t, configuredParameters["emptyArray"])
+	require.Equal(t, configuredParameters["emptyArray"].Value, []any{})
+}
+
 const paramsArmJson = `{
 	"$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
 	"contentVersion": "1.0.0.0",
@@ -421,6 +449,12 @@ func prepareBicepMocks(
 			"environmentName": {Type: "string"},
 			"location":        {Type: "string"},
 			"kvSecret":        {Type: "securestring"},
+			"regularString":   {Type: "string", DefaultValue: ""},
+			"emptyString":     {Type: "string", DefaultValue: ""},
+			"regularObject":   {Type: "array", DefaultValue: make([]string, 0)},
+			"emptyObject":     {Type: "array", DefaultValue: make([]string, 0)},
+			"regularArray":    {Type: "object", DefaultValue: make(map[string]int)},
+			"emptyArray":      {Type: "object", DefaultValue: make(map[string]int)},
 		},
 		Outputs: azure.ArmTemplateOutputs{
 			"WEBSITE_URL": {Type: "string"},

--- a/cli/azd/test/functional/testdata/mock-samples/webapp/infra/main.parameters.json
+++ b/cli/azd/test/functional/testdata/mock-samples/webapp/infra/main.parameters.json
@@ -15,6 +15,26 @@
         },
         "secretName": "secretName"
       }
+    },
+    "regularString": {
+      "value": "test"
+    },
+    "emptyString": {
+      "value": null
+    },
+    "regularObject": {
+      "value": {
+        "test": "test"
+      }
+    },
+    "emptyObject": {
+      "value": {}
+    },
+    "regularArray": {
+      "value": ["test"]
+    },
+    "emptyArray": {
+      "value": []
     }
   }
 }


### PR DESCRIPTION
This PR aims to solve #5151.

I have implemented additional checks for the type of a parameter that is read from the `main.parameters.json` file. I have defined the following restrictions. Please let me know if you all agree with these or whether I should change it up!

- `string`  is valid when it's not `null` (this was already implemented).
- `array`  is always valid. So this means that `[]` and `[...]` is supported.
- `object` is only valid when at least one element is defined. This means that `{}` is invalid and any form of `{key:value}` will be accepted.

Looking forward to any reviews/comments on my first contribution to this repository.