### PR TITLE
Update azure.ai.finetune extension to Go 1.26 and add golangci-lint

### DIFF
--- a/.github/workflows/lint-ext-azure-ai-finetune.yml
+++ b/.github/workflows/lint-ext-azure-ai-finetune.yml
@@ -1,0 +1,22 @@
+name: ext-azure-ai-finetune-ci
+
+on:
+  pull_request:
+    paths:
+      - "cli/azd/extensions/azure.ai.finetune/**"
+      - ".github/workflows/lint-ext-azure-ai-finetune.yml"
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lint:
+    uses: ./.github/workflows/lint-go.yml
+    with:
+      working-directory: cli/azd/extensions/azure.ai.finetune

--- a/cli/azd/extensions/azure.ai.finetune/.golangci.yaml
+++ b/cli/azd/extensions/azure.ai.finetune/.golangci.yaml
@@ -1,0 +1,17 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - gosec
+    - lll
+    - unused
+    - errorlint
+  settings:
+    lll:
+      line-length: 220
+      tab-width: 4
+
+formatters:
+  enable:
+    - gofmt

--- a/cli/azd/extensions/azure.ai.finetune/go.mod
+++ b/cli/azd/extensions/azure.ai.finetune/go.mod
@@ -1,6 +1,6 @@
 module azure.ai.finetune
 
-go 1.25
+go 1.26.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0

--- a/cli/azd/extensions/azure.ai.finetune/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.finetune/internal/cmd/init.go
@@ -179,7 +179,10 @@ func extractProjectDetails(projectResourceId string) (*FoundryProject, error) {
 	// Validate that this is a Cognitive Services project resource
 	if resourceId.ResourceType.Namespace != "Microsoft.CognitiveServices" || len(resourceId.ResourceType.Types) != 2 ||
 		resourceId.ResourceType.Types[0] != "accounts" || resourceId.ResourceType.Types[1] != "projects" {
-		return nil, fmt.Errorf("the given resource ID is not a Microsoft Foundry project. Expected format: /subscriptions/[SUBSCRIPTION_ID]/resourceGroups/[RESOURCE_GROUP]/providers/Microsoft.CognitiveServices/accounts/[ACCOUNT_NAME]/projects/[PROJECT_NAME]")
+		return nil, fmt.Errorf(
+			"the given resource ID is not a Microsoft Foundry project. Expected format: " +
+				"/subscriptions/[SUBSCRIPTION_ID]/resourceGroups/[RESOURCE_GROUP]/providers/" +
+				"Microsoft.CognitiveServices/accounts/[ACCOUNT_NAME]/projects/[PROJECT_NAME]")
 	}
 
 	// Extract the components
@@ -777,10 +780,12 @@ method:
 		}
 
 		yamlFilePath := filepath.Join(outputDir, "config", "job.yaml")
+		//nolint:gosec // project config directory should be readable and traversable
 		if err := os.MkdirAll(filepath.Dir(yamlFilePath), 0755); err != nil {
 			return fmt.Errorf("failed to create config directory: %w", err)
 		}
 
+		//nolint:gosec // generated config file should be readable by project tooling
 		if err := os.WriteFile(yamlFilePath, []byte(yamlContent), 0644); err != nil {
 			return fmt.Errorf("failed to write job.yaml file: %w", err)
 		}
@@ -941,10 +946,12 @@ method:
 		}
 
 		yamlFilePath := filepath.Join(outputDir, "config", "job.yaml")
+		//nolint:gosec // project config directory should be readable and traversable
 		if err := os.MkdirAll(filepath.Dir(yamlFilePath), 0755); err != nil {
 			return fmt.Errorf("failed to create config directory: %w", err)
 		}
 
+		//nolint:gosec // generated config file should be readable by project tooling
 		if err := os.WriteFile(yamlFilePath, []byte(yamlContent), 0644); err != nil {
 			return fmt.Errorf("failed to write job.yaml file: %w", err)
 		}
@@ -1046,12 +1053,14 @@ func downloadDirectoryContents(
 				return fmt.Errorf("failed to download file %s: %w", itemPath, err)
 			}
 
+			//nolint:gosec // downloaded project files are intended to be readable by project tooling
 			if err := os.WriteFile(itemLocalPath, []byte(fileContent), 0644); err != nil {
 				return fmt.Errorf("failed to write file %s: %w", itemLocalPath, err)
 			}
 		} else if itemType == "dir" {
 			// Recursively download subdirectory
 			fmt.Printf("Downloading directory: %s\n", itemPath)
+			//nolint:gosec // scaffolded directories are intended to be readable/traversable
 			if err := os.MkdirAll(itemLocalPath, 0755); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", itemLocalPath, err)
 			}
