### PR TITLE
add remoteBuild for flex consumption apps

### DIFF
--- a/.vscode/cspell.misc.yaml
+++ b/.vscode/cspell.misc.yaml
@@ -35,3 +35,4 @@ overrides:
           - myimage
           - azureai
           - entra
+          - flexconsumption

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -59,6 +59,9 @@ type ServiceConfig struct {
 	// Condition for deploying the service. When evaluated, the service is only deployed if the value
 	// is a truthy boolean (1, true, TRUE, True, yes). If not defined, the service is enabled by default.
 	Condition osutil.ExpandableString `yaml:"condition,omitempty"`
+	// Whether to build the service remotely. Only applicable to function app services.
+	// When set to nil (unset), the default behavior based on language is used.
+	RemoteBuild *bool `yaml:"remoteBuild,omitempty"`
 
 	// AdditionalProperties captures any unknown YAML fields for extension support
 	AdditionalProperties map[string]interface{} `yaml:",inline"`

--- a/cli/azd/test/functional/testdata/samples/funcapp copy/up.log
+++ b/cli/azd/test/functional/testdata/samples/funcapp copy/up.log
@@ -1,0 +1,14 @@
+2026/02/12 14:35:31 main.go:60: azd version: 0.0.0-dev.0 (commit 0000000000000000000000000000000000000000)
+2026/02/12 14:35:31 detect_process.go:56: detect_process.go: Parent process detection: depth=0, pid=73536, ppid=33753, name="/opt/homebrew/bi", executable="/opt/homebrew/bin/fish"
+2026/02/12 14:35:31 detect_process.go:56: detect_process.go: Parent process detection: depth=1, pid=33753, ppid=33551, name="/Applications/Vi", executable="/Applications/Visual"
+2026/02/12 14:35:31 detect_process.go:56: detect_process.go: Parent process detection: depth=2, pid=33551, ppid=1, name="/Applications/Vi", executable="/Applications/Visual"
+2026/02/12 14:35:31 detect_process.go:72: detect_process.go: Parent process detection: no agent found in process tree
+2026/02/12 14:35:31 detect.go:25: Agent detection result: detected=false, no AI coding agent detected
+2026/02/12 14:35:31 main.go:228: using cached latest version: 1.23.4 (expires on: 2026-02-13T22:18:45Z)
+2026/02/12 14:35:31 middleware.go:100: running middleware 'debug'
+2026/02/12 14:35:31 middleware.go:100: running middleware 'ux'
+2026/02/12 14:35:31 middleware.go:100: running middleware 'telemetry'
+2026/02/12 14:35:31 telemetry.go:66: TraceID: a8c353d7cf2be1bd0d78e51af0841dcc
+2026/02/12 14:35:31 middleware.go:100: running middleware 'error'
+2026/02/12 14:35:31 middleware.go:100: running middleware 'loginGuard'
+2026/02/12 14:35:31 main.go:102: eliding update message for dev build

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -228,6 +228,11 @@
                         "type": "string",
                         "title": "Relative path to service deployment artifacts"
                     },
+                    "remoteBuild": {
+                        "type": "boolean",
+                        "title": "Optional. Whether to use remote build for function app deployment",
+                        "description": "When set to true, the deployment package will be built remotely using Oryx. When set to false, the package is deployed as-is. If omitted, defaults to true for JavaScript, TypeScript, and Python function apps."
+                    },
                     "docker": {
                         "$ref": "#/definitions/docker"
                     },
@@ -411,6 +416,19 @@
                                 "k8s": false,
                                 "apiVersion": false,
                                 "env": false
+                            }
+                        }
+                    },
+                    {
+                        "comment": "remoteBuild is only valid for function host",
+                        "if": {
+                            "properties": {
+                                "host": { "not": { "const": "function" } }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "remoteBuild": false
                             }
                         }
                     }

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -134,6 +134,11 @@
                         "type": "string",
                         "title": "Relative path to service deployment artifacts"
                     },
+                    "remoteBuild": {
+                        "type": "boolean",
+                        "title": "Optional. Whether to use remote build for function app deployment",
+                        "description": "When set to true, the deployment package will be built remotely using Oryx. When set to false, the package is deployed as-is. If omitted, defaults to true for JavaScript, TypeScript, and Python function apps."
+                    },
                     "docker": {
                         "$ref": "#/definitions/docker"
                     },
@@ -317,6 +322,19 @@
                                 "k8s": false,
                                 "apiVersion": false,
                                 "env": false
+                            }
+                        }
+                    },
+                    {
+                        "comment": "remoteBuild is only valid for function host",
+                        "if": {
+                            "properties": {
+                                "host": { "not": { "const": "function" } }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "remoteBuild": false
                             }
                         }
                     }


### PR DESCRIPTION
Adds support for `remoteBuild` option in `azure.yaml` to allow users to explicitly control remote build behavior for Azure Function services on `flexconsumption` plan.

Addresses #6531