### PR TITLE
chore: adopt errors.AsType[T] for type-safe error matching

### DIFF
--- a/cli/azd/cmd/auth_login.go
+++ b/cli/azd/cmd/auth_login.go
@@ -311,10 +311,10 @@ func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		// We print any non-setup related errors to stderr.
 		// We always return a zero exit code.
 		token, err := la.verifyLoggedIn(ctx)
-		var loginExpiryError *auth.ReLoginRequiredError
+		_, loginExpiryError := errors.AsType[*auth.ReLoginRequiredError](err)
 		if err != nil &&
 			!errors.Is(err, auth.ErrNoCurrentUser) &&
-			!errors.As(err, &loginExpiryError) {
+			!loginExpiryError {
 			fmt.Fprintln(la.console.Handles().Stderr, err.Error())
 		}
 

--- a/cli/azd/cmd/auth_status.go
+++ b/cli/azd/cmd/auth_status.go
@@ -81,10 +81,10 @@ func (a *authStatusAction) Run(ctx context.Context) (*actions.ActionResult, erro
 
 	// get user account information
 	details, err := a.authManager.LogInDetails(ctx)
-	var loginExpiryError *auth.ReLoginRequiredError
+	_, loginExpiryError := errors.AsType[*auth.ReLoginRequiredError](err)
 	if err != nil {
 		if !errors.Is(err, auth.ErrNoCurrentUser) &&
-			!errors.As(err, &loginExpiryError) {
+			!loginExpiryError {
 			// print a useful message for unknown errors
 			fmt.Fprintln(a.console.Handles().Stderr, err.Error())
 		}

--- a/cli/azd/cmd/auto_install.go
+++ b/cli/azd/cmd/auto_install.go
@@ -429,8 +429,8 @@ func ExecuteWithAutoInstall(ctx context.Context, rootContainer *ioc.NestedContai
 		}
 
 		// auto-install for target service
-		var unsupportedErr *project.UnsupportedServiceHostError
-		if !errors.As(err, &unsupportedErr) {
+		unsupportedErr, ok := errors.AsType[*project.UnsupportedServiceHostError](err)
+		if !ok {
 			return err
 		}
 

--- a/cli/azd/cmd/middleware/error.go
+++ b/cli/azd/cmd/middleware/error.go
@@ -72,15 +72,12 @@ const (
 // AzureContextAndOtherError, MachineContextError, or UserContextError
 func classifyError(err error) ErrorCategory {
 	// --- Machine context: typed errors ---
-	var toolCheckErr *tools.MissingToolErrors
-	var semverErr *tools.ErrSemver
-	var extRunErr *extensions.ExtensionRunError
-	var packStatusErr *pack.StatusCodeError
+	_, toolCheckErr := errors.AsType[*tools.MissingToolErrors](err)
+	_, semverErr := errors.AsType[*tools.ErrSemver](err)
+	_, extRunErr := errors.AsType[*extensions.ExtensionRunError](err)
+	_, packStatusErr := errors.AsType[*pack.StatusCodeError](err)
 
-	if errors.As(err, &toolCheckErr) ||
-		errors.As(err, &semverErr) ||
-		errors.As(err, &extRunErr) ||
-		errors.As(err, &packStatusErr) {
+	if toolCheckErr || semverErr || extRunErr || packStatusErr {
 		return MachineContextError
 	}
 
@@ -89,10 +86,10 @@ func classifyError(err error) ErrorCategory {
 	}
 
 	// --- User context: typed errors ---
-	var loginErr *auth.ReLoginRequiredError
-	var authFailedErr *auth.AuthFailedError
+	_, loginErr := errors.AsType[*auth.ReLoginRequiredError](err)
+	_, authFailedErr := errors.AsType[*auth.AuthFailedError](err)
 
-	if errors.As(err, &loginErr) || errors.As(err, &authFailedErr) {
+	if loginErr || authFailedErr {
 		return UserContextError
 	}
 
@@ -130,8 +127,8 @@ func shouldSkipErrorAnalysis(err error) bool {
 	}
 
 	// Environment was already initialized
-	var envInitErr *environment.EnvironmentInitError
-	return errors.As(err, &envInitErr)
+	_, ok := errors.AsType[*environment.EnvironmentInitError](err)
+	return ok
 }
 
 func NewErrorMiddleware(
@@ -174,8 +171,7 @@ func (e *ErrorMiddleware) Run(ctx context.Context, next NextFn) (*actions.Action
 	}
 
 	// Check if error already has a suggestion
-	var suggestionErr *internal.ErrorWithSuggestion
-	if errors.As(err, &suggestionErr) {
+	if _, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
 		// Already has a suggestion, return as-is
 		return actionResult, err
 	}
@@ -218,7 +214,6 @@ func (e *ErrorMiddleware) Run(ctx context.Context, next NextFn) (*actions.Action
 
 	attempt := 0
 	var previousError error
-	var errorWithTraceId *internal.ErrorWithTraceId
 	AIDisclaimer := output.WithGrayFormat("The following content is AI-generated. AI responses may be incorrect.")
 	agentName := "agent mode"
 
@@ -242,7 +237,7 @@ func (e *ErrorMiddleware) Run(ctx context.Context, next NextFn) (*actions.Action
 			}
 		}
 
-		if errors.As(originalError, &errorWithTraceId) {
+		if errorWithTraceId, ok := errors.AsType[*internal.ErrorWithTraceId](originalError); ok {
 			e.console.Message(ctx, output.WithErrorFormat("TraceID: %s", errorWithTraceId.TraceId))
 		}
 

--- a/cli/azd/cmd/middleware/telemetry.go
+++ b/cli/azd/cmd/middleware/telemetry.go
@@ -121,12 +121,11 @@ func (m *TelemetryMiddleware) Run(ctx context.Context, next NextFn) (*actions.Ac
 		// where we have full server logs to troubleshoot from.
 		//
 		// For client errors, we don't want to show the trace ID, as it is not useful to the user currently.
-		var respErr *azcore.ResponseError
-		var azureErr *azapi.AzureDeploymentError
-		var toolExitErr *exec.ExitError
+		_, respErr := errors.AsType[*azcore.ResponseError](err)
+		_, azureErr := errors.AsType[*azapi.AzureDeploymentError](err)
+		toolExitErr, toolExitOk := errors.AsType[*exec.ExitError](err)
 
-		if errors.As(err, &respErr) || errors.As(err, &azureErr) ||
-			(errors.As(err, &toolExitErr) && toolExitErr.Cmd == "terraform") {
+		if respErr || azureErr || (toolExitOk && toolExitErr.Cmd == "terraform") {
 			err = &internal.ErrorWithTraceId{
 				Err:     err,
 				TraceId: span.SpanContext().TraceID().String(),

--- a/cli/azd/cmd/middleware/ux.go
+++ b/cli/azd/cmd/middleware/ux.go
@@ -45,16 +45,10 @@ func (m *UxMiddleware) Run(ctx context.Context, next NextFn) (*actions.ActionRes
 	m.console.StopSpinner(ctx, "", input.Step)
 
 	if err != nil {
-		var suggestionErr *internal.ErrorWithSuggestion
-		var errorWithTraceId *internal.ErrorWithTraceId
-
-		// For specific errors, we silent the output display here and let the caller handle it
-		var unsupportedErr *project.UnsupportedServiceHostError
-
 		// Use ErrorWithSuggestion for errors with suggestions (better UX).
 		// This catches errors wrapped by the error pipeline's YAML rules
 		// or other host code that already created an ErrorWithSuggestion.
-		if errors.As(err, &suggestionErr) {
+		if suggestionErr, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
 			displayErr := &ux.ErrorWithSuggestion{
 				Err:        suggestionErr.Err,
 				Message:    suggestionErr.Message,
@@ -83,8 +77,7 @@ func (m *UxMiddleware) Run(ctx context.Context, next NextFn) (*actions.ActionRes
 		}
 
 		// ExtensionRunError without suggestion
-		var extensionRunErr *extensions.ExtensionRunError
-		if errors.As(err, &extensionRunErr) {
+		if _, ok := errors.AsType[*extensions.ExtensionRunError](err); ok {
 			if message := azdext.ErrorMessage(err); message != "" {
 				m.console.Message(ctx, output.WithErrorFormat("\nERROR: %s", message))
 			}
@@ -95,13 +88,13 @@ func (m *UxMiddleware) Run(ctx context.Context, next NextFn) (*actions.ActionRes
 		errorMessage := &strings.Builder{}
 		errorMessage.WriteString(output.WithErrorFormat("\nERROR: %s", err.Error()))
 
-		if errors.As(err, &errorWithTraceId) {
+		if errorWithTraceId, ok := errors.AsType[*internal.ErrorWithTraceId](err); ok {
 			errorMessage.WriteString(output.WithErrorFormat("\nTraceID: %s", errorWithTraceId.TraceId))
 		}
 
 		errMessage := errorMessage.String()
 
-		if errors.As(err, &unsupportedErr) {
+		if unsupportedErr, ok := errors.AsType[*project.UnsupportedServiceHostError](err); ok {
 			// set the error message so the caller can use it if needed
 			unsupportedErr.ErrorMessage = errMessage
 			return actionResult, err
@@ -110,8 +103,10 @@ func (m *UxMiddleware) Run(ctx context.Context, next NextFn) (*actions.ActionRes
 		m.console.Message(ctx, errMessage)
 
 		// Print out additional text for errors that have it.
-		var uxItemErr ux.UxItem
-		if errors.As(err, &uxItemErr) {
+		if uxItemErr, ok := errors.AsType[interface {
+			error
+			ux.UxItem
+		}](err); ok {
 			m.console.Message(ctx, "")
 			m.console.MessageUxItem(ctx, uxItemErr)
 			return actionResult, err

--- a/cli/azd/cmd/update.go
+++ b/cli/azd/cmd/update.go
@@ -291,8 +291,7 @@ func (a *updateAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	stdout := a.console.Handles().Stdout
 	if err := mgr.Update(ctx, cfg, stdout); err != nil {
 		// UpdateError already has the right code, just track it
-		var updateErr *update.UpdateError
-		if errors.As(err, &updateErr) {
+		if updateErr, ok := errors.AsType[*update.UpdateError](err); ok {
 			tracing.SetUsageAttributes(fields.UpdateResult.String(updateErr.Code))
 		} else {
 			tracing.SetUsageAttributes(fields.UpdateResult.String(update.CodeReplaceFailed))

--- a/cli/azd/internal/agent/tools/dev/command_executor.go
+++ b/cli/azd/internal/agent/tools/dev/command_executor.go
@@ -205,8 +205,7 @@ func (t CommandExecutorTool) executeCommand(ctx context.Context, command string,
 	var cmdError error
 
 	if err != nil {
-		var exitError *exec.ExitError
-		if errors.As(err, &exitError) {
+		if exitError, ok := errors.AsType[*exec.ExitError](err); ok {
 			// Command ran but exited with non-zero code - this is normal
 			exitCode = exitError.ExitCode()
 			cmdError = nil // Don't treat non-zero exit as a system error

--- a/cli/azd/internal/cmd/add/add_select_ai.go
+++ b/cli/azd/internal/cmd/add/add_select_ai.go
@@ -97,8 +97,7 @@ func (a *AddAction) promptOpenAi(
 
 		_, err = a.rm.FindResourceGroupForEnvironment(
 			ctx, a.env.GetSubscriptionId(), a.env.Name())
-		var notFoundError *azureutil.ResourceNotFoundError
-		if errors.As(err, &notFoundError) { // not yet provisioned, we're safe here
+		if _, ok := errors.AsType[*azureutil.ResourceNotFoundError](err); ok { // not yet provisioned, we're safe here
 			console.MessageUxItem(ctx, &ux.WarningMessage{
 				Description: fmt.Sprintf("No models found in %s", a.env.GetLocation()),
 			})

--- a/cli/azd/internal/cmd/errors.go
+++ b/cli/azd/internal/cmd/errors.go
@@ -44,28 +44,11 @@ func MapError(err error, span tracing.Span) {
 	var errCode string
 	var errDetails []attribute.KeyValue
 
-	// external service errors
-	var respErr *azcore.ResponseError
-	var armDeployErr *azapi.AzureDeploymentError
-	var authFailedErr *auth.AuthFailedError
-	var extServiceErr *azdext.ServiceError
-	var extLocalErr *azdext.LocalError
-
-	// external tool errors
-	var toolExecErr *exec.ExitError
-	var toolCheckErr *tools.MissingToolErrors
-	var extensionRunErr *extensions.ExtensionRunError
-
-	// internal errors
-	var errWithSuggestion *internal.ErrorWithSuggestion
-	var loginErr *auth.ReLoginRequiredError
-	var updateErr *update.UpdateError
-
-	if errors.As(err, &updateErr) {
+	if updateErr, ok := errors.AsType[*update.UpdateError](err); ok {
 		errCode = updateErr.Code
-	} else if errors.As(err, &loginErr) {
+	} else if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {
 		errCode = "auth.login_required"
-	} else if errors.As(err, &errWithSuggestion) {
+	} else if errWithSuggestion, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
 		errCode = "error.suggestion"
 		inner := errWithSuggestion.Unwrap()
 		if code := classifySentinel(inner); code != "" {
@@ -74,7 +57,7 @@ func MapError(err error, span tracing.Span) {
 			span.SetAttributes(
 				fields.ErrType.String(errorType(inner)))
 		}
-	} else if errors.As(err, &respErr) {
+	} else if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok {
 		serviceName := "other"
 		statusCode := -1
 		errDetails = append(errDetails, fields.ServiceErrorCode.String(respErr.ErrorCode))
@@ -95,7 +78,7 @@ func MapError(err error, span tracing.Span) {
 		}
 
 		errCode = fmt.Sprintf("service.%s.%d", serviceName, statusCode)
-	} else if errors.As(err, &armDeployErr) {
+	} else if armDeployErr, ok := errors.AsType[*azapi.AzureDeploymentError](err); ok {
 		errDetails = append(errDetails, fields.ServiceName.String("arm"))
 		codes := []*deploymentErrorCode{}
 		var collect func(details []*azapi.DeploymentErrorLine, frame int)
@@ -129,7 +112,7 @@ func MapError(err error, span tracing.Span) {
 			operation = "deployment"
 		}
 		errCode = fmt.Sprintf("service.arm.%s.failed", operation)
-	} else if errors.As(err, &extServiceErr) {
+	} else if extServiceErr, ok := errors.AsType[*azdext.ServiceError](err); ok {
 		// Handle structured service errors from extensions.
 		// Emit whatever details are available rather than requiring all fields.
 		serviceName := ""
@@ -160,7 +143,7 @@ func MapError(err error, span tracing.Span) {
 		default:
 			errCode = "ext.service.unknown.failed"
 		}
-	} else if errors.As(err, &extLocalErr) {
+	} else if extLocalErr, ok := errors.AsType[*azdext.LocalError](err); ok {
 		domain := string(azdext.NormalizeLocalErrorCategory(extLocalErr.Category))
 		code := normalizeCodeSegment(extLocalErr.Code, "failed")
 
@@ -170,9 +153,9 @@ func MapError(err error, span tracing.Span) {
 		)
 
 		errCode = fmt.Sprintf("ext.%s.%s", domain, code)
-	} else if errors.As(err, &extensionRunErr) {
+	} else if _, ok := errors.AsType[*extensions.ExtensionRunError](err); ok {
 		errCode = "ext.run.failed"
-	} else if errors.As(err, &toolExecErr) {
+	} else if toolExecErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		toolName := "other"
 		cmdName := cmdAsName(toolExecErr.Cmd)
 		if cmdName != "" {
@@ -184,7 +167,7 @@ func MapError(err error, span tracing.Span) {
 			fields.ToolName.String(toolName))
 
 		errCode = fmt.Sprintf("tool.%s.failed", toolName)
-	} else if errors.As(err, &toolCheckErr) {
+	} else if toolCheckErr, ok := errors.AsType[*tools.MissingToolErrors](err); ok {
 		if len(toolCheckErr.ToolNames) == 1 {
 			toolName := toolCheckErr.ToolNames[0]
 			errCode = fmt.Sprintf("tool.%s.missing", toolName)
@@ -193,7 +176,7 @@ func MapError(err error, span tracing.Span) {
 			errCode = "tool.multiple.missing"
 			errDetails = append(errDetails, fields.ToolName.String(strings.Join(toolCheckErr.ToolNames, ",")))
 		}
-	} else if errors.As(err, &authFailedErr) {
+	} else if authFailedErr, ok := errors.AsType[*auth.AuthFailedError](err); ok {
 		errDetails = append(errDetails, fields.ServiceName.String("aad"))
 		if authFailedErr.Parsed != nil {
 			codes := make([]string, 0, len(authFailedErr.Parsed.ErrorCodes))
@@ -399,20 +382,17 @@ func isNetworkError(err error) bool {
 	}
 
 	// Check for DNS errors
-	var dnsErr *net.DNSError
-	if errors.As(err, &dnsErr) {
+	if _, ok := errors.AsType[*net.DNSError](err); ok {
 		return true
 	}
 
 	// Check for network operation errors (connection refused, timeout, etc.)
-	var opErr *net.OpError
-	if errors.As(err, &opErr) {
+	if _, ok := errors.AsType[*net.OpError](err); ok {
 		return true
 	}
 
 	// Check for TLS errors
-	var tlsRecordErr *tls.RecordHeaderError
-	if errors.As(err, &tlsRecordErr) {
+	if _, ok := errors.AsType[*tls.RecordHeaderError](err); ok {
 		return true
 	}
 

--- a/cli/azd/internal/grpcserver/server.go
+++ b/cli/azd/internal/grpcserver/server.go
@@ -207,11 +207,10 @@ func wrapErrorWithSuggestion(err error) error {
 		return nil
 	}
 
-	var loginErr *auth.ReLoginRequiredError
-	isAuthErr := errors.Is(err, auth.ErrNoCurrentUser) || errors.As(err, &loginErr)
+	_, loginErr := errors.AsType[*auth.ReLoginRequiredError](err)
+	isAuthErr := errors.Is(err, auth.ErrNoCurrentUser) || loginErr
 
-	var suggestionErr *internal.ErrorWithSuggestion
-	if errors.As(err, &suggestionErr) {
+	if suggestionErr, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
 		msg := fmt.Sprintf("%s\n%s", err.Error(), suggestionErr.Suggestion)
 		if isAuthErr {
 			return status.Error(codes.Unauthenticated, msg)

--- a/cli/azd/internal/mapper/errors.go
+++ b/cli/azd/internal/mapper/errors.go
@@ -19,10 +19,10 @@ import (
 //		// Handle missing mapper case
 //	}
 //
-// 2. Using errors.As() for detailed inspection:
+// 2. Using errors.AsType() for detailed inspection:
 //
 //	var noMapperErr *NoMapperError
-//	if errors.As(err, &noMapperErr) {
+//	if noMapperErr, ok := errors.AsType[*NoMapperError](err); ok {
 //		log.Printf("Missing mapper from %v to %v", noMapperErr.SrcType, noMapperErr.DstType)
 //	}
 //
@@ -52,10 +52,10 @@ var ErrConversionFailure = &ConversionError{}
 // It wraps the original error and provides context about which types were being converted.
 // Callers can check for this error in multiple ways:
 //
-// 1. Using errors.As() for detailed inspection:
+// 1. Using errors.AsType() for detailed inspection:
 //
 //	var convErr *ConversionError
-//	if errors.As(err, &convErr) {
+//	if convErr, ok := errors.AsType[*ConversionError](err); ok {
 //		log.Printf("Conversion failed from %v to %v: %v", convErr.SrcType, convErr.DstType, convErr.Err)
 //	}
 //
@@ -103,8 +103,8 @@ func (e *NoMapperError) Is(target error) bool {
 
 // IsNoMapperError returns true if the error is a NoMapperError
 func IsNoMapperError(err error) bool {
-	var noMapperErr *NoMapperError
-	return err != nil && errors.As(err, &noMapperErr)
+	_, ok := errors.AsType[*NoMapperError](err)
+	return err != nil && ok
 }
 
 // cleanTypeName returns a user-friendly type name with package prefixes for clarity
@@ -184,6 +184,6 @@ func (e *ConversionError) Is(target error) bool {
 
 // IsConversionError returns true if the error is a ConversionError
 func IsConversionError(err error) bool {
-	var convErr *ConversionError
-	return err != nil && errors.As(err, &convErr)
+	_, ok := errors.AsType[*ConversionError](err)
+	return err != nil && ok
 }

--- a/cli/azd/internal/mapper/mapper.go
+++ b/cli/azd/internal/mapper/mapper.go
@@ -238,7 +238,7 @@ func MustRegister[S, T any](fn func(context.Context, S) (T, error)) {
 //	var target *UserProto
 //	if err := mapper.Convert(user, &target); err != nil {
 //	    var noMapper *NoMapperError
-//	    if errors.As(err, &noMapper) {
+//	    if noMapper, ok := errors.AsType[*NoMapperError](err); ok {
 //	        log.Printf("No converter from %v to %v", noMapper.SrcType, noMapper.DstType)
 //	    }
 //	    return err

--- a/cli/azd/internal/vsrpc/server.go
+++ b/cli/azd/internal/vsrpc/server.go
@@ -161,8 +161,7 @@ func serveRpc(w http.ResponseWriter, r *http.Request, handlers map[string]Handle
 			defer func() {
 				if respErr != nil {
 					cmd.MapError(respErr, span)
-					var rpcErr *jsonrpc2.Error
-					if errors.As(respErr, &rpcErr) {
+					if rpcErr, ok := errors.AsType[*jsonrpc2.Error](respErr); ok {
 						span.SetAttributes(fields.JsonRpcErrorCode.Int(int(rpcErr.Code)))
 					}
 				}

--- a/cli/azd/pkg/account/credentials.go
+++ b/cli/azd/pkg/account/credentials.go
@@ -66,8 +66,7 @@ func (p *subscriptionCredentialProvider) CredentialForSubscription(
 		// If this is an AADSTS refresh token error, enhance it with tenant-specific login guidance
 		if aadRefreshTokenExpiredRegex.MatchString(err.Error()) {
 			// Check if the error already has a suggestion (ErrorWithSuggestion from auth layer)
-			var errWithSuggestion *internal.ErrorWithSuggestion
-			if errors.As(err, &errWithSuggestion) {
+			if errWithSuggestion, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
 				// Enhance the existing suggestion with tenant-specific guidance
 				enhancedSuggestion := fmt.Sprintf(
 					"%s To re-authenticate specifically to this tenant, run `azd auth login --tenant-id %s`.",

--- a/cli/azd/pkg/auth/azd_credential.go
+++ b/cli/azd/pkg/auth/azd_credential.go
@@ -36,8 +36,7 @@ func (c *azdCredential) GetToken(ctx context.Context, options policy.TokenReques
 		public.WithClaims(options.Claims))
 
 	if err != nil {
-		var authFailed *AuthFailedError
-		if errors.As(err, &authFailed) {
+		if authFailed, ok := errors.AsType[*AuthFailedError](err); ok {
 			if loginErr, ok := newReLoginRequiredError(authFailed.Parsed, options.Scopes, c.cloud); ok {
 				log.Println(authFailed.httpErrorDetails())
 

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -132,12 +132,10 @@ type AuthFailedError struct {
 }
 
 func newAuthFailedErrorFromMsalErr(err error) error {
-	var msalCallErr msal.CallErr
-	var authFailedErr *AuthFailedError
 	var res *http.Response
-	if errors.As(err, &msalCallErr) {
+	if msalCallErr, ok := errors.AsType[msal.CallErr](err); ok {
 		res = msalCallErr.Resp
-	} else if errors.As(err, &authFailedErr) { // in case this is re-thrown in a retry loop
+	} else if authFailedErr, ok := errors.AsType[*AuthFailedError](err); ok { // in case this is re-thrown in a retry loop
 		res = authFailedErr.RawResp
 	}
 

--- a/cli/azd/pkg/azapi/container_registry.go
+++ b/cli/azd/pkg/azapi/container_registry.go
@@ -144,8 +144,7 @@ func (crs *containerRegistryService) Credentials(
 	// First attempt to get ACR credentials from the logged in user
 	dockerCreds, tokenErr := crs.getTokenCredentials(ctx, subscriptionId, loginServer)
 	if tokenErr != nil {
-		var httpErr *azcore.ResponseError
-		if errors.As(tokenErr, &httpErr) {
+		if httpErr, ok := errors.AsType[*azcore.ResponseError](tokenErr); ok {
 			if httpErr.StatusCode == 404 {
 				// No need to try admin user credentials if getToken returns 404. It means the registry was not found.
 				return nil, tokenErr

--- a/cli/azd/pkg/azapi/deployments.go
+++ b/cli/azd/pkg/azapi/deployments.go
@@ -369,8 +369,7 @@ func responseToDeploymentError(title string, respErr *azcore.ResponseError, oper
 
 // Attempts to create an Azure Deployment error from the HTTP response error
 func createDeploymentError(err error, operation DeploymentOperation) error {
-	var responseErr *azcore.ResponseError
-	if errors.As(err, &responseErr) {
+	if responseErr, ok := errors.AsType[*azcore.ResponseError](err); ok {
 		title := "Deployment Error Details"
 		switch operation {
 		case DeploymentOperationValidate:

--- a/cli/azd/pkg/azapi/resource_service.go
+++ b/cli/azd/pkg/azapi/resource_service.go
@@ -301,8 +301,9 @@ func (rs *ResourceService) DeleteResourceGroup(ctx context.Context, subscription
 	}
 
 	poller, err := client.BeginDelete(ctx, resourceGroupName, nil)
-	var respErr *azcore.ResponseError
-	if errors.As(err, &respErr) && respErr.StatusCode == 404 { // Resource group is already deleted
+	// Resource group is already deleted
+	if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok &&
+		respErr.StatusCode == 404 {
 		return nil
 	}
 

--- a/cli/azd/pkg/azapi/standard_deployments.go
+++ b/cli/azd/pkg/azapi/standard_deployments.go
@@ -124,8 +124,7 @@ func (ds *StandardDeployments) GetSubscriptionDeployment(
 
 	deployment, err := deploymentClient.GetAtSubscriptionScope(ctx, deploymentName, nil)
 	if err != nil {
-		var errDetails *azcore.ResponseError
-		if errors.As(err, &errDetails) && errDetails.StatusCode == 404 {
+		if errDetails, ok := errors.AsType[*azcore.ResponseError](err); ok && errDetails.StatusCode == 404 {
 			return nil, ErrDeploymentNotFound
 		}
 		return nil, fmt.Errorf("getting deployment from subscription: %w", err)
@@ -174,8 +173,7 @@ func (ds *StandardDeployments) GetResourceGroupDeployment(
 
 	deployment, err := deploymentClient.Get(ctx, resourceGroupName, deploymentName, nil)
 	if err != nil {
-		var errDetails *azcore.ResponseError
-		if errors.As(err, &errDetails) && errDetails.StatusCode == 404 {
+		if errDetails, ok := errors.AsType[*azcore.ResponseError](err); ok && errDetails.StatusCode == 404 {
 			return nil, ErrDeploymentNotFound
 		}
 		return nil, fmt.Errorf("getting deployment from resource group: %w", err)
@@ -292,8 +290,7 @@ func (ds *StandardDeployments) ListSubscriptionDeploymentOperations(
 
 	for getDeploymentsPager.More() {
 		page, err := getDeploymentsPager.NextPage(ctx)
-		var errDetails *azcore.ResponseError
-		if errors.As(err, &errDetails) && errDetails.StatusCode == 404 {
+		if errDetails, ok := errors.AsType[*azcore.ResponseError](err); ok && errDetails.StatusCode == 404 {
 			return nil, ErrDeploymentNotFound
 		}
 		if err != nil {
@@ -322,8 +319,7 @@ func (ds *StandardDeployments) ListResourceGroupDeploymentOperations(
 
 	for getDeploymentsPager.More() {
 		page, err := getDeploymentsPager.NextPage(ctx)
-		var errDetails *azcore.ResponseError
-		if errors.As(err, &errDetails) && errDetails.StatusCode == 404 {
+		if errDetails, ok := errors.AsType[*azcore.ResponseError](err); ok && errDetails.StatusCode == 404 {
 			return nil, ErrDeploymentNotFound
 		}
 		if err != nil {

--- a/cli/azd/pkg/azapi/webapp.go
+++ b/cli/azd/pkg/azapi/webapp.go
@@ -131,14 +131,14 @@ func resumeDeployment(err error, progressLog func(msg string)) bool {
 		return true
 	}
 
-	var httpErr *azcore.ResponseError
-	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+	if httpErr, ok := errors.AsType[*azcore.ResponseError](err); ok && httpErr.StatusCode == http.StatusNotFound {
 		progressLog("Resource not found. Failed to enable tracking runtime status." +
 			"Resuming deployment without tracking status.")
 		return true
 	}
 
-	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusInternalServerError {
+	if httpErr, ok := errors.AsType[*azcore.ResponseError](err); ok &&
+		httpErr.StatusCode == http.StatusInternalServerError {
 		progressLog("Internal server error. Failed to enable tracking runtime status. " +
 			"Resuming deployment without tracking status.")
 		return true

--- a/cli/azd/pkg/azdext/extension_error.go
+++ b/cli/azd/pkg/azdext/extension_error.go
@@ -72,8 +72,7 @@ func WrapError(err error) *ExtensionError {
 	}
 
 	// Check for extension error types (already structured)
-	var extServiceErr *ServiceError
-	if errors.As(err, &extServiceErr) {
+	if extServiceErr, ok := errors.AsType[*ServiceError](err); ok {
 		extErr.Message = extServiceErr.Message
 		extErr.Suggestion = extServiceErr.Suggestion
 		extErr.Origin = ErrorOrigin_ERROR_ORIGIN_SERVICE
@@ -88,8 +87,7 @@ func WrapError(err error) *ExtensionError {
 		return extErr
 	}
 
-	var extLocalErr *LocalError
-	if errors.As(err, &extLocalErr) {
+	if extLocalErr, ok := errors.AsType[*LocalError](err); ok {
 		normalizedCategory := NormalizeLocalErrorCategory(extLocalErr.Category)
 		extErr.Message = extLocalErr.Message
 		extErr.Suggestion = extLocalErr.Suggestion
@@ -104,8 +102,7 @@ func WrapError(err error) *ExtensionError {
 	}
 
 	// Try to detect Azure SDK errors
-	var respErr *azcore.ResponseError
-	if errors.As(err, &respErr) {
+	if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok {
 		extErr.Origin = ErrorOrigin_ERROR_ORIGIN_SERVICE
 		serviceName := ""
 		if respErr.RawResponse != nil && respErr.RawResponse.Request != nil {
@@ -125,9 +122,11 @@ func WrapError(err error) *ExtensionError {
 	// Detect gRPC Unauthenticated errors as an auth safety net.
 	// If the extension didn't already classify the error, this ensures auth failures
 	// from azd host calls are reported with the correct category in telemetry.
-	// Use errors.As to detect gRPC status errors even when wrapped by fmt.Errorf.
-	var grpcErr interface{ GRPCStatus() *status.Status }
-	if errors.As(err, &grpcErr) {
+	// Use errors.AsType to detect gRPC status errors even when wrapped by fmt.Errorf.
+	if grpcErr, ok := errors.AsType[interface {
+		error
+		GRPCStatus() *status.Status
+	}](err); ok {
 		if st := grpcErr.GRPCStatus(); st.Code() == codes.Unauthenticated {
 			extErr.Origin = ErrorOrigin_ERROR_ORIGIN_LOCAL
 			extErr.Message = st.Message()

--- a/cli/azd/pkg/azdext/run.go
+++ b/cli/azd/pkg/azdext/run.go
@@ -98,13 +98,11 @@ func printError(err error) {
 // ErrorSuggestion extracts the Suggestion field from a [LocalError] or [ServiceError].
 // Returns an empty string if the error has no suggestion.
 func ErrorSuggestion(err error) string {
-	var localErr *LocalError
-	if errors.As(err, &localErr) && localErr.Suggestion != "" {
+	if localErr, ok := errors.AsType[*LocalError](err); ok && localErr.Suggestion != "" {
 		return localErr.Suggestion
 	}
 
-	var svcErr *ServiceError
-	if errors.As(err, &svcErr) && svcErr.Suggestion != "" {
+	if svcErr, ok := errors.AsType[*ServiceError](err); ok && svcErr.Suggestion != "" {
 		return svcErr.Suggestion
 	}
 
@@ -114,13 +112,11 @@ func ErrorSuggestion(err error) string {
 // ErrorMessage extracts the user-friendly Message field from a [LocalError] or [ServiceError].
 // Returns an empty string if the error is not an extension error type.
 func ErrorMessage(err error) string {
-	var localErr *LocalError
-	if errors.As(err, &localErr) && localErr.Message != "" {
+	if localErr, ok := errors.AsType[*LocalError](err); ok && localErr.Message != "" {
 		return localErr.Message
 	}
 
-	var svcErr *ServiceError
-	if errors.As(err, &svcErr) && svcErr.Message != "" {
+	if svcErr, ok := errors.AsType[*ServiceError](err); ok && svcErr.Message != "" {
 		return svcErr.Message
 	}
 

--- a/cli/azd/pkg/azsdk/storage/storage_blob_client.go
+++ b/cli/azd/pkg/azsdk/storage/storage_blob_client.go
@@ -235,8 +235,7 @@ func (bc *blobClient) resetAndEnsureContainer(ctx context.Context) error {
 
 // isContainerNotFound checks if the error indicates the container was not found.
 func (bc *blobClient) isContainerNotFound(err error) bool {
-	var respErr *azcore.ResponseError
-	if errors.As(err, &respErr) {
+	if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok {
 		return respErr.ErrorCode == "ContainerNotFound"
 	}
 	return false

--- a/cli/azd/pkg/containerregistry/remote_build.go
+++ b/cli/azd/pkg/containerregistry/remote_build.go
@@ -224,8 +224,7 @@ func streamLogs(ctx context.Context, blobClient *blockblob.Client, writer io.Wri
 				}
 			}
 		}()
-		var azErr *azcore.ResponseError
-		if errors.As(err, &azErr) {
+		if azErr, ok := errors.AsType[*azcore.ResponseError](err); ok {
 			if azErr.StatusCode == http.StatusNotFound {
 				// Mark log not found as a retryable error, we assume that the blob client was formed around a result from
 				// the queue job request and the fact that the log is not found means that the log is not yet available, not

--- a/cli/azd/pkg/entraid/entraid.go
+++ b/cli/azd/pkg/entraid/entraid.go
@@ -161,14 +161,15 @@ func (ad *entraIdService) CreateOrUpdateServicePrincipal(
 		application, err = ad.createApplication(ctx, subscriptionId, appIdOrName, options)
 		if err != nil {
 			// Check if the error is specifically "ServiceTreeNullValueProvided"
-			var responseError *azcore.ResponseError
-			if errors.As(err, &responseError) && responseError.ErrorCode == "ServiceTreeNullValueProvided" {
+			if responseError, ok := errors.AsType[*azcore.ResponseError](err); ok &&
+				responseError.ErrorCode == "ServiceTreeNullValueProvided" {
 				return nil, &ServiceTreeNullValueError{
 					ApplicationName: appIdOrName,
 					Err:             err,
 				}
 			}
-			if errors.As(err, &responseError) && responseError.ErrorCode == "ServiceTreeInvalid" {
+			if responseError, ok := errors.AsType[*azcore.ResponseError](err); ok &&
+				responseError.ErrorCode == "ServiceTreeInvalid" {
 				return nil, &ServiceTreeInvalidError{
 					ApplicationName: appIdOrName,
 					Err:             err,
@@ -600,14 +601,15 @@ func (ad *entraIdService) applyRoleAssignmentWithRetryImpl(
 		}, nil)
 
 		if err != nil {
-			var responseError *azcore.ResponseError
 			// If the response is a 409 conflict then the role has already been assigned.
-			if errors.As(err, &responseError) && responseError.StatusCode == http.StatusConflict {
+			if responseError, ok := errors.AsType[*azcore.ResponseError](err); ok &&
+				responseError.StatusCode == http.StatusConflict {
 				return nil
 			}
 
 			// If the response is a 403 then the required role is missing.
-			if errors.As(err, &responseError) && responseError.StatusCode == http.StatusForbidden {
+			if responseError, ok := errors.AsType[*azcore.ResponseError](err); ok &&
+				responseError.StatusCode == http.StatusForbidden {
 				return &internal.ErrorWithSuggestion{
 					Suggestion: fmt.Sprintf("\nSuggested Action: Ensure you have either the `User Access Administrator`, " +
 						"Owner` or custom azure roles assigned to your subscription to perform action " +

--- a/cli/azd/pkg/environment/storage_blob_data_store.go
+++ b/cli/azd/pkg/environment/storage_blob_data_store.go
@@ -227,9 +227,7 @@ func (sbd *StorageBlobDataStore) Delete(ctx context.Context, name string) error 
 }
 
 func describeError(err error) error {
-	var responseErr *azcore.ResponseError
-
-	if errors.As(err, &responseErr) {
+	if responseErr, ok := errors.AsType[*azcore.ResponseError](err); ok {
 		switch responseErr.ErrorCode {
 		case "AuthorizationPermissionMismatch":
 			errorMsg := "Ensure your Azure account has `Storage Blob Contributor` role on the storage account or container."

--- a/cli/azd/pkg/exec/command_runner.go
+++ b/cli/azd/pkg/exec/command_runner.go
@@ -179,8 +179,7 @@ func (r *commandRunner) Run(ctx context.Context, args RunArgs) (RunResult, error
 
 	logMsg.result = &result
 
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		outputAvailable := !args.Interactive
 		err = NewExitError(
 			*exitErr,
@@ -241,8 +240,7 @@ func (r *commandRunner) RunList(ctx context.Context, commands []string, args Run
 	)
 	logMsg.result = &result
 
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		err = NewExitError(
 			*exitErr,
 			args.Cmd,

--- a/cli/azd/pkg/ext/event_dispatcher.go
+++ b/cli/azd/pkg/ext/event_dispatcher.go
@@ -125,8 +125,8 @@ func (ed *EventDispatcher[T]) RaiseEvent(ctx context.Context, name Event, eventA
 		var suggestions []string
 		for i, err := range handlerErrors {
 			lines[i] = err.Error()
-			var errWithSuggestion *internal.ErrorWithSuggestion
-			if errors.As(err, &errWithSuggestion) && errWithSuggestion.Suggestion != "" {
+			if errWithSuggestion, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok &&
+				errWithSuggestion.Suggestion != "" {
 				suggestions = append(suggestions, errWithSuggestion.Suggestion)
 			}
 		}

--- a/cli/azd/pkg/infra/azure_resource_manager.go
+++ b/cli/azd/pkg/infra/azure_resource_manager.go
@@ -285,8 +285,7 @@ func (rm *AzureResourceManager) FindResourceGroupForEnvironment(
 ) (string, error) {
 	// Let's first try to find the resource group by environment name tag (azd-env-name)
 	rgs, err := rm.GetResourceGroupsForEnvironment(ctx, subscriptionId, envName)
-	var notFoundError *azureutil.ResourceNotFoundError
-	if err != nil && !errors.As(err, &notFoundError) {
+	if _, ok := errors.AsType[*azureutil.ResourceNotFoundError](err); err != nil && !ok {
 		return "", fmt.Errorf("getting resource group for environment: %s: %w", envName, err)
 	}
 	// Several Azure resources can create managed resource groups automatically. Here are a few examples:

--- a/cli/azd/pkg/infra/scope.go
+++ b/cli/azd/pkg/infra/scope.go
@@ -221,8 +221,7 @@ func (s *ResourceGroupScope) ResourceGroupName() string {
 func (s *ResourceGroupScope) ListDeployments(ctx context.Context) ([]*azapi.ResourceDeployment, error) {
 	deployments, err := s.deploymentService.ListResourceGroupDeployments(ctx, s.subscriptionId, s.resourceGroupName)
 
-	var respErr *azcore.ResponseError
-	if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+	if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok && respErr.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("%w: %w", ErrDeploymentsNotFound, respErr)
 	}
 

--- a/cli/azd/pkg/keyvault/keyvault.go
+++ b/cli/azd/pkg/keyvault/keyvault.go
@@ -155,8 +155,7 @@ func (kvs *keyVaultService) GetKeyVaultSecret(
 
 	response, err := client.GetSecret(ctx, secretName, "", nil)
 	if err != nil {
-		var httpErr *azcore.ResponseError
-		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		if httpErr, ok := errors.AsType[*azcore.ResponseError](err); ok && httpErr.StatusCode == http.StatusNotFound {
 			return nil, ErrAzCliSecretNotFound
 		}
 		return nil, fmt.Errorf("getting key vault secret: %w", err)
@@ -203,8 +202,7 @@ func (kvs *keyVaultService) PurgeKeyVault(
 
 	poller, err := client.BeginPurgeDeleted(ctx, vaultName, location, nil)
 	if err != nil {
-		var httpErr *azcore.ResponseError
-		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		if httpErr, ok := errors.AsType[*azcore.ResponseError](err); ok && httpErr.StatusCode == http.StatusNotFound {
 			// no need to purge if the vault is already deleted (not found)
 			log.Printf("key vault '%s' was not found. No need to purge.", vaultName)
 			return nil

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -382,10 +382,8 @@ func (pm *PipelineManager) Configure(
 				options)
 
 			if err != nil {
-				var serviceTreeError *entraid.ServiceTreeNullValueError
-				var serviceTreeInvalidError *entraid.ServiceTreeInvalidError
-				invalidInput := errors.As(err, &serviceTreeInvalidError)
-				if errors.As(err, &serviceTreeError) || invalidInput {
+				serviceTreeInvalidError, invalidInput := errors.AsType[*entraid.ServiceTreeInvalidError](err)
+				if _, ok := errors.AsType[*entraid.ServiceTreeNullValueError](err); ok || invalidInput {
 					pm.console.StopSpinner(ctx, displayMsg, input.GetStepResultFormat(err))
 
 					invalidInputNotes := ""

--- a/cli/azd/pkg/project/ai_helper.go
+++ b/cli/azd/pkg/project/ai_helper.go
@@ -222,8 +222,7 @@ func (a *aiHelper) CreateEnvironmentVersion(
 	if err != nil {
 		// An http 404 error is expected if the environment container does not exist
 		// Therefore we default to version 1
-		var httpErr *azcore.ResponseError
-		isHttpError := errors.As(err, &httpErr)
+		httpErr, isHttpError := errors.AsType[*azcore.ResponseError](err)
 		if !isHttpError || (isHttpError && httpErr.StatusCode != http.StatusNotFound) {
 			return nil, fmt.Errorf("failed getting environment container: %w", err)
 		}
@@ -300,8 +299,7 @@ func (a *aiHelper) CreateModelVersion(
 	if err != nil {
 		// An http 404 error is expected if the environment container does not exist
 		// Therefore we default to version 1
-		var httpErr *azcore.ResponseError
-		isHttpError := errors.As(err, &httpErr)
+		httpErr, isHttpError := errors.AsType[*azcore.ResponseError](err)
 		if !isHttpError || (isHttpError && httpErr.StatusCode != http.StatusNotFound) {
 			return nil, fmt.Errorf("failed getting environment container: %w", err)
 		}
@@ -716,8 +714,7 @@ func (a *aiHelper) waitForDeployment(
 			nil,
 		)
 		if err != nil {
-			var sdkErr *azcore.ResponseError
-			parseOk := errors.As(err, &sdkErr)
+			sdkErr, parseOk := errors.AsType[*azcore.ResponseError](err)
 			if parseOk && sdkErr.StatusCode == http.StatusNotFound {
 				// retryable error
 				return retry.RetryableError(err)

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -303,8 +303,7 @@ func (ch *ContainerHelper) Credentials(
 		func(ctx context.Context) error {
 			cred, err := ch.containerRegistryService.Credentials(ctx, targetResource.SubscriptionId(), loginServer)
 			if err != nil {
-				var httpErr *azcore.ResponseError
-				if errors.As(err, &httpErr) {
+				if httpErr, ok := errors.AsType[*azcore.ResponseError](err); ok {
 					if httpErr.StatusCode == 404 {
 						// Retry if the registry is not found while logging in
 						return retry.RetryableError(err)
@@ -1022,8 +1021,8 @@ func (ch *ContainerHelper) packBuild(
 	if err != nil {
 		span.EndWithStatus(err)
 
-		var statusCodeErr *pack.StatusCodeError
-		if errors.As(err, &statusCodeErr) && statusCodeErr.Code == pack.StatusCodeUndetectedNoError {
+		if statusCodeErr, ok := errors.AsType[*pack.StatusCodeError](err); ok &&
+			statusCodeErr.Code == pack.StatusCodeUndetectedNoError {
 			return nil, &internal.ErrorWithSuggestion{
 				Err: err,
 				Suggestion: "No Dockerfile was found, and image could not be automatically built from source. " +

--- a/cli/azd/pkg/project/resource_manager.go
+++ b/cli/azd/pkg/project/resource_manager.go
@@ -276,9 +276,9 @@ func (rm *resourceManager) resolveServiceResource(
 
 	// If the service target supports delayed provisioning, the resource isn't expected to be found yet.
 	// Return the empty resource
-	var resourceNotFoundError *azureutil.ResourceNotFoundError
+	_, resourceNotFound := errors.AsType[*azureutil.ResourceNotFoundError](err)
 	if err != nil &&
-		errors.As(err, &resourceNotFoundError) &&
+		resourceNotFound &&
 		ServiceTargetKind(serviceConfig.Host).SupportsDelayedProvisioning() {
 		return &azapi.ResourceExtended{}, nil
 	}

--- a/cli/azd/pkg/project/service_target_containerapp.go
+++ b/cli/azd/pkg/project/service_target_containerapp.go
@@ -464,8 +464,7 @@ func (at *containerAppTarget) ResolveTargetResource(
 		return targetResource, nil
 	}
 
-	var resourceNotFoundError *azureutil.ResourceNotFoundError
-	if errors.As(err, &resourceNotFoundError) {
+	if _, ok := errors.AsType[*azureutil.ResourceNotFoundError](err); ok {
 		resourceGroupTemplate := serviceConfig.ResourceGroupName
 		if resourceGroupTemplate.Empty() {
 			resourceGroupTemplate = serviceConfig.Project.ResourceGroupName

--- a/cli/azd/pkg/tools/ensure.go
+++ b/cli/azd/pkg/tools/ensure.go
@@ -54,8 +54,7 @@ func EnsureInstalled(ctx context.Context, tools ...ExternalTool) error {
 		}
 
 		err := tool.CheckInstalled(ctx)
-		var errSem *ErrSemver
-		if errors.As(err, &errSem) {
+		if _, ok := errors.AsType[*ErrSemver](err); ok {
 			errorMsg := err.Error()
 			if _, hasV := errorsEncountered[errorMsg]; !hasV {
 				allErrors = append(allErrors, err)

--- a/cli/azd/pkg/ux/task_list.go
+++ b/cli/azd/pkg/ux/task_list.go
@@ -229,8 +229,7 @@ func (t *TaskList) Render(printer Printer) error {
 
 		var errorDescription string
 		if task.Error != nil {
-			var detailedErr *common.DetailedError
-			if errors.As(task.Error, &detailedErr) {
+			if detailedErr, ok := errors.AsType[*common.DetailedError](task.Error); ok {
 				errorDescription = detailedErr.Description()
 			} else {
 				errorDescription = task.Error.Error()


### PR DESCRIPTION
## Summary

Replace `errors.As` with Go 1.26's `errors.AsType[T]` across the codebase for type-safe, single-expression error matching.

## Pattern

```go
// Before — requires pre-declared variable
var httpErr *azcore.ResponseError
if errors.As(err, &httpErr) {
    // use httpErr
}

// After — type-safe, single expression
if httpErr, ok := errors.AsType[*azcore.ResponseError](err); ok {
    // use httpErr
}
```

## Scope

**88 transformations** across **40 files** covering:
- `pkg/azapi/` — Azure API error handling
- `pkg/infra/` — infrastructure/provisioning errors
- `cmd/` and `internal/cmd/` — command-level error handling
- `pkg/auth/`, `pkg/pipeline/`, `pkg/project/`, and more

## Validation

- ✅ `go build ./...` passes
- ✅ Targeted package tests pass
- ✅ No behavioral changes — purely mechanical transformation

Fixes #7090
Fixes #7091
Fixes #7092