### PR TITLE
minor fix for agent azd init agent UX

### DIFF
--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -262,11 +262,14 @@ func (i *initAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	header := "New project initialized!"
 	followUp := heredoc.Docf(`
 	You can view the template code in your directory: %s
-	Learn more about running 3rd party code on our DevHub: %s
-	%s Run azd up to deploy project to the cloud.`,
+	Learn more about running 3rd party code on our DevHub: %s`,
 		output.WithLinkFormat("%s", wd),
-		output.WithLinkFormat("%s", "https://aka.ms/azd-third-party-code-notice"),
-		color.HiMagentaString("Next steps:"))
+		output.WithLinkFormat("%s", "https://aka.ms/azd-third-party-code-notice"))
+
+	if i.featuresManager.IsEnabled(llm.FeatureLlm) {
+		followUp += fmt.Sprintf("\n%s Run azd up to deploy project to the cloud.`",
+			color.HiMagentaString("Next steps:"))
+	}
 
 	switch initTypeSelect {
 	case initAppTemplate:


### PR DESCRIPTION
Update line ```Next step...` to only show in azd init agent mode.

Current behavior without the change:
<img width="687" height="181" alt="image" src="https://github.com/user-attachments/assets/207d5658-1502-4a90-8ae0-5db88b41d6e6" />
