### PR TITLE
Update `azd show` to show endpoints from custom service targets

### DIFF
--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -151,16 +151,18 @@ func NewRootCmd(
 		DefaultFormat:  output.NoneFormat,
 	})
 
-	root.Add("show", &actions.ActionDescriptorOptions{
-		Command:        show.NewShowCmd(),
-		FlagsResolver:  show.NewShowFlags,
-		ActionResolver: show.NewShowAction,
-		OutputFormats:  []output.Format{output.JsonFormat, output.NoneFormat},
-		DefaultFormat:  output.NoneFormat,
-		GroupingOptions: actions.CommandGroupOptions{
-			RootLevelHelp: actions.CmdGroupManage,
-		},
-	})
+	root.
+		Add("show", &actions.ActionDescriptorOptions{
+			Command:        show.NewShowCmd(),
+			FlagsResolver:  show.NewShowFlags,
+			ActionResolver: show.NewShowAction,
+			OutputFormats:  []output.Format{output.JsonFormat, output.NoneFormat},
+			DefaultFormat:  output.NoneFormat,
+			GroupingOptions: actions.CommandGroupOptions{
+				RootLevelHelp: actions.CmdGroupManage,
+			},
+		}).
+		UseMiddleware("extensions", middleware.NewExtensionsMiddleware)
 
 	//deprecate:cmd hide login
 	login := newLoginCmd("")

--- a/cli/azd/internal/cmd/show/show.go
+++ b/cli/azd/internal/cmd/show/show.go
@@ -491,12 +491,7 @@ func (s *showAction) serviceEndpoint(
 	ctx context.Context, subId string, serviceConfig *project.ServiceConfig, env *environment.Environment) string {
 	resourceManager, err := s.lazyResourceManager.GetValue()
 	if err != nil {
-		log.Printf("error: getting lazy target-resource. Endpoints will be empty: %v", err)
-		return ""
-	}
-	targetResource, err := resourceManager.GetTargetResource(ctx, subId, serviceConfig)
-	if err != nil {
-		log.Printf("error: getting target-resource. Endpoints will be empty: %v", err)
+		log.Printf("error: getting lazy resource manager. Endpoints will be empty: %v", err)
 		return ""
 	}
 
@@ -505,11 +500,25 @@ func (s *showAction) serviceEndpoint(
 		log.Printf("error: getting lazy service manager. Endpoints will be empty: %v", err)
 		return ""
 	}
+
+	// Initialize the service to ensure external service targets can create provider instances
+	if err := serviceManager.Initialize(ctx, serviceConfig); err != nil {
+		log.Printf("error: initializing service. Endpoints will be empty: %v", err)
+		return ""
+	}
+
 	st, err := serviceManager.GetServiceTarget(ctx, serviceConfig)
 	if err != nil {
 		log.Printf("error: getting service target. Endpoints will be empty: %v", err)
 		return ""
 	}
+
+	targetResource, err := s.resolveTargetResource(ctx, st, resourceManager, subId, serviceConfig)
+	if err != nil {
+		log.Printf("error: getting target-resource. Endpoints will be empty: %v", err)
+		return ""
+	}
+
 	endpoints, err := st.Endpoints(ctx, serviceConfig, targetResource)
 	if err != nil {
 		log.Printf("error: getting service endpoints. Endpoints might be empty: %v", err)
@@ -525,6 +534,30 @@ func (s *showAction) serviceEndpoint(
 	}
 
 	return endpoints[0]
+}
+
+func (s *showAction) resolveTargetResource(
+	ctx context.Context,
+	st project.ServiceTarget,
+	resourceManager project.ResourceManager,
+	subId string,
+	serviceConfig *project.ServiceConfig,
+) (*environment.TargetResource, error) {
+	// Handle custom service targets with their own custom GetTargetResource resolution
+	if resolver, ok := st.(project.TargetResourceResolver); ok {
+		defaultResolver := func() (*environment.TargetResource, error) {
+			return resourceManager.GetTargetResource(ctx, subId, serviceConfig)
+		}
+
+		resource, err := resolver.ResolveTargetResource(ctx, subId, serviceConfig, defaultResolver)
+		if err != nil {
+			return nil, fmt.Errorf("resolving target resource via external service target: %w", err)
+		}
+		return resource, nil
+	}
+
+	// Default target resource resolution
+	return resourceManager.GetTargetResource(ctx, subId, serviceConfig)
 }
 
 func showTypeFromLanguage(language project.ServiceLanguageKind) contracts.ShowType {

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -843,18 +843,6 @@ func runCommand[T any](
 	return result, err
 }
 
-// getTargetResourceForService resolves the target resource for a service configuration.
-// For DotNetContainerAppTarget, it handles container app environment resolution.
-// For other service types, it delegates to the resource manager.
-type targetResourceResolver interface {
-	ResolveTargetResource(
-		ctx context.Context,
-		subscriptionId string,
-		serviceConfig *ServiceConfig,
-		defaultResolver func() (*environment.TargetResource, error),
-	) (*environment.TargetResource, error)
-}
-
 // / GetTargetResource finds and resolves the target Azure resource for the specified service configuration and host
 func (sm *serviceManager) GetTargetResource(
 	ctx context.Context,
@@ -862,7 +850,7 @@ func (sm *serviceManager) GetTargetResource(
 	serviceTarget ServiceTarget,
 ) (*environment.TargetResource, error) {
 	if serviceTarget != nil {
-		if resolver, ok := serviceTarget.(targetResourceResolver); ok {
+		if resolver, ok := serviceTarget.(TargetResourceResolver); ok {
 			// Callback for computing the default target resource
 			defaultResolver := func() (*environment.TargetResource, error) {
 				return sm.resourceManager.GetTargetResource(ctx, sm.env.GetSubscriptionId(), serviceConfig)

--- a/cli/azd/pkg/project/service_target_external.go
+++ b/cli/azd/pkg/project/service_target_external.go
@@ -32,6 +32,15 @@ type ExternalServiceTarget struct {
 	responseChans sync.Map
 }
 
+type TargetResourceResolver interface {
+	ResolveTargetResource(
+		ctx context.Context,
+		subscriptionId string,
+		serviceConfig *ServiceConfig,
+		defaultResolver func() (*environment.TargetResource, error),
+	) (*environment.TargetResource, error)
+}
+
 func envResolver(env *environment.Environment) mapper.Resolver {
 	return func(key string) string {
 		if env == nil {


### PR DESCRIPTION
Fixes #6066

This PR enables `azd show` to work with custom service targets provided by extensions, allowing them to control what endpoints are displayed:

<img width="763" height="152" alt="image" src="https://github.com/user-attachments/assets/b0e19c36-d8fb-4f25-bfcb-79bf74e2e349" />

The highlighted endpoint in red above is controlled by the extension:
https://github.com/Azure/azure-dev/blob/60c513052483e4c28582885ccdf95d3536dde345/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go#L100-L135

### Changes

1. Added extensions middleware to `show` command in `root.go` - extensions with service-target-provider capabilities are now initialized before show command execution
2. Implemented custom target resource resolution in `show.go` - External service targets can define their own `Endpoints()` and `GetTargetResource()` logic. Since `Endpoints()` takes in a `TargetResource`, `azd show` needs to be updated to call the custom service target's implementation of `GetTargetResource` before calling `Endpoints()`.