### PR TITLE
handle existing ci variables and secrets

### DIFF
--- a/cli/azd/pkg/output/ux/created_repo_value.go
+++ b/cli/azd/pkg/output/ux/created_repo_value.go
@@ -18,12 +18,17 @@ const (
 )
 
 type CreatedRepoValue struct {
-	Name string
-	Kind GitHubValueKind
+	Name   string
+	Kind   GitHubValueKind
+	Action string
 }
 
 func (cr *CreatedRepoValue) ToString(currentIndentation string) string {
-	return fmt.Sprintf("%s%s Setting %s repo %s", currentIndentation, donePrefix, cr.Name, cr.Kind)
+	action := cr.Action
+	if action == "" {
+		action = "Setting"
+	}
+	return fmt.Sprintf("%s%s %s %s repo %s", currentIndentation, donePrefix, action, cr.Name, cr.Kind)
 }
 
 func (cr *CreatedRepoValue) MarshalJSON() ([]byte, error) {

--- a/cli/azd/pkg/pipeline/github_provider.go
+++ b/cli/azd/pkg/pipeline/github_provider.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"maps"
 	"net/url"
 	"path/filepath"
 	"regexp"
@@ -617,7 +618,7 @@ func (p *GitHubCiProvider) configurePipeline(
 	msg := ""
 	var procErr error
 	ciSecrets, ciVariables := []string{}, []string{}
-	if len(options.projectVariables) > 0 {
+	if len(options.projectVariables) > 0 || len(options.providerParameters) > 0 {
 		msg = "Setting up project's variables to be used in the pipeline"
 		ciSecretsInstance, err := p.ghCli.ListSecrets(ctx, repoSlug)
 		if err != nil {
@@ -656,47 +657,355 @@ func (p *GitHubCiProvider) configurePipeline(
 	for _, value := range options.projectSecrets {
 		variablesAndSecretsMap[value] = value
 	}
+	for _, providerParam := range options.providerParameters {
+		for _, envVar := range providerParam.EnvVarMapping {
+			variablesAndSecretsMap[envVar] = envVar
+		}
+	}
+
+	deleteAllUnused := false
+	ignoreAllUnused := false
+	updateAllDuplicates := false
+	ignoreAllDuplicates := false
+	toBeSetSecrets := maps.Clone(options.secrets)
+	const selectionIgnore string = "Keep existing secret from pipeline (ignore)."
+	const selectionIgnoreAll string = "Keep ALL existing secrets from pipeline (ignore this and any other existing secret)."
+	const selectionUpdate string = "Set the secret again (update)."
+	const selectionUpdateAll string = "Set ALL existing secrets again (update this and any other existing secret)."
+	const selectionIgnoreUnused string = "Ignore and keep the secret."
+	const selectionIgnoreAllUnused string = "Ignore and keep ALL unused secrets from the pipeline."
+	const selectionDelete string = "Delete the secret from the pipeline."
+	const selectionDeleteAll string = "Delete ALL unused secrets from the pipeline."
 
 	// iterate the existing secrets on the pipeline and remove the ones matching the project's secrets or variables
 	for _, existingSecret := range ciSecrets {
-		if _, willBeUpdated := options.secrets[existingSecret]; willBeUpdated {
-			// if the secret will be updated, we don't need to delete it
+		if _, willBeUpdated := toBeSetSecrets[existingSecret]; willBeUpdated {
+			if ignoreAllDuplicates {
+				// ignore this secret, as it will be updated
+				delete(toBeSetSecrets, existingSecret)
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingSecret,
+					Kind:   ux.GitHubSecret,
+					Action: "Ignore",
+				})
+				continue
+			}
+			if updateAllDuplicates {
+				// if the secret will be updated, we don't need to delete it
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingSecret,
+					Kind:   ux.GitHubSecret,
+					Action: "Update",
+				})
+				continue
+			}
+			// prompt the user to ignore or delete the secret
+			options := []string{
+				selectionIgnore,
+				selectionIgnoreAll,
+				selectionUpdate,
+				selectionUpdateAll,
+			}
+			selectionIndex, err := p.console.Select(ctx, input.ConsoleOptions{
+				Message: fmt.Sprintf(
+					"The secret %s already exists in the pipeline. What would you like AZD to do?", existingSecret),
+				Options:      options,
+				DefaultValue: selectionIgnore,
+			})
+			if err != nil {
+				procErr = fmt.Errorf("prompting for secret update: %w", err)
+				return nil, procErr
+			}
+			switch options[selectionIndex] {
+			case selectionIgnore:
+				delete(toBeSetSecrets, existingSecret)
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingSecret,
+					Kind:   ux.GitHubSecret,
+					Action: "Ignore",
+				})
+			case selectionIgnoreAll:
+				ignoreAllDuplicates = true
+				delete(toBeSetSecrets, existingSecret)
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingSecret,
+					Kind:   ux.GitHubSecret,
+					Action: "Ignore",
+				})
+			case selectionUpdate:
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingSecret,
+					Kind:   ux.GitHubSecret,
+					Action: "Update",
+				})
+			case selectionUpdateAll:
+				updateAllDuplicates = true
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingSecret,
+					Kind:   ux.GitHubSecret,
+					Action: "Update",
+				})
+			}
 			continue
 		}
 		// only delete if the secret is defined in the project's secrets or variables (azure.yaml)
 		if _, exists := variablesAndSecretsMap[existingSecret]; exists {
-			deleteErr := p.ghCli.DeleteSecret(ctx, repoSlug, existingSecret)
-			if deleteErr != nil {
-				procErr = fmt.Errorf("failed deleting %s secret: %w", existingSecret, deleteErr)
+			if ignoreAllUnused {
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingSecret,
+					Kind:   ux.GitHubSecret,
+					Action: "Ignore un-used",
+				})
+				continue
+			}
+			if deleteAllUnused {
+				deleteErr := p.ghCli.DeleteSecret(ctx, repoSlug, existingSecret)
+				if deleteErr != nil {
+					procErr = fmt.Errorf("failed deleting %s secret: %w", existingSecret, deleteErr)
+					return nil, procErr
+				}
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingSecret,
+					Kind:   ux.GitHubSecret,
+					Action: "Delete un-used",
+				})
+				continue
+			}
+			// prompt the user to ignore or delete the secret
+			options := []string{
+				selectionIgnoreUnused,
+				selectionIgnoreAllUnused,
+				selectionDelete,
+				selectionDeleteAll,
+			}
+			selectionIndex, err := p.console.Select(ctx, input.ConsoleOptions{
+				Message: fmt.Sprintf(
+					"The secret %s exists in the pipeline but is no longer required. What would you like AZD to do?",
+					existingSecret),
+				Options:      options,
+				DefaultValue: selectionIgnoreUnused,
+			})
+			if err != nil {
+				procErr = fmt.Errorf("prompting for secret update: %w", err)
 				return nil, procErr
+			}
+			switch options[selectionIndex] {
+			case selectionIgnoreUnused:
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingSecret,
+					Kind:   ux.GitHubSecret,
+					Action: "Ignore un-used",
+				})
+			case selectionIgnoreAllUnused:
+				ignoreAllUnused = true
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingSecret,
+					Kind:   ux.GitHubSecret,
+					Action: "Ignore un-used",
+				})
+			case selectionDelete:
+				deleteErr := p.ghCli.DeleteSecret(ctx, repoSlug, existingSecret)
+				if deleteErr != nil {
+					procErr = fmt.Errorf("failed deleting %s secret: %w", existingSecret, deleteErr)
+					return nil, procErr
+				}
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingSecret,
+					Kind:   ux.GitHubSecret,
+					Action: "Delete un-used",
+				})
+			case selectionDeleteAll:
+				deleteAllUnused = true
+				deleteErr := p.ghCli.DeleteSecret(ctx, repoSlug, existingSecret)
+				if deleteErr != nil {
+					procErr = fmt.Errorf("failed deleting %s secret: %w", existingSecret, deleteErr)
+					return nil, procErr
+				}
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingSecret,
+					Kind:   ux.GitHubSecret,
+					Action: "Delete un-used",
+				})
 			}
 		}
 	}
