### PR TITLE
feat: avoid prompting for layer outputs in `pipeline config`

### DIFF
--- a/cli/azd/cmd/pipeline.go
+++ b/cli/azd/cmd/pipeline.go
@@ -186,19 +186,68 @@ func (p *pipelineConfigAction) Run(ctx context.Context) (*actions.ActionResult, 
 	layers := infra.Options.GetLayers()
 	allParameters := []provisioning.Parameter{}
 
-	for _, layer := range layers {
+	inputParameters := func(layer provisioning.Options) ([]provisioning.Parameter, error) {
 		err = p.provisioningManager.Initialize(ctx, p.projectConfig.Path, layer)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf(
+				"failed to initialize infra provider %s: %w",
+				layer.Provider,
+				err,
+			)
 		}
 
-		// Pull provider specific parameters
-		providerParameters, err := p.provisioningManager.Parameters(ctx)
+		parameters, err := p.provisioningManager.Parameters(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get parameters for provider %s: %w", pipelineProviderName, err)
+			return nil, fmt.Errorf(
+				"failed to get parameters for infra provider %s: %w",
+				layer.Provider,
+				err,
+			)
 		}
 
-		allParameters = append(allParameters, providerParameters...)
+		return parameters, nil
+	}
+
+	if len(layers) <= 1 {
+		for _, layer := range layers {
+			parameters, err := inputParameters(layer)
+			if err != nil {
+				return nil, err
+			}
+
+			allParameters = append(allParameters, parameters...)
+		}
+	} else {
+		// virtualEnv contains all accumulated outputs from previous layers.
+		virtualEnv := map[string]string{}
+
+		for _, layer := range layers {
+			layer.VirtualEnv = virtualEnv
+
+			parameters, err := inputParameters(layer)
+			if err != nil {
+				return nil, fmt.Errorf("layer '%s': %w", layer.Name, err)
+			}
+
+			allParameters = append(allParameters, parameters...)
+
+			outputs, err := p.provisioningManager.PlannedOutputs(ctx)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"layer '%s': failed to get planned outputs for infra provider %s: %w",
+					layer.Name,
+					layer.Provider,
+					err,
+				)
+			}
+
+			// Save current outputs
+			for _, output := range outputs {
+				// Use a sentinel value that records the source layer and output name so
+				// downstream virtual env substitutions remain traceable during planning.
+				virtualEnv[output.Name] = fmt.Sprintf("%s--%s", layer.Name, output.Name)
+			}
+		}
 	}
 
 	p.manager.SetParameters(allParameters)

--- a/cli/azd/internal/cmd/provision_test.go
+++ b/cli/azd/internal/cmd/provision_test.go
@@ -100,6 +100,10 @@ func (p *mockProvider) Parameters(_ context.Context) ([]provisioning.Parameter, 
 	return nil, nil
 }
 
+func (p *mockProvider) PlannedOutputs(_ context.Context) ([]provisioning.PlannedOutput, error) {
+	return nil, nil
+}
+
 // TestProvisionAction_PreflightAborted verifies that when the user declines
 // preflight warnings, ProvisionAction.Run returns ErrAbortedByUser and does NOT
 // attempt to read deployResult.Deployment.Outputs (which would nil-panic).

--- a/cli/azd/pkg/devcenter/provision_provider.go
+++ b/cli/azd/pkg/devcenter/provision_provider.go
@@ -536,3 +536,8 @@ func (p *ProvisionProvider) Parameters(ctx context.Context) ([]provisioning.Para
 	// not supported (no-op)
 	return nil, nil
 }
+
+func (p *ProvisionProvider) PlannedOutputs(ctx context.Context) ([]provisioning.PlannedOutput, error) {
+	// not supported (no-op)
+	return nil, nil
+}

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -1725,16 +1725,25 @@ type loadParametersResult struct {
 	locationParams []string
 	// envMapping is a map of parameter name to environment variable names
 	// holds information about which parameters are mapped to which env vars for
-	// cases like "param": "${env:AZURE_FOO}-${env:AZURE_BAR}", envMapping will
+	// cases like "param": "${AZURE_FOO}-${AZURE_BAR}", envMapping will
 	// contain {"param": ["AZURE_FOO", "AZURE_BAR"]}
+	//
 	// This information is useful for setting a CI/CD automatically. Each env var
 	// will be set to the value of the parameter as variable or secret.
 	envMapping map[string][]string
+
+	// parameters that should be considered virtual, i.e. their values are only
+	// known at runtime.
+	//
+	// These parameters should not be prompted and treated as resolved values,
+	// with other potential unmapped environment variables stored in envMapping.
+	virtualMapping map[string]struct{}
 }
 
 // envSubstResult contains the results of environment variable substitution
 type envSubstResult struct {
 	hasUnsetEnvVar                  bool
+	hasVirtualEnvVar                bool
 	mappedEnvVars                   []string
 	parametersMappedToAzureLocation []string
 }
