### PR TITLE
Disable telemetry in snapshot tests

### DIFF
--- a/cli/azd/cmd/figspec_test.go
+++ b/cli/azd/cmd/figspec_test.go
@@ -27,6 +27,7 @@ import (
 func TestFigSpec(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("AZD_CONFIG_DIR", configDir)
+	t.Setenv("AZURE_DEV_COLLECT_TELEMETRY", "no")
 
 	cli := azdcli.NewCLI(t)
 

--- a/cli/azd/cmd/usage_test.go
+++ b/cli/azd/cmd/usage_test.go
@@ -29,6 +29,7 @@ func TestUsage(t *testing.T) {
 	t.Setenv("TERM", "dumb")
 	configDir := t.TempDir()
 	t.Setenv("AZD_CONFIG_DIR", configDir)
+	t.Setenv("AZURE_DEV_COLLECT_TELEMETRY", "no")
 
 	cli := azdcli.NewCLI(t)
 


### PR DESCRIPTION
Fix #6361

During test cleanup, when deleting the temp folder the telemetry upload process may still be running, causing it to fail. This PR sets `AZURE_DEV_COLLECT_TELEMETRY=no` to disable telemetry.
