### PR TITLE
vscode: fix handling of azure.yaml directory movements

### DIFF
--- a/ext/vscode/package-lock.json
+++ b/ext/vscode/package-lock.json
@@ -13,7 +13,6 @@
                 "@microsoft/vscode-azureresources-api": "~2",
                 "dayjs": "~1",
                 "dotenv": "~16",
-                "rxjs": "~7",
                 "semver": "~7",
                 "yaml": "~2"
             },
@@ -4469,14 +4468,6 @@
             ],
             "dependencies": {
                 "queue-microtask": "^1.2.2"
-            }
-        },
-        "node_modules/rxjs": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.6.0.tgz",
-            "integrity": "sha512-DDa7d8TFNUalGC9VqXvQ1euWNN7sc63TrUCuM9J998+ViviahMIjKSOU7rfcgFOF+FCD71BhDRv4hrFz+ImDLQ==",
-            "dependencies": {
-                "tslib": "^2.1.0"
             }
         },
         "node_modules/safe-buffer": {

--- a/ext/vscode/package.json
+++ b/ext/vscode/package.json
@@ -544,7 +544,6 @@
         "@microsoft/vscode-azureresources-api": "~2",
         "dayjs": "~1",
         "dotenv": "~16",
-        "rxjs": "~7",
         "semver": "~7",
         "yaml": "~2"
     }

--- a/ext/vscode/src/views/workspace/AzureDevCliWorkspaceResourceProvider.ts
+++ b/ext/vscode/src/views/workspace/AzureDevCliWorkspaceResourceProvider.ts
@@ -4,52 +4,94 @@
 import { WorkspaceResource, WorkspaceResourceProvider } from '@microsoft/vscode-azureresources-api';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { Subscription } from 'rxjs';
-import { AzureDevApplication, AzureDevApplicationProvider } from '../../services/AzureDevApplicationProvider';
+import { AzureDevApplicationProvider, AzureDevApplication } from '../../services/AzureDevApplicationProvider';
 
 export class AzureDevCliWorkspaceResourceProvider extends vscode.Disposable implements WorkspaceResourceProvider {
     private readonly onDidChangeResourceEmitter = new vscode.EventEmitter<WorkspaceResource | undefined>();
-    private readonly applicationsSubscription: Subscription;
+    private readonly workspaceFolderSubscription: vscode.Disposable;
+    private readonly configFileWatcher: vscode.FileSystemWatcher;
+    private readonly configFolderWatchers = new Map<string, vscode.FileSystemWatcher>();
 
-    private applications: AzureDevApplication[] = [];
-
-    constructor(applicationProvider: AzureDevApplicationProvider) {
+    constructor(private applicationProvider: AzureDevApplicationProvider) {
         super(
             () => {
-                this.applicationsSubscription.unsubscribe();
+                this.workspaceFolderSubscription.dispose();
+                this.configFileWatcher.dispose();
+                this.configFolderWatchers.forEach(watcher => watcher.dispose());
+                this.configFolderWatchers.clear();
                 this.onDidChangeResourceEmitter.dispose();
             });
 
-        this.applicationsSubscription =
-            applicationProvider
-                .applications
-                .subscribe(
-                    applications => {
-                        this.applications = applications;
-                        this.onDidChangeResourceEmitter.fire(undefined);
-                    });
+        // Listen to workspace folder changes
+        this.workspaceFolderSubscription = vscode.workspace.onDidChangeWorkspaceFolders(() => {
+            this.onDidChangeResourceEmitter.fire(undefined);
+        });
+
+        // Listen to azure.yaml file changes globally
+        this.configFileWatcher = vscode.workspace.createFileSystemWatcher(
+            '**/azure.{yml,yaml}',
+            false, false, false
+        );
+
+        const onFileChange = () => {
+            this.onDidChangeResourceEmitter.fire(undefined);
+        };
+
+        this.configFileWatcher.onDidCreate(onFileChange);
+        this.configFileWatcher.onDidChange(onFileChange);
+        this.configFileWatcher.onDidDelete(onFileChange);
     }
 
     readonly onDidChangeResource = this.onDidChangeResourceEmitter.event;
 
     async getResources(): Promise<WorkspaceResource[]> {
+        const applications = await this.applicationProvider.getApplications();
         const resources: WorkspaceResource[] = [];
-    
-        for (const folder of vscode.workspace.workspaceFolders || []) {
-            for (const application of this.applications.filter(application => application.workspaceFolder === folder)) {
-                const configurationFilePath = application.configurationPath.fsPath;
-                const configurationFolderName = path.basename(path.dirname(configurationFilePath));
 
-                resources.push({
-                    folder,
-                    id: application.configurationPath.fsPath,
-                    name: configurationFolderName,
-                    resourceType: 'ms-azuretools.azure-dev.application'
-                });
-            }
+        this.updateConfigFolderWatchers(applications);
 
+        for (const application of applications) {
+            const configurationFilePath = application.configurationPath.fsPath;
+            const configurationFolder = application.configurationFolder;
+            const configurationFolderName = path.basename(configurationFolder);
+
+            resources.push({
+                folder: application.workspaceFolder,
+                id: configurationFilePath,
+                name: configurationFolderName,
+                resourceType: 'ms-azuretools.azure-dev.application'
+            });
         }
 
         return resources;
+    }
+
+    private updateConfigFolderWatchers(applications: AzureDevApplication[]): void {
+         // Remove any watchers for configuration folders that no longer exist
+        for (const [configFolder, watcher] of this.configFolderWatchers) {
+            if (applications.findIndex(app => app.configurationFolder === configFolder) === -1) {
+                watcher.dispose();
+                this.configFolderWatchers.delete(configFolder);
+            }
+        }
+
+        // Add new watchers for newly added configuration folders
+        for (const application of applications) {
+            if (this.configFolderWatchers.has(application.configurationFolder)) {
+                // already registered
+                continue;
+            }
+
+            const watcher = vscode.workspace.createFileSystemWatcher(
+                application.configurationFolder,
+                true, true, false
+            );
+
+            watcher.onDidDelete(() => {
+                this.onDidChangeResourceEmitter.fire(undefined);
+            });
+
+            this.configFolderWatchers.set(application.configurationFolder, watcher);
+        }
     }
 }


### PR DESCRIPTION
Problem: user is currently trapped in repeated error dialogs when a directory containing `azure.yaml` is deleted or renamed.

This fix addresses the problem by:

1. Subscribing for `azure.yaml` configuration directory changes as they occur.
2. Changing refresh button behavior to rediscover all azd applications in current workspace(s). This allows user to perform a manual refresh in case of any missed filesystem updates.

Underneath-the-covers, the AzureDevApplicationProvider is made to be a stateless data provider to support the scenario as described in 2. above.

Fixes: #5690