### PR TITLE
Fix fig spec: action flag values and environment option deduplication

### DIFF
--- a/cli/azd/cmd/copilot.go
+++ b/cli/azd/cmd/copilot.go
@@ -126,7 +126,7 @@ func (f *copilotConsentListFlags) Bind(local *pflag.FlagSet, global *internal.Gl
 	)
 	local.StringVar(&f.target, "target", "", "Specific target to operate on (server/tool format)")
 	local.StringVar(&f.operation, "operation", "", "Operation to filter by (tool, sampling)")
-	local.StringVar(&f.action, "action", "", "Action type to filter by (readonly, any)")
+	local.StringVar(&f.action, "action", "", "Action type to filter by (all, readonly)")
 	local.StringVar(&f.permission, "permission", "", "Permission to filter by (allow, deny, prompt)")
 }
 
@@ -185,7 +185,7 @@ func (f *copilotConsentRevokeFlags) Bind(local *pflag.FlagSet, global *internal.
 	)
 	local.StringVar(&f.target, "target", "", "Specific target to operate on (server/tool format)")
 	local.StringVar(&f.operation, "operation", "", "Operation to filter by (tool, sampling)")
-	local.StringVar(&f.action, "action", "", "Action type to filter by (readonly, any)")
+	local.StringVar(&f.action, "action", "", "Action type to filter by (all, readonly)")
 	local.StringVar(&f.permission, "permission", "", "Permission to filter by (allow, deny, prompt)")
 }
 

