### PR TITLE
Removes duplicate changelog.md

### DIFF
--- a/cli/azd/extensions/azure.coding-agent/changelog.md
+++ b/cli/azd/extensions/azure.coding-agent/changelog.md
@@ -1,3 +1,0 @@
-# Release History
-
-## 0.0.1 - Initial Version


### PR DESCRIPTION
The changelog.md was added as `CHANGELOG.md` and `changelog.md` which is causing issues on Windows machines.  This removes the lowercase version to align to our single unified naming.