### PR TITLE
bicep: cleanup + fix bicepparam evaluation

### DIFF
--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -118,6 +118,7 @@ func (p *BicepProvider) Initialize(ctx context.Context, projectPath string, opt 
 
 	p.projectPath = projectPath
 	p.options = opt
+	p.ignoreDeploymentState = opt.IgnoreDeploymentState
 
 	p.console.ShowSpinner(ctx, "Initialize bicep provider", input.Step)
 	err := p.EnsureEnv(ctx)
@@ -1552,13 +1553,7 @@ type loadParametersResult struct {
 // doing environment and command substitutions, and returns the values.
 func (p *BicepProvider) loadParameters(ctx context.Context) (loadParametersResult, error) {
 	parametersFilename := fmt.Sprintf("%s.parameters.json", p.options.Module)
-	parametersRoot := p.options.Path
-
-	if !filepath.IsAbs(parametersRoot) {
-		parametersRoot = filepath.Join(p.projectPath, parametersRoot)
-	}
-
-	paramFilePath := filepath.Join(parametersRoot, parametersFilename)
+	paramFilePath := filepath.Join(filepath.Dir(p.path), parametersFilename)
 	parametersBytes, err := os.ReadFile(paramFilePath)
 	// if the file does not exist, we return an empty parameters map
 	// This makes AZD to support deploying bicep modules without parameters file, assuming AZD prompts for all required

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -52,8 +52,7 @@ func TestBicepPlan(t *testing.T) {
 
 	require.Nil(t, err)
 
-	require.IsType(t, &deploymentDetails{}, deploymentPlan)
-	configuredParameters := deploymentPlan.CompiledBicep.Parameters
+	configuredParameters := deploymentPlan.Parameters
 
 	require.Equal(t, infraProvider.env.GetLocation(), configuredParameters["location"].Value)
 	require.Equal(
@@ -72,8 +71,7 @@ func TestBicepPlanKeyVaultRef(t *testing.T) {
 
 	require.Nil(t, err)
 
-	require.IsType(t, &deploymentDetails{}, deploymentPlan)
-	configuredParameters := deploymentPlan.CompiledBicep.Parameters
+	configuredParameters := deploymentPlan.Parameters
 
 	require.NotEmpty(t, configuredParameters["kvSecret"])
 	require.NotNil(t, configuredParameters["kvSecret"].KeyVaultReference)
@@ -90,8 +88,7 @@ func TestBicepPlanParameterTypes(t *testing.T) {
 
 	require.Nil(t, err)
 
-	require.IsType(t, &deploymentDetails{}, deploymentPlan)
-	configuredParameters := deploymentPlan.CompiledBicep.Parameters
+	configuredParameters := deploymentPlan.Parameters
 
 	require.NotEmpty(t, configuredParameters["regularString"])
 	require.Equal(t, configuredParameters["regularString"].Value, "test")
@@ -153,7 +150,7 @@ func TestBicepPlanPrompt(t *testing.T) {
 
 	require.NoError(t, err)
 
-	require.Equal(t, "value", plan.CompiledBicep.Parameters["stringParam"].Value)
+	require.Equal(t, "value", plan.Parameters["stringParam"].Value)
 }
 
 func TestBicepState(t *testing.T) {

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -223,7 +223,7 @@ func TestBicepDestroy(t *testing.T) {
 	})
 }
 
-func TestPlanForResourceGroup(t *testing.T) {
+func TestDeploymentForResourceGroup(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
@@ -335,8 +335,11 @@ func TestPlanForResourceGroup(t *testing.T) {
 	planResult, err := infraProvider.plan(*mockContext.Context)
 	require.Nil(t, err)
 	require.NotNil(t, planResult)
+
+	deployment, err := infraProvider.generateDeploymentObject(planResult)
+	require.NoError(t, err)
 	require.Equal(t, "rg-test-env",
-		planResult.Target.(*infra.ResourceGroupDeployment).ResourceGroupName())
+		deployment.(*infra.ResourceGroupDeployment).ResourceGroupName())
 }
 
 func TestIsValueAssignableToParameterType(t *testing.T) {
@@ -425,7 +428,6 @@ func createBicepProvider(t *testing.T, mockContext *mocks.MockContext) *BicepPro
 			cloud.AzurePublic(),
 		),
 		cloud.AzurePublic(),
-		nil,
 		nil,
 	)
 
@@ -1020,12 +1022,11 @@ func TestUserDefinedTypes(t *testing.T) {
 		),
 		cloud.AzurePublic(),
 		nil,
-		nil,
 	)
 	bicepProvider, gooCast := provider.(*BicepProvider)
 	require.True(t, gooCast)
 
-	compiled, err := bicepProvider.compileBicep(*mockContext.Context, "user-defined-types")
+	compiled, err := bicepProvider.compileBicep(*mockContext.Context)
 
 	require.NoError(t, err)
 	require.NotNil(t, compiled)

--- a/cli/azd/pkg/infra/provisioning/bicep/prompt.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt.go
@@ -105,7 +105,7 @@ func (a *BicepProvider) locationsWithQuotaFor(
 	var sharedResults sync.Map
 	var wg sync.WaitGroup
 
-	azureAiServicesLocations, err := a.azureClient.GetResourceSkuLocations(
+	azureAiServicesLocations, err := a.azapi.GetResourceSkuLocations(
 		ctx, subId, "AIServices", "S0", "Standard", "accounts")
 	if err != nil {
 		return nil, fmt.Errorf("getting Azure AI Services locations: %w", err)
@@ -124,7 +124,7 @@ func (a *BicepProvider) locationsWithQuotaFor(
 		wg.Add(1)
 		go func(location string) {
 			defer wg.Done()
-			results, err := a.azureClient.GetAiUsages(ctx, subId, location)
+			results, err := a.azapi.GetAiUsages(ctx, subId, location)
 			if err != nil {
 				// log the error but don't return it
 				log.Println("error getting usage for location", location, ":", err)


### PR DESCRIPTION
Light refactoring to replace functions for retrieving module path and bicep module with upfront initialization.

Force a full `bicep build-params` to happen right before deploy. This ends up being the "right behavior" that matches closer to azd's usage of environment variables to be injected right before deployment occurs.

Fixes #4402