### PR TITLE
Reduce provisioning progress polling interval from 10s to 3s

### DIFF
--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -642,7 +642,7 @@ func (p *BicepProvider) Deploy(ctx context.Context) (*provisioning.DeployResult,
 		progressDisplay := p.deploymentManager.ProgressDisplay(deployment)
 		// Make initial delay shorter to be more responsive in displaying initial progress
 		initialDelay := 3 * time.Second
-		regularDelay := 10 * time.Second
+		regularDelay := 3 * time.Second
 		timer := time.NewTimer(initialDelay)
 		queryStartTime := time.Now()
 


### PR DESCRIPTION
Moving from 10 seconds to 3 seconds for the regular polling delay provides more responsive progress updates that better reflect the near real-time status shown in the Azure Portal dashboard. 

## Impact
- Users will see provisioning status updates (Creating/Updating resources) every 3 seconds instead of every 10 seconds
- First check still occurs at 3 seconds (initialDelay unchanged)
- More closely aligns with Azure Portal's real-time dashboard experience
- API call impact (from ~6 calls/minute to ~20 calls/minute during active provisioning)