### PR TITLE
Extension Templates: add missing Python packages to support `azd x build`

### DIFF
--- a/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/python/build.ps1
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/python/build.ps1
@@ -63,6 +63,8 @@ foreach ($PLATFORM in $PLATFORMS) {
     $PYTHON_MAIN_FILE = "main.py"
 
     Write-Host "Installing Python dependencies..."
+    python -m venv .venv
+    .venv\Scripts\Activate.ps1
     pip install -r requirements.txt
 
     $PYINSTALLER_NAME = "$EXTENSION_ID_SAFE-$OS-$ARCH"

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/python/build.ps1
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/python/build.ps1
@@ -64,8 +64,22 @@ foreach ($PLATFORM in $PLATFORMS) {
 
     Write-Host "Installing Python dependencies..."
     python -m venv .venv
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to create virtual environment."
+        exit 1
+    }
+
     .venv\Scripts\Activate.ps1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to activate virtual environment."
+        exit 1
+    }
+
     pip install -r requirements.txt
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to install dependencies."
+        exit 1
+    }
 
     $PYINSTALLER_NAME = "$EXTENSION_ID_SAFE-$OS-$ARCH"
     if ($OS -eq "windows") {

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/python/build.sh
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/python/build.sh
@@ -58,7 +58,38 @@ for PLATFORM in "${PLATFORMS[@]}"; do
     [ -f "$OUTPUT_NAME" ] && rm -f "$OUTPUT_NAME"
 
     PYTHON_MAIN_FILE="main.py"
+    
+    OS_TYPE=$(uname -s)
+    # Install dependencies based on OS
+    if [ "$OS_TYPE" == "Linux" ]; then
+        # For Linux, install python3-venv
+        echo "Linux detected. Installing dependencies..."
+        if ! dpkg -s python3-venv &> /dev/null; then
+            echo "python3-venv not found, attempting to install it..."
+            if [[ $EUID -ne 0 ]]; then
+                echo "Root permission required to install packages. Using sudo..."
+                sudo apt-get update
+                sudo apt-get install -y python3-venv python3-dev libpython3-dev binutils
+            else
+                apt-get update
+                apt-get install -y python3-venv python3-dev libpython3-dev binutils
+            fi
+        fi
+    elif [ "$OS_TYPE" == "Darwin" ]; then
+        # For macOS, install python3-venv via Homebrew
+        echo "macOS detected. Installing dependencies..."
+        if ! brew list python3 &> /dev/null; then
+            echo "Homebrew Python3 not found, installing it..."
+            brew install python3
+        fi
+    else
+        echo "Unsupported OS: $OS_TYPE"
+        exit 1
+    fi
 
+    echo "Creating virtual environment..."
+    python3 -m venv .venv
+    source .venv/bin/activate
     echo "Installing Python dependencies..."
     pip install -r requirements.txt
 
@@ -66,7 +97,7 @@ for PLATFORM in "${PLATFORMS[@]}"; do
     [ "$OS" = "windows" ] && PYINSTALLER_NAME+='.exe'
 
     echo "Running PyInstaller for $OS/$ARCH..."
-    python -m PyInstaller \
+    python3 -m PyInstaller \
         --onefile \
         --add-data "generated_proto:generated_proto" \
         --add-data "version.py:." \

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/python/build.sh
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/python/build.sh
@@ -69,18 +69,43 @@ for PLATFORM in "${PLATFORMS[@]}"; do
             if [[ $EUID -ne 0 ]]; then
                 echo "Root permission required to install packages. Using sudo..."
                 sudo apt-get update
+                if [ $? -ne 0 ]; then
+                    echo "Failed to update package list."
+                    exit 1
+                fi
                 sudo apt-get install -y python3-venv python3-dev libpython3-dev binutils
+                if [ $? -ne 0 ]; then
+                    echo "Failed to install required packages."
+                    exit 1
+                fi
             else
                 apt-get update
+                if [ $? -ne 0 ]; then
+                    echo "Failed to update package list."
+                    exit 1
+                fi
                 apt-get install -y python3-venv python3-dev libpython3-dev binutils
+                if [ $? -ne 0 ]; then
+                    echo "Failed to install required packages."
+                    exit 1
+                fi
             fi
         fi
     elif [ "$OS_TYPE" == "Darwin" ]; then
         # For macOS, install python3-venv via Homebrew
         echo "macOS detected. Installing dependencies..."
+        if ! command -v brew &> /dev/null; then
+            echo "Homebrew not found. Please install Homebrew first: https://brew.sh/"
+            exit 1
+        fi
+
         if ! brew list python3 &> /dev/null; then
             echo "Homebrew Python3 not found, installing it..."
             brew install python3
+            if [ $? -ne 0 ]; then
+                echo "Failed to install Python3 via Homebrew."
+                exit 1
+            fi
         fi
     else
         echo "Unsupported OS: $OS_TYPE"
@@ -89,9 +114,23 @@ for PLATFORM in "${PLATFORMS[@]}"; do
 
     echo "Creating virtual environment..."
     python3 -m venv .venv
+    if [ $? -ne 0 ]; then
+        echo "Failed to create virtual environment."
+        exit 1
+    fi
+
     source .venv/bin/activate
+    if [ $? -ne 0 ]; then
+        echo "Failed to activate virtual environment."
+        exit 1
+    fi
+
     echo "Installing Python dependencies..."
     pip install -r requirements.txt
+    if [ $? -ne 0 ]; then
+        echo "Failed to install Python dependencies."
+        exit 1
+    fi
 
     PYINSTALLER_NAME="$EXTENSION_ID_SAFE-$OS-$ARCH"
     [ "$OS" = "windows" ] && PYINSTALLER_NAME+='.exe'

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/python/requirements.txt
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/resources/languages/python/requirements.txt
@@ -8,3 +8,4 @@ rich==14.0.0
 typer==0.15.2
 aiohttp==3.11.18
 asyncio==3.4.3
+pyinstaller==6.13.0


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-dev/issues/5168.
- Added Python virtual environment creation and `PyInstaller` dependencies

@rajeshkamal5050 and @wbreza for notification.