### PR TITLE
[azd update] apply code sign verification for windows msi isntall

### DIFF
--- a/cli/azd/pkg/update/manager.go
+++ b/cli/azd/pkg/update/manager.go
@@ -507,10 +507,10 @@ func (m *Manager) updateViaMSI(ctx context.Context, cfg *UpdateConfig, writer io
 			fmt.Errorf("failed to hash safety copy before install: %w", hashErr))
 	}
 
-	log.Printf("Running install script: powershell %s", strings.Join(psArgs, " "))
+	log.Printf("Running install script: pwsh %s", strings.Join(psArgs, " "))
 	fmt.Fprintf(writer, "Installing azd %s channel...\n", cfg.Channel)
 
-	runArgs := exec.NewRunArgs("powershell", psArgs...).
+	runArgs := exec.NewRunArgs("pwsh", psArgs...).
 		WithStdOut(writer).
 		WithStdErr(writer)
 

--- a/cli/azd/pkg/update/manager.go
+++ b/cli/azd/pkg/update/manager.go
@@ -507,10 +507,10 @@ func (m *Manager) updateViaMSI(ctx context.Context, cfg *UpdateConfig, writer io
 			fmt.Errorf("failed to hash safety copy before install: %w", hashErr))
 	}
 
-	log.Printf("Running install script: pwsh %s", strings.Join(psArgs, " "))
+	log.Printf("Running install script: powershell %s", strings.Join(psArgs, " "))
 	fmt.Fprintf(writer, "Installing azd %s channel...\n", cfg.Channel)
 
-	runArgs := exec.NewRunArgs("pwsh", psArgs...).
+	runArgs := exec.NewRunArgs("powershell", psArgs...).
 		WithStdOut(writer).
 		WithStdErr(writer)
 

--- a/cli/azd/pkg/update/msi_windows.go
+++ b/cli/azd/pkg/update/msi_windows.go
@@ -150,35 +150,32 @@ func isStandardMSIInstall() error {
 	return nil
 }
 
+func escapeForPSSingleQuote(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
 // buildInstallScriptArgs constructs the PowerShell arguments to run install-azd.ps1.
-//
-// For the stable channel the script is piped directly through Invoke-Expression.
-// No named parameters are needed because the default MSI install location is correct.
-//
-// For other channels (e.g. daily) the script must be downloaded to a temp directory
-// first, because Invoke-Expression from a pipe does not support passing named
-// parameters such as -Version or -InstallFolder to the script.
-//
+// For all channels, the script is downloaded to a temp directory.
+// For daily channel, additional parameters (-Version, -InstallFolder) are passed
+// to the script. The install folder is escaped for PowerShell single-quoted strings
+// to handle paths containing apostrophes (e.g. O'Connor).
 // Returns the arguments to pass to the "powershell" command.
 func buildInstallScriptArgs(channel Channel) []string {
+	var scriptArgs string
 	switch channel {
 	case ChannelDaily:
-		script := fmt.Sprintf(
-			"$tmpScript = Join-Path $env:TEMP 'azd-install.ps1'; "+
-				"Invoke-RestMethod '%s' -OutFile $tmpScript; "+
-				"& $tmpScript -Version 'daily' -InstallFolder '%s'; "+
-				"Remove-Item $tmpScript -Force -ErrorAction SilentlyContinue",
-			installScriptURL, expectedPerUserInstallDir(),
-		)
-		return []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script}
+		scriptArgs = fmt.Sprintf(" -Version 'daily' -InstallFolder '%s'",
+			escapeForPSSingleQuote(expectedPerUserInstallDir()))
 	default:
-		script := fmt.Sprintf(
-			"$tmpScript = Join-Path $env:TEMP 'azd-install.ps1'; "+
-				"Invoke-RestMethod '%s' -OutFile $tmpScript; "+
-				"& $tmpScript; "+
-				"Remove-Item $tmpScript -Force -ErrorAction SilentlyContinue",
-			installScriptURL,
-		)
-		return []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script}
+		scriptArgs = " -Version 'stable'"
 	}
