### PR TITLE
auth: add support for generic oidc

### DIFF
--- a/cli/azd/cmd/auth_login.go
+++ b/cli/azd/cmd/auth_login.go
@@ -163,7 +163,8 @@ func (lf *loginFlags) Bind(local *pflag.FlagSet, global *internal.GlobalCommandO
 		&lf.federatedTokenProvider,
 		cFederatedCredentialProviderFlagName,
 		"",
-		"The provider to use to acquire a federated token to authenticate with.")
+		"The provider to use to acquire a federated token to authenticate with. "+
+			"Supported values: github, azure-pipelines, oidc")
 	local.StringVar(
 		&lf.tenantID,
 		"tenant-id",
@@ -529,6 +530,12 @@ func (la *loginAction) login(ctx context.Context) error {
 
 			if _, err := la.authManager.LoginWithAzurePipelinesFederatedTokenProvider(
 				ctx, la.flags.tenantID, la.flags.clientID, serviceConnectionID,
+			); err != nil {
+				return fmt.Errorf("logging in: %w", err)
+			}
+		case la.flags.federatedTokenProvider == "oidc": // generic oidc provider
+			if _, err := la.authManager.LoginWithOidcFederatedTokenProvider(
+				ctx, la.flags.tenantID, la.flags.clientID,
 			); err != nil {
 				return fmt.Errorf("logging in: %w", err)
 			}

--- a/cli/azd/cmd/testdata/TestUsage-azd-auth-login.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-auth-login.snap
@@ -9,7 +9,7 @@ Flags
         --client-certificate string            	: The path to the client certificate for the service principal to authenticate with.
         --client-id string                     	: The client id for the service principal to authenticate with.
         --client-secret string                 	: The client secret for the service principal to authenticate with. Set to the empty string to read the value from the console.
-        --federated-credential-provider string 	: The provider to use to acquire a federated token to authenticate with.
+        --federated-credential-provider string 	: The provider to use to acquire a federated token to authenticate with. Supported values: github, azure-pipelines, oidc
         --managed-identity                     	: Use a managed identity to authenticate.
         --redirect-port int                    	: Choose the port to be used as part of the redirect URI during interactive login.
         --tenant-id string                     	: The tenant id or domain name to authenticate with.

--- a/cli/azd/pkg/auth/federated_token_client_test.go
+++ b/cli/azd/pkg/auth/federated_token_client_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-package github
+package auth
 
 import (
 	"bytes"
@@ -16,9 +16,6 @@ import (
 )
 
 func TestTokenForAudience(t *testing.T) {
-	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "http://localhost/api/token")
-	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "fake-token")
-
 	mockContext := mocks.NewMockContext(context.Background())
 
 	var req http.Request
@@ -30,9 +27,12 @@ func TestTokenForAudience(t *testing.T) {
 		Body:       io.NopCloser(bytes.NewBufferString(`{ "value": "abc" }`)),
 	})
 
-	client := NewFederatedTokenClient(&azcore.ClientOptions{
-		Transport: mockContext.HttpClient,
-	})
+	client := NewFederatedTokenClient(
+		"http://localhost/api/token",
+		"fake-token",
+		azcore.ClientOptions{
+			Transport: mockContext.HttpClient,
+		})
 
 	token, err := client.TokenForAudience(context.Background(), "api://AzureADTokenExchange")
 	require.NoError(t, err)
@@ -43,9 +43,6 @@ func TestTokenForAudience(t *testing.T) {
 }
 
 func TestTokenForAudienceDefault(t *testing.T) {
-	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "http://localhost/api/token")
-	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "fake-token")
-
 	mockContext := mocks.NewMockContext(context.Background())
 
 	var req http.Request
@@ -57,9 +54,12 @@ func TestTokenForAudienceDefault(t *testing.T) {
 		Body:       io.NopCloser(bytes.NewBufferString(`{ "value": "abc" }`)),
 	})
 
-	client := NewFederatedTokenClient(&azcore.ClientOptions{
-		Transport: mockContext.HttpClient,
-	})
+	client := NewFederatedTokenClient(
+		"http://localhost/api/token",
+		"fake-token",
+		azcore.ClientOptions{
+			Transport: mockContext.HttpClient,
+		})
 
 	token, err := client.TokenForAudience(context.Background(), "")
 	require.NoError(t, err)
@@ -70,9 +70,6 @@ func TestTokenForAudienceDefault(t *testing.T) {
 }
 
 func TestTokenForAudienceFailure(t *testing.T) {
-	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "http://localhost/api/token")
-	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "fake-token")
-
 	mockContext := mocks.NewMockContext(context.Background())
 
 	mockContext.HttpClient.When(func(request *http.Request) bool {
@@ -82,9 +79,12 @@ func TestTokenForAudienceFailure(t *testing.T) {
 		Body:       io.NopCloser(bytes.NewBufferString("")),
 	})
 
-	client := NewFederatedTokenClient(&azcore.ClientOptions{
-		Transport: mockContext.HttpClient,
-	})
+	client := NewFederatedTokenClient(
+		"http://localhost/api/token",
+		"fake-token",
+		azcore.ClientOptions{
+			Transport: mockContext.HttpClient,
+		})
 
 	_, err := client.TokenForAudience(context.Background(), "api://AzureADTokenExchange")
 	require.Error(t, err)

--- a/cli/azd/pkg/auth/manager_test.go
+++ b/cli/azd/pkg/auth/manager_test.go
@@ -15,7 +15,6 @@ import (
 
 	_ "embed"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
@@ -23,7 +22,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
-	"github.com/azure/azure-dev/cli/azd/pkg/github"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/az"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
@@ -146,11 +144,8 @@ func TestServicePrincipalLoginFederatedTokenProvider(t *testing.T) {
 		configManager:     newMemoryConfigManager(),
 		userConfigManager: newMemoryUserConfigManager(),
 		credentialCache:   credentialCache,
-		ghClient: github.NewFederatedTokenClient(&azcore.ClientOptions{
-			Transport: mockContext.HttpClient,
-			Cloud:     cloud.AzurePublic().Configuration,
-		}),
-		cloud: cloud.AzurePublic(),
+		httpClient:        mockContext.HttpClient,
+		cloud:             cloud.AzurePublic(),
 	}
 
 	cred, err := m.LoginWithGitHubFederatedTokenProvider(context.Background(), "testClientId", "testTenantId")


### PR DESCRIPTION
Add support for generic OIDC providers, with  `azd auth login --federated-credential-provider oidc`.

Along with the flag passed, a user can set `AZURE_OIDC_TOKEN` to enable OIDC authentication with any CI provider.
In cases where a token exchange is required, `AZURE_OIDC_REQUEST_TOKEN` and `AZURE_OIDC_REQUEST_URL` dan be set.

Addresses #3242, #3304