### PR TITLE
chore: modernize slice/sort patterns with slices and maps packages

### DIFF
--- a/cli/azd/pkg/account/subscriptions.go
+++ b/cli/azd/pkg/account/subscriptions.go
@@ -4,9 +4,10 @@
 package account
 
 import (
+	"cmp"
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
@@ -81,8 +82,8 @@ func (s *SubscriptionsService) ListSubscriptions(
 		subscriptions = append(subscriptions, page.SubscriptionListResult.Value...)
 	}
 
-	sort.Slice(subscriptions, func(i, j int) bool {
-		return *subscriptions[i].DisplayName < *subscriptions[j].DisplayName
+	slices.SortFunc(subscriptions, func(a, b *armsubscriptions.Subscription) int {
+		return cmp.Compare(*a.DisplayName, *b.DisplayName)
 	})
 
 	return subscriptions, nil
@@ -136,8 +137,8 @@ func (s *SubscriptionsService) ListSubscriptionLocations(
 		}
 	}
 
-	sort.Slice(locations, func(i, j int) bool {
-		return locations[i].RegionalDisplayName < locations[j].RegionalDisplayName
+	slices.SortFunc(locations, func(a, b Location) int {
+		return cmp.Compare(a.RegionalDisplayName, b.RegionalDisplayName)
 	})
 
 	return locations, nil
@@ -165,9 +166,11 @@ func (s *SubscriptionsService) ListTenants(ctx context.Context) ([]armsubscripti
 		}
 	}
 
-	sort.Slice(tenants, func(i, j int) bool {
-		return convert.ToValueWithDefault(tenants[i].DisplayName, "") <
-			convert.ToValueWithDefault(tenants[j].DisplayName, "")
+	slices.SortFunc(tenants, func(a, b armsubscriptions.TenantIDDescription) int {
+		return cmp.Compare(
+			convert.ToValueWithDefault(a.DisplayName, ""),
+			convert.ToValueWithDefault(b.DisplayName, ""),
+		)
 	})
 
 	return tenants, nil

--- a/cli/azd/pkg/account/subscriptions_manager.go
+++ b/cli/azd/pkg/account/subscriptions_manager.go
@@ -4,12 +4,13 @@
 package account
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"log"
 	"math"
 	"os"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -326,8 +327,8 @@ func (m *SubscriptionsManager) ListSubscriptions(ctx context.Context) ([]Subscri
 	}
 	close(results)
 
-	sort.Slice(allSubscriptions, func(i, j int) bool {
-		return allSubscriptions[i].Name < allSubscriptions[j].Name
+	slices.SortFunc(allSubscriptions, func(a, b Subscription) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	if !oneSuccess && len(tenants) > 0 {

--- a/cli/azd/pkg/azdext/scope_detector.go
+++ b/cli/azd/pkg/azdext/scope_detector.go
@@ -5,6 +5,7 @@ package azdext
 
 import (
 	"errors"
+	"maps"
 	"net/url"
 	"slices"
 	"strings"
@@ -113,11 +114,7 @@ func NewScopeDetector(opts *ScopeDetectorOptions) *ScopeDetector {
 
 	if opts != nil {
 		// Sort keys for deterministic rule evaluation order.
-		keys := make([]string, 0, len(opts.CustomRules))
-		for k := range opts.CustomRules {
-			keys = append(keys, k)
-		}
-		slices.Sort(keys)
+		keys := slices.Sorted(maps.Keys(opts.CustomRules))
 
 		for _, hostSuffix := range keys {
 			if hostSuffix == "" {

--- a/cli/azd/pkg/infra/provisioning_progress_display.go
+++ b/cli/azd/pkg/infra/provisioning_progress_display.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"os"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -179,11 +178,11 @@ func (display *ProvisioningProgressDisplay) ReportProgress(
 		return err
 	}
 
-	sort.Slice(newlyDeployedResources, func(i int, j int) bool {
-		return time.Time.Before(
-			*newlyDeployedResources[i].Properties.Timestamp,
-			*newlyDeployedResources[j].Properties.Timestamp,
-		)
+	slices.SortFunc(newlyDeployedResources, func(
+		a *armresources.DeploymentOperation,
+		b *armresources.DeploymentOperation,
+	) int {
+		return a.Properties.Timestamp.Compare(*b.Properties.Timestamp)
 	})
 
 	displayedResources := append(newlyDeployedResources, newlyFailedResources...)


### PR DESCRIPTION
## Summary
- replace manual endpoint slice cloning with `slices.Clone`
- replace manual custom-rule key collection with `slices.Sorted(maps.Keys(...))`
- migrate remaining non-test `sort.Slice` calls to `slices.SortFunc` comparators

## Testing
- go build ./...
- go test ./pkg/account/... ./pkg/project/... ./pkg/azdext/... ./pkg/infra/... -count=1 -short
- UPDATE_SNAPSHOTS=true go test ./cmd -run 'TestFigSpec|TestUsage' -count=1\n\nFixes #7084\nFixes #7085\nFixes #7086