### PR TITLE
azure.ai.agents - Fix agent playground URL

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -920,6 +920,6 @@ func encodeSubscriptionID(subscriptionID string) (string, error) {
 	guidBytes, _ := guid.MarshalBinary()
 
 	// Encode as base64 and remove padding
-	encoded := base64.StdEncoding.EncodeToString(guidBytes)
+	encoded := base64.URLEncoding.EncodeToString(guidBytes)
 	return strings.TrimRight(encoded, "="), nil
 }


### PR DESCRIPTION
The encoded subscription ID needs to be URL-safe (`-` and `_` in place of `+` and `/` respectively)