### PR TITLE
Update azure.coding-agent extension to Go 1.26 and add golangci-lint

### DIFF
--- a/.github/workflows/lint-ext-azure-coding-agent.yml
+++ b/.github/workflows/lint-ext-azure-coding-agent.yml
@@ -1,0 +1,22 @@
+name: ext-azure-coding-agent-ci
+
+on:
+  pull_request:
+    paths:
+      - "cli/azd/extensions/azure.coding-agent/**"
+      - ".github/workflows/lint-ext-azure-coding-agent.yml"
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lint:
+    uses: ./.github/workflows/lint-go.yml
+    with:
+      working-directory: cli/azd/extensions/azure.coding-agent

--- a/cli/azd/extensions/azure.coding-agent/.golangci.yaml
+++ b/cli/azd/extensions/azure.coding-agent/.golangci.yaml
@@ -1,0 +1,17 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - gosec
+    - lll
+    - unused
+    - errorlint
+  settings:
+    lll:
+      line-length: 220
+      tab-width: 4
+
+formatters:
+  enable:
+    - gofmt

--- a/cli/azd/extensions/azure.coding-agent/go.mod
+++ b/cli/azd/extensions/azure.coding-agent/go.mod
@@ -1,6 +1,6 @@
 module azurecodingagent
 
-go 1.25
+go 1.26.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0

--- a/cli/azd/extensions/azure.coding-agent/internal/cmd/coding_agent_config.go
+++ b/cli/azd/extensions/azure.coding-agent/internal/cmd/coding_agent_config.go
@@ -115,7 +115,9 @@ func newConfigCommand() *cobra.Command {
 	cc := &cobra.Command{
 		Use:   "config",
 		Short: "Configure the GitHub Copilot coding agent to access Azure resources via the Azure MCP",
-		Long:  "Configure the GitHub Copilot coding agent to access Azure resources via the Azure MCP.\n\nFor more information about this command, including prerequisites and troubleshooting, view the readme at " + ux.Hyperlink("https://github.com/Azure/azure-dev/blob/main/cli/azd/extensions/azure.coding-agent/README.md"),
+		Long: "Configure the GitHub Copilot coding agent to access Azure resources via the Azure MCP.\n\n" +
+			"For more information about this command, including prerequisites and troubleshooting, view the readme at " +
+			ux.Hyperlink("https://github.com/Azure/azure-dev/blob/main/cli/azd/extensions/azure.coding-agent/README.md"),
 	}
 
 	flagValues := setupFlags(cc.Flags())
@@ -392,6 +394,7 @@ func listRemotes(ctx context.Context, gitCLI gitCLI, gitRepoRoot string) ([]stri
 func writeCopilotSetupStepsYaml(gitRepoRoot string) error {
 	workflowsDir := filepath.Join(gitRepoRoot, ".github", "workflows")
 
+	//nolint:gosec // GitHub workflows directory should be readable and traversable
 	if err := os.MkdirAll(workflowsDir, 0755); err != nil {
 		return fmt.Errorf("failed to create the %s folder: %w", workflowsDir, err)
 	}


### PR DESCRIPTION
## Changes

- Update Go version from 1.25 to 1.26.0 in go.mod
- Add `.golangci.yaml` configuration file (gosec, lll, unused, errorlint, gofmt)
- Add GitHub Actions workflow for golangci-lint CI on PRs
- Fix all golangci-lint issues (gosec nolint annotation, line length)

Follows the same pattern established in the azure.ai.agents extension.