### PR TITLE
[Agents extension] Detect agent manifest at cwd

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -217,7 +217,11 @@ func newInitCommand(rootFlags *rootFlagsDefinition) *cobra.Command {
 				if checkDir == "" {
 					checkDir = "."
 				}
-				if detected := detectLocalManifest(checkDir); detected != "" {
+				detected, detectErr := detectLocalManifest(checkDir)
+				if detectErr != nil {
+					return fmt.Errorf("checking for existing manifest: %w", detectErr)
+				}
+				if detected != "" {
 					useExisting := flags.NoPrompt
 					if !flags.NoPrompt {
 						confirmResp, promptErr := azdClient.Prompt().Confirm(ctx, &azdext.ConfirmRequest{

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -71,6 +71,37 @@ func (a *InitFromCodeAction) Run(ctx context.Context) error {
 		a.flags.src = relPath
 	}
 
+	// Default src to current directory when not specified
+	srcDir := a.flags.src
+	if srcDir == "" {
+		srcDir = "."
+	}
+
+	// Check if agent.yaml already exists before the interactive setup so the user
+	// doesn't complete the full agent configuration only to have it discarded.
+	agentYamlPath := filepath.Join(srcDir, "agent.yaml")
+	if _, statErr := os.Stat(agentYamlPath); statErr == nil {
+		if a.flags.NoPrompt {
+			return exterrors.Cancelled("agent.yaml already exists; overwrite declined in no-prompt mode")
+		}
+
+		confirmResp, err := a.azdClient.Prompt().Confirm(ctx, &azdext.ConfirmRequest{
+			Options: &azdext.ConfirmOptions{
+				Message:      fmt.Sprintf("An agent.yaml already exists in %q. Overwrite?", srcDir),
+				DefaultValue: new(false),
+			},
+		})
+		if err != nil {
+			if exterrors.IsCancellation(err) {
+				return exterrors.Cancelled("overwrite confirmation was cancelled")
+			}
+			return fmt.Errorf("prompting for overwrite confirmation: %w", err)
+		}
+		if !*confirmResp.Value {
+			return exterrors.Cancelled("agent.yaml already exists; overwrite declined")
+		}
+	}
+
 	// No manifest pointer provided - process local agent code
 	// Create a definition based on user prompts
 	localDefinition, err := a.createDefinitionFromLocalAgent(ctx)
@@ -79,33 +110,6 @@ func (a *InitFromCodeAction) Run(ctx context.Context) error {
 	}
 
 	if localDefinition != nil {
-		// Default src to current directory when not specified
-		srcDir := a.flags.src
-		if srcDir == "" {
-			srcDir = "."
-		}
-
-		// Check if agent.yaml already exists and prompt before overwriting
-		agentYamlPath := filepath.Join(srcDir, "agent.yaml")
-		if _, statErr := os.Stat(agentYamlPath); statErr == nil {
-			if !a.flags.NoPrompt {
-				confirmResp, err := a.azdClient.Prompt().Confirm(ctx, &azdext.ConfirmRequest{
-					Options: &azdext.ConfirmOptions{
-						Message:      fmt.Sprintf("An agent.yaml already exists in %q. Overwrite?", srcDir),
-						DefaultValue: new(false),
-					},
-				})
-				if err != nil {
-					if exterrors.IsCancellation(err) {
-						return exterrors.Cancelled("overwrite confirmation was cancelled")
-					}
-					return fmt.Errorf("prompting for overwrite confirmation: %w", err)
-				}
-				if !*confirmResp.Value {
-					return exterrors.Cancelled("agent.yaml already exists; overwrite declined")
-				}
-			}
-		}
 
 		// Write the definition to a file in the src directory
 		_, err := a.writeDefinitionToSrcDir(localDefinition, srcDir)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_templates_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_templates_helpers.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -263,19 +264,31 @@ func findAgentManifest(dir string) (string, error) {
 }
 
 // detectLocalManifest checks only the immediate directory for an agent manifest file.
-// Returns the path to the found manifest, preferring agent.manifest.yaml over agent.yaml,
-// or an empty string if neither exists or none contain valid manifest content.
-func detectLocalManifest(dir string) string {
-	// Prefer agent.manifest.yaml (richer manifest format) over agent.yaml.
-	for _, name := range []string{"agent.manifest.yaml", "agent.yaml"} {
+// Returns the path to the found manifest (preferring agent.manifest.yaml over agent.yaml,
+// then .yml variants), or an empty string if none contain valid manifest content.
+// Returns a non-nil error for unexpected I/O failures (e.g. permission errors).
+func detectLocalManifest(dir string) (string, error) {
+	candidates := []string{
+		"agent.manifest.yaml",
+		"agent.yaml",
+		"agent.manifest.yml",
+		"agent.yml",
+	}
+
+	for _, name := range candidates {
 		candidate := filepath.Join(dir, name)
-		if _, err := os.Stat(candidate); err == nil {
-			if isValidManifestFile(candidate) {
-				return candidate
-			}
+		_, err := os.Stat(candidate)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return "", fmt.Errorf("checking for manifest %s: %w", candidate, err)
+		}
+		if isValidManifestFile(candidate) {
+			return candidate, nil
 		}
 	}
-	return ""
+	return "", nil
 }
 
 // isValidManifestFile reads the file and checks whether it can be loaded as

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_templates_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_templates_helpers_test.go
@@ -317,7 +317,8 @@ template:
 		dir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "main.py"), []byte("print()"), 0600))
 
-		result := detectLocalManifest(dir)
+		result, err := detectLocalManifest(dir)
+		require.NoError(t, err)
 		require.Empty(t, result)
 	})
 
@@ -326,7 +327,8 @@ template:
 		dir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.yaml"), []byte(validManifest), 0600))
 
-		result := detectLocalManifest(dir)
+		result, err := detectLocalManifest(dir)
+		require.NoError(t, err)
 		require.Equal(t, filepath.Join(dir, "agent.yaml"), result)
 	})
 
@@ -335,7 +337,8 @@ template:
 		dir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.manifest.yaml"), []byte(validManifest), 0600))
 
-		result := detectLocalManifest(dir)
+		result, err := detectLocalManifest(dir)
+		require.NoError(t, err)
 		require.Equal(t, filepath.Join(dir, "agent.manifest.yaml"), result)
 	})
 
@@ -345,7 +348,8 @@ template:
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.yaml"), []byte(validManifest), 0600))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.manifest.yaml"), []byte(validManifest), 0600))
 
-		result := detectLocalManifest(dir)
+		result, err := detectLocalManifest(dir)
+		require.NoError(t, err)
 		require.Equal(t, filepath.Join(dir, "agent.manifest.yaml"), result)
 	})
 
@@ -356,7 +360,8 @@ template:
 		require.NoError(t, os.MkdirAll(subDir, 0700))
 		require.NoError(t, os.WriteFile(filepath.Join(subDir, "agent.yaml"), []byte(validManifest), 0600))
 
-		result := detectLocalManifest(dir)
+		result, err := detectLocalManifest(dir)
+		require.NoError(t, err)
 		require.Empty(t, result)
 	})
 
@@ -364,7 +369,8 @@ template:
 		t.Parallel()
 		dir := t.TempDir()
 
-		result := detectLocalManifest(dir)
+		result, err := detectLocalManifest(dir)
+		require.NoError(t, err)
 		require.Empty(t, result)
 	})
 
@@ -373,7 +379,8 @@ template:
 		dir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.yaml"), []byte("not: valid: yaml: ["), 0600))
 
-		result := detectLocalManifest(dir)
+		result, err := detectLocalManifest(dir)
+		require.NoError(t, err)
 		require.Empty(t, result)
 	})
 
@@ -382,7 +389,8 @@ template:
 		dir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.yaml"), []byte("foo: bar\n"), 0600))
 
-		result := detectLocalManifest(dir)
+		result, err := detectLocalManifest(dir)
+		require.NoError(t, err)
 		require.Empty(t, result)
 	})
 
@@ -392,7 +400,39 @@ template:
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.manifest.yaml"), []byte("foo: bar\n"), 0600))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.yaml"), []byte(validManifest), 0600))
 
-		result := detectLocalManifest(dir)
+		result, err := detectLocalManifest(dir)
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(dir, "agent.yaml"), result)
+	})
+
+	t.Run("detects agent.yml variant", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.yml"), []byte(validManifest), 0600))
+
+		result, err := detectLocalManifest(dir)
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(dir, "agent.yml"), result)
+	})
+
+	t.Run("detects agent.manifest.yml variant", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.manifest.yml"), []byte(validManifest), 0600))
+
+		result, err := detectLocalManifest(dir)
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(dir, "agent.manifest.yml"), result)
+	})
+
+	t.Run("prefers yaml over yml", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.yaml"), []byte(validManifest), 0600))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.yml"), []byte(validManifest), 0600))
+
+		result, err := detectLocalManifest(dir)
+		require.NoError(t, err)
 		require.Equal(t, filepath.Join(dir, "agent.yaml"), result)
 	})
 }


### PR DESCRIPTION
On `init`, detect if there's a manifest in the current working directory and ask if the user wants to use that one.