### PR TITLE
[Aspire] handle annotated strings with uri format

### DIFF
--- a/cli/azd/pkg/apphost/generate.go
+++ b/cli/azd/pkg/apphost/generate.go
@@ -510,13 +510,19 @@ func GenerateProjectArtifacts(
 	return files, nil
 }
 
+type annotatedString struct {
+	Filter string
+	Value  string
+}
+
 type infraGenerator struct {
 	dapr              map[string]genDapr
 	projects          map[string]genProject
 	connectionStrings map[string]string
 	// keeps the value from value.v0 resources if provided.
-	valueStrings  map[string]string
-	resourceTypes map[string]string
+	valueStrings     map[string]string
+	annotatedStrings map[string]annotatedString
+	resourceTypes    map[string]string
 
 	bicepContext                 genBicepTemplateContext
 	containerAppTemplateContexts map[string]genContainerAppManifestTemplateContext
@@ -551,6 +557,8 @@ func newInfraGenerator() *infraGenerator {
 		dapr:                         make(map[string]genDapr),
 		projects:                     make(map[string]genProject),
 		connectionStrings:            make(map[string]string),
+		valueStrings:                 make(map[string]string),
+		annotatedStrings:             make(map[string]annotatedString),
 		resourceTypes:                make(map[string]string),
 		containerAppTemplateContexts: make(map[string]genContainerAppManifestTemplateContext),
 		buildContainers:              make(map[string]genBuildContainer),
@@ -738,6 +746,11 @@ func (b *infraGenerator) LoadManifest(m *Manifest) error {
 			}
 			if err := b.addInputParameter(name, comp); err != nil {
 				return fmt.Errorf("adding bicep parameter from resource %s (%s): %w", name, comp.Type, err)
+			}
+		case "annotated.string":
+			b.annotatedStrings[name] = annotatedString{
+				Filter: comp.Filter,
+				Value:  comp.Value,
 			}
 		case "azure.bicep.v0", "azure.bicep.v1":
 			if err := b.addBicep(name, comp); err != nil {
@@ -1534,6 +1547,23 @@ func (b infraGenerator) evalBindingRef(v string, emitType inputEmitType) (string
 		}
 
 		return res, nil
+	}
+	if annotatedString, has := b.annotatedStrings[resource]; has && prop == "value" {
+		if annotatedString.Filter != "uri" {
+			return "", fmt.Errorf("unsupported annotated.string filter '%s' in binding expression for resource %s",
+				annotatedString.Filter, resource)
+		}
+		// uri is currently the only supported filter for annotated.string
+		res, err := EvalString(annotatedString.Value, func(s string) (string, error) {
+			return b.evalBindingRef(s, emitType)
+		})
+		if err != nil {
+			return "", fmt.Errorf("evaluating annotated.string's value string for %s: %w", resource, err)
+		}
+
+		return strings.ReplaceAll(
+			strings.ReplaceAll(res, "{{ ", "{{ uriEncode ("),
+			"}}", ")}}"), nil
 	}
 
 	if strings.HasPrefix(prop, "inputs.") {

--- a/cli/azd/pkg/apphost/manifest.go
+++ b/cli/azd/pkg/apphost/manifest.go
@@ -136,6 +136,9 @@ type Resource struct {
 	// parameter.v0 uses value field to define the value of the parameter.
 	Value string
 
+	// annotated.string uses filter to define the filter to apply to the string.
+	Filter string `json:"filter,omitempty"`
+
 	// container.v0 uses volumes field to define the volumes of the container.
 	Volumes []*Volume `json:"volumes,omitempty"`
 

--- a/cli/azd/pkg/project/service_target_dotnet_containerapp.go
+++ b/cli/azd/pkg/project/service_target_dotnet_containerapp.go
@@ -285,6 +285,7 @@ func (at *dotnetContainerAppTarget) Deploy(
 		// allows to update the logic of pulling secret parameters in the future, if azd changes the way it
 		// stores the parameter value.
 		"securedParameter": fns.Parameter,
+		"uriEncode":        url.QueryEscape,
 		"secretOutput":     fns.kvSecret,
 		"targetPortOrDefault": func(targetPortFromManifest int) int {
 			// portNumber is 0 for dockerfile.v0, so we use the targetPort from the manifest


### PR DESCRIPTION
Annotated strings are used within the manifest to represent the usage intention for a parameter.
When using uri filter, azd must encode the value as URI.

For example, for a value like `pFbl=TJGk@L9S@qh918zOk`  annotated with filter=uri, azd applies `url.QueryEscape` to the value, generating something like `pFbl%3DTJGk%40L9S%40qh918zOk`

fix: https://github.com/Azure/azure-dev/issues/5972