### PR TITLE
Fix panic on azd auth token unsupported output

### DIFF
--- a/cli/azd/cmd/auto_install.go
+++ b/cli/azd/cmd/auto_install.go
@@ -421,17 +421,18 @@ func ExecuteWithAutoInstall(ctx context.Context, rootContainer *ioc.NestedContai
 		// Known command, proceed with normal execution
 		err := rootCmd.ExecuteContext(ctx)
 
+		// Only attempt service-host auto-install when the command failed with that specific error.
+		// Other command errors (for example, unsupported output formats) should be returned directly.
+		unsupportedErr, ok := errors.AsType[*project.UnsupportedServiceHostError](err)
+		if !ok {
+			return err
+		}
+
 		if err := rootContainer.Resolve(&extensionManager); err != nil {
 			log.Panic("failed to resolve extension manager for auto-install:", err)
 		}
 		if err := rootContainer.Resolve(&console); err != nil {
 			log.Panic("failed to resolve console for unknown flags error:", err)
-		}
-
-		// auto-install for target service
-		unsupportedErr, ok := errors.AsType[*project.UnsupportedServiceHostError](err)
-		if !ok {
-			return err
 		}
 
 		requiredHost := unsupportedErr.Host

--- a/cli/azd/cmd/auto_install_integration_test.go
+++ b/cli/azd/cmd/auto_install_integration_test.go
@@ -4,12 +4,14 @@
 package cmd
 
 import (
+	"io"
 	"os"
 	"slices"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/runcontext/agentdetect"
+	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -75,6 +77,53 @@ func TestExecuteWithAutoInstallIntegration(t *testing.T) {
 
 	// Restore original args
 	os.Args = originalArgs
+}
+
+func TestExecuteWithAutoInstall_ReturnsCommandErrorWithoutPanicForOutputFlags(t *testing.T) {
+	originalArgs := os.Args
+	defer func() {
+		os.Args = originalArgs
+	}()
+
+	clearAgentEnvVarsForTest(t)
+	agentdetect.ResetDetection()
+	defer agentdetect.ResetDetection()
+
+	os.Args = []string{
+		"azd",
+		"auth",
+		"token",
+		"--scope",
+		"https://graph.microsoft.com/.default",
+		"--tenant-id",
+		"00000000-0000-0000-0000-000000000000",
+		"--output",
+		"none",
+	}
+
+	rootContainer := ioc.NewNestedContainer(nil)
+	stderrReader, stderrWriter, err := os.Pipe()
+	require.NoError(t, err)
+
+	originalStderr := os.Stderr
+	os.Stderr = stderrWriter
+	defer func() {
+		os.Stderr = originalStderr
+	}()
+
+	var execErr error
+	require.NotPanics(t, func() {
+		execErr = ExecuteWithAutoInstall(t.Context(), rootContainer)
+	})
+
+	require.NoError(t, stderrWriter.Close())
+
+	stderrBytes, err := io.ReadAll(stderrReader)
+	require.NoError(t, err)
+
+	require.ErrorContains(t, execErr, "unsupported format 'none'")
+	require.NotContains(t, string(stderrBytes), "panic:")
+	require.Contains(t, string(stderrBytes), "Error: unsupported format 'none'")
 }
 
 // TestAgentDetectionIntegration tests the full agent detection integration flow.

--- a/cli/azd/cmd/cobra_builder.go
+++ b/cli/azd/cmd/cobra_builder.go
@@ -131,7 +131,15 @@ func (cb *CobraBuilder) configureActionResolver(cmd *cobra.Command, descriptor *
 		actionName := createActionName(cmd)
 		_, err = middlewareRunner.RunAction(ctx, runOptions, actionName)
 
-		// At this point, we know that there might be an error, so we can silence cobra from showing it after us.
+		// Only silence Cobra if the command-scoped console can resolve. When console resolution fails
+		// (for example, because output formatter validation failed before UX middleware ran), we want
+		// Cobra to print the raw error instead of suppressing it.
+		if err != nil {
+			var console input.Console
+			cmd.SilenceErrors = cmdContainer.Resolve(&console) == nil
+			return err
+		}
+
 		cmd.SilenceErrors = true
 
 		return err

--- a/cli/azd/pkg/output/parameter.go
+++ b/cli/azd/pkg/output/parameter.go
@@ -67,7 +67,7 @@ func GetCommandFormatter(cmd *cobra.Command) (Formatter, error) {
 
 	supported := slices.Contains(supportedFormatters, desiredFormatter)
 	if !supported {
-		return nil, fmt.Errorf("unsupported format '%s'", desiredFormatter)
+		return nil, fmt.Errorf("unsupported format '%s' for --output", desiredFormatter)
 	}
 
 	// Check for --query flag and validate it requires JSON output


### PR DESCRIPTION
Fix panic on `azd auth token` unsupported output flag. 

## Changes:
- Update the happy-path handling in `auto_install.go` to short-circuit if the error isn't `UnsupportedServiceHostError`. 
- Fix the root execution flow in `cobra_builder.go` to correctly print error messages if console isn't resolvable (which happens in the case of the output formatter not instantiated from `--output` flag).

Closes #7303