### PR TITLE
compose - `azd add` fit and finish

### DIFF
--- a/cli/azd/internal/cmd/add/add.go
+++ b/cli/azd/internal/cmd/add/add.go
@@ -197,6 +197,9 @@ func (a *AddAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	}
 
 	for _, svc := range usedBy {
+		if slices.Contains(prjConfig.Resources[svc].Uses, resourceToAdd.Name) {
+			continue
+		}
 		err = yamlnode.Append(&doc, fmt.Sprintf("resources.%s.uses[]?", svc), &yaml.Node{
 			Kind:  yaml.ScalarNode,
 			Value: resourceToAdd.Name,

--- a/cli/azd/internal/cmd/add/add_configure.go
+++ b/cli/azd/internal/cmd/add/add_configure.go
@@ -311,7 +311,7 @@ func promptUsedBy(
 		if isHost && otherIsHost && r.Type != other.Type {
 			continue
 		}
-		if otherIsHost && !slices.Contains(r.Uses, other.Name) {
+		if otherIsHost && !slices.Contains(other.Uses, r.Name) {
 			svc = append(svc, other.Name)
 		}
 	}

--- a/cli/azd/internal/cmd/add/add_configure_host.go
+++ b/cli/azd/internal/cmd/add/add_configure_host.go
@@ -22,7 +22,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
-	"github.com/fatih/color"
 )
 
 // LanguageMap is a map of supported languages.
@@ -310,7 +309,7 @@ func addServiceAsResource(
 		console.Message(ctx,
 			fmt.Sprintf("\nazd will use %s to host this project on %s.",
 				output.WithHighLightFormat(string(runtime.Stack)+" "+runtime.Version),
-				color.MagentaString("Azure App Service")))
+				output.WithHighLightFormat("Azure App Service")))
 
 		resSpec.Props = project.AppServiceProps{
 			Port:    port,

--- a/cli/azd/internal/cmd/add/add_select.go
+++ b/cli/azd/internal/cmd/add/add_select.go
@@ -106,18 +106,29 @@ func selectHost(
 	console input.Console,
 	ctx context.Context,
 	p PromptOptions) (*project.ResourceConfig, error) {
+	// ACA is the default host type, and should be shown first in the list
+	defaultHostType := project.ResourceTypeHostContainerApp
+	defaultHostDisplayName := fmt.Sprintf("%s (default)", defaultHostType.String())
 	resourceTypesDisplayMap := make(map[string]project.ResourceType)
+	resourceTypesDisplayMap[defaultHostDisplayName] = defaultHostType
+	resourceTypesDisplay := []string{defaultHostDisplayName}
+
+	otherHostTypes := []string{}
 	for _, resourceType := range project.AllResourceTypes() {
-		if strings.HasPrefix(string(resourceType), "host.") {
+		if strings.HasPrefix(string(resourceType), "host.") && resourceType != defaultHostType {
 			resourceTypesDisplayMap[resourceType.String()] = resourceType
+			otherHostTypes = append(otherHostTypes, resourceType.String())
 		}
 	}
 
+	slices.Sort(otherHostTypes)
+	resourceTypesDisplay = append(resourceTypesDisplay, otherHostTypes...)
+
 	r := &project.ResourceConfig{}
-	resourceTypesDisplay := slices.Sorted(maps.Keys(resourceTypesDisplayMap))
 	hostOption, err := console.Select(ctx, input.ConsoleOptions{
-		Message: "Which type of host?",
-		Options: resourceTypesDisplay,
+		Message:      "Which type of host?",
+		Options:      resourceTypesDisplay,
+		DefaultValue: defaultHostDisplayName,
 	})
 	if err != nil {
 		return nil, err

--- a/cli/azd/internal/cmd/add/add_select_ai.go
+++ b/cli/azd/internal/cmd/add/add_select_ai.go
@@ -356,6 +356,9 @@ func (a *AddAction) aiDeploymentCatalog(
 
 	var sharedResults sync.Map
 	var wg sync.WaitGroup
+
+	a.console.ShowSpinner(ctx, "Retrieving available models...", input.Step)
+
 	for _, location := range allLocations {
 		wg.Add(1)
 		go func(location string) {
@@ -387,6 +390,7 @@ func (a *AddAction) aiDeploymentCatalog(
 		}(location.Name)
 	}
 	wg.Wait()
+	a.console.StopSpinner(ctx, "", input.StepDone)
 
 	combinedResults := map[string]ModelCatalogKind{}
 	sharedResults.Range(func(key, value any) bool {

--- a/cli/azd/internal/scaffold/resource_meta.go
+++ b/cli/azd/internal/scaffold/resource_meta.go
@@ -107,9 +107,10 @@ var Resources = []ResourceMeta{
 		ApiVersion:   "2023-06-01-preview",
 	},
 	{
-		ResourceType:      "Microsoft.DBforMySQL/flexibleServers",
+		ResourceType:      "Microsoft.DBforMySQL/flexibleServers/databases",
 		ApiVersion:        "2023-12-30",
 		StandardVarPrefix: "MYSQL",
+		ParentForEval:     "Microsoft.DBforMySQL/flexibleServers",
 		Variables: map[string]string{
 			"database": "${spec.name}",
 			"host":     "${.properties.fullyQualifiedDomainName}",
@@ -120,9 +121,10 @@ var Resources = []ResourceMeta{
 		},
 	},
 	{
-		ResourceType:      "Microsoft.DBforPostgreSQL/flexibleServers",
+		ResourceType:      "Microsoft.DBforPostgreSQL/flexibleServers/databases",
 		ApiVersion:        "2022-12-01",
 		StandardVarPrefix: "POSTGRES",
+		ParentForEval:     "Microsoft.DBforPostgreSQL/flexibleServers",
 		Variables: map[string]string{
 			"database": "${spec.name}",
 			"host":     "${.properties.fullyQualifiedDomainName}",


### PR DESCRIPTION
Resolves #4877
Resolves #5184

This PR contains some fixes and enhancements in the `azd add` flow:

### 1. Prevent same resource being added under 'uses' multiple times
When adding multiple AI Services/Foundry models, if a service host already 'uses' the AI project, azd will not show that service when prompting for 'uses'.

![image](https://github.com/user-attachments/assets/c8a4ddd0-03f8-4069-b15f-acf1b2700f7c)

### 2. Fix `azd add` preview for MySQL and Postgres
Previously, the `azd add` preview was not showing the resource type or binding variables.

![image](https://github.com/user-attachments/assets/620b5cce-29d2-45ef-b4b6-384a450f39e2)

### 3. Show spinner while loading available Foundry models
After the "Retrieving locations..." spinner:

https://github.com/user-attachments/assets/52675ea7-e93d-4373-bd68-67c39647af74

### 4. App Service UX review changes

Host types are displayed in a custom sorted order, with **Container App (default)** as the first option.
![image](https://github.com/user-attachments/assets/8940c675-7582-482c-8e9e-c7bca071c9f2)

The text **Azure App Service** is now highlighted in the standard bright blue colour.
![image](https://github.com/user-attachments/assets/240ace5a-a3ee-48fd-b4d5-d9c7f57ddb09)



