### PR TITLE
fix(coding-agent): use UserTenantId for credential resolution

### DIFF
--- a/cli/azd/extensions/azure.coding-agent/internal/cmd/coding_agent_config.go
+++ b/cli/azd/extensions/azure.coding-agent/internal/cmd/coding_agent_config.go
@@ -199,7 +199,7 @@ func runConfigCommand(cmd *cobra.Command, flagValues *flagValues) error {
 		return fmt.Errorf("failed getting a subscription from prompt. Try logging in manually with 'azd auth login' before running this command %w", err)
 	}
 
-	tenantID := subscriptionResponse.Subscription.TenantId
+	tenantID := subscriptionResponse.Subscription.UserTenantId
 	subscriptionID := subscriptionResponse.Subscription.Id
 
 	cred, err := azidentity.NewAzureDeveloperCLICredential(&azidentity.AzureDeveloperCLICredentialOptions{


### PR DESCRIPTION
## Fix

Multiple extensions were using `Subscription.TenantId` (the **resource tenant** — the tenant that owns the subscription) when creating `AzureDeveloperCLICredential` after user subscription selection.

For multi-tenant/guest users, `TenantId` differs from `UserTenantId` (the tenant the user authenticated through). Using the resource tenant causes the credential to target a tenant the user may not have direct auth tokens for, resulting in `AADSTS70043`/`AADSTS700082` "refresh token expired" errors.

### Change

```diff
- tenantId = resp.Subscription.TenantId
+ tenantId = resp.Subscription.UserTenantId
```

This aligns all extensions with how azd core resolves credentials — `SubscriptionsManager.LookupTenant()` returns `UserAccessTenantId`, not `TenantId`.

For single-tenant users, `TenantId == UserTenantId`, so no behavior change.

### Affected extensions

| Extension | Files |
|-----------|-------|
| azure.coding-agent | coding_agent_config.go |
| azure.ai.models | custom.go, init.go |
| azure.ai.agents | init.go, init_from_code.go |
| azure.ai.finetune | init.go |
| microsoft.azd.ai.builder | start.go |
| microsoft.azd.demo | prompt.go |

Extensions already correct (using `LookupTenant()`): azure.appservice, azure.ai.agents (parser.go, service_target_agent.go).

Fixes #7077
Related: #7070