### PR TITLE
Filter finetune SKUs by default from ResolveModelDeployments

### DIFF
--- a/cli/azd/grpc/proto/ai_model.proto
+++ b/cli/azd/grpc/proto/ai_model.proto
@@ -153,6 +153,9 @@ message ResolveModelDeploymentsRequest {
   AiModelDeploymentOptions options = 3;
   // Optional quota filter. Requires options.locations with exactly one location.
   QuotaCheckOptions quota = 4;
+  // Include fine-tune SKUs (usage names ending with "-finetune").
+  // Defaults to false (fine-tune SKUs are excluded).
+  bool include_finetune_skus = 5;
 }
 
 message ResolveModelDeploymentsResponse {

--- a/cli/azd/internal/grpcserver/ai_model_service.go
+++ b/cli/azd/internal/grpcserver/ai_model_service.go
@@ -75,6 +75,7 @@ func (s *aiModelService) ResolveModelDeployments(
 	if options == nil {
 		options = &ai.DeploymentOptions{}
 	}
+	options.IncludeFinetuneSkus = req.IncludeFinetuneSkus
 
 	var deployments []ai.AiModelDeployment
 	if req.Quota != nil {

--- a/cli/azd/internal/grpcserver/prompt_service.go
+++ b/cli/azd/internal/grpcserver/prompt_service.go
@@ -1198,7 +1198,7 @@ func buildSkuCandidatesForVersion(
 			continue
 		}
 
-		if !includeFinetuneSkus && isFinetuneUsageName(sku.UsageName) {
+		if !includeFinetuneSkus && ai.IsFinetuneUsageName(sku.UsageName) {
 			continue
 		}
 
@@ -1247,10 +1247,6 @@ func maxSkuCandidateRemaining(skuCandidates []skuCandidate) (float64, bool) {
 	}
 
 	return maxRemaining, found
-}
-
-func isFinetuneUsageName(usageName string) bool {
-	return strings.HasSuffix(strings.ToLower(usageName), "-finetune")
 }
 
 func validateDeploymentCapacity(value string, sku ai.AiModelSku) (int32, error) {

--- a/cli/azd/pkg/ai/model_service.go
+++ b/cli/azd/pkg/ai/model_service.go
@@ -457,6 +457,7 @@ func (s *AiModelService) resolveDeployments(
 				continue
 			}
 
+			// TODO: Once armcognitiveservices SDK supports 2025-10-01-preview or above, we can instead filter based on Scope property of the model SKU.
 			if !options.IncludeFinetuneSkus && IsFinetuneUsageName(sku.UsageName) {
 				continue
 			}

--- a/cli/azd/pkg/ai/model_service.go
+++ b/cli/azd/pkg/ai/model_service.go
@@ -457,6 +457,10 @@ func (s *AiModelService) resolveDeployments(
 				continue
 			}
 
+			if !options.IncludeFinetuneSkus && IsFinetuneUsageName(sku.UsageName) {
+				continue
+			}
+
 			capacity := ResolveCapacity(sku, options.Capacity)
 
 			// Quota check

--- a/cli/azd/pkg/ai/model_service.go
+++ b/cli/azd/pkg/ai/model_service.go
@@ -457,7 +457,8 @@ func (s *AiModelService) resolveDeployments(
 				continue
 			}
 
-			// TODO: Once armcognitiveservices SDK supports 2025-10-01-preview or above, we can instead filter based on Scope property of the model SKU.
+			// TODO: Once armcognitiveservices SDK supports 2025-10-01-preview or above, we can instead
+			// filter based on Scope property of the model SKU.
 			if !options.IncludeFinetuneSkus && IsFinetuneUsageName(sku.UsageName) {
 				continue
 			}

--- a/cli/azd/pkg/ai/model_service_test.go
+++ b/cli/azd/pkg/ai/model_service_test.go
@@ -407,6 +407,27 @@ func TestFilterModelsByAnyLocationQuota(t *testing.T) {
 	require.Equal(t, []string{"model-a", "model-b"}, filteredNames)
 }
 
+func TestIsFinetuneUsageName(t *testing.T) {
+	tests := []struct {
+		usageName string
+		expected  bool
+	}{
+		{"OpenAI.Standard.gpt-4o", false},
+		{"OpenAI.GlobalStandard.gpt-4o", false},
+		{"OpenAI.Standard.gpt-4o-finetune", true},
+		{"OpenAI.GlobalStandard.gpt-4o-FINEtune", true},
+		{"OpenAI.ProvisionedManaged", false},
+		{"OpenAI.ProvisionedManaged-finetune", true},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.usageName, func(t *testing.T) {
+			require.Equal(t, tt.expected, IsFinetuneUsageName(tt.usageName))
+		})
+	}
+}
+
 func intPtr(v int32) *int32 {
 	return &v
 }

--- a/cli/azd/pkg/ai/types.go
+++ b/cli/azd/pkg/ai/types.go
@@ -8,7 +8,11 @@ import "strings"
 // IsFinetuneUsageName reports whether the given usage name represents a fine-tune SKU.
 // Fine-tune usage names end with "-finetune" (case-insensitive).
 func IsFinetuneUsageName(usageName string) bool {
-	return strings.HasSuffix(strings.ToLower(usageName), "-finetune")
+	const suffix = "-finetune"
+	if len(usageName) < len(suffix) {
+		return false
+	}
+	return strings.EqualFold(usageName[len(usageName)-len(suffix):], suffix)
 }
 
 // AiModel represents an AI model available in the Azure Cognitive Services catalog.

--- a/cli/azd/pkg/ai/types.go
+++ b/cli/azd/pkg/ai/types.go
@@ -3,6 +3,14 @@
 
 package ai
 
+import "strings"
+
+// IsFinetuneUsageName reports whether the given usage name represents a fine-tune SKU.
+// Fine-tune usage names end with "-finetune" (case-insensitive).
+func IsFinetuneUsageName(usageName string) bool {
+	return strings.HasSuffix(strings.ToLower(usageName), "-finetune")
+}
+
 // AiModel represents an AI model available in the Azure Cognitive Services catalog.
 // It is SDK-agnostic and decoupled from armcognitiveservices types.
 type AiModel struct {
@@ -138,4 +146,7 @@ type DeploymentOptions struct {
 	// Capacity is the preferred deployment capacity. If set and valid
 	// (within min/max, aligned to step), used directly. If nil, uses SKU default.
 	Capacity *int32
+	// IncludeFinetuneSkus controls whether fine-tune SKUs (usage names ending with
+	// "-finetune") are included. Defaults to false (excluded).
+	IncludeFinetuneSkus bool
 }

--- a/cli/azd/pkg/azdext/ai_model.pb.go
+++ b/cli/azd/pkg/azdext/ai_model.pb.go
@@ -773,9 +773,12 @@ type ResolveModelDeploymentsRequest struct {
 	// Optional deployment filters (locations/versions/SKUs/capacity).
 	Options *AiModelDeploymentOptions `protobuf:"bytes,3,opt,name=options,proto3" json:"options,omitempty"`
 	// Optional quota filter. Requires options.locations with exactly one location.
-	Quota         *QuotaCheckOptions `protobuf:"bytes,4,opt,name=quota,proto3" json:"quota,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Quota *QuotaCheckOptions `protobuf:"bytes,4,opt,name=quota,proto3" json:"quota,omitempty"`
+	// Include fine-tune SKUs (usage names ending with "-finetune").
+	// Defaults to false (fine-tune SKUs are excluded).
+	IncludeFinetuneSkus bool `protobuf:"varint,5,opt,name=include_finetune_skus,json=includeFinetuneSkus,proto3" json:"include_finetune_skus,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *ResolveModelDeploymentsRequest) Reset() {
@@ -834,6 +837,13 @@ func (x *ResolveModelDeploymentsRequest) GetQuota() *QuotaCheckOptions {
 		return x.Quota
 	}
 	return nil
+}
+
+func (x *ResolveModelDeploymentsRequest) GetIncludeFinetuneSkus() bool {
+	if x != nil {
+		return x.IncludeFinetuneSkus
+	}
+	return false
 }
 
 type ResolveModelDeploymentsResponse struct {
@@ -1320,13 +1330,14 @@ const file_ai_model_proto_rawDesc = "" +
 	"\razure_context\x18\x01 \x01(\v2\x14.azdext.AzureContextR\fazureContext\x124\n" +
 	"\x06filter\x18\x02 \x01(\v2\x1c.azdext.AiModelFilterOptionsR\x06filter\"=\n" +
 	"\x12ListModelsResponse\x12'\n" +
-	"\x06models\x18\x01 \x03(\v2\x0f.azdext.AiModelR\x06models\"\xe7\x01\n" +
+	"\x06models\x18\x01 \x03(\v2\x0f.azdext.AiModelR\x06models\"\x9b\x02\n" +
 	"\x1eResolveModelDeploymentsRequest\x129\n" +
 	"\razure_context\x18\x01 \x01(\v2\x14.azdext.AzureContextR\fazureContext\x12\x1d\n" +
 	"\n" +
 	"model_name\x18\x02 \x01(\tR\tmodelName\x12:\n" +
 	"\aoptions\x18\x03 \x01(\v2 .azdext.AiModelDeploymentOptionsR\aoptions\x12/\n" +
-	"\x05quota\x18\x04 \x01(\v2\x19.azdext.QuotaCheckOptionsR\x05quota\"^\n" +
+	"\x05quota\x18\x04 \x01(\v2\x19.azdext.QuotaCheckOptionsR\x05quota\x122\n" +
+	"\x15include_finetune_skus\x18\x05 \x01(\bR\x13includeFinetuneSkus\"^\n" +
 	"\x1fResolveModelDeploymentsResponse\x12;\n" +
 	"\vdeployments\x18\x01 \x03(\v2\x19.azdext.AiModelDeploymentR\vdeployments\"j\n" +
 	"\x11ListUsagesRequest\x129\n" +


### PR DESCRIPTION
This PR filters out fine-tune SKUs (e.g. `OpenAI.Standard.gpt-4o-finetune`) from `ResolveModelDeployments` results by default based on the usage name, preventing extensions from unintentionally selecting a fine-tune deployment.

It adds an `include_finetune_skus` field (default `false`) to `ResolveModelDeploymentsRequest`, similar to `PromptAiDeploymentRequest`.

> [!NOTE]
> Once a newer version of the [armcognitiveservices SDK](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices/v3#section-readme) supports API version `2025-10-01-preview` or above, we can instead filter based on the Scope property from `/models` response:
>
> <img width="819" height="545" alt="image" src="https://github.com/user-attachments/assets/c01c1438-413b-4990-b405-98d21abd416c" />
> 
> Doing so right now would be quite involved as the Go types don't support it and we'd probably have to make raw HTTP calls.