### PR TITLE
EngSys: Disable SBOM generation in non-release builds

### DIFF
--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -11,7 +11,7 @@ trigger:
       - /eng/pipelines/templates/jobs/build-cli.yml
       - /eng/pipelines/templates/jobs/cross-build-cli.yml
       - /eng/pipelines/templates/variables/image.yml
-# Test change to trigger a PR build
+
 pr:
   paths:
     include:


### PR DESCRIPTION
Fix failure where PRs from forks generate a "continue on error" orange status. In these cases, sbom does not work for PRs from forks and is not necessary in non-release builds.

<img width="1045" height="204" alt="image" src="https://github.com/user-attachments/assets/cdc7b332-8b93-4240-86a2-e4661a78455c" />

With changes, sbom is skipped in PR builds, making jobs green instead of orange: 

<img width="276" height="544" alt="image" src="https://github.com/user-attachments/assets/4c4cab1f-80a5-4e78-ac87-20d7778c86d1" />

Example PR build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5205253&view=results
