### PR TITLE
Add authorization failure hints for ARM deployments

### DIFF
--- a/cli/azd/cmd/middleware/auth_hint.go
+++ b/cli/azd/cmd/middleware/auth_hint.go
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package middleware
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
+)
+
+// authFailureHints maps ARM authorization error codes to actionable user guidance.
+var authFailureHints = map[string]string{
+	"AuthorizationFailed": "You do not have sufficient permissions for this deployment. " +
+		"Ensure you have the Owner or Contributor role on the target subscription or resource group.",
+	"LinkedAuthorizationFailed": "The deployment requires cross-resource authorization. " +
+		"Ensure you have Owner or User Access Administrator role to create role assignments.",
+	"RoleAssignmentUpdateNotPermitted": "You cannot update the existing role assignment. " +
+		"Ensure you have the Owner or User Access Administrator role on the subscription.",
+	"PrincipalNotFound": "The service principal referenced in the template was not found. " +
+		"Ensure the principal exists in your Microsoft Entra ID (formerly Azure Active Directory) tenant " +
+		"and has not been recently deleted.",
+	"NoRegisteredProviderFound": "A required Azure resource provider is not registered in your subscription. " +
+		"Register it with 'az provider register --namespace <ProviderNamespace>' and retry.",
+	"RoleAssignmentExists": "A role assignment already exists with the same principal and role. " +
+		"This is usually safe to ignore. The template should handle this gracefully.",
+}
+
+// deploymentAuthHint inspects a deployment error for authorization-related root causes
+// and returns actionable guidance if found.
+func deploymentAuthHint(err error) string {
+	var armErr *azapi.AzureDeploymentError
+	if !errors.As(err, &armErr) {
+		return ""
+	}
+
+	if armErr.Details == nil {
+		return ""
+	}
+
+	return findAuthHint(armErr.Details)
+}
+
+func findAuthHint(line *azapi.DeploymentErrorLine) string {
+	if line == nil {
+		return ""
+	}
+
+	if line.Code != "" {
+		if hint, ok := authFailureHints[line.Code]; ok {
+			return hint
+		}
+
+		if line.Code == "Forbidden" {
+			messageLower := strings.ToLower(line.Message)
+			if strings.Contains(messageLower, "roleassignment") || // cspell:disable-line
+				strings.Contains(messageLower, "role assignment") {
+				return "You do not have permission to manage role assignments. " +
+					"Ensure you have the Owner or User Access Administrator role on the subscription."
+			}
+		}
+	}
+
+	for _, inner := range line.Inner {
+		if hint := findAuthHint(inner); hint != "" {
+			return hint
+		}
+	}
+
+	return ""
+}

