### PR TITLE
Removes feature flag block for MCP server

### DIFF
--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -19,7 +19,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azd"
 	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
 	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
-	"github.com/azure/azure-dev/cli/azd/pkg/llm"
 	"github.com/azure/azure-dev/cli/azd/pkg/platform"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
@@ -129,6 +128,7 @@ func NewRootCmd(
 	templatesActions(root)
 	authActions(root)
 	hooksActions(root)
+	mcpActions(root)
 
 	root.Add("version", &actions.ActionDescriptorOptions{
 		Command: &cobra.Command{
@@ -425,11 +425,6 @@ func NewRootCmd(
 					}
 				}
 			}
-		}
-
-		// Enable MCP commands when LLM feature is enabled
-		if alphaFeatureManager.IsEnabled(llm.FeatureLlm) {
-			mcpActions(root)
 		}
 
 		return nil


### PR DESCRIPTION
Removes the `llm` feature flag from blocking the usage of the `mcp` command group.