### PR TITLE
[CI]: Cancel CI runs that become obsolete

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -8,6 +8,11 @@ on:
       - "go.mod"
     branches: [main]
 
+# If two events are triggered within a short time in the same PR, cancel the run of the oldest event
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/devops-ext-ci.yml
+++ b/.github/workflows/devops-ext-ci.yml
@@ -7,6 +7,11 @@ on:
       - ".github/workflows/devops-ext-ci.yml"
     branches: [main]
 
+# If two events are triggered within a short time in the same PR, cancel the run of the oldest event
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   actions: read
   contents: read

--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -7,6 +7,11 @@ on:
       - ".github/workflows/vscode-ci.yml"
     branches: [main]
 
+# If two events are triggered within a short time in the same PR, cancel the run of the oldest event
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   actions: read
   contents: read


### PR DESCRIPTION
### Change Summary
Currently, if a PR is open and a push happens, the **cli-ci** workflow will start running. If, shortly after a subsequent push on the *same* PR happens, the workflow will start running again without cancelling the previous (now obsolete) run. With these changes, the first run would be cancelled, thus **saving compute resources** (see below for quantity) that can be used to **speed up your overall CI/CD**, without sacrificing functionality, since the second run will contain the changes from the first push as well. 🌱

### Example
Here is an example of the behaviour described above: the commit `9b896ab` triggered [this](https://github.com/Azure/azure-dev/actions/runs/13643772836/) workflow run, and shortly after the commit `a28c769`, that happened on top of the first commit, triggered [this](https://github.com/Azure/azure-dev/actions/runs/13643785999/) workflow. Both workflows ran till the end, spending approximately 5 CPU minutes each. With the proposed changes, the first run would be cancelled, hence saving ~5 CPU minutes and clearing the queue for other workflows. Note that this is an example of a single concurrent run; the accumulated gain for all PRs would be higher, with a lower estimate at **1 CPU hours** over the last few months.

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Kindly let us know (here or in the email below) if you would like more details, if you want to reject the proposed changes for other reasons, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)
konstantinos.kitsios@uzh.ch