### PR TITLE
Fix auth error telemetry classification

### DIFF
--- a/cli/azd/internal/cmd/errors.go
+++ b/cli/azd/internal/cmd/errors.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/agent/consent"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
@@ -48,6 +49,7 @@ func MapError(err error, span tracing.Span) {
 		errCode = updateErr.Code
 	} else if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {
 		errCode = "auth.login_required"
+		errDetails = append(errDetails, fields.ErrCategory.String("auth"))
 	} else if errWithSuggestion, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
 		errCode = "error.suggestion"
 		span.SetAttributes(fields.ErrType.String(classifySuggestionType(errWithSuggestion.Unwrap())))
@@ -184,6 +186,12 @@ func MapError(err error, span tracing.Span) {
 				fields.ServiceCorrelationId.String(authFailedErr.Parsed.CorrelationId))
 		}
 		errCode = "service.aad.failed"
+	} else if errors.Is(err, auth.ErrNoCurrentUser) {
+		errCode = "auth.not_logged_in"
+		errDetails = append(errDetails, fields.ErrCategory.String("auth"))
+	} else if _, ok := errors.AsType[*azidentity.AuthenticationFailedError](err); ok {
+		errCode = "auth.identity_failed"
+		errDetails = append(errDetails, fields.ErrCategory.String("auth"))
 	} else if code := classifySentinel(err); code != "" {
 		errCode = code
 	} else if isNetworkError(err) {
@@ -268,8 +276,6 @@ func classifySentinel(err error) string {
 		return "user.canceled"
 	case errors.Is(err, context.DeadlineExceeded):
 		return "internal.timeout"
-	case errors.Is(err, auth.ErrNoCurrentUser):
-		return "auth.not_logged_in"
 	case errors.Is(err, consent.ErrToolExecutionDenied):
 		return "user.tool_denied"
 	case errors.Is(err, git.ErrNotRepository):
@@ -372,6 +378,14 @@ func classifySuggestionType(err error) string {
 
 	if _, ok := errors.AsType[*auth.AuthFailedError](err); ok {
 		return "service.aad.failed"
+	}
+
+	if errors.Is(err, auth.ErrNoCurrentUser) {
+		return "auth.not_logged_in"
+	}
+
+	if _, ok := errors.AsType[*azidentity.AuthenticationFailedError](err); ok {
+		return "auth.identity_failed"
 	}
 
 	if code := classifySentinel(err); code != "" {

--- a/cli/azd/internal/cmd/errors_test.go
+++ b/cli/azd/internal/cmd/errors_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/agent/consent"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
@@ -202,6 +203,22 @@ func Test_MapError(t *testing.T) {
 			},
 		},
 		{
+			name:          "WithReLoginRequiredError",
+			err:           &auth.ReLoginRequiredError{},
+			wantErrReason: "auth.login_required",
+			wantErrDetails: []attribute.KeyValue{
+				fields.ErrorKey(fields.ErrCategory.Key).String("auth"),
+			},
+		},
+		{
+			name:          "WithAzidentityAuthenticationFailedError",
+			err:           &azidentity.AuthenticationFailedError{},
+			wantErrReason: "auth.identity_failed",
+			wantErrDetails: []attribute.KeyValue{
+				fields.ErrorKey(fields.ErrCategory.Key).String("auth"),
+			},
+		},
+		{
 			name: "WithExtServiceError",
 			err: &azdext.ServiceError{
 				Message:     "Rate limit exceeded",
@@ -274,16 +291,20 @@ func Test_MapError(t *testing.T) {
 			wantErrDetails: nil,
 		},
 		{
-			name:           "WithErrNoCurrentUser",
-			err:            auth.ErrNoCurrentUser,
-			wantErrReason:  "auth.not_logged_in",
-			wantErrDetails: nil,
+			name:          "WithErrNoCurrentUser",
+			err:           auth.ErrNoCurrentUser,
+			wantErrReason: "auth.not_logged_in",
+			wantErrDetails: []attribute.KeyValue{
+				fields.ErrorKey(fields.ErrCategory.Key).String("auth"),
+			},
 		},
 		{
-			name:           "WithWrappedErrNoCurrentUser",
-			err:            fmt.Errorf("failed to create credential: %w: %w", errors.New("inner"), auth.ErrNoCurrentUser),
-			wantErrReason:  "auth.not_logged_in",
-			wantErrDetails: nil,
+			name:          "WithWrappedErrNoCurrentUser",
+			err:           fmt.Errorf("failed to create credential: %w: %w", errors.New("inner"), auth.ErrNoCurrentUser),
+			wantErrReason: "auth.not_logged_in",
+			wantErrDetails: []attribute.KeyValue{
+				fields.ErrorKey(fields.ErrCategory.Key).String("auth"),
+			},
 		},
 		{
 			name:           "WithErrToolExecutionDenied",
@@ -973,6 +994,14 @@ func Test_ClassifySuggestionType_MatchesMapError(t *testing.T) {
 			err: &auth.AuthFailedError{
 				Parsed: &auth.AadErrorResponse{Error: "invalid_grant"},
 			},
+		},
+		{
+			name: "ReLoginRequiredError",
+			err:  &auth.ReLoginRequiredError{},
+		},
+		{
+			name: "AzidentityAuthenticationFailedError",
+			err:  &azidentity.AuthenticationFailedError{},
 		},
 		// Sentinels
 		{name: "context.Canceled", err: context.Canceled},


### PR DESCRIPTION
## Summary

Fixes #7233

Auth errors (`login_required`, `not_logged_in`, `azidentity.AuthenticationFailedError`) were classified as `"unknown"` in telemetry because they did not set `fields.ServiceName.String("aad")`. This affected **~610K errors per 28 days** and made the `"unknown"` error category bucket unreliable for analysis.

## Changes

| Error Type | Before | After |
|---|---|---|
| `ReLoginRequiredError` → `auth.login_required` | ❌ no ServiceName | ✅ `aad` |
| `ErrNoCurrentUser` → `auth.not_logged_in` | ❌ no ServiceName (handled in `classifySentinel`) | ✅ `aad` (moved to `MapError` if-else chain) |
| `azidentity.AuthenticationFailedError` | ❌ fell through to `internal.*` catch-all | ✅ new code `auth.identity_failed` with ServiceName `aad` |

### Code
- **`errors.go`**: Added `ServiceName("aad")` to `ReLoginRequiredError` branch, moved `ErrNoCurrentUser` out of `classifySentinel()` into `MapError()`, added `azidentity.AuthenticationFailedError` handler, updated `classifySuggestionType()` to stay in sync.
- **`errors_test.go`**: Added test cases for `ReLoginRequiredError` and `azidentity.AuthenticationFailedError`, updated `ErrNoCurrentUser` tests to expect `ServiceName("aad")`, added entries to `ClassifySuggestionType_MatchesMapError`.

## Expected Telemetry Impact

After this fix, the Kusto `AzdErrorCategory` column will show:

| Result Code | Category (before) | Category (after) |
|---|---|---|
| `auth.login_required` | `unknown` ❌ | `aad` ✅ |
| `auth.not_logged_in` | `unknown` ❌ | `aad` ✅ |
| `auth.identity_failed` (was `internal.azidentity_*`) | `unknown` ❌ | `aad` ✅ |
| `service.aad.failed` | `aad` ✅ | `aad` ✅ (unchanged) |

This removes **~610K errors/28d from the `"unknown"` bucket**.