### PR TITLE
fix: Make hook shell optional with OS-based defaults (#3613)

### DIFF
--- a/cli/azd/cmd/hooks.go
+++ b/cli/azd/cmd/hooks.go
@@ -129,6 +129,11 @@ func (hra *hooksRunAction) Run(ctx context.Context) (*actions.ActionResult, erro
 		),
 	})
 
+	// Validate hooks and display warnings
+	if err := hra.validateAndWarnHooks(ctx); err != nil {
+		return nil, fmt.Errorf("failed validating hooks: %w", err)
+	}
+
 	// Validate service name
 	if hra.flags.service != "" {
 		if has, err := hra.importManager.HasService(ctx, hra.projectConfig, hra.flags.service); err != nil {
@@ -259,6 +264,44 @@ func (hra *hooksRunAction) execHook(
 	err := hooksRunner.RunHooks(ctx, hookType, runOptions, commandName)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// Validates hooks and displays warnings for default shell usage and other issues
+func (hra *hooksRunAction) validateAndWarnHooks(ctx context.Context) error {
+	// Collect all hooks from project and services
+	allHooks := make(map[string][]*ext.HookConfig)
+
+	// Add project hooks
+	for hookName, hookConfigs := range hra.projectConfig.Hooks {
+		allHooks[hookName] = append(allHooks[hookName], hookConfigs...)
+	}
+
+	// Add service hooks
+	stableServices, err := hra.importManager.ServiceStable(ctx, hra.projectConfig)
+	if err == nil {
+		for _, service := range stableServices {
+			for hookName, hookConfigs := range service.Hooks {
+				allHooks[hookName] = append(allHooks[hookName], hookConfigs...)
+			}
+		}
+	}
+
+	// Create hooks manager and validate
+	hooksManager := ext.NewHooksManager(hra.projectConfig.Path, hra.commandRunner)
+	validationResult := hooksManager.ValidateHooks(ctx, allHooks)
+
+	// Display any warnings
+	for _, warning := range validationResult.Warnings {
+		hra.console.MessageUxItem(ctx, &ux.WarningMessage{
+			Description: warning.Message,
+		})
+		if warning.Suggestion != "" {
+			hra.console.Message(ctx, warning.Suggestion)
+		}
+		hra.console.Message(ctx, "")
 	}
 
 	return nil

--- a/cli/azd/pkg/ext/hooks_manager.go
+++ b/cli/azd/pkg/ext/hooks_manager.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	osexec "os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -142,17 +143,51 @@ func (h *HooksManager) ValidateHooks(ctx context.Context, allHooks map[string][]
 	}
 
 	hasPowerShellHooks := false
+	hasDefaultShellHooks := false
 
-	// Check all hooks
+	// First, perform lightweight validation to set flags like usingDefaultShell
+	// without creating temporary files (which full validation does)
+	for _, hookConfigs := range allHooks {
+		for _, hookConfig := range hookConfigs {
+			// Set the working directory for validation
+			if hookConfig.cwd == "" {
+				hookConfig.cwd = h.cwd
+			}
+
+			// Only perform shell detection for warning purposes, not full validation
+			if !hookConfig.validated && hookConfig.Run != "" {
+				// Check if it's an inline script (no file exists)
+				relativeCheckPath := strings.ReplaceAll(hookConfig.Run, "/", string(os.PathSeparator))
+				fullCheckPath := relativeCheckPath
+				if hookConfig.cwd != "" {
+					fullCheckPath = filepath.Join(hookConfig.cwd, hookConfig.Run)
+				}
+
+				_, err := os.Stat(fullCheckPath)
+				isInlineScript := err != nil // File doesn't exist, so it's inline
+
+				// If shell is not specified and it's an inline script, set default for warning
+				if hookConfig.Shell == ScriptTypeUnknown && isInlineScript {
+					if runtime.GOOS == "windows" {
+						hookConfig.Shell = ShellTypePowershell
+					} else {
+						hookConfig.Shell = ShellTypeBash
+					}
+					hookConfig.usingDefaultShell = true
+				}
+			}
+		}
+	}
+
+	// Now check all hooks for warning conditions
 	for _, hookConfigs := range allHooks {
 		for _, hookConfig := range hookConfigs {
 			if hookConfig.IsPowerShellHook() {
 				hasPowerShellHooks = true
-				break
 			}
-		}
-		if hasPowerShellHooks {
-			break
+			if hookConfig.IsUsingDefaultShell() {
+				hasDefaultShellHooks = true
+			}
 		}
 	}
 
@@ -181,6 +216,32 @@ func (h *HooksManager) ValidateHooks(ctx context.Context, allHooks map[string][]
 				),
 			})
 		}
