### PR TITLE
Fix nil panic when user declines preflight warnings

### DIFF
--- a/cli/azd/internal/cmd/provision.go
+++ b/cli/azd/internal/cmd/provision.go
@@ -424,10 +424,10 @@ func (p *ProvisionAction) Run(ctx context.Context) (*actions.ActionResult, error
 			}, nil
 		}
 
-		skipped := deployResult.SkippedReason == provisioning.DeploymentStateSkipped
+		skipped := isDeploymentSkipped(deployResult)
 		allSkipped = allSkipped && skipped
 		if skipped {
-			// Simply continue here; message is printed in the provider implementation
+			// Simply continue here; message is printed in the provider implementation.
 			continue
 		}
 
@@ -549,4 +549,13 @@ func GetCmdProvisionHelpDescription(c *cobra.Command) string {
 			fmt.Sprintf("\nWhen <layer> is specified, only provisions resources for the given layer." +
 				" When omitted, provisions resources for all layers defined in the project."),
 		})
+}
+
+// isDeploymentSkipped returns true if the deployment was skipped and the caller
+// should not access deployResult.Deployment (which may be nil).
+// A deployment is considered skipped when SkippedReason is non-empty, which includes
+// states such as DeploymentStateSkipped (no changes) and PreflightAbortedSkipped
+// (user declined after preflight warnings).
+func isDeploymentSkipped(deployResult *provisioning.DeployResult) bool {
+	return deployResult != nil && deployResult.SkippedReason != ""
 }

--- a/cli/azd/internal/cmd/provision_test.go
+++ b/cli/azd/internal/cmd/provision_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsDeploymentSkipped_AllSkipReasons verifies that isDeploymentSkipped
+// correctly identifies ALL skip reasons, not just DeploymentStateSkipped.
+//
+// Regression test for https://github.com/Azure/azure-dev/issues/7305:
+// When the user declines preflight validation warnings, Deploy returns
+// PreflightAbortedSkipped with a nil Deployment. If this skip reason is not
+// detected, the caller dereferences nil Deployment.Outputs and panics.
+func TestIsDeploymentSkipped_AllSkipReasons(t *testing.T) {
+	tests := []struct {
+		name          string
+		result        *provisioning.DeployResult
+		expectSkipped bool
+		nilDeployment bool
+	}{
+		{
+			name: "DeploymentStateSkipped",
+			result: &provisioning.DeployResult{
+				SkippedReason: provisioning.DeploymentStateSkipped,
+			},
+			expectSkipped: true,
+			nilDeployment: true,
+		},
+		{
+			// This is the regression case from issue #7305.
+			// Before the fix, this was NOT detected as skipped, causing a nil
+			// pointer dereference when accessing Deployment.Outputs.
+			name: "PreflightAbortedSkipped",
+			result: &provisioning.DeployResult{
+				SkippedReason: provisioning.PreflightAbortedSkipped,
+			},
+			expectSkipped: true,
+			nilDeployment: true,
+		},
+		{
+			name: "NotSkipped_WithDeployment",
+			result: &provisioning.DeployResult{
+				Deployment: &provisioning.Deployment{
+					Outputs: map[string]provisioning.OutputParameter{},
+				},
+			},
+			expectSkipped: false,
+			nilDeployment: false,
+		},
+		{
+			name:          "NilDeployResult",
+			result:        nil,
+			expectSkipped: false,
+			nilDeployment: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skipped := isDeploymentSkipped(tt.result)
+			require.Equal(t, tt.expectSkipped, skipped,
+				"isDeploymentSkipped returned unexpected value")
+
+			if tt.result == nil {
+				return
+			}
+
+			// Verify the Deployment nil/non-nil state matches expectations.
+			// This is important: the bug in #7305 was caused by accessing
+			// Deployment.Outputs when Deployment was nil.
+			if tt.nilDeployment {
+				require.Nil(t, tt.result.Deployment,
+					"when skipped, Deployment may be nil (accessing it would panic)")
+			} else {
+				require.NotNil(t, tt.result.Deployment,
+					"when not skipped, Deployment must not be nil (callers access Deployment.Outputs)")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Fixes #7305

When the user declines preflight validation warnings during `azd up`, the provisioning manager returns `DeployResult{SkippedReason: PreflightAbortedSkipped, Deployment: nil}`. The caller in `ProvisionAction.Run` only checked for `DeploymentStateSkipped`, so `PreflightAbortedSkipped` fell through to code that dereferences `Deployment.Outputs` — causing a nil pointer panic.

### Changes

- **Extract `isDeploymentSkipped()` helper** that checks `SkippedReason != ""` instead of matching a single constant. This catches all current and future skip reasons.
- **Add regression test** (`TestIsDeploymentSkipped_AllSkipReasons`) with 3 table-driven cases covering `DeploymentStateSkipped`, `PreflightAbortedSkipped`, and the non-skipped path.

### Testing

- `mage preflight` passes (gofmt, lint, spell check, build, all unit tests)
- Regression test demonstrated: fails with old logic, passes with fix