### PR TITLE
Add support for multi-agent projects

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -836,7 +836,10 @@ func (p *AgentServiceTargetProvider) registerAgentEnvironmentVariables(
 		agentVersionResponse.Version,
 	)
 
-	serviceKey := strings.ToUpper(strings.ReplaceAll(serviceConfig.Name, " ", "_"))
+	// Create environment variable keys
+	serviceKey := strings.ReplaceAll(serviceConfig.Name, " ", "_")
+	serviceKey = strings.ReplaceAll(serviceKey, "-", "_")
+	serviceKey = strings.ToUpper(serviceKey)
 
 	envVars := map[string]string{
 		fmt.Sprintf("AGENT_%s_NAME", serviceKey):     agentVersionResponse.Name,


### PR DESCRIPTION
Update generated environment variables to support multi agent project.  The following environment variables are now set after a successful deployment where `{NAME}` is equal to the key in the `azd` services node.

- `AGENT_{NAME}_NAME`
- `AGENT_{NAME}_VERSION`
- `AGENT_{NAME}_ENDPOINT`