### PR TITLE
Update azure.foundry.ai.agents to use AccountService to look up tenant IDs and AzureDeveloperCLICredential

### DIFF
--- a/cli/azd/extensions/azure.foundry.ai.agents/go.mod
+++ b/cli/azd/extensions/azure.foundry.ai.agents/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.8.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
-	github.com/azure/azure-dev v0.0.0-20251023224406-ec6ba2a0cddc
+	github.com/azure/azure-dev v0.0.0-20251024053325-326f63f72d65
 	github.com/fatih/color v1.18.0
 	github.com/google/uuid v1.6.0
 	github.com/mark3labs/mcp-go v0.41.1

--- a/cli/azd/extensions/azure.foundry.ai.agents/go.sum
+++ b/cli/azd/extensions/azure.foundry.ai.agents/go.sum
@@ -45,8 +45,8 @@ github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWp
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/azure/azure-dev v0.0.0-20251023224406-ec6ba2a0cddc h1:CRAUm8FM+vCui1fqy7HapiufSC83UEldOVm9Eeff6jA=
-github.com/azure/azure-dev v0.0.0-20251023224406-ec6ba2a0cddc/go.mod h1:fxSuNif5f3su+U252I7Ba7emSfo1rKyvr36YkexqDHo=
+github.com/azure/azure-dev v0.0.0-20251024053325-326f63f72d65 h1:v63xUinXYvJ8tbJ3HRLpsXEoICiKG+3hG4Nje9FYMkI=
+github.com/azure/azure-dev v0.0.0-20251024053325-326f63f72d65/go.mod h1:fxSuNif5f3su+U252I7Ba7emSfo1rKyvr36YkexqDHo=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=


### PR DESCRIPTION
Fixes #5974

This PR refactors the credential and tenant ID handling in the agents extension to use AzureDeveloperCLICredential instead of DefaultAzureCredential and look up the tenant ID for a given subscription using the new AccountService added in #5995. 

`AdditionallyAllowedTenants` on the AzureDeveloperCLICredential is set to to `*` as an extra measure to allow the credential to authenticate to any tenant ([docs](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#AzureDeveloperCLICredentialOptions)), but I think setting the appropriate tenant ID alone should be sufficient. 

There were also some changes made to reuse the credential object where possible.