### PR TITLE
fix: eliminate flaky timing race in TestReady_BlocksUntilRunStarts

### DIFF
--- a/cli/azd/pkg/grpcbroker/message_broker_test.go
+++ b/cli/azd/pkg/grpcbroker/message_broker_test.go
@@ -752,21 +752,36 @@ func TestReady_BlocksUntilRunStarts(t *testing.T) {
 	broker := NewMessageBroker(stream.ClientStream(), envelope, "client", nil)
 
 	readyDone := make(chan error, 1)
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
 
-	// Start Ready() - should block
+	// Use a short-lived context just for the blocking check
+	blockCtx, blockCancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer blockCancel()
+
+	// Start Ready() with the short context - should block and then timeout
 	go func() {
-		readyDone <- broker.Ready(ctx)
+		readyDone <- broker.Ready(blockCtx)
 	}()
 
 	// Should timeout because Ready() blocks until Run() starts
 	select {
 	case err := <-readyDone:
-		t.Fatalf("Ready() should have blocked but returned with: %v", err)
-	case <-time.After(50 * time.Millisecond):
-		// Expected - Ready() is blocking
+		if err == nil {
+			t.Fatal("Ready() should have blocked but returned nil")
+		}
+		// Expected - context deadline exceeded because Run() hasn't started
+		assert.ErrorIs(t, err, context.DeadlineExceeded, "Ready() should timeout before Run() starts")
+	case <-time.After(1 * time.Second):
+		t.Fatal("Ready() goroutine didn't return after its context expired")
 	}
+
+	// Now use a generous context for the second Ready() call
+	readyCtx, readyCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer readyCancel()
+
+	readyDone2 := make(chan error, 1)
+	go func() {
+		readyDone2 <- broker.Ready(readyCtx)
+	}()
 
 	// Start Run()
 	runCtx, runCancel := context.WithCancel(context.Background())
@@ -776,11 +791,11 @@ func TestReady_BlocksUntilRunStarts(t *testing.T) {
 		_ = broker.Run(runCtx)
 	}()
 
-	// Ready() should complete quickly
+	// Ready() should complete quickly after Run() starts
 	select {
-	case err := <-readyDone:
+	case err := <-readyDone2:
 		assert.NoError(t, err, "Ready() should complete after Run() starts")
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(5 * time.Second):
 		t.Fatal("Ready() should have completed after Run() started")
 	}
 }


### PR DESCRIPTION
## Problem

`TestReady_BlocksUntilRunStarts` in `pkg/grpcbroker` was flaky in CI. It used a single 100ms context shared across two test phases:

1. **Phase 1 (~50ms):** Confirm `Ready()` blocks before `Run()` starts.
2. **Phase 2 (remaining ~50ms):** Wait for `Ready()` to unblock after `Run()` starts.

On slow CI machines (e.g., Windows runners), goroutine scheduling delays could consume the remaining context budget, causing `Ready()` to return `context deadline exceeded` instead of `nil` ([failed build
](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5969857&view=logs&j=12494761-d332-5a1c-a5ee-2bea7198f339&t=e8c28b77-9b2d-5977-b9e2-564f8e6b9e54)).

## Fix

Split the test into two independent phases with separate contexts:

1. A **50ms context** that is expected to timeout, proving `Ready()` blocks when `Run()` hasn't started.
2. A **fresh 5s context** for a second `Ready()` call that should complete promptly once `Run()` starts.

This eliminates the shared-deadline race and gives generous time for goroutine scheduling on slow machines.