### PR TITLE
Route error spans through MapError to reduce UnknownFailure bucket

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -92,6 +92,9 @@ dictionaryDefinitions:
 dictionaries:
   - azdProjectDictionary
 overrides:
+  - filename: cmd/mcp.go
+    words:
+      - internalcmd
   - filename: internal/tracing/fields/domains.go
     words:
       - azmk

--- a/cli/azd/cmd/mcp.go
+++ b/cli/azd/cmd/mcp.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
+	internalcmd "github.com/azure/azure-dev/cli/azd/internal/cmd"
 	"github.com/azure/azure-dev/cli/azd/internal/grpcserver"
 	"github.com/azure/azure-dev/cli/azd/internal/mcp"
 	"github.com/azure/azure-dev/cli/azd/internal/mcp/tools"
@@ -152,7 +153,10 @@ func (a *mcpStartAction) Run(ctx context.Context) (*actions.ActionResult, error)
 				}
 
 				result, err = next(ctx, request)
-				span.EndWithStatus(err)
+				if err != nil {
+					internalcmd.MapError(err, span)
+				}
+				span.End()
 
 				return result, err
 			}

--- a/cli/azd/internal/agent/copilot_agent.go
+++ b/cli/azd/internal/agent/copilot_agent.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/internal/agent/consent"
 	agentcopilot "github.com/azure/azure-dev/cli/azd/internal/agent/copilot"
+	"github.com/azure/azure-dev/cli/azd/internal/cmd"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/events"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
@@ -86,7 +87,10 @@ func (a *CopilotAgent) Initialize(ctx context.Context, opts ...InitOption) (resu
 				fields.CopilotInitReasoningEffort.String(result.ReasoningEffort),
 			)
 		}
-		span.EndWithStatus(err)
+		if err != nil {
+			cmd.MapError(err, span)
+		}
+		span.End()
 	}()
 
 	options := &initOptions{}
@@ -600,7 +604,10 @@ func (a *CopilotAgent) ensureSession(ctx context.Context, resumeSessionID string
 		if sessionID != "" {
 			span.SetAttributes(fields.StringHashed(fields.CopilotSessionId, sessionID))
 		}
-		span.EndWithStatus(err)
+		if err != nil {
+			cmd.MapError(err, span)
+		}
+		span.End()
 	}()
 
 	isResume := resumeSessionID != ""

--- a/cli/azd/internal/tracing/tracer.go
+++ b/cli/azd/internal/tracing/tracer.go
@@ -107,7 +107,7 @@ func (s *wrapperSpan) End(options ...trace.SpanEndOption) {
 
 func (s *wrapperSpan) EndWithStatus(err error, options ...trace.SpanEndOption) {
 	if err != nil {
-		s.span.SetStatus(codes.Error, errorDescription(err))
+		s.span.SetStatus(codes.Error, "internal."+errorDescription(err))
 	} else {
 		s.span.SetStatus(codes.Ok, "")
 	}


### PR DESCRIPTION
## Summary

Fixes #7239

The `UnknownFailure` result code is the **single largest error bucket in telemetry** — 2.35M errors/28d with zero classification. Root cause: several high-volume code paths used `span.EndWithStatus(err)` which bypasses `MapError()`, the central error classification function.

### Root Cause

`EndWithStatus(err)` calls `errorDescription(err)` which produces a raw Go type name (e.g., `errors_errorString`) as the span status description. When this is empty or unrecognized, the telemetry converter falls back to `"UnknownFailure"`:

```go
// span_to_envelope.go
if requestData.ResponseCode == "" {
    if span.Status().Code == codes.Error {
        requestData.ResponseCode = "UnknownFailure"  // ← 2.35M of these
    }
}
```

Meanwhile, `MapError()` produces structured codes like `service.arm.400`, `auth.login_required`, `tool.docker.failed` — but these paths bypass it.

## Changes

### 1. MCP tool handler (`cmd/mcp.go`)
Replaced `span.EndWithStatus(err)` with `internalcmd.MapError(err, span)` + `span.End()`. Every MCP tool failure now gets proper telemetry classification.

### 2. Copilot agent (`internal/agent/copilot_agent.go`)
Both `Initialize()` and `ensureSession()` now route errors through `cmd.MapError` instead of `EndWithStatus`.

### 3. `EndWithStatus` fallback (`internal/tracing/tracer.go`)
For remaining callers in `pkg/` (container_helper.go, extensions/manager.go) that cannot import `internal/cmd`, `EndWithStatus()` now prefixes error descriptions with `internal.` to match `MapError`'s catch-all convention. This ensures consistent `internal.*` codes instead of bare type names.

## Expected Impact

| Before | After |
|---|---|
| MCP tool errors → `UnknownFailure` or raw type name | MCP tool errors → `service.arm.400`, `auth.login_required`, etc. |
| Copilot agent errors → raw type name | Copilot agent errors → structured codes via MapError |
| Container/extension errors → `errors_errorString` | Container/extension errors → `internal.errors_errorString` (consistent convention) |

This should significantly reduce the 2.35M `UnknownFailure` bucket by routing errors through the existing classification infrastructure.