### PR TITLE
[azd update] Improve error message by replacing non-standard install language with administrator-managed messaging

### DIFF
--- a/cli/azd/pkg/update/msi_windows.go
+++ b/cli/azd/pkg/update/msi_windows.go
@@ -139,9 +139,9 @@ func isStandardMSIInstall() error {
 	if !strings.EqualFold(filepath.Clean(actualDir), filepath.Clean(expectedDir)) {
 		return newUpdateError(CodeNonStandardInstall, fmt.Errorf(
 			"azd installation might be managed by an administrator (installed at: %s).\n"+
-				"Contact your administrator to update azd, or reinstall with the "+
-				"default configuration:\n"+
-				"  ALLUSERS=2  INSTALLDIR=\"%s\"\n"+
+				"Contact your administrator to update azd, or reinstall with a "+
+				"user-managed configuration:\n"+
+				"ALLUSERS=2 INSTALLDIR=\"%s\"\n"+
 				"See https://github.com/Azure/azure-dev/blob/main/cli/installer/README.md#msi-configuration\n"+
 				"To suppress update notifications, set AZD_SKIP_UPDATE_CHECK=1",
 			actualDir, expectedDir,

--- a/cli/azd/pkg/update/msi_windows.go
+++ b/cli/azd/pkg/update/msi_windows.go
@@ -138,11 +138,12 @@ func isStandardMSIInstall() error {
 	// Normalize both paths for comparison (case-insensitive on Windows, clean slashes)
 	if !strings.EqualFold(filepath.Clean(actualDir), filepath.Clean(expectedDir)) {
 		return newUpdateError(CodeNonStandardInstall, fmt.Errorf(
-			"azd is installed in a non-standard location: %s\n"+
-				"azd update only supports the default per-user install.\n"+
-				"Please reinstall azd with the default configuration:\n"+
+			"azd installation might be managed by an administrator (installed at: %s).\n"+
+				"Contact your administrator to update azd, or reinstall with the "+
+				"default configuration:\n"+
 				"  ALLUSERS=2  INSTALLDIR=\"%s\"\n"+
-				"See https://github.com/Azure/azure-dev/blob/main/cli/installer/README.md#msi-configuration",
+				"See https://github.com/Azure/azure-dev/blob/main/cli/installer/README.md#msi-configuration\n"+
+				"To suppress update notifications, set AZD_SKIP_UPDATE_CHECK=1",
 			actualDir, expectedDir,
 		))
 	}

--- a/cli/azd/pkg/update/msi_windows_test.go
+++ b/cli/azd/pkg/update/msi_windows_test.go
@@ -187,6 +187,7 @@ func TestIsStandardMSIInstall_NonStandardPath(t *testing.T) {
 	require.ErrorAs(t, err, &updateErr)
 	require.Equal(t, CodeNonStandardInstall, updateErr.Code)
 	require.Contains(t, err.Error(), "managed by an administrator")
+	require.Contains(t, err.Error(), "AZD_SKIP_UPDATE_CHECK=1")
 }
 
 func TestIsStandardMSIInstall_MissingLocalAppData(t *testing.T) {

--- a/cli/azd/pkg/update/msi_windows_test.go
+++ b/cli/azd/pkg/update/msi_windows_test.go
@@ -186,7 +186,7 @@ func TestIsStandardMSIInstall_NonStandardPath(t *testing.T) {
 	var updateErr *UpdateError
 	require.ErrorAs(t, err, &updateErr)
 	require.Equal(t, CodeNonStandardInstall, updateErr.Code)
-	require.Contains(t, err.Error(), "non-standard location")
+	require.Contains(t, err.Error(), "managed by an administrator")
 }
 
 func TestIsStandardMSIInstall_MissingLocalAppData(t *testing.T) {

--- a/cli/installer/README.md
+++ b/cli/installer/README.md
@@ -134,6 +134,8 @@ When installing using the MSI directly (instead of the install script) the MSI b
 | `ALLUSERS` | `2`: Default. Install for current user (no privilege elevation required). <br/> `1`: Install for _all_ users (may require privilege elevation). |
 | `INSTALLDIR` | Installation path. <br/> `"%LOCALAPPDATA%\Programs\Azure Dev CLI"`: Default. <br/> `"%PROGRAMFILES%\Azure Dev CLI"`: Default all users. |
 
+> **Note:** Installing per-machine (`ALLUSERS=1`) means the administrator is responsible for managing updates. To suppress update notifications in environments where administrators manage updates, set the `AZD_SKIP_UPDATE_CHECK=1` environment variable.
+
 ### Custom install location 
 
 #### Windows 


### PR DESCRIPTION
## Description
Fixes #7414

### Changes
1. **cli/azd/pkg/update/msi_windows.go** - Updated `isStandardMSIInstall()` error message:
   - Replaced `azd is installed in a non-standard location` with `azd installation might be managed by an administrator`
   - Changed guidance to suggest contacting the administrator or reinstalling with default config
   - Added `AZD_SKIP_UPDATE_CHECK=1` hint to suppress update notifications

2. **cli/azd/pkg/update/msi_windows_test.go** - Updated test assertion to match new message text

3. **cli/installer/README.md** - Added note after MSI configuration table documenting that per-machine installs (`ALLUSERS=1`) require the administrator to manage updates, with `AZD_SKIP_UPDATE_CHECK=1` to suppress notifications