### PR TITLE
Fix: replace invalid branch name characters when generating federated credential names

### DIFF
--- a/cli/azd/pkg/pipeline/github_provider.go
+++ b/cli/azd/pkg/pipeline/github_provider.go
@@ -398,8 +398,9 @@ func (p *GitHubCiProvider) credentialOptions(
 		}
 
 		for _, branch := range branches {
+			safeBranchName := regexp.MustCompile(`[^A-Za-z0-9-]`).ReplaceAllString(branch, "-")
 			branchCredentials := &graphsdk.FederatedIdentityCredential{
-				Name:        url.PathEscape(fmt.Sprintf("%s-%s", credentialSafeName, branch)),
+				Name:        url.PathEscape(fmt.Sprintf("%s-%s", credentialSafeName, safeBranchName)),
 				Issuer:      federatedIdentityIssuer,
 				Subject:     fmt.Sprintf("repo:%s:ref:refs/heads/%s", repoSlug, branch),
 				Description: to.Ptr("Created by Azure Developer CLI"),


### PR DESCRIPTION
Fixes issue https://github.com/Azure/azure-dev/issues/5554.

When generating `branchCredentials` name in the `azd pipeline config` command, replace all non-`[A-Za-z0-9-]` characters in the branch name with `-`.

@rajeshkamal5050 and @vhvb1989 for notification.
