### PR TITLE
Extension Framework: Enables MCP Server capability

### DIFF
--- a/cli/azd/extensions/extension.schema.json
+++ b/cli/azd/extensions/extension.schema.json
@@ -78,7 +78,7 @@
     "capabilities": {
       "type": "array",
       "title": "Capabilities",
-      "description": "List of capabilities provided by the extension. Supported values: custom-commands, lifecycle-events. Select one or more from the allowed list. Each value must be unique.",
+      "description": "List of capabilities provided by the extension. Supported values: custom-commands, lifecycle-events, mcp-server. Select one or more from the allowed list. Each value must be unique.",
       "minItems": 1,
       "uniqueItems": true,
       "items": {
@@ -94,6 +94,12 @@
             "const": "lifecycle-events",
             "title": "Lifecycle Events",
             "description": "Lifecycle events enable extensions to subscribe to AZD project and service lifecycle events."
+          },
+          {
+            "type": "string",
+            "const": "mcp-server",
+            "title": "MCP Server",
+            "description": "MCP server capability enables extensions to provide Model Context Protocol tools that can be used by AI agents."
           }
         ]
       }
@@ -147,6 +153,40 @@
         "description": "Custom metadata for a particular platform.",
         "additionalProperties": true
       }
+    },
+    "mcp": {
+      "type": "object",
+      "title": "MCP Configuration",
+      "description": "Configuration for Model Context Protocol server functionality. Required when mcp-server capability is declared.",
+      "properties": {
+        "serve": {
+          "type": "object",
+          "title": "MCP Server Configuration",
+          "description": "Configuration for starting the extension's MCP server.",
+          "properties": {
+            "args": {
+              "type": "array",
+              "title": "Server Arguments",
+              "description": "Command-line arguments to pass when starting the MCP server. Typically ['mcp', 'serve'] or similar.",
+              "items": {
+                "type": "string"
+              },
+              "default": ["mcp", "serve"]
+            },
+            "env": {
+              "type": "array",
+              "title": "Environment Variables",
+              "description": "Additional environment variables to set when starting the MCP server.",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            }
+          },
+          "required": ["args"]
+        }
+      },
+      "required": ["serve"]
     }
   },
   "required": [

--- a/cli/azd/extensions/microsoft.azd.demo/extension.yaml
+++ b/cli/azd/extensions/microsoft.azd.demo/extension.yaml
@@ -9,6 +9,7 @@ language: go
 capabilities:
   - custom-commands
   - lifecycle-events
+  - mcp-server
 examples:
   - name: context
     description: Displays the current `azd` project & environment context.
@@ -16,3 +17,6 @@ examples:
   - name: prompt
     description: Display prompt capabilities.
     usage: azd demo prompt
+  - name: mcp
+    description: Start MCP server with demo tools.
+    usage: azd demo mcp start

--- a/cli/azd/extensions/microsoft.azd.demo/internal/cmd/mcp.go
+++ b/cli/azd/extensions/microsoft.azd.demo/internal/cmd/mcp.go
@@ -1,0 +1,238 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/spf13/cobra"
+)
+
+func newMcpCommand() *cobra.Command {
+	mcpCmd := &cobra.Command{
+		Use:   "mcp",
+		Short: "MCP server commands for demo extension",
+	}
+
+	mcpCmd.AddCommand(newMcpStartCommand())
+
+	return mcpCmd
+}
+
+func newMcpStartCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "start",
+		Short: "Start MCP server with demo tools",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMcpServer(cmd.Context())
+		},
+	}
+}
+
+func runMcpServer(ctx context.Context) error {
+	// Create MCP server
+	s := server.NewMCPServer(
+		"AZD Demo Extension MCP Server", "1.0.0",
+		server.WithToolCapabilities(true),
+	)
+
+	// Add demo tools
+	demoTools := []server.ServerTool{
+		newDemoGreetingTool(),
+		newDemoCalculatorTool(),
+		newDemoAzdInfoTool(),
+	}
+
+	s.AddTools(demoTools...)
+
+	// Start the server using stdio transport
+	if err := server.ServeStdio(s); err != nil {
+		fmt.Fprintf(os.Stderr, "MCP server error: %v\n", err)
+		return err
+	}
+
+	return nil
+}
+
+// newDemoGreetingTool creates a simple greeting tool for testing
+func newDemoGreetingTool() server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool(
+			"demo_greeting",
+			mcp.WithDescription("A simple greeting tool that takes a name and returns a personalized greeting"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithIdempotentHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithString("name",
+				mcp.Description("The name of the person to greet"),
+				mcp.Required(),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			// Cast arguments to map
+			args, ok := request.Params.Arguments.(map[string]interface{})
+			if !ok {
+				return mcp.NewToolResultError("Invalid arguments format"), nil
+			}
+
+			name, ok := args["name"].(string)
+			if !ok || name == "" {
+				return mcp.NewToolResultError("name parameter is required and must be a string"), nil
+			}
+
+			greeting := fmt.Sprintf("Hello, %s! Welcome to the AZD Demo Extension MCP server!", name)
+			return mcp.NewToolResultText(greeting), nil
+		},
+	}
+}
+
+// newDemoCalculatorTool creates a simple calculator tool for testing
+func newDemoCalculatorTool() server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool(
+			"demo_calculator",
+			mcp.WithDescription("A simple calculator that can perform basic arithmetic operations (add, subtract, multiply, divide)"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithIdempotentHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithString("operation",
+				mcp.Description("The operation to perform: add, subtract, multiply, divide"),
+				mcp.Required(),
+			),
+			mcp.WithNumber("a",
+				mcp.Description("First number"),
+				mcp.Required(),
+			),
+			mcp.WithNumber("b",
+				mcp.Description("Second number"),
+				mcp.Required(),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			// Cast arguments to map
+			args, ok := request.Params.Arguments.(map[string]interface{})
+			if !ok {
+				return mcp.NewToolResultError("Invalid arguments format"), nil
+			}
+
+			operation, ok := args["operation"].(string)
+			if !ok {
+				return mcp.NewToolResultError("operation parameter is required and must be a string"), nil
+			}
+
+			a, ok := args["a"].(float64)
+			if !ok {
+				return mcp.NewToolResultError("'a' parameter is required and must be a number"), nil
+			}
+
+			b, ok := args["b"].(float64)
+			if !ok {
+				return mcp.NewToolResultError("'b' parameter is required and must be a number"), nil
+			}
+
+			var result float64
+			var opSymbol string
+
+			switch operation {
+			case "add":
+				result = a + b
+				opSymbol = "+"
+			case "subtract":
+				result = a - b
+				opSymbol = "-"
+			case "multiply":
+				result = a * b
+				opSymbol = "*"
+			case "divide":
+				if b == 0 {
+					return mcp.NewToolResultError("Division by zero is not allowed"), nil
+				}
+				result = a / b
+				opSymbol = "/"
+			default:
+				return mcp.NewToolResultError(fmt.Sprintf("Unknown operation '%s'. Supported operations: add, subtract, multiply, divide", operation)), nil
+			}
+
+			response := fmt.Sprintf("%.2f %s %.2f = %.2f", a, opSymbol, b, result)
+			return mcp.NewToolResultText(response), nil
+		},
+	}
+}
+
+// newDemoAzdInfoTool creates a tool that demonstrates access to AZD context using the azd client
+func newDemoAzdInfoTool() server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool(
+			"demo_azd_info",
+			mcp.WithDescription("Gets AZD project and environment information using the azd client"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithIdempotentHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var info []string
+			info = append(info, "=== AZD Demo Extension - Context Information ===")
+
+			// Create a new context that includes the AZD access token
+			ctx = azdext.WithAccessToken(ctx)
+
+			// Create a new AZD client
+			azdClient, err := azdext.NewAzdClient()
+			if err != nil {
+				info = append(info, fmt.Sprintf("❌ Failed to create AZD client: %v", err))
+				return mcp.NewToolResultText(strings.Join(info, "\n")), nil
+			}
+			defer azdClient.Close()
+
+			// Get project information
+			getProjectResponse, err := azdClient.Project().Get(ctx, &azdext.EmptyRequest{})
+			if err == nil {
+				info = append(info, "\n📂 Project Information:")
+				info = append(info, fmt.Sprintf("  Name: %s", getProjectResponse.Project.Name))
+				info = append(info, fmt.Sprintf("  Path: %s", getProjectResponse.Project.Path))
+			} else {
+				info = append(info, "\n❌ No azd project found in current directory")
+			}
+
+			// Get current environment
+			getCurrentEnvResponse, err := azdClient.Environment().GetCurrent(ctx, &azdext.EmptyRequest{})
+			if err == nil {
+				currentEnvName := getCurrentEnvResponse.Environment.Name
+				info = append(info, "\n🌍 Environment Information:")
+				info = append(info, fmt.Sprintf("  Current Environment: %s", currentEnvName))
+
+				// Get environment values
+				getValuesResponse, err := azdClient.Environment().GetValues(ctx, &azdext.GetEnvironmentRequest{
+					Name: currentEnvName,
+				})
+				if err == nil && len(getValuesResponse.KeyValues) > 0 {
+					info = append(info, "  Environment Variables:")
+					for _, pair := range getValuesResponse.KeyValues {
+						// Truncate long values for display
+						value := pair.Value
+						if len(value) > 50 {
+							value = value[:47] + "..."
+						}
+						info = append(info, fmt.Sprintf("    %s: %s", pair.Key, value))
+					}
+				}
+			} else {
+				info = append(info, "\n❌ No azd environment found")
+			}
+
+			info = append(info, "\n🔧 Extension Information:")
+			info = append(info, "  Extension ID: microsoft.azd.demo")
+			info = append(info, "  MCP Server: Active")
+			info = append(info, "  Available Tools: demo_greeting, demo_calculator, demo_azd_info")
+
+			return mcp.NewToolResultText(strings.Join(info, "\n")), nil
+		},
+	}
+}