--- a/cli/azd/cmd/testdata/TestFigSpec.ts
+++ b/cli/azd/cmd/testdata/TestFigSpec.ts
@@ -1549,7 +1549,7 @@ const completionSpec: Fig.Spec = {
 							options: [
 								{
 									name: ['--action'],
-									description: 'Action type to filter by (readonly, any)',
+									description: 'Action type to filter by (all, readonly)',
 									args: [
 										{
 											name: 'action',
@@ -1604,7 +1604,7 @@ const completionSpec: Fig.Spec = {
 							options: [
 								{
 									name: ['--action'],
-									description: 'Action type to filter by (readonly, any)',
+									description: 'Action type to filter by (all, readonly)',
 									args: [
 										{
 											name: 'action',
@@ -1728,15 +1728,6 @@ const completionSpec: Fig.Spec = {
 					description: 'Deploys all services that are listed in azure.yaml',
 				},
 				{
-					name: ['--environment', '-e'],
-					description: 'The name of the environment to use.',
-					args: [
-						{
-							name: 'environment',
-						},
-					],
-				},
-				{
 					name: ['--from-package'],
 					description: 'Deploys the packaged service located at the provided path. Supports zipped file packages (file path) or container images (image tag).',
 					args: [
@@ -1765,15 +1756,6 @@ const completionSpec: Fig.Spec = {
 			description: 'Delete your project\'s Azure resources.',
 			options: [
 				{
-					name: ['--environment', '-e'],
-					description: 'The name of the environment to use.',
-					args: [
-						{
-							name: 'environment',
-						},
-					],
-				},
-				{
 					name: ['--force'],
 					description: 'Does not require confirmation before it deletes resources.',
 					isDangerous: true,
@@ -1800,17 +1782,6 @@ const completionSpec: Fig.Spec = {
 						{
 							name: ['get'],
 							description: 'Gets a configuration value from the environment.',
-							options: [
-								{
-									name: ['--environment', '-e'],
-									description: 'The name of the environment to use.',
-									args: [
-										{
-											name: 'environment',
-										},
-									],
-								},
-							],
 							args: {
 								name: 'path',
 							},
@@ -1818,17 +1789,6 @@ const completionSpec: Fig.Spec = {
 						{
 							name: ['set'],
 							description: 'Sets a configuration value in the environment.',
-							options: [
-								{
-									name: ['--environment', '-e'],
-									description: 'The name of the environment to use.',
-									args: [
-										{
-											name: 'environment',
-										},
-									],
-								},
-							],
 							args: [
 								{
 									name: 'path',
@@ -1841,17 +1801,6 @@ const completionSpec: Fig.Spec = {
 						{
 							name: ['unset'],
 							description: 'Unsets a configuration value in the environment.',
-							options: [
-								{
-									name: ['--environment', '-e'],
-									description: 'The name of the environment to use.',
-									args: [
-										{
-											name: 'environment',
-										},
-									],
-								},
-							],
 							args: {
 								name: 'path',
 							},
@@ -1861,17 +1810,6 @@ const completionSpec: Fig.Spec = {
 				{
 					name: ['get-value'],
 					description: 'Get specific environment value.',
-					options: [
-						{
-							name: ['--environment', '-e'],
-							description: 'The name of the environment to use.',
-							args: [
-								{
-									name: 'environment',
-								},
-							],
-						},
-					],
 					args: {
 						name: 'keyName',
 						generators: azdGenerators.listEnvironmentVariables,
@@ -1880,17 +1818,6 @@ const completionSpec: Fig.Spec = {
 				{
 					name: ['get-values'],
 					description: 'Get all environment values.',
-					options: [
-						{
-							name: ['--environment', '-e'],
-							description: 'The name of the environment to use.',
-							args: [
-								{
-									name: 'environment',
-								},
-							],
-						},
-					],
 				},
 				{
 					name: ['list', 'ls'],
@@ -1928,15 +1855,6 @@ const completionSpec: Fig.Spec = {
 					description: 'Refresh environment values by using information from a previous infrastructure provision.',
 					options: [
 						{
-							name: ['--environment', '-e'],
-							description: 'The name of the environment to use.',
-							args: [
-								{
-									name: 'environment',
-								},
-							],
-						},
-						{
 							name: ['--hint'],
 							description: 'Hint to help identify the environment to refresh',
 							args: [
@@ -1964,15 +1882,6 @@ const completionSpec: Fig.Spec = {
 					description: 'Remove an environment.',
 					options: [
 						{
-							name: ['--environment', '-e'],
-							description: 'The name of the environment to use.',
-							args: [
-								{
-									name: 'environment',
-								},
-							],
-						},
-						{
 							name: ['--force'],
 							description: 'Skips confirmation before performing removal.',
 							isDangerous: true,
@@ -1995,15 +1904,6 @@ const completionSpec: Fig.Spec = {
 					name: ['set'],
 					description: 'Set one or more environment values.',
 					options: [
-						{
-							name: ['--environment', '-e'],
-							description: 'The name of the environment to use.',
-							args: [
-								{
-									name: 'environment',
-								},
-							],
-						},
 						{
 							name: ['--file'],
 							description: 'Path to .env formatted file to load environment values from.',
@@ -2028,17 +1928,6 @@ const completionSpec: Fig.Spec = {
 				{
 					name: ['set-secret'],
 					description: 'Set a name as a reference to a Key Vault secret in the environment.',
-					options: [
-						{
-							name: ['--environment', '-e'],
-							description: 'The name of the environment to use.',
-							args: [
-								{
-									name: 'environment',
-								},
-							],
-						},
-					],
 					args: {
 						name: 'name',
 					},
@@ -2252,15 +2141,6 @@ const completionSpec: Fig.Spec = {
 					description: 'Runs the specified hook for the project, provisioning layers, and services',
 					options: [
 						{
-							name: ['--environment', '-e'],
-							description: 'The name of the environment to use.',
-							args: [
-								{
-									name: 'environment',
-								},
-							],
-						},
-						{
 							name: ['--layer'],
 							description: 'Only runs hooks for the specified provisioning layer.',
 							args: [
@@ -2321,15 +2201,6 @@ const completionSpec: Fig.Spec = {
 					description: 'Write IaC for your project to disk, allowing you to manually manage it.',
 					options: [
 						{
-							name: ['--environment', '-e'],
-							description: 'The name of the environment to use.',
-							args: [
-								{
-									name: 'environment',
-								},
-							],
-						},
-						{
 							name: ['--force'],
 							description: 'Overwrite any existing files without prompting',
 							isDangerous: true,
@@ -2348,15 +2219,6 @@ const completionSpec: Fig.Spec = {
 					args: [
 						{
 							name: 'branch',
-						},
-					],
-				},
-				{
-					name: ['--environment', '-e'],
-					description: 'The name of the environment to use.',
-					args: [
-						{
-							name: 'environment',
 						},
 					],
 				},
@@ -2428,15 +2290,6 @@ const completionSpec: Fig.Spec = {
 			description: 'Monitor a deployed project.',
 			options: [
 				{
-					name: ['--environment', '-e'],
-					description: 'The name of the environment to use.',
-					args: [
-						{
-							name: 'environment',
-						},
-					],
-				},
-				{
 					name: ['--live'],
 					description: 'Open a browser to Application Insights Live Metrics. Live Metrics is currently not supported for Python apps.',
 				},
@@ -2457,15 +2310,6 @@ const completionSpec: Fig.Spec = {
 				{
 					name: ['--all'],
 					description: 'Packages all services that are listed in azure.yaml',
-				},
-				{
-					name: ['--environment', '-e'],
-					description: 'The name of the environment to use.',
-					args: [
-						{
-							name: 'environment',
-						},
-					],
 				},
 				{
 					name: ['--output-path'],
@@ -2506,15 +2350,6 @@ const completionSpec: Fig.Spec = {
 								{
 									name: 'auth-type',
 									suggestions: ['federated', 'client-credentials'],
-								},
-							],
-						},
-						{
-							name: ['--environment', '-e'],
-							description: 'The name of the environment to use.',
-							args: [
-								{
-									name: 'environment',
 								},
 							],
 						},
@@ -2574,15 +2409,6 @@ const completionSpec: Fig.Spec = {
 			description: 'Provision Azure resources for your project.',
 			options: [
 				{
-					name: ['--environment', '-e'],
-					description: 'The name of the environment to use.',
-					args: [
-						{
-							name: 'environment',
-						},
-					],
-				},
-				{
 					name: ['--location', '-l'],
 					description: 'Azure location for the new environment',
 					args: [
@@ -2623,15 +2449,6 @@ const completionSpec: Fig.Spec = {
 					description: 'Publishes all services that are listed in azure.yaml',
 				},
 				{
-					name: ['--environment', '-e'],
-					description: 'The name of the environment to use.',
-					args: [
-						{
-							name: 'environment',
-						},
-					],
-				},
-				{
 					name: ['--from-package'],
 					description: 'Publishes the service from a container image (image tag).',
 					args: [
@@ -2663,15 +2480,6 @@ const completionSpec: Fig.Spec = {
 					name: ['--all'],
 					description: 'Restores all services that are listed in azure.yaml',
 				},
-				{
-					name: ['--environment', '-e'],
-					description: 'The name of the environment to use.',
-					args: [
-						{
-							name: 'environment',
-						},
-					],
-				},
 			],
 			args: {
 				name: 'service',
@@ -2682,15 +2490,6 @@ const completionSpec: Fig.Spec = {
 			name: ['show'],
 			description: 'Display information about your project and its resources.',
 			options: [
-				{
-					name: ['--environment', '-e'],
-					description: 'The name of the environment to use.',
-					args: [
-						{
-							name: 'environment',
-						},
-					],
-				},
 				{
 					name: ['--show-secrets'],
 					description: 'Unmask secrets in output.',
@@ -2799,15 +2598,6 @@ const completionSpec: Fig.Spec = {
 			name: ['up'],
 			description: 'Provision and deploy your project to Azure with a single command.',
 			options: [
-				{
-					name: ['--environment', '-e'],
-					description: 'The name of the environment to use.',
-					args: [
-						{
-							name: 'environment',
-						},
-					],
-				},
 				{
 					name: ['--location', '-l'],
 					description: 'Azure location for the new environment',

--- a/cli/azd/cmd/testdata/TestUsage-azd-copilot-consent-list.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-copilot-consent-list.snap
@@ -5,7 +5,7 @@ Usage
   azd copilot consent list [flags]
 
 Flags
-        --action string     	: Action type to filter by (readonly, any)
+        --action string     	: Action type to filter by (all, readonly)
         --operation string  	: Operation to filter by (tool, sampling)
         --permission string 	: Permission to filter by (allow, deny, prompt)
         --scope string      	: Consent scope to filter by (global, project). If not specified, lists rules from all scopes.

--- a/cli/azd/cmd/testdata/TestUsage-azd-copilot-consent-revoke.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-copilot-consent-revoke.snap
@@ -5,7 +5,7 @@ Usage
   azd copilot consent revoke [flags]
 
 Flags
-        --action string     	: Action type to filter by (readonly, any)
+        --action string     	: Action type to filter by (all, readonly)
         --operation string  	: Operation to filter by (tool, sampling)
         --permission string 	: Permission to filter by (allow, deny, prompt)
         --scope string      	: Consent scope to filter by (global, project). If not specified, revokes rules from all scopes.

--- a/cli/azd/internal/figspec/spec_builder.go
+++ b/cli/azd/internal/figspec/spec_builder.go
@@ -190,8 +190,10 @@ func (sb *SpecBuilder) generateOptions(flagSet *pflag.FlagSet, commandPath strin
 			return
 		}
 
-		// Skip non-persistent global flags for subcommands since they're already defined as persistent at root
-		if !persistent && slices.Contains(cmd.NonPersistentGlobalFlags, flag.Name) {
+		// Skip global flags for subcommands since they're already defined as persistent at root.
+		// This covers both persistent global flags (--environment, --cwd, etc.) and
+		// non-persistent global flags (--help, --docs) to avoid duplicate option entries.
+		if !persistent && sb.globalFlagNames[flag.Name] {
 			return
 		}
 

--- a/cli/azd/internal/figspec/spec_builder.go
+++ b/cli/azd/internal/figspec/spec_builder.go
@@ -190,8 +190,9 @@ func (sb *SpecBuilder) generateOptions(flagSet *pflag.FlagSet, commandPath strin
 			return
 		}
 
-		// Skip global flags for subcommands since they're already defined as persistent at root.
-		// This covers both persistent global flags (--environment, --cwd, etc.) and
+		// Skip global flags when generating non-persistent (local) options.
+		// These are already defined as persistent at root level, covering both
+		// persistent global flags (--environment, --cwd, etc.) and
 		// non-persistent global flags (--help, --docs) to avoid duplicate option entries.
 		if !persistent && sb.globalFlagNames[flag.Name] {
 			return


### PR DESCRIPTION
Addresses review comments from https://github.com/microsoft/vscode/pull/308613.

### Changes

- **Fix `--action` flag description** in `copilot consent list` and `copilot consent revoke`: changed `(readonly, any)` to `(all, readonly)` to match actual valid values and fig spec suggestions
- **Deduplicate `--environment` option** in fig spec: skip persistent global flags when generating per-command options, since they're already defined at root level as `persistentOptions`. Removes ~200 lines of duplicate entries from the generated spec