+
+	script := fmt.Sprintf(
+		"$tmpScript = Join-Path $env:TEMP 'azd-install.ps1'; "+
+			"Invoke-RestMethod '%s' -OutFile $tmpScript; "+
+			"& $tmpScript%s; "+
+			"Remove-Item $tmpScript -Force -ErrorAction SilentlyContinue",
+		installScriptURL, scriptArgs,
+	)
+	return []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script}
 }

--- a/cli/azd/pkg/update/msi_windows.go
+++ b/cli/azd/pkg/update/msi_windows.go
@@ -173,7 +173,10 @@ func buildInstallScriptArgs(channel Channel) []string {
 		return []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script}
 	default:
 		script := fmt.Sprintf(
-			"Invoke-RestMethod '%s' | Invoke-Expression",
+			"$tmpScript = Join-Path $env:TEMP 'azd-install.ps1'; "+
+				"Invoke-RestMethod '%s' -OutFile $tmpScript; "+
+				"& $tmpScript; "+
+				"Remove-Item $tmpScript -Force -ErrorAction SilentlyContinue",
 			installScriptURL,
 		)
 		return []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script}

--- a/cli/azd/pkg/update/msi_windows.go
+++ b/cli/azd/pkg/update/msi_windows.go
@@ -159,17 +159,15 @@ func isStandardMSIInstall() error {
 // first, because Invoke-Expression from a pipe does not support passing named
 // parameters such as -Version or -InstallFolder to the script.
 //
-// installDir is the target installation directory (e.g. %LOCALAPPDATA%\Programs\Azure Dev CLI).
-//
 // Returns the arguments to pass to the "powershell" command.
 func buildInstallScriptArgs(channel Channel) []string {
 	switch channel {
 	case ChannelDaily:
 		script := fmt.Sprintf(
-			"$tmpDir = Join-Path $env:TEMP 'azd-install.ps1'; "+
-				"Invoke-RestMethod '%s' -OutFile $tmpDir; "+
-				"& $tmpDir -Version 'daily' -InstallFolder '%s'; "+
-				"Remove-Item $tmpDir -Force -ErrorAction SilentlyContinue",
+			"$tmpScript = Join-Path $env:TEMP 'azd-install.ps1'; "+
+				"Invoke-RestMethod '%s' -OutFile $tmpScript; "+
+				"& $tmpScript -Version 'daily' -InstallFolder '%s'; "+
+				"Remove-Item $tmpScript -Force -ErrorAction SilentlyContinue",
 			installScriptURL, expectedPerUserInstallDir(),
 		)
 		return []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script}

--- a/cli/azd/pkg/update/msi_windows.go
+++ b/cli/azd/pkg/update/msi_windows.go
@@ -156,7 +156,7 @@ func escapeForPSSingleQuote(s string) string {
 
 // buildInstallScriptArgs constructs the PowerShell arguments to run install-azd.ps1.
 // For all channels, the script is downloaded to a temp directory.
-// For daily channel, additional parameters (-Version, -InstallFolder) are passed
+// For daily channel, an additional parameter (-InstallFolder) is passed
 // to the script. The install folder is escaped for PowerShell single-quoted strings
 // to handle paths containing apostrophes (e.g. O'Connor).
 // Returns the arguments to pass to the "powershell" command.

--- a/cli/azd/pkg/update/msi_windows.go
+++ b/cli/azd/pkg/update/msi_windows.go
@@ -150,35 +150,34 @@ func isStandardMSIInstall() error {
 	return nil
 }
 
-// versionFlag returns the install script parameter value for the given channel.
-func versionFlag(channel Channel) string {
-	switch channel {
-	case ChannelDaily:
-		return "daily"
-	case ChannelStable:
-		return "stable"
-	default:
-		return "stable"
-	}
-}
-
-// buildInstallScriptArgs constructs the PowerShell arguments to download and run
-// install-azd.ps1 with the appropriate -Version flag.
-// The -SkipVerify flag is passed because Authenticode verification via
-// Get-AuthenticodeSignature failed.
-// The MSI is already downloaded over HTTPS from a Microsoft-controlled domain,
-// so the transport-level integrity is sufficient.
+// buildInstallScriptArgs constructs the PowerShell arguments to run install-azd.ps1.
+//
+// For the stable channel the script is piped directly through Invoke-Expression.
+// No named parameters are needed because the default MSI install location is correct.
+//
+// For other channels (e.g. daily) the script must be downloaded to a temp directory
+// first, because Invoke-Expression from a pipe does not support passing named
+// parameters such as -Version or -InstallFolder to the script.
+//
+// installDir is the target installation directory (e.g. %LOCALAPPDATA%\Programs\Azure Dev CLI).
+//
 // Returns the arguments to pass to the "powershell" command.
 func buildInstallScriptArgs(channel Channel) []string {
-	version := versionFlag(channel)
-	// Download the script to a temp file, then invoke it with the appropriate -Version flag.
-	// Using -ExecutionPolicy Bypass ensures the script runs even if the system policy is restrictive.
-	script := fmt.Sprintf(
-		`$script = Join-Path $env:TEMP 'install-azd.ps1'; `+
-			`Invoke-RestMethod '%s' -OutFile $script; `+
-			`& $script -Version '%s' -SkipVerify; `+
-			`Remove-Item $script -Force -ErrorAction SilentlyContinue`,
-		installScriptURL, version,
-	)
-	return []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script}
+	switch channel {
+	case ChannelDaily:
+		script := fmt.Sprintf(
+			"$tmpDir = Join-Path $env:TEMP 'azd-install.ps1'; "+
+				"Invoke-RestMethod '%s' -OutFile $tmpDir; "+
+				"& $tmpDir -Version 'daily' -InstallFolder '%s'; "+
+				"Remove-Item $tmpDir -Force -ErrorAction SilentlyContinue",
+			installScriptURL, expectedPerUserInstallDir(),
+		)
+		return []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script}
+	default:
+		script := fmt.Sprintf(
+			"Invoke-RestMethod '%s' | Invoke-Expression",
+			installScriptURL,
+		)
+		return []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script}
+	}
 }

