### PR TITLE
[Agents Extension] Update show and monitor commands to not require parameters

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
@@ -4,11 +4,13 @@
 package cmd
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"azureaiagent/internal/exterrors"
@@ -212,6 +214,10 @@ func promptForAgentService(
 	services []*azdext.ServiceConfig,
 	noPrompt bool,
 ) (*azdext.ServiceConfig, error) {
+	slices.SortFunc(services, func(a, b *azdext.ServiceConfig) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
 	if noPrompt {
 		names := make([]string, len(services))
 		for i, s := range services {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor.go
@@ -36,7 +36,7 @@ func newMonitorCommand() *cobra.Command {
 	flags := &monitorFlags{}
 
 	cmd := &cobra.Command{
-		Use:   "monitor [service]",
+		Use:   "monitor [name]",
 		Short: "Monitor logs from a hosted agent.",
 		Long: `Monitor logs from a hosted agent.
 
@@ -51,8 +51,8 @@ configuration and the current azd environment. Optionally specify the service na
 		Example: `  # Monitor logs (auto-resolves from azure.yaml)
   azd ai agent monitor
 
-  # Monitor logs for a specific service
-  azd ai agent monitor my-service
+  # Monitor logs for a specific agent service
+  azd ai agent monitor my-agent
 
   # Stream session logs
   azd ai agent monitor --session <session-id>

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor_test.go
@@ -15,32 +15,20 @@ import (
 
 func TestMonitorCommand_AcceptsPositionalArg(t *testing.T) {
 	cmd := newMonitorCommand()
-
-	// The command should accept a positional argument without Cobra arg-count error.
-	cmd.SetArgs([]string{"my-service"})
-	err := cmd.Execute()
-	// Expect a runtime error (no azd client available), not an arg-count error
-	assert.Error(t, err)
-	assert.NotContains(t, err.Error(), "accepts at most")
+	err := cmd.Args(cmd, []string{"my-agent"})
+	assert.NoError(t, err)
 }
 
 func TestMonitorCommand_AcceptsNoArgs(t *testing.T) {
 	cmd := newMonitorCommand()
-
-	cmd.SetArgs([]string{})
-	err := cmd.Execute()
-	// Expect a runtime error (no azd client available), not a missing-flag error
-	assert.Error(t, err)
-	assert.NotContains(t, err.Error(), "required flag")
+	err := cmd.Args(cmd, []string{})
+	assert.NoError(t, err)
 }
 
 func TestMonitorCommand_RejectsMultipleArgs(t *testing.T) {
 	cmd := newMonitorCommand()
-
-	cmd.SetArgs([]string{"svc1", "svc2"})
-	err := cmd.Execute()
+	err := cmd.Args(cmd, []string{"svc1", "svc2"})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "accepts at most 1 arg")
 }
 
 func TestValidateMonitorFlags_Valid(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/show.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/show.go
@@ -31,7 +31,7 @@ func newShowCommand() *cobra.Command {
 	flags := &showFlags{}
 
 	cmd := &cobra.Command{
-		Use:   "show [service]",
+		Use:   "show [name]",
 		Short: "Show the status of a hosted agent deployment.",
 		Long: `Show the status of a hosted agent deployment.
 
@@ -44,8 +44,8 @@ configuration and the current azd environment. Optionally specify the service na
 		Example: `  # Show status (auto-resolves from azure.yaml)
   azd ai agent show
 
-  # Show status for a specific service
-  azd ai agent show my-service
+  # Show status for a specific agent service
+  azd ai agent show my-agent
 
   # Show status in table format
   azd ai agent show --output table`,

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/show_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/show_test.go
@@ -15,33 +15,20 @@ import (
 
 func TestShowCommand_AcceptsPositionalArg(t *testing.T) {
 	cmd := newShowCommand()
-
-	// The command should accept a positional argument without error from Cobra arg validation.
-	// It will fail at runtime (no azd client), but Cobra should not reject the args.
-	cmd.SetArgs([]string{"my-service"})
-	err := cmd.Execute()
-	// Expect a runtime error (no azd client available), not an arg-count error
-	assert.Error(t, err)
-	assert.NotContains(t, err.Error(), "accepts at most")
+	err := cmd.Args(cmd, []string{"my-agent"})
+	assert.NoError(t, err)
 }
 
 func TestShowCommand_AcceptsNoArgs(t *testing.T) {
 	cmd := newShowCommand()
-
-	cmd.SetArgs([]string{})
-	err := cmd.Execute()
-	// Expect a runtime error (no azd client available), not a missing-flag error
-	assert.Error(t, err)
-	assert.NotContains(t, err.Error(), "required flag")
+	err := cmd.Args(cmd, []string{})
+	assert.NoError(t, err)
 }
 
 func TestShowCommand_RejectsMultipleArgs(t *testing.T) {
 	cmd := newShowCommand()
-
-	cmd.SetArgs([]string{"svc1", "svc2"})
-	err := cmd.Execute()
+	err := cmd.Args(cmd, []string{"svc1", "svc2"})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "accepts at most 1 arg")
 }
 
 func TestPrintStatusJSON(t *testing.T) {


### PR DESCRIPTION
Other commands rely on the azd service entry to get name/version/etc. details. This PR brings `show` and `monitor` in line with the rest