--- a/cli/azd/cmd/middleware/auth_hint_test.go
+++ b/cli/azd/cmd/middleware/auth_hint_test.go
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package middleware
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_deploymentAuthHint(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantHint string
+	}{
+		{
+			name:     "NonArmError",
+			err:      errors.New("some error"),
+			wantHint: "",
+		},
+		{
+			name: "AuthorizationFailed",
+			err: &azapi.AzureDeploymentError{
+				Details: &azapi.DeploymentErrorLine{
+					Code: "",
+					Inner: []*azapi.DeploymentErrorLine{
+						{
+							Code:    "AuthorizationFailed",
+							Message: "The client does not have authorization",
+						},
+					},
+				},
+			},
+			wantHint: "You do not have sufficient permissions for this deployment. " +
+				"Ensure you have the Owner or Contributor role on the target subscription or resource group.",
+		},
+		{
+			name: "NestedAuthorizationFailed",
+			err: &azapi.AzureDeploymentError{
+				Details: &azapi.DeploymentErrorLine{
+					Code: "",
+					Inner: []*azapi.DeploymentErrorLine{
+						{
+							Code: "",
+							Inner: []*azapi.DeploymentErrorLine{
+								{
+									Code:    "AuthorizationFailed",
+									Message: "Authorization failed",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantHint: "You do not have sufficient permissions for this deployment. " +
+				"Ensure you have the Owner or Contributor role on the target subscription or resource group.",
+		},
+		{
+			name: "NoRegisteredProvider",
+			err: &azapi.AzureDeploymentError{
+				Details: &azapi.DeploymentErrorLine{
+					Code:    "NoRegisteredProviderFound",
+					Message: "No registered provider found for location",
+				},
+			},
+			wantHint: "A required Azure resource provider is not registered in your subscription. " +
+				"Register it with 'az provider register --namespace <ProviderNamespace>' and retry.",
+		},
+		{
+			name: "RoleAssignmentExists",
+			err: &azapi.AzureDeploymentError{
+				Details: &azapi.DeploymentErrorLine{
+					Code:    "RoleAssignmentExists",
+					Message: "The role assignment already exists",
+				},
+			},
+			wantHint: "A role assignment already exists with the same principal and role. " +
+				"This is usually safe to ignore. The template should handle this gracefully.",
+		},
+		{
+			name: "PrincipalNotFound",
+			err: &azapi.AzureDeploymentError{
+				Details: &azapi.DeploymentErrorLine{
+					Code:    "PrincipalNotFound",
+					Message: "Principal not found in the directory",
+				},
+			},
+			wantHint: "The service principal referenced in the template was not found. " +
+				"Ensure the principal exists in your Microsoft Entra ID (formerly Azure Active Directory) tenant " +
+				"and has not been recently deleted.",
+		},
+		{
+			name: "ForbiddenWithRoleAssignment",
+			err: &azapi.AzureDeploymentError{
+				Details: &azapi.DeploymentErrorLine{
+					Code:    "Forbidden",
+					Message: "Cannot create roleAssignment: insufficient privileges",
+				},
+			},
+			wantHint: "You do not have permission to manage role assignments. " +
+				"Ensure you have the Owner or User Access Administrator role on the subscription.",
+		},
+		{
+			name: "UnrelatedArmError",
+			err: &azapi.AzureDeploymentError{
+				Details: &azapi.DeploymentErrorLine{
+					Code:    "ResourceNotFound",
+					Message: "Resource was not found",
+				},
+			},
+			wantHint: "",
+		},
+		{
+			name: "NilDetails",
+			err: &azapi.AzureDeploymentError{
+				Details: nil,
+			},
+			wantHint: "",
+		},
+		{
+			name: "LinkedAuthorizationFailed",
+			err: &azapi.AzureDeploymentError{
+				Details: &azapi.DeploymentErrorLine{
+					Code:    "LinkedAuthorizationFailed",
+					Message: "The linked authorization check failed",
+				},
+			},
+			wantHint: "The deployment requires cross-resource authorization. " +
+				"Ensure you have Owner or User Access Administrator role to create role assignments.",
+		},
+		{
+			name: "RoleAssignmentUpdateNotPermitted",
+			err: &azapi.AzureDeploymentError{
+				Details: &azapi.DeploymentErrorLine{
+					Code:    "RoleAssignmentUpdateNotPermitted",
+					Message: "Role assignment update not permitted",
+				},
+			},
+			wantHint: "You cannot update the existing role assignment. " +
+				"Ensure you have the Owner or User Access Administrator role on the subscription.",
+		},
+		{
+			name: "ForbiddenWithoutRoleAssignment",
+			err: &azapi.AzureDeploymentError{
+				Details: &azapi.DeploymentErrorLine{
+					Code:    "Forbidden",
+					Message: "Some other forbidden error",
+				},
+			},
+			wantHint: "",
+		},
+		{
+			name: "ForbiddenWithRoleAssignmentUpperCase",
+			err: &azapi.AzureDeploymentError{
+				Details: &azapi.DeploymentErrorLine{
+					Code:    "Forbidden",
+					Message: "Cannot create RoleAssignment for principal",
+				},
+			},
+			wantHint: "You do not have permission to manage role assignments. " +
+				"Ensure you have the Owner or User Access Administrator role on the subscription.",
+		},
+		{
+			name: "ForbiddenWithRoleAssignmentSpaced",
+			err: &azapi.AzureDeploymentError{
+				Details: &azapi.DeploymentErrorLine{
+					Code:    "Forbidden",
+					Message: "Cannot create role assignment for principal",
+				},
+			},
+			wantHint: "You do not have permission to manage role assignments. " +
+				"Ensure you have the Owner or User Access Administrator role on the subscription.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deploymentAuthHint(tt.err)
+			require.Equal(t, tt.wantHint, got)
+		})
+	}
+}

--- a/cli/azd/extensions/azure.ai.models/pkg/models/pending_upload.go
+++ b/cli/azd/extensions/azure.ai.models/pkg/models/pending_upload.go
@@ -5,20 +5,20 @@ package models
 
 // PendingUploadResponse is the API response from startPendingUpload.
 type PendingUploadResponse struct {
-	BlobReferenceForConsumption *BlobReferenceForConsumption `json:"blobReferenceForConsumption"`
-	ImageReferenceForConsumption interface{}                 `json:"imageReferenceForConsumption"`
-	TemporaryDataReferenceID     string                     `json:"temporaryDataReferenceId"`
-	TemporaryDataReferenceType   *string                    `json:"temporaryDataReferenceType"`
+	BlobReferenceForConsumption  *BlobReferenceForConsumption `json:"blobReferenceForConsumption"`
+	ImageReferenceForConsumption interface{}                  `json:"imageReferenceForConsumption"`
+	TemporaryDataReferenceID     string                       `json:"temporaryDataReferenceId"`
+	TemporaryDataReferenceType   *string                      `json:"temporaryDataReferenceType"`
 }
 
 // BlobReferenceForConsumption contains the blob storage details for upload.
 type BlobReferenceForConsumption struct {
-	BlobURI              string          `json:"blobUri"`
-	StorageAccountArmID  string          `json:"storageAccountArmId"`
-	Credential           BlobCredential  `json:"credential"`
-	IsSingleFile         bool            `json:"isSingleFile"`
-	BlobManifestDigest   *string         `json:"blobManifestDigest"`
-	ConnectionName       *string         `json:"connectionName"`
+	BlobURI             string         `json:"blobUri"`
+	StorageAccountArmID string         `json:"storageAccountArmId"`
+	Credential          BlobCredential `json:"credential"`
+	IsSingleFile        bool           `json:"isSingleFile"`
+	BlobManifestDigest  *string        `json:"blobManifestDigest"`
+	ConnectionName      *string        `json:"connectionName"`
 }
 
 // BlobCredential contains the SAS credential for blob upload.


### PR DESCRIPTION
## Summary
Detects common authorization-related ARM error codes in deployment errors and displays actionable guidance to help users resolve permission issues.

Fixes #6798

## Changes

### auth_hint.go (new)
- Maps 5 ARM auth error codes to actionable guidance (AuthorizationFailed, LinkedAuthorizationFailed, RoleAssignmentUpdateNotPermitted, PrincipalNotFound, NoRegisteredProviderFound)
- Handles RoleAssignmentExists idempotently
- Detects Forbidden with roleAssignment context

### auth_hint_test.go (new)
- 13 table-driven test cases covering all mapped codes, nested errors, nil details

### error.go
- Integrated auth hint display in ErrorMiddleware.Run()

## Data Context
Authorization errors account for 2.68% of all azd errors (~3,432). AI templates hit 4.84%.