### PR TITLE
add infra fix instructions to fix name conflicts for error handling workflow

### DIFF
--- a/cli/azd/internal/mcp/tools/prompts/azd_error_troubleshooting.md
+++ b/cli/azd/internal/mcp/tools/prompts/azd_error_troubleshooting.md
@@ -108,7 +108,7 @@
    
    a. **Hardcoded in Infrastructure Files (Bicep/Terraform)**
       - Search for hardcoded values in `main.bicep`, `*.bicep`, `main.tf`, `*.tf` files in the `infra/` directory
-      - **Example:** `name: 'kv-hardcodedname'` or `resource "azurerm_key_vault" "kv" { name = "hardcoded-name" }`
+      - **Example:** `name: 'kv-hardcoded-name'` or `resource "azurerm_key_vault" "kv" { name = "hardcoded-name" }`
       - **Action Required:** Update the infrastructure file directly to use parameters or variables instead
       
    b. **Defined in Environment Files**
@@ -131,7 +131,7 @@
         ```bicep
         // ❌ BEFORE (Hardcoded - causes conflicts)
         resource keyVault 'Microsoft.KeyVault/vaults@2023-02-01' = {
-          name: 'kv-ctriipyyhopq4'  // This hardcoded name will conflict
+          name: 'kv-hardcoded-name'  // This hardcoded name will conflict
           location: location
           // ...
         }
@@ -148,11 +148,11 @@
         @description('Primary location for all resources')
         param location string
 
-        var abbrs = loadJsonContent('./abbreviations.json')
+        var abbreviations = loadJsonContent('./abbreviations.json')
         var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
         
         resource keyVault 'Microsoft.KeyVault/vaults@2023-02-01' = {
-          name: !empty(keyVaultName) ? keyVaultName : '${abbrs.keyVaultVaults}${resourceToken}'  // Generates unique name per deployment
+          name: !empty(keyVaultName) ? keyVaultName : '${abbreviations.keyVaultVaults}${resourceToken}'  // Generates unique name per deployment
           location: location
           // ...
         }
@@ -183,7 +183,7 @@
    
    3. **If Name is in Environment/Parameter Files:**
       - Update `.env` or `parameters.json` with new unique value
-      - Use `azd env set KEY_VAULT_NAME=kv-newuniquename` if applicable
+      - Use `azd env set KEY_VAULT_NAME=kv-new-unique-name` if applicable
    
    4. **Verification:**
       - **Show the user which specific file(s) need to be updated**


### PR DESCRIPTION
fix #6325 
This fix works but I want to revisit it in future to see if we have better ways to categorize infra kind of common error to a new tool like azd_error_infra_common_fix while analyzing telemetry data and common errors. 

<img width="1852" height="866" alt="image" src="https://github.com/user-attachments/assets/621138fa-a37d-44c1-b4eb-8d22cf59b6cc" />
<img width="1862" height="893" alt="image" src="https://github.com/user-attachments/assets/10aad443-1961-453b-ad51-a2eba36cb724" />
