### PR TITLE
Fix PowerShell 7 suggestion text not showing for service-level hooks 

### DIFF
--- a/cli/azd/pkg/ext/event_dispatcher.go
+++ b/cli/azd/pkg/ext/event_dispatcher.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/internal"
 )
 
 type Event string
@@ -89,12 +91,25 @@ func (ed *EventDispatcher[T]) RaiseEvent(ctx context.Context, name Event, eventA
 
 	// Build final error string if their are any failures
 	if len(handlerErrors) > 0 {
+		// For multiple errors, join them as before
 		lines := make([]string, len(handlerErrors))
+		// If any of the errors have a suggestion, collect them
+		var suggestions []string
 		for i, err := range handlerErrors {
 			lines[i] = err.Error()
+			var errWithSuggestion *internal.ErrorWithSuggestion
+			if errors.As(err, &errWithSuggestion) && errWithSuggestion.Suggestion != "" {
+				suggestions = append(suggestions, errWithSuggestion.Suggestion)
+			}
 		}
-
-		return errors.New(strings.Join(lines, ","))
+		combinedErr := errors.New(strings.Join(lines, ","))
+		if len(suggestions) > 0 {
+			return &internal.ErrorWithSuggestion{
+				Err:        combinedErr,
+				Suggestion: strings.Join(suggestions, "\n"),
+			}
+		}
+		return combinedErr
 	}
 
 	return nil


### PR DESCRIPTION
fix #5453 

Copilot PR #5454 solves the issue by skipping the multiple error wrap process. If there're more than one error, suggestions will lose again. This PR wrap errors and suggestions if there're any.

![image](https://github.com/user-attachments/assets/563b9222-60c4-4fcc-99d7-53d7917f400d)
