### PR TITLE
Simplify error troubleshooting workflow with two-step guidance

### DIFF
--- a/cli/azd/cmd/middleware/error.go
+++ b/cli/azd/cmd/middleware/error.go
@@ -162,10 +162,8 @@ func (e *ErrorMiddleware) Run(ctx context.Context, next NextFn) (*actions.Action
 
 		e.console.Message(ctx, "")
 		troubleshootScope, err := e.promptTroubleshootingWithConsent(ctx)
-		troubleshootScope, err := e.promptTroubleshootingWithConsent(ctx)
 		if err != nil {
 			span.SetStatus(codes.Error, "agent.consent.failed")
-			return nil, fmt.Errorf("prompting for troubleshooting scope: %w", err)
 			return nil, fmt.Errorf("prompting for troubleshooting scope: %w", err)
 		}
 

--- a/cli/azd/cmd/middleware/error.go
+++ b/cli/azd/cmd/middleware/error.go
@@ -240,7 +240,6 @@ func (e *ErrorMiddleware) Run(ctx context.Context, next NextFn) (*actions.Action
 
 		if !confirmFix {
 			if troubleshootScope != "" {
-			if troubleshootScope != "" {
 				span.SetStatus(codes.Ok, "agent.troubleshoot.only")
 			} else {
 				span.SetStatus(codes.Error, "agent.fix.declined")

--- a/cli/azd/cmd/middleware/error.go
+++ b/cli/azd/cmd/middleware/error.go
@@ -517,7 +517,7 @@ func (e *ErrorMiddleware) promptForFixGuidance(ctx context.Context) (bool, error
 	}
 
 	selector := uxlib.NewSelect(&uxlib.SelectOptions{
-		Message:         "Do you want to generate step by step fix guidance?",
+		Message:         "Do you want to generate step-by-step fix guidance?",
 		Choices:         choices,
 		EnableFiltering: uxlib.Ptr(false),
 		DisplayCount:    len(choices),

--- a/cli/azd/cmd/middleware/error.go
+++ b/cli/azd/cmd/middleware/error.go
@@ -162,10 +162,8 @@ func (e *ErrorMiddleware) Run(ctx context.Context, next NextFn) (*actions.Action
 
 		e.console.Message(ctx, "")
 		troubleshootScope, err := e.promptTroubleshootingWithConsent(ctx)
-		troubleshootScope, err := e.promptTroubleshootingWithConsent(ctx)
 		if err != nil {
 			span.SetStatus(codes.Error, "agent.consent.failed")
-			return nil, fmt.Errorf("prompting for troubleshooting scope: %w", err)
 			return nil, fmt.Errorf("prompting for troubleshooting scope: %w", err)
 		}
 
@@ -239,7 +237,6 @@ func (e *ErrorMiddleware) Run(ctx context.Context, next NextFn) (*actions.Action
 		}
 
 		if !confirmFix {
-			if troubleshootScope != "" {
 			if troubleshootScope != "" {
 				span.SetStatus(codes.Ok, "agent.troubleshoot.only")
 			} else {
@@ -441,7 +438,7 @@ func promptForErrorHandlingConsent(
 
 // promptTroubleshootingWithConsent combines consent and scope selection into a single prompt.
 // Checks if a saved preference exists (e.g. mcp.errorHandling.troubleshooting.explain).
-// Returns the scope ("explain", "fix", "summary") or "" if skipped.
+// Returns the scope ("explain") or "" if skipped.
 func (e *ErrorMiddleware) promptTroubleshootingWithConsent(ctx context.Context) (string, error) {
 	const configPrefix = "mcp.errorHandling.troubleshooting"
 

--- a/cli/azd/cmd/middleware/error.go
+++ b/cli/azd/cmd/middleware/error.go
@@ -437,7 +437,7 @@ func promptForErrorHandlingConsent(
 }
 
 // promptTroubleshootingWithConsent combines consent and scope selection into a single prompt.
-// Checks if a saved preference exists (e.g. mcp.errorHandling.troubleshooting.explain).
+// Checks if a saved preference exists (e.g. mcp.errorHandling.troubleshooting.skip).
 // Returns the scope ("explain") or "" if skipped.
 func (e *ErrorMiddleware) promptTroubleshootingWithConsent(ctx context.Context) (string, error) {
 	const configPrefix = "mcp.errorHandling.troubleshooting"
@@ -450,7 +450,7 @@ func (e *ErrorMiddleware) promptTroubleshootingWithConsent(ctx context.Context) 
 	// Check for saved "always skip" preference
 	if val, ok := userConfig.GetString(configPrefix + ".skip"); ok && val == "allow" {
 		e.console.Message(ctx, output.WithWarningFormat(
-			"Troubleshooting is set to always skip. To change, run %s.\n",
+			"Error explanation is set to always skip. To change, run %s.\n",
 			output.WithHighLightFormat(fmt.Sprintf("azd config unset %s.skip", configPrefix)),
 		))
 		return "", nil
@@ -463,8 +463,8 @@ func (e *ErrorMiddleware) promptTroubleshootingWithConsent(ctx context.Context) 
 	}
 
 	selector := uxlib.NewSelect(&uxlib.SelectOptions{
-		Message: "Generate troubleshooting steps?",
-		HelpMessage: fmt.Sprintf("This action will run AI tools to generate troubleshooting steps."+
+		Message: "Would you like agent to explain this error?",
+		HelpMessage: fmt.Sprintf("Agent will first explain the error, then offer optional step-by-step fix guidance."+
 			" Edit permissions anytime by running %s.",
 			output.WithHighLightFormat("azd mcp consent")),
 		Choices:         choices,

--- a/cli/azd/cmd/middleware/error_test.go
+++ b/cli/azd/cmd/middleware/error_test.go
@@ -515,58 +515,7 @@ func Test_ExtractSuggestedSolutions(t *testing.T) {
 	}
 }
 
-func Test_PromptTroubleshootingWithConsent_SavedExplain(t *testing.T) {
-	mockContext := mocks.NewMockContext(context.Background())
-	cfg := config.NewEmptyConfig()
-	_ = cfg.Set("mcp.errorHandling.troubleshooting.explain", "allow")
-	mockContext.ConfigManager.WithConfig(cfg)
-	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
-
-	middleware := &ErrorMiddleware{
-		console:           mockContext.Console,
-		userConfigManager: userConfigManager,
-	}
-
-	scope, err := middleware.promptTroubleshootingWithConsent(*mockContext.Context)
-	require.NoError(t, err)
-	require.Equal(t, "explain", scope)
-}
-
-func Test_PromptTroubleshootingWithConsent_SavedGuide(t *testing.T) {
-	mockContext := mocks.NewMockContext(context.Background())
-	cfg := config.NewEmptyConfig()
-	_ = cfg.Set("mcp.errorHandling.troubleshooting.guide", "allow")
-	mockContext.ConfigManager.WithConfig(cfg)
-	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
-
-	middleware := &ErrorMiddleware{
-		console:           mockContext.Console,
-		userConfigManager: userConfigManager,
-	}
-
-	scope, err := middleware.promptTroubleshootingWithConsent(*mockContext.Context)
-	require.NoError(t, err)
-	require.Equal(t, "guide", scope)
-}
-
-func Test_PromptTroubleshootingWithConsent_SavedSummarize(t *testing.T) {
-	mockContext := mocks.NewMockContext(context.Background())
-	cfg := config.NewEmptyConfig()
-	_ = cfg.Set("mcp.errorHandling.troubleshooting.summarize", "allow")
-	mockContext.ConfigManager.WithConfig(cfg)
-	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
-
-	middleware := &ErrorMiddleware{
-		console:           mockContext.Console,
-		userConfigManager: userConfigManager,
-	}
-
-	scope, err := middleware.promptTroubleshootingWithConsent(*mockContext.Context)
-	require.NoError(t, err)
-	require.Equal(t, "summarize", scope)
-}
-
-func Test_PromptTroubleshootingWithConsent_SavedSkip(t *testing.T) {
+func Test_PromptTroubleshootingWithConsent_SavedSkipDisplaysWarning(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	cfg := config.NewEmptyConfig()
 	_ = cfg.Set("mcp.errorHandling.troubleshooting.skip", "allow")
@@ -581,38 +530,20 @@ func Test_PromptTroubleshootingWithConsent_SavedSkip(t *testing.T) {
 	scope, err := middleware.promptTroubleshootingWithConsent(*mockContext.Context)
 	require.NoError(t, err)
 	require.Equal(t, "", scope, "skip should return empty scope")
-}
-
-func Test_PromptTroubleshootingWithConsent_SavedScopeDisplaysWarning(t *testing.T) {
-	mockContext := mocks.NewMockContext(context.Background())
-	cfg := config.NewEmptyConfig()
-	_ = cfg.Set("mcp.errorHandling.troubleshooting.explain", "allow")
-	mockContext.ConfigManager.WithConfig(cfg)
-	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
-
-	middleware := &ErrorMiddleware{
-		console:           mockContext.Console,
-		userConfigManager: userConfigManager,
-	}
-
-	_, err := middleware.promptTroubleshootingWithConsent(*mockContext.Context)
-	require.NoError(t, err)
 
 	consoleOutput := mockContext.Console.Output()
 	require.NotEmpty(t, consoleOutput, "should display a warning message")
 	found := false
 	for _, msg := range consoleOutput {
-		if strings.Contains(msg, "explain") && strings.Contains(msg, "azd config unset") {
+		if strings.Contains(msg, "always skip") && strings.Contains(msg, "azd config unset") {
 			found = true
 			break
 		}
 	}
-	require.True(t, found, "warning should mention the scope and how to unset it")
+	require.True(t, found, "warning should mention always skip and how to unset it")
 }
 
-func Test_PromptTroubleshootingWithConsent_AlwaysSelectionSavesConfig(t *testing.T) {
-	// Simulate what happens after the selector returns an "always." choice
-	// by testing the config save logic directly
+func Test_PromptTroubleshootingWithConsent_AlwaysSkipSavesAndPersistsConfig(t *testing.T) {
 	mockContext := mocks.NewMockContext(context.Background())
 	cfg := config.NewEmptyConfig()
 	mockContext.ConfigManager.WithConfig(cfg)
@@ -621,41 +552,23 @@ func Test_PromptTroubleshootingWithConsent_AlwaysSelectionSavesConfig(t *testing
 	// Verify config is empty initially
 	loadedCfg, err := userConfigManager.Load()
 	require.NoError(t, err)
-	_, ok := loadedCfg.GetString("mcp.errorHandling.troubleshooting.guide")
-	require.False(t, ok, "config should not have guide scope initially")
+	_, ok := loadedCfg.GetString("mcp.errorHandling.troubleshooting.skip")
+	require.False(t, ok, "config should not have skip preference initially")
 
-	// Simulate what "always.guide" selection does: set and save the config key
-	err = loadedCfg.Set("mcp.errorHandling.troubleshooting.guide", "allow")
-	require.NoError(t, err)
-	err = userConfigManager.Save(loadedCfg)
-	require.NoError(t, err)
-
-	// Now verify that promptTroubleshootingWithConsent auto-returns the saved scope
-	middleware := &ErrorMiddleware{
-		console:           mockContext.Console,
-		userConfigManager: userConfigManager,
-	}
-
-	scope, err := middleware.promptTroubleshootingWithConsent(*mockContext.Context)
-	require.NoError(t, err)
-	require.Equal(t, "guide", scope)
-}
-
-func Test_PromptTroubleshootingWithConsent_AlwaysSkipSavesConfig(t *testing.T) {
-	mockContext := mocks.NewMockContext(context.Background())
-	cfg := config.NewEmptyConfig()
-	mockContext.ConfigManager.WithConfig(cfg)
-	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
-
-	loadedCfg, err := userConfigManager.Load()
-	require.NoError(t, err)
-
-	// Simulate "always.skip" selection
+	// Simulate what "always.skip" selection does: set and save the config key
 	err = loadedCfg.Set("mcp.errorHandling.troubleshooting.skip", "allow")
 	require.NoError(t, err)
 	err = userConfigManager.Save(loadedCfg)
 	require.NoError(t, err)
 
+	// Verify the value was persisted
+	reloadedCfg, err := userConfigManager.Load()
+	require.NoError(t, err)
+	val, ok := reloadedCfg.GetString("mcp.errorHandling.troubleshooting.skip")
+	require.True(t, ok, "config should have skip preference after save")
+	require.Equal(t, "allow", val)
+
+	// Now verify that promptTroubleshootingWithConsent auto-returns empty scope
 	middleware := &ErrorMiddleware{
 		console:           mockContext.Console,
 		userConfigManager: userConfigManager,
@@ -663,5 +576,5 @@ func Test_PromptTroubleshootingWithConsent_AlwaysSkipSavesConfig(t *testing.T) {
 
 	scope, err := middleware.promptTroubleshootingWithConsent(*mockContext.Context)
 	require.NoError(t, err)
-	require.Equal(t, "", scope, "always.skip should return empty scope")
+	require.Equal(t, "", scope, "always.skip should auto-return empty scope")
 }


### PR DESCRIPTION
Iterate https://github.com/Azure/azure-dev/issues/6834 based on @kristenwomack's feedback

## Summary

Simplifies the error troubleshooting prompt workflow for a clearer, more guided user experience.

## Changes

### Streamlined troubleshooting prompt
- Reduced the **Generate troubleshooting steps?** options from 8 choices to just 3:
  - **Explain the error** — runs the MCP tool and shows a structured explanation
  - **Skip** — skips troubleshooting
  - **Always skip** — persists skip preference

### Two-step guidance flow
- After the error explanation is displayed, users are now prompted:
  **Do you want to generate step by step fix guidance?**
  - **Yes** — generates actionable fix steps (max 5)
  - **No, I know what to do (exit agent mode)** — exits immediately

### Improved error explanation formatting
- The explain prompt now instructs the LLM to structure output with bold section titles:
  - **What's happening** — 1-2 sentence error explanation
  - **Why it's happening** — 1-3 sentence root cause analysis

### Removed
- Removed **guide**, **summarize**, and their **always** variants from the initial prompt
- Removed saved always-preference logic for explain/guide/summarize (only always-skip is kept)