### PR TITLE
Update azure.appservice extension to Go 1.26 and add golangci-lint

### DIFF
--- a/.github/workflows/lint-ext-azure-appservice.yml
+++ b/.github/workflows/lint-ext-azure-appservice.yml
@@ -1,0 +1,22 @@
+name: ext-azure-appservice-ci
+
+on:
+  pull_request:
+    paths:
+      - "cli/azd/extensions/azure.appservice/**"
+      - ".github/workflows/lint-ext-azure-appservice.yml"
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lint:
+    uses: ./.github/workflows/lint-go.yml
+    with:
+      working-directory: cli/azd/extensions/azure.appservice

--- a/cli/azd/extensions/azure.appservice/.golangci.yaml
+++ b/cli/azd/extensions/azure.appservice/.golangci.yaml
@@ -1,0 +1,17 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - gosec
+    - lll
+    - unused
+    - errorlint
+  settings:
+    lll:
+      line-length: 220
+      tab-width: 4
+
+formatters:
+  enable:
+    - gofmt

--- a/cli/azd/extensions/azure.appservice/go.mod
+++ b/cli/azd/extensions/azure.appservice/go.mod
@@ -1,6 +1,6 @@
 module azureappservice
 
-go 1.25
+go 1.26.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0


### PR DESCRIPTION
## Changes

- Update Go version from 1.25 to 1.26.0 in go.mod
- Add `.golangci.yaml` configuration file (gosec, lll, unused, errorlint, gofmt)
- Add GitHub Actions workflow for golangci-lint CI on PRs
- No lint issues found (clean pass)

Follows the same pattern established in the azure.ai.agents extension.