### PR TITLE
Fix SWA deployment

### DIFF
--- a/cli/azd/pkg/project/framework_service_swa.go
+++ b/cli/azd/pkg/project/framework_service_swa.go
@@ -56,7 +56,7 @@ func NewSwaProjectAsFrameworkService(
 func (p *swaProject) Requirements() FrameworkRequirements {
 	return FrameworkRequirements{
 		Package: FrameworkPackageRequirements{
-			RequireRestore: false,
+			RequireRestore: true,
 			RequireBuild:   true,
 		},
 	}
@@ -137,7 +137,7 @@ func (p *swaProject) Package(
 	return &ServicePackageResult{
 		Artifacts: ArtifactCollection{
 			{
-				Kind:         ArtifactKindDirectory,
+				Kind:         ArtifactKindConfig,
 				Location:     serviceConfig.Path(),
 				LocationKind: LocationKindLocal,
 				Metadata: map[string]string{


### PR DESCRIPTION
fix: https://github.com/Azure/azure-dev/issues/6334

Fixing an artifacts issue after https://github.com/Azure/azure-dev/commit/bf7ef26cd0eb58443367932538443fda281f348c

The swa framework service must produce an artifact during `package` which the static webapp service target can use to identify that the user is using swa-cli.config.json. Since the artifact was a directory kind, the deployment was expecting a project without swa-cli.config.json.

The swa framework service must also require a restore to ensure `npm install` is invoked for dependencies on a fresh new `azd up`.