### PR TITLE
fix: sync --version flag to extension metadata in azd x publish

### DIFF
--- a/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/publish.go
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/publish.go
@@ -113,6 +113,8 @@ func runPublishAction(ctx context.Context, flags *publishFlags, defaultRegistryU
 
 	if flags.version == "" {
 		flags.version = extensionMetadata.Version
+	} else {
+		extensionMetadata.Version = flags.version
 	}
 
 	// Use artifacts patterns from flag


### PR DESCRIPTION
## Problem

When the `--version` flag is provided to `azd x publish`, it was only used for GitHub release tag lookup and artifact discovery, but **not propagated** to `extensionMetadata.Version`. This caused the registry entry to always use the version from `extension.yaml`, overwriting the existing entry instead of appending a new version.

### Root Cause

In `publish.go`, the version sync was one-directional. `flags.version` defaulted to `extensionMetadata.Version` when empty, but the reverse never happened. This meant `flags.version` controlled artifact/release lookup while `extensionMetadata.Version` (from `extension.yaml`) controlled the registry entry version.

Passing `--version 0.2.0` with `extension.yaml` at `0.1.0` would download 0.2.0 artifacts but write them under the 0.1.0 registry entry.

## Fix

Sync `flags.version` back to `extensionMetadata.Version` when the flag is explicitly provided, ensuring the registry entry uses the correct version and new versions are appended rather than overwriting existing entries.
