### PR TITLE
test: parallelize vs tests, fix flakiness

### DIFF
--- a/cli/azd/test/functional/env_test.go
+++ b/cli/azd/test/functional/env_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -36,9 +37,12 @@ func Test_CLI_EnvCommandsWorkWhenLoggedOut(t *testing.T) {
 	envNew(ctx, t, cli, "env1", true)
 	envNew(ctx, t, cli, "env2", true)
 
-	// set a private config dir, this well ensure we are logged out.
+	// set a private config dir, this will ensure we are logged out.
 	configDir := t.TempDir()
-	t.Setenv("AZD_CONFIG_DIR", configDir)
+	cli.Env = append(cli.Env, os.Environ()...)
+	cli.Env = append(cli.Env, "AZD_CONFIG_DIR="+configDir)
+	// disable telemetry that would write to the temporary directory we create here
+	cli.Env = append(cli.Env, "AZURE_DEV_COLLECT_TELEMETRY=no")
 
 	// check to make sure we are logged out as expected.
 	res, err := cli.RunCommand(ctx, "auth", "login", "--check-status", "--output", "json")

--- a/cli/azd/test/functional/vs_server_test.go
+++ b/cli/azd/test/functional/vs_server_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func Test_CLI_VsServerExternalAuth(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := newTestContext(t)
 	defer cancel()
 
@@ -139,6 +141,8 @@ func Test_CLI_VsServerExternalAuth(t *testing.T) {
 }
 
 func Test_CLI_VsServer(t *testing.T) {
+	t.Parallel()
+
 	testDir := filepath.Join("testdata", "vs-server", "tests")
 	// List all tests
 	var stdout, stderr bytes.Buffer

--- a/eng/pipelines/templates/jobs/build-cli.yml
+++ b/eng/pipelines/templates/jobs/build-cli.yml
@@ -141,6 +141,12 @@ jobs:
           # Code Coverage: Generate junit report to publish results
           GOTESTSUM_JUNITFILE: junitTestReport.xml
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          # Disable MSBuild node reuse for Aspire-related tests.
+          # MSBuild node reuse is a pure performance optimization that is generally recommended to be disabled on CI environments
+          # that deal with short-lived processes.
+          #
+          # Without this disabled, we often see tests failing due to MSBuild worker processes being shared across concurrent tests.
+          MSBUILDDISABLENODEREUSE: 1
 
       - task: PublishTestResults@2
         inputs:


### PR DESCRIPTION
Run VsServer tests in parallel.

Also, 
1. Fix flakiness in Test_CLI_EnvCommandsWorkWhenLoggedOut
2. Fix flakiness when multiple Aspire related tests run in parallel

Addresses #5392