### PR TITLE
Improve warning message formatting

### DIFF
--- a/cli/azd/cmd/middleware/hooks.go
+++ b/cli/azd/cmd/middleware/hooks.go
@@ -244,6 +244,9 @@ func (m *HooksMiddleware) validateHooks(ctx context.Context, projectConfig *proj
 		m.console.MessageUxItem(ctx, &ux.WarningMessage{
 			Description: warning.Message,
 		})
+		if warning.Suggestion != "" {
+			m.console.Message(ctx, warning.Suggestion)
+		}
 		m.console.Message(ctx, "")
 	}
 

--- a/cli/azd/pkg/ext/hooks_manager.go
+++ b/cli/azd/pkg/ext/hooks_manager.go
@@ -131,7 +131,8 @@ type HookValidationResult struct {
 
 // HookWarning represents a validation warning for hooks
 type HookWarning struct {
-	Message string
+	Message    string
+	Suggestion string
 }
 
 // ValidateHooks validates hook configurations and returns any warnings
@@ -163,25 +164,21 @@ func (h *HooksManager) ValidateHooks(ctx context.Context, allHooks map[string][]
 			// Check if legacy powershell is available
 			if powershellErr := h.commandRunner.ToolInPath("powershell"); !errors.Is(powershellErr, osexec.ErrNotFound) {
 				//nolint:lll
-				warningMessage = "PowerShell 7 (`pwsh`) commands found in project. Your computer only has PowerShell 5.1 (`powershell`) installed. azd will use `powershell` but errors may occur.\n\nTo resolve warning, install `pwsh`"
+				warningMessage = "PowerShell 7 (`pwsh`) commands found in project. Your computer only has PowerShell 5.1 (`powershell`) installed. azd will use `powershell` but errors may occur."
 			} else {
 				//nolint:lll
-				warningMessage = "PowerShell 7 (`pwsh`) commands found in project. No PowerShell installation detected. Powershell scripts will fail. \n\nTo resolve warning, install `pwsh`"
+				warningMessage = "PowerShell 7 (`pwsh`) commands found in project. No PowerShell installation detected. PowerShell scripts will fail."
 			}
-
-			// Append install instructions link
-			warningMessage = fmt.Sprintf(
-				"%s (%s)",
-				warningMessage,
-				output.WithHyperlink(
-					//nolint:lll
-					"https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.4",
-					"Install Instructions",
-				),
-			)
 
 			result.Warnings = append(result.Warnings, HookWarning{
 				Message: warningMessage,
+				Suggestion: fmt.Sprintf(
+					"To resolve warning, install `pwsh` (%s)",
+					output.WithHyperlink(
+						"https://learn.microsoft.com/powershell/scripting/install/installing-powershell",
+						"Install Instructions",
+					),
+				),
 			})
 		}
 	}

--- a/cli/azd/pkg/output/ux/warning.go
+++ b/cli/azd/pkg/output/ux/warning.go
@@ -10,6 +10,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
+// Warning message with hidable prefix "WARNING: "
 type WarningMessage struct {
 	Description string
 	HidePrefix  bool

--- a/cli/azd/pkg/output/ux/warning.go
+++ b/cli/azd/pkg/output/ux/warning.go
@@ -18,7 +18,7 @@ type WarningMessage struct {
 func (t *WarningMessage) ToString(currentIndentation string) string {
 	var prefix string
 	if !t.HidePrefix {
-		prefix = "Warning: "
+		prefix = "WARNING: "
 	}
 	return output.WithWarningFormat("%s%s%s", currentIndentation, prefix, t.Description)
 }
@@ -26,7 +26,7 @@ func (t *WarningMessage) ToString(currentIndentation string) string {
 func (t *WarningMessage) MarshalJSON() ([]byte, error) {
 	var prefix string
 	if !t.HidePrefix {
-		prefix = "Warning: "
+		prefix = "WARNING: "
 	}
 
 	return json.Marshal(output.EventForMessage(fmt.Sprintf("%s%s", prefix, t.Description)))

--- a/cli/azd/pkg/output/ux/warning_alt.go
+++ b/cli/azd/pkg/output/ux/warning_alt.go
@@ -10,6 +10,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
+// Warning message with the prefix "(!) Warning: "
 type WarningAltMessage struct {
 	Message string
 }


### PR DESCRIPTION
Fixes #5589 

### Changes

* Update the prefix for `WarningMessage` to be "WARNING: " in all caps, making it consistent with our current design pattern.

* Improve how hook warnings are displayed, with the suggestion text for installing `pwsh` displayed in a neutral colour.

* Restore a few changes from #5585 that were inadvertently reverted.

### Before

<img width="1531" height="250" alt="image" src="https://github.com/user-attachments/assets/e646d1cc-92ca-4948-b323-aa9d6caf62ab" />

### After

<img width="1511" height="231" alt="image" src="https://github.com/user-attachments/assets/bded22d3-3c05-4287-8907-f195897c4378" />