### PR TITLE
Moving hooks warning from console to logs

### DIFF
--- a/cli/azd/pkg/ext/hooks_manager.go
+++ b/cli/azd/pkg/ext/hooks_manager.go
@@ -224,7 +224,7 @@ func (h *HooksManager) ValidateHooks(ctx context.Context, allHooks map[string][]
 		}
 	}
 
-	// If we found hooks using default shell, warn the user
+	// If we found hooks using default shell, warn the user - only log
 	if hasDefaultShellHooks {
 		var warningMessage string
 		var defaultShell string
@@ -243,13 +243,7 @@ func (h *HooksManager) ValidateHooks(ctx context.Context, allHooks map[string][]
 			output.WithHyperlink("aka.ms/azd-hooks", "aka.ms/azd-hooks"),
 		)
 
-		result.Warnings = append(result.Warnings, HookWarning{
-			Message: warningMessage,
-			Suggestion: fmt.Sprintf(
-				"Add 'shell: %s' to your hook configurations to remove this warning.",
-				defaultShell,
-			),
-		})
+		log.Println(warningMessage)
 	}
 
 	return result


### PR DESCRIPTION
As suggested in : https://github.com/Azure/azure-dev/issues/3613#issuecomment-3471755509

We will only show the note in logs (when running with debug) but should not use the main output by default