@@ -1747,6 +1756,7 @@ func evalParamEnvSubst(
 	principalType string,
 	paramName string,
 	env *environment.Environment,
+	virtualEnv map[string]string,
 ) (string, envSubstResult, error) {
 	result := envSubstResult{}
 
@@ -1760,13 +1770,23 @@ func evalParamEnvSubst(
 		if name == environment.LocationEnvVarName {
 			result.parametersMappedToAzureLocation = append(result.parametersMappedToAzureLocation, paramName)
 		}
-		// principalId and locations are intentionally excluded from the mapped env vars as
-		// they are global env vars
+
+		if virtualEnv != nil {
+			if value, has := virtualEnv[name]; has {
+				result.hasVirtualEnvVar = true
+				return value
+			}
+		}
+
+		// principalId and principalType are intentionally excluded from the mapped env vars
+		// as they are global env vars.
 		result.mappedEnvVars = append(result.mappedEnvVars, name)
-		if _, isDefined := env.LookupEnv(name); !isDefined {
+
+		value, isDefined := env.LookupEnv(name)
+		if !isDefined {
 			result.hasUnsetEnvVar = true
 		}
-		return env.Getenv(name)
+		return value
 	})
 	return replaced, result, err
 }
@@ -1820,6 +1840,7 @@ func (p *BicepProvider) loadParameters(ctx context.Context, template *azure.ArmT
 	parametersMappedToAzureLocation := []string{}
 	resolvedParams := map[string]azure.ArmParameter{}
 	envMapping := map[string][]string{}
+	virtualMapping := map[string]struct{}{}
 
 	// resolving each parameter to keep track of the name during the resolution.
 	// We used to resolve all the file before, supporting env var substitution at any part of the file.
@@ -1847,6 +1868,7 @@ func (p *BicepProvider) loadParameters(ctx context.Context, template *azure.ArmT
 					string(principalType),
 					paramName,
 					p.env,
+					p.options.VirtualEnv,
 				)
 				if err != nil {
 					return loadParametersResult{}, err
@@ -1855,6 +1877,12 @@ func (p *BicepProvider) loadParameters(ctx context.Context, template *azure.ArmT
 				envMapping[paramName] = substResult.mappedEnvVars
 				parametersMappedToAzureLocation = append(
 					parametersMappedToAzureLocation, substResult.parametersMappedToAzureLocation...)
+
+				if substResult.hasVirtualEnvVar {
+					// Record the parameter as virtual, skip further processing
+					virtualMapping[paramName] = struct{}{}
+					continue
+				}
 
 				// Omit unset parameters
 				if replaced == "" && substResult.hasUnsetEnvVar {
@@ -1901,6 +1929,7 @@ func (p *BicepProvider) loadParameters(ctx context.Context, template *azure.ArmT
 			string(principalType),
 			paramName,
 			p.env,
+			p.options.VirtualEnv,
 		)
 		if err != nil {
 			return loadParametersResult{}, fmt.Errorf("substituting environment variables for %s: %w", paramName, err)
@@ -1910,12 +1939,17 @@ func (p *BicepProvider) loadParameters(ctx context.Context, template *azure.ArmT
 		parametersMappedToAzureLocation = append(
 			parametersMappedToAzureLocation, substResult.parametersMappedToAzureLocation...)
 
+		if substResult.hasVirtualEnvVar {
+			// Record the parameter as virtual, skip further processing
+			virtualMapping[paramName] = struct{}{}
+			continue
+		}
+
 		// resolve command substitutions like `secretOrRandomPassword`
 		replaced, err = p.evalCommandSubstitution(ctx, replaced)
 		if err != nil {
 			return loadParametersResult{}, err
 		}
-
 		var resolvedParam azure.ArmParameter
 		if err := json.Unmarshal([]byte(replaced), &resolvedParam); err != nil {
 			return loadParametersResult{}, fmt.Errorf("error unmarshalling Bicep template parameters: %w", err)
@@ -1952,6 +1986,7 @@ func (p *BicepProvider) loadParameters(ctx context.Context, template *azure.ArmT
 		parameters:     resolvedParams,
 		locationParams: parametersMappedToAzureLocation,
 		envMapping:     envMapping,
+		virtualMapping: virtualMapping,
 	}, nil
 }
 
@@ -2490,6 +2525,7 @@ func (p *BicepProvider) ensureParameters(
 	}
 	parameters := parametersResult.parameters
 	locationParameters := parametersResult.locationParams
+	virtualParameters := parametersResult.virtualMapping
 
 	if len(template.Parameters) == 0 {
 		return azure.ArmParameters{}, nil
@@ -2542,6 +2578,11 @@ func (p *BicepProvider) ensureParameters(
 		param := template.Parameters[key]
 		parameterType := provisioning.ParameterTypeFromArmType(param.Type)
 		azdMetadata, hasMetadata := param.AzdMetadata()
+
+		// If a value is marked virtual, we skip configuration entirely
+		if _, has := virtualParameters[key]; has {
+			continue
+		}
 
 		// If a value is explicitly configured via a parameters file, use it.
 		if v, has := parameters[key]; has {
@@ -2852,10 +2893,24 @@ func (p *BicepProvider) Parameters(ctx context.Context) ([]provisioning.Paramete
 
 	provisionParameters := []provisioning.Parameter{}
 	for key, param := range templateParameters {
+		_, isVirtual := parametersInfo.virtualMapping[key]
+		if isVirtual {
+			// For virtual parameters, we pass through remaining env var mappings
+			provisionParameters = append(provisionParameters, provisioning.Parameter{
+				Name:               key,
+				Secret:             param.Secure(),
+				EnvVarMapping:      parametersInfo.envMapping[key],
+				LocalPrompt:        false,
+				UsingEnvVarMapping: true,
+			})
+			continue
+		}
+
 		if _, usingParam := resolvedParams[key]; !usingParam {
 			// No resolved param for this parameter definition.
 			continue
 		}
+
 		_, isPrompt := p.env.Config.Get(fmt.Sprintf("infra.parameters.%s", key))
 		singleMapping := len(parametersInfo.envMapping[key]) == 1
 		usingEnvVarMapping := false
@@ -2877,4 +2932,24 @@ func (p *BicepProvider) Parameters(ctx context.Context) ([]provisioning.Paramete
 	}
 
 	return provisionParameters, nil
+}
+
+func (p *BicepProvider) PlannedOutputs(ctx context.Context) ([]provisioning.PlannedOutput, error) {
+	compileResult, err := p.compileBicep(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating template: %w", err)
+	}
+
+	var outputs []provisioning.PlannedOutput
+	for key, output := range compileResult.Template.Outputs {
+		if azure.IsSecuredARMType(output.Type) {
+			continue
+		}
+
+		outputs = append(outputs, provisioning.PlannedOutput{
+			Name: key,
+		})
+	}
+
+	return outputs, nil
 }

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -12,6 +12,8 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1694,6 +1696,7 @@ func TestArrayParameterViaEnvVarSimple(t *testing.T) {
 		"ServicePrincipal",
 		"testParam",
 		env,
+		nil,
 	)
 
 	require.Nil(t, err)
@@ -1704,6 +1707,18 @@ func TestArrayParameterViaEnvVarSimple(t *testing.T) {
 
 func createBicepProviderWithEnv(
 	t *testing.T, mockContext *mocks.MockContext, armTemplate azure.ArmTemplate, envVars map[string]string) *BicepProvider {
+	return createBicepProviderWithEnvAndMode(t, mockContext, armTemplate, envVars, provisioning.ModeDeploy)
+}
+
+func createBicepProviderWithEnvAndMode(
+	t *testing.T,
+	mockContext *mocks.MockContext,
+	armTemplate azure.ArmTemplate,
+	envVars map[string]string,
+	mode provisioning.Mode,
+) *BicepProvider {
+	t.Helper()
+
 	bicepBytes, _ := json.Marshal(armTemplate)
 
 	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
@@ -1724,6 +1739,7 @@ func createBicepProviderWithEnv(
 	options := provisioning.Options{
 		Path:   "infra",
 		Module: "main",
+		Mode:   mode,
 	}
 
 	baseEnvVars := map[string]string{
@@ -1805,6 +1821,7 @@ func TestObjectParameterEnvSubst(t *testing.T) {
 		"ServicePrincipal",
 		"testParam",
 		env,
+		nil,
 	)
 
 	require.Nil(t, err)
@@ -1904,6 +1921,7 @@ func TestHelperEvalParamEnvSubst(t *testing.T) {
 		"ServicePrincipal",
 		"testParam",
 		env,
+		nil,
 	)
 
 	require.Nil(t, err)
@@ -1913,7 +1931,6 @@ func TestHelperEvalParamEnvSubst(t *testing.T) {
 	require.Contains(t, substResult.mappedEnvVars, "VAR2")
 	require.False(t, substResult.hasUnsetEnvVar)
 }
-
 func TestSetPreflightOutcome_SetsSpanAndUsageAttributes(t *testing.T) {
 	span := &mocktracing.Span{}
 	provider := &BicepProvider{}
@@ -2004,4 +2021,227 @@ func findSpanAttribute(
 		}
 	}
 	return nil
+}
+
+func TestEvalParamEnvSubstUsesVirtualEnv(t *testing.T) {
+	env := environment.NewWithValues("test-env", map[string]string{})
+	virtualKey := "AZD_TEST_VIRTUAL_LAYER_OUTPUT"
+	virtualValue := "layer1--WEBSITE_URL"
+	virtualEnv := map[string]string{virtualKey: virtualValue}
+
+	testCases := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "simple substitution",
+			value: "${AZD_TEST_VIRTUAL_LAYER_OUTPUT}",
+			want:  "layer1--WEBSITE_URL",
+		},
+		{
+			name:  "mixed expression substitution",
+			value: "prefix-${AZD_TEST_VIRTUAL_LAYER_OUTPUT}-suffix",
+			want:  "prefix-layer1--WEBSITE_URL-suffix",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, substResult, err := evalParamEnvSubst(
+				tc.value,
+				"principal-id",
+				"ServicePrincipal",
+				"testParam",
+				env,
+				virtualEnv,
+			)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, result)
+			require.True(t, substResult.hasVirtualEnvVar)
+			require.False(t, substResult.hasUnsetEnvVar)
+			require.Empty(t, substResult.mappedEnvVars)
+		})
+	}
+}
+
+func TestParameters_IncludesRealEnvMappingsForMixedRefs(t *testing.T) {
+	const (
+		realEnvVarName = "AZD_TEST_REAL_SECRET"
+		virtualEnvKey  = "AZD_TEST_VIRTUAL_LAYER_OUTPUT"
+	)
+
+	testCases := []struct {
+		name    string
+		envVars map[string]string
+	}{
+		{
+			name:    "set real env var",
+			envVars: map[string]string{realEnvVarName: "secret-value"},
+		},
+		{
+			name:    "unset real env var",
+			envVars: map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockContext := mocks.NewMockContext(context.Background())
+
+			armTemplate := azure.ArmTemplate{
+				// nolint: lll
+				Schema:         "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+				ContentVersion: "1.0.0.0",
+				Parameters: azure.ArmTemplateParameterDefinitions{
+					"environmentName": {Type: "string", DefaultValue: "test-env"},
+					"location":        {Type: "string", DefaultValue: "westus2"},
+					"mixedValue":      {Type: "string"},
+				},
+				Outputs: azure.ArmTemplateOutputs{},
+			}
+
+			infraProvider := createBicepProviderWithEnvAndMode(
+				t,
+				mockContext,
+				armTemplate,
+				tc.envVars,
+				provisioning.ModeDestroy,
+			)
+
+			tmpInfraDir := filepath.Join(t.TempDir(), "infra")
+			require.NoError(t, os.MkdirAll(tmpInfraDir, 0o755))
+
+			require.NoError(t, os.WriteFile(filepath.Join(tmpInfraDir, "main.parameters.json"), []byte(`{
+				"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+				"contentVersion": "1.0.0.0",
+				"parameters": {
+					"mixedValue": {
+						"value": "${AZD_TEST_VIRTUAL_LAYER_OUTPUT}/${AZD_TEST_REAL_SECRET}"
+					}
+				}
+			}`), 0o600))
+
+			infraProvider.path = filepath.Join(tmpInfraDir, "main.bicep")
+			infraProvider.options.VirtualEnv = map[string]string{
+				virtualEnvKey: "layer1--WEBSITE_URL",
+			}
+
+			compileResult, err := infraProvider.compileBicep(*mockContext.Context)
+			require.NoError(t, err)
+
+			loadResult, err := infraProvider.loadParameters(*mockContext.Context, &compileResult.Template)
+			require.NoError(t, err)
+			require.Contains(t, loadResult.virtualMapping, "mixedValue")
+			require.Equal(t, []string{realEnvVarName}, loadResult.envMapping["mixedValue"])
+			require.NotContains(t, loadResult.envMapping["mixedValue"], virtualEnvKey)
+			require.NotContains(t, loadResult.parameters, "mixedValue")
+
+			parameters, err := infraProvider.Parameters(*mockContext.Context)
+			require.NoError(t, err)
+			require.Len(t, parameters, 1)
+			require.Equal(t, provisioning.Parameter{
+				Name:               "mixedValue",
+				Secret:             false,
+				Value:              nil,
+				EnvVarMapping:      []string{realEnvVarName},
+				LocalPrompt:        false,
+				UsingEnvVarMapping: true,
+			}, parameters[0])
+		})
+	}
+}
+
+func TestEnsureParametersSkipsVirtualEnvMappedRequiredParameters(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+
+	armTemplate := azure.ArmTemplate{
+		Schema:         "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+		ContentVersion: "1.0.0.0",
+		Parameters: azure.ArmTemplateParameterDefinitions{
+			"environmentName": {Type: "string", DefaultValue: "test-env"},
+			"location":        {Type: "string", DefaultValue: "westus2"},
+			"dependentValue":  {Type: "string"},
+			"compositeValue":  {Type: "string"},
+		},
+		Outputs: azure.ArmTemplateOutputs{},
+	}
+
+	infraProvider := createBicepProviderWithEnvAndMode(
+		t,
+		mockContext,
+		armTemplate,
+		map[string]string{},
+		provisioning.ModeDestroy,
+	)
+
+	tmpInfraDir := filepath.Join(t.TempDir(), "infra")
+	require.NoError(t, os.MkdirAll(tmpInfraDir, 0o755))
+
+	const virtualEnvKey = "AZD_TEST_VIRTUAL_LAYER_OUTPUT"
+	require.NoError(t, os.WriteFile(filepath.Join(tmpInfraDir, "main.parameters.json"), []byte(`{
+		"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+		"contentVersion": "1.0.0.0",
+		"parameters": {
+			"dependentValue": {
+				"value": "${AZD_TEST_VIRTUAL_LAYER_OUTPUT}"
+			},
+			"compositeValue": {
+				"value": "prefix-${AZD_TEST_VIRTUAL_LAYER_OUTPUT}-suffix"
+			}
+		}
+	}`), 0o600))
+
+	infraProvider.path = filepath.Join(tmpInfraDir, "main.bicep")
+	infraProvider.options.VirtualEnv = map[string]string{
+		virtualEnvKey: "layer1--WEBSITE_URL",
+	}
+
+	compileResult, err := infraProvider.compileBicep(*mockContext.Context)
+	require.NoError(t, err)
+
+	loadResult, err := infraProvider.loadParameters(*mockContext.Context, &compileResult.Template)
+	require.NoError(t, err)
+	require.Contains(t, loadResult.virtualMapping, "dependentValue")
+	require.Contains(t, loadResult.virtualMapping, "compositeValue")
+	require.NotContains(t, loadResult.parameters, "dependentValue")
+	require.NotContains(t, loadResult.parameters, "compositeValue")
+
+	configuredParameters, err := infraProvider.ensureParameters(*mockContext.Context, compileResult.Template)
+	require.NoError(t, err)
+	require.NotContains(t, configuredParameters, "dependentValue")
+	require.NotContains(t, configuredParameters, "compositeValue")
+}
+
+func TestPlannedOutputsSkipsSecureOutputs(t *testing.T) {
+	mockContext := mocks.NewMockContext(context.Background())
+
+	armTemplate := azure.ArmTemplate{
+		Schema:         "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+		ContentVersion: "1.0.0.0",
+		Outputs: azure.ArmTemplateOutputs{
+			"publicUrl": {
+				Type: "string",
+			},
+			"connectionString": {
+				Type: "secureString",
+			},
+			"config": {
+				Type: "object",
+			},
+			"secretConfig": {
+				Type: "secureObject",
+			},
+		},
+	}
+
+	infraProvider := createBicepProviderWithEnv(t, mockContext, armTemplate, map[string]string{})
+
+	outputs, err := infraProvider.PlannedOutputs(*mockContext.Context)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []provisioning.PlannedOutput{
+		{Name: "publicUrl"},
+		{Name: "config"},
+	}, outputs)
 }

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -75,6 +75,14 @@ func (m *Manager) Parameters(ctx context.Context) ([]Parameter, error) {
 	return m.provider.Parameters(ctx)
 }
 
+// PlannedOutputs returns the list of outputs in the current plan.
+func (m *Manager) PlannedOutputs(ctx context.Context) ([]PlannedOutput, error) {
+	if m.provider == nil {
+		panic("called PlannedOutputs() with provider not initialized. Make sure to call manager.Initialize() first.")
+	}
+	return m.provider.PlannedOutputs(ctx)
+}
+
 // Gets the latest deployment details for the specified scope
 func (m *Manager) State(ctx context.Context, options *StateOptions) (*StateResult, error) {
 	result, err := m.provider.State(ctx, options)

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -49,6 +49,11 @@ type Options struct {
 	IgnoreDeploymentState bool `yaml:"-"`
 	// The mode in which the deployment is being run.
 	Mode Mode `yaml:"-"`
+	// Environment variables that should be considered as resolved when prompting for parameters.
+	//
+	// This is used when planning multiple layers, and would be set to plan-time outputs
+	// from previous layers.
+	VirtualEnv map[string]string `yaml:"-"`
 }
 
 // GetWithDefaults merges the provided infra options with the default provisioning options
@@ -179,6 +184,13 @@ type Parameter struct {
 	UsingEnvVarMapping bool
 }
 
+// PlannedOutput represents a plan-time output.
+// It does not contain the actual output value.
+type PlannedOutput struct {
+	// The name of the planned output
+	Name string
+}
+
 type Provider interface {
 	Name() string
 	Initialize(ctx context.Context, projectPath string, options Options) error
@@ -188,4 +200,5 @@ type Provider interface {
 	Destroy(ctx context.Context, options DestroyOptions) (*DestroyResult, error)
 	EnsureEnv(ctx context.Context) error
 	Parameters(ctx context.Context) ([]Parameter, error)
+	PlannedOutputs(ctx context.Context) ([]PlannedOutput, error)
 }

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -811,3 +811,8 @@ func (t *TerraformProvider) Parameters(ctx context.Context) ([]provisioning.Para
 	// not supported (no-op)
 	return nil, nil
 }
+
+func (t *TerraformProvider) PlannedOutputs(ctx context.Context) ([]provisioning.PlannedOutput, error) {
+	// not supported (no-op)
+	return nil, nil
+}

--- a/cli/azd/pkg/infra/provisioning/test/test_provider.go
+++ b/cli/azd/pkg/infra/provisioning/test/test_provider.go
@@ -134,6 +134,11 @@ func (p *TestProvider) Parameters(ctx context.Context) ([]provisioning.Parameter
 	return nil, nil
 }
 
+func (p *TestProvider) PlannedOutputs(ctx context.Context) ([]provisioning.PlannedOutput, error) {
+	// not supported (no-op)
+	return nil, nil
+}
+
 func NewTestProvider(
 	envManager environment.Manager,
 	env *environment.Environment,

--- a/cli/azd/pkg/pipeline/pipeline.go
+++ b/cli/azd/pkg/pipeline/pipeline.go
@@ -169,18 +169,20 @@ func mergeProjectVariablesAndSecrets(
 			// env var == 0 AND no local prompt, ignore it
 			continue
 		}
-		if envVarsCount > 1 {
-			if parameter.LocalPrompt {
-				return nil, nil,
-					fmt.Errorf(
-						"parameter %s got its value from a local prompt and it has more than one mapped environment "+
-							"variable. "+
-							"The value can't be configured in CI mapped to multiple ENV VARS if azd prompt for its value. "+
-							"Define a single mapping for %s to one ENV VAR as part of the infra parameters definition",
-						parameter.Name, parameter.Name)
-			}
-			// env var > 1 AND no local prompt, ignore it
-			// for parameters mapped to more than one ENV VAR, each env var becomes either a variable or a secret
+
+		if envVarsCount > 1 && parameter.LocalPrompt {
+			return nil, nil,
+				fmt.Errorf(
+					"parameter %s got its value from a local prompt and it has more than one mapped environment "+
+						"variable. "+
+						"The value can't be configured in CI mapped to multiple ENV VARS if azd prompt for its value. "+
+						"Define a single mapping for %s to one ENV VAR as part of the infra parameters definition",
+					parameter.Name, parameter.Name)
+		}
+
+		if envVarsCount > 1 || parameter.Value == nil {
+			// for parameters mapped to multiple env vars, or without a resolved value,
+			// each env var becomes either a variable or a secret
 			for _, envVar := range parameter.EnvVarMapping {
 				// see if the env var is set in the system env or azd env
 				// NOTE: provider parameters have access to system env vars but not project env vars/secrets.
@@ -201,6 +203,7 @@ func mergeProjectVariablesAndSecrets(
 			// nothing else to do for parameters mapped to multiple env vars
 			continue
 		}
+
 		// Param mapped to a single env var, use that ENV VAR to set the link in CI
 		// marshall the value to a string
 		envVar := parameter.EnvVarMapping[0]

--- a/cli/azd/pkg/pipeline/pipeline_test.go
+++ b/cli/azd/pkg/pipeline/pipeline_test.go
@@ -5,6 +5,7 @@ package pipeline
 import (
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -153,4 +154,61 @@ func Test_escapeValuesForPipeline(t *testing.T) {
 			assert.Equal(t, tt.expected, values["test"])
 		})
 	}
+}
+
+func Test_ConfigOptions_ProviderParameterWithNilValueUsesMappedEnvVar(t *testing.T) {
+	initialVariables := map[string]string{}
+	initialSecrets := map[string]string{}
+	providerParameters := []provisioning.Parameter{
+		{
+			Name:               "mixedValue",
+			Secret:             true,
+			EnvVarMapping:      []string{"REAL_SECRET"},
+			LocalPrompt:        false,
+			UsingEnvVarMapping: true,
+		},
+	}
+	env := map[string]string{
+		"REAL_SECRET": "secret-value",
+	}
+
+	variables, secrets, err := mergeProjectVariablesAndSecrets(
+		nil,
+		nil,
+		initialVariables,
+		initialSecrets,
+		providerParameters,
+		env,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, variables)
+	assert.Equal(t, map[string]string{"REAL_SECRET": "secret-value"}, secrets)
+}
+
+func Test_ConfigOptions_ProviderParameterWithNilValueSkipsUnsetMappedEnvVar(t *testing.T) {
+	const envVarName = "AZD_TEST_UNSET_REAL_SECRET"
+
+	t.Setenv(envVarName, "")
+
+	providerParameters := []provisioning.Parameter{
+		{
+			Name:               "mixedValue",
+			Secret:             true,
+			EnvVarMapping:      []string{envVarName},
+			LocalPrompt:        false,
+			UsingEnvVarMapping: true,
+		},
+	}
+
+	variables, secrets, err := mergeProjectVariablesAndSecrets(
+		nil,
+		nil,
+		map[string]string{},
+		map[string]string{},
+		providerParameters,
+		map[string]string{},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, variables)
+	assert.Empty(t, secrets)
 }


### PR DESCRIPTION
## Summary

Add support for `pipeline config` to detect outputs between layers and avoid prompting for them.
 
## Why

In a normal provision run, these outputs are not user-provided, and would be automatically set by the provisioning engine.

## What's changing

- In `cmd/pipeline.go`, we collect outputs from each previous layer, store them as a virtual env-mapped values.
- In the provider implementation, we treat parameters mapped to virtual values as resolved without prompting.

A new `PlannedOutputs()` function is added to the infra provider interface that represents plan-time outputs (no resolved values).

## Testing

- Add tests for virtual env substitution and required-parameter prompt skipping paths

Fixes #7182