+
+	deleteAllUnusedVars := false
+	ignoreAllUnusedVars := false
+	updateAllDuplicatesVars := false
+	ignoreAllDuplicatesVars := false
+	toBeSetVariables := maps.Clone(options.variables)
+	const selectionIgnoreVars string = "Keep existing variable from pipeline (ignore)."
+	const selectionIgnoreAllVars string = "Keep ALL existing variables from pipeline " +
+		"(ignore this and any other existing variable)."
+	const selectionUpdateVars string = "Set the variable again (update)."
+	const selectionUpdateAllVars string = "Set ALL existing variables again (update this and any other existing variable)."
+	const selectionIgnoreUnusedVars string = "Ignore and keep the variable."
+	const selectionIgnoreAllUnusedVars string = "Ignore and keep ALL unused variables from the pipeline."
+	const selectionDeleteVars string = "Delete the variable from the pipeline."
+	const selectionDeleteAllVars string = "Delete ALL unused variables from the pipeline."
 	// iterate the existing variables on the pipeline and remove the ones matching the project's secrets or variables
 	for _, existingVariable := range ciVariables {
-		if _, willBeUpdated := options.variables[existingVariable]; willBeUpdated {
-			// if the variable will be updated, we don't need to delete it
+		if _, willBeUpdated := toBeSetVariables[existingVariable]; willBeUpdated {
+			if ignoreAllDuplicatesVars {
+				// ignore this variable, as it will be updated
+				delete(toBeSetVariables, existingVariable)
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingVariable,
+					Kind:   ux.GitHubVariable,
+					Action: "Ignore",
+				})
+				continue
+			}
+			if updateAllDuplicatesVars {
+				// if the secret will be updated, we don't need to delete it
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingVariable,
+					Kind:   ux.GitHubVariable,
+					Action: "Update",
+				})
+				continue
+			}
+			// prompt the user to ignore or delete the secret
+			options := []string{
+				selectionIgnoreVars,
+				selectionIgnoreAllVars,
+				selectionUpdateVars,
+				selectionUpdateAllVars,
+			}
+			selectionIndex, err := p.console.Select(ctx, input.ConsoleOptions{
+				Message: fmt.Sprintf(
+					"The variable %s already exists in the pipeline. What would you like AZD to do?", existingVariable),
+				Options:      options,
+				DefaultValue: selectionIgnoreVars,
+			})
+			if err != nil {
+				procErr = fmt.Errorf("prompting for variable update: %w", err)
+				return nil, procErr
+			}
+			switch options[selectionIndex] {
+			case selectionIgnoreVars:
+				delete(toBeSetVariables, existingVariable)
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingVariable,
+					Kind:   ux.GitHubVariable,
+					Action: "Ignore",
+				})
+			case selectionIgnoreAllVars:
+				ignoreAllDuplicatesVars = true
+				delete(toBeSetVariables, existingVariable)
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingVariable,
+					Kind:   ux.GitHubVariable,
+					Action: "Ignore",
+				})
+			case selectionUpdateVars:
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingVariable,
+					Kind:   ux.GitHubVariable,
+					Action: "Update",
+				})
+			case selectionUpdateAllVars:
+				updateAllDuplicatesVars = true
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingVariable,
+					Kind:   ux.GitHubVariable,
+					Action: "Update",
+				})
+			}
 			continue
 		}
 		// only delete if the variable is defined in the project's secrets or variables (azure.yaml)
 		if _, exists := variablesAndSecretsMap[existingVariable]; exists {
-			deleteErr := p.ghCli.DeleteVariable(ctx, repoSlug, existingVariable)
-			if deleteErr != nil {
-				procErr = fmt.Errorf("failed deleting %s variable: %w", existingVariable, deleteErr)
+			if ignoreAllUnusedVars {
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingVariable,
+					Kind:   ux.GitHubVariable,
+					Action: "Ignore un-used",
+				})
+				continue
+			}
+			if deleteAllUnusedVars {
+				deleteErr := p.ghCli.DeleteVariable(ctx, repoSlug, existingVariable)
+				if deleteErr != nil {
+					procErr = fmt.Errorf("failed deleting %s variable: %w", existingVariable, deleteErr)
+					return nil, procErr
+				}
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingVariable,
+					Kind:   ux.GitHubVariable,
+					Action: "Delete un-used",
+				})
+				continue
+			}
+			// prompt the user to ignore or delete the variable
+			options := []string{
+				selectionIgnoreUnusedVars,
+				selectionIgnoreAllUnusedVars,
+				selectionDeleteVars,
+				selectionDeleteAllVars,
+			}
+			selectionIndex, err := p.console.Select(ctx, input.ConsoleOptions{
+				Message: fmt.Sprintf(
+					"The variable %s exists in the pipeline but is no longer required. What would you like AZD to do?",
+					existingVariable),
+				Options:      options,
+				DefaultValue: selectionIgnoreUnusedVars,
+			})
+			if err != nil {
+				procErr = fmt.Errorf("prompting for variable update: %w", err)
 				return nil, procErr
+			}
+			switch options[selectionIndex] {
+			case selectionIgnoreUnusedVars:
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingVariable,
+					Kind:   ux.GitHubVariable,
+					Action: "Ignore un-used",
+				})
+			case selectionIgnoreAllUnusedVars:
+				ignoreAllUnusedVars = true
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingVariable,
+					Kind:   ux.GitHubVariable,
+					Action: "Ignore un-used",
+				})
+			case selectionDeleteVars:
+				deleteErr := p.ghCli.DeleteVariable(ctx, repoSlug, existingVariable)
+				if deleteErr != nil {
+					procErr = fmt.Errorf("failed deleting %s variable: %w", existingVariable, deleteErr)
+					return nil, procErr
+				}
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingVariable,
+					Kind:   ux.GitHubVariable,
+					Action: "Delete un-used",
+				})
+			case selectionDeleteAllVars:
+				deleteAllUnusedVars = true
+				deleteErr := p.ghCli.DeleteVariable(ctx, repoSlug, existingVariable)
+				if deleteErr != nil {
+					procErr = fmt.Errorf("failed deleting %s variable: %w", existingVariable, deleteErr)
+					return nil, procErr
+				}
+				p.console.MessageUxItem(ctx, &ux.CreatedRepoValue{
+					Name:   existingVariable,
+					Kind:   ux.GitHubVariable,
+					Action: "Delete un-used",
+				})
 			}
 		}
 	}
 
 	// set the new variables and secrets
