### PR TITLE
Fix changelog skill to list version.txt inline

### DIFF
--- a/.github/skills/changelog-generation/SKILL.md
+++ b/.github/skills/changelog-generation/SKILL.md
@@ -45,10 +45,13 @@ Auto-detect scope from the current working directory:
 
 ### Step 2 — Determine Version & Update Files
 
-Per [references/scope-rules.md](references/scope-rules.md) § Version Files.
+**Files to update (core):** `cli/azd/CHANGELOG.md`, `cli/version.txt`
+**Files to update (extension):** `<extension>/CHANGELOG.md`, `<extension>/version.txt`, `<extension>/extension.yaml`
 
-- **Core**: derive version from the existing unreleased header (strip `-beta.*` and `(Unreleased)`), use today's date.
-- **Extension**: ask the user for the new version number via `ask_user`.
+For version derivation rules, see [references/scope-rules.md](references/scope-rules.md) § Version Files.
+
+- **Core**: derive version from the existing unreleased header (strip `-beta.*` and `(Unreleased)`), use today's date. Update `cli/version.txt` to the released version.
+- **Extension**: ask the user for the new version number via `ask_user`. Update both `version.txt` and `extension.yaml` — they must match exactly.
 
 Present the version and date to the user for confirmation before writing any files.
 


### PR DESCRIPTION
Skill was delegating file update instructions to a reference file. Coding agent skipped the reference and missed updating `version.txt`.

Lists the files to update inline in Step 2 so they cannot be missed. Reference file kept for version derivation details.

Fixes #7508