### PR TITLE
Revert "Remove automatic --no-prompt and TTY override for AI agent detection"

### DIFF
--- a/cli/azd/cmd/auto_install.go
+++ b/cli/azd/cmd/auto_install.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/internal/runcontext/agentdetect"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/resource"
 	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -635,6 +636,9 @@ func CreateGlobalFlagSet() *pflag.FlagSet {
 // Uses ParseErrorsAllowlist to gracefully ignore unknown flags (like extension-specific flags).
 // This function is designed to be called BEFORE Cobra command tree construction to enable
 // early access to global flag values for auto-install and other pre-execution logic.
+//
+// Agent Detection: If --no-prompt is not explicitly set and an AI coding agent (like Claude Code,
+// GitHub Copilot CLI, Cursor, etc.) is detected as the caller, NoPrompt is automatically enabled.
 func ParseGlobalFlags(args []string, opts *internal.GlobalCommandOptions) error {
 	globalFlagSet := CreateGlobalFlagSet()
 
@@ -666,6 +670,14 @@ func ParseGlobalFlags(args []string, opts *internal.GlobalCommandOptions) error 
 
 	if boolVal, err := globalFlagSet.GetBool("no-prompt"); err == nil {
 		opts.NoPrompt = boolVal
+	}
+
+	// Agent Detection: If --no-prompt was not explicitly set and we detect an AI coding agent
+	// as the caller, automatically enable no-prompt mode for non-interactive execution.
+	noPromptFlag := globalFlagSet.Lookup("no-prompt")
+	noPromptExplicitlySet := noPromptFlag != nil && noPromptFlag.Changed
+	if !noPromptExplicitlySet && agentdetect.IsRunningInAgent() {
+		opts.NoPrompt = true
 	}
 
 	return nil

--- a/cli/azd/cmd/auto_install_integration_test.go
+++ b/cli/azd/cmd/auto_install_integration_test.go
@@ -76,7 +76,7 @@ func TestExecuteWithAutoInstallIntegration(t *testing.T) {
 	os.Args = originalArgs
 }
 
-// TestAgentDetectionIntegration tests that agent detection works but no longer auto-enables no-prompt.
+// TestAgentDetectionIntegration tests the full agent detection integration flow.
 func TestAgentDetectionIntegration(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -86,39 +86,39 @@ func TestAgentDetectionIntegration(t *testing.T) {
 		description      string
 	}{
 		{
-			name:             "Claude Code agent detected - no-prompt not auto-enabled",
+			name:             "Claude Code agent enables no-prompt automatically",
 			args:             []string{"version"},
 			envVars:          map[string]string{"CLAUDE_CODE": "1"},
-			expectedNoPrompt: false,
-			description:      "Agent detection no longer auto-enables --no-prompt",
+			expectedNoPrompt: true,
+			description:      "When running under Claude Code, --no-prompt should be auto-enabled",
 		},
 		{
-			name:             "GitHub Copilot CLI detected - no-prompt not auto-enabled",
+			name:             "GitHub Copilot CLI enables no-prompt automatically",
 			args:             []string{"deploy"},
 			envVars:          map[string]string{"GITHUB_COPILOT_CLI": "true"},
-			expectedNoPrompt: false,
-			description:      "Agent detection no longer auto-enables --no-prompt",
+			expectedNoPrompt: true,
+			description:      "When running under GitHub Copilot CLI, --no-prompt should be auto-enabled",
 		},
 		{
-			name:             "Gemini agent detected - no-prompt not auto-enabled",
+			name:             "Gemini agent enables no-prompt automatically",
 			args:             []string{"init"},
 			envVars:          map[string]string{"GEMINI_CLI": "1"},
-			expectedNoPrompt: false,
-			description:      "Agent detection no longer auto-enables --no-prompt",
+			expectedNoPrompt: true,
+			description:      "When running under Gemini, --no-prompt should be auto-enabled",
 		},
 		{
-			name:             "OpenCode agent detected - no-prompt not auto-enabled",
+			name:             "OpenCode agent enables no-prompt automatically",
 			args:             []string{"provision"},
 			envVars:          map[string]string{"OPENCODE": "1"},
-			expectedNoPrompt: false,
-			description:      "Agent detection no longer auto-enables --no-prompt",
+			expectedNoPrompt: true,
+			description:      "When running under OpenCode, --no-prompt should be auto-enabled",
 		},
 		{
-			name:             "User can still explicitly set --no-prompt",
-			args:             []string{"--no-prompt", "up"},
+			name:             "User can override agent detection with --no-prompt=false",
+			args:             []string{"--no-prompt=false", "up"},
 			envVars:          map[string]string{"CLAUDE_CODE": "1"},
-			expectedNoPrompt: true,
-			description:      "Explicit --no-prompt should still work when agent is detected",
+			expectedNoPrompt: false,
+			description:      "Explicit --no-prompt=false should override agent detection",
 		},
 		{
 			name:             "Normal execution without agent detection",
@@ -128,13 +128,13 @@ func TestAgentDetectionIntegration(t *testing.T) {
 			description:      "Without agent detection, prompting should remain enabled by default",
 		},
 		{
-			name: "User agent string triggers detection but not no-prompt",
+			name: "User agent string triggers detection",
 			args: []string{"up"},
 			envVars: map[string]string{
 				internal.AzdUserAgentEnvVar: "claude-code/1.0.0",
 			},
-			expectedNoPrompt: false,
-			description:      "Agent detected via user agent but no-prompt not auto-enabled",
+			expectedNoPrompt: true,
+			description:      "AZURE_DEV_USER_AGENT containing agent identifier should trigger detection",
 		},
 	}
 
@@ -159,21 +159,27 @@ func TestAgentDetectionIntegration(t *testing.T) {
 			assert.Equal(t, tt.expectedNoPrompt, opts.NoPrompt,
 				"NoPrompt mismatch: %s", tt.description)
 
-			// Verify agent detection still works for telemetry even though no-prompt is not auto-set
+			// Verify agent detection status matches expectation
 			agent := agentdetect.GetCallingAgent()
-			if len(tt.envVars) > 0 && tt.envVars["CLAUDE_CODE"] != "" ||
-				tt.envVars["GITHUB_COPILOT_CLI"] != "" ||
-				tt.envVars["GEMINI_CLI"] != "" ||
-				tt.envVars["OPENCODE"] != "" ||
-				tt.envVars[internal.AzdUserAgentEnvVar] != "" {
+			if tt.expectedNoPrompt && len(tt.envVars) > 0 && !containsNoPromptFalse(tt.args) {
 				assert.True(t, agent.Detected,
-					"Agent should still be detected for telemetry: %s", tt.description)
+					"Agent should be detected when agent env vars are set: %s", tt.description)
 			}
 
 			// Clean up
 			agentdetect.ResetDetection()
 		})
 	}
+}
+
+// containsNoPromptFalse checks if args contain --no-prompt=false
+func containsNoPromptFalse(args []string) bool {
+	for _, arg := range args {
+		if arg == "--no-prompt=false" {
+			return true
+		}
+	}
+	return false
 }
 
 // clearAgentEnvVarsForTest clears all environment variables that could trigger agent detection.

--- a/cli/azd/cmd/auto_install_test.go
+++ b/cli/azd/cmd/auto_install_test.go
@@ -345,19 +345,19 @@ func TestParseGlobalFlags_AgentDetection(t *testing.T) {
 			expectedNoPrompt: false,
 		},
 		{
-			name:             "agent detected via env var, no flag - no longer auto-enables no-prompt",
+			name:             "agent detected via env var, no flag",
 			args:             []string{"up"},
 			envVars:          map[string]string{"CLAUDE_CODE": "1"},
-			expectedNoPrompt: false,
+			expectedNoPrompt: true,
 		},
 		{
-			name:             "agent detected with --no-prompt=false explicitly set",
+			name:             "agent detected but --no-prompt=false explicitly set",
 			args:             []string{"--no-prompt=false", "up"},
 			envVars:          map[string]string{"CLAUDE_CODE": "1"},
 			expectedNoPrompt: false,
 		},
 		{
-			name:             "agent detected with --no-prompt explicitly set true",
+			name:             "agent detected but --no-prompt explicitly set true",
 			args:             []string{"--no-prompt", "up"},
 			envVars:          map[string]string{"GEMINI_CLI": "1"},
 			expectedNoPrompt: true,
@@ -369,22 +369,22 @@ func TestParseGlobalFlags_AgentDetection(t *testing.T) {
 			expectedNoPrompt: true,
 		},
 		{
-			name:             "Gemini agent detected - no longer auto-enables no-prompt",
+			name:             "Gemini agent detected",
 			args:             []string{"init"},
 			envVars:          map[string]string{"GEMINI_CLI": "1"},
-			expectedNoPrompt: false,
+			expectedNoPrompt: true,
 		},
 		{
-			name:             "GitHub Copilot CLI agent detected - no longer auto-enables no-prompt",
+			name:             "GitHub Copilot CLI agent detected",
 			args:             []string{"deploy"},
 			envVars:          map[string]string{"GITHUB_COPILOT_CLI": "true"},
-			expectedNoPrompt: false,
+			expectedNoPrompt: true,
 		},
 		{
-			name:             "OpenCode agent detected - no longer auto-enables no-prompt",
+			name:             "OpenCode agent detected",
 			args:             []string{"provision"},
 			envVars:          map[string]string{"OPENCODE": "1"},
-			expectedNoPrompt: false,
+			expectedNoPrompt: true,
 		},
 	}
 

--- a/cli/azd/internal/runcontext/agentdetect/types.go
+++ b/cli/azd/internal/runcontext/agentdetect/types.go
@@ -3,7 +3,7 @@
 
 // Package agentdetect provides functionality to detect when azd is invoked
 // by known AI coding agents (Claude Code, GitHub Copilot, Gemini, OpenCode)
-// for telemetry and tracing purposes.
+// and enables automatic adjustment of behavior (e.g., no-prompt mode).
 package agentdetect
 
 // AgentType represents a known AI coding agent.

--- a/cli/azd/internal/terminal/terminal.go
+++ b/cli/azd/internal/terminal/terminal.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/azure/azure-dev/cli/azd/internal/runcontext/agentdetect"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/resource"
 	"github.com/mattn/go-isatty"
 )
