### PR TITLE
Handle secured bicep outputs

### DIFF
--- a/cli/azd/pkg/azapi/deployments.go
+++ b/cli/azd/pkg/azapi/deployments.go
@@ -287,6 +287,10 @@ type AzCliDeploymentOutput struct {
 	Value interface{} `json:"value"`
 }
 
+func (o AzCliDeploymentOutput) Secured() bool {
+	return azure.IsSecuredARMType(o.Type)
+}
+
 type AzCliDeploymentResult struct {
 	Properties AzCliDeploymentResultProperties `json:"properties"`
 }

--- a/cli/azd/pkg/azure/arm_template.go
+++ b/cli/azd/pkg/azure/arm_template.go
@@ -116,7 +116,11 @@ type ArmTemplateParameterDefinition struct {
 }
 
 func (d *ArmTemplateParameterDefinition) Secure() bool {
-	lowerCase := strings.ToLower(d.Type)
+	return IsSecuredARMType(d.Type)
+}
+
+func IsSecuredARMType(t string) bool {
+	lowerCase := strings.ToLower(t)
 	return lowerCase == "secureobject" || lowerCase == "securestring"
 }
 

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -1518,6 +1518,12 @@ func (p *BicepProvider) createOutputParameters(
 	outputParams := make(map[string]provisioning.OutputParameter, len(azureOutputParams))
 
 	for key, azureParam := range azureOutputParams {
+		if azureParam.Secured() {
+			// Secured output can't be retrieved, so we skip it.
+			// https://learn.microsoft.com/azure/azure-resource-manager/bicep/outputs?tabs=azure-powershell#secure-outputs
+			log.Println("Skipping secured output parameter:", key)
+			continue
+		}
 		var paramName string
 		canonicalCasing, found := canonicalOutputCasings[strings.ToLower(key)]
 		if found {


### PR DESCRIPTION
# Handle Secure Output Parameters in AZD

## Problem
AZD currently panics when encountering output parameters annotated with `secure()`. This causes issues when working with Bicep modules that use secure outputs.

## Solution
This PR modifies AZD to properly handle secure output parameters:
- Skip secure outputs instead of panicking
- Do not set secure outputs as variables in AZD's environment
- Maintain security by not persisting secure outputs in deployments

## Context
- Secure outputs are commonly used in nested Bicep modules
- Main modules may also use secure outputs if they're intended to be consumed by other Bicep files
- Azure does not persist secure output values in deployment objects for security reasons

## Related Issue
Fixes #5477
