### PR TITLE
Adding context7 repository settings

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Azure Developer CLI",
+  "description": "Open-source CLI tool that accelerates provisioning and deploying app resources on Azure with developer-friendly commands for terminal, IDE, or CI/CD workflows.",
+  "folders": [
+    "cli/azd/docs",
+    "cli/azd/CONTRIBUTING.md",
+    "cli/azd/README.md"
+  ],
+  "excludeFolders": [],
+  "excludeFiles": []
+}


### PR DESCRIPTION
context7 already has one entry for azd: https://context7.com/azure/azure-dev

This PR updates the configuration for context7 to get only docs folder, readme and contributing. Excluding source code and other files.

The plan is to create a new entry in context7 for azd documentation and samples pointing to the docs repo.