### PR TITLE
AI Extensions - Disable create resource group option in `finetune` and update dependencies

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/go.mod
+++ b/cli/azd/extensions/azure.ai.agents/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.8.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
-	github.com/azure/azure-dev/cli/azd v0.0.0-20260116183934-428498d0f124
+	github.com/azure/azure-dev/cli/azd v0.0.0-20260122173819-89795b295491
 	github.com/braydonk/yaml v0.9.0
 	github.com/drone/envsubst v1.0.3
 	github.com/fatih/color v1.18.0

--- a/cli/azd/extensions/azure.ai.agents/go.sum
+++ b/cli/azd/extensions/azure.ai.agents/go.sum
@@ -51,8 +51,8 @@ github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWp
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/azure/azure-dev/cli/azd v0.0.0-20260116183934-428498d0f124 h1:V3jGfHri9K94pW8BjnPB3RmZkKHkXcwe9naOHR63P8A=
-github.com/azure/azure-dev/cli/azd v0.0.0-20260116183934-428498d0f124/go.mod h1:j+bdvNwQPdYtSfFe/xbfWqYr8Guw9hiP1JOVpIBERj0=
+github.com/azure/azure-dev/cli/azd v0.0.0-20260122173819-89795b295491 h1:k3ymt8L+5ovZCsXbqWzmY8rGqiGh89GXnJ+ojKbCxk8=
+github.com/azure/azure-dev/cli/azd v0.0.0-20260122173819-89795b295491/go.mod h1:j+bdvNwQPdYtSfFe/xbfWqYr8Guw9hiP1JOVpIBERj0=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -949,10 +949,7 @@ func (a *InitAction) downloadAgentYaml(
 			nil, // externalPromptCfg
 		)
 
-		ghCli, err = github.NewGitHubCli(ctx, console, commandRunner)
-		if err != nil {
-			return nil, "", fmt.Errorf("creating GitHub CLI: %w", err)
-		}
+		ghCli := github.NewGitHubCli(console, commandRunner)
 
 		urlInfo, err = a.parseGitHubUrl(ctx, manifestPointer)
 		if err != nil {

--- a/cli/azd/extensions/azure.ai.finetune/go.mod
+++ b/cli/azd/extensions/azure.ai.finetune/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.8.0
-	github.com/azure/azure-dev/cli/azd v0.0.0-20260116183934-428498d0f124
+	github.com/azure/azure-dev/cli/azd v0.0.0-20260122143218-a49ee677cf18
 	github.com/braydonk/yaml v0.9.0
 	github.com/fatih/color v1.18.0
 	github.com/openai/openai-go/v3 v3.2.0

--- a/cli/azd/extensions/azure.ai.finetune/go.mod
+++ b/cli/azd/extensions/azure.ai.finetune/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.8.0
-	github.com/azure/azure-dev/cli/azd v0.0.0-20260122143218-a49ee677cf18
+	github.com/azure/azure-dev/cli/azd v0.0.0-20260122173819-89795b295491
 	github.com/braydonk/yaml v0.9.0
 	github.com/fatih/color v1.18.0
 	github.com/openai/openai-go/v3 v3.2.0

--- a/cli/azd/extensions/azure.ai.finetune/go.sum
+++ b/cli/azd/extensions/azure.ai.finetune/go.sum
@@ -35,8 +35,8 @@ github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWp
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/azure/azure-dev/cli/azd v0.0.0-20260116183934-428498d0f124 h1:V3jGfHri9K94pW8BjnPB3RmZkKHkXcwe9naOHR63P8A=
-github.com/azure/azure-dev/cli/azd v0.0.0-20260116183934-428498d0f124/go.mod h1:j+bdvNwQPdYtSfFe/xbfWqYr8Guw9hiP1JOVpIBERj0=
+github.com/azure/azure-dev/cli/azd v0.0.0-20260122143218-a49ee677cf18 h1:tYLlADpqst03VOZRiMEx56tdWZPK6cZI+C5YSg1H0hs=
+github.com/azure/azure-dev/cli/azd v0.0.0-20260122143218-a49ee677cf18/go.mod h1:j+bdvNwQPdYtSfFe/xbfWqYr8Guw9hiP1JOVpIBERj0=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=

--- a/cli/azd/extensions/azure.ai.finetune/go.sum
+++ b/cli/azd/extensions/azure.ai.finetune/go.sum
@@ -35,8 +35,8 @@ github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWp
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/azure/azure-dev/cli/azd v0.0.0-20260122143218-a49ee677cf18 h1:tYLlADpqst03VOZRiMEx56tdWZPK6cZI+C5YSg1H0hs=
-github.com/azure/azure-dev/cli/azd v0.0.0-20260122143218-a49ee677cf18/go.mod h1:j+bdvNwQPdYtSfFe/xbfWqYr8Guw9hiP1JOVpIBERj0=
+github.com/azure/azure-dev/cli/azd v0.0.0-20260122173819-89795b295491 h1:k3ymt8L+5ovZCsXbqWzmY8rGqiGh89GXnJ+ojKbCxk8=
+github.com/azure/azure-dev/cli/azd v0.0.0-20260122173819-89795b295491/go.mod h1:j+bdvNwQPdYtSfFe/xbfWqYr8Guw9hiP1JOVpIBERj0=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=

--- a/cli/azd/extensions/azure.ai.finetune/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.finetune/internal/cmd/init.go
@@ -464,6 +464,11 @@ func ensureAzureContext(
 		resourceGroupResponse, err := azdClient.Prompt().
 			PromptResourceGroup(ctx, &azdext.PromptResourceGroupRequest{
 				AzureContext: azureContext,
+				Options: &azdext.PromptResourceGroupOptions{
+					SelectOptions: &azdext.PromptResourceSelectOptions{
+						AllowNewResource: to.Ptr(false),
+					},
+				},
 			})
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to prompt for resource group: %w", err)
@@ -629,7 +634,6 @@ method:
 		if a.isGitHubUrl(a.flags.template) {
 			// For container agents, download the entire parent directory
 			fmt.Println("Downloading full directory for fine-tuning configuration from GitHub...")
-			var ghCli *github.Cli
 			var console input.Console
 			var urlInfo *GitHubUrlInfo
 			// Create a simple console and command runner for GitHub CLI
@@ -650,10 +654,8 @@ method:
 				nil, // formatter
 				nil, // externalPromptCfg
 			)
-			ghCli, err = github.NewGitHubCli(ctx, console, commandRunner)
-			if err != nil {
-				return fmt.Errorf("creating GitHub CLI: %w", err)
-			}
+
+			ghCli := github.NewGitHubCli(console, commandRunner)
 
 			// Create a new AZD client
 			azdClient, err := azdext.NewAzdClient()


### PR DESCRIPTION
This PR updates the `github.com/azure/azure-dev/cli/azd` dependency in the `azure.ai.agents` and `azure.ai.finetune` extensions, and disables resource group creation in the `finetune` extension's init command.