--- a/cli/azd/pkg/update/msi_windows_test.go
+++ b/cli/azd/pkg/update/msi_windows_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockexec"
 	"github.com/stretchr/testify/require"
 )
@@ -61,12 +62,11 @@ func TestBuildInstallScriptArgs(t *testing.T) {
 				"-ExecutionPolicy", "Bypass",
 				"-Command",
 				installScriptURL,
-				"Invoke-Expression",
+				"-Version 'stable'",
+				"Remove-Item",
 			},
 			wantNotContains: []string{
-				"-Version",
 				"-InstallFolder",
-				"Remove-Item",
 			},
 		},
 		{
@@ -103,6 +103,36 @@ func TestBuildInstallScriptArgs(t *testing.T) {
 	}
 }
 
+func TestEscapeForPSSingleQuote(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"no quotes", `C:\Users\testuser`, `C:\Users\testuser`},
+		{"single apostrophe", `C:\Users\O'Connor`, `C:\Users\O''Connor`},
+		{"multiple apostrophes", `C:\it's\a'path`, `C:\it''s\a''path`},
+		{"empty string", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, escapeForPSSingleQuote(tt.input))
+		})
+	}
+}
+
+func TestBuildInstallScriptArgs_ApostropheInPath(t *testing.T) {
+	t.Setenv("LOCALAPPDATA", `C:\Users\O'Connor\AppData\Local`)
+
+	args := buildInstallScriptArgs(ChannelDaily)
+	script := args[4]
+
+	// The apostrophe must be doubled for a valid PowerShell single-quoted string.
+	require.Contains(t, script, `O''Connor`)
+	// Must NOT contain unescaped apostrophe inside the -InstallFolder value.
+	require.NotContains(t, script, `-InstallFolder 'C:\Users\O'Connor`)
+}
+
 func TestBuildInstallScriptArgs_Structure(t *testing.T) {
 	t.Setenv("LOCALAPPDATA", `C:\Users\testuser\AppData\Local`)
 	expectedDir := expectedPerUserInstallDir()
@@ -115,14 +145,13 @@ func TestBuildInstallScriptArgs_Structure(t *testing.T) {
 	require.Equal(t, "Bypass", args[2])
 	require.Equal(t, "-Command", args[3])
 
-	// Stable pipes directly — no temp file download
+	// Stable downloads to temp file — passes -Version 'stable' explicitly
 	script := args[4]
 	require.Contains(t, script, "Invoke-RestMethod")
 	require.Contains(t, script, installScriptURL)
-	require.Contains(t, script, "Invoke-Expression")
+	require.Contains(t, script, "Remove-Item")
+	require.Contains(t, script, "-Version 'stable'")
 	require.NotContains(t, script, "-InstallFolder")
-	require.NotContains(t, script, "Remove-Item")
-	require.NotContains(t, script, "-Version")
 
 	// Daily downloads to temp file with -Version 'daily'
 	argsDaily := buildInstallScriptArgs(ChannelDaily)
@@ -252,4 +281,58 @@ func TestUpdateViaMSI_NonStandardInstallBlocks(t *testing.T) {
 	var updateErr *UpdateError
 	require.True(t, errors.As(err, &updateErr))
 	require.Equal(t, CodeNonStandardInstall, updateErr.Code)
+}
+
+// TestUpdateViaMSI_InvokesPowerShellWithCorrectArgs verifies that updateViaMSI calls
+// "powershell" with the arguments produced by buildInstallScriptArgs.
+func TestUpdateViaMSI_InvokesPowerShellWithCorrectArgs(t *testing.T) {
+	// Point LOCALAPPDATA at the test binary so isStandardMSIInstall passes.
+	exePath, err := os.Executable()
+	require.NoError(t, err)
+	exePath, err = filepath.EvalSymlinks(exePath)
+	require.NoError(t, err)
+
+	actualDir := filepath.Dir(exePath)
+	suffix := filepath.Join("Programs", "Azure Dev CLI")
+	if !strings.HasSuffix(strings.ToLower(filepath.Clean(actualDir)), strings.ToLower(suffix)) {
+		t.Skipf("test binary dir %q does not end with %q; skipping", actualDir, suffix)
+	}
+
+	localAppData := strings.TrimSuffix(filepath.Clean(actualDir), filepath.Clean(suffix))
+	localAppData = strings.TrimRight(localAppData, string(filepath.Separator))
+	t.Setenv("LOCALAPPDATA", localAppData)
+
+	for _, channel := range []Channel{ChannelStable, ChannelDaily} {
+		t.Run(string(channel), func(t *testing.T) {
+			var capturedArgs exec.RunArgs
+			captured := false
+
+			mockRunner := mockexec.NewMockCommandRunner()
+			mockRunner.When(func(args exec.RunArgs, command string) bool {
+				return strings.HasPrefix(command, "powershell")
+			}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				capturedArgs = args
+				captured = true
+				return exec.NewRunResult(0, "", ""), nil
+			})
+
+			m := NewManager(mockRunner, nil)
+			var buf strings.Builder
+			cfg := &UpdateConfig{Channel: channel}
+
+			// updateViaMSI will likely fail at backup/hash stage in test, but
+			// if the mock is reached we can validate the invocation.
+			_ = m.updateViaMSI(context.Background(), cfg, &buf)
+
+			if !captured {
+				t.Skip("powershell mock was not reached (backupCurrentExe failed in test env)")
+			}
+
+			require.Equal(t, "powershell", capturedArgs.Cmd, "expected powershell executable")
+
+			// Verify args match buildInstallScriptArgs output.
+			expectedArgs := buildInstallScriptArgs(channel)
+			require.Equal(t, expectedArgs, capturedArgs.Args)
+		})
+	}
 }

--- a/cli/azd/pkg/update/msi_windows_test.go
+++ b/cli/azd/pkg/update/msi_windows_test.go
@@ -11,10 +11,16 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockexec"
 	"github.com/stretchr/testify/require"
 )
