### PR TITLE
Add funcignore handling fix (#7223) to 1.23.12 changelog

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs Fixed
 
+- [[#7223]](https://github.com/Azure/azure-dev/pull/7223) Improve `.funcignore` handling for flex-consumption function apps by inferring `remoteBuild` from file contents and failing fast on incompatible configurations.
 - [[#7274]](https://github.com/Azure/azure-dev/pull/7274) Revert env-flag change from v1.23.11 to fix regression where the `-e` shorthand for `--environment` conflicted with extension commands that use `-e` for their own flags (e.g., `--project-endpoint` in `azure.ai.models` and `azure.ai.finetune`), restoring compatibility with those extensions.
 
 ### Other Changes


### PR DESCRIPTION
Followup to #7276 — adds the changelog entry for #7223 (funcignore handling improvement) under the 1.23.12 release.

No version bump needed, 1.23.12 hasn't shipped yet.