### PR TITLE
auth: handle claims challenges due to Conditional Access Evaluation

### DIFF
--- a/cli/azd/pkg/auth/azd_credential.go
+++ b/cli/azd/pkg/auth/azd_credential.go
@@ -6,12 +6,15 @@ package auth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
+	"os"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 )
 
 type azdCredential struct {
@@ -29,12 +32,29 @@ func newAzdCredential(client publicClient, account *public.Account, cloud *cloud
 }
 
 func (c *azdCredential) GetToken(ctx context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	res, err := c.client.AcquireTokenSilent(ctx, options.Scopes, public.WithSilentAccount(*c.account))
+	res, err := c.client.AcquireTokenSilent(ctx,
+		options.Scopes,
+		public.WithSilentAccount(*c.account),
+		public.WithClaims(options.Claims))
+
 	if err != nil {
 		var authFailed *AuthFailedError
 		if errors.As(err, &authFailed) {
 			if loginErr, ok := newReLoginRequiredError(authFailed.Parsed, options.Scopes, c.cloud); ok {
 				log.Println(authFailed.httpErrorDetails())
+
+				if options.Claims != "" {
+					claimsFile, err := claimsFilePath()
+					if err != nil {
+						return azcore.AccessToken{}, fmt.Errorf("getting claims path: %w", err)
+					}
+
+					err = os.WriteFile(claimsFile, []byte(options.Claims), osutil.PermissionFile)
+					if err != nil {
+						return azcore.AccessToken{}, fmt.Errorf("saving claims: %w", err)
+					}
+				}
+
 				return azcore.AccessToken{}, loginErr
 			}
 

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -105,6 +105,8 @@ func matchesLoginScopes(scopes []string, cloud *cloud.Cloud) bool {
 	}
 
 	return true
+// Marker method to indicate this as non-retriable when executed within an armruntime pipeline
+func (e *ReLoginRequiredError) NonRetriable() {
 }
 
 const authFailedPrefix string = "failed to authenticate"
@@ -169,6 +171,10 @@ func (e *AuthFailedError) parseResponse() {
 	}
 
 	e.Parsed = &er
+}
+
+// Marker method to indicate this as non-retriable when executed within an armruntime pipeline
+func (e *AuthFailedError) NonRetriable() {
 }
 
 func (e *AuthFailedError) Unwrap() error {

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -72,8 +72,11 @@ func (e *ReLoginRequiredError) init(response *AadErrorResponse, scopes []string,
 	e.errText = response.ErrorDescription
 	e.scenario = "reauthentication required"
 	e.loginCmd = "azd auth login"
-	if !matchesLoginScopes(scopes, cloud) { // if matching default login scopes, no scopes need to be specified
-		for _, scope := range scopes {
+
+	loginScopes := LoginScopesFull(cloud)
+	for _, scope := range scopes {
+		// filter out default login scopes
+		if !slices.Contains(loginScopes, scope) {
 			e.loginCmd += fmt.Sprintf(" --scope %s", scope)
 		}
 	}
@@ -95,16 +98,6 @@ func (e *ReLoginRequiredError) Error() string {
 	return e.errText
 }
 
-// matchesLoginScopes checks if the elements contained in the slice match the scopes acquired during login.
-func matchesLoginScopes(scopes []string, cloud *cloud.Cloud) bool {
-	for _, scope := range scopes {
-		_, matchLogin := loginScopesMap(cloud)[scope]
-		if !matchLogin {
-			return false
-		}
-	}
-
-	return true
 // Marker method to indicate this as non-retriable when executed within an armruntime pipeline
 func (e *ReLoginRequiredError) NonRetriable() {
 }

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -697,6 +697,25 @@ func (m *Manager) LoginInteractive(
 		acquireTokenOptions = append(acquireTokenOptions, public.WithOpenURL(options.WithOpenUrl))
 	}
 
+	claimsFile, err := claimsFilePath()
+	if err != nil {
+		return nil, err
+	}
+
+	bytes, err := os.ReadFile(claimsFile)
+	if errors.Is(err, os.ErrNotExist) {
+		// do nothing, no claims to add
+	} else if err != nil {
+		return nil, fmt.Errorf("reading claims file: %w", err)
+	} else {
+		var validJson map[string]any
+		if err := json.Unmarshal(bytes, &validJson); err == nil {
+			acquireTokenOptions = append(acquireTokenOptions, public.WithClaims(string(bytes)))
+		} else if err := os.Remove(claimsFile); err != nil { // remove file immediately if it's not valid json
+			return nil, fmt.Errorf("removing claims file '%s': %w. Remove this file manually to recover", claimsFile, err)
+		}
+	}
+
 	res, err := m.publicClient.AcquireTokenInteractive(ctx, scopes, acquireTokenOptions...)
 	if err != nil {
 		return nil, err
@@ -706,6 +725,7 @@ func (m *Manager) LoginInteractive(
 		return nil, err
 	}
 
+	_ = os.Remove(claimsFile)
 	return newAzdCredential(m.publicClient, &res.Account, m.cloud), nil
 }
 
@@ -1228,6 +1248,15 @@ func readUserProperties(cfg config.Config) (*userProperties, error) {
 	}
 
 	return &user, nil
+}
+
+func claimsFilePath() (string, error) {
+	configDir, err := config.GetUserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get config dir: %w", err)
+	}
+
+	return filepath.Join(configDir, "auth.claims"), nil
 }
 
 const (

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -160,11 +160,20 @@ func NewManager(
 	}, nil
 }
 
-// LoginScopes returns the scopes that we request an access token for when checking if a user is signed in.
+// LoginScopes returns the default scopes requested when logging in.
 func LoginScopes(cloud *cloud.Cloud) []string {
-	resourceManagerUrl := cloud.Configuration.Services[azcloud.ResourceManager].Endpoint
+	arm := cloud.Configuration.Services[azcloud.ResourceManager]
 	return []string{
-		fmt.Sprintf("%s//.default", resourceManagerUrl),
+		fmt.Sprintf("%s//.default", arm.Endpoint),
+	}
+}
+
+// LoginScopesFull returns LoginScopes and any additional equivalent scopes.
+func LoginScopesFull(cloud *cloud.Cloud) []string {
+	arm := cloud.Configuration.Services[azcloud.ResourceManager]
+	return []string{
+		fmt.Sprintf("%s//.default", arm.Endpoint),
+		fmt.Sprintf("%s//.default", strings.TrimSuffix(arm.Audience, "/")), // handle possible trailing slashes
 	}
 }
 
@@ -175,12 +184,6 @@ func (m *Manager) LoginScopes() []string {
 // Cloud returns the cloud that the manager is configured to use.
 func (m *Manager) Cloud() *cloud.Cloud {
 	return m.cloud
-}
-
-func loginScopesMap(cloud *cloud.Cloud) map[string]struct{} {
-	resourceManagerUrl := cloud.Configuration.Services[azcloud.ResourceManager].Endpoint
-
-	return map[string]struct{}{resourceManagerUrl: {}}
 }
 
 // EnsureLoggedInCredential uses the credential's GetToken method to ensure an access token can be fetched.

--- a/cli/azd/pkg/azapi/azure_deployment_error.go
+++ b/cli/azd/pkg/azapi/azure_deployment_error.go
@@ -29,13 +29,15 @@ func newErrorLine(code string, message string, inner []*DeploymentErrorLine) *De
 }
 
 type AzureDeploymentError struct {
-	Json string
+	Json  string
+	Inner error
+	Title string
 
 	Details *DeploymentErrorLine
 }
 
-func NewAzureDeploymentError(jsonErrorResponse string) *AzureDeploymentError {
-	err := &AzureDeploymentError{Json: jsonErrorResponse}
+func NewAzureDeploymentError(title string, jsonErrorResponse string) *AzureDeploymentError {
+	err := &AzureDeploymentError{Title: title, Json: jsonErrorResponse}
 	err.init()
 	return err
 }
@@ -48,15 +50,16 @@ func (e *AzureDeploymentError) init() {
 }
 
 func (e *AzureDeploymentError) Error() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("\n\n%s:\n", e.Title))
+
 	// Return the original error string if we can't parse the JSON
 	if e.Details == nil {
-		return e.Json
+		sb.WriteString(e.Json)
+		return sb.String()
 	}
 
 	lines := generateErrorOutput(e.Details)
-
-	var sb strings.Builder
-
 	for _, line := range lines {
 		sb.WriteString(fmt.Sprintln(output.WithErrorFormat(line)))
 	}

--- a/cli/azd/pkg/azapi/azure_deployment_error_test.go
+++ b/cli/azd/pkg/azapi/azure_deployment_error_test.go
@@ -29,10 +29,10 @@ func Test_Parse_Azure_ARM_Deploy_Error_04(t *testing.T) {
 
 func Test_Not_Json_Error(t *testing.T) {
 	nonJsonError := "I'm just a regular error message"
-	deploymentError := AzureDeploymentError{Json: nonJsonError}
+	deploymentError := AzureDeploymentError{Title: "Title", Json: nonJsonError}
 	errorString := deploymentError.Error()
 
-	require.Equal(t, nonJsonError, errorString)
+	require.Equal(t, "\n\nTitle:\n"+nonJsonError, errorString)
 }
 
 func assertOutputsMatch(t *testing.T, jsonPath string, expectedOutputPath string) {
@@ -47,11 +47,18 @@ func assertOutputsMatch(t *testing.T, jsonPath string, expectedOutputPath string
 	}
 
 	errorJson := string(data)
-	deploymentError := NewAzureDeploymentError(errorJson)
+	deploymentError := NewAzureDeploymentError("Title", errorJson)
 	errorString := deploymentError.Error()
 
 	actualLines := strings.Split(errorString, "\n")
 	expectedLines := strings.Split(string(expected), "\n")
+
+	titleLines := actualLines[:3]
+	actualLines = actualLines[3:]
+
+	require.Empty(t, titleLines[0])
+	require.Empty(t, titleLines[1])
+	require.Equal(t, "Title:", titleLines[2])
 
 	require.Equal(t, len(expectedLines), len(actualLines))
 

--- a/cli/azd/pkg/azapi/stack_deployments.go
+++ b/cli/azd/pkg/azapi/stack_deployments.go
@@ -264,11 +264,7 @@ func (d *StackDeployments) DeployToSubscription(
 
 	_, err = poller.PollUntilDone(ctx, nil)
 	if err != nil {
-		deploymentError := createDeploymentError(err)
-		return nil, fmt.Errorf(
-			"deploying to subscription:\n\nDeployment Error Details:\n%w",
-			deploymentError,
-		)
+		return nil, fmt.Errorf("deploying to subscription: %w", createDeploymentError(err))
 	}
 
 	return d.GetSubscriptionDeployment(ctx, subscriptionId, deploymentName)
@@ -342,11 +338,7 @@ func (d *StackDeployments) DeployToResourceGroup(
 
 	_, err = poller.PollUntilDone(ctx, nil)
 	if err != nil {
-		deploymentError := createDeploymentError(err)
-		return nil, fmt.Errorf(
-			"deploying to resource group:\n\nDeployment Error Details:\n%w",
-			deploymentError,
-		)
+		return nil, fmt.Errorf("deploying to resource group: %w", createDeploymentError(err))
 	}
 
 	return d.GetResourceGroupDeployment(ctx, subscriptionId, resourceGroup, deploymentName)

--- a/cli/azd/pkg/azapi/standard_deployments.go
+++ b/cli/azd/pkg/azapi/standard_deployments.go
@@ -235,11 +235,7 @@ func (ds *StandardDeployments) DeployToSubscription(
 	// wait for deployment creation
 	deployResult, err := createFromTemplateOperation.PollUntilDone(ctx, nil)
 	if err != nil {
-		deploymentError := createDeploymentError(err)
-		return nil, fmt.Errorf(
-			"deploying to subscription:\n\nDeployment Error Details:\n%w",
-			deploymentError,
-		)
+		return nil, fmt.Errorf("deploying to subscription: %w", createDeploymentError(err))
 	}
 
 	return ds.convertFromArmDeployment(&deployResult.DeploymentExtended), nil
@@ -275,11 +271,7 @@ func (ds *StandardDeployments) DeployToResourceGroup(
 	// wait for deployment creation
 	deployResult, err := createFromTemplateOperation.PollUntilDone(ctx, nil)
 	if err != nil {
-		deploymentError := createDeploymentError(err)
-		return nil, fmt.Errorf(
-			"deploying to resource group:\n\nDeployment Error Details:\n%w",
-			deploymentError,
-		)
+		return nil, fmt.Errorf("deploying to resource group: %w", createDeploymentError(err))
 	}
 
 	return ds.convertFromArmDeployment(&deployResult.DeploymentExtended), nil
@@ -566,11 +558,7 @@ func (ds *StandardDeployments) WhatIfDeployToSubscription(
 	// wait for deployment creation
 	deployResult, err := createFromTemplateOperation.PollUntilDone(ctx, nil)
 	if err != nil {
-		deploymentError := createDeploymentError(err)
-		return nil, fmt.Errorf(
-			"deploying to subscription:\n\nDeployment Error Details:\n%w",
-			deploymentError,
-		)
+		return nil, fmt.Errorf("deploying to subscription: %w", createDeploymentError(err))
 	}
 
 	return &deployResult.WhatIfOperationResult, nil
@@ -603,11 +591,7 @@ func (ds *StandardDeployments) WhatIfDeployToResourceGroup(
 	// wait for deployment creation
 	deployResult, err := createFromTemplateOperation.PollUntilDone(ctx, nil)
 	if err != nil {
-		deploymentError := createDeploymentError(err)
-		return nil, fmt.Errorf(
-			"deploying to resource group:\n\nDeployment Error Details:\n%w",
-			deploymentError,
-		)
+		return nil, fmt.Errorf("deploying to resource group: %w", createDeploymentError(err))
 	}
 
 	return &deployResult.WhatIfOperationResult, nil
@@ -742,9 +726,10 @@ func validatePreflightError(
 	err error,
 	typeMessage string,
 ) error {
+	title := "Validation Error Details"
 	var respErr *azcore.ResponseError
 	if errors.As(err, &respErr) {
-		err = createDeploymentError(err)
+		err = responseToDeploymentError(title, respErr)
 	} else if err != nil {
 		// Error returned from azure sdk go bug: we receive a 400 Bad Request from the API,
 		// but the client-handling in azure sdk fails internally with a different error
@@ -758,11 +743,11 @@ func validatePreflightError(
 					typeMessage, errOnRawResponse)
 			}
 
-			err = NewAzureDeploymentError(string(body))
+			err = NewAzureDeploymentError(title, string(body))
 		}
 	}
 	return fmt.Errorf(
-		"validating deployment to %s:\n\nValidation Error Details:\n%w",
+		"validating deployment to %s: %w",
 		typeMessage,
 		err,
 	)


### PR DESCRIPTION
Adds support for claims challenges that can occur as part of [Conditional Access Evaluation](https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-continuous-access-evaluation).

When a request is rejected by ARM, the following will occur:
1. ARM returns 401 Unauthorized with `claims` populated in `Www-Authenticate` header.
2. [BearerTokenPolicy](https://github.com/Azure/azure-sdk-for-go/blob/4975987a031547cc54fff1a162f55144498bfad4/sdk/azcore/runtime/policy_bearer_token.go#L152) handles parsing of the claims, and will call the credential's `GetToken` implementation with `TokenRequestOptions.Claims` populated.
3. In our credential implementation (azd_credential.go), we now pass the claims through to `azidentity`'s `AcquireTokenSilent` implementation. In almost all cases, this call will fail, meaning the claims aren't satisifable by the current auth token. We save the claims and return a `newReLoginRequiredError` informing the user to log in.

Additionally, two other small changes included to fix the error presented to the user:

1. Refactoring the deployment error to avoid presenting to the user the login error as a "Validation Error" https://github.com/Azure/azure-dev/commit/baeb3453c17b12c22bdeadaefb0da92cff6a6d06
2. Fixing the error message to omit default scope for ARM, i.e. show `azd auth login` instead of `azd auth login --scope https://management.core.windows.net//.default` https://github.com/Azure/azure-dev/commit/f7536a80e320d57cfc4516fddb3d2544af8d5372

Error message displayed:
<img width="2556" height="260" alt="image" src="https://github.com/user-attachments/assets/551997bd-2a8d-421f-bd43-5015eed42f9a" />

Contributes to #5425