### PR TITLE
Add PullRequest back to publish criteria

### DIFF
--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -141,5 +141,5 @@ extends:
     # Do not publish on scheduled builds, only release from Azure/azure-dev
     - ${{ if and(ne(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Repository.Name'], 'Azure/azure-dev')) }}:
       # Only publish if build is manually triggered & DoPublish is true, or if it's a CI build (push to main)
-      - ${{ if or(and(eq('Manual', variables['Build.Reason']), eq('true', parameters.DoPublish)), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
+      - ${{ if or(and(eq('Manual', variables['Build.Reason']), eq('true', parameters.DoPublish)), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest')) }}:
         - template: /eng/pipelines/templates/stages/publish.yml


### PR DESCRIPTION
Defensive change was too exacting. CI and PR builds should run their automated publish stage.