### PR TITLE
Bypass agentic error handling flow in non-interactive scenarios

### DIFF
--- a/cli/azd/internal/agent/tools/dev/command_executor.go
+++ b/cli/azd/internal/agent/tools/dev/command_executor.go
@@ -121,18 +121,17 @@ func (t CommandExecutorTool) Call(ctx context.Context, input string) (string, er
 	}
 
 	if req.Command == "azd" {
-		blockedCommands := []string{"up", "provision", "deploy", "down"}
-
-		for _, blocked := range blockedCommands {
-			if req.Args[0] == blocked && (len(req.Args) < 2 || req.Args[1] != "--preview") {
-				errorResponse := common.ErrorResponse{
-					Error:   true,
-					Message: "azd command is not supported",
-				}
-
-				jsonData, _ := json.MarshalIndent(errorResponse, "", "  ")
-				return string(jsonData), nil
+		// Ensure --no-prompt is included in args
+		hasNoPrompt := false
+		for _, arg := range req.Args {
+			if arg == "--no-prompt" {
+				hasNoPrompt = true
+				break
 			}
+		}
+
+		if !hasNoPrompt {
+			req.Args = append(req.Args, "--no-prompt")
 		}
 	}
 

--- a/cli/azd/internal/agent/tools/dev/command_executor.go
+++ b/cli/azd/internal/agent/tools/dev/command_executor.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/internal/agent/tools/common"
@@ -121,16 +122,11 @@ func (t CommandExecutorTool) Call(ctx context.Context, input string) (string, er
 	}
 
 	if req.Command == "azd" {
-		// Ensure --no-prompt is included in args
-		hasNoPrompt := false
-		for _, arg := range req.Args {
-			if arg == "--no-prompt" {
-				hasNoPrompt = true
-				break
-			}
-		}
-
-		if !hasNoPrompt {
+		// Ensure --no-prompt is included in args to prevent interactive prompts
+		// that would block execution in agent/automation scenarios. The azd CLI
+		// may prompt for user input (confirmations, selections, etc.) which cannot
+		// be handled in a non-interactive agent context, so we force non-interactive mode.
+		if !slices.Contains(req.Args, "--no-prompt") {
 			req.Args = append(req.Args, "--no-prompt")
 		}
 	}


### PR DESCRIPTION
## Overview

Enhances the error middleware and MCP command executor to properly handle non-interactive scenarios by preventing AI-powered error handling when user interaction is not possible or desired.

We want to avoid `azd` getting stuck in an agentic error handling loop when it may choose to call another `azd` command from within itself especially during an error handling flow.

## Changes Made

### Enhanced Error Middleware Short-Circuit Logic
- Added CI detection capability to bypass AI error handling in automated environments
- Extended short-circuit conditions to include:
  - LLM feature disabled
  - `--no-prompt` flag specified
  - Running in CI/CD environment
- Prevents AI error handling from attempting user interaction in automated pipelines

### Simplified MCP Command Executor for `azd` Commands
- Removed overly restrictive command blocking for `up`, `provision`, `deploy`, `down` commands
- Automatically appends `--no-prompt` flag to `azd` commands when not already present
- Allows AI agents to execute commands while ensuring non-interactive mode

## Benefits

- **CI/CD Safety**: Prevents hanging in automated environments where user interaction is impossible
- **Performance**: Eliminates unnecessary AI processing in non-interactive scenarios
- **Better UX**: AI error handling only runs when actually useful (interactive sessions)
- **Reliability**: Uses existing, well-tested CI detection supporting 15+ platforms