### PR TITLE
Migu/patch cobo fixes

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/project/parser.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/parser.go
@@ -164,7 +164,6 @@ func (p *FoundryParser) CoboPostDeploy(ctx context.Context, args *azdext.Project
 	// Get required values from azd environment
 	containerAppPrincipalID := azdEnv["COBO_ACA_IDENTITY_PRINCIPAL_ID"]
 	aiFoundryProjectResourceID := azdEnv["AZURE_AI_PROJECT_ID"]
-	deploymentName := azdEnv["DEPLOYMENT_NAME"]
 	resourceID := azdEnv["SERVICE_API_RESOURCE_ID"]
 	agentName := azdEnv["AGENT_NAME"]
 	//aiProjectEndpoint := azdEnv["AI_PROJECT_ENDPOINT"]
@@ -189,9 +188,6 @@ func (p *FoundryParser) CoboPostDeploy(ctx context.Context, args *azdext.Project
 		return err
 	}
 	if err := validateRequired("COBO_ACA_IDENTITY_PRINCIPAL_ID", containerAppPrincipalID); err != nil {
-		return err
-	}
-	if err := validateRequired("DEPLOYMENT_NAME", deploymentName); err != nil {
 		return err
 	}
 	if err := validateRequired("AGENT_NAME", agentName); err != nil {
@@ -227,7 +223,6 @@ func (p *FoundryParser) CoboPostDeploy(ctx context.Context, args *azdext.Project
 
 	fmt.Printf("Microsoft Foundry region: %s\n", aiFoundryRegion)
 	fmt.Printf("Project: %s\n", projectName)
-	fmt.Printf("Deployment: %s\n", deploymentName)
 	fmt.Printf("Agent: %s\n", agentName)
 
 	// Assign Azure AI User role


### PR DESCRIPTION
# Fix Container Agent (CoBO) Environment Variable Configuration

## Summary
This PR fixes environment variable configuration issues in the Azure AI Agents extension for Container Apps (CoBO). The changes correct environment variable naming to align with Bicep infrastructure definitions and remove unused environment variables to simplify the deployment process.

## Changes Made

### 1. Rename Environment Variable for Principal ID
**File:** `cli/azd/extensions/azure.ai.agents/internal/project/parser.go`

- Renamed environment variable: `SERVICE_API_IDENTITY_PRINCIPAL_ID` → `COBO_ACA_IDENTITY_PRINCIPAL_ID`
- Updated the validation check to use the new variable name
- **Rationale:** Aligns the environment variable naming with the Bicep infrastructure definitions, ensuring consistency between infrastructure code and application logic. The original name was generic and didn't clearly indicate it was specific to the CoBO Container App identity.

### 2. Remove Unused DEPLOYMENT_NAME Environment Variable
**File:** `cli/azd/extensions/azure.ai.agents/internal/project/parser.go`

- Removed the `deploymentName` variable assignment from azd environment
- Removed the validation check for `DEPLOYMENT_NAME`
- Removed the deployment name from console output
- **Rationale:** The `DEPLOYMENT_NAME` variable was not being used anywhere in the postdeploy logic and unnecessarily required users to set it in their environment.

## Detailed Changes

### Environment Variable Reads
```go
// Before
containerAppPrincipalID := azdEnv["SERVICE_API_IDENTITY_PRINCIPAL_ID"]
deploymentName := azdEnv["DEPLOYMENT_NAME"]

// After
containerAppPrincipalID := azdEnv["COBO_ACA_IDENTITY_PRINCIPAL_ID"]
```

### Validation Logic
```go
// Before
if err := validateRequired("SERVICE_API_IDENTITY_PRINCIPAL_ID", containerAppPrincipalID); err != nil {
    return err
}
if err := validateRequired("DEPLOYMENT_NAME", deploymentName); err != nil {
    return err
}

// After
if err := validateRequired("COBO_ACA_IDENTITY_PRINCIPAL_ID", containerAppPrincipalID); err != nil {
    return err
}
```

### Console Output
```go
// Before
fmt.Printf("Microsoft Foundry region: %s\n", aiFoundryRegion)
fmt.Printf("Project: %s\n", projectName)
fmt.Printf("Deployment: %s\n", deploymentName)
fmt.Printf("Agent: %s\n", agentName)

// After
fmt.Printf("Microsoft Foundry region: %s\n", aiFoundryRegion)
fmt.Printf("Project: %s\n", projectName)
fmt.Printf("Agent: %s\n", agentName)
```

## Impact

### Before
- Environment variable `SERVICE_API_IDENTITY_PRINCIPAL_ID` didn't clearly indicate CoBO-specific usage
- Users had to set the `DEPLOYMENT_NAME` environment variable even though it wasn't used
- Mismatch between Bicep output naming and application code expectations

### After
- Clear, descriptive environment variable name (`COBO_ACA_IDENTITY_PRINCIPAL_ID`)
- Simplified environment variable requirements (no longer need `DEPLOYMENT_NAME`)
- Consistent naming between Bicep infrastructure outputs and application code
- Reduced user configuration burden

## Testing Recommendations

1. Deploy a Container App agent project and verify the postdeploy hook succeeds
2. Confirm that the `COBO_ACA_IDENTITY_PRINCIPAL_ID` environment variable is correctly read from Bicep outputs
3. Verify that Azure AI User role assignment works correctly with the renamed environment variable
4. Confirm no errors occur due to missing `DEPLOYMENT_NAME` variable
5. Verify the console output no longer shows deployment name

## Files Changed
- `cli/azd/extensions/azure.ai.agents/internal/project/parser.go` (+2, -7 lines)

## Commits
- `81fb7bf7` - Rename SERVICE_API_IDENTITY_PRINCIPAL_ID to COBO_ACA_IDENTITY_PRINCIPAL_ID
- `e31ff6fd` - Remove requirement of azd env DEPLOYMENT_NAME
