### PR TITLE
Unwrap golobby errors and check for container error

### DIFF
--- a/cli/azd/pkg/ioc/container.go
+++ b/cli/azd/pkg/ioc/container.go
@@ -301,6 +301,12 @@ func (c *NestedContainer) NewScopeRegistrationsOnly() (*NestedContainer, error) 
 // developer container registration error or an error that was
 // returned while instantiating a dependency.
 func inspectResolveError(err error) error {
+	// Unwrap the current error
+	if unwrapped := errors.Unwrap(err); unwrapped != nil {
+		err = unwrapped
+	}
+
+	// If the unwrapped error is still a container error then return ErrResolveInstance
 	if containerErrorRegex.Match([]byte(err.Error())) {
 		return fmt.Errorf("%w: %w", ErrResolveInstance, err)
 	}

--- a/cli/azd/pkg/ioc/container_test.go
+++ b/cli/azd/pkg/ioc/container_test.go
@@ -49,7 +49,7 @@ func Test_Container_Resolve(t *testing.T) {
 		err := container.Resolve(&instance)
 
 		require.Error(t, err)
-		require.True(t, errors.Is(err, ErrResolveInstance))
+		require.False(t, errors.Is(err, ErrResolveInstance))
 		require.True(t, errors.Is(err, azdcontext.ErrNoProject))
 	})
 }


### PR DESCRIPTION
Fixes #5198 

Before upgrading the `golobby/container` package the package was not wrapping errors when there was a container resolution failure.

**Root Cause golobby change:**
https://github.com/golobby/container/compare/v3.3.1...master#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL242

With the recent update the are wrapping all errors and now we need to unwrap the error to determine if the root error was still a container related configuration issue or another error returns by the component initializer/constructor.

We are also able to revert the previous change that was not a full fix for the original issue:
https://github.com/Azure/azure-dev/pull/5065/files#diff-b03e5b88fe3c56354b85e98942a63eff1755fe891f4ccc81ead0088a6f52577eL52