### PR TITLE
Fixing race condition in ux.TaskList when accessing the completed count

### DIFF
--- a/cli/azd/pkg/ux/task_list.go
+++ b/cli/azd/pkg/ux/task_list.go
@@ -296,7 +296,7 @@ func (t *TaskList) Render(printer Printer) error {
 
 // isCompleted checks if all async tasks are complete.
 func (t *TaskList) isCompleted() bool {
-	return int(t.completed) == len(t.allTasks)
+	return int(atomic.LoadInt32(&t.completed)) == len(t.allTasks)
 }
 
 // runSyncTasks executes all synchronous tasks in order after async tasks are completed.


### PR DESCRIPTION
Just a little unprotected access to a variable. This should just happen if you run `go test -race`

This is the test I used to repro it, but I'm unsure if you already have `-race` turned on in testing, etc... Let me know, I'll move this into the right spot.

```go
package bug_test

import (
	"testing"

	"github.com/azure/azure-dev/cli/azd/pkg/ux"
	"github.com/stretchr/testify/require"
)

func TestUseUXTaskList_RaceCondition(t *testing.T) {
	taskList := ux.NewTaskList(&ux.TaskListOptions{})

	taskList.AddTask(ux.TaskOptions{
		Title: "hello",
		Action: func(spf ux.SetProgressFunc) (ux.TaskState, error) {
			return ux.Success, nil
		},
	})

	taskList.AddTask(ux.TaskOptions{
		Title: "hello2",
		Action: func(spf ux.SetProgressFunc) (ux.TaskState, error) {
			return ux.Success, nil
		},
	})

	err := taskList.Run()
	require.NoError(t, err)
}
```