### PR TITLE
fix: remove AZURE_RECORD_MODE override from Set-CliBuildVariables.ps1

### DIFF
--- a/eng/scripts/Set-CliBuildVariables.ps1
+++ b/eng/scripts/Set-CliBuildVariables.ps1
@@ -24,13 +24,5 @@
  }
 
 
-# AZURE_RECORD_MODE is used for running tests in a specific recording mode.
-if (-not $env:AZURE_RECORD_MODE) {
-    $recordMode = "playback"
-
-    if ($BuildReason -eq "PullRequest") {
-        $recordMode = "playback"
-    }
-
-    Set-BuildVariable -Key "AZURE_RECORD_MODE" -Value $recordMode
-}
+# AZURE_RECORD_MODE is controlled by the AzureRecordMode pipeline parameter
+# defined in release-cli.yml and passed through build-and-test.yml → build-cli.yml.


### PR DESCRIPTION
## Problem

Manually triggered CI runs with `AzureRecordMode=live` still execute tests in playback mode (~30 min instead of ~2 hours).

## Root Cause

`eng/scripts/Set-CliBuildVariables.ps1` unconditionally sets `AZURE_RECORD_MODE=playback` as a pipeline variable (via `##vso[task.setvariable]`) before the test task runs. This overrides the `env: AZURE_RECORD_MODE` value set on the test task from the `AzureRecordMode` pipeline parameter introduced in #6893.

## Fix

Remove the `AZURE_RECORD_MODE` block from the script. The record mode is now fully controlled by the pipeline parameter chain:
`release-cli.yml` → `build-and-test.yml` → `build-cli.yml`

Fixes #7102