### PR TITLE
Fix issue with extension errors not being printed when using `ReportError()`

### DIFF
--- a/cli/azd/pkg/azdext/extension_error.go
+++ b/cli/azd/pkg/azdext/extension_error.go
@@ -155,5 +155,9 @@ func UnwrapError(msg *ExtensionError) error {
 		}
 	}
 
-	return errors.New(msg.GetMessage())
+	return &LocalError{
+		Message:    msg.GetMessage(),
+		Category:   LocalErrorCategoryLocal,
+		Suggestion: msg.GetSuggestion(),
+	}
 }

--- a/cli/azd/pkg/azdext/extension_error_test.go
+++ b/cli/azd/pkg/azdext/extension_error_test.go
@@ -33,6 +33,13 @@ func TestExtensionError_RoundTrip(t *testing.T) {
 				assert.Nil(t, protoErr.GetSource())
 
 				assert.Equal(t, "simple error", goErr.Error())
+
+				// Untyped errors round-trip as LocalError so the message is preserved
+				// through the display and telemetry pipelines.
+				var localErr *LocalError
+				require.ErrorAs(t, goErr, &localErr)
+				assert.Equal(t, "simple error", localErr.Message)
+				assert.Equal(t, LocalErrorCategoryLocal, localErr.Category)
 			},
 		},
 		{


### PR DESCRIPTION
This PR fixes a bug from #6835 where extension custom commands returning plain `fmt.Errorf(...)` errors didn't output the error when using `ReportError()`.