@@ -1082,6 +1091,7 @@ func copyDirectory(src, dst string) error {
 
 		if d.IsDir() {
 			// Create directory and continue processing its contents
+			//nolint:gosec // copied project directories should remain readable/traversable
 			return os.MkdirAll(dstPath, 0755)
 		} else {
 			// Copy file
@@ -1093,11 +1103,13 @@ func copyDirectory(src, dst string) error {
 // copyFile copies a single file from src to dst
 func copyFile(src, dst string) error {
 	// Create the destination directory if it doesn't exist
+	//nolint:gosec // copied project directories should remain readable/traversable
 	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
 		return err
 	}
 
 	// Open source file
+	//nolint:gosec // src is a local project file path from directory walk
 	srcFile, err := os.Open(src)
 	if err != nil {
 		return err
@@ -1105,6 +1117,7 @@ func copyFile(src, dst string) error {
 	defer srcFile.Close()
 
 	// Create destination file
+	//nolint:gosec // dst is a local project file path from directory walk
 	dstFile, err := os.Create(dst)
 	if err != nil {
 		return err

--- a/cli/azd/extensions/azure.ai.finetune/internal/cmd/operations.go
+++ b/cli/azd/extensions/azure.ai.finetune/internal/cmd/operations.go
@@ -164,7 +164,7 @@ func newOperationSubmitCommand() *cobra.Command {
 	cmd.Flags().Int64VarP(&seed, "seed", "r", 0, "Random seed for reproducibility of the job. If a seed is not specified, one will be generated for you. Overrides config file.")
 
 	//Either config file should be provided or at least `model` & `training-file` parameters
-	cmd.MarkFlagFilename("file", "yaml", "yml")
+	_ = cmd.MarkFlagFilename("file", "yaml", "yml") //nolint:gosec // error is informational only
 	cmd.MarkFlagsOneRequired("file", "model")
 	cmd.MarkFlagsRequiredTogether("model", "training-file")
 	return cmd
@@ -223,21 +223,21 @@ func newOperationShowCommand() *cobra.Command {
 
 			switch output {
 			case "json":
-				utils.PrintObject(job, utils.FormatJSON)
+				_ = utils.PrintObject(job, utils.FormatJSON)
 			case "yaml":
-				utils.PrintObject(job, utils.FormatYAML)
+				_ = utils.PrintObject(job, utils.FormatYAML)
 			case "table", "":
 				views := job.ToDetailViews()
 				indent := "  "
-				utils.PrintObjectWithIndent(views.Details, utils.FormatTable, indent)
+				_ = utils.PrintObjectWithIndent(views.Details, utils.FormatTable, indent)
 
 				fmt.Println("\nTimestamps:")
-				utils.PrintObjectWithIndent(views.Timestamps, utils.FormatTable, indent)
+				_ = utils.PrintObjectWithIndent(views.Timestamps, utils.FormatTable, indent)
 				fmt.Println("\nConfiguration:")
-				utils.PrintObjectWithIndent(views.Configuration, utils.FormatTable, indent)
+				_ = utils.PrintObjectWithIndent(views.Configuration, utils.FormatTable, indent)
 
 				fmt.Println("\nData:")
-				utils.PrintObjectWithIndent(views.Data, utils.FormatTable, indent)
+				_ = utils.PrintObjectWithIndent(views.Data, utils.FormatTable, indent)
 			default:
 				return fmt.Errorf("unsupported output format: %s (supported: table, json, yaml)", output)
 			}
@@ -276,7 +276,7 @@ func newOperationShowCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&jobID, "id", "i", "", "Job ID (required)")
 	cmd.Flags().BoolVar(&logs, "logs", false, "Include recent training logs")
 	cmd.Flags().StringVarP(&output, "output", "o", "table", "Output format: table, json, yaml")
-	cmd.MarkFlagRequired(requiredFlag)
+	_ = cmd.MarkFlagRequired(requiredFlag)
 
 	return cmd
 }
@@ -330,9 +330,9 @@ func newOperationListCommand() *cobra.Command {
 
 			switch output {
 			case "json":
-				utils.PrintObject(jobs, utils.FormatJSON)
+				_ = utils.PrintObject(jobs, utils.FormatJSON)
 			case "table", "":
-				utils.PrintObject(jobs, utils.FormatTable)
+				_ = utils.PrintObject(jobs, utils.FormatTable)
 			default:
 				return fmt.Errorf("unsupported output format: %s (supported: table, json)", output)
 			}
@@ -400,7 +400,7 @@ func newOperationPauseCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&jobID, "id", "i", "", "Job ID (required)")
-	cmd.MarkFlagRequired(requiredFlag)
+	_ = cmd.MarkFlagRequired(requiredFlag)
 
 	return cmd
 }
@@ -459,7 +459,7 @@ func newOperationResumeCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&jobID, "id", "i", "", "Job ID (required)")
-	cmd.MarkFlagRequired(requiredFlag)
+	_ = cmd.MarkFlagRequired(requiredFlag)
 
 	return cmd
 }
@@ -488,7 +488,7 @@ func newOperationCancelCommand() *cobra.Command {
 			if !force {
 				fmt.Printf("Cancel fine-tuning job %s? (y/N): ", jobID)
 				var response string
-				fmt.Scanln(&response)
+				_, _ = fmt.Scanln(&response)
 				response = strings.ToLower(strings.TrimSpace(response))
 				if response != "y" && response != "yes" {
 					fmt.Println("Operation aborted.")
@@ -530,7 +530,7 @@ func newOperationCancelCommand() *cobra.Command {
 
 	cmd.Flags().StringVarP(&jobID, "id", "i", "", "Job ID (required)")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt")
-	cmd.MarkFlagRequired(requiredFlag)
+	_ = cmd.MarkFlagRequired(requiredFlag)
 
 	return cmd
 }
@@ -682,8 +682,8 @@ func newOperationDeployModelCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&version, "version", "v", "1", "Model version")
 	cmd.Flags().Int32VarP(&capacity, "capacity", "c", 1, "Capacity units")
 	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Do not wait for deployment to complete")
-	cmd.MarkFlagRequired(requiredFlagJobID)
-	cmd.MarkFlagRequired(requiredFlagDeploymentName)
+	_ = cmd.MarkFlagRequired(requiredFlagJobID)
+	_ = cmd.MarkFlagRequired(requiredFlagDeploymentName)
 
 	return cmd
 }

--- a/cli/azd/extensions/azure.ai.finetune/internal/providers/openai/provider.go
+++ b/cli/azd/extensions/azure.ai.finetune/internal/providers/openai/provider.go
@@ -169,6 +169,7 @@ func (p *OpenAIProvider) UploadFile(ctx context.Context, filePath string) (strin
 		fmt.Printf("failed to start spinner: %v\n", err)
 	}
 
+	//nolint:gosec // filePath is an explicit user-provided local file path
 	file, err := os.Open(filePath)
 	if err != nil {
 		_ = spinner.Stop(ctx)

--- a/cli/azd/extensions/azure.ai.finetune/internal/utils/parser.go
+++ b/cli/azd/extensions/azure.ai.finetune/internal/utils/parser.go
@@ -13,6 +13,7 @@ import (
 
 func ParseCreateFineTuningRequestConfig(filePath string) (*models.CreateFineTuningRequest, error) {
 	// Read the YAML file
+	//nolint:gosec // filePath is an explicit user-provided config path
 	yamlFile, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file %s: %w", filePath, err)

--- a/cli/azd/extensions/azure.ai.finetune/internal/utils/parser_test.go
+++ b/cli/azd/extensions/azure.ai.finetune/internal/utils/parser_test.go
@@ -155,7 +155,7 @@ func TestParseCreateFineTuningRequestConfig_TempFile(t *testing.T) {
 	content := `model: gpt-4o-mini
 training_file: file-abc123
 `
-	err := os.WriteFile(tempFile, []byte(content), 0644)
+	err := os.WriteFile(tempFile, []byte(content), 0600)
 	require.NoError(t, err)
 
 	config, err := ParseCreateFineTuningRequestConfig(tempFile)
@@ -169,7 +169,7 @@ func TestParseCreateFineTuningRequestConfig_EmptyFile(t *testing.T) {
 	tempDir := t.TempDir()
 	tempFile := filepath.Join(tempDir, "empty_config.yaml")
 
-	err := os.WriteFile(tempFile, []byte(""), 0644)
+	err := os.WriteFile(tempFile, []byte(""), 0600)
 	require.NoError(t, err)
 
 	config, err := ParseCreateFineTuningRequestConfig(tempFile)
@@ -183,7 +183,7 @@ func TestParseCreateFineTuningRequestConfig_WhitespaceOnlyFile(t *testing.T) {
 	tempDir := t.TempDir()
 	tempFile := filepath.Join(tempDir, "whitespace_config.yaml")
 
-	err := os.WriteFile(tempFile, []byte("   \n\n   \t\t\n"), 0644)
+	err := os.WriteFile(tempFile, []byte("   \n\n   \t\t\n"), 0600)
 	require.NoError(t, err)
 
 	config, err := ParseCreateFineTuningRequestConfig(tempFile)
@@ -201,7 +201,7 @@ model: gpt-4o-mini  # Model name
 training_file: file-abc123
 # Final comment
 `
-	err := os.WriteFile(tempFile, []byte(content), 0644)
+	err := os.WriteFile(tempFile, []byte(content), 0600)
 	require.NoError(t, err)
 
 	config, err := ParseCreateFineTuningRequestConfig(tempFile)
@@ -219,7 +219,7 @@ training_file: file-abc123
 unknown_field: some_value
 another_unknown: 123
 `
-	err := os.WriteFile(tempFile, []byte(content), 0644)
+	err := os.WriteFile(tempFile, []byte(content), 0600)
 	require.NoError(t, err)
 
 	// Should parse successfully, ignoring unknown fields


### PR DESCRIPTION
## Changes

- Update Go version from 1.25 to 1.26.0 in go.mod
- Add `.golangci.yaml` configuration file (gosec, lll, unused, errorlint, gofmt)
- Add GitHub Actions workflow for golangci-lint CI on PRs
- Fix all golangci-lint issues (gosec nolint annotations, unhandled errors, WriteFile permissions, line length)

Follows the same pattern established in the azure.ai.agents extension.