### PR TITLE
[ai agents extension] Use PromptAiDeployment in init-from-code for explicit SKU selection

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -646,21 +646,30 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 	// Add model resource if a model was selected
 	if selectedModel != nil {
 		if existingDeployment == nil {
-			deploymentResp, err := a.azdClient.Prompt().PromptAiDeployment(ctx, &azdext.PromptAiDeploymentRequest{
-				AzureContext: a.azureContext,
-				ModelName:    selectedModel.Name,
-				Options: &azdext.AiModelDeploymentOptions{
-					Locations: []string{a.azureContext.Scope.Location},
-				},
-				Quota: &azdext.QuotaCheckOptions{
-					MinRemainingCapacity: 1,
-				},
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed to prompt for model deployment: %w", err)
-			}
+			var modelDetails *azdext.AiModelDeployment
 
-			modelDetails := deploymentResp.Deployment
+			if a.flags.NoPrompt {
+				resolved, err := a.resolveModelDeploymentNoPrompt(ctx, selectedModel, a.azureContext.Scope.Location)
+				if err != nil {
+					return nil, fmt.Errorf("failed to resolve model deployment: %w", err)
+				}
+				modelDetails = resolved
+			} else {
+				deploymentResp, err := a.azdClient.Prompt().PromptAiDeployment(ctx, &azdext.PromptAiDeploymentRequest{
+					AzureContext: a.azureContext,
+					ModelName:    selectedModel.Name,
+					Options: &azdext.AiModelDeploymentOptions{
+						Locations: []string{a.azureContext.Scope.Location},
+					},
+					Quota: &azdext.QuotaCheckOptions{
+						MinRemainingCapacity: 1,
+					},
+				})
+				if err != nil {
+					return nil, fmt.Errorf("failed to prompt for model deployment: %w", err)
+				}
+				modelDetails = deploymentResp.Deployment
+			}
 			a.deploymentDetails = append(a.deploymentDetails, project.Deployment{
 				Name: modelDetails.ModelName,
 				Model: project.DeploymentModel{
@@ -1467,4 +1476,76 @@ func (a *InitFromCodeAction) processExistingFoundryProject(ctx context.Context, 
 	return nil
 }
 
+func (a *InitFromCodeAction) resolveModelDeploymentNoPrompt(
+	ctx context.Context,
+	model *azdext.AiModel,
+	location string,
+) (*azdext.AiModelDeployment, error) {
+	resolveResp, err := a.azdClient.Ai().ResolveModelDeployments(ctx, &azdext.ResolveModelDeploymentsRequest{
+		AzureContext: a.azureContext,
+		ModelName:    model.Name,
+		Options: &azdext.AiModelDeploymentOptions{
+			Locations: []string{location},
+		},
+		Quota: &azdext.QuotaCheckOptions{
+			MinRemainingCapacity: 1,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve model deployment: %w", err)
+	}
+
+	if len(resolveResp.Deployments) == 0 {
+		return nil, fmt.Errorf("no deployment candidates found for model '%s' in location '%s'", model.Name, location)
+	}
+
+	orderedCandidates := slices.Clone(resolveResp.Deployments)
+	defaultVersions := make(map[string]struct{}, len(model.Versions))
+	for _, version := range model.Versions {
+		if version.IsDefault {
+			defaultVersions[version.Version] = struct{}{}
+		}
+	}
+
+	slices.SortFunc(orderedCandidates, func(a, b *azdext.AiModelDeployment) int {
+		_, aDefault := defaultVersions[a.Version]
+		_, bDefault := defaultVersions[b.Version]
+		if aDefault != bDefault {
+			if aDefault {
+				return -1
+			}
+			return 1
+		}
+
+		aSkuPriority := skuPriority(a.Sku.Name)
+		bSkuPriority := skuPriority(b.Sku.Name)
+		if aSkuPriority != bSkuPriority {
+			if aSkuPriority < bSkuPriority {
+				return -1
+			}
+			return 1
+		}
+
+		if cmp := strings.Compare(a.Version, b.Version); cmp != 0 {
+			return cmp
+		}
+
+		if cmp := strings.Compare(a.Sku.Name, b.Sku.Name); cmp != 0 {
+			return cmp
+		}
+
+		return strings.Compare(a.Sku.UsageName, b.Sku.UsageName)
+	})
+
+	for _, candidate := range orderedCandidates {
+		capacity, ok := resolveNoPromptCapacity(candidate)
+		if !ok {
+			continue
+		}
+
+		return cloneDeploymentWithCapacity(candidate, capacity), nil
+	}
+
+	return nil, fmt.Errorf("no deployment candidates found for model '%s' with a valid non-interactive capacity", model.Name)
+}
 


### PR DESCRIPTION
## Problem

The `init-from-code` flow auto-selected deployment SKU via `resolveModelDeploymentNoPrompt`, picking by priority (GlobalStandard first) without user visibility. This caused quota mismatches where:
- Model prompt showed high available quota (aggregated across all SKUs)
- Deployment failed because the auto-selected SKU (e.g., GlobalStandard) had zero quota

## Fix

Replace `resolveModelDeploymentNoPrompt` with `PromptAiDeployment` in interactive mode so users explicitly select version, SKU, and capacity — matching the regular `init` flow. Users now see per-SKU quota and can choose accordingly.

In `--no-prompt` mode, `resolveModelDeploymentNoPrompt` is preserved as a fallback for non-interactive scenarios.

## Changes

- `init_from_code.go`: Call `PromptAiDeployment` in interactive mode, fall back to `resolveModelDeploymentNoPrompt` when `--no-prompt` is set