### PR TITLE
Add Microsoft.App/agents (SRE Agent) resource type support

### DIFF
--- a/cli/azd/pkg/azapi/azure_resource_types.go
+++ b/cli/azd/pkg/azapi/azure_resource_types.go
@@ -19,6 +19,7 @@ const (
 	AzureResourceTypeContainerApp              AzureResourceType = "Microsoft.App/containerApps"
 	AzureResourceTypeContainerAppJob           AzureResourceType = "Microsoft.App/jobs"
 	AzureResourceTypeContainerAppEnvironment   AzureResourceType = "Microsoft.App/managedEnvironments"
+	AzureResourceTypeSreAgent                  AzureResourceType = "Microsoft.App/agents"
 	AzureResourceTypeDeployment                AzureResourceType = "Microsoft.Resources/deployments"
 	AzureResourceTypeKeyVault                  AzureResourceType = "Microsoft.KeyVault/vaults"
 	AzureResourceTypeManagedHSM                AzureResourceType = "Microsoft.KeyVault/managedHSMs"
@@ -92,6 +93,8 @@ func GetResourceTypeDisplayName(resourceType AzureResourceType) string {
 		return "Container App Job"
 	case AzureResourceTypeContainerAppEnvironment:
 		return "Container Apps Environment"
+	case AzureResourceTypeSreAgent:
+		return "SRE Agent"
 	case AzureResourceTypeServiceBusNamespace:
 		return "Service Bus Namespace"
 	case AzureResourceTypeEventHubsNamespace:

--- a/cli/azd/pkg/azapi/azure_resource_types_test.go
+++ b/cli/azd/pkg/azapi/azure_resource_types_test.go
@@ -46,6 +46,11 @@ func TestGetResourceTypeDisplayName(t *testing.T) {
 			expected:     "Azure DocumentDB",
 		},
 		{
+			name:         "SreAgent",
+			resourceType: AzureResourceTypeSreAgent,
+			expected:     "SRE Agent",
+		},
+		{
 			name:         "UnknownResourceType",
 			resourceType: AzureResourceType("Microsoft.Unknown/unknownResource"),
 			expected:     "",


### PR DESCRIPTION
## Summary

Azure SRE Agent (`Microsoft.App/agents`) is a new Azure resource type for AI-powered Operational tool ([docs](https://learn.microsoft.com/azure/sre-agent/)).

Currently, when deploying an SRE Agent via Bicep with `azd up`, the resource is silently skipped in the provisioning progress output because azd doesn't recognize the `Microsoft.App/agents` resource type.

## Changes

- Added `AzureResourceTypeSreAgent` constant for `Microsoft.App/agents`
- Added display name `SRE Agent` in `GetResourceTypeDisplayName`
- Added test case

## Before
```
(✓) Done: Container App: ca-grubify-xxx (17s)
// SRE Agent silently skipped — not shown
```

## After
```
(✓) Done: Container App: ca-grubify-xxx (17s)
(✓) Done: SRE Agent: sre-agent-xxx (45s)
```

## Resource Details
- **Resource type:** `Microsoft.App/agents`
- **API version:** `2025-05-01-preview`
- **Regions:** eastus2, swedencentral, australiaeast
