### PR TITLE
Always run extensions middleware for `provision` but skip lifecycle events in preview mode

### DIFF
--- a/cli/azd/cmd/root.go
+++ b/cli/azd/cmd/root.go
@@ -287,13 +287,7 @@ func NewRootCmd(
 			}
 			return true
 		}).
-		UseMiddlewareWhen("extensions", middleware.NewExtensionsMiddleware, func(descriptor *actions.ActionDescriptor) bool {
-			if onPreview, _ := descriptor.Options.Command.Flags().GetBool("preview"); onPreview {
-				log.Println("Skipping provision hooks due to preview flag.")
-				return false
-			}
-			return true
-		})
+		UseMiddleware("extensions", middleware.NewExtensionsMiddleware)
 
 	root.
 		Add("package", &actions.ActionDescriptorOptions{

--- a/cli/azd/docs/extension-framework.md
+++ b/cli/azd/docs/extension-framework.md
@@ -649,6 +649,9 @@ Extensions can subscribe to project and service lifecycle events (both pre and p
 Your extension _**must**_ include a `listen` command to subscribe to these events.
 `azd` will automatically invoke your extension during supported commands to establish bi-directional communication.
 
+> [!NOTE]
+> Provision lifecycle events (`preprovision`, `postprovision`) are **not** fired when running `azd provision --preview`.
+
 ##### Service Target Providers (`service-target-provider`)
 
 > Extensions must declare the `service-target-provider` capability in their `extension.yaml` file.

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -143,13 +143,7 @@ func (t *aksTarget) Initialize(ctx context.Context, serviceConfig *ServiceConfig
 		ctx,
 		"postprovision",
 		func(ctx context.Context, args ProjectLifecycleEventArgs) error {
-			// Only set the k8s context if we are not in preview mode
-			previewMode, has := args.Args["preview"]
-			if !has || !previewMode.(bool) {
-				return t.setK8sContext(ctx, serviceConfig, "postprovision")
-			}
-
-			return nil
+			return t.setK8sContext(ctx, serviceConfig, "postprovision")
 		},
 	)
 


### PR DESCRIPTION
Fixes #6387

This PR fixes an issue where running `azd provision --preview` would incorrectly trigger the extension auto-install prompt for custom service targets (e.g., `azure.ai.agent`), even when the extension was already installed, and cause the command to not work as expected.

The root cause was that the extensions middleware was conditionally skipped when the `--preview` flag was set. Without the middleware running, extension processes were never started, meaning their service target providers were never registered in the IoC container via gRPC. When `projectManager.Initialize()` subsequently called `GetServiceTarget()` for a custom host, it failed to resolve the target and threw `UnsupportedServiceHostError`, triggering the auto-install flow.

The fix ensures extensions middleware always runs for the provision command, allowing extensions to register their service target providers before project initialization occurs.

- Removed conditional predicate from extensions middleware for provision command
- Refactored provision action to skip lifecycle event invocation (`preprovision`/`postprovision`) in preview mode, rather than passing a `preview` flag in event args
- Simplified AKS target's `postprovision` handler since preview mode check is now handled upstream
- Updated documentation to note that provision lifecycle events are not fired in preview mode

<img width="2361" height="615" alt="image" src="https://github.com/user-attachments/assets/39706e0d-2383-4d61-84e3-4cc1284bd58e" />

