### PR TITLE
avoid saving IMAGE_NAME in env for containerapp target

### DIFF
--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -189,13 +189,6 @@ func Test_ContainerApp_Publish(t *testing.T) {
 	// Verify the Package field is set correctly
 	require.NotNil(t, publishResult.Package)
 	require.Equal(t, packageResult, publishResult.Package)
-
-	// Verify the environment variable was set correctly
-	require.Equal(t, "REGISTRY.azurecr.io/test-app/api-test:azd-deploy-0", env.Dotenv()["SERVICE_API_IMAGE_NAME"])
-
-	// Verify the publish result contains the expected image name
-	containerDetails := publishResult.Details.(*ContainerPublishDetails)
-	require.Equal(t, "REGISTRY.azurecr.io/test-app/api-test:azd-deploy-0", containerDetails.RemoteImage)
 }
 
 func createContainerAppServiceTarget(

--- a/cli/azd/test/functional/testdata/samples/containerapp/infra/main.bicep
+++ b/cli/azd/test/functional/testdata/samples/containerapp/infra/main.bicep
@@ -30,6 +30,6 @@ module resources 'resources.bicep' = {
 
 
 output AZURE_CONTAINER_REGISTRY_NAME string = resources.outputs.containerRegistryName
-output AZURE_CONTAINER_ENVIRONMENT_NAME string = resources.outputs.containerAppsEnvironmentName
-output AZURE_CONTAINER_REGISTRY_ENDPOINT string = resources.outputs.containerRegistryloginServer
+output AZURE_CONTAINER_ENVIRONMENT_ID string = resources.outputs.containerAppsEnvironmentId
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = resources.outputs.containerRegistryLoginServer
 output SERVICE_WEB_IDENTITY_ID string = resources.outputs.managedIdentityId

--- a/cli/azd/test/functional/testdata/samples/containerapp/infra/resources.bicep
+++ b/cli/azd/test/functional/testdata/samples/containerapp/infra/resources.bicep
@@ -82,6 +82,6 @@ resource caeMiRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01
 }
 
 output containerRegistryName string = containerRegistry.name
-output containerAppsEnvironmentName string = containerAppsEnvironment.name
-output containerRegistryloginServer string = containerRegistry.properties.loginServer
+output containerAppsEnvironmentId string = containerAppsEnvironment.id
+output containerRegistryLoginServer string = containerRegistry.properties.loginServer
 output managedIdentityId string = managedIdentity.id

--- a/cli/azd/test/functional/testdata/samples/containerapp/infra/web.bicep
+++ b/cli/azd/test/functional/testdata/samples/containerapp/infra/web.bicep
@@ -1,60 +1,52 @@
-@minLength(1)
-@maxLength(64)
-@description('Name of the the environment which is used to generate a short unique hash used in all resources.')
 param environmentName string
-
-@minLength(1)
-@description('Primary location for all resources')
 param location string
 
-param containerRegistryName string
-param containerAppsEnvironmentName string
-
+param containerRegistryEndpoint string
+param containerEnvironmentId string
 param imageName string
-
 param identityId string
 
-resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' existing = {
-  name: containerRegistryName
-}
-
-resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2022-03-01' existing = {
-  name: containerAppsEnvironmentName
-}
-
-module web 'br/public:avm/res/app/container-app:0.8.0' = {
+resource web 'Microsoft.App/containerApps@2025-01-01' = {
   name: 'web'
-  params: {
-    name: 'web'
-    ingressTargetPort: 8080
-    scaleMinReplicas: 1
-    scaleMaxReplicas: 10
-    secrets: {
-      secureList:  [
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${identityId}': {}
+    }
+  }
+  properties: {
+    environmentId: containerEnvironmentId
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: true
+        targetPort: 8080
+        transport: 'http'
+        allowInsecure: false
+      }
+      registries: [
+        {
+          server: containerRegistryEndpoint
+          identity: identityId
+        }
       ]
     }
-    containers: [
-      {
-        image: imageName
-        name: 'main'
-        resources: {
-          cpu: json('0.5')
-          memory: '1.0Gi'
+    template: { 
+      containers: [
+        {
+          image: imageName
+          name: 'main'
+          resources: {
+            cpu: json('0.5')
+            memory: '1.0Gi'
+          }
         }
+      ]
+      scale: {
+        minReplicas: 1
       }
-    ]
-    managedIdentities:{
-      systemAssigned: false
-      userAssignedResourceIds: [identityId]
     }
-    registries:[
-      {
-        server: containerRegistry.properties.loginServer
-        identity: identityId
-      }
-    ]
-    environmentResourceId: containerAppsEnvironment.id
-    location: location
-    tags: { 'azd-env-name': environmentName, 'azd-service-name': 'web' }
   }
+  tags: { 'azd-env-name': environmentName, 'azd-service-name': 'web' }
 }

--- a/cli/azd/test/functional/testdata/samples/containerapp/infra/web.parameters.json
+++ b/cli/azd/test/functional/testdata/samples/containerapp/infra/web.parameters.json
@@ -8,11 +8,11 @@
     "location": {
       "value": "${AZURE_LOCATION}"
     },
-    "containerRegistryName": {
-      "value": "${AZURE_CONTAINER_REGISTRY_NAME}"
+    "containerRegistryEndpoint": {
+      "value": "${AZURE_CONTAINER_REGISTRY_ENDPOINT}"
     },
-    "containerAppsEnvironmentName": {
-      "value": "${AZURE_CONTAINER_ENVIRONMENT_NAME}"
+    "containerEnvironmentId": {
+      "value": "${AZURE_CONTAINER_ENVIRONMENT_ID}"
     },
     "imageName": {
       "value": "${SERVICE_WEB_IMAGE_NAME}"


### PR DESCRIPTION
Avoid saving IMAGE_NAME in env for containerapp target. Instead, apply it in context when needed.

Makes it easier to reuse publishing for init/sidecar containers without stepping on toes.