### PR TITLE
Extension Templates: add missing Javascript packages to support `azd x build`

### DIFF
--- a/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/javascript/build.ps1
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/javascript/build.ps1
@@ -61,6 +61,7 @@ foreach ($PLATFORM in $PLATFORMS) {
     }
 
     Write-Host "Installing dependencies..."
+    npm install -g pkg
     npm install
 
     Write-Host "Building JavaScript extension for $OS/$ARCH..."

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/javascript/build.ps1
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/javascript/build.ps1
@@ -60,12 +60,35 @@ foreach ($PLATFORM in $PLATFORMS) {
         $EXPECTED_OUTPUT_NAME += ".exe"
     }
 
+    # Check Node.js and npm
+    if (-not (Get-Command node -ErrorAction SilentlyContinue) -or -not (Get-Command npm -ErrorAction SilentlyContinue)) {
+        Write-Host "Node.js or npm is not installed. Please install them from https://nodejs.org."
+        exit 1
+    }
+
+    # Check npx
+    if (-not (Get-Command npx -ErrorAction SilentlyContinue)) {
+        Write-Host "npx is not available."
+        exit 1
+    }
+
+    # Run npx pkg
+    Write-Host "Ensuring pkg is available using npx..."
+    npx --yes --package pkg echo "Ensured pkg is available"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Failed to download 'pkg' via npx."
+        exit 1
+    }
+
     Write-Host "Installing dependencies..."
-    npm install -g pkg
     npm install
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Failed to install npm dependencies."
+        exit 1
+    }
 
     Write-Host "Building JavaScript extension for $OS/$ARCH..."
-    pkg $ENTRY_FILE -o $OUTPUT_DIR/$EXPECTED_OUTPUT_NAME --targets $TARGET --config package.json
+    npx pkg $ENTRY_FILE -o $OUTPUT_DIR/$EXPECTED_OUTPUT_NAME --targets $TARGET --config package.json
 
     if ($LASTEXITCODE -ne 0) {
         Write-Host "An error occurred while building for $OS/$ARCH"

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/javascript/build.sh
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/javascript/build.sh
@@ -65,12 +65,37 @@ for PLATFORM in "${PLATFORMS[@]}"; do
         EXPECTED_OUTPUT_NAME+='.exe'
     fi
 
+    # Check Node.js and npm
+    if ! command -v node &> /dev/null || ! command -v npm &> /dev/null
+    then
+        echo "Node.js or npm is not installed. Please install them from https://nodejs.org."
+        exit 1
+    fi
+
+    # Check npx
+    if ! command -v npx &> /dev/null
+    then
+        echo "npx is not available."
+        exit 1
+    fi
+
+    # Run npx pkg
+    echo "Ensuring pkg is available using npx..."
+    npx --yes --package pkg echo "Ensured pkg is available"
+    if [ $? -ne 0 ]; then
+        echo "Failed to download 'pkg' via npx."
+        exit 1
+    fi
+    
     echo "Installing dependencies..."
-    npm install -g pkg
     npm install
+    if [ $? -ne 0 ]; then
+        echo "Failed to install npm dependencies."
+        exit 1
+    fi
 
     echo "Building JavaScript extension for $OS/$ARCH..."
-    pkg "$ENTRY_FILE" --output "$OUTPUT_DIR/$EXPECTED_OUTPUT_NAME" --targets "$TARGET"
+    npx pkg "$ENTRY_FILE" --output "$OUTPUT_DIR/$EXPECTED_OUTPUT_NAME" --targets "$TARGET"
 
     if [ $? -ne 0 ]; then
         echo "An error occurred while building for $OS/$ARCH"

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/javascript/build.sh
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/javascript/build.sh
@@ -66,6 +66,7 @@ for PLATFORM in "${PLATFORMS[@]}"; do
     fi
 
     echo "Installing dependencies..."
+    npm install -g pkg
     npm install
 
     echo "Building JavaScript extension for $OS/$ARCH..."


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-dev/issues/5167.
- Added `pkg` package.

@rajeshkamal5050 and @wbreza for notification.