### PR TITLE
compose - `azd show` support for App Service

### DIFF
--- a/cli/azd/internal/cmd/show/show.go
+++ b/cli/azd/internal/cmd/show/show.go
@@ -308,12 +308,12 @@ func (s *showAction) showResource(ctx context.Context, name string, env *environ
 	resType := id.ResourceType.Namespace + "/" + id.ResourceType.Type
 	var item ux.UxItem
 	switch {
-	case strings.EqualFold(resType, "Microsoft.App/containerApps"):
+	case strings.EqualFold(resType, string(azapi.AzureResourceTypeContainerApp)):
 		item, err = showContainerApp(ctx, credential, id, resourceOptions)
 		if err != nil {
 			return err
 		}
-	case strings.EqualFold(resType, "Microsoft.Web/sites"):
+	case strings.EqualFold(resType, string(azapi.AzureResourceTypeWebSite)):
 		item, err = showAppService(ctx, credential, id, resourceOptions)
 		if err != nil {
 			return err
@@ -394,7 +394,7 @@ func showAppService(
 		}
 
 		value := *val
-		// TODO: Resolve the actual secret value from the AKV secret URI
+		// TODO(azure/azure-dev#5174): Resolve the actual secret value from the AKV secret ref @Microsoft.KeyVault(...)
 		isSecret := strings.HasPrefix(value, "@Microsoft.KeyVault(") || slices.Contains(knownSecretKeys, key)
 
 		if isSecret && !opts.showSecrets {

--- a/cli/azd/internal/cmd/show/show.go
+++ b/cli/azd/internal/cmd/show/show.go
@@ -351,8 +351,9 @@ func showAppService(
 	opts showResourceOptions,
 ) (*ux.ShowService, error) {
 	service := &ux.ShowService{
-		Name: id.Name,
-		Env:  make(map[string]string),
+		Name:        id.Name,
+		Env:         make(map[string]string),
+		DisplayType: "App Service",
 	}
 
 	client, err := armappservice.NewWebAppsClient(id.SubscriptionID, cred, opts.clientOpts)
@@ -412,8 +413,9 @@ func showContainerApp(
 	id *arm.ResourceID,
 	opts showResourceOptions) (*ux.ShowService, error) {
 	service := &ux.ShowService{
-		Name: id.Name,
-		Env:  make(map[string]string),
+		Name:        id.Name,
+		Env:         make(map[string]string),
+		DisplayType: "Container App",
 	}
 	client, err := armappcontainers.NewContainerAppsClient(id.SubscriptionID, cred, opts.clientOpts)
 	if err != nil {

--- a/cli/azd/pkg/output/ux/show.go
+++ b/cli/azd/pkg/output/ux/show.go
@@ -13,9 +13,10 @@ import (
 )
 
 type ShowService struct {
-	Name      string
-	IngresUrl string
-	Env       map[string]string
+	Name        string
+	IngresUrl   string
+	Env         map[string]string
+	DisplayType string
 }
 
 func (s *ShowService) ToString(currentIndentation string) string {
@@ -24,7 +25,7 @@ func (s *ShowService) ToString(currentIndentation string) string {
 			"  Endpoint: %s\n"+
 			"  Environment variables:\n"+
 			output.WithHighLightFormat(formatEnv("    ", s.Env)),
-		color.HiMagentaString("%s (Container App)", s.Name),
+		color.HiMagentaString("%s (%s)", s.Name, s.DisplayType),
 		output.WithLinkFormat(s.IngresUrl))
 }
 


### PR DESCRIPTION
Resolves #5093

`azd show <name>`:
<img width="364" alt="image" src="https://github.com/user-attachments/assets/d8d7b221-97a6-48e7-a81f-d641301aa2d0" />

> [!NOTE]
> In Compose, secrets for Redis and MongoDB are exported to the project Key Vault, and azd stores them in the App Service app settings as Key Vault references in the form `@Microsoft.KeyVault(SecretUri=https://myvault.vault.azure.net/secrets/mysecret)`. With these changes, `azd show <name> --show-secrets` displays the reference string but doesn't resolve them to the actual secret value. Created https://github.com/Azure/azure-dev/issues/5174 to track this.
>
> Secrets for Postgres and MySQL are not stored as Key Vault references, so `azd show <name> --show-secrets` displays the actual secret value.
>
> On the other hand, Container Apps has first-class support for secrets, so `azd show <name> --show-secrets` resolves the actual secret value from Key Vault secret references.

`azd show <name> --show-secrets`:
<img width="659" alt="image" src="https://github.com/user-attachments/assets/a4652cdc-f10e-41df-b9e8-93f3c4e34fae" />

