### PR TITLE
Use `--flag=value` syntax in `extractGlobalArgs` to prevent bool flags leaking as positional args

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -1007,7 +1007,9 @@ func extractGlobalArgs() []string {
 	var result []string
 	globalFlagSet.VisitAll(func(f *pflag.Flag) {
 		if f.Changed {
-			result = append(result, fmt.Sprintf("--%s", f.Name), f.Value.String())
+			// Use --flag=value syntax to avoid ambiguity. The two-arg form (--flag value)
+			// doesn't work for boolean flags, where the value is treated as a positional arg.
+			result = append(result, fmt.Sprintf("--%s=%s", f.Name, f.Value.String()))
 		}
 	})
 	return result

--- a/cli/azd/cmd/container_test.go
+++ b/cli/azd/cmd/container_test.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/middleware"
@@ -310,6 +311,56 @@ func Test_WorkflowCmdAdapter_ContextPropagation(t *testing.T) {
 		require.Len(t, commandTreeInstances, 2, "Factory should have been called twice")
 		require.NotSame(t, commandTreeInstances[0], commandTreeInstances[1],
 			"Each execution should use a distinct command tree instance")
+	})
+
+	t.Run("GlobalBoolFlagsRemainSingleTokenWhenMerged", func(t *testing.T) {
+		originalArgs := os.Args
+		os.Args = []string{"azd", "--debug", "up"}
+		t.Cleanup(func() {
+			os.Args = originalArgs
+		})
+
+		globalArgs := extractGlobalArgs()
+		require.Equal(t, []string{"--debug=true"}, globalArgs)
+
+		var (
+			capturedPositionalArgs []string
+			debugEnabled           bool
+		)
+
+		newCommand := func() *cobra.Command {
+			rootCmd := &cobra.Command{Use: "root"}
+			rootCmd.PersistentFlags().AddFlagSet(CreateGlobalFlagSet())
+
+			packageCmd := &cobra.Command{
+				Use:  "package",
+				Args: cobra.NoArgs,
+				RunE: func(cmd *cobra.Command, args []string) error {
+					capturedPositionalArgs = append([]string(nil), args...)
+
+					var err error
+					debugEnabled, err = cmd.Flags().GetBool("debug")
+					require.NoError(t, err)
+
+					return nil
+				},
+			}
+			packageCmd.Flags().Bool("all", false, "")
+			rootCmd.AddCommand(packageCmd)
+
+			return rootCmd
+		}
+
+		adapter := &workflowCmdAdapter{
+			newCommand: newCommand,
+			globalArgs: globalArgs,
+		}
+
+		err := adapter.ExecuteContext(context.WithoutCancel(context.Background()), []string{"package", "--all"})
+		require.NoError(t, err)
+		require.True(t, debugEnabled, "global --debug flag should still be parsed on the rebuilt tree")
+		require.Empty(t, capturedPositionalArgs,
+			"boolean global flag value should not leak into workflow step positional args")
 	})
 
 	t.Run("NewRootCmdPreservesMiddlewareChain", func(t *testing.T) {


### PR DESCRIPTION
Resolves #7211

#7171 introduced `extractGlobalArgs()` which formats boolean flags as two tokens (`--debug`, `true`). pflag boolean flags don't consume the next token, so cobra treats `"true"` as a positional `<service>` argument during workflow step execution (e.g. `package --all`).

This caused commands like `azd up --debug` and `azd up --no-prompt` to fail with:

<img width="1312" height="207" alt="image" src="https://github.com/user-attachments/assets/cfe415ce-8373-4ab3-a99c-9684029667dd" />

### Fix

Use `--flag=value` syntax (`--debug=true`) for all extracted global args. This is unambiguous for all pflag types and prevents stray positional arguments.

### Validation

<img width="863" height="307" alt="image" src="https://github.com/user-attachments/assets/baa8dd3e-1286-4faf-ba6b-9c88c415fe03" />
