### PR TITLE
Export `WaitForDebugger` for extension command debugging

### DIFF
--- a/cli/azd/pkg/azdext/debugger.go
+++ b/cli/azd/pkg/azdext/debugger.go
@@ -15,9 +15,10 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// waitForDebugger checks if AZD_EXT_DEBUG environment variable is set to a truthy value.
+// WaitForDebugger checks if AZD_EXT_DEBUG environment variable is set to a truthy value.
 // If set, prompts the user to attach a debugger to the current process.
-func waitForDebugger(ctx context.Context, extensionId string, azdClient *AzdClient) {
+// This should be called at the start of extension command implementations to enable debugging.
+func WaitForDebugger(ctx context.Context, azdClient *AzdClient) {
 	debugValue := os.Getenv("AZD_EXT_DEBUG")
 	if debugValue == "" {
 		return
@@ -28,6 +29,7 @@ func waitForDebugger(ctx context.Context, extensionId string, azdClient *AzdClie
 		return
 	}
 
+	extensionId := getExtensionId(ctx)
 	message := fmt.Sprintf("Extension '%s' ready to debug (pid: %d).", extensionId, os.Getpid())
 
 	_, err = azdClient.Prompt().Confirm(ctx, &ConfirmRequest{

--- a/cli/azd/pkg/azdext/extension_host.go
+++ b/cli/azd/pkg/azdext/extension_host.go
@@ -146,7 +146,7 @@ func (er *ExtensionHost) Run(ctx context.Context) error {
 	er.init(extensionId)
 
 	// Wait for debugger if AZD_EXT_DEBUG is set
-	waitForDebugger(ctx, extensionId, er.client)
+	WaitForDebugger(ctx, er.client)
 
 	// Determine which managers will be active
 	hasServiceTargets := len(er.serviceTargets) > 0


### PR DESCRIPTION
Fixes #6432

This PR enables `AZD_EXT_DEBUG` support for custom extension commands like `azd ai agent init`, allowing one to attach a debugger to the extension process at startup. This is done by exporting `WaitForDebugger(ctx, azdClient)` in the `azdext` package to be used by extension commands.

Previously, `AZD_EXT_DEBUG=true` only worked when extensions were invoked as service targets (e.g., via `azd deploy`), but not for custom extension commands.

### Validation
Tested `AZD_EXT_DEBUG=true azd ai agent init`, which now displays the debug prompt with PID:

<img width="1152" height="737" alt="image" src="https://github.com/user-attachments/assets/325f30ca-fb4c-4584-8595-dda0e4aa3eed" />