+
+// NOTE: Automated testing of updateViaMSI invoking PowerShell with the correct
+// arguments and isStandardMSIInstall succeeding on a standard path are limited
+// because go test compiles to temp directories that never match the expected MSI
+// install path (Programs\Azure Dev CLI), and backupCurrentExe cannot rename the
+// running test binary. We rely on manual testing on actual per-user MSI installs
+// to validate these code paths.
 
 func TestExpectedPerUserInstallDir(t *testing.T) {
 	tests := []struct {
@@ -67,6 +73,7 @@ func TestBuildInstallScriptArgs(t *testing.T) {
 			},
 			wantNotContains: []string{
 				"-InstallFolder",
+				"-SkipVerify",
 			},
 		},
 		{
@@ -81,6 +88,9 @@ func TestBuildInstallScriptArgs(t *testing.T) {
 				"-InstallFolder",
 				expectedDir,
 				"Remove-Item",
+			},
+			wantNotContains: []string{
+				"-SkipVerify",
 			},
 		},
 	}
@@ -164,32 +174,6 @@ func TestBuildInstallScriptArgs_Structure(t *testing.T) {
 	require.Contains(t, scriptDaily, "-InstallFolder")
 	require.Contains(t, scriptDaily, expectedDir)
 	require.Contains(t, scriptDaily, "Remove-Item")
-}
-
-func TestIsStandardMSIInstall_StandardPath(t *testing.T) {
-	// Get the actual exe path and set LOCALAPPDATA so that
-	// expectedPerUserInstallDir() == filepath.Dir(exePath).
-	// expectedPerUserInstallDir = LOCALAPPDATA + \Programs\Azure Dev CLI
-	// So we need LOCALAPPDATA = filepath.Dir(exePath) stripped of "\Programs\Azure Dev CLI".
-	exePath, err := os.Executable()
-	require.NoError(t, err)
-	exePath, err = filepath.EvalSymlinks(exePath)
-	require.NoError(t, err)
-
-	actualDir := filepath.Dir(exePath)
-	suffix := filepath.Join("Programs", "Azure Dev CLI")
-	if !strings.HasSuffix(strings.ToLower(filepath.Clean(actualDir)), strings.ToLower(suffix)) {
-		// The test binary isn't in the expected suffix path (typical in CI/dev).
-		// Skip this test since we can't synthetically set LOCALAPPDATA to match.
-		t.Skipf("test binary dir %q does not end with %q; skipping standard-path test", actualDir, suffix)
-	}
-
-	localAppData := strings.TrimSuffix(filepath.Clean(actualDir), filepath.Clean(suffix))
-	localAppData = strings.TrimRight(localAppData, string(filepath.Separator))
-	t.Setenv("LOCALAPPDATA", localAppData)
-
-	err = isStandardMSIInstall()
-	require.NoError(t, err)
 }
 
 func TestIsStandardMSIInstall_NonStandardPath(t *testing.T) {
@@ -281,58 +265,4 @@ func TestUpdateViaMSI_NonStandardInstallBlocks(t *testing.T) {
 	var updateErr *UpdateError
 	require.True(t, errors.As(err, &updateErr))
 	require.Equal(t, CodeNonStandardInstall, updateErr.Code)
-}
-
-// TestUpdateViaMSI_InvokesPowerShellWithCorrectArgs verifies that updateViaMSI calls
-// "powershell" with the arguments produced by buildInstallScriptArgs.
-func TestUpdateViaMSI_InvokesPowerShellWithCorrectArgs(t *testing.T) {
-	// Point LOCALAPPDATA at the test binary so isStandardMSIInstall passes.
-	exePath, err := os.Executable()
-	require.NoError(t, err)
-	exePath, err = filepath.EvalSymlinks(exePath)
-	require.NoError(t, err)
-
-	actualDir := filepath.Dir(exePath)
-	suffix := filepath.Join("Programs", "Azure Dev CLI")
-	if !strings.HasSuffix(strings.ToLower(filepath.Clean(actualDir)), strings.ToLower(suffix)) {
-		t.Skipf("test binary dir %q does not end with %q; skipping", actualDir, suffix)
-	}
-
-	localAppData := strings.TrimSuffix(filepath.Clean(actualDir), filepath.Clean(suffix))
-	localAppData = strings.TrimRight(localAppData, string(filepath.Separator))
-	t.Setenv("LOCALAPPDATA", localAppData)
-
-	for _, channel := range []Channel{ChannelStable, ChannelDaily} {
-		t.Run(string(channel), func(t *testing.T) {
-			var capturedArgs exec.RunArgs
-			captured := false
-
-			mockRunner := mockexec.NewMockCommandRunner()
-			mockRunner.When(func(args exec.RunArgs, command string) bool {
-				return strings.HasPrefix(command, "powershell")
-			}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-				capturedArgs = args
-				captured = true
-				return exec.NewRunResult(0, "", ""), nil
-			})
-
-			m := NewManager(mockRunner, nil)
-			var buf strings.Builder
-			cfg := &UpdateConfig{Channel: channel}
-
-			// updateViaMSI will likely fail at backup/hash stage in test, but
-			// if the mock is reached we can validate the invocation.
-			_ = m.updateViaMSI(context.Background(), cfg, &buf)
-
-			if !captured {
-				t.Skip("powershell mock was not reached (backupCurrentExe failed in test env)")
-			}
-
-			require.Equal(t, "powershell", capturedArgs.Cmd, "expected powershell executable")
-
-			// Verify args match buildInstallScriptArgs output.
-			expectedArgs := buildInstallScriptArgs(channel)
-			require.Equal(t, expectedArgs, capturedArgs.Args)
-		})
-	}
 }

