### PR TITLE
Add `apiVersion` and `resourceGroup`  properties to azure.yaml schema

### DIFF
--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -95,6 +95,11 @@
                     "host"
                 ],
                 "properties": {
+                    "apiVersion": {
+                        "type": "string",
+                        "title": "Resource provider API version for deployments",
+                        "description": "Optional. The resource provider API version to use for the service. If not specified, the default SDK API version is used. Only valid when host is 'containerapp'."
+                    },
                     "resourceGroup": {
                         "type": "string",
                         "title": "Name of the Azure resource group that contains the resource",
@@ -341,6 +346,22 @@
                                     "type": "string",
                                     "description": "Optional. The path to the directory containing a single Java archive file (.jar/.ear/.war), or the path to the specific Java archive file to be included in the deployment artifact. If omitted, the CLI will detect the output directory based on the build system in-use. For maven, the default output directory 'target' is assumed."
                                 }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "not": {
+                                "properties": {
+                                    "host": {
+                                        "const": "containerapp"
+                                    }
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "apiVersion": false
                             }
                         }
                     },

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -71,6 +71,16 @@
                     "host"
                 ],
                 "properties": {
+                    "apiVersion": {
+                        "type": "string",
+                        "title": "Resource provider API version for deployments",
+                        "description": "Optional. The resource provider API version to use for the service. If not specified, the default SDK API version is used. Only valid when host is 'containerapp'."
+                    },
+                    "resourceGroup": {
+                        "type": "string",
+                        "title": "Name of the Azure resource group that contains the resource",
+                        "description": "By default, the CLI will discover the Azure resource within the default resource group. When specified, the CLI will instead find the Azure resource within the specified resource group. Supports environment variable substitution."
+                    },
                     "resourceName": {
                         "type": "string",
                         "title": "Name of the Azure resource that implements the service",
@@ -312,6 +322,22 @@
                                     "type": "string",
                                     "description": "Optional. The path to the directory containing a single Java archive file (.jar/.ear/.war), or the path to the specific Java archive file to be included in the deployment artifact. If omitted, the CLI will detect the output directory based on the build system in-use. For maven, the default output directory 'target' is assumed."
                                 }
+                            }
+                        }
+                    },
+                    {
+                        "if": {
+                            "not": {
+                                "properties": {
+                                    "host": {
+                                        "const": "containerapp"
+                                    }
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "apiVersion": false
                             }
                         }
                     },


### PR DESCRIPTION
Fixes #5472
Contributes to #5109

`apiVersion` was added in #4272, for `containerapp` services only.
<img width="1293" height="186" alt="image" src="https://github.com/user-attachments/assets/f536f30e-837f-4524-ae7e-c596ba20936a" />

`resourceGroup` was added in #3744 but only documented in the alpha schema.
<img width="1297" height="172" alt="image" src="https://github.com/user-attachments/assets/16d0001d-0661-4998-8c0f-df2216dc0c48" />
