### PR TITLE
Update progress log previewer to handle no-tty mode better

### DIFF
--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -336,7 +336,18 @@ func (c *AskerConsole) ShowPreviewer(ctx context.Context, options *ShowPreviewer
 		options = defaultShowPreviewerOptions()
 	}
 
-	c.previewer = NewProgressLog(options.MaxLineCount, options.Prefix, options.Title, c.currentIndent.Load()+currentMsg)
+	c.previewer = newProgressLogWithWidthFn(
+		options.MaxLineCount,
+		options.Prefix,
+		options.Title,
+		c.currentIndent.Load()+currentMsg,
+		func() int {
+			if c.consoleWidth == nil {
+				return 0
+			}
+
+			return int(c.consoleWidth.Load())
+		})
 	c.previewer.Start()
 	c.writer = c.previewer
 	return &consolePreviewerWriter{

--- a/cli/azd/pkg/input/progress_log.go
+++ b/cli/azd/pkg/input/progress_log.go
@@ -55,8 +55,8 @@ type progressLog struct {
 	output []string
 	// The mutex is used to coordinate updating the header, stopping the component and printing logs.
 	outputMutex sync.Mutex
-	// This function is used to find out what's the terminal width. The log progress is disabled if this function
-	// returns a number <= 0.
+	// This function is used to find out what's the terminal width. The log progress is disabled, i.e. writes are no-opt,
+	// if this function returns a number <= 0.
 	terminalWidthFn TerminalWidthFn
 }
 
@@ -95,6 +95,11 @@ func (p *progressLog) Start() {
 	defer p.outputMutex.Unlock()
 
 	if p.output != nil {
+		return
+	}
+
+	consoleLen := p.terminalWidthFn()
+	if consoleLen <= 0 {
 		return
 	}
 


### PR DESCRIPTION
Changes:
- Pass the console width to progress log previewer. This allows the component to respect azd's TTY behavior, including `AZD_FORCE_TTY`
- Add a check in progress log previewer to no-opt during `Start()`. This was previously logging blank lines.

Contributes to https://github.com/Azure/azure-dev/issues/6586
