### PR TITLE
Alternative shell support

### DIFF
--- a/cli/azd/pkg/ext/hooks_runner.go
+++ b/cli/azd/pkg/ext/hooks_runner.go
@@ -191,6 +191,7 @@ func (h *HooksRunner) execHook(ctx context.Context, hookConfig *HookConfig, opti
 		defer h.console.StopPreviewer(ctx, false)
 	}
 	options.UserPwsh = string(hookConfig.Shell)
+	options.StrictShell = hookConfig.StrictShell
 
 	log.Printf("Executing script '%s'\n", hookConfig.path)
 	res, err := script.Execute(ctx, hookConfig.path, *options)

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -63,6 +63,9 @@ type HookConfig struct {
 	Name string `yaml:",omitempty"`
 	// The type of script hook (bash or powershell)
 	Shell ShellType `yaml:"shell,omitempty"`
+	// If true, azd won't try to use alternative shell to execute the command. For example, pwsh won't be tried with
+	// powershell (pwsh5) in Windows.
+	StrictShell bool `yaml:"strictShell,omitempty"`
 	// The inline script to execute or path to existing file
 	Run string `yaml:"run,omitempty"`
 	// When set to true will not halt command execution even when a script error occurs.

--- a/cli/azd/pkg/tools/powershell/powershell.go
+++ b/cli/azd/pkg/tools/powershell/powershell.go
@@ -6,6 +6,7 @@ package powershell
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
@@ -54,11 +55,26 @@ func checkPath(options tools.ExecOptions) (err error) {
 // Executes the specified powershell script
 // When interactive is true will attach to stdin, stdout & stderr
 func (bs *powershellScript) Execute(ctx context.Context, path string, options tools.ExecOptions) (exec.RunResult, error) {
-	if err := bs.checkInstalled(options); err != nil {
+	// block alternative shells for non-windows.
+	// This is because the only alternative shell supported is powershell5 which is not available on non-windows platforms.
+	if runtime.GOOS != "windows" {
+		options.StrictShell = true
+	}
+
+	if err := bs.checkInstalled(options); err != nil && options.StrictShell {
 		return exec.RunResult{}, &internal.ErrorWithSuggestion{
 			Err: err,
 			Suggestion: fmt.Sprintf("PowerShell 7 is not installed or not in the path. To install PowerShell 7, visit %s",
 				output.WithLinkFormat("https://learn.microsoft.com/powershell/scripting/install/installing-powershell")),
+		}
+	}
+
+	// non-strict mode, check for alternative shell powershell 5
+	options.UserPwsh = "powershell"
+	if err := bs.checkInstalled(options); err != nil {
+		return exec.RunResult{}, &internal.ErrorWithSuggestion{
+			Err:        err,
+			Suggestion: "Make sure Powershell is installed in your system.",
 		}
 	}
 

--- a/cli/azd/pkg/tools/script.go
+++ b/cli/azd/pkg/tools/script.go
@@ -15,6 +15,9 @@ type ExecOptions struct {
 	Interactive *bool
 	StdOut      io.Writer
 	UserPwsh    string
+	// If true, azd won't try to use alternative shell to execute the command. For example, pwsh won't be tried with
+	// powershell (pwsh5) in Windows.
+	StrictShell bool
 }
 
 // Utility to easily execute a bash script across platforms


### PR DESCRIPTION
Adding alternative shells support for running hooks. This allows pwsh to try running in pwsh5 when pwsh7 is not found in windows. User can set templates to be ShellStrict and fail if pwsh7 is not found