### PR TITLE
Update uninstall instructions

### DIFF
--- a/cli/installer/README.md
+++ b/cli/installer/README.md
@@ -85,17 +85,7 @@ yum install -y azd-<version>-1.x86_64.rpm
 
 ### Windows
 
-#### Uninstalling 0.5.0-beta.1 and later
-
 The Azure Developer CLI uses MSI to install on Windows. Use the "Add or remove programs" dialog in Windows to remove the "Azure Developer CLI" application. 
-
-#### Uninstalling version 0.4.0-beta.1 and earlier
-
-Use this PowerShell script to uninstall Azure Developer CLI 0.4.0-beta.1 and earlier.
-
-```powershell
-powershell -ex AllSigned -c "Invoke-RestMethod 'https://aka.ms/uninstall-azd.ps1' | Invoke-Expression"
-```
 
 ### Linux/MacOS
 
@@ -236,18 +226,13 @@ To download and install the "daily" version of azd (most recent build)
 
 The Azure Developer CLI will write files to `~/.azd/` that are specific to the application's usage. Since this is user data uninstall processes do not alter or remove this data.
 
-### Windows 
- For versions released after `0.5.0-beta.1` use the following procedure to remove `azd`: 
+### Windows
+
+Use the following procedure to remove `azd`:
 
 1. Search for `Add or remove programs` in Windows
-2. Locate `Azure Developer CLI` 
+2. Locate `Azure Developer CLI`
 3. Select `Uninstall`
-
-Uninstall script for version s released before `0.5.0-beta.1` (does not work on versions `0.5.0-beta.1` and later): 
-
-```powershell
-powershell -ex AllSigned -c "Invoke-RestMethod 'https://aka.ms/uninstall-azd.ps1' | Invoke-Expression"
-```
 
 ### Linux/MacOS
 


### PR DESCRIPTION
These instructions applied to 0.5.0-beta.1 and before which were versions of azd released before January 2023. At this point, instructions about that produces more confusion than clarity.