### PR TITLE
AI extensions - ensure GitHub CLI is installed before proceeding

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -949,7 +949,10 @@ func (a *InitAction) downloadAgentYaml(
 			nil, // externalPromptCfg
 		)
 
-		ghCli := github.NewGitHubCli(console, commandRunner)
+		ghCli = github.NewGitHubCli(console, commandRunner)
+		if err := ghCli.EnsureInstalled(ctx); err != nil {
+			return nil, "", fmt.Errorf("ensuring gh is installed: %w", err)
+		}
 
 		urlInfo, err = a.parseGitHubUrl(ctx, manifestPointer)
 		if err != nil {

--- a/cli/azd/extensions/azure.ai.finetune/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.finetune/internal/cmd/init.go
@@ -656,6 +656,9 @@ method:
 			)
 
 			ghCli := github.NewGitHubCli(console, commandRunner)
+			if err := ghCli.EnsureInstalled(ctx); err != nil {
+				return fmt.Errorf("ensuring gh is installed: %w", err)
+			}
 
 			// Create a new AZD client
 			azdClient, err := azdext.NewAzdClient()


### PR DESCRIPTION
This PR adds a missing `EnsureInstalled()` and fixes variable shadowing after incomplete fix in https://github.com/Azure/azure-dev/pull/6590

`gh` commands now work:
<img width="1277" height="843" alt="image" src="https://github.com/user-attachments/assets/7a57d3b5-4160-427b-8bf4-b819306c629b" />