--- a/cli/azd/extensions/microsoft.azd.demo/internal/cmd/root.go
+++ b/cli/azd/extensions/microsoft.azd.demo/internal/cmd/root.go
@@ -26,6 +26,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.AddCommand(newPromptCommand())
 	rootCmd.AddCommand(newColorsCommand())
 	rootCmd.AddCommand(newVersionCommand())
+	rootCmd.AddCommand(newMcpCommand())
 
 	return rootCmd
 }

--- a/cli/azd/pkg/extensions/extension.go
+++ b/cli/azd/pkg/extensions/extension.go
@@ -23,6 +23,7 @@ type Extension struct {
 	Usage        string           `json:"usage"`
 	Path         string           `json:"path"`
 	Source       string           `json:"source"`
+	McpConfig    *McpConfig       `json:"mcp,omitempty"`
 
 	stdin  *bytes.Buffer
 	stdout *output.DynamicMultiWriter

--- a/cli/azd/pkg/extensions/registry.go
+++ b/cli/azd/pkg/extensions/registry.go
@@ -24,6 +24,8 @@ const (
 	CustomCommandCapability CapabilityType = "custom-commands"
 	// Lifecycle events enable extensions to subscribe to AZD project & service lifecycle events
 	LifecycleEventsCapability CapabilityType = "lifecycle-events"
+	// McpServerCapability enables extensions to start an MCP server
+	McpServerCapability CapabilityType = "mcp-server"
 )
 
 // Extension represents an extension in the registry
@@ -54,6 +56,20 @@ type ExtensionDependency struct {
 	Version string `json:"version,omitempty"`
 }
 
+// McpConfig represents the MCP server configuration for an extension
+type McpConfig struct {
+	// Serve contains configuration for starting the extension's MCP server
+	Serve McpServeConfig `json:"serve"`
+}
+
+// McpServeConfig represents the configuration for starting an extension's MCP server
+type McpServeConfig struct {
+	// Args are the command-line arguments to pass when starting the MCP server
+	Args []string `json:"args"`
+	// Env are additional environment variables to set when starting the MCP server
+	Env []string `json:"env,omitempty"`
+}
+
 // ExtensionVersion represents a version of an extension
 type ExtensionVersion struct {
 	// Capabilities is a list of capabilities that the extension provides
@@ -73,6 +89,8 @@ type ExtensionVersion struct {
 	// Entry point is the entry point for the extension
 	// This will typically be the name of the executable or script to run
 	EntryPoint string `json:"entryPoint,omitempty"`
+	// McpConfig is the MCP server configuration for this extension version
+	McpConfig *McpConfig `json:"mcp,omitempty"`
 }
 
 // ExtensionArtifact represents the artifact information of an extension


### PR DESCRIPTION
Allows extension authors the capability to expose MCP tools from an extension and have the available within the `azd` agent as well as Azure MCP server.