### PR TITLE
Fail fast when deploying SWA from the root with no output folder

### DIFF
--- a/cli/azd/pkg/project/framework_service_swa.go
+++ b/cli/azd/pkg/project/framework_service_swa.go
@@ -124,6 +124,7 @@ func (p *swaProject) Package(
 	_ *async.Progress[ServiceProgress],
 ) (*ServicePackageResult, error) {
 	return &ServicePackageResult{
-		Build: buildOutput,
+		Build:   buildOutput,
+		Details: "using swa-cli.config.json",
 	}, nil
 }

--- a/cli/azd/pkg/project/service_target_staticwebapp.go
+++ b/cli/azd/pkg/project/service_target_staticwebapp.go
@@ -15,7 +15,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
-	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/swa"
 )
@@ -124,12 +123,12 @@ func (at *staticWebAppTarget) Deploy(
 			cwd == serviceConfig.Project.Path {
 			return nil, &internal.ErrorWithSuggestion{
 				Err: fmt.Errorf("service source and output folder cannot be at the root: %s", serviceConfig.RelativePath),
-				Suggestion: (&ux.MultilineMessage{Lines: []string{
+				Suggestion: strings.Join([]string{
 					"If your service is at the root of your project, next to azure.yaml, move your service to a subfolder.",
 					"Azure Static Web Apps does not support deploying from a folder that is for both the service" +
 						" source and the output folder.",
 					"Update the path of the service in azure.yaml to point to the subfolder and try deploying again.",
-				}}).ToString(""),
+				}, "\n"),
 			}
 		}
 

--- a/cli/azd/pkg/project/service_target_staticwebapp.go
+++ b/cli/azd/pkg/project/service_target_staticwebapp.go
@@ -10,10 +10,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/swa"
 )
@@ -85,7 +87,7 @@ func (at *staticWebAppTarget) Package(
 func usingSwaConfig(packageResult *ServicePackageResult) bool {
 	// The swa framework service does not set a packageOutput.PackagePath during package b/c the output
 	// is governed by the swa-cli.config.json file.
-	return packageResult.PackagePath == ""
+	return packageResult.PackagePath == "" && packageResult.Details != nil
 }
 
 // Deploys the packaged build output using the SWA CLI
@@ -117,6 +119,20 @@ func (at *staticWebAppTarget) Deploy(
 	dOptions := swa.DeployOptions{}
 	cwd := serviceConfig.Path()
 	if !usingSwaConfig(packageOutput) {
+
+		if (packageOutput.PackagePath == "" || cwd == packageOutput.PackagePath) &&
+			cwd == serviceConfig.Project.Path {
+			return nil, &internal.ErrorWithSuggestion{
+				Err: fmt.Errorf("service source and output folder cannot be at the root: %s", serviceConfig.RelativePath),
+				Suggestion: (&ux.MultilineMessage{Lines: []string{
+					"If your service is at the root of your project, next to azure.yaml, move your service to a subfolder.",
+					"Azure Static Web Apps does not support deploying from a folder that is for both the service" +
+						" source and the output folder.",
+					"Update the path of the service in azure.yaml to point to the subfolder and try deploying again.",
+				}}).ToString(""),
+			}
+		}
+
 		dOptions.AppFolderPath = serviceConfig.RelativePath
 		dOptions.OutputRelativeFolderPath = packageOutput.PackagePath
 		cwd = serviceConfig.Project.Path


### PR DESCRIPTION
fix: https://github.com/Azure/azure-dev/issues/5506

This change makes the SWA deployment to validate if users are trying to deploy a service from the root of the project (next to azure.yaml) without using an output folder for the service and fail with a details error and suggestion about it.

Azure SWA has a limitation (Azure/static-web-apps#1672) about deploying applications which source code is the output at the same time. For example, trying to deploy a single HTML file to say hello world.

The returned suggestion helps AI agents to make the required changes to the project to make deployment work.

```
ERROR: error executing step command 'deploy --all': failed deploying service 'name': Application folder path and Application Output folder path cannot be the same
If your service is at the root of your project, next to azure.yaml, move your service to a subfolder.
Azure Static Web Apps does not support deploying from a folder that is for both the service source and the output folder.
Update the path of the service in azure.yaml to point to the subfolder and try deploying again.
```