### PR TITLE
Refactor container helper to avoid environment confusion bugs

### DIFF
--- a/cli/azd/pkg/project/framework_service_docker.go
+++ b/cli/azd/pkg/project/framework_service_docker.go
@@ -148,7 +148,7 @@ func (p *dockerProject) Build(
 	if ignoreAspireMultiStageDeployment(serviceConfig) {
 		return &ServiceBuildResult{}, nil
 	}
-	return p.containerHelper.Build(ctx, serviceConfig, serviceContext, progress)
+	return p.containerHelper.Build(ctx, serviceConfig, serviceContext, p.env, progress)
 }
 
 func (p *dockerProject) Package(
@@ -160,7 +160,7 @@ func (p *dockerProject) Package(
 	if ignoreAspireMultiStageDeployment(serviceConfig) {
 		return &ServicePackageResult{}, nil
 	}
-	return p.containerHelper.Package(ctx, serviceConfig, serviceContext, progress)
+	return p.containerHelper.Package(ctx, serviceConfig, serviceContext, p.env, progress)
 }
 
 func useDotnetPublishForDockerBuild(serviceConfig *ServiceConfig) bool {

--- a/cli/azd/pkg/project/framework_service_docker_test.go
+++ b/cli/azd/pkg/project/framework_service_docker_test.go
@@ -119,7 +119,7 @@ services:
 		env,
 		docker,
 		NewContainerHelper(
-			azdCtx, envManager, clock.NewMock(), nil, nil, mockContext.CommandRunner,
+			clock.NewMock(), nil, nil, mockContext.CommandRunner,
 			docker, dotnetCli, mockContext.Console, cloud.AzurePublic()),
 		mockinput.NewMockConsole(),
 		mockContext.AlphaFeaturesManager,
@@ -234,7 +234,7 @@ services:
 		env,
 		docker,
 		NewContainerHelper(
-			azdCtx, envManager, clock.NewMock(), nil, nil, mockContext.CommandRunner,
+			clock.NewMock(), nil, nil, mockContext.CommandRunner,
 			docker, dotnetCli, mockContext.Console, cloud.AzurePublic()),
 		mockinput.NewMockConsole(),
 		mockContext.AlphaFeaturesManager,
@@ -535,7 +535,7 @@ func Test_DockerProject_Build(t *testing.T) {
 				env,
 				dockerCli,
 				NewContainerHelper(
-					azdCtx, envManager, clock.NewMock(), nil, nil, mockContext.CommandRunner,
+					clock.NewMock(), nil, nil, mockContext.CommandRunner,
 					dockerCli, dotnetCli, mockContext.Console, cloud.AzurePublic()),
 				mockinput.NewMockConsole(),
 				mockContext.AlphaFeaturesManager,
@@ -686,7 +686,7 @@ func Test_DockerProject_Package(t *testing.T) {
 				env,
 				dockerCli,
 				NewContainerHelper(
-					azdCtx, envManager, clock.NewMock(), nil, nil, mockContext.CommandRunner,
+					clock.NewMock(), nil, nil, mockContext.CommandRunner,
 					dockerCli, dotnetCli, mockContext.Console, cloud.AzurePublic()),
 				mockinput.NewMockConsole(),
 				mockContext.AlphaFeaturesManager,

--- a/cli/azd/pkg/project/service_target_aks.go
+++ b/cli/azd/pkg/project/service_target_aks.go
@@ -200,7 +200,7 @@ func (t *aksTarget) Publish(
 	if serviceConfig.Docker.RemoteBuild || hasPackage {
 		// Login, tag & push container image to ACR
 		publishResult, err := t.containerHelper.Publish(
-			ctx, serviceConfig, serviceContext, targetResource, progress, publishOptions)
+			ctx, serviceConfig, serviceContext, targetResource, t.env, progress, publishOptions)
 		if err != nil {
 			return nil, err
 		}

--- a/cli/azd/pkg/project/service_target_aks_test.go
+++ b/cli/azd/pkg/project/service_target_aks_test.go
@@ -1004,8 +1004,6 @@ func createAksServiceTarget(
 		mockContext.ArmClientOptions,
 	)
 	containerHelper := NewContainerHelper(
-		azdCtx,
-		envManager,
 		clock.NewMock(),
 		containerRegistryService,
 		remoteBuildManager,

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -143,7 +143,7 @@ func (at *containerAppTarget) Publish(
 	if publishResult == nil {
 		// Login, tag & push container image to ACR
 		publishResult, err = at.containerHelper.Publish(
-			ctx, serviceConfig, serviceContext, targetResource, progress, publishOptions)
+			ctx, serviceConfig, serviceContext, targetResource, at.env, progress, publishOptions)
 		if err != nil {
 			return nil, err
 		}

--- a/cli/azd/pkg/project/service_target_containerapp_test.go
+++ b/cli/azd/pkg/project/service_target_containerapp_test.go
@@ -260,8 +260,6 @@ func createContainerAppServiceTarget(
 		mockContext.ArmClientOptions,
 	)
 	containerHelper := NewContainerHelper(
-		azdCtx,
-		envManager,
 		clock.NewMock(),
 		containerRegistryService,
 		remoteBuildManager,


### PR DESCRIPTION
Refactored `ContainerHelper` to accept `*environment.Environment` explicitly in method signatures instead of implicitly resolving it via `getCurrentEnvironment()`. This fixes a bug where the helper was always fetching the default environment, makes it stateless and reusable as library code.

The issue in #6019 is not regressed since `container_service.go` continues to observe the environment updates using `*lazy.Lazy[*environment.Environment]`.

Fixes a concern raised in #6641