### PR TITLE
Publish azure.ai.agents v0.1.20-preview to registry

### DIFF
--- a/cli/azd/cmd/testdata/TestFigSpec.ts
+++ b/cli/azd/cmd/testdata/TestFigSpec.ts
@@ -278,11 +278,20 @@ const completionSpec: Fig.Spec = {
 							description: 'Send a message to your agent.',
 							options: [
 								{
-									name: ['--conversation'],
+									name: ['--conversation-id'],
 									description: 'Explicit conversation ID override',
 									args: [
 										{
-											name: 'conversation',
+											name: 'conversation-id',
+										},
+									],
+								},
+								{
+									name: ['--input-file', '-f'],
+									description: 'Path to a file whose contents are sent as the request body',
+									args: [
+										{
+											name: 'input-file',
 										},
 									],
 								},
@@ -308,11 +317,11 @@ const completionSpec: Fig.Spec = {
 									],
 								},
 								{
-									name: ['--session', '-s'],
+									name: ['--session-id', '-s'],
 									description: 'Explicit session ID override',
 									args: [
 										{
-											name: 'session',
+											name: 'session-id',
 										},
 									],
 								},

--- a/cli/azd/extensions/registry.json
+++ b/cli/azd/extensions/registry.json
@@ -3025,6 +3025,82 @@
               "url": "https://github.com/Azure/azure-dev/releases/download/azd-ext-azure-ai-agents_0.1.19-preview/azure-ai-agents-windows-arm64.zip"
             }
           }
+        },
+        {
+          "version": "0.1.20-preview",
+          "requiredAzdVersion": "\u003e1.23.6",
+          "capabilities": [
+            "custom-commands",
+            "lifecycle-events",
+            "mcp-server",
+            "service-target-provider",
+            "metadata"
+          ],
+          "providers": [
+            {
+              "name": "azure.ai.agent",
+              "type": "service-target",
+              "description": "Deploys agents to the Foundry Agent Service"
+            }
+          ],
+          "usage": "azd ai agent \u003ccommand\u003e [options]",
+          "examples": [
+            {
+              "name": "init",
+              "description": "Initialize a new AI agent project.",
+              "usage": "azd ai agent init"
+            }
+          ],
+          "artifacts": {
+            "darwin/amd64": {
+              "checksum": {
+                "algorithm": "sha256",
+                "value": "7ebdead1c9f6a5e4ed4ecb619654d7cd2167043207d545f2340285b5bf73896e"
+              },
+              "entryPoint": "azure-ai-agents-darwin-amd64",
+              "url": "https://github.com/Azure/azure-dev/releases/download/azd-ext-azure-ai-agents_0.1.20-preview/azure-ai-agents-darwin-amd64.zip"
+            },
+            "darwin/arm64": {
+              "checksum": {
+                "algorithm": "sha256",
+                "value": "27deab2e9eeb91d34e3c7a6767bdaa62b5ee69ed766f1029dbb4d51b025cd2db"
+              },
+              "entryPoint": "azure-ai-agents-darwin-arm64",
+              "url": "https://github.com/Azure/azure-dev/releases/download/azd-ext-azure-ai-agents_0.1.20-preview/azure-ai-agents-darwin-arm64.zip"
+            },
+            "linux/amd64": {
+              "checksum": {
+                "algorithm": "sha256",
+                "value": "5888303efb6e2d67e41b5d78d592b4a8d3097077e6f20267a87d0ea88bd0a438"
+              },
+              "entryPoint": "azure-ai-agents-linux-amd64",
+              "url": "https://github.com/Azure/azure-dev/releases/download/azd-ext-azure-ai-agents_0.1.20-preview/azure-ai-agents-linux-amd64.tar.gz"
+            },
+            "linux/arm64": {
+              "checksum": {
+                "algorithm": "sha256",
+                "value": "973c938ed1945e745337495978262b13f5fb8aa64718f75f7411669aba713db5"
+              },
+              "entryPoint": "azure-ai-agents-linux-arm64",
+              "url": "https://github.com/Azure/azure-dev/releases/download/azd-ext-azure-ai-agents_0.1.20-preview/azure-ai-agents-linux-arm64.tar.gz"
+            },
+            "windows/amd64": {
+              "checksum": {
+                "algorithm": "sha256",
+                "value": "d41544242411dd4b9f2bfca45e66717740ca5ec324de22e45ff1551d71ee74b5"
+              },
+              "entryPoint": "azure-ai-agents-windows-amd64.exe",
+              "url": "https://github.com/Azure/azure-dev/releases/download/azd-ext-azure-ai-agents_0.1.20-preview/azure-ai-agents-windows-amd64.zip"
+            },
+            "windows/arm64": {
+              "checksum": {
+                "algorithm": "sha256",
+                "value": "5f18fae3cc684582b2cd87262c51fad69db16d6514d792f117b2c0f0d831d701"
+              },
+              "entryPoint": "azure-ai-agents-windows-arm64.exe",
+              "url": "https://github.com/Azure/azure-dev/releases/download/azd-ext-azure-ai-agents_0.1.20-preview/azure-ai-agents-windows-arm64.zip"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
Add version 0.1.20-preview of the azure.ai.agents extension to the official registry.

**Changes:**
- Added v0.1.20-preview entry to `cli/azd/extensions/registry.json`
- Updated FigSpec snapshot (flag renames in new version metadata)