### PR TITLE
auth: add claims support for devicecode flow

### DIFF
--- a/cli/azd/pkg/auth/azd_credential.go
+++ b/cli/azd/pkg/auth/azd_credential.go
@@ -8,13 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
-	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 )
 
 type azdCredential struct {
@@ -44,13 +42,7 @@ func (c *azdCredential) GetToken(ctx context.Context, options policy.TokenReques
 				log.Println(authFailed.httpErrorDetails())
 
 				if options.Claims != "" {
-					claimsFile, err := claimsFilePath()
-					if err != nil {
-						return azcore.AccessToken{}, fmt.Errorf("getting claims path: %w", err)
-					}
-
-					err = os.WriteFile(claimsFile, []byte(options.Claims), osutil.PermissionFile)
-					if err != nil {
+					if err := saveClaims(options.Claims); err != nil {
 						return azcore.AccessToken{}, fmt.Errorf("saving claims: %w", err)
 					}
 				}

--- a/cli/azd/pkg/auth/manager_test.go
+++ b/cli/azd/pkg/auth/manager_test.go
@@ -209,7 +209,7 @@ func TestLoginInteractive(t *testing.T) {
 		cloud:             cloud.AzurePublic(),
 	}
 
-	cred, err := m.LoginInteractive(context.Background(), nil, nil)
+	cred, err := m.LoginInteractive(context.Background(), nil, "", nil)
 
 	require.NoError(t, err)
 	require.IsType(t, new(azdCredential), cred)
@@ -238,7 +238,7 @@ func TestLoginDeviceCode(t *testing.T) {
 		cloud:             cloud.AzurePublic(),
 	}
 
-	cred, err := m.LoginWithDeviceCode(context.Background(), "", nil, func(url string) error { return nil })
+	cred, err := m.LoginWithDeviceCode(context.Background(), "", nil, "", func(url string) error { return nil })
 
 	require.Regexp(t, "Start by copying the next code: 123-456", console.Output())
 


### PR DESCRIPTION
Adds claims support for device-code login flows, following up on previous change in #5545.

1. A hidden flag `--claims` is added to `auth login` for debugging / one-off utility purposes.
2. Refactor claims logic slightly to support multiple codepaths.

Contributes to #5425