### PR TITLE
fix copilot.session.id classification

### DIFF
--- a/cli/azd/internal/agent/copilot_agent.go
+++ b/cli/azd/internal/agent/copilot_agent.go
@@ -514,7 +514,7 @@ func (a *CopilotAgent) Stop() error {
 		fields.CopilotConsentDeniedCount.Int(a.consentDeniedCount),
 	)
 	if a.sessionID != "" {
-		tracing.SetUsageAttributes(fields.StringHashed(fields.CopilotSessionId, a.sessionID))
+		tracing.SetUsageAttributes(fields.CopilotSessionId.String(a.sessionID))
 	}
 
 	tasks := a.cleanupTasks
@@ -598,7 +598,7 @@ func (a *CopilotAgent) ensureSession(ctx context.Context, resumeSessionID string
 			sessionID = resumeSessionID
 		}
 		if sessionID != "" {
-			span.SetAttributes(fields.StringHashed(fields.CopilotSessionId, sessionID))
+			span.SetAttributes(fields.CopilotSessionId.String(sessionID))
 		}
 		span.EndWithStatus(err)
 	}()

--- a/cli/azd/internal/tracing/fields/fields.go
+++ b/cli/azd/internal/tracing/fields/fields.go
@@ -624,10 +624,10 @@ var (
 
 // Copilot agent session related fields
 var (
-	// CopilotSessionId is the hashed session ID for correlation across messages.
+	// CopilotSessionId is the session ID for correlation across messages.
 	CopilotSessionId = AttributeKey{
 		Key:            attribute.Key("copilot.session.id"),
-		Classification: EndUserPseudonymizedInformation,
+		Classification: SystemMetadata,
 		Purpose:        FeatureInsight,
 	}
 	// CopilotSessionIsNew indicates whether this was a new session (true) or resumed (false).


### PR DESCRIPTION
Update `copilot.session.id` to the appropriate classification and avoid hashing.

Contributes to #7163 