-	for key, value := range options.secrets {
+	for key, value := range toBeSetSecrets {
 		if err := p.ghCli.SetSecret(ctx, repoSlug, key, value); err != nil {
 			procErr = fmt.Errorf("failed setting %s secret: %w", key, err)
 			return nil, procErr
 		}
 	}
 
-	for key, value := range options.variables {
+	for key, value := range toBeSetVariables {
 		if err := p.ghCli.SetVariable(ctx, repoSlug, key, value); err != nil {
 			procErr = fmt.Errorf("failed setting %s secret: %w", key, err)
 			return nil, procErr

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_App_host_-_fed_Cred.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_App_host_-_fed_Cred.snap
@@ -44,8 +44,6 @@ steps:
         azd provision --no-prompt
     env:
       AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
-      AZURE_ENV_NAME: $(AZURE_ENV_NAME)
-      AZURE_LOCATION: $(AZURE_LOCATION)
 
   - task: AzureCLI@2
     displayName: Deploy Application

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_branch_name.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_branch_name.snap
@@ -35,8 +35,6 @@ steps:
         azd provision --no-prompt
     env:
       AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
-      AZURE_ENV_NAME: $(AZURE_ENV_NAME)
-      AZURE_LOCATION: $(AZURE_LOCATION)
 
   - task: AzureCLI@2
     displayName: Deploy Application

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_no_app_host_-_client_cred.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_no_app_host_-_client_cred.snap
@@ -35,8 +35,6 @@ steps:
         azd provision --no-prompt
     env:
       AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
-      AZURE_ENV_NAME: $(AZURE_ENV_NAME)
-      AZURE_LOCATION: $(AZURE_LOCATION)
 
   - task: AzureCLI@2
     displayName: Deploy Application

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_no_app_host_-_fed_Cred.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_no_app_host_-_fed_Cred.snap
@@ -35,8 +35,6 @@ steps:
         azd provision --no-prompt
     env:
       AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
-      AZURE_ENV_NAME: $(AZURE_ENV_NAME)
-      AZURE_LOCATION: $(AZURE_LOCATION)
 
   - task: AzureCLI@2
     displayName: Deploy Application

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_no_app_host_-_variables_and_secrets.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_azdo_selected_-_no_app_host_-_variables_and_secrets.snap
@@ -35,8 +35,6 @@ steps:
         azd provision --no-prompt
     env:
       AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
-      AZURE_ENV_NAME: $(AZURE_ENV_NAME)
-      AZURE_LOCATION: $(AZURE_LOCATION)
       VAR_1: $(VAR_1)
       VAR_2: $(VAR_2)
       SECRET_1: $(SECRET_1)

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles_azureDevOpsDirectory-no_files_-_azdo_selected_-_azuredevops_dir_-_client_cred.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles_azureDevOpsDirectory-no_files_-_azdo_selected_-_azuredevops_dir_-_client_cred.snap
@@ -35,8 +35,6 @@ steps:
         azd provision --no-prompt
     env:
       AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
-      AZURE_ENV_NAME: $(AZURE_ENV_NAME)
-      AZURE_LOCATION: $(AZURE_LOCATION)
 
   - task: AzureCLI@2
     displayName: Deploy Application

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles_azureDevOpsDirectory-no_files_-_azdo_selected_-_azuredevops_dir_-_fed_Cred.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles_azureDevOpsDirectory-no_files_-_azdo_selected_-_azuredevops_dir_-_fed_Cred.snap
@@ -35,8 +35,6 @@ steps:
         azd provision --no-prompt
     env:
       AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
-      AZURE_ENV_NAME: $(AZURE_ENV_NAME)
-      AZURE_LOCATION: $(AZURE_LOCATION)
 
   - task: AzureCLI@2
     displayName: Deploy Application

--- a/cli/azd/pkg/tools/github/github.go
+++ b/cli/azd/pkg/tools/github/github.go
@@ -232,6 +232,22 @@ func ghOutputToList(output string) []string {
 	return result
 }
 
+func ghOutputToMap(output string) (map[string]string, error) {
+	lines := strings.Split(output, "\n")
+	result := map[string]string{}
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		valueParts := strings.Split(line, "\t")
+		if len(valueParts) < 2 {
+			return nil, fmt.Errorf("unexpected format to parse string to map: %s", line)
+		}
+		result[valueParts[0]] = valueParts[1]
+	}
+	return result, nil
+}
+
 func (cli *Cli) ListSecrets(ctx context.Context, repoSlug string) ([]string, error) {
 	runArgs := cli.newRunArgs("-R", repoSlug, "secret", "list")
 	output, err := cli.run(ctx, runArgs)
@@ -241,13 +257,13 @@ func (cli *Cli) ListSecrets(ctx context.Context, repoSlug string) ([]string, err
 	return ghOutputToList(output.Stdout), nil
 }
 
-func (cli *Cli) ListVariables(ctx context.Context, repoSlug string) ([]string, error) {
+func (cli *Cli) ListVariables(ctx context.Context, repoSlug string) (map[string]string, error) {
 	runArgs := cli.newRunArgs("-R", repoSlug, "variable", "list")
 	output, err := cli.run(ctx, runArgs)
 	if err != nil {
 		return nil, fmt.Errorf("failed running gh secret list: %w", err)
 	}
-	return ghOutputToList(output.Stdout), nil
+	return ghOutputToMap(output.Stdout)
 }
 
 func (cli *Cli) SetSecret(ctx context.Context, repoSlug string, name string, value string) error {

--- a/cli/azd/resources/pipeline/.azdo/azure-dev.ymlt
+++ b/cli/azd/resources/pipeline/.azdo/azure-dev.ymlt
@@ -53,8 +53,6 @@ steps:
         azd provision --no-prompt
     env:
       AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
-      AZURE_ENV_NAME: $(AZURE_ENV_NAME)
-      AZURE_LOCATION: $(AZURE_LOCATION)
 {{- range $variable := .Variables }}
       {{ $variable }}: $({{ $variable }})
 {{- end}}


### PR DESCRIPTION
During pipeline config, AZD ask confirmation before overriding variables or secrets.
This change provides a better and easier control for variables/secrets during pipelines config. For example, users can manually override CI secrets/variables from GitHub UI and then ask AZD to ignore setting them again.