@@ -23,6 +24,11 @@ func IsTerminal(stdoutFd uintptr, stdinFd uintptr) bool {
 	// If this is affecting you locally while debugging on a CI machine,
 	// use the override AZD_FORCE_TTY=true.
 	if resource.IsRunningOnCI() {
+		return false
+	}
+
+	// If running under an AI coding agent, disable TTY mode to prevent interactive prompts.
+	if agentdetect.IsRunningInAgent() {
 		return false
 	}
 

--- a/cli/azd/internal/terminal/terminal_test.go
+++ b/cli/azd/internal/terminal/terminal_test.go
@@ -7,11 +7,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/internal/runcontext/agentdetect"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestIsTerminal_ForceTTY(t *testing.T) {
 	clearTestEnvVars(t)
+	agentdetect.ResetDetection()
 
 	// Test AZD_FORCE_TTY=true forces TTY mode
 	t.Setenv("AZD_FORCE_TTY", "true")
@@ -22,10 +24,73 @@ func TestIsTerminal_ForceTTY(t *testing.T) {
 	assert.False(t, IsTerminal(0, 0), "AZD_FORCE_TTY=false should disable TTY mode")
 }
 
+func TestIsTerminal_AgentDetection(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVars  map[string]string
+		expected bool
+	}{
+		{
+			name:     "Claude Code agent disables TTY",
+			envVars:  map[string]string{"CLAUDE_CODE": "1"},
+			expected: false,
+		},
+		{
+			name:     "GitHub Copilot CLI disables TTY",
+			envVars:  map[string]string{"GITHUB_COPILOT_CLI": "true"},
+			expected: false,
+		},
+		{
+			name:     "Gemini CLI disables TTY",
+			envVars:  map[string]string{"GEMINI_CLI": "1"},
+			expected: false,
+		},
+		{
+			name:     "OpenCode disables TTY",
+			envVars:  map[string]string{"OPENCODE": "1"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearTestEnvVars(t)
+			agentdetect.ResetDetection()
+
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+
+			result := IsTerminal(0, 0)
+			assert.Equal(t, tt.expected, result,
+				"IsTerminal should return %v when agent is detected", tt.expected)
+		})
+	}
+}
+
+func TestIsTerminal_ForceTTYOverridesAgent(t *testing.T) {
+	clearTestEnvVars(t)
+	agentdetect.ResetDetection()
+
+	// Set an agent env var that would normally disable TTY
+	t.Setenv("CLAUDE_CODE", "1")
+
+	// But AZD_FORCE_TTY should take precedence
+	t.Setenv("AZD_FORCE_TTY", "true")
+
+	assert.True(t, IsTerminal(0, 0),
+		"AZD_FORCE_TTY=true should override agent detection and enable TTY")
+}
+
 // clearTestEnvVars clears environment variables that affect terminal detection.
 func clearTestEnvVars(t *testing.T) {
 	envVarsToUnset := []string{
 		"AZD_FORCE_TTY",
+		// Agent env vars
+		"CLAUDE_CODE", "CLAUDE_CODE_ENTRYPOINT",
+		"GITHUB_COPILOT_CLI", "GH_COPILOT",
+		"GEMINI_CLI", "GEMINI_CLI_NO_RELAUNCH",
+		"OPENCODE",
 		// CI env vars
 		"CI", "TF_BUILD", "GITHUB_ACTIONS",
 	}


### PR DESCRIPTION
This reverts commit c0f40cb1a8e3dfde24ee03339ade913d341cd91f (PR #6751).

## Reason for Revert
https://github.com/github/copilot-cli/releases/tag/v0.0.408 fixes are not working yet with AZD

## Original PR
Reverts #6751