### PR TITLE
package: support ignore files for zip deploy

### DIFF
--- a/.vscode/cspell-github-user-aliases.txt
+++ b/.vscode/cspell-github-user-aliases.txt
@@ -10,6 +10,7 @@ braydonk
 briandowns
 buger
 cobey
+denormal
 dnaeon
 eerhardt
 ellismg

--- a/cli/azd/.vscode/cspell-azd-dictionary.txt
+++ b/cli/azd/.vscode/cspell-azd-dictionary.txt
@@ -113,6 +113,7 @@ flexconsumption
 Frontends
 fsnotify
 funcapp
+funcignore
 functionapp
 gjson
 go-imath
@@ -244,6 +245,7 @@ utsname
 vite
 vsrpc
 vuejs
+webappignore
 webfrontend
 westus2
 wireinject

--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -70,7 +70,7 @@ overrides:
   - filename: pkg/spin/run.go
     words:
       - errored
-  - filename: pkg/project/framework_service_python.go
+  - filename: pkg/project/project_utils.go
     words:
       - __pycache__
       - Venv

--- a/cli/azd/pkg/project/project_utils.go
+++ b/cli/azd/pkg/project/project_utils.go
@@ -4,26 +4,95 @@
 package project
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/rzip"
-	"github.com/otiai10/copy"
+	"github.com/denormal/go-gitignore"
 )
 
 // CreateDeployableZip creates a zip file of a folder, recursively.
 // Returns the path to the created zip file or an error if it fails.