--- a/cli/azd/pkg/update/msi_windows_test.go
+++ b/cli/azd/pkg/update/msi_windows_test.go
@@ -42,31 +42,16 @@ func TestExpectedPerUserInstallDir(t *testing.T) {
 	}
 }
 
-func TestVersionFlag(t *testing.T) {
-	tests := []struct {
-		name    string
-		channel Channel
-		want    string
-	}{
-		{"stable channel", ChannelStable, "stable"},
-		{"daily channel", ChannelDaily, "daily"},
-		{"unknown defaults to stable", Channel("nightly"), "stable"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := versionFlag(tt.channel)
-			require.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func TestBuildInstallScriptArgs(t *testing.T) {
+	t.Setenv("LOCALAPPDATA", `C:\Users\testuser\AppData\Local`)
+	expectedDir := expectedPerUserInstallDir()
+
 	tests := []struct {
 		name    string
 		channel Channel
 		// We check that certain substrings appear in the constructed args
-		wantContains []string
+		wantContains    []string
+		wantNotContains []string
 	}{
 		{
 			name:    "stable",
@@ -76,8 +61,12 @@ func TestBuildInstallScriptArgs(t *testing.T) {
 				"-ExecutionPolicy", "Bypass",
 				"-Command",
 				installScriptURL,
-				"-Version 'stable'",
-				"-SkipVerify",
+				"Invoke-Expression",
+			},
+			wantNotContains: []string{
+				"-Version",
+				"-InstallFolder",
+				"Remove-Item",
 			},
 		},
 		{
@@ -89,7 +78,9 @@ func TestBuildInstallScriptArgs(t *testing.T) {
 				"-Command",
 				installScriptURL,
 				"-Version 'daily'",
-				"-SkipVerify",
+				"-InstallFolder",
+				expectedDir,
+				"Remove-Item",
 			},
 		},
 	}
@@ -105,26 +96,46 @@ func TestBuildInstallScriptArgs(t *testing.T) {
 			for _, s := range tt.wantContains {
 				require.Contains(t, joined, s, "expected args to contain %q", s)
 			}
+			for _, s := range tt.wantNotContains {
+				require.NotContains(t, joined, s, "expected args NOT to contain %q", s)
+			}
 		})
 	}
 }
 
 func TestBuildInstallScriptArgs_Structure(t *testing.T) {
+	t.Setenv("LOCALAPPDATA", `C:\Users\testuser\AppData\Local`)
+	expectedDir := expectedPerUserInstallDir()
+
 	args := buildInstallScriptArgs(ChannelStable)
 
-	// The args should be: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", <script>]
+	// Stable: ["-NoProfile", "-ExecutionPolicy", "AllSigned", "-Command", <script>]
 	require.Equal(t, 5, len(args), "expected exactly 5 args")
 	require.Equal(t, "-NoProfile", args[0])
 	require.Equal(t, "-ExecutionPolicy", args[1])
 	require.Equal(t, "Bypass", args[2])
 	require.Equal(t, "-Command", args[3])
 
-	// The script (args[4]) should be a single string containing the full PowerShell pipeline
+	// Stable pipes directly — no temp file download
 	script := args[4]
 	require.Contains(t, script, "Invoke-RestMethod")
 	require.Contains(t, script, installScriptURL)
-	require.Contains(t, script, "-SkipVerify")
-	require.Contains(t, script, "Remove-Item")
+	require.Contains(t, script, "Invoke-Expression")
+	require.NotContains(t, script, "-InstallFolder")
+	require.NotContains(t, script, "Remove-Item")
+	require.NotContains(t, script, "-Version")
+
+	// Daily downloads to temp file with -Version 'daily'
+	argsDaily := buildInstallScriptArgs(ChannelDaily)
+	require.Equal(t, 5, len(argsDaily))
+	require.Equal(t, "Bypass", argsDaily[2])
+	scriptDaily := argsDaily[4]
+	require.Contains(t, scriptDaily, "Invoke-RestMethod")
+	require.Contains(t, scriptDaily, installScriptURL)
+	require.Contains(t, scriptDaily, "-Version 'daily'")
+	require.Contains(t, scriptDaily, "-InstallFolder")
+	require.Contains(t, scriptDaily, expectedDir)
+	require.Contains(t, scriptDaily, "Remove-Item")
 }
 
 func TestIsStandardMSIInstall_StandardPath(t *testing.T) {

--- a/cli/azd/pkg/update/msi_windows_test.go
+++ b/cli/azd/pkg/update/msi_windows_test.go
@@ -109,7 +109,6 @@ func TestBuildInstallScriptArgs_Structure(t *testing.T) {
 
 	args := buildInstallScriptArgs(ChannelStable)
 
-	// Stable: ["-NoProfile", "-ExecutionPolicy", "AllSigned", "-Command", <script>]
 	require.Equal(t, 5, len(args), "expected exactly 5 args")
 	require.Equal(t, "-NoProfile", args[0])
 	require.Equal(t, "-ExecutionPolicy", args[1])


### PR DESCRIPTION
#7265 
This pull request refactors how the Windows MSI installation script arguments are constructed and tested, improving clarity and correctness for different release channels (stable vs. daily). The main change is to simplify and clarify the logic for building PowerShell command arguments, ensuring that stable and daily channels are handled distinctly and tested accordingly.

Refactoring and logic improvements for install script arguments:

* Replaced the `versionFlag` function and refactored `buildInstallScriptArgs` to directly construct the appropriate PowerShell command for each channel, ensuring that stable uses a piped script and daily downloads and executes the script with additional parameters.

Test updates for new logic and coverage:

* Removed the now-obsolete `TestVersionFlag` and updated `TestBuildInstallScriptArgs` to verify the presence or absence of key substrings in the generated arguments, matching the new logic for stable and daily channels. [[1]](diffhunk://#diff-54b83ff058baaa3f7634c7b08148a863ab682dd97d7931d60dc88a8278b7596eL45-R54) [[2]](diffhunk://#diff-54b83ff058baaa3f7634c7b08148a863ab682dd97d7931d60dc88a8278b7596eL79-R69) [[3]](diffhunk://#diff-54b83ff058baaa3f7634c7b08148a863ab682dd97d7931d60dc88a8278b7596eL92-R83)
* Enhanced `TestBuildInstallScriptArgs` and `TestBuildInstallScriptArgs_Structure` to check for correct argument construction, including validation that stable does not use temporary files or extra parameters, while daily does.