+	}
+
+	// If we found hooks using default shell, warn the user
+	if hasDefaultShellHooks {
+		var warningMessage string
+		var defaultShell string
+
+		if runtime.GOOS == "windows" {
+			defaultShell = "pwsh"
+		} else {
+			defaultShell = "sh"
+		}
+
+		warningMessage = fmt.Sprintf(
+			"Hook configurations found without explicit shell specification. Using OS default shell '%s'. "+
+				"For better reliability, consider specifying the shell explicitly in your hook configuration.",
+			defaultShell,
+		)
+
+		result.Warnings = append(result.Warnings, HookWarning{
+			Message: warningMessage,
+			Suggestion: fmt.Sprintf(
+				"Add 'shell: %s' to your hook configurations to remove this warning.",
+				defaultShell,
+			),
+		})
 	}
 
 	return result

--- a/cli/azd/pkg/ext/hooks_runner_test.go
+++ b/cli/azd/pkg/ext/hooks_runner_test.go
@@ -450,12 +450,12 @@ func Test_GetScript_Validation(t *testing.T) {
 
 	scriptValidations := []scriptValidationTest{
 		{
-			name: "Missing Script Type",
+			name: "Missing Script Type - Should Use Default Shell",
 			config: &HookConfig{
 				Name: "test1",
 				Run:  "echo 'Hello'",
 			},
-			expectedError: ErrScriptTypeUnknown,
+			expectedError: nil, // Should no longer error, should use default shell
 		},
 		{
 			name: "Missing Run param",


### PR DESCRIPTION
## Overview

This PR addresses issue #3613 by making the shell configuration optional for hooks and implementing automatic OS-based shell detection.

## Changes Made

### Core Functionality
- **Auto-detect shell based on OS**: When no shell is specified, automatically use `pwsh` on Windows and `sh` on Linux/macOS
- **Comprehensive warning system**: Display user-friendly warnings when default shells are used
- **Backward compatibility**: Existing hook configurations with explicit shell settings continue to work unchanged

### Key Files Modified
- `pkg/ext/models.go`: Added OS-based shell detection and default shell tracking
- `pkg/ext/hooks_manager.go`: Enhanced validation to detect and warn about default shell usage
- `cmd/hooks.go`: Added validation and warning display to `azd hooks run` command
- Updated tests to reflect new behavior where missing shell is no longer an error

### Warning Examples

**Before (Error):**
```
ERROR: unable to determine script type. Ensure 'Shell' parameter is set in configuration options
```

**After (Working with Warning):**
```
WARNING: Hook configurations found without explicit shell specification. Using OS default shell 'sh'. 
For better reliability, consider specifying the shell explicitly in your hook configuration.
Add 'shell: sh' to your hook configurations to remove this warning.
```

### Example Usage

```yaml
# This now works (was previously an error)
hooks:
  prebuild:
    - run: "echo 'Building...'"  # Uses pwsh on Windows, sh on Linux/macOS
      
# Explicit shell (recommended, no warning)
hooks:
  prebuild:
    - shell: sh
      run: "echo 'Building...'"
```

## Testing

- All existing tests pass
- New tests added for default shell behavior and warning system
- Integration tested with `azd hooks run` command
- No regressions in middleware or core hook functionality

## Fixes

Closes #3613

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which improves existing functionality)