### PR TITLE
Fix unclear error when deploying to improperly-tagged container app in non-revision mode

### DIFF
--- a/cli/azd/pkg/project/service_target.go
+++ b/cli/azd/pkg/project/service_target.go
@@ -147,13 +147,15 @@ func (st ServiceTargetKind) IgnoreFile() string {
 	}
 }
 
-// SupportsDelayedProvisioning returns true if the service target kind
-// supports delayed provisioning resources at deployment time, otherwise false.
+// SupportsDelayedProvisioning returns true if the service target supports provisioning
+// resources during deployment when they don't exist yet.
 //
-// As an example, ContainerAppTarget is able to provision the container app as part of deployment,
-// and thus returns true.
+// Deprecated: Use TargetResourceResolver interface for custom resource resolution instead.
+// Container Apps supports delayed provisioning but implements TargetResourceResolver to
+// provide better error messages when resources are missing in non-bicep deployment scenarios.
+// Retained only for AKS backward compatibility.
 func (st ServiceTargetKind) SupportsDelayedProvisioning() bool {
-	return st == AksTarget || st == ContainerAppTarget
+	return st == AksTarget
 }
 
 func checkResourceType(resource *environment.TargetResource, expectedResourceType azapi.AzureResourceType) error {

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -6,6 +6,7 @@ package project
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
+	"github.com/azure/azure-dev/cli/azd/pkg/azureutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/containerapps"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
@@ -393,6 +395,45 @@ func (at *containerAppTarget) validateTargetResource(
 	}
 
 	return nil
+}
+
+// ResolveTargetResource implements TargetResourceResolver for containerAppTarget.
+// It attempts to find an existing container app resource. If not found, it returns a partial
+// target resource (with resource group but no resource name) to support bicep-based deployments
+// that provision the container app on-demand.
+func (at *containerAppTarget) ResolveTargetResource(
+	ctx context.Context,
+	subscriptionId string,
+	serviceConfig *ServiceConfig,
+	defaultResolver func() (*environment.TargetResource, error),
+) (*environment.TargetResource, error) {
+	targetResource, err := defaultResolver()
+	if err == nil {
+		return targetResource, nil
+	}
+
+	var resourceNotFoundError *azureutil.ResourceNotFoundError
+	if errors.As(err, &resourceNotFoundError) {
+		resourceGroupTemplate := serviceConfig.ResourceGroupName
+		if resourceGroupTemplate.Empty() {
+			resourceGroupTemplate = serviceConfig.Project.ResourceGroupName
+		}
+
+		resourceGroupName, rgErr := at.resourceManager.GetResourceGroupName(ctx, subscriptionId, resourceGroupTemplate)
+		if rgErr != nil {
+			return nil, err
+		}
+
+		// Return partial target resource to enable bicep-based deployments
+		return environment.NewTargetResource(
+			subscriptionId,
+			resourceGroupName,
+			"",
+			string(azapi.AzureResourceTypeContainerApp),
+		), nil
+	}
+
+	return nil, err
 }
 
 func (at *containerAppTarget) addPreProvisionChecks(ctx context.Context, serviceConfig *ServiceConfig) error {


### PR DESCRIPTION
Fixes #6342

### Problem

When deploying to a Container App that is missing or improperly tagged, users were getting an unhelpful error:

```
ERROR: failed deploying service 'CalculatorAgentLG': updating container app service: getting container app: parameter containerAppName cannot be empty
```

Instead of the previous clear, actionable message:

```
ERROR: getting target resource: resource not found: unable to find a resource tagged with 'azd-service-name: CalculatorAgentLG'. Ensure the service resource is correctly tagged in your infrastructure configuration, and rerun provision
```

### Root Cause

When we added Container Apps to `SupportsDelayedProvisioning()` in #5694 ([v1.20.0](https://github.com/Azure/azure-dev/releases/tag/azure-dev-cli_1.20.0)), it made `resolveServiceResource` swallow `ResourceNotFoundError` errors and return an empty resource instead of propagating the error.

When `Deploy()` later tried to use the resolved resource in non-revision mode, it would call `GetTargetResource` again to fetch the resource. However, this call goes through `resolveServiceResource` which was still swallowing the error, returning an empty resource.

### Solution

This PR implements @weikanglim's suggestion in https://github.com/Azure/azure-dev/issues/6342#issuecomment-3634821371 to implement a custom `ResolveTargetResource` instead of using `SupportsDelayedProvisioning`:

1. **Remove Container Apps from `SupportsDelayedProvisioning()`** - Only AKS remains for backward compatibility. The method is now marked as deprecated.

2. **Implement `TargetResourceResolver` for `containerAppTarget`** - This localizes the delayed provisioning logic within the Container App target itself:
   - If resource is found: return it normally
   - If resource not found (`ResourceNotFoundError`): return partial target resource (with resource group but no resource name) to support bicep-based deployments
   - For other errors (e.g., multiple resources found): propagate the error for clear user feedback

3. **Non-revision mode now gets proper errors** - When `Deploy()` calls `GetTargetResource` in non-revision mode, errors are no longer swallowed, so users see the helpful error message about missing tags.

### Validation

- Tested revision-based todo-nodejs-mongo-aca sample app deploys successfully: https://github.com/Azure-Samples/todo-nodejs-mongo-aca/pull/8/files#diff-834bc11e3cb55730076a7d70767b75f794dc9a37305f27d99926e0fd24363c13

- Tested deploying improperly-tagged ACA in non-revision mode fails with previous error:
    <img width="1615" height="192" alt="image" src="https://github.com/user-attachments/assets/fd14c92d-408a-49c8-ab32-47d1c54f686b" />
