### PR TITLE
Improve azd ai agent init for non-interactive environments

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -390,3 +390,50 @@ func TestParseGitHubUrlNaive(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeEnvName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"simple name", "my-project", "my-project"},
+		{"with spaces", "my project", "my-project"},
+		{"special chars", "my@project!v2", "my-project-v2"},
+		{"dots allowed", "my.project", "my.project"},
+		{
+			"underscores allowed",
+			"my_project", "my_project",
+		},
+		{"root slash", "/", ""},
+		{"single dot", ".", ""},
+		{"single dash", "-", ""},
+		{"empty string", "", ""},
+		{
+			"unicode chars",
+			"projeçt-naïve", "proje-t-na-ve",
+		},
+		{
+			"all invalid",
+			"@#$%", "----",
+		},
+		{
+			"mixed valid and invalid",
+			"Hello World (v2)", "Hello-World--v2-",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeEnvName(tt.input)
+			if result != tt.expected {
+				t.Errorf(
+					"sanitizeEnvName(%q) = %q, want %q",
+					tt.input, result, tt.expected,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`azd ai agent init` is unusable in non-interactive (non-TTY) environments because two required inputs (environment name and subscription) have no non-interactive defaults. This blocks CI/CD pipelines, IDE-integrated terminals, AI coding assistants, and scripted automation.

Root cause analysis identified 4 sequential blockers when running without a TTY. This PR addresses the first two:

## Changes

### 1. Default environment name to directory basename (#6817)

When `--no-prompt` is active and no `-e` flag is provided, the environment name now defaults to the current directory's basename -- consistent with how `azd init` suggests `-dev` etc.

**Before:** `no default response for prompt 'Enter a unique environment name:'`
**After:** Automatically creates environment named after the working directory

### 2. Auto-select subscription in non-interactive mode (#6818)

When `--no-prompt` is active and no subscription is configured, the command now:
- Lists available subscriptions via `azdClient.Account().ListSubscriptions()`
- Auto-selects if exactly one subscription exists
- Returns a clear error with remediation hint if multiple subscriptions exist

**Before:** `failed to prompt for subscription: rpc error: ... cannot prompt in non-interactive mode`
**After:**
- 1 subscription: `Auto-selected subscription: My Sub (guid)`
- Multiple: `multiple subscriptions found but running in non-interactive mode. Set a default with 'azd config set defaults.subscription <id>'`

## Testing

All existing extension tests pass. Changes are in the initialization flow which requires end-to-end testing with Azure resources.

## Related Issues

- #6816 (P1, assigned to @JeffreyCA) -- `--model-deployment` flag (still blocking for full non-interactive flow)
- #6819 (P3, assigned to @alexwolfmsft) -- Document `--no-prompt` behavior
- #6820 (P3, assigned to @JeffreyCA) -- Remediation hints in error messages

Fixes #6817
Fixes #6818
