### PR TITLE
containerapp: fix check for resource exists

### DIFF
--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -356,7 +356,7 @@ func (at *containerAppTarget) addPreProvisionChecks(_ context.Context, serviceCo
 
 		// Check if the target resource already exists
 		targetResource, err := at.resourceManager.GetTargetResource(ctx, at.env.GetSubscriptionId(), serviceConfig)
-		if targetResource != nil && err == nil {
+		if err == nil && targetResource != nil && targetResource.ResourceName() != "" {
 			exists = true
 		}
 


### PR DESCRIPTION
Context: In #5931, it is found that for resource-group based deployments with container apps, the resource existence check is now returning true regardless of whether the resource exists. This happened after #5694 due to this single [line](https://github.com/Azure/azure-dev/pull/5694/files#diff-4fb3fa08cdb5c918e58a4f5dd4d9a3344290170a1cc8e8cb321ec8e2b4dd40a3) change.

This is a targeted fix to patch the issue, with follow-ups to make better improvements.

Fixes #5931