### PR TITLE
fix: update mock expectations from SendMessage to SendMessageWithRetry

### DIFF
--- a/cli/azd/cmd/middleware/middleware_coverage2_test.go
+++ b/cli/azd/cmd/middleware/middleware_coverage2_test.go
@@ -1430,7 +1430,7 @@ func TestErrorMiddleware_Run_AgentSendMessageError(t *testing.T) {
 
 	ag := &mockAgent{}
 	ag.On("Stop").Return(nil)
-	ag.On("SendMessage", mock.Anything, mock.Anything, mock.Anything).
+	ag.On("SendMessageWithRetry", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, errors.New("model rate limited"))
 
 	factory := &mockAgentFactory{}
@@ -1695,7 +1695,7 @@ func TestErrorMiddleware_Run_ErrorWithTraceId(t *testing.T) {
 	console := mockinput.NewMockConsole()
 
 	ag := &mockAgent{}
-	ag.On("SendMessage", mock.Anything, mock.Anything, mock.Anything).
+	ag.On("SendMessageWithRetry", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, errors.New("agent failed"))
 	ag.On("Stop").Return(nil)
 
@@ -1737,7 +1737,7 @@ func TestErrorMiddleware_Run_SavedCategoryGuidance(t *testing.T) {
 	console := mockinput.NewMockConsole()
 
 	ag := &mockAgent{}
-	ag.On("SendMessage", mock.Anything, mock.Anything, mock.Anything).
+	ag.On("SendMessageWithRetry", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, errors.New("agent error"))
 	ag.On("Stop").Return(nil)
 
@@ -1771,7 +1771,7 @@ func TestErrorMiddleware_Run_SavedCategoryTroubleshoot(t *testing.T) {
 	console := mockinput.NewMockConsole()
 
 	ag := &mockAgent{}
-	ag.On("SendMessage", mock.Anything, mock.Anything, mock.Anything).
+	ag.On("SendMessageWithRetry", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, errors.New("agent error"))
 	ag.On("Stop").Return(nil)
 


### PR DESCRIPTION
## Summary

4 tests in `middleware_coverage2_test.go` were mocking `SendMessage` but production code (`error.go:247`) calls `SendMessageWithRetry`, causing test failures on main after PR #7424 merged.

## Changes

- Updated mock expectations in 4 tests from `SendMessage` to `SendMessageWithRetry`:
  - `TestErrorMiddleware_Run_AgentSendMessageError`
  - `TestErrorMiddleware_Run_ErrorWithTraceId`
  - `TestErrorMiddleware_Run_SavedCategoryGuidance`
  - `TestErrorMiddleware_Run_SavedCategoryTroubleshoot`

## Root Cause

PR #7401 renamed the agent method from `SendMessage` to `SendMessageWithRetry`. PR #7424 (coverage tests) was rebased onto main but these 4 string-literal mock expectations were missed -- they compile fine even when wrong, only failing at runtime.

## Testing

- All 4 affected tests pass
- Full `go test ./... -short` passes with zero failures