### PR TITLE
Get az account to get principal type for legacy auth

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -60,6 +60,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
 	"github.com/azure/azure-dev/cli/azd/pkg/state"
 	"github.com/azure/azure-dev/cli/azd/pkg/templates"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/az"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/docker"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/dotnet"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/git"
@@ -625,6 +626,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.MustRegisterSingleton(swa.NewCli)
 	container.MustRegisterScoped(ai.NewPythonBridge)
 	container.MustRegisterScoped(project.NewAiHelper)
+	container.MustRegisterSingleton(az.NewCli)
 
 	// Provisioning
 	container.MustRegisterSingleton(func(

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -33,6 +33,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/az"
 	"github.com/cli/browser"
 )
 
@@ -98,6 +99,7 @@ type Manager struct {
 	httpClient          HttpClient
 	console             input.Console
 	externalAuthCfg     ExternalAuthConfiguration
+	azCli               az.AzCli
 }
 
 type ExternalAuthConfiguration struct {
@@ -113,6 +115,7 @@ func NewManager(
 	httpClient HttpClient,
 	console input.Console,
 	externalAuthCfg ExternalAuthConfiguration,
+	azCli az.AzCli,
 ) (*Manager, error) {
 	cfgRoot, err := config.GetUserConfigDir()
 	if err != nil {
@@ -158,6 +161,7 @@ func NewManager(
 		httpClient:          httpClient,
 		console:             console,
 		externalAuthCfg:     externalAuthCfg,
+		azCli:               azCli,
 	}, nil
 }
 
@@ -1154,6 +1158,32 @@ type LogInDetails struct {
 
 // LogInDetails method for Manager to return login details
 func (m *Manager) LogInDetails(ctx context.Context) (*LogInDetails, error) {
+	userConfig, err := m.userConfigManager.Load()
+	if err != nil {
+		return nil, fmt.Errorf("reading user config: %w", err)
+	}
+
+	if shouldUseLegacyAuth(userConfig) {
+		log.Printf("delegating auth to az since %s is set to true", useAzCliAuthKey)
+
+		if err := m.azCli.CheckInstalled(); err != nil {
+			return nil, fmt.Errorf("checking az cli installation (using legacy auth): %w", err)
+		}
+
+		logInType := EmailLoginType
+		azAccount, err := m.azCli.Account(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("fetching az cli account: %w", err)
+		}
+		if azAccount.User.Type != "user" {
+			logInType = ClientIdLoginType
+		}
+		return &LogInDetails{
+			LoginType: logInType,
+			Account:   azAccount.User.Name,
+		}, nil
+	}
+
 	cfg, err := m.readAuthConfig()
 	if err != nil {
 		return nil, fmt.Errorf("fetching current user: %w", err)

--- a/cli/azd/pkg/tools/az/az.go
+++ b/cli/azd/pkg/tools/az/az.go
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package az
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/tools"
+)
+
+func NewCli(
+	commandRunner exec.CommandRunner,
+) (AzCli, error) {
+	return AzCli{
+		runner: commandRunner,
+	}, nil
+}
+
+type AzCli struct {
+	runner exec.CommandRunner
+}
+
+func (az AzCli) CheckInstalled() error {
+	return tools.ToolInPath("az")
+}
+
+type AzAccountUser struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type AzAccountResponse struct {
+	User AzAccountUser `json:"user"`
+}
+
+func (az AzCli) Account(ctx context.Context) (AzAccountResponse, error) {
+	cmd := exec.NewRunArgs("az", "account", "show", "--output", "json")
+
+	output, err := az.runner.Run(ctx, cmd)
+	if err != nil {
+		return AzAccountResponse{}, err
+	}
+
+	if strings.Contains(output.Stderr, "az login") || strings.Contains(output.Stdout, "az login") {
+		return AzAccountResponse{}, fmt.Errorf("az is not authenticated.")
+	}
+
+	var accountResponse AzAccountResponse
+	if err := json.Unmarshal([]byte(output.Stdout), &accountResponse); err != nil {
+		return AzAccountResponse{}, err
+	}
+
+	return accountResponse, nil
+}


### PR DESCRIPTION
fix: https://github.com/Azure/azure-dev/issues/5390

This change fix finding the principal type when legacy auth is enabled by calling `az account`