### PR TITLE
Add azure.ai.agents 0.1.17-preview to extension registry

### DIFF
--- a/cli/azd/cmd/testdata/TestFigSpec.ts
+++ b/cli/azd/cmd/testdata/TestFigSpec.ts
@@ -220,7 +220,7 @@ const completionSpec: Fig.Spec = {
 			subcommands: [
 				{
 					name: ['agent'],
-					description: 'Extension for the Foundry Agent Service. (Preview)',
+					description: 'Ship agents with Microsoft Foundry from your terminal. (Preview)',
 					subcommands: [
 						{
 							name: ['init'],
@@ -3101,7 +3101,7 @@ const completionSpec: Fig.Spec = {
 					subcommands: [
 						{
 							name: ['agent'],
-							description: 'Extension for the Foundry Agent Service. (Preview)',
+							description: 'Ship agents with Microsoft Foundry from your terminal. (Preview)',
 							subcommands: [
 								{
 									name: ['init'],

--- a/cli/azd/cmd/testdata/TestUsage-azd-ai-agent.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-ai-agent.snap
@@ -1,5 +1,5 @@
 
-Extension for the Foundry Agent Service. (Preview)
+Ship agents with Microsoft Foundry from your terminal. (Preview)
 
 Usage
   azd ai agent [flags]

--- a/cli/azd/cmd/testdata/TestUsage-azd-ai.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-ai.snap
@@ -5,7 +5,7 @@ Usage
   azd ai [command]
 
 Available Commands
-  agent     	: Extension for the Foundry Agent Service. (Preview)
+  agent     	: Ship agents with Microsoft Foundry from your terminal. (Preview)
   finetuning	: Extension for Foundry Fine Tuning. (Preview)
   models    	: Extension for managing custom models in Azure AI Foundry. (Preview)
 

--- a/cli/azd/extensions/registry.json
+++ b/cli/azd/extensions/registry.json
@@ -1447,7 +1447,7 @@
       "id": "azure.ai.agents",
       "namespace": "ai.agent",
       "displayName": "Foundry agents (Preview)",
-      "description": "Extension for the Foundry Agent Service. (Preview)",
+      "description": "Ship agents with Microsoft Foundry from your terminal. (Preview)",
       "versions": [
         {
           "version": "0.0.6",
@@ -2795,6 +2795,82 @@
               },
               "entryPoint": "azure-ai-agents-windows-arm64.exe",
               "url": "https://github.com/Azure/azure-dev/releases/download/azd-ext-azure-ai-agents_0.1.16-preview/azure-ai-agents-windows-arm64.zip"
+            }
+          }
+        },
+        {
+          "version": "0.1.17-preview",
+          "requiredAzdVersion": "\u003e1.23.6",
+          "capabilities": [
+            "custom-commands",
+            "lifecycle-events",
+            "mcp-server",
+            "service-target-provider",
+            "metadata"
+          ],
+          "providers": [
+            {
+              "name": "azure.ai.agent",
+              "type": "service-target",
+              "description": "Deploys agents to the Foundry Agent Service"
+            }
+          ],
+          "usage": "azd ai agent \u003ccommand\u003e [options]",
+          "examples": [
+            {
+              "name": "init",
+              "description": "Initialize a new AI agent project.",
+              "usage": "azd ai agent init"
+            }
+          ],
+          "artifacts": {
+            "darwin/amd64": {
+              "checksum": {
+                "algorithm": "sha256",
+                "value": "2cafe851463b9329f4284ea41ff161b8deb6e7bc79e2519cda9c83a4413deff0"
+              },
+              "entryPoint": "azure-ai-agents-darwin-amd64",
+              "url": "https://github.com/Azure/azure-dev/releases/download/azd-ext-azure-ai-agents_0.1.17-preview/azure-ai-agents-darwin-amd64.zip"
+            },
+            "darwin/arm64": {
+              "checksum": {
+                "algorithm": "sha256",
+                "value": "cd4756b84f0ee721089ea3d3e1e0b47b23d8cf152c1861bd13be29e24c98027f"
+              },
+              "entryPoint": "azure-ai-agents-darwin-arm64",
+              "url": "https://github.com/Azure/azure-dev/releases/download/azd-ext-azure-ai-agents_0.1.17-preview/azure-ai-agents-darwin-arm64.zip"
+            },
+            "linux/amd64": {
+              "checksum": {
+                "algorithm": "sha256",
+                "value": "4c7ea2edbd8c273ef387d9866c997be079f306ac19534eb8739a0e93b2f3f614"
+              },
+              "entryPoint": "azure-ai-agents-linux-amd64",
+              "url": "https://github.com/Azure/azure-dev/releases/download/azd-ext-azure-ai-agents_0.1.17-preview/azure-ai-agents-linux-amd64.tar.gz"
+            },
+            "linux/arm64": {
+              "checksum": {
+                "algorithm": "sha256",
+                "value": "3b1e95a55d31b08d7153b14226d21ad98b138ebf438b9cb4b617ac6e5092389c"
+              },
+              "entryPoint": "azure-ai-agents-linux-arm64",
+              "url": "https://github.com/Azure/azure-dev/releases/download/azd-ext-azure-ai-agents_0.1.17-preview/azure-ai-agents-linux-arm64.tar.gz"
+            },
+            "windows/amd64": {
+              "checksum": {
+                "algorithm": "sha256",
+                "value": "cbcaaa3b037f5c9d2c9a92e6d40165520ad5fa518689b000df44c279d73a14eb"
+              },
+              "entryPoint": "azure-ai-agents-windows-amd64.exe",
+              "url": "https://github.com/Azure/azure-dev/releases/download/azd-ext-azure-ai-agents_0.1.17-preview/azure-ai-agents-windows-amd64.zip"
+            },
+            "windows/arm64": {
+              "checksum": {
+                "algorithm": "sha256",
+                "value": "2b3ae89d3cd4476f334ce75db4a12329c0f424ecd499941ba298707892fa5146"
+              },
+              "entryPoint": "azure-ai-agents-windows-arm64.exe",
+              "url": "https://github.com/Azure/azure-dev/releases/download/azd-ext-azure-ai-agents_0.1.17-preview/azure-ai-agents-windows-arm64.zip"
             }
           }
         }


### PR DESCRIPTION
## Changes

- Add azure.ai.agents version 0.1.17-preview to the extension registry with all 6 platform artifacts and checksums
- Update extension description: *Ship agents with Microsoft Foundry from your terminal*
- Update command snapshots (TestFigSpec, TestUsage) for the new version