### PR TITLE
fix tf tests bug for the process cannot access the file as it is used by another process

### DIFF
--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -651,7 +651,12 @@ func (t *TerraformProvider) dataDirPath() string {
 // in comments), it's sufficient for the common case of detecting actual backend configurations.
 func (t *TerraformProvider) isRemoteBackendConfig() (bool, error) {
 	modulePath := t.modulePath()
-	infraDir, _ := os.Open(modulePath)
+	infraDir, err := os.Open(modulePath)
+	if err != nil {
+		return false, fmt.Errorf("opening module directory: %w", err)
+	}
+	defer infraDir.Close()
+
 	files, err := infraDir.ReadDir(0)
 
 	if err != nil {


### PR DESCRIPTION
Fix error `TempDir RemoveAll cleanup: unlinkat ... The process cannot access the file because it is being used by another process` in https://dev.azure.com/azure-sdk/internal/_build?definitionId=4643&_a=summary&branchFilter=172188%2C172188%2C172188%2C172188%2C172188%2C172188%2C172188%2C172188%2C172188%2C172188%2C172188

This pull request makes a small but important update to error handling in the `TerraformProvider` implementation. The change ensures that errors encountered when opening the module directory are properly handled and reported.

* Improved error handling: The `isRemoteBackendConfig` method in `terraform_provider.go` now checks for errors when opening the module directory and returns a descriptive error if the operation fails.