### PR TITLE
fix: propagate context in remote build upload and log streaming

### DIFF
--- a/cli/azd/pkg/containerregistry/remote_build.go
+++ b/cli/azd/pkg/containerregistry/remote_build.go
@@ -70,7 +70,7 @@ func (r *RemoteBuildManager) UploadBuildSource(
 	}
 	defer dockerContext.Close()
 
-	_, err = blobClient.UploadFile(context.Background(), dockerContext, nil)
+	_, err = blobClient.UploadFile(ctx, dockerContext, nil)
 	if err != nil {
 		return armcontainerregistry.SourceUploadDefinition{}, err
 	}
@@ -193,7 +193,11 @@ func streamLogs(ctx context.Context, blobClient *blockblob.Client, writer io.Wri
 						}
 					}
 
-					time.Sleep(1 * time.Second)
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-time.After(1 * time.Second):
+					}
 					continue
 				}
 


### PR DESCRIPTION
## Description

Propagate caller context in remote ACR build operations so cancellation (Ctrl+C) is respected.

**Closes**: #6921
**Parent**: #6886 (Performance Review Audit -- Finding 17)

## Changes

`pkg/containerregistry/remote_build.go`:
- `UploadBuildSource`: Changed `blobClient.UploadFile(context.Background(), ...)` to `blobClient.UploadFile(ctx, ...)` so blob upload respects cancellation
- `streamLogs`: Replaced `time.Sleep(1 * time.Second)` with `select { case <-ctx.Done(): return ctx.Err() case <-time.After(1 * time.Second): }` so log polling responds to Ctrl+C promptly

## Testing

- `go build` clean
- Same pattern applied successfully in Findings 12 (SWA) and 11 (FuncApp)
