### PR TITLE
adding more enhancements

### DIFF
--- a/cli/azd/extensions/azure.ai.models/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.models/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 - Added async model registration with server-side validation and polling support
 - Removed `--blob-uri` flag from `custom create` to prevent invalid data reference errors when registering models with externally uploaded blobs
+- Improved 409 error handling in `custom create` with guidance to use `show` to fetch latest version
+- `custom show` now defaults to latest version when `--version` is omitted
+- `custom create` auto-extracts version from `--base-model` azureml:// URI when `--version` is not explicitly provided
 
 ## 0.0.3-preview (2026-02-19)
 

--- a/cli/azd/extensions/azure.ai.models/internal/cmd/custom_create.go
+++ b/cli/azd/extensions/azure.ai.models/internal/cmd/custom_create.go
@@ -53,6 +53,13 @@ provide a file containing the URL instead.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := azdext.WithAccessToken(cmd.Context())
 
+			// If --version not explicitly set, try to extract from --base-model URI
+			if !cmd.Flags().Changed("version") {
+				if v := extractVersionFromURI(flags.BaseModel); v != "" {
+					flags.Version = v
+				}
+			}
+
 			// Resolve source from --source-file if --source is not set
 			if flags.Source == "" && flags.SourceFile != "" {
 				data, err := os.ReadFile(flags.SourceFile)
@@ -138,6 +145,16 @@ func runCustomCreate(ctx context.Context, parentFlags *customFlags, flags *custo
 	fmt.Println()
 
 	if err != nil {
+		if strings.Contains(err.Error(), "409") || strings.Contains(err.Error(), "already exists") {
+			fmt.Println()
+			color.Red("✗ Model '%s' version '%s' already exists.", flags.Name, flags.Version)
+			fmt.Println()
+			color.Yellow("To fetch the latest version, use show without --version:")
+			fmt.Printf("  azd ai models custom show --name %s\n\n", flags.Name)
+			color.Yellow("Then create with a new version:")
+			fmt.Printf("  azd ai models custom create --name %s --version <next-version> ...\n", flags.Name)
+			return fmt.Errorf("model version already exists")
+		}
 		return fmt.Errorf("failed to get upload location: %w", err)
 	}
 
@@ -277,4 +294,20 @@ func extractBaseModelName(baseModel string) string {
 		}
 	}
 	return baseModel
+}
+
+// extractVersionFromURI extracts the version segment from an azureml:// URI.
+// e.g. "azureml://registries/azureml-fireworks/models/FW-Qwen3-14B/versions/2" → "2"
+// Returns empty string if not an azureml URI or version not found.
+func extractVersionFromURI(uri string) string {
+	if !strings.HasPrefix(uri, "azureml://") {
+		return ""
+	}
+	parts := strings.Split(uri, "/")
+	for i, p := range parts {
+		if p == "versions" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return ""
 }

--- a/cli/azd/extensions/azure.ai.models/internal/cmd/custom_show.go
+++ b/cli/azd/extensions/azure.ai.models/internal/cmd/custom_show.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"azure.ai.models/internal/client"
 	"azure.ai.models/internal/utils"
+	"azure.ai.models/pkg/models"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
@@ -38,7 +40,7 @@ func newCustomShowCommand(parentFlags *customFlags) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&flags.Name, "name", "n", "", "Model name (required)")
-	cmd.Flags().StringVar(&flags.Version, "version", "1", "Model version")
+	cmd.Flags().StringVar(&flags.Version, "version", "", "Model version (defaults to latest)")
 	cmd.Flags().StringVarP(&flags.Output, "output", "o", "table", "Output format (table, json)")
 
 	_ = cmd.MarkFlagRequired("name")
@@ -83,7 +85,39 @@ func runCustomShow(ctx context.Context, parentFlags *customFlags, flags *customS
 		return err
 	}
 
-	model, err := foundryClient.GetModel(ctx, flags.Name, flags.Version)
+	model, err := func() (*models.CustomModel, error) {
+		// If version specified, fetch directly
+		if flags.Version != "" {
+			return foundryClient.GetModel(ctx, flags.Name, flags.Version)
+		}
+
+		// Otherwise, find the latest version via list
+		listResp, err := foundryClient.ListModels(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list models: %w", err)
+		}
+
+		var latest *models.CustomModel
+		latestVersion := 0
+		for i := range listResp.Value {
+			m := &listResp.Value[i]
+			if !strings.EqualFold(m.Name, flags.Name) {
+				continue
+			}
+			v, _ := strconv.Atoi(m.Version)
+			if latest == nil || v > latestVersion {
+				latest = m
+				latestVersion = v
+			}
+		}
+
+		if latest == nil {
+			return nil, fmt.Errorf("model '%s' not found", flags.Name)
+		}
+
+		// Fetch full details for the latest version
+		return foundryClient.GetModel(ctx, flags.Name, latest.Version)
+	}()
 	_ = spinner.Stop(ctx)
 	fmt.Print("\n\n")
 


### PR DESCRIPTION
This pull request improves the user experience and error handling for custom model registration and retrieval commands in the Azure AI Models CLI extension. The main changes add better guidance when a model version already exists, make the `custom show` command default to showing the latest version if none is specified, and streamline version extraction from AzureML URIs.

**Improvements to error handling and user guidance:**

* Enhanced the `custom create` command to detect 409 (already exists) errors and provide clear instructions on how to fetch the latest version and create a new one, improving usability when version conflicts occur. [[1]](diffhunk://#diff-a5c1a3912460fdd81356738d23939fbc23d27fa2a56fdeb94b43e7cebddf707cR148-R157) [[2]](diffhunk://#diff-1b82c0350b71a22af40920bee5889f796a794f54becbc8336fcbeb6e4d20cca4R8-R10)

**Enhancements to version handling:**

* Updated the `custom show` command so that if the `--version` flag is omitted, it automatically fetches and displays the latest version of the specified model. [[1]](diffhunk://#diff-bf85194a080a2d3cd77b3c1c4a041e3d8e6922a761df7f5d3e87e9e2c367d426L41-R43) [[2]](diffhunk://#diff-bf85194a080a2d3cd77b3c1c4a041e3d8e6922a761df7f5d3e87e9e2c367d426L86-R120) [[3]](diffhunk://#diff-1b82c0350b71a22af40920bee5889f796a794f54becbc8336fcbeb6e4d20cca4R8-R10)
* Modified the `custom create` command to auto-extract the version from the `--base-model` AzureML URI if the `--version` flag is not explicitly provided, reducing manual input and potential errors. [[1]](diffhunk://#diff-a5c1a3912460fdd81356738d23939fbc23d27fa2a56fdeb94b43e7cebddf707cR56-R62) [[2]](diffhunk://#diff-a5c1a3912460fdd81356738d23939fbc23d27fa2a56fdeb94b43e7cebddf707cR298-R313) [[3]](diffhunk://#diff-1b82c0350b71a22af40920bee5889f796a794f54becbc8336fcbeb6e4d20cca4R8-R10)

**Minor code and dependency updates:**

* Added necessary imports to support new logic for version parsing and model handling.