### PR TITLE
Fix for Aspire projects with containers but not projects

### DIFF
--- a/cli/azd/pkg/project/service_target_dotnet_containerapp.go
+++ b/cli/azd/pkg/project/service_target_dotnet_containerapp.go
@@ -117,14 +117,6 @@ func (at *dotnetContainerAppTarget) Deploy(
 		return nil, fmt.Errorf("validating target resource: %w", err)
 	}
 
-	progress.SetProgress(NewServiceProgress("Logging in to registry"))
-
-	// Login, tag & push container image to ACR
-	dockerCreds, err := at.containerHelper.Credentials(ctx, serviceConfig, targetResource)
-	if err != nil {
-		return nil, fmt.Errorf("logging in to registry: %w", err)
-	}
-
 	progress.SetProgress(NewServiceProgress("Pushing container image"))
 
 	var remoteImageName string
@@ -157,6 +149,14 @@ func (at *dotnetContainerAppTarget) Deploy(
 	} else if serviceConfig.DotNetContainerApp.ContainerImage != "" {
 		remoteImageName = serviceConfig.DotNetContainerApp.ContainerImage
 	} else {
+		progress.SetProgress(NewServiceProgress("Logging in to registry"))
+
+		// Login, tag & push container image to ACR
+		dockerCreds, err := at.containerHelper.Credentials(ctx, serviceConfig, targetResource)
+		if err != nil {
+			return nil, fmt.Errorf("logging in to registry: %w", err)
+		}
+
 		imageName := fmt.Sprintf("%s:%s",
 			at.containerHelper.DefaultImageName(serviceConfig),
 			at.containerHelper.DefaultImageTag())


### PR DESCRIPTION
AZD was trying to login to Azure Container Registry before deploying Aspire services (either a project or a container).
This was a bug because for containers, Aspire supports public images and provides the ACA definition which is not required to push to ACR.

This change moves logging in to ACR only for doing Dotnet publish for Aspire projects.

Fix: https://github.com/dotnet/aspire/issues/8422
