### PR TITLE
Release checkbox

### DIFF
--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -146,8 +146,8 @@ extends:
     - ${{ if ne(variables['Build.Reason'], 'Schedule') }}:
       - template: /eng/pipelines/templates/stages/sign.yml
 
-      # Do not publish on scheduled builds, only release from Azure/azure-dev
-      - ${{ if and(ne(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Repository.Name'], 'Azure/azure-dev')) }}:
-        # Only publish if build is manually triggered & DoPublish is true, or if it's a CI build (push to main)
-        - ${{ if or(and(eq('Manual', variables['Build.Reason']), eq('true', parameters.DoPublish)), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
-          - template: /eng/pipelines/templates/stages/publish.yml
+    # Do not publish on scheduled builds, only release from Azure/azure-dev
+    - ${{ if and(ne(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Repository.Name'], 'Azure/azure-dev')) }}:
+      # Only publish if build is manually triggered & DoPublish is true, or if it's a CI build (push to main)
+      - ${{ if or(and(eq('Manual', variables['Build.Reason']), eq('true', parameters.DoPublish)), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
+        - template: /eng/pipelines/templates/stages/publish.yml


### PR DESCRIPTION
Adds additional defense against unintended releases by only including the publishing stages if a box is checked: 

<img width="265" height="238" alt="image" src="https://github.com/user-attachments/assets/d1d680e7-5cfd-4b14-a7be-ee2aae449c16" />

Example run with checkbox unchecked: 

<img width="812" height="801" alt="image" src="https://github.com/user-attachments/assets/531dcbe6-9378-4ba5-829f-7afc2dca2369" />

Example run with checkbox checked: 

<img width="1127" height="698" alt="image" src="https://github.com/user-attachments/assets/e7552172-bc48-431a-8e31-c4471b6b832a" />
