### PR TITLE
Exclude cspell files from "azure-dev - cli" triggers

### DIFF
--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -24,6 +24,8 @@ pr:
     exclude:
       - cli/azd/docs/**
       - cli/azd/extensions/**
+      - cli/azd/.vscode/cspell.yaml
+      - cli/azd/.vscode/cspell-azd-dictionary.txt
 
 extends: 
   template: /eng/pipelines/templates/stages/1es-redirect.yml


### PR DESCRIPTION
This prevents the "azure-dev -cli" pipeline from triggering on PRs where `cspell.yaml` is updated as part of extension changes for example.