### PR TITLE
Fix duplicated "Suggestion:" prefix in error output

### DIFF
--- a/cli/azd/internal/grpcserver/prompt_service_test.go
+++ b/cli/azd/internal/grpcserver/prompt_service_test.go
@@ -599,7 +599,7 @@ func Test_PromptService_PromptSubscription_ErrorWithSuggestion(t *testing.T) {
 
 	authErr := &internal.ErrorWithSuggestion{
 		Err:        errors.New("AADSTS70043: The refresh token has expired"),
-		Suggestion: "Suggestion: login expired, run `azd auth login` to acquire a new token.",
+		Suggestion: "login expired, run `azd auth login` to acquire a new token.",
 	}
 
 	mockPrompter.
@@ -627,7 +627,7 @@ func Test_PromptService_PromptResourceGroup_ErrorWithSuggestion(t *testing.T) {
 
 	authErr := &internal.ErrorWithSuggestion{
 		Err:        errors.New("AADSTS70043: The refresh token has expired"),
-		Suggestion: "Suggestion: login expired, run `azd auth login` to acquire a new token.",
+		Suggestion: "login expired, run `azd auth login` to acquire a new token.",
 	}
 
 	mockPrompter.

--- a/cli/azd/internal/grpcserver/server_test.go
+++ b/cli/azd/internal/grpcserver/server_test.go
@@ -130,7 +130,7 @@ func Test_wrapErrorWithSuggestion(t *testing.T) {
 			name: "error with suggestion includes suggestion text",
 			err: &internal.ErrorWithSuggestion{
 				Err:        errors.New("authentication failed"),
-				Suggestion: "Suggestion: run `azd auth login` to acquire a new token.",
+				Suggestion: "run `azd auth login` to acquire a new token.",
 			},
 			wantContain: "azd auth login",
 		},
@@ -138,7 +138,7 @@ func Test_wrapErrorWithSuggestion(t *testing.T) {
 			name: "wrapped error with suggestion includes suggestion text",
 			err: fmt.Errorf("failed to prompt: %w", &internal.ErrorWithSuggestion{
 				Err:        errors.New("token expired"),
-				Suggestion: "Suggestion: login expired, run `azd auth login` to acquire a new token.",
+				Suggestion: "login expired, run `azd auth login` to acquire a new token.",
 			}),
 			wantContain: "azd auth login",
 		},

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -55,7 +55,9 @@ func newReLoginRequiredError(
 		"interaction_required":
 		err := ReLoginRequiredError{}
 		err.init(response, scopes, cloud)
-		suggestion := fmt.Sprintf("Suggestion: %s, run `%s` to acquire a new token.", err.scenario, err.loginCmd)
+		// Note: Do not prefix with "Suggestion:" here — the UX renderer
+		// (ErrorWithSuggestion.ToString) already adds that prefix when displaying.
+		suggestion := fmt.Sprintf("%s, run `%s` to acquire a new token.", err.scenario, err.loginCmd)
 		if err.helpLink != "" {
 			suggestion += fmt.Sprintf(" See %s for more info.", err.helpLink)
 		}

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -1024,7 +1024,7 @@ func (ch *ContainerHelper) packBuild(
 			} else if isContainerdEnabled {
 				return nil, &internal.ErrorWithSuggestion{
 					Err: err,
-					Suggestion: "Suggestion: disable containerd image store in Docker settings: " +
+					Suggestion: "disable containerd image store in Docker settings: " +
 						output.WithLinkFormat("https://docs.docker.com/desktop/features/containerd"),
 				}
 			}


### PR DESCRIPTION
The suggestion text in `pkg/auth/errors.go` and `pkg/project/container_helper.go` included a `"Suggestion: "` prefix, but the UX renderer (`pkg/output/ux/error_with_suggestion.go`) already prepends one — resulting in `"Suggestion: Suggestion: ..."` in the CLI output.

This was observed during `azd provision` with an expired token:

```
Suggestion: Suggestion: login expired, run `azd auth login` to acquire a new token.
```

### Fix

Remove the redundant `"Suggestion: "` prefix from the suggestion values in:
- `pkg/auth/errors.go`
- `pkg/project/container_helper.go`

Update test expectations in:
- `internal/grpcserver/server_test.go`
- `internal/grpcserver/prompt_service_test.go`