### PR TITLE
Add operations-per-run limit to stale issues workflow

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -33,4 +33,5 @@ jobs:
           # Exclude PRs from closing or being marked as stale
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          operations-per-run: 500
           


### PR DESCRIPTION
Currently we are running everyday at 3am, it will grab 30 at a time (it does auto paginate), picks up where it left off. However, at this pace will take ~31 days to get through our issues. However when new issues are added, it starts over.