### PR TITLE
[minor-fixes] azd update: infer channel from binary version and block PR builds

### DIFF
--- a/cli/azd/cmd/update.go
+++ b/cli/azd/cmd/update.go
@@ -101,10 +101,9 @@ func newUpdateAction(
 }
 
 func (a *updateAction) Run(ctx context.Context) (*actions.ActionResult, error) {
-	// Dev builds (0.0.0-dev.0) should not self-update — developers build from source.
-	if internal.IsDevVersion() {
-		return nil, fmt.Errorf(
-			"azd update is not supported for dev builds. Build from source with `go build` instead")
+	// Non-production builds (dev and PR) should not self-update.
+	if internal.IsNonProdVersion() {
+		return nil, fmt.Errorf("azd update is not supported for dev or PR builds")
 	}
 
 	// Auto-enable the alpha feature if not already enabled.

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -63,7 +63,7 @@ func main() {
 	}
 
 	// Auto-update: check for applied update marker and display banner
-	if !internal.IsDevVersion() {
+	if !internal.IsNonProdVersion() {
 		if fromVersion, err := update.ReadAppliedMarker(); err == nil && fromVersion != "" {
 			update.RemoveAppliedMarker()
 			fmt.Fprintln(
@@ -75,7 +75,7 @@ func main() {
 
 	// Auto-update: apply staged binary if one exists (before anything else)
 	showedElevationWarning := false
-	if !internal.IsDevVersion() && update.HasStagedUpdate() {
+	if !internal.IsNonProdVersion() && update.HasStagedUpdate() {
 		applyConfigMgr := config.NewUserConfigManager(config.NewFileConfigManager(config.NewManager()))
 		applyCfg, cfgErr := applyConfigMgr.Load()
 		if cfgErr != nil {
@@ -141,15 +141,14 @@ func main() {
 	bgCancel()
 
 	// If we were able to fetch a latest version, check to see if we are up to date and
-	// print a warning if we are not. Note that we don't print this warning when the CLI version
-	// is exactly 0.0.0-dev.0, which is a sentinel value used for `internal.Version` when
-	// a version is not explicitly applied at build time (i.e. dev builds installed with `go install`)
+	// print a warning if we are not. Non-production builds (dev builds via `go install` and
+	// PR builds with "-pr." prerelease tags) are excluded since they should not suggest updates.
 	//
 	// Don't write this message when JSON output is enabled, since in that case we use stderr to return structured
 	// information about command progress.
 	if !isJsonOutput() && ok && !suppressUpdateBanner() && !showedElevationWarning {
-		if internal.IsDevVersion() {
-			log.Printf("eliding update message for dev build")
+		if internal.IsNonProdVersion() {
+			log.Printf("eliding update message for non-production build")
 		} else if versionInfo.HasUpdate {
 			currentVersionStr := internal.VersionInfo().Version.String()
 			latestVersionStr := versionInfo.Version

--- a/cli/azd/pkg/update/config.go
+++ b/cli/azd/pkg/update/config.go
@@ -12,8 +12,10 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
@@ -80,10 +82,28 @@ func (c *UpdateConfig) DefaultCheckInterval() time.Duration {
 	return DefaultCheckIntervalStable
 }
 
+// inferChannelFromVersion returns ChannelDaily if the running binary's version
+// string contains a "daily." build number suffix, otherwise ChannelStable.
+func inferChannelFromVersion() Channel {
+	return inferChannelFromVersionString(internal.Version)
+}
+
+// inferChannelFromVersionString returns ChannelDaily if the given version
+// string contains a "daily." build number suffix, otherwise ChannelStable.
+func inferChannelFromVersionString(version string) Channel {
+	if strings.Contains(version, "daily.") {
+		return ChannelDaily
+	}
+	return ChannelStable
+}
+
 // LoadUpdateConfig reads update configuration from the user config.
+// When no channel is explicitly configured, the channel is inferred from
+// the running binary's version string so that daily builds automatically
+// check the daily update source.
 func LoadUpdateConfig(cfg config.Config) *UpdateConfig {
 	uc := &UpdateConfig{
-		Channel: ChannelStable,
+		Channel: inferChannelFromVersion(),
 	}
 
 	if ch, ok := cfg.GetString(configKeyChannel); ok {

--- a/cli/azd/pkg/update/config_test.go
+++ b/cli/azd/pkg/update/config_test.go
@@ -100,6 +100,25 @@ func TestLoadUpdateConfig(t *testing.T) {
 	}
 }
 
+func TestInferChannelFromVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    Channel
+	}{
+		{"stable release", "1.23.6", ChannelStable},
+		{"daily build", "1.24.0-beta.1-daily.5963821", ChannelDaily},
+		{"daily with commit info", "1.24.0-beta.1-daily.5963821 (commit abc123)", ChannelDaily},
+		{"empty", "", ChannelStable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, inferChannelFromVersionString(tt.version))
+		})
+	}
+}
+
 func TestUpdateConfigDefaultCheckInterval(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Follow-up to #6942.

`azd update` on a daily build says "stable channel" and checks for stable updates instead of daily ones. The channel was hardcoded to default to `stable` when no config was set. Now it looks at the binary version string — if it contains `daily.`, defaults to daily channel instead. Explicit config still wins.

Also switched the dev-build guard from `IsDevVersion()` to `IsNonProdVersion()` so PR builds are also blocked from self-updating (they were slipping through before).

All update tests pass, no snapshot changes.

Related: #6721