### PR TITLE
Remove cgo requirement for osversion on Darwin

### DIFF
--- a/cli/azd/pkg/osutil/osversion/osversion_darwin.go
+++ b/cli/azd/pkg/osutil/osversion/osversion_darwin.go
@@ -1,43 +1,28 @@
 package osversion
 
-/*
-#cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework Foundation
-#import <Foundation/Foundation.h>
-#import <Foundation/NSProcessInfo.h>
-
-NSOperatingSystemVersion c_getVersion() {
-	NSProcessInfo *pInfo = [NSProcessInfo processInfo];
-	// check availability of the property operatingSystemVersion (10.10+) at runtime
-	if ([pInfo respondsToSelector:@selector(operatingSystemVersion)])
-	{
-		return [pInfo operatingSystemVersion];
-	}
-	else
-	{
-		NSOperatingSystemVersion version;
-		version.majorVersion = 10;
-		version.minorVersion = 9;
-		version.patchVersion = 0;
-		return version;
-	}
-}
-*/
-import "C"
-
 import (
+	"bytes"
 	"fmt"
+	"os/exec"
+	"strings"
 )
 
-func verToStr(ver C.NSOperatingSystemVersion) string {
-	res := fmt.Sprintf("%d.%d.%d", int(ver.majorVersion), int(ver.minorVersion), int(ver.patchVersion))
-	return res
-}
-
-func doGetVersion() string {
-	return verToStr(C.c_getVersion())
-}
-
 func GetVersion() (string, error) {
-	return doGetVersion(), nil
+	swVersCmd := exec.Command("sw_vers", "--productVersion")
+	outputBytes, err := swVersCmd.Output()
+
+	if err != nil {
+		return "", err
+	}
+
+	output := string(bytes.TrimSpace(outputBytes))
+
+	fmt.Printf("count = %d\n", strings.Count(output, "."))
+
+	if strings.Count(output, ".") == 1 {
+		// they're not including the patch version, we'll tack it on for compatibility
+		return output + ".0", nil
+	}
+
+	return output, err
 }


### PR DESCRIPTION
If you're using 'azd' as a library (for instance, writing an extension in Go), obversion will require you to have CGO_ENABLED _and_ you have to have the proper cross compilers for it to work. 

This call appears to only be used once (when initializing telemetry) and it's fast so I think this should still fit in well with everything else in azd.