### PR TITLE
Reject positional args in azd env get-values

### DIFF
--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -1230,6 +1230,7 @@ func newEnvGetValuesCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "get-values",
 		Short: "Get all environment values.",
+		Args:  cobra.NoArgs,
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `cobra.NoArgs` validation to the `azd env get-values` command. Previously, passing empty or unexpected positional arguments like `azd env get-values ""` would succeed silently instead of returning an error.

## Changes

One-line fix: added `Args: cobra.NoArgs` to the command definition in `newEnvGetValuesCmd()`.

Follows the existing pattern used by:
- `env get-value`: `cobra.MaximumNArgs(1)`
- `env refresh`: `cobra.MaximumNArgs(1)` with flag/arg conflict checks

Fixes #3354