### PR TITLE
adding project-endpoint to init command

### DIFF
--- a/cli/azd/extensions/azure.ai.finetune/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.finetune/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 0.0.12-preview (2026-01-23)
+
+- Add Project-endpoint parameter to init command
+
 ## 0.0.11-preview (2026-01-22)
 
 - Add metadata capability

--- a/cli/azd/extensions/azure.ai.finetune/extension.yaml
+++ b/cli/azd/extensions/azure.ai.finetune/extension.yaml
@@ -3,7 +3,7 @@ namespace: ai.finetuning
 displayName: Foundry Fine Tuning (Preview)
 description: Extension for Foundry Fine Tuning. (Preview)
 usage: azd ai finetuning <command> [options]
-version: 0.0.11-preview
+version: 0.0.12-preview
 language: go
 capabilities:
     - custom-commands

--- a/cli/azd/extensions/azure.ai.finetune/version.txt
+++ b/cli/azd/extensions/azure.ai.finetune/version.txt
@@ -1,1 +1,1 @@
-0.0.11-preview
+0.0.12-preview


### PR DESCRIPTION
This pull request adds support for specifying a project endpoint URL to the `init` command in the Azure AI Foundry Fine Tuning extension. Users can now initialize their environment using either an ARM project resource ID or a project endpoint URL, improving flexibility and usability. The update includes new flag options, endpoint parsing, and logic to resolve project details from the endpoint.

**New project endpoint support:**

* Added a `--project-endpoint` (`-e`) flag to the `init` command, allowing users to specify the Azure AI Foundry project endpoint URL as an alternative to the ARM resource ID. [[1]](diffhunk://#diff-df294812aa47f034fd51fd2515479b00959c79fa774a6a5ef2f87bfabee7c0b3R36-R37) [[2]](diffhunk://#diff-df294812aa47f034fd51fd2515479b00959c79fa774a6a5ef2f87bfabee7c0b3L140-R158)
* Implemented `parseProjectEndpoint` and `findProjectByEndpoint` functions to extract account and project names from the endpoint URL, search for the corresponding resources in Azure, and retrieve project details.
* Updated the environment initialization logic to handle project endpoint URLs, including prompting for subscription ID if not provided, and using a spinner for user feedback during the search.

**Flag and parameter changes:**

* Changed the `--project` flag to `--project-resource-id` (`-p`) and updated its description for clarity. Added new flags for `--subscription` (`-s`), `--project-endpoint` (`-e`), and changed `--environment` short flag from `-e` to `-n`.

**Other updates:**

* Version bumped to `0.0.12-preview` in `extension.yaml`, `CHANGELOG.md`, and `version.txt`. [[1]](diffhunk://#diff-737693fa27e6c8452fc112cca3dc84ed12ced5806c409fe28dcfb87f77f78bbbL6-R6) [[2]](diffhunk://#diff-0b69eda1a567386d333d0a09b8415d83412d22e554c85b762967b87a1aef2ccfR3-R6) [[3]](diffhunk://#diff-3e4600e12243ffdb2e2bd388eec04172019b30b0d51b03df0e1eeb809a573cc2L1-R1)
* Updated logic throughout `init.go` to support the new endpoint-based workflow, including environment variable assignments and command argument construction. [[1]](diffhunk://#diff-df294812aa47f034fd51fd2515479b00959c79fa774a6a5ef2f87bfabee7c0b3L261-R421) [[2]](diffhunk://#diff-df294812aa47f034fd51fd2515479b00959c79fa774a6a5ef2f87bfabee7c0b3L290-R450)