-func createDeployableZip(projectName string, appName string, path string) (string, error) {
-	// TODO: should probably avoid picking up files that weren't meant to be deployed (ie, local .env files, etc..)
-	filePath := filepath.Join(os.TempDir(), fmt.Sprintf("%s-%s-azddeploy-%d.zip", projectName, appName, time.Now().Unix()))
+func createDeployableZip(svc *ServiceConfig, root string) (string, error) {
+	filePath := filepath.Join(
+		os.TempDir(),
+		fmt.Sprintf("%s-%s-azddeploy-%d.zip", svc.Project.Name, svc.Name, time.Now().Unix()))
 	zipFile, err := os.Create(filePath)
 	if err != nil {
-		return "", fmt.Errorf("failed when creating zip package to deploy %s: %w", appName, err)
+		return "", fmt.Errorf("failed when creating zip package to deploy %s: %w", svc.Name, err)
 	}
 
-	if err := rzip.CreateFromDirectory(path, zipFile); err != nil {
+	ignoreFile := svc.Host.IgnoreFile()
+	var ignorer gitignore.GitIgnore
+	if ignoreFile != "" {
+		ig, err := gitignore.NewFromFile(filepath.Join(root, ignoreFile))
+		if !errors.Is(err, fs.ErrNotExist) && err != nil {
+			return "", fmt.Errorf("reading ignore file: %w", err)
+		}
+
+		ignorer = ig
+	}
+
+	// apply exclusions for zip deployment
+	onZip := func(src string, info os.FileInfo) (bool, error) {
+		name := info.Name()
+		isDir := info.IsDir()
+
+		// resolve symlink if needed
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Stat(src)
+			if err != nil {
+				return false, err
+			}
+			isDir = target.IsDir()
+		}
+
+		if name == ".azure" && isDir {
+			return false, nil
+		}
+
+		if name == ignoreFile && !isDir {
+			return false, nil
+		}
+
+		// host specific exclusions
+		if svc.Host == AzureFunctionTarget {
+			if name == "local.settings.json" && !isDir {
+				return false, nil
+			}
+		}
+
+		// apply exclusions from ignore file
+		if ignorer != nil && ignorer.Absolute(src, isDir) != nil {
+			return false, nil
+		} else if ignorer == nil { // default exclusions without ignorefile control
+			if svc.Language == ServiceLanguagePython {
+				if isDir {
+					// check for .venv containing pyvenv.cfg
+					if _, err := os.Stat(filepath.Join(src, "pyvenv.cfg")); err == nil {
+						return false, nil
+					}
+
+					if strings.ToLower(name) == "__pycache__" {
+						return false, nil
+					}
+				}
+			} else if svc.Language == ServiceLanguageJavaScript || svc.Language == ServiceLanguageTypeScript {
+				if name == "node_modules" && isDir {
+					return false, nil
+				}
+			}
+		}
+
+		return true, nil
+	}
+
+	if err := rzip.CreateFromDirectory(root, zipFile, onZip); err != nil {
 		// if we fail here just do our best to close things out and cleanup
 		zipFile.Close()
 		os.Remove(zipFile.Name())
@@ -37,37 +106,4 @@ func createDeployableZip(projectName string, appName string, path string) (strin
 	}
 
 	return zipFile.Name(), nil
-}
-
-// excludeDirEntryCondition resolves when a file or directory should be considered or not as part of build, when build is a
-// copy-paste source strategy. Return true to exclude the directory entry.
-type excludeDirEntryCondition func(path string, file os.FileInfo) bool
-
-// buildForZipOptions provides a set of options for doing build for zip
-type buildForZipOptions struct {
-	excludeConditions []excludeDirEntryCondition
-}
-
-// buildForZip is use by projects which build strategy is to only copy the source code into a folder which is later
-// zipped for packaging. For example Python and Node framework languages. buildForZipOptions provides the specific
-// details for each language which should not be ever copied.
-func buildForZip(src, dst string, options buildForZipOptions) error {
-
-	// these exclude conditions applies to all projects
-	options.excludeConditions = append(options.excludeConditions, globalExcludeAzdFolder)
-
-	return copy.Copy(src, dst, copy.Options{
-		Skip: func(srcInfo os.FileInfo, src, dest string) (bool, error) {
-			for _, checkExclude := range options.excludeConditions {
-				if checkExclude(src, srcInfo) {
-					return true, nil
-				}
-			}
-			return false, nil
-		},
-	})
-}
-
-func globalExcludeAzdFolder(path string, file os.FileInfo) bool {
-	return file.IsDir() && file.Name() == ".azure"
 }

--- a/cli/azd/pkg/project/service_target.go
+++ b/cli/azd/pkg/project/service_target.go
@@ -133,6 +133,19 @@ func resourceTypeMismatchError(
 	)
 }
 
+// IgnoreFile returns the ignore file associated with the service target.
+// Returns an empty string if no ignore file is used.
+func (st ServiceTargetKind) IgnoreFile() string {
+	switch st {
+	case AppServiceTarget:
+		return ".webappignore"
+	case AzureFunctionTarget:
+		return ".funcignore"
+	default:
+		return ""
+	}
+}
+
 // SupportsDelayedProvisioning returns true if the service target kind
 // supports delayed provisioning resources at deployment time, otherwise false.
 //

--- a/cli/azd/pkg/project/service_target_appservice.go
+++ b/cli/azd/pkg/project/service_target_appservice.go
@@ -51,8 +51,7 @@ func (st *appServiceTarget) Package(
 ) (*ServicePackageResult, error) {
 	progress.SetProgress(NewServiceProgress("Compressing deployment artifacts"))
 	zipFilePath, err := createDeployableZip(
-		serviceConfig.Project.Name,
-		serviceConfig.Name,
+		serviceConfig,
 		packageOutput.PackagePath,
 	)
 	if err != nil {

--- a/cli/azd/pkg/project/service_target_functionapp.go
+++ b/cli/azd/pkg/project/service_target_functionapp.go
@@ -53,8 +53,7 @@ func (f *functionAppTarget) Package(
 ) (*ServicePackageResult, error) {
 	progress.SetProgress(NewServiceProgress("Compressing deployment artifacts"))
 	zipFilePath, err := createDeployableZip(
-		serviceConfig.Project.Name,
-		serviceConfig.Name,
+		serviceConfig,
 		packageOutput.PackagePath,
 	)
 	if err != nil {

--- a/cli/azd/test/functional/package_test.go
+++ b/cli/azd/test/functional/package_test.go
@@ -4,9 +4,13 @@
 package cli_test
 
 import (
+	"archive/zip"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
@@ -67,6 +71,126 @@ func Test_CLI_Package_FromServiceDirectory(t *testing.T) {
 	result, err := cli.RunCommand(ctx, "package")
 	require.NoError(t, err)
 	require.Contains(t, result.Stdout, "Packaging service web")
+}
+
+func Test_CLI_Package_ZipDeploy_Exclusions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		subdir        string
+		files         map[string]string
+		expectedFiles []string
+	}{
+		{
+			name:   "PythonApp_ExcludesVenvAndCache",
+			subdir: "pyapp",
+			files: map[string]string{
+				".venv/pyvenv.cfg": "py - virtual env",
+				"__pycache__/file": "pycache file",
+			},
+			expectedFiles: []string{"requirements.txt"},
+		},
+		{
+			name:   "PythonApp_WebAppIgnore",
+			subdir: "pyapp",
+			files: map[string]string{
+				// exclude everything except __pycache__
+				".webappignore": ".venv/\ntest.log\ntests/**",
+
+				".venv/pyvenv.cfg": "py - virtual env",
+				"__pycache__/file": "pycache file",
+				"log/test.log":     "some log file",
+				"tests/some.py":    "some test file",
+			},
+			expectedFiles: []string{"requirements.txt", "__pycache__/file"},
+		},
+		{
+			name:   "PythonApp_FuncIgnore",
+			subdir: "funcapp",
+			files: map[string]string{
+				// exclude everything except __pycache__
+				".funcignore": ".venv/\ntest.log\ntests/**",
+
+				"local.settings.json":             "local settings -- always ignored",
+				"other/other/local.settings.json": "local settings -- always ignored",
+
+				".venv/pyvenv.cfg": "py - virtual env",
+				"__pycache__/file": "pycache file",
+				"log/test.log":     "some log file",
+				"tests/some.py":    "some test file",
+			},
+			expectedFiles: []string{"requirements.txt", "host.json", "__pycache__/file"},
+		},
+		{
+			name:   "Npm_ExcludeNodeModules",
+			subdir: "nodeapp",
+			files: map[string]string{
+				"node_modules/file": "file.txt",
+			},
+			expectedFiles: []string{"package.json", "package-lock.json"},
+		},
+		{
+			name:   "Npm_WebAppIgnore",
+			subdir: "nodeapp",
+			files: map[string]string{
+				".webappignore": "node_modules/\ntest.log",
+
+				"log/test.log": "some log file",
+				"src/some.js":  "some test file",
+
+				"node_modules/file": "file.txt",
+			},
+			expectedFiles: []string{"package.json", "package-lock.json", "src/some.js"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := newTestContext(t)
+			defer cancel()
+
+			dir := tempDirWithDiagnostics(t)
+			t.Logf("DIR: %s", dir)
+
+			err := copySample(dir, "restoreapp")
+			require.NoError(t, err, "failed expanding sample")
+
+			cli := azdcli.NewCLI(t)
+			cli.Env = append(os.Environ(), "AZURE_LOCATION=eastus2")
+			cli.WorkingDirectory = dir
+
+			envName := randomEnvName()
+			t.Logf("AZURE_ENV_NAME: %s", envName)
+
+			_, err = cli.RunCommandWithStdIn(ctx, stdinForInit(envName), "init")
+			require.NoError(t, err)
+
+			appDir := filepath.Join(dir, tc.subdir)
+			setupFiles(t, appDir, tc.files)
+
+			cli.WorkingDirectory = appDir
+			outputZip := filepath.Join(dir, "dist", tc.name+".zip")
+			_, err = cli.RunCommand(ctx, "package", "--output-path", outputZip)
+			require.NoError(t, err)
+
+			checkFiles(t, outputZip, tc.expectedFiles)
+		})
+	}
+}
+
+// setupFiles writes files to the filesystem based on the provided map of filepaths and their contents.
+// Directories are created automatically if they do not yet exist.
+// All files and directories are placed under the provided root.
+func setupFiles(t *testing.T, root string, files map[string]string) {
+	for path, content := range files {
+		fullPath := filepath.Join(root, path)
+		err := os.MkdirAll(filepath.Dir(fullPath), 0755)
+		require.NoError(t, err)
+
+		err = os.WriteFile(fullPath, []byte(content), 0600)
+		require.NoError(t, err)
+	}
 }
 
 func Test_CLI_Package_WithOutputPath(t *testing.T) {
@@ -162,4 +286,49 @@ func Test_CLI_Package(t *testing.T) {
 	packageResult, err := cli.RunCommand(ctx, "package", "web")
 	require.NoError(t, err)
 	require.Contains(t, packageResult.Stdout, fmt.Sprintf("Package Output: %s", os.TempDir()))
+}
+
+func checkFiles(
+	t *testing.T,
+	zipFilePath string,
+	expectedFiles []string) {
+	zipFile, err := os.Open(zipFilePath)
+	require.NoError(t, err, "opening zip file")
+
+	// Reopen the zip file for reading
+	_, err = zipFile.Seek(0, 0)
+	require.NoError(t, err, "failed to seek to start of zip file")
+	zipInfo, err := zipFile.Stat()
+	require.NoError(t, err, "failed to get zip file info")
+	zipReader, err := zip.NewReader(zipFile, zipInfo.Size())
+	require.NoError(t, err, "failed to open zip for reading")
+
+	entries := map[string]struct{}{}
+	for _, f := range expectedFiles {
+		entries[f] = struct{}{}
+	}
+
+	for _, zipFile := range zipReader.File {
+		_, exists := entries[zipFile.Name]
+		if !exists {
+			t.Errorf("unexpected file in zip: %s", zipFile.Name)
+			continue
+		}
+
+		delete(entries, zipFile.Name)
+	}
+
+	if len(entries) > 0 {
+		t.Errorf("missing files:\n%v", formatFiles(entries))
+	}
+}
+
+func formatFiles(files map[string]struct{}) string {
+	var sb strings.Builder
+	keys := slices.Collect(maps.Keys(files))
+	slices.Sort(keys)
+	for _, path := range keys {
+		sb.WriteString(fmt.Sprintf("- %s\n", path))
+	}
+	return sb.String()
 }

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/braydonk/yaml v0.9.0
 	github.com/buger/goterm v1.0.4
 	github.com/cli/browser v1.3.0
+	github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817
 	github.com/drone/envsubst v1.0.3
 	github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203
 	github.com/fatih/color v1.18.0
@@ -87,6 +88,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.1.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,9 +100,13 @@ github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEf
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5EPKqaS1UYVg1uYah5Xf51mBfIoWehClUQ=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964/go.mod h1:Xd9hchkHSWYkEqJwUGisez3G1QY8Ryz0sdWrLPMGjLk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817 h1:0nsrg//Dc7xC74H/TZ5sYR8uk4UQRNjsw8zejqH5a4Q=
+github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817/go.mod h1:C/+sI4IFnEpCn6VQ3GIPEp+FrQnQw+YQP3+n+GdGq7o=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/drone/envsubst v1.0.3 h1:PCIBwNDYjs50AsLZPYdfhSATKaRg/FJmDc2D6+C2x8g=


### PR DESCRIPTION
Support `.webappignore` and `.funcignore` files for zip deploy with behavior described in #4381.

Other notable changes:
1. For function apps, `local.settings.json` is always excluded from the zip package. This makes the behavior consistent with Azure Function Core Tools (`func`).
2. Improve packaging performance slightly for python and npm applications by skipping an extra copy-to-staging step. Notably, this also centralizes the logic of zip deploy packaging for different apps.
3. Add surrounding tests for the behavioral changes.

Addresses #4381, #1039, #4215 