### PR TITLE
Add jongio and wbreza as code owners on all rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,26 +8,26 @@
 /**                                         @wbreza @vhvb1989 @hemarina @weikanglim @JeffreyCA @tg-msft @rajeshkamal5050 @jongio
 
 # ── CLI installer ─────────────────────────────────────────────────────────────
-/cli/installer/                             @danieljurek @vhvb1989 @tg-msft @rajeshkamal5050
+/cli/installer/                             @jongio @wbreza @danieljurek @vhvb1989 @tg-msft @rajeshkamal5050
 
 # ── CLI extensions (AI) ──────────────────────────────────────────────────────
-/cli/azd/extensions/azure.ai.agents/        @wbreza @vhvb1989 @hemarina @weikanglim @JeffreyCA @tg-msft @rajeshkamal5050 @trangevi @trrwilson @therealjohn
-/cli/azd/extensions/azure.ai.finetune/      @wbreza @vhvb1989 @hemarina @weikanglim @JeffreyCA @tg-msft @rajeshkamal5050 @trangevi @achauhan-scc @kingernupur @rabollin @saanikaguptamicrosoft
-/cli/azd/extensions/azure.ai.models/        @wbreza @vhvb1989 @hemarina @weikanglim @JeffreyCA @tg-msft @rajeshkamal5050 @trangevi @achauhan-scc @kingernupur @rabollin @saanikaguptamicrosoft
+/cli/azd/extensions/azure.ai.agents/        @jongio @wbreza @vhvb1989 @hemarina @weikanglim @JeffreyCA @tg-msft @rajeshkamal5050 @trangevi @trrwilson @therealjohn
+/cli/azd/extensions/azure.ai.finetune/      @jongio @wbreza @vhvb1989 @hemarina @weikanglim @JeffreyCA @tg-msft @rajeshkamal5050 @trangevi @achauhan-scc @kingernupur @rabollin @saanikaguptamicrosoft
+/cli/azd/extensions/azure.ai.models/        @jongio @wbreza @vhvb1989 @hemarina @weikanglim @JeffreyCA @tg-msft @rajeshkamal5050 @trangevi @achauhan-scc @kingernupur @rabollin @saanikaguptamicrosoft
 
 # ── Extensions ────────────────────────────────────────────────────────────────
-/ext/                                       @karolz-ms @vhvb1989 @tg-msft @rajeshkamal5050
-/ext/azuredevops/                           @vhvb1989 @hemarina @tg-msft @rajeshkamal5050
-/ext/devcontainer/                          @vhvb1989 @hemarina @tg-msft @rajeshkamal5050
-/ext/vscode/                                @bwateratmsft @vhvb1989 @tg-msft @rajeshkamal5050 @karolz-ms
+/ext/                                       @jongio @wbreza @karolz-ms @vhvb1989 @tg-msft @rajeshkamal5050
+/ext/azuredevops/                           @jongio @wbreza @vhvb1989 @hemarina @tg-msft @rajeshkamal5050
+/ext/devcontainer/                          @jongio @wbreza @vhvb1989 @hemarina @tg-msft @rajeshkamal5050
+/ext/vscode/                                @jongio @wbreza @bwateratmsft @vhvb1989 @tg-msft @rajeshkamal5050 @karolz-ms
 
 # ── Infra / CI / Engineering ─────────────────────────────────────────────────
-/.github/                                   @danieljurek @vhvb1989 @tg-msft @rajeshkamal5050
-/eng/                                       @danieljurek @vhvb1989 @tg-msft @rajeshkamal5050
-/.config/1espt/                             @Azure/azure-sdk-eng
+/.github/                                   @jongio @wbreza @danieljurek @vhvb1989 @tg-msft @rajeshkamal5050
+/eng/                                       @jongio @wbreza @danieljurek @vhvb1989 @tg-msft @rajeshkamal5050
+/.config/1espt/                             @jongio @wbreza @Azure/azure-sdk-eng
 
 # ── Schemas ───────────────────────────────────────────────────────────────────
-/schemas/                                   @wbreza @vhvb1989 @tg-msft @rajeshkamal5050
+/schemas/                                   @jongio @wbreza @vhvb1989 @tg-msft @rajeshkamal5050
 
 # ── This file (most specific -- must be last for /.github/) ───────────────────
 /.github/CODEOWNERS                         @rajeshkamal5050 @Azure/azure-sdk-eng


### PR DESCRIPTION
## Summary

Add `@jongio` and `@wbreza` to every CODEOWNERS rule (except the `/.github/CODEOWNERS` rule itself) so that either of their approvals is sufficient for any PR, regardless of which path-specific rule matches.

## Changes

- Added `@jongio` and `@wbreza` to all CODEOWNERS rules where they were previously missing:
  - `/cli/installer/`
  - `/cli/azd/extensions/azure.ai.agents/`
  - `/cli/azd/extensions/azure.ai.finetune/`
  - `/cli/azd/extensions/azure.ai.models/`
  - `/ext/`
  - `/ext/azuredevops/`
  - `/ext/devcontainer/`
  - `/ext/vscode/`
  - `/.github/`
  - `/eng/`
  - `/.config/1espt/`
  - `/schemas/`
- The `/**` catch-all and AI extension rules already had both users; verified they remain correct
- The `/.github/CODEOWNERS` rule is intentionally **not** modified (ownership of that file stays with `@rajeshkamal5050` and `@Azure/azure-sdk-eng`)

## Motivation

Ensure `@jongio` and `@wbreza` can approve PRs touching any part of the repo without being blocked by path-specific ownership rules that previously excluded them.

*No related issue.*

---
*Co-authored-by: Copilot*
