### PR TITLE
Fix init with project-id when agent.yaml doesn't contain a model resource

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -568,9 +568,7 @@ func (a *InitAction) configureModelChoice(
 			}
 
 			if selectedProject == nil {
-				if err := ensureLocation(ctx, a.azdClient, a.azureContext, a.environment.Name); err != nil {
-					return nil, err
-				}
+				return nil, fmt.Errorf("foundry project not found: %s", a.flags.projectResourceId)
 			}
 		} else {
 			newCred, err := ensureSubscriptionAndLocation(

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_templates_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_templates_helpers.go
@@ -21,7 +21,7 @@ import (
 	"github.com/fatih/color"
 )
 
-const agentTemplatesURL = "https://raw.githubusercontent.com/therealjohn/awesome-azd/refs/heads/agent-tooling-templates/website/static/agent-templates.json"
+const agentTemplatesURL = "https://aka.ms/foundry-agents"
 
 // Template type constants
 const (


### PR DESCRIPTION
Copilot created
Fixes #7409 