### PR TITLE
add mcp event prefix for classification

### DIFF
--- a/cli/azd/cmd/mcp.go
+++ b/cli/azd/cmd/mcp.go
@@ -19,6 +19,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal/mcp/tools"
 	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
+	"github.com/azure/azure-dev/cli/azd/internal/tracing/events"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
@@ -141,7 +142,7 @@ func (a *mcpStartAction) Run(ctx context.Context) (*actions.ActionResult, error)
 		server.WithHooks(mcpHost.Hooks()),
 		server.WithToolHandlerMiddleware(func(next server.ToolHandlerFunc) server.ToolHandlerFunc {
 			return func(ctx context.Context, request mmcp.CallToolRequest) (result *mmcp.CallToolResult, err error) {
-				ctx, span := tracing.Start(ctx, "mcp."+request.Params.Name)
+				ctx, span := tracing.Start(ctx, events.McpEventPrefix+request.Params.Name)
 				if session := server.ClientSessionFromContext(ctx); session != nil {
 					if sessionWithClientInfo, ok := session.(server.SessionWithClientInfo); ok {
 						clientInfo := sessionWithClientInfo.GetClientInfo()

--- a/cli/azd/internal/tracing/events/events.go
+++ b/cli/azd/internal/tracing/events/events.go
@@ -15,6 +15,9 @@ const CommandEventPrefix = "cmd."
 // Prefix for vsrpc events.
 const VsRpcEventPrefix = "vsrpc."
 
+// Prefix for MCP related events.
+const McpEventPrefix = "mcp."
+
 // PackBuildEvent is the name of the event which tracks the overall pack build operation.
 const PackBuildEvent = "tools.pack.build"
 


### PR DESCRIPTION
This refactors the mcp event prefix into a constant and allows for auto-classification to take place.

Contributes to #7163