### PR TITLE
Extension management improvements

### DIFF
--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -49,7 +49,6 @@ func extensionActions(root *actions.ActionDescriptor) *actions.ActionDescriptor 
 		Command: &cobra.Command{
 			Use:   "show <extension-name>",
 			Short: "Show details for a specific extension.",
-			Args:  cobra.ExactArgs(1),
 		},
 		OutputFormats:  []output.Format{output.JsonFormat, output.NoneFormat},
 		DefaultFormat:  output.NoneFormat,
@@ -364,6 +363,12 @@ func (t *extensionShowItem) Display(writer io.Writer) error {
 }
 
 func (a *extensionShowAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	if len(a.args) == 0 {
+		return nil, fmt.Errorf("must specify an extension name")
+	}
+	if len(a.args) > 1 {
+		return nil, fmt.Errorf("cannot specify multiple extensions")
+	}
 	extensionId := a.args[0]
 	filterOptions := &extensions.FilterOptions{
 		Source: a.flags.source,
@@ -873,6 +878,12 @@ func newExtensionSourceRemoveAction(
 }
 
 func (a *extensionSourceRemoveAction) Run(ctx context.Context) (*actions.ActionResult, error) {
+	if len(a.args) == 0 {
+		return nil, fmt.Errorf("must specify an extension source name")
+	}
+	if len(a.args) > 1 {
+		return nil, fmt.Errorf("cannot specify multiple extension sources")
+	}
 	a.console.MessageUxItem(ctx, &ux.MessageTitle{
 		Title: "Remove extension source (azd extension source remove)",
 	})

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -172,12 +172,12 @@ func newExtensionListAction(
 }
 
 type extensionListItem struct {
-	Id        string `json:"id"`
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-	Version   string `json:"version"`
-	Installed bool   `json:"installed"`
-	Source    string `json:"source"`
+	Id               string `json:"id"`
+	Name             string `json:"name"`
+	Namespace        string `json:"namespace"`
+	Version          string `json:"version"`
+	InstalledVersion string `json:"installedVersion"`
+	Source           string `json:"source"`
 }
 
 func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, error) {
@@ -212,20 +212,18 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 			continue
 		}
 
-		var version string
-		if has {
-			version = installedExtension.Version
-		} else {
-			version = extension.Versions[len(extension.Versions)-1].Version
+		var installedVersion string
+		if installed {
+			installedVersion = installedExtension.Version
 		}
 
 		extensionRows = append(extensionRows, extensionListItem{
-			Id:        extension.Id,
-			Name:      extension.DisplayName,
-			Namespace: extension.Namespace,
-			Version:   version,
-			Source:    extension.Source,
-			Installed: installed,
+			Id:               extension.Id,
+			Name:             extension.DisplayName,
+			Namespace:        extension.Namespace,
+			Version:          extension.Versions[len(extension.Versions)-1].Version,
+			InstalledVersion: installedVersion,
+			Source:           extension.Source,
 		})
 	}
 
@@ -264,12 +262,12 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 				ValueTemplate: `{{.Version}}`,
 			},
 			{
-				Heading:       "Source",
-				ValueTemplate: `{{.Source}}`,
+				Heading:       "Installed Version",
+				ValueTemplate: `{{.InstalledVersion}}`,
 			},
 			{
-				Heading:       "Installed",
-				ValueTemplate: `{{.Installed}}`,
+				Heading:       "Source",
+				ValueTemplate: `{{.Source}}`,
 			},
 		}
 

--- a/cli/azd/cmd/testdata/TestUsage-azd-extension-show.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-extension-show.snap
@@ -4,6 +4,9 @@ Show details for a specific extension.
 Usage
   azd extension show <extension-name> [flags]
 
+Flags
+    -s, --source string 	: The extension source to use.
+
 Global Flags
     -C, --cwd string 	: Sets the current working directory.
         --debug      	: Enables debugging and diagnostics logging.

--- a/cli/azd/docs/extension-framework.md
+++ b/cli/azd/docs/extension-framework.md
@@ -44,6 +44,12 @@ The official extension source registry is pre-configured in `azd` and is hosted 
 
 The registry is hosted in the [`azd` github repo](https://github.com/Azure/azure-dev/blob/main/cli/azd/extensions/registry.json).
 
+If you previously removed it and want to add it back:
+
+```bash
+azd extension source add -n azd -t url -l "https://aka.ms/azd/extensions/registry"
+```
+
 #### Development Registry
 
 > [!CAUTION]
@@ -81,11 +87,17 @@ Extensions are a collection of executable artifacts that extend or enhance funct
 
 #### `azd extension list [flags]`
 
-Lists matching extensions from one or more extension sources
+Lists matching extensions from one or more extension sources.
 
 - `--installed` When set displays a list of installed extensions.
 - `--source` When set will only list extensions from the specified source.
 - `--tags` Allows filtering extensions by tags (e.g., AI, test)
+
+#### `azd extension show <extension-name> [flags]`
+
+Shows detailed information for a specific extension, including description, tags, versions, and installation status.
+
+- `-s, --source` The extension source to use. Use this flag when the same extension ID exists in multiple sources.
 
 #### `azd extension install <extension-names> [flags]`
 

--- a/cli/azd/pkg/extensions/manager.go
+++ b/cli/azd/pkg/extensions/manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Masterminds/semver/v3"
+	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
@@ -158,7 +159,8 @@ func (m *Manager) GetInstalled(options LookupOptions) (*Extension, error) {
 	return nil, ErrInstalledExtensionNotFound
 }
 
-// GetFromRegistry retrieves an extension from the registry by name
+// GetFromRegistry retrieves an extension from the registry by name.
+// Returns an error if multiple extensions with the same ID are found across different sources.
 func (m *Manager) GetFromRegistry(
 	ctx context.Context,
 	extensionId string,
@@ -181,7 +183,7 @@ func (m *Manager) GetFromRegistry(
 		return nil, fmt.Errorf("failed getting extension sources: %w", err)
 	}
 
-	var match *ExtensionMetadata
+	var matches []*ExtensionMetadata
 	var sourceErr error
 
 	for _, source := range sources {
@@ -189,13 +191,23 @@ func (m *Manager) GetFromRegistry(
 		if err != nil {
 			sourceErr = err
 		} else if extension != nil {
-			match = extension
-			break
+			matches = append(matches, extension)
 		}
 	}
 
-	if match != nil {
-		return match, nil
+	if len(matches) > 1 {
+		sourceNames := make([]string, len(matches))
+		for i, match := range matches {
+			sourceNames[i] = match.Source
+		}
+		return nil, &internal.ErrorWithSuggestion{
+			Err:        fmt.Errorf("extension '%s' found in multiple sources: %s", extensionId, strings.Join(sourceNames, ", ")),
+			Suggestion: "Suggestion: specify the exact source using --source or -s.",
+		}
+	}
+
+	if len(matches) == 1 {
+		return matches[0], nil
 	}
 
 	if sourceErr != nil {

--- a/cli/azd/pkg/extensions/manager.go
+++ b/cli/azd/pkg/extensions/manager.go
@@ -201,7 +201,11 @@ func (m *Manager) GetFromRegistry(
 			sourceNames[i] = match.Source
 		}
 		return nil, &internal.ErrorWithSuggestion{
-			Err:        fmt.Errorf("extension '%s' found in multiple sources: %s", extensionId, strings.Join(sourceNames, ", ")),
+			Err: fmt.Errorf(
+				"extension '%s' found in multiple sources: %s",
+				extensionId,
+				strings.Join(sourceNames, ", "),
+			),
 			Suggestion: "Suggestion: specify the exact source using --source or -s.",
 		}
 	}

--- a/cli/azd/pkg/extensions/source_manager.go
+++ b/cli/azd/pkg/extensions/source_manager.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -167,8 +167,8 @@ func (sm *SourceManager) List(ctx context.Context) ([]*SourceConfig, error) {
 		allSourceConfigs = append(allSourceConfigs, defaultSource)
 	}
 
-	sort.Slice(allSourceConfigs, func(i, j int) bool {
-		return allSourceConfigs[i].Name < allSourceConfigs[j].Name
+	slices.SortFunc(allSourceConfigs, func(a, b *SourceConfig) int {
+		return strings.Compare(a.Name, b.Name)
 	})
 
 	return allSourceConfigs, nil

--- a/cli/azd/pkg/extensions/source_manager.go
+++ b/cli/azd/pkg/extensions/source_manager.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -165,6 +166,10 @@ func (sm *SourceManager) List(ctx context.Context) ([]*SourceConfig, error) {
 
 		allSourceConfigs = append(allSourceConfigs, defaultSource)
 	}
+
+	sort.Slice(allSourceConfigs, func(i, j int) bool {
+		return allSourceConfigs[i].Name < allSourceConfigs[j].Name
+	})
 
 	return allSourceConfigs, nil
 }


### PR DESCRIPTION
Fixes #5037
Fixes #5637

This PR includes several improvements to the `azd extension` commands, removing ambiguity and non-determinism especially when there are multiple sources with the same extension ID (common scenario when developing and testing already-published extensions).

## Changes

* `azd extension list` output is now consistently ordered by source name and ID.
* `azd extension list` now shows the installed extension version (**Installed Version**) instead of a simple boolean (**Installed**). Previously, the wrong version was being shown in some situations and you couldn't tell if the installed version was different from latest available version.
    <img width="590" height="149" alt="image" src="https://github.com/user-attachments/assets/82f50dd4-9d7f-4a24-b4cc-52a2ebfa347b" />
* `azd extension` `show`, `install`, and `upgrade` now return an error if `--source`/`-s` isn't provided and there are multiple sources with the specified extension ID. Previously, these commands had non-deterministic behaviour.
* `azd extension show` now accepts a `--source`/`-s` flag and the output now includes a **Source** property.
* Improve argument validation for `azd ext show` and `azd ext source remove`

## Screenshots

Say there are 2 azd extension sources configured, `azd` and `dev`, with different versions of the extension `microsoft.azd.extensions`:

| Source `azd` | Source `dev` |
|--------|--------|
| v0.4.2 | v0.5.0 |

### Old `azd ext show microsoft.azd.extensions`
Before it would sometimes show details from source `azd` and sometimes from `dev`, unclear which source it was using. The same would happen for `azd ext install` and `azd ext upgrade`.

<img width="1050" height="741" alt="image" src="https://github.com/user-attachments/assets/9145ae5d-9d7d-4812-80c9-d948b19d90d0" />

## New `azd ext show microsoft.azd.extensions`
Returns error, with suggestion for user to specify exact source name:

<img width="680" height="47" alt="image" src="https://github.com/user-attachments/assets/47426ca3-24d1-4396-af58-f551fed63ef3" />

## New `azd ext show microsoft.azd.extensions -s azd/dev`
When a source is explicitly specified:
<img width="569" height="399" alt="image" src="https://github.com/user-attachments/assets/813f7a42-ecdc-434e-8f0b-3117beea856a" />

## New `azd ext install`, `azd ext upgrade`

<img width="1313" height="220" alt="image" src="https://github.com/user-attachments/assets/60dccaab-a1a6-459c-9d5a-380c6b38d911" />

<img width="1574" height="219" alt="image" src="https://github.com/user-attachments/assets/31cc51cc-32ea-41e6-aa0d-fb7260f444d5" />

---

## Old `azd ext show`, `azd ext source remove`
<img width="915" height="220" alt="image" src="https://github.com/user-attachments/assets/4877a82c-fbfe-4519-a36b-54a914e81d67" />

## New `azd ext show`, `azd ext source remove`
<img width="1136" height="155" alt="image" src="https://github.com/user-attachments/assets/a018fba9-e81e-4cbf-9fe8-a6762ce04871" />