### PR TITLE
Dynamically resolve resource display name in `azd down`

### DIFF
--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -412,6 +412,7 @@ func createBicepProvider(t *testing.T, mockContext *mocks.MockContext) *BicepPro
 		azCli,
 		bicepCli,
 		resourceService,
+		&mockResourceManager{},
 		deploymentManager,
 		envManager,
 		env,
@@ -864,6 +865,41 @@ type mockedScope struct {
 	baseDate string
 }
 
+type mockResourceManager struct{}
+
+func (m *mockResourceManager) GetDeploymentResourceOperations(
+	ctx context.Context,
+	deployment infra.Deployment,
+	queryStart *time.Time,
+) ([]*armresources.DeploymentOperation, error) {
+	return nil, nil
+}
+
+func (m *mockResourceManager) GetResourceTypeDisplayName(
+	ctx context.Context,
+	subscriptionId string,
+	resourceId string,
+	resourceType azapi.AzureResourceType,
+) (string, error) {
+	return azapi.GetResourceTypeDisplayName(resourceType), nil
+}
+
+func (m *mockResourceManager) GetResourceGroupsForEnvironment(
+	ctx context.Context,
+	subscriptionId string,
+	envName string,
+) ([]*azapi.Resource, error) {
+	return nil, nil
+}
+
+func (m *mockResourceManager) FindResourceGroupForEnvironment(
+	ctx context.Context,
+	subscriptionId string,
+	envName string,
+) (string, error) {
+	return "", nil
+}
+
 func (m *mockedScope) SubscriptionId() string {
 	return "sub-id"
 }
@@ -930,6 +966,7 @@ func TestUserDefinedTypes(t *testing.T) {
 		azCli,
 		bicepCli,
 		nil,
+		&mockResourceManager{},
 		nil,
 		&mockenv.MockEnvManager{},
 		env,


### PR DESCRIPTION
Fixes #5825 

This PR enhances the `azd down` preview to dynamically resolve resource names.

### Problem
When running `azd down` on a Function App, the resource may inaccurately be displayed as "Web App" because the `generateResourcesToDelete` function used a static lookup that doesn't differentiate between different kinds of `Microsoft.Web/sites` resources. Other resources types like `Microsoft.CognitiveServices/accounts` also have this issue.

### Solution
Updated `BicepProvider` to use the dynamic `ResourceManager.GetResourceTypeDisplayName()` method, which queries the Azure resource properties to determine the correct display name based on the resource's `Kind` property (e.g., "functionapp" → "Function App").

### Validation
<img width="2409" height="965" alt="image" src="https://github.com/user-attachments/assets/54ca7529-811f-4fc9-839e-5b283f92c0ff" />
