### PR TITLE
Set a default value for resource group prompt

### DIFF
--- a/cli/azd/pkg/prompt/prompter.go
+++ b/cli/azd/pkg/prompt/prompter.go
@@ -188,11 +188,18 @@ func (p *DefaultPrompter) PromptResourceGroupFrom(
 		choices[idx+canCreateOverride] = fmt.Sprintf("%d. %s", idx+canCreateOverride+1, group.Name)
 	}
 
-	choice, err := p.console.Select(ctx, input.ConsoleOptions{
+	pickPrompt := input.ConsoleOptions{
 		Message: "Pick a resource group to use:",
 		Options: choices,
 		Help:    options.PickResourceGroupHelp,
-	})
+	}
+
+	if canCreateNeResourceGroup && options.DefaultName != "" {
+		// Default selection to create new resource group with the default name provided
+		pickPrompt.DefaultValue = choices[0]
+	}
+
+	choice, err := p.console.Select(ctx, pickPrompt)
 	if err != nil {
 		return "", fmt.Errorf("selecting resource group: %w", err)
 	}


### PR DESCRIPTION
Set a default value for resource group prompt

This allows resource-group deployment with `AZURE_RESOURCE_GROUP` set in `no-prompt` mode to continue. If the resource group already exists, the prompt is skipped. If the resource group does not exist, we create it.

Contributes to #6586