### PR TITLE
`azure.ai.agents` - Show agent endpoint on successful deploy and improve error handling

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -630,11 +630,25 @@ func (p *AgentServiceTargetProvider) startAgentContainer(
 				}
 
 				// Check if operation is complete
-				if completedOperation.Status == "Succeeded" || completedOperation.Status == "Failed" {
-					if completedOperation.Status == "Failed" {
-						return fmt.Errorf("operation failed: %s", completedOperation.Error)
+				if completedOperation.Status == "Failed" {
+					// Try to get reason for failure by querying container API
+					containerInfo, containerErr := agentClient.GetAgentContainer(
+						ctx, agentVersionResponse.Name, agentVersionResponse.Version, apiVersion)
+					if containerErr != nil {
+						return fmt.Errorf("operation failed (id: %s): failed to retrieve container details: %w", operation.Body.ID, containerErr)
 					}
 
+					var errorMsg string
+					if containerInfo.ErrorMessage != nil && *containerInfo.ErrorMessage != "" {
+						errorMsg = fmt.Sprintf("operation failed (id: %s): container status is %q with error: %s", operation.Body.ID, containerInfo.Status, *containerInfo.ErrorMessage)
+					} else {
+						errorMsg = fmt.Sprintf("operation failed (id: %s): container status is %q with no error details", operation.Body.ID, containerInfo.Status)
+					}
+
+					return errors.New(errorMsg)
+				}
+
+				if completedOperation.Status == "Succeeded" {
 					if completedOperation.Container != nil {
 						fmt.Fprintf(os.Stderr, "Agent container '%s' (version: %s) operation completed! Container status: %s\n",
 							agentVersionResponse.Name, agentVersionResponse.Version, completedOperation.Container.Status)
@@ -647,6 +661,7 @@ func (p *AgentServiceTargetProvider) startAgentContainer(
 					return nil
 				}
 
+				// Still in progress, continue polling
 				fmt.Fprintf(os.Stderr, "Operation status: %s\n", completedOperation.Status)
 			}
 		}


### PR DESCRIPTION
Closes #6044

This PR improves the deployment and error handling logic for hosted agents in the `azure.ai.agents` extension.

### Deploy artifact

`Deploy()` now returns the agent details as an endpoint artifact to show up in the output on a successful deploy:

<img width="1562" height="280" alt="image" src="https://github.com/user-attachments/assets/38771965-896c-49ba-9c90-125677b4dd54" />

### Error handling and diagnostics

Based on guidance from the service team, when starting an agent container fails, the extension now attempts to get the failure error message from the agent container API. Sometimes the API may return an empty error message, in which case the following is shown:

<img width="1896" height="172" alt="image" src="https://github.com/user-attachments/assets/1ea88cd9-6517-47af-8bbf-80b78d26d5f2" />

In addition, the operation ID is now included to help with debugging and investigations.