### PR TITLE
Makes language optional in the schema

### DIFF
--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -205,7 +205,7 @@
                     "language": {
                         "type": "string",
                         "title": "Service implementation language",
-                        "enum": [
+                        "examples": [
                             "dotnet",
                             "csharp",
                             "fsharp",
@@ -310,9 +310,6 @@
                                     "required": [
                                         "image"
                                     ],
-                                    "properties": {
-                                        "language": false
-                                    },
                                     "not": {
                                         "required": [
                                             "project"
@@ -364,8 +361,7 @@
                         },
                         "then": {
                             "required": [
-                                "project",
-                                "language"
+                                "project"
                             ],
                             "properties": {
                                 "docker": false

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -112,7 +112,7 @@
                     "language": {
                         "type": "string",
                         "title": "Service implementation language",
-                        "enum": [
+                        "examples": [
                             "dotnet",
                             "csharp",
                             "fsharp",
@@ -207,9 +207,6 @@
                                     "required": [
                                         "image"
                                     ],
-                                    "properties": {
-                                        "language": false
-                                    },
                                     "not": {
                                         "required": [
                                             "project"
@@ -261,8 +258,7 @@
                         },
                         "then": {
                             "required": [
-                                "project",
-                                "language"
+                                "project"
                             ],
                             "properties": {
                                 "docker": false


### PR DESCRIPTION
To support hosts that support more dynamic languages or hosts that do not require any language such as declarative foundry agents we will turn off strict schema validation.

For example - the upcoming `foundry.hostedagent` can be used without any language when building declarative agents.  Since this service target comes from an extension we also do not have enough metadata to know whether or not language is required.