### PR TITLE
Replace channel-based cancellation with context cancellation in provisioning progress display

### DIFF
--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -707,36 +708,44 @@ func (p *BicepProvider) Deploy(ctx context.Context) (*provisioning.DeployResult,
 		p.console.StopSpinner(ctx, "", input.StepDone)
 	}
 
-	cancelProgress := make(chan bool)
-	defer func() { cancelProgress <- true }()
+	progressCtx, cancelProgress := context.WithCancel(ctx)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	defer func() {
+		cancelProgress()
+		// Wait for the progress reporting goroutine to exit to guarantee stopping the spinner
+		wg.Wait()
+		// Clean up the spinner fully
+		p.console.StopSpinner(ctx, "", input.StepDone)
+	}()
+
 	go func() {
+		defer wg.Done()
 		// Disable reporting progress if needed
 		if use, err := strconv.ParseBool(os.Getenv("AZD_DEBUG_PROVISION_PROGRESS_DISABLE")); err == nil && use {
 			log.Println("Disabling progress reporting since AZD_DEBUG_PROVISION_PROGRESS_DISABLE was set")
-			<-cancelProgress
+			<-progressCtx.Done()
 			return
 		}
 
 		// Report incremental progress
 		progressDisplay := p.deploymentManager.ProgressDisplay(deployment)
-		// Make initial delay shorter to be more responsive in displaying initial progress
-		initialDelay := 3 * time.Second
-		regularDelay := 3 * time.Second
-		timer := time.NewTimer(initialDelay)
+		delay := 3 * time.Second
+		timer := time.NewTimer(delay)
 		queryStartTime := time.Now()
 
 		for {
 			select {
-			case <-cancelProgress:
+			case <-progressCtx.Done():
 				timer.Stop()
 				return
 			case <-timer.C:
-				if err := progressDisplay.ReportProgress(ctx, &queryStartTime); err != nil {
+				if err := progressDisplay.ReportProgress(progressCtx, &queryStartTime); err != nil {
 					// We don't want to fail the whole deployment if a progress reporting error occurs
 					log.Printf("error while reporting progress: %v", err)
 				}
 
-				timer.Reset(regularDelay)
+				timer.Reset(delay)
 			}
 		}
 	}()


### PR DESCRIPTION
## Summary

Replace the `cancelProgress` channel in `BicepProvider.Deploy` with `context.WithCancel` for cancelling the progress-reporting goroutine.

## Impact

Users will observe a faster progress update when the deployment is completed, but we're still polling for new progress operations (which is very common).

## Changes

- **`bicep_provider.go`**: Use `context.WithCancel` instead of a channel. Use `sync.WaitGroup` to ensure the goroutine fully exits before stopping the spinner. 

## Motivation

The channel-based approach blocks the caller on `defer func() { cancelProgress <- true }()` until the goroutine finishes its current `ReportProgress` cycle. With context cancellation:
- `cancelProgress()` returns immediately (broadcast signal via channel close)
- In-flight API calls abort promptly via context
- `wg.Wait()` ensures the goroutine exits before `StopSpinner` is called, eliminating the race where the goroutine could restart the spinner after it was stopped

Contributes to #6915