### PR TITLE
compose - Fix Bicep generation for implicit key vault resource

### DIFF
--- a/cli/azd/pkg/project/scaffold_gen.go
+++ b/cli/azd/pkg/project/scaffold_gen.go
@@ -185,6 +185,9 @@ func infraSpec(projectConfig *ProjectConfig) (*scaffold.InfraSpec, error) {
 		}
 	}
 
+	// Re-calculate keys to include any added dependent resources
+	keys = slices.Sorted(maps.Keys(resources))
+
 	for _, k := range keys {
 		res := resources[k]
 		if res.Existing {


### PR DESCRIPTION
Fix bug where the Bicep for the compose Key Vault isn't being generated if it isn't present in **azure.yaml** but a resource implicitly depends on it.

In this example, since both Postgres and Redis require a Key Vault, the generated Bicep should include a Key Vault resource.

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/alpha/azure.yaml.json

name: minimal
metadata:
    template: azd-init@0.0.0-dev.0
services:
    minimal:
        project: .
        host: containerapp
        language: python
resources:
    minimal:
        type: host.containerapp
        uses:
            - psql
            - redis
        port: 80
    psql:
        type: db.postgres
    redis:
        type: db.redis
```

This used to work but may have been affected by #4943.