### PR TITLE
[bug-fix] azd update: fix SIGKILL during binary replacement on macOS

### DIFF
--- a/cli/azd/pkg/update/manager.go
+++ b/cli/azd/pkg/update/manager.go
@@ -619,11 +619,7 @@ func copyFile(src, dst string) error {
 	if runtime.GOOS != "windows" {
 		removeErr := os.Remove(dst)
 		if removeErr != nil && !os.IsNotExist(removeErr) {
-			if os.IsPermission(removeErr) {
-				return removeErr
-			}
-			// Unexpected error removing dst — log but continue to os.Create fallback
-			log.Printf("warning: could not remove %s before replacement: %v", dst, removeErr)
+			return fmt.Errorf("removing %s before replacement: %w", dst, removeErr)
 		}
 	}
 

--- a/cli/azd/pkg/update/manager_unix_test.go
+++ b/cli/azd/pkg/update/manager_unix_test.go
@@ -7,6 +7,7 @@ package update
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -16,6 +17,10 @@ import (
 )
 
 func TestReplaceBinary_CreatesNewInode(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("test requires non-root to force rename failure via directory permissions")
+	}
+
 	// When replaceBinary falls back to copyFile (e.g. cross-device rename fails),
 	// it must remove the old file first, then create a new one. Truncating in place
 	// (same inode) corrupts memory-mapped pages of a running binary and causes
@@ -36,10 +41,15 @@ func TestReplaceBinary_CreatesNewInode(t *testing.T) {
 	require.NoError(t, os.Chmod(srcDir, 0o555))
 	t.Cleanup(func() { os.Chmod(srcDir, 0o755) })
 
-	// Record original inode
+	// Record original inode. Hold the old file open so the OS cannot reuse its
+	// inode number — on Linux tmpfs, freed inodes are recycled immediately.
 	origInfo, err := os.Stat(dst)
 	require.NoError(t, err)
 	origIno := origInfo.Sys().(*syscall.Stat_t).Ino
+
+	oldFile, err := os.Open(dst)
+	require.NoError(t, err)
+	defer oldFile.Close()
 
 	m := &Manager{}
 	require.NoError(t, m.replaceBinary(context.Background(), src, dst))
@@ -53,7 +63,12 @@ func TestReplaceBinary_CreatesNewInode(t *testing.T) {
 		"replaceBinary should remove then create (new inode), not truncate in place — "+
 			"truncating a running binary causes macOS to SIGKILL the process")
 
-	// Verify content is correct
+	// The old fd should still read the old content (OS kept the inode alive)
+	oldContent, err := io.ReadAll(oldFile)
+	require.NoError(t, err)
+	require.Equal(t, "old content", string(oldContent))
+
+	// Verify new file has correct content
 	copied, err := os.ReadFile(dst)
 	require.NoError(t, err)
 	require.Equal(t, "new content", string(copied))


### PR DESCRIPTION
`azd update` on macOS crashes with `zsh: killed` and leaves the binary broken when azd lives on a different filesystem than `/tmp` (e.g. `/usr/local/bin`).

`os.Rename` fails cross-device, falls through to `copyFile`, which truncates the running binary in place. macOS kills the process when memory-mapped pages go invalid.

**Fix:** on unix, remove the old file before creating the new one. The running process keeps its fd to the old inode, new file gets a fresh inode. This replaces the previous Linux-only ETXTBSY workaround with a single approach that works on both macOS and Linux.

Our E2E tests missed this because test binaries were on the same filesystem as `/tmp`, so `os.Rename` always succeeded.

**Test:** `TestReplaceBinary_CreatesNewInode` — forces the `copyFile` path, verifies the inode changes and old fd still reads old content. Passes on macOS and Linux.

Related: #6721, #6982