### PR TITLE
Typo in check to default to os.Stderr, results in us never mapping it to os.Stderr

### DIFF
--- a/cli/azd/pkg/exec/command_runner.go
+++ b/cli/azd/pkg/exec/command_runner.go
@@ -65,7 +65,7 @@ func NewCommandRunner(opt *RunnerOptions) CommandRunner {
 		runner.stdout = os.Stdout
 	}
 
-	if runner.stdout == nil {
+	if runner.stderr == nil {
 		runner.stderr = os.Stderr
 	}
 


### PR DESCRIPTION
Just something I noticed during a review.