### PR TITLE
chore: add generic SyncMap[K, V] and migrate sync.Map usages

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -48,6 +48,7 @@ words:
   - protoreflect
   - SNAPPROCESS
   - structpb
+  - syncmap
   - syscall
   - Retryable
   - runcontext

--- a/cli/azd/internal/cmd/add/add_select_ai.go
+++ b/cli/azd/internal/cmd/add/add_select_ai.go
@@ -20,6 +20,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
+	"github.com/azure/azure-dev/cli/azd/pkg/syncmap"
 )
 
 func (a *AddAction) selectSearch(
@@ -353,7 +354,7 @@ func (a *AddAction) aiDeploymentCatalog(
 		return nil, fmt.Errorf("getting locations: %w", err)
 	}
 
-	var sharedResults sync.Map
+	var sharedResults syncmap.Map[string, []ModelList]
 	var wg sync.WaitGroup
 
 	a.console.ShowSpinner(ctx, "Retrieving available models...", input.Step)
@@ -391,10 +392,7 @@ func (a *AddAction) aiDeploymentCatalog(
 	a.console.StopSpinner(ctx, "", input.StepDone)
 
 	combinedResults := map[string]ModelCatalogKind{}
-	sharedResults.Range(func(key, value any) bool {
-		// cast should be safe as the call to sharedResults.Store() use a string key
-		locationNameKey := key.(string)
-		models := value.([]ModelList)
+	sharedResults.Range(func(locationNameKey string, models []ModelList) bool {
 		for _, model := range models {
 			if model.Kind == "OpenAI" {
 				// OpenAI kind is part of the `Add OpenAI` where clients connect directly to the service w/o an AIProject

--- a/cli/azd/pkg/ai/model_service.go
+++ b/cli/azd/pkg/ai/model_service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
+	"github.com/azure/azure-dev/cli/azd/pkg/syncmap"
 )
 
 // AiModelService provides operations for querying AI model availability,
@@ -215,7 +216,7 @@ func (s *AiModelService) ListLocationsWithQuota(
 		allowedLocations = skuLocations
 	}
 
-	var sharedResults sync.Map
+	var sharedResults syncmap.Map[string, []*armcognitiveservices.Usage]
 	var wg sync.WaitGroup
 
 	for _, loc := range allowedLocations {
@@ -235,10 +236,7 @@ func (s *AiModelService) ListLocationsWithQuota(
 	wg.Wait()
 
 	var results []string
-	sharedResults.Range(func(key, value any) bool {
-		loc := key.(string)
-		usages := value.([]*armcognitiveservices.Usage)
-
+	sharedResults.Range(func(loc string, usages []*armcognitiveservices.Usage) bool {
 		for _, req := range requirements {
 			minCap := req.MinCapacity
 			if minCap <= 0 {
@@ -300,7 +298,7 @@ func (s *AiModelService) ListModelLocationsWithQuota(
 		})
 	}
 
-	var sharedResults sync.Map
+	var sharedResults syncmap.Map[string, []AiModelUsage]
 	var wg sync.WaitGroup
 
 	for _, loc := range modelLocations {
@@ -315,9 +313,7 @@ func (s *AiModelService) ListModelLocationsWithQuota(
 	wg.Wait()
 
 	results := []ModelLocationQuota{}
-	sharedResults.Range(func(key, value any) bool {
-		loc := key.(string)
-		usages := value.([]AiModelUsage)
+	sharedResults.Range(func(loc string, usages []AiModelUsage) bool {
 		usageMap := make(map[string]AiModelUsage, len(usages))
 		for _, usage := range usages {
 			usageMap[usage.Name] = usage

--- a/cli/azd/pkg/auth/credential_providers.go
+++ b/cli/azd/pkg/auth/credential_providers.go
@@ -5,9 +5,9 @@ package auth
 
 import (
 	"context"
-	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/azure/azure-dev/cli/azd/pkg/syncmap"
 )
 
 // MultiTenantCredentialProvider provides token credentials for different tenants.
@@ -24,7 +24,7 @@ type multiTenantCredentialProvider struct {
 	// In-memory store for tenant credentials. Since azcore.TokenCredential is usually backed by a publicClient
 	// that holds an in-memory cache, we need to hold on to azcore.TokenCredential instances to maintain that cache.
 	// It also allows us to call EnsureLoggedInCredential once.
-	tenantCredentials sync.Map
+	tenantCredentials syncmap.Map[string, azcore.TokenCredential]
 }
 
 func NewMultiTenantCredentialProvider(auth *Manager) MultiTenantCredentialProvider {
@@ -37,7 +37,7 @@ func NewMultiTenantCredentialProvider(auth *Manager) MultiTenantCredentialProvid
 func (t *multiTenantCredentialProvider) GetTokenCredential(
 	ctx context.Context, tenantId string) (azcore.TokenCredential, error) {
 	if val, ok := t.tenantCredentials.Load(tenantId); ok {
-		return val.(azcore.TokenCredential), nil
+		return val, nil
 	}
 
 	credential, err := t.auth.CredentialForCurrentUser(ctx, &CredentialForCurrentUserOptions{

--- a/cli/azd/pkg/containerapps/container_app.go
+++ b/cli/azd/pkg/containerapps/container_app.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"slices"
 	"strings"
-	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -28,6 +27,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/syncmap"
 	"github.com/benbjohnson/clock"
 	"github.com/braydonk/yaml"
 )
@@ -115,8 +115,8 @@ type containerAppService struct {
 	clock               clock.Clock
 	armClientOptions    *arm.ClientOptions
 	alphaFeatureManager *alpha.FeatureManager
-	appsClientCache     sync.Map
-	jobsClientCache     sync.Map
+	appsClientCache     syncmap.Map[string, *armappcontainers.ContainerAppsClient]
+	jobsClientCache     syncmap.Map[string, *armappcontainers.JobsClient]
 }
 
 type ContainerAppOptions struct {
@@ -550,7 +550,7 @@ func (cas *containerAppService) createContainerAppsClient(
 ) (*armappcontainers.ContainerAppsClient, error) {
 	if customPolicy == nil {
 		if cachedClient, ok := cas.appsClientCache.Load(subscriptionId); ok {
-			return cachedClient.(*armappcontainers.ContainerAppsClient), nil
+			return cachedClient, nil
 		}
 	}
 
@@ -573,7 +573,7 @@ func (cas *containerAppService) createContainerAppsClient(
 
 	if customPolicy == nil {
 		if cachedClient, loaded := cas.appsClientCache.LoadOrStore(subscriptionId, client); loaded {
-			return cachedClient.(*armappcontainers.ContainerAppsClient), nil
+			return cachedClient, nil
 		}
 	}
 
@@ -587,7 +587,7 @@ func (cas *containerAppService) createJobsClient(
 ) (*armappcontainers.JobsClient, error) {
 	if customPolicy == nil {
 		if cached, ok := cas.jobsClientCache.Load(subscriptionId); ok {
-			return cached.(*armappcontainers.JobsClient), nil
+			return cached, nil
 		}
 	}
 
@@ -620,7 +620,7 @@ func (cas *containerAppService) createJobsClient(
 		if cached, loaded := cas.jobsClientCache.LoadOrStore(
 			subscriptionId, client,
 		); loaded {
-			return cached.(*armappcontainers.JobsClient), nil
+			return cached, nil
 		}
 	}
 

--- a/cli/azd/pkg/devcentersdk/developer_client.go
+++ b/cli/azd/pkg/devcentersdk/developer_client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/azure/azure-dev/cli/azd/pkg/syncmap"
 )
 
 const (
@@ -35,7 +36,8 @@ type devCenterClient struct {
 	options             *azcore.ClientOptions
 	resourceGraphClient *armresourcegraph.Client
 	pipeline            runtime.Pipeline
-	cache               sync.Map
+	projectCache        syncmap.Map[string, []*Project]
+	devCenterCache      syncmap.Map[string, []*DevCenter]
 	cacheMutex          sync.RWMutex
 	cloud               *cloud.Cloud
 }
@@ -54,7 +56,6 @@ func NewDevCenterClient(
 		credential:          credential,
 		options:             options,
 		resourceGraphClient: resourceGraphClient,
-		cache:               sync.Map{},
 		cloud:               cloud,
 	}, nil
 }
@@ -72,10 +73,8 @@ func (c *devCenterClient) DevCenterByName(name string) *DevCenterItemRequestBuil
 }
 
 func (c *devCenterClient) projectList(ctx context.Context) ([]*Project, error) {
-	if cachedProjects, has := c.cache.Load(projectKey); has {
-		if value, ok := cachedProjects.([]*Project); ok {
-			return value, nil
-		}
+	if cachedProjects, has := c.projectCache.Load(projectKey); has {
+		return cachedProjects, nil
 	}
 
 	query := `
@@ -148,7 +147,7 @@ func (c *devCenterClient) projectList(ctx context.Context) ([]*Project, error) {
 	// This cache is safe since during the lifetime of this client the list will be only be used by a single user
 	c.cacheMutex.Lock()
 	defer c.cacheMutex.Unlock()
-	c.cache.Store(projectKey, projects)
+	c.projectCache.Store(projectKey, projects)
 
 	return projects, nil
 }
@@ -194,10 +193,8 @@ func (c *devCenterClient) projectByDevCenter(
 }
 
 func (c *devCenterClient) devCenterList(ctx context.Context) ([]*DevCenter, error) {
-	if cachedDevCenters, has := c.cache.Load(devCenterKey); has {
-		if value, ok := cachedDevCenters.([]*DevCenter); ok {
-			return value, nil
-		}
+	if cachedDevCenters, has := c.devCenterCache.Load(devCenterKey); has {
+		return cachedDevCenters, nil
 	}
 
 	devCenters := []*DevCenter{}
@@ -220,7 +217,7 @@ func (c *devCenterClient) devCenterList(ctx context.Context) ([]*DevCenter, erro
 	// This cache is safe since during the lifetime of this client the list will be only be used by a single user
 	c.cacheMutex.Lock()
 	defer c.cacheMutex.Unlock()
-	c.cache.Store(devCenterKey, devCenters)
+	c.devCenterCache.Store(devCenterKey, devCenters)
 
 	return devCenters, nil
 }

--- a/cli/azd/pkg/grpcbroker/message_broker.go
+++ b/cli/azd/pkg/grpcbroker/message_broker.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/syncmap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -77,10 +78,10 @@ type MessageBroker[TMessage any] struct {
 	logger        *log.Logger // Private logger for broker trace output; can be silenced independently
 	stream        BidiStream[TMessage]
 	envelope      MessageEnvelope[TMessage]
-	name          string     // Name identifier for logging purposes
-	responseChans sync.Map   // Used for storing response channels by request id
-	handlers      sync.Map   // Used for storing message handlers by request type
-	sendMu        sync.Mutex // Protects concurrent stream.Send() calls
+	name          string                                     // Name identifier for logging purposes
+	responseChans syncmap.Map[string, chan *TMessage]        // Used for storing response channels by request id
+	handlers      syncmap.Map[reflect.Type, *handlerWrapper] // Used for storing message handlers by request type
+	sendMu        sync.Mutex                                 // Protects concurrent stream.Send() calls
 
 	// Ready signaling for when the broker starts receiving messages
 	readyCh   chan struct{} // Closed when Run() starts, signals readiness to all waiters
@@ -475,14 +476,13 @@ func (mb *MessageBroker[TMessage]) processMessage(ctx context.Context, resp *TMe
 	if mb.envelope.IsProgressMessage(resp) {
 		mb.logger.Printf("[%s] Received progress message: RequestId=%s, MessageType=%v", mb.name, requestId, msgType)
 		if ch, ok := mb.responseChans.Load(requestId); ok {
-			channelTyped := ch.(chan *TMessage)
 			mb.logger.Printf(
 				"[%s] Dispatching progress message to channel for RequestId=%s, MessageType=%v",
 				mb.name,
 				requestId,
 				msgType,
 			)
-			channelTyped <- resp
+			ch <- resp
 		} else {
 			mb.logger.Printf(
 				"[%s] WARNING: No channel found for progress message RequestId=%s, MessageType=%v",
@@ -499,22 +499,20 @@ func (mb *MessageBroker[TMessage]) processMessage(ctx context.Context, resp *TMe
 	// Try to route to channel first (client pattern - awaiting response)
 	if requestId != "" {
 		if ch, ok := mb.responseChans.Load(requestId); ok {
-			channelTyped := ch.(chan *TMessage)
-
-			// Check if channel is full
-			if len(channelTyped) >= cap(channelTyped)-1 {
+			// Warn when channel buffer is actually nearly full
+			if cap(ch) > 1 && len(ch) >= cap(ch)-1 {
 				mb.logger.Printf(
 					"[%s] WARNING: Channel buffer nearly full for RequestId=%s (len=%d, cap=%d)",
 					mb.name,
 					requestId,
-					len(channelTyped),
-					cap(channelTyped),
+					len(ch),
+					cap(ch),
 				)
 			}
 
 			mb.logger.Printf("[%s] Dispatching message to channel for RequestId=%s, MessageType=%v",
 				mb.name, requestId, msgType)
-			channelTyped <- resp
+			ch <- resp
 			mb.logger.Printf("[%s] Message dispatched successfully to RequestId=%s, MessageType=%v",
 				mb.name, requestId, msgType)
 			return
@@ -551,7 +549,7 @@ func (mb *MessageBroker[TMessage]) processHandlerRequest(
 		return
 	}
 
-	wrapper := handlerVal.(*handlerWrapper)
+	wrapper := handlerVal
 	mb.logger.Printf(
 		"[%s] Dispatching to handler for RequestId=%s, MessageType=%v",
 		mb.name,
@@ -674,8 +672,7 @@ func (mb *MessageBroker[TMessage]) createProgressFunc(ctx context.Context, reque
 // Close gracefully shuts down the broker (optional, for cleanup)
 func (mb *MessageBroker[TMessage]) Close() {
 	// Close all pending channels
-	mb.responseChans.Range(func(key, value any) bool {
-		ch := value.(chan *TMessage)
+	mb.responseChans.Range(func(key string, ch chan *TMessage) bool {
 		close(ch)
 		mb.responseChans.Delete(key)
 		return true

--- a/cli/azd/pkg/grpcbroker/message_broker_test.go
+++ b/cli/azd/pkg/grpcbroker/message_broker_test.go
@@ -208,7 +208,7 @@ func TestOn_RegistersHandlerWithProgress(t *testing.T) {
 	wrapper, ok := broker.handlers.Load(requestType)
 	require.True(t, ok, "Handler should be registered")
 
-	handlerWrapper := wrapper.(*handlerWrapper)
+	handlerWrapper := wrapper
 	assert.True(t, handlerWrapper.hasProgress, "Handler should be marked as having progress")
 	assert.Equal(t, 2, handlerWrapper.progressIndex, "Progress parameter should be at index 2")
 }
@@ -666,7 +666,7 @@ func TestClose_ClosesAllChannels(t *testing.T) {
 
 	// Verify all channels are removed
 	count := 0
-	broker.responseChans.Range(func(key, value any) bool {
+	broker.responseChans.Range(func(_ string, _ chan *TestMessage) bool {
 		count++
 		return true
 	})

--- a/cli/azd/pkg/syncmap/syncmap.go
+++ b/cli/azd/pkg/syncmap/syncmap.go
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package syncmap
+
+import "sync"
+
+// Map is a type-safe wrapper around sync.Map that eliminates
+// type assertions at call sites.
+//
+// A Map must not be copied after first use.
+type Map[K comparable, V any] struct {
+	noCopy noCopy //nolint:unused
+	m      sync.Map
+}
+
+// Load returns the stored value for key.
+func (s *Map[K, V]) Load(key K) (V, bool) {
+	v, ok := s.m.Load(key)
+	if !ok {
+		var zero V
+		return zero, false
+	}
+
+	return v.(V), true
+}
+
+// Store saves value under key.
+func (s *Map[K, V]) Store(key K, value V) {
+	s.m.Store(key, value)
+}
+
+// LoadOrStore returns the existing value for the key if present.
+func (s *Map[K, V]) LoadOrStore(key K, value V) (V, bool) {
+	actual, loaded := s.m.LoadOrStore(key, value)
+	return actual.(V), loaded
+}
+
+// LoadAndDelete deletes the value for key and returns it if
+// present.
+func (s *Map[K, V]) LoadAndDelete(key K) (V, bool) {
+	v, loaded := s.m.LoadAndDelete(key)
+	if !loaded {
+		var zero V
+		return zero, false
+	}
+
+	return v.(V), true
+}
+
+// Delete removes the value for key.
+func (s *Map[K, V]) Delete(key K) {
+	s.m.Delete(key)
+}
+
+// Range calls f sequentially for each key and value present in
+// the map.
+func (s *Map[K, V]) Range(f func(key K, value V) bool) {
+	s.m.Range(func(k, v any) bool {
+		return f(k.(K), v.(V))
+	})
+}
+
+// noCopy may be added to structs which must not be copied after
+// first use. See https://golang.org/issues/8005#issuecomment-190753527
+type noCopy struct{}
+
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}

--- a/cli/azd/pkg/ux/canvas.go
+++ b/cli/azd/pkg/ux/canvas.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 	"sync"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/syncmap"
 )
 
 // Canvas is a base component for UX components that require a canvas for rendering.
@@ -150,16 +152,14 @@ func newCanvasSize() *CanvasSize {
 }
 
 type canvasManager struct {
-	items         sync.Map
+	items         syncmap.Map[Canvas, struct{}]
 	focusedCanvas Canvas
 	focusLock     sync.Mutex
 	updateLock    sync.Mutex
 }
 
 func newCanvasManager() *canvasManager {
-	return &canvasManager{
-		items: sync.Map{},
-	}
+	return &canvasManager{}
 }
 
 func (cm *canvasManager) Add(canvas Canvas) {
@@ -187,8 +187,8 @@ func (cm *canvasManager) Focus(canvas Canvas) func() {
 	cm.focusedCanvas = canvas
 
 	// Clear non-focused canvases
-	cm.items.Range(func(key, value any) bool {
-		if c, ok := key.(Canvas); ok && c != canvas {
+	cm.items.Range(func(c Canvas, _ struct{}) bool {
+		if c != canvas {
 			c.Clear()
 		}
 		return true


### PR DESCRIPTION
## Summary

Create a type-safe `syncmap.Map[K, V]` generic wrapper around `sync.Map` and migrate all existing usages. This eliminates type assertions at every `Load`/`Store`/`Range` call site, preventing type mismatch bugs at compile time.

## Changes

### New Package
- **`pkg/syncmap/syncmap.go`** — Generic `Map[K, V]` with full `sync.Map` API: `Load`, `Store`, `LoadOrStore`, `LoadAndDelete`, `Delete`, `Range`

### Migrations

| File | Key Type | Value Type |
|------|----------|------------|
| `internal/cmd/add/add_select_ai.go` | `string` | `[]ModelList` |
| `pkg/ai/model_service.go` | `string` | `[]*armcognitiveservices.Usage`, `[]AiModelUsage` |
| `pkg/auth/credential_providers.go` | `string` | `azcore.TokenCredential` |
| `pkg/containerapps/container_app.go` | `string` | `*armappcontainers.ContainerAppsClient`, `*armappcontainers.JobsClient` |
| `pkg/devcentersdk/developer_client.go` | `string` | `[]*Project`, `[]*DevCenter` |
| `pkg/grpcbroker/message_broker.go` | `string` | `chan *TMessage`; `reflect.Type` | `*handlerWrapper` |
| `pkg/ux/canvas.go` | `Canvas` | `struct{}` |

## Validation

- ✅ `go build ./...`
- ✅ `go test` passes for all affected packages
- ✅ `cspell` clean (`syncmap` added to dictionary)

Fixes #7089