### PR TITLE
Fix `Test_CLI_Package_ZipDeploy_Exclusions` failures on Windows - close zip after opening in `checkFiles`

### DIFF
--- a/cli/azd/test/functional/package_test.go
+++ b/cli/azd/test/functional/package_test.go
@@ -294,6 +294,7 @@ func checkFiles(
 	expectedFiles []string) {
 	zipFile, err := os.Open(zipFilePath)
 	require.NoError(t, err, "opening zip file")
+	defer zipFile.Close()
 
 	// Reopen the zip file for reading
 	_, err = zipFile.Seek(0, 0)


### PR DESCRIPTION
Fixes #5547