### PR TITLE
Emit `codes.Unauthenticated` for auth errors in gRPC server and add safety net in `WrapError`

### DIFF
--- a/cli/azd/internal/grpcserver/server.go
+++ b/cli/azd/internal/grpcserver/server.go
@@ -12,6 +12,7 @@ import (
 	"net"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -198,14 +199,28 @@ func (s *Server) tokenAuthInterceptor(serverInfo *ServerInfo) grpc.UnaryServerIn
 // returns a new error that includes the suggestion text in the error message.
 // This ensures that helpful suggestions (like "run azd auth login") are preserved
 // when errors are transmitted over gRPC, where only the error message string is sent.
+//
+// Auth-related errors (ReLoginRequiredError, ErrNoCurrentUser) are returned with
+// codes.Unauthenticated so that extensions can detect auth failures via gRPC status code.
 func wrapErrorWithSuggestion(err error) error {
 	if err == nil {
 		return nil
 	}
 
+	var loginErr *auth.ReLoginRequiredError
+	isAuthErr := errors.Is(err, auth.ErrNoCurrentUser) || errors.As(err, &loginErr)
+
 	var suggestionErr *internal.ErrorWithSuggestion
 	if errors.As(err, &suggestionErr) {
+		msg := fmt.Sprintf("%s\n%s", err.Error(), suggestionErr.Suggestion)
+		if isAuthErr {
+			return status.Error(codes.Unauthenticated, msg)
+		}
 		return fmt.Errorf("%w\n%s", err, suggestionErr.Suggestion)
+	}
+
+	if isAuthErr {
+		return status.Error(codes.Unauthenticated, err.Error())
 	}
 
 	return err

--- a/cli/azd/internal/grpcserver/server_test.go
+++ b/cli/azd/internal/grpcserver/server_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
 	"github.com/stretchr/testify/require"
@@ -114,6 +115,7 @@ func Test_wrapErrorWithSuggestion(t *testing.T) {
 		wantNil          bool
 		wantContain      string
 		wantSameInstance bool
+		wantGrpcCode     codes.Code
 	}{
 		{
 			name:    "nil error returns nil",
@@ -142,6 +144,27 @@ func Test_wrapErrorWithSuggestion(t *testing.T) {
 			}),
 			wantContain: "azd auth login",
 		},
+		{
+			name:         "ErrNoCurrentUser returns Unauthenticated",
+			err:          auth.ErrNoCurrentUser,
+			wantContain:  "not logged in",
+			wantGrpcCode: codes.Unauthenticated,
+		},
+		{
+			name:         "wrapped ErrNoCurrentUser returns Unauthenticated",
+			err:          fmt.Errorf("failed to list subscriptions: %w", auth.ErrNoCurrentUser),
+			wantContain:  "not logged in",
+			wantGrpcCode: codes.Unauthenticated,
+		},
+		{
+			name: "ReLoginRequiredError with suggestion returns Unauthenticated",
+			err: &internal.ErrorWithSuggestion{
+				Err:        &auth.ReLoginRequiredError{},
+				Suggestion: "login expired, run `azd auth login` to acquire a new token.",
+			},
+			wantContain:  "azd auth login",
+			wantGrpcCode: codes.Unauthenticated,
+		},
 	}
 
 	for _, tt := range tests {
@@ -155,6 +178,11 @@ func Test_wrapErrorWithSuggestion(t *testing.T) {
 			require.Contains(t, result.Error(), tt.wantContain)
 			if tt.wantSameInstance {
 				require.Same(t, tt.err, result, "expected error to be returned unchanged (same instance)")
+			}
+			if tt.wantGrpcCode != 0 {
+				st, ok := status.FromError(result)
+				require.True(t, ok, "expected gRPC status error")
+				require.Equal(t, tt.wantGrpcCode, st.Code())
 			}
 		})
 	}

--- a/cli/azd/pkg/azdext/extension_error.go
+++ b/cli/azd/pkg/azdext/extension_error.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // ServiceError represents an HTTP/gRPC service error from an extension.
@@ -47,8 +49,18 @@ func (e *ServiceError) Error() string {
 	return e.Message
 }
 
-// WrapError wraps a Go error into an ExtensionError for transmission over gRPC.
-// It detects the error type and populates the appropriate source details.
+// WrapError converts a Go error into an ExtensionError proto for transmission to the azd host.
+// It is called from extension processes (via [ReportError] and envelope SetError methods)
+// to serialize errors before sending them over gRPC.
+//
+// The function applies detection in priority order:
+//  1. [ServiceError] / [LocalError] — already structured by extension code (highest specificity)
+//  2. [azcore.ResponseError] — Azure SDK HTTP errors
+//  3. gRPC Unauthenticated — auto-classified as auth category (safety net)
+//  4. Fallback — unclassified error with original message
+//
+// The counterpart [UnwrapError] is called from the azd host to deserialize
+// the proto back into typed Go errors for telemetry classification.
 func WrapError(err error) *ExtensionError {
 	if err == nil {
 		return nil
@@ -107,12 +119,35 @@ func WrapError(err error) *ExtensionError {
 				ServiceName: serviceName,
 			},
 		}
+		return extErr
+	}
+
+	// Detect gRPC Unauthenticated errors as an auth safety net.
+	// If the extension didn't already classify the error, this ensures auth failures
+	// from azd host calls are reported with the correct category in telemetry.
+	// Use errors.As to detect gRPC status errors even when wrapped by fmt.Errorf.
+	var grpcErr interface{ GRPCStatus() *status.Status }
+	if errors.As(err, &grpcErr) {
+		if st := grpcErr.GRPCStatus(); st.Code() == codes.Unauthenticated {
+			extErr.Origin = ErrorOrigin_ERROR_ORIGIN_LOCAL
+			extErr.Message = st.Message()
+			extErr.Source = &ExtensionError_LocalError{
+				LocalError: &LocalErrorDetail{
+					Code:     "auth_failed",
+					Category: string(LocalErrorCategoryAuth),
+				},
+			}
+			return extErr
+		}
 	}
 
 	return extErr
 }
 
-// UnwrapError converts an ExtensionError back to a typed Go error.
+// UnwrapError converts an ExtensionError proto back to a typed Go error.
+// It is called from the azd host (via [ExtensionService.ReportError] handler
+// and envelope GetError methods) to deserialize errors received from extensions
+// for telemetry classification and error handling.
 // It returns the appropriate error type based on the origin field.
 func UnwrapError(msg *ExtensionError) error {
 	if msg == nil || msg.GetMessage() == "" {

--- a/cli/azd/pkg/azdext/extension_error_test.go
+++ b/cli/azd/pkg/azdext/extension_error_test.go
@@ -5,11 +5,14 @@ package azdext
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestExtensionError_RoundTrip(t *testing.T) {
@@ -113,6 +116,37 @@ func TestExtensionError_RoundTrip(t *testing.T) {
 				require.ErrorAs(t, goErr, &svcErr)
 				assert.Equal(t, "ResourceNotFound", svcErr.ErrorCode)
 				assert.Equal(t, 404, svcErr.StatusCode)
+			},
+		},
+		{
+			name:     "GrpcUnauthenticatedError",
+			inputErr: status.Error(codes.Unauthenticated, "not logged in, run `azd auth login` to login"),
+			verify: func(t *testing.T, protoErr *ExtensionError, goErr error) {
+				assert.Equal(t, ErrorOrigin_ERROR_ORIGIN_LOCAL, protoErr.GetOrigin())
+				assert.Contains(t, protoErr.GetMessage(), "not logged in")
+
+				localDetail := protoErr.GetLocalError()
+				require.NotNil(t, localDetail)
+				assert.Equal(t, "auth_failed", localDetail.GetCode())
+				assert.Equal(t, "auth", localDetail.GetCategory())
+
+				var localErr *LocalError
+				require.ErrorAs(t, goErr, &localErr)
+				assert.Equal(t, LocalErrorCategoryAuth, localErr.Category)
+				assert.Equal(t, "auth_failed", localErr.Code)
+			},
+		},
+		{
+			name:     "WrappedGrpcUnauthenticatedError",
+			inputErr: fmt.Errorf("failed to prompt: %w", status.Error(codes.Unauthenticated, "login expired")),
+			verify: func(t *testing.T, protoErr *ExtensionError, goErr error) {
+				assert.Equal(t, ErrorOrigin_ERROR_ORIGIN_LOCAL, protoErr.GetOrigin())
+				assert.Equal(t, "login expired", protoErr.GetMessage())
+
+				localDetail := protoErr.GetLocalError()
+				require.NotNil(t, localDetail)
+				assert.Equal(t, "auth_failed", localDetail.GetCode())
+				assert.Equal(t, "auth", localDetail.GetCategory())
 			},
 		},
 	}


### PR DESCRIPTION
Contributes to #6976 
Relates to https://github.com/Azure/azure-dev/pull/6979

### Problem

Auth errors (`ErrNoCurrentUser`, `ReLoginRequiredError`) from azd host gRPC calls were returned with `codes.Unknown`, making it difficult for extensions to distinguish auth failures from other errors. Extensions that didn't explicitly handle these errors would report `ext.local.failed` in telemetry instead of `ext.auth.*`.

### Changes

**gRPC server interceptor** (`internal/grpcserver/server.go`):
- `wrapErrorWithSuggestion()` now returns `status.Error(codes.Unauthenticated, ...)` when the underlying error is `ReLoginRequiredError` or `ErrNoCurrentUser`. All extensions benefit automatically.

**`WrapError` safety net** (`pkg/azdext/extension_error.go`):
- Added gRPC `codes.Unauthenticated` detection after the existing `azcore.ResponseError` check. Any unhandled auth error is auto-classified as `LocalError{Category: "auth", Code: "auth_failed"}` during serialization, ensuring correct telemetry even if an extension doesn't explicitly handle auth errors.
- Improved doc comments on `WrapError` and `UnwrapError` clarifying that `WrapError` is called from extensions (serialization) and `UnwrapError` from azd core (deserialization).

### Testing

- Added `wrapErrorWithSuggestion` tests for `ErrNoCurrentUser`, wrapped `ErrNoCurrentUser`, and `ReLoginRequiredError` with suggestion — all verify `codes.Unauthenticated` is returned.
- Added `WrapError` round-trip tests for direct and wrapped gRPC `Unauthenticated` errors — verify `LocalError{Category: "auth"}` classification.
