### PR TITLE
Make sure to always use latest static-web-apps CLI npm package

### DIFF
--- a/cli/azd/pkg/exec/util_test.go
+++ b/cli/azd/pkg/exec/util_test.go
@@ -209,9 +209,9 @@ func TestRedactSensitiveData(t *testing.T) {
 
 		{scenario: "SWADeploymentToken",
 			// nolint:lll
-			input: `npx -y @azure/static-web-apps-cli@1.0.6 deploy --tenant-id abc-123 --subscription-id abc-123 --resource-group r --app-name app-name --app-location / --output-location . --env default --no-use-keychain --deployment-token abc-123`,
+			input: `npx -y @azure/static-web-apps-cli@latest deploy --tenant-id abc-123 --subscription-id abc-123 --resource-group r --app-name app-name --app-location / --output-location . --env default --no-use-keychain --deployment-token abc-123`,
 			// nolint:lll
-			expected: `npx -y @azure/static-web-apps-cli@1.0.6 deploy --tenant-id abc-123 --subscription-id abc-123 --resource-group r --app-name app-name --app-location / --output-location . --env default --no-use-keychain --deployment-token <redacted>`},
+			expected: `npx -y @azure/static-web-apps-cli@latest deploy --tenant-id abc-123 --subscription-id abc-123 --resource-group r --app-name app-name --app-location / --output-location . --env default --no-use-keychain --deployment-token <redacted>`},
 
 		{scenario: "DockerLoginUsernameAndPassword",
 			input:    `docker login --username crusername123 --password abc123 some.azurecr.io`,

--- a/cli/azd/pkg/tools/swa/swa.go
+++ b/cli/azd/pkg/tools/swa/swa.go
@@ -17,7 +17,7 @@ import (
 )
 
 // swaCliPackage is the npm package (including the version version) we execute with npx to run the SWA CLI.
-const swaCliPackage = "@azure/static-web-apps-cli@2.0.5"
+const swaCliPackage = "@azure/static-web-apps-cli@latest"
 
 var _ tools.ExternalTool = (*Cli)(nil)
 


### PR DESCRIPTION
This change makes sure that the `latest` tag is used when calling the static-web-apps NPM package when using `az deploy` with a StaticWebApp resource. This ensures that the latest version of the package is always used, which is beneficial because it ensures that the latest features and bug fixes are always included in the deployment process. 