### PR TITLE
azure.ai.agents - reduce noisy logs in `azd ai agent init` and redirect `log` output when `--debug` is used

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/AGENTS.md
+++ b/cli/azd/extensions/azure.ai.agents/AGENTS.md
@@ -130,6 +130,28 @@ When bumping the extension version for a patch release, update **only** these fi
 
 **Do NOT update `cli/azd/extensions/registry.json`.** The registry entry (checksums, artifact URLs) is generated automatically by CI after the release build produces the binaries. Editing it manually by hand will result in wrong or placeholder checksums that break installation.
 
+## Output: `log` vs `fmt`
+
+Extensions write directly to stdout/stderr — there is no `Console` abstraction from azd core.
+
+- **`fmt.Print*`** — user-facing output (stdout). Pair with `output.With*Format` helpers for styled text.
+- **`log.Print*`** — developer diagnostics (stderr). Hidden unless `--debug` is set. Never use `log` for anything the user needs to see.
+- Do not use `log.Fatal` or `log.Panic` for expected failures — return a structured error via `exterrors` instead.
+
+```go
+// ✅ log — internal detail the user doesn't need to see
+log.Printf("ARM response: status=%d, id=%s", resp.StatusCode, resourceId)
+
+// ✅ fmt — user-facing status and results
+fmt.Println(output.WithSuccessFormat("Agent deployed to %s", endpoint))
+
+// ❌ fmt used for debug noise — user sees internal details they can't act on
+fmt.Printf("Parsed resource ID: sub=%s, rg=%s\n", subId, rg)    // use log.Printf
+
+// ❌ log used for user-facing info — user never sees it without --debug
+log.Printf("No Foundry projects found in subscription")          // use fmt + output helper
+```
+
 ## Other extension conventions
 
 - Use modern Go 1.26 patterns where they help readability

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/banner.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/banner.go
@@ -10,6 +10,7 @@ import (
 
 	"azureaiagent/internal/version"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/fatih/color"
 )
 
@@ -27,16 +28,15 @@ const bannerArt = `███████╗ ██████╗ ██╗   �
 
 func printBanner(w io.Writer) {
 	purple := color.RGB(109, 53, 255).Add(color.Bold)
-	dim := color.New(color.Faint)
 	fmt.Fprintln(w)
 
 	for line := range strings.SplitSeq(bannerArt, "\n") {
 		purple.Fprintln(w, line) //nolint:gosec // G104 - banner output errors are non-critical
 	}
 
-	dim.Fprintf(w, "v%s", version.Version) //nolint:gosec // G104 - banner output errors are non-critical
+	fmt.Fprint(w, output.WithGrayFormat("v%s", version.Version)) //nolint:gosec // G104 - banner output errors are non-critical
 	fmt.Fprint(w, " ")
 	fmt.Fprintln(w)
-	dim.Fprintln(w, "Visit the docs at https://aka.ms/azd-ai-agent-docs") //nolint:gosec // G104 - banner output errors are non-critical
+	fmt.Fprintln(w, output.WithGrayFormat("Visit the docs at https://aka.ms/azd-ai-agent-docs")) //nolint:gosec // G104 - banner output errors are non-critical
 	fmt.Fprintln(w)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/debug.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/debug.go
@@ -25,34 +25,39 @@ var connectionStringJSONRegex = regexp.MustCompile(`("[\w]*(?:CONNECTION_STRING|
 // is enabled, and additionally configures the Azure SDK logger when debugging.
 // Returns a cleanup function that should be deferred by the caller.
 func setupDebugLogging(flags *pflag.FlagSet) func() {
-	if isDebug(flags) {
-		currentDate := time.Now().Format("2006-01-02")
-		logFileName := fmt.Sprintf("azd-ai-agents-%s.log", currentDate)
-
-		//nolint:gosec // log file name is generated locally from date and not user-controlled
-		logFile, err := os.OpenFile(logFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
-		if err != nil {
-			log.SetOutput(os.Stderr)
-			return func() {}
-		}
-
-		log.SetOutput(logFile)
-
-		azcorelog.SetListener(func(event azcorelog.Event, msg string) {
-			msg = connectionStringJSONRegex.ReplaceAllString(msg, `${1}"REDACTED"`)
-			fmt.Fprintf(logFile, "[%s] %s: %s\n", time.Now().Format(time.RFC3339), event, msg)
-		})
-
-		return func() {
-			log.SetOutput(io.Discard)
-			azcorelog.SetListener(nil)
-			logFile.Close() //nolint:gosec // best-effort cleanup of debug log file
-		}
+	if !isDebug(flags) {
+		log.SetOutput(io.Discard)
+		azcorelog.SetListener(nil)
+		return func() {}
 	}
 
-	log.SetOutput(io.Discard)
-	azcorelog.SetListener(nil)
-	return func() {}
+	currentDate := time.Now().Format("2006-01-02")
+	logFileName := fmt.Sprintf("azd-ai-agents-%s.log", currentDate)
+
+	//nolint:gosec // log file name is generated locally from date and not user-controlled
+	logFile, err := os.OpenFile(logFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+
+	var w io.Writer
+	var closeFile func()
+	if err != nil {
+		w = os.Stderr
+		closeFile = func() {}
+	} else {
+		w = logFile
+		closeFile = func() { logFile.Close() } //nolint:gosec // best-effort cleanup of debug log file
+	}
+
+	log.SetOutput(w)
+	azcorelog.SetListener(func(event azcorelog.Event, msg string) {
+		msg = connectionStringJSONRegex.ReplaceAllString(msg, `${1}"REDACTED"`)
+		fmt.Fprintf(w, "[%s] %s: %s\n", time.Now().Format(time.RFC3339), event, msg)
+	})
+
+	return func() {
+		log.SetOutput(io.Discard)
+		azcorelog.SetListener(nil)
+		closeFile()
+	}
 }
 
 // isDebug checks if debug mode is enabled via --debug flag or AZD_EXT_DEBUG environment variable

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/debug.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/debug.go
@@ -5,6 +5,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"regexp"
 	"strconv"
@@ -16,7 +18,11 @@ import (
 
 var connectionStringJSONRegex = regexp.MustCompile(`("[\w]*(?:CONNECTION_STRING|ConnectionString)":\s*)"[^"]*"`)
 
-// setupDebugLogging configures the Azure SDK logger if debug mode is enabled.
+// setupDebugLogging configures debug logging for the extension.
+// By default Go's standard log package writes to stderr, which causes internal
+// messages (e.g. from the command runner and GitHub CLI wrapper) to appear as
+// noisy user-facing output. This function silences those logs unless debug mode
+// is enabled, and additionally configures the Azure SDK logger when debugging.
 func setupDebugLogging(flags *pflag.FlagSet) {
 	if isDebug(flags) {
 		currentDate := time.Now().Format("2006-01-02")
@@ -27,10 +33,15 @@ func setupDebugLogging(flags *pflag.FlagSet) {
 		if err != nil {
 			logFile = os.Stderr
 		}
+
+		log.SetOutput(logFile)
+
 		azcorelog.SetListener(func(event azcorelog.Event, msg string) {
 			msg = connectionStringJSONRegex.ReplaceAllString(msg, `${1}"REDACTED"`)
 			fmt.Fprintf(logFile, "[%s] %s: %s\n", time.Now().Format(time.RFC3339), event, msg)
 		})
+	} else {
+		log.SetOutput(io.Discard)
 	}
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/debug.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/debug.go
@@ -23,15 +23,17 @@ var connectionStringJSONRegex = regexp.MustCompile(`("[\w]*(?:CONNECTION_STRING|
 // messages (e.g. from the command runner and GitHub CLI wrapper) to appear as
 // noisy user-facing output. This function silences those logs unless debug mode
 // is enabled, and additionally configures the Azure SDK logger when debugging.
-func setupDebugLogging(flags *pflag.FlagSet) {
+// Returns a cleanup function that should be deferred by the caller.
+func setupDebugLogging(flags *pflag.FlagSet) func() {
 	if isDebug(flags) {
 		currentDate := time.Now().Format("2006-01-02")
 		logFileName := fmt.Sprintf("azd-ai-agents-%s.log", currentDate)
 
 		//nolint:gosec // log file name is generated locally from date and not user-controlled
-		logFile, err := os.OpenFile(logFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		logFile, err := os.OpenFile(logFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 		if err != nil {
-			logFile = os.Stderr
+			log.SetOutput(os.Stderr)
+			return func() {}
 		}
 
 		log.SetOutput(logFile)
@@ -40,9 +42,17 @@ func setupDebugLogging(flags *pflag.FlagSet) {
 			msg = connectionStringJSONRegex.ReplaceAllString(msg, `${1}"REDACTED"`)
 			fmt.Fprintf(logFile, "[%s] %s: %s\n", time.Now().Format(time.RFC3339), event, msg)
 		})
-	} else {
-		log.SetOutput(io.Discard)
+
+		return func() {
+			log.SetOutput(io.Discard)
+			azcorelog.SetListener(nil)
+			logFile.Close() //nolint:gosec // best-effort cleanup of debug log file
+		}
 	}
+
+	log.SetOutput(io.Discard)
+	azcorelog.SetListener(nil)
+	return func() {}
 }
 
 // isDebug checks if debug mode is enabled via --debug flag or AZD_EXT_DEBUG environment variable

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/files.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/files.go
@@ -198,7 +198,8 @@ Agent details are automatically resolved from the azd environment.`,
   azd ai agent files upload --file ./input.csv --agent-name my-agent --session <session-id>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := azdext.WithAccessToken(cmd.Context())
-			setupDebugLogging(cmd.Flags())
+			logCleanup := setupDebugLogging(cmd.Flags())
+			defer logCleanup()
 
 			fc, err := resolveFilesContext(ctx, &flags.filesFlags)
 			if err != nil {
@@ -296,7 +297,8 @@ Agent details are automatically resolved from the azd environment.`,
   azd ai agent files download --file /data/output.csv --session <session-id>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := azdext.WithAccessToken(cmd.Context())
-			setupDebugLogging(cmd.Flags())
+			logCleanup := setupDebugLogging(cmd.Flags())
+			defer logCleanup()
 
 			fc, err := resolveFilesContext(ctx, &flags.filesFlags)
 			if err != nil {
@@ -401,7 +403,8 @@ Agent details are automatically resolved from the azd environment.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := azdext.WithAccessToken(cmd.Context())
-			setupDebugLogging(cmd.Flags())
+			logCleanup := setupDebugLogging(cmd.Flags())
+			defer logCleanup()
 
 			fc, err := resolveFilesContext(ctx, &flags.filesFlags)
 			if err != nil {
@@ -523,7 +526,8 @@ Agent details are automatically resolved from the azd environment.`,
   azd ai agent files remove --file /data/old-file.csv --session <session-id>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := azdext.WithAccessToken(cmd.Context())
-			setupDebugLogging(cmd.Flags())
+			logCleanup := setupDebugLogging(cmd.Flags())
+			defer logCleanup()
 
 			fc, err := resolveFilesContext(ctx, &flags.filesFlags)
 			if err != nil {
@@ -601,7 +605,8 @@ Agent details are automatically resolved from the azd environment.`,
   azd ai agent files mkdir --dir /data/output --session <session-id>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := azdext.WithAccessToken(cmd.Context())
-			setupDebugLogging(cmd.Flags())
+			logCleanup := setupDebugLogging(cmd.Flags())
+			defer logCleanup()
 
 			fc, err := resolveFilesContext(ctx, flags)
 			if err != nil {
@@ -684,7 +689,8 @@ Agent details are automatically resolved from the azd environment.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := azdext.WithAccessToken(cmd.Context())
-			setupDebugLogging(cmd.Flags())
+			logCleanup := setupDebugLogging(cmd.Flags())
+			defer logCleanup()
 
 			fc, err := resolveFilesContext(ctx, &flags.filesFlags)
 			if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -215,7 +215,8 @@ func newInitCommand(rootFlags *rootFlagsDefinition) *cobra.Command {
 
 			ctx := azdext.WithAccessToken(cmd.Context())
 
-			setupDebugLogging(cmd.Flags())
+			logCleanup := setupDebugLogging(cmd.Flags())
+			defer logCleanup()
 
 			azdClient, err := azdext.NewAzdClient()
 			if err != nil {
@@ -1456,11 +1457,11 @@ func downloadParentDirectory(
 
 	// Download directory contents
 	if useGhCli {
-		if err := downloadDirectoryContents(ctx, urlInfo.Hostname, urlInfo.RepoSlug, parentDirPath, urlInfo.Branch, targetDir, ghCli, console); err != nil {
+		if err := downloadDirectoryContents(ctx, urlInfo.Hostname, urlInfo.RepoSlug, parentDirPath, parentDirPath, urlInfo.Branch, targetDir, ghCli, console); err != nil {
 			return fmt.Errorf("failed to download directory contents with GH CLI: %w", err)
 		}
 	} else {
-		if err := downloadDirectoryContentsWithoutGhCli(ctx, urlInfo.RepoSlug, parentDirPath, urlInfo.Branch, targetDir, httpClient); err != nil {
+		if err := downloadDirectoryContentsWithoutGhCli(ctx, urlInfo.RepoSlug, parentDirPath, parentDirPath, urlInfo.Branch, targetDir, httpClient); err != nil {
 			return fmt.Errorf("failed to download directory contents without GH CLI: %w", err)
 		}
 	}
@@ -1471,7 +1472,7 @@ func downloadParentDirectory(
 }
 
 func downloadDirectoryContents(
-	ctx context.Context, hostname string, repoSlug string, dirPath string, branch string, localPath string, ghCli *github.Cli, console input.Console) error {
+	ctx context.Context, hostname string, repoSlug string, dirPath string, rootDirPath string, branch string, localPath string, ghCli *github.Cli, console input.Console) error {
 
 	// Get directory contents using GitHub API
 	apiPath := fmt.Sprintf("/repos/%s/contents/%s", repoSlug, dirPath)
@@ -1507,7 +1508,8 @@ func downloadDirectoryContents(
 
 		if itemType == "file" {
 			// Download file
-			fmt.Println(output.WithGrayFormat("  %s", name))
+			relativePath := strings.TrimPrefix(itemPath, rootDirPath+"/")
+			fmt.Println(output.WithGrayFormat("  %s", relativePath))
 			log.Printf("Downloading file: %s", itemPath)
 			fileApiPath := fmt.Sprintf("/repos/%s/contents/%s", repoSlug, itemPath)
 			if branch != "" {
@@ -1527,7 +1529,6 @@ func downloadDirectoryContents(
 			}
 		} else if itemType == "dir" {
 			// Recursively download subdirectory
-			fmt.Println(output.WithGrayFormat("  %s/", name))
 			log.Printf("Downloading directory: %s", itemPath)
 			//nolint:gosec // scaffolded directories are intended to be readable/traversable
 			if err := os.MkdirAll(itemLocalPath, 0755); err != nil {
@@ -1535,7 +1536,7 @@ func downloadDirectoryContents(
 			}
 
 			// Recursively download directory contents
-			if err := downloadDirectoryContents(ctx, hostname, repoSlug, itemPath, branch, itemLocalPath, ghCli, console); err != nil {
+			if err := downloadDirectoryContents(ctx, hostname, repoSlug, itemPath, rootDirPath, branch, itemLocalPath, ghCli, console); err != nil {
 				return fmt.Errorf("failed to download subdirectory %s: %w", itemPath, err)
 			}
 		}
@@ -1545,7 +1546,7 @@ func downloadDirectoryContents(
 }
 
 func downloadDirectoryContentsWithoutGhCli(
-	ctx context.Context, repoSlug string, dirPath string, branch string, localPath string, httpClient *http.Client) error {
+	ctx context.Context, repoSlug string, dirPath string, rootDirPath string, branch string, localPath string, httpClient *http.Client) error {
 
 	// Get directory contents using GitHub API directly
 	apiUrl := fmt.Sprintf("https://api.github.com/repos/%s/contents/%s", repoSlug, dirPath)
@@ -1598,7 +1599,8 @@ func downloadDirectoryContentsWithoutGhCli(
 
 		if itemType == "file" {
 			// Download file using GitHub Contents API with raw accept header
-			fmt.Println(output.WithGrayFormat("  %s", name))
+			relativePath := strings.TrimPrefix(itemPath, rootDirPath+"/")
+			fmt.Println(output.WithGrayFormat("  %s", relativePath))
 			log.Printf("Downloading file: %s", itemPath)
 			fileURL := &url.URL{
 				Scheme: "https",
@@ -1639,7 +1641,6 @@ func downloadDirectoryContentsWithoutGhCli(
 			}
 		} else if itemType == "dir" {
 			// Recursively download subdirectory
-			fmt.Println(output.WithGrayFormat("  %s/", name))
 			log.Printf("Downloading directory: %s", itemPath)
 			//nolint:gosec // scaffolded directories are intended to be readable/traversable
 			if err := os.MkdirAll(itemLocalPath, 0755); err != nil {
@@ -1647,7 +1648,7 @@ func downloadDirectoryContentsWithoutGhCli(
 			}
 
 			// Recursively download directory contents
-			if err := downloadDirectoryContentsWithoutGhCli(ctx, repoSlug, itemPath, branch, itemLocalPath, httpClient); err != nil {
+			if err := downloadDirectoryContentsWithoutGhCli(ctx, repoSlug, itemPath, rootDirPath, branch, itemLocalPath, httpClient); err != nil {
 				return fmt.Errorf("failed to download subdirectory %s: %w", itemPath, err)
 			}
 		}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -28,6 +29,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/github"
 	"github.com/fatih/color"
@@ -705,9 +707,9 @@ func (a *InitAction) configureModelChoice(
 
 		if selectedProject == nil {
 			// No existing project selected (no projects found or user chose "Create new") → fall back to "deploy new" path
-			_, _ = color.New(color.Faint).Println(
+			fmt.Println(output.WithGrayFormat(
 				"No existing Foundry project was selected. Falling back to deploying a new model.",
-			)
+			))
 			if err := ensureLocation(ctx, a.azdClient, a.azureContext, a.environment.Name); err != nil {
 				return nil, err
 			}
@@ -838,7 +840,7 @@ func (a *InitAction) downloadAgentYaml(
 	// Check if manifestPointer is a local file path or a URI
 	if a.isLocalFilePath(manifestPointer) {
 		// Handle local file path
-		fmt.Printf("Reading agent.yaml from local file: %s\n", manifestPointer)
+		log.Printf("Reading agent.yaml from local file: %s", manifestPointer)
 		//nolint:gosec // manifest path is an explicit user-provided local path
 		content, err = os.ReadFile(manifestPointer)
 		if err != nil {
@@ -904,7 +906,8 @@ func (a *InitAction) downloadAgentYaml(
 		//  - https://api.<hostname>/repos/<owner>/<repo>/contents/<path>/<file>.json
 		//    - This url comes from users familiar with the GitHub API. Usually for programmatic registration of templates.
 
-		fmt.Printf("Downloading agent.yaml from GitHub: %s\n", manifestPointer)
+		fmt.Println(output.WithGrayFormat("Downloading manifest from GitHub..."))
+		log.Printf("Downloading manifest from GitHub: %s", manifestPointer)
 		isGitHubUrl = true
 
 		// Create a simple console and command runner for GitHub CLI
@@ -946,7 +949,7 @@ func (a *InitAction) downloadAgentYaml(
 				escapedBranch := url.QueryEscape(urlInfo.Branch)
 				fileApiUrl += fmt.Sprintf("?ref=%s", escapedBranch)
 			}
-			fmt.Printf("Attempting to download manifest from '%s' in repository '%s', branch '%s'\n", urlInfo.FilePath, urlInfo.RepoSlug, urlInfo.Branch)
+			log.Printf("Attempting to download manifest from '%s' in repository '%s', branch '%s'", urlInfo.FilePath, urlInfo.RepoSlug, urlInfo.Branch)
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileApiUrl, nil)
 			if err == nil {
@@ -959,14 +962,14 @@ func (a *InitAction) downloadAgentYaml(
 						bodyBytes, readErr := io.ReadAll(resp.Body)
 						if readErr == nil {
 							contentStr = string(bodyBytes)
-							fmt.Printf("Downloaded manifest from branch: %s\n", urlInfo.Branch)
+							log.Printf("Downloaded manifest from branch: %s", urlInfo.Branch)
 						}
 					}
 				}
 			}
 			if contentStr == "" {
-				fmt.Printf("Warning: naive GitHub URL parsing failed to download manifest\n")
-				fmt.Println("Proceeding with full parsing and download logic...")
+				log.Print("Naive GitHub URL parsing failed to download manifest")
+				log.Print("Proceeding with full parsing and download logic...")
 			}
 		}
 
@@ -980,7 +983,7 @@ func (a *InitAction) downloadAgentYaml(
 
 			apiPath := fmt.Sprintf("/repos/%s/contents/%s", urlInfo.RepoSlug, urlInfo.FilePath)
 			if urlInfo.Branch != "" {
-				fmt.Printf("Downloaded manifest from branch: %s\n", urlInfo.Branch)
+				log.Printf("Downloaded manifest from branch: %s", urlInfo.Branch)
 				apiPath += fmt.Sprintf("?ref=%s", urlInfo.Branch)
 			}
 
@@ -1002,7 +1005,7 @@ func (a *InitAction) downloadAgentYaml(
 		var versionResult *registry_api.Manifest
 		if registryManifest.manifestVersion == "" {
 			// No version specified, get latest version from GetAllLatest
-			fmt.Printf("No version provided for manifest '%s', retrieving latest version\n", registryManifest.manifestName)
+			log.Printf("No version provided for manifest '%s', retrieving latest version", registryManifest.manifestName)
 
 			allManifests, err := manifestClient.GetAllLatest(ctx)
 			if err != nil {
@@ -1022,7 +1025,8 @@ func (a *InitAction) downloadAgentYaml(
 			}
 		} else {
 			// Specific version requested
-			fmt.Printf("Downloading agent.yaml from registry: %s\n", manifestPointer)
+			fmt.Println(output.WithGrayFormat("Downloading manifest from registry..."))
+			log.Printf("Downloading manifest from registry: %s", manifestPointer)
 
 			manifest, err := manifestClient.GetManifest(ctx, registryManifest.manifestName, registryManifest.manifestVersion)
 			if err != nil {
@@ -1037,7 +1041,7 @@ func (a *InitAction) downloadAgentYaml(
 			return nil, "", fmt.Errorf("processing manifest with parameters: %w", err)
 		}
 
-		fmt.Println("Retrieved and processed manifest from registry")
+		log.Print("Retrieved and processed manifest from registry")
 
 		// Convert to YAML bytes for the content variable
 		manifestBytes, err := yaml.Marshal(processedManifest)
@@ -1060,7 +1064,7 @@ func (a *InitAction) downloadAgentYaml(
 		return nil, "", err
 	}
 
-	fmt.Println("✓ YAML content successfully validated against AgentManifest format")
+	fmt.Println(output.WithGrayFormat("✓ Manifest validated successfully"))
 
 	agentId := agentManifest.Name
 
@@ -1114,7 +1118,7 @@ func (a *InitAction) downloadAgentYaml(
 				return nil, "", fmt.Errorf("resolving target directory %s: %w", targetDir, err)
 			}
 			if !isSamePath(srcAbs, dstAbs) {
-				fmt.Println("Copying full directory for container agent")
+				log.Print("Copying full directory for container agent")
 				err := copyDirectory(manifestDir, targetDir)
 				if err != nil {
 					return nil, "", fmt.Errorf("copying parent directory: %w", err)
@@ -1127,7 +1131,7 @@ func (a *InitAction) downloadAgentYaml(
 
 		if isHostedContainer {
 			// For container agents, download the entire parent directory
-			fmt.Println("Downloading full directory for container agent")
+			log.Print("Downloading full directory for container agent")
 			err := downloadParentDirectory(ctx, urlInfo, targetDir, ghCli, console, useGhCli, a.httpClient)
 			if err != nil {
 				return nil, "", exterrors.Dependency(
@@ -1162,7 +1166,7 @@ func writeAgentDefinitionFile(targetDir string, agentManifest *agent_yaml.AgentM
 		return fmt.Errorf("saving file to %s: %w", filePath, err)
 	}
 
-	fmt.Printf("Processed agent.yaml at %s\n", filePath)
+	fmt.Println(output.WithGrayFormat("Processed agent.yaml at %s", filePath))
 	return nil
 }
 
@@ -1442,12 +1446,13 @@ func downloadParentDirectory(
 	// Get parent directory by removing the filename from the file path
 	pathParts := strings.Split(urlInfo.FilePath, "/")
 	if len(pathParts) <= 1 {
-		fmt.Println("The file agent.yaml is at repository root, no parent directory to download")
+		log.Print("The file agent.yaml is at repository root, no parent directory to download")
 		return nil
 	}
 
 	parentDirPath := strings.Join(pathParts[:len(pathParts)-1], "/")
-	fmt.Printf("Downloading parent directory '%s' from repository '%s', branch '%s'\n", parentDirPath, urlInfo.RepoSlug, urlInfo.Branch)
+	log.Printf("Downloading parent directory '%s' from repository '%s', branch '%s'", parentDirPath, urlInfo.RepoSlug, urlInfo.Branch)
+	fmt.Println(output.WithGrayFormat("Downloading files..."))
 
 	// Download directory contents
 	if useGhCli {
@@ -1460,7 +1465,8 @@ func downloadParentDirectory(
 		}
 	}
 
-	fmt.Printf("Successfully downloaded parent directory to: %s\n", targetDir)
+	fmt.Println(output.WithGrayFormat("Downloaded to: %s", targetDir))
+	fmt.Println()
 	return nil
 }
 
@@ -1501,7 +1507,8 @@ func downloadDirectoryContents(
 
 		if itemType == "file" {
 			// Download file
-			fmt.Printf("%s\n", color.New(color.Faint).Sprintf("Downloading file: %s", itemPath))
+			fmt.Println(output.WithGrayFormat("  %s", name))
+			log.Printf("Downloading file: %s", itemPath)
 			fileApiPath := fmt.Sprintf("/repos/%s/contents/%s", repoSlug, itemPath)
 			if branch != "" {
 				fileApiPath += fmt.Sprintf("?ref=%s", branch)
@@ -1520,7 +1527,8 @@ func downloadDirectoryContents(
 			}
 		} else if itemType == "dir" {
 			// Recursively download subdirectory
-			fmt.Printf("Downloading directory: %s\n", itemPath)
+			fmt.Println(output.WithGrayFormat("  %s/", name))
+			log.Printf("Downloading directory: %s", itemPath)
 			//nolint:gosec // scaffolded directories are intended to be readable/traversable
 			if err := os.MkdirAll(itemLocalPath, 0755); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", itemLocalPath, err)
@@ -1590,7 +1598,8 @@ func downloadDirectoryContentsWithoutGhCli(
 
 		if itemType == "file" {
 			// Download file using GitHub Contents API with raw accept header
-			fmt.Printf("%s\n", color.New(color.Faint).Sprintf("Downloading file: %s", itemPath))
+			fmt.Println(output.WithGrayFormat("  %s", name))
+			log.Printf("Downloading file: %s", itemPath)
 			fileURL := &url.URL{
 				Scheme: "https",
 				Host:   "api.github.com",
@@ -1630,7 +1639,8 @@ func downloadDirectoryContentsWithoutGhCli(
 			}
 		} else if itemType == "dir" {
 			// Recursively download subdirectory
-			fmt.Printf("Downloading directory: %s\n", itemPath)
+			fmt.Println(output.WithGrayFormat("  %s/", name))
+			log.Printf("Downloading directory: %s", itemPath)
 			//nolint:gosec // scaffolded directories are intended to be readable/traversable
 			if err := os.MkdirAll(itemLocalPath, 0755); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", itemLocalPath, err)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_templates_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_templates_helpers.go
@@ -20,7 +20,7 @@ import (
 	"azureaiagent/internal/pkg/agents/agent_yaml"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
-	"github.com/fatih/color"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
 const agentTemplatesURL = "https://aka.ms/foundry-agents"
@@ -158,7 +158,7 @@ func promptAgentTemplate(
 		)
 	}
 
-	_, _ = color.New(color.Faint).Println("Retrieving agent templates...")
+	fmt.Println(output.WithGrayFormat("Retrieving agent templates..."))
 
 	templates, err := fetchAgentTemplates(ctx, httpClient)
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
@@ -84,7 +84,8 @@ session automatically. Pass --new-session to force a reset.`,
 		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := azdext.WithAccessToken(cmd.Context())
-			setupDebugLogging(cmd.Flags())
+			logCleanup := setupDebugLogging(cmd.Flags())
+			defer logCleanup()
 
 			switch len(args) {
 			case 2:

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
@@ -30,7 +30,8 @@ func newListenCommand() *cobra.Command {
 			// Create a new context that includes the AZD access token.
 			ctx := azdext.WithAccessToken(cmd.Context())
 
-			setupDebugLogging(cmd.Flags())
+			logCleanup := setupDebugLogging(cmd.Flags())
+			defer logCleanup()
 
 			// Create a new AZD client.
 			azdClient, err := azdext.NewAzdClient()

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor.go
@@ -73,7 +73,8 @@ configuration and the current azd environment. Optionally specify the service na
 			}
 
 			ctx := azdext.WithAccessToken(cmd.Context())
-			setupDebugLogging(cmd.Flags())
+			logCleanup := setupDebugLogging(cmd.Flags())
+			defer logCleanup()
 
 			azdClient, err := azdext.NewAzdClient()
 			if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/run.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/run.go
@@ -61,7 +61,8 @@ Use a separate terminal to invoke the running agent:
 				flags.name = args[0]
 			}
 			ctx := azdext.WithAccessToken(cmd.Context())
-			setupDebugLogging(cmd.Flags())
+			logCleanup := setupDebugLogging(cmd.Flags())
+			defer logCleanup()
 			return runRun(ctx, flags)
 		},
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/show.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/show.go
@@ -54,7 +54,8 @@ configuration and the current azd environment. Optionally specify the service na
 				flags.name = args[0]
 			}
 			ctx := azdext.WithAccessToken(cmd.Context())
-			setupDebugLogging(cmd.Flags())
+			logCleanup := setupDebugLogging(cmd.Flags())
+			defer logCleanup()
 
 			azdClient, err := azdext.NewAzdClient()
 			if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/registry_api/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/registry_api/helpers.go
@@ -6,6 +6,7 @@ package registry_api
 import (
 	"context"
 	"fmt"
+	"log"
 	"reflect"
 	"strconv"
 	"strings"
@@ -279,7 +280,7 @@ func ProcessManifestParameters(
 	noPrompt bool) (*agent_yaml.AgentManifest, error) {
 	// If no parameters are defined, return the manifest as-is
 	if len(manifest.Parameters.Properties) == 0 {
-		fmt.Println("The manifest does not contain parameters that need to be configured.")
+		log.Print("The manifest does not contain parameters that need to be configured.")
 		return manifest, nil
 	}
 


### PR DESCRIPTION
Resolves #7595 

`azd ai agent init` was printing many internal/debug messages to the terminal that cluttered the user experience. This PR cleans up the output by:

1. **Silencing Go `log` package output by default** — The command runner (`pkg/exec`) and GitHub CLI wrapper (`pkg/tools/github`) write exec details and version info via Go's standard `log` package, which defaults to stderr. The extension now redirects `log.SetOutput(io.Discard)` unless `--debug` is enabled, matching the behavior of the core `azd` process.

    When `--debug` is passed, `log` statements from the extension should get written to the generated debug `.log` file.

3. **Moving internal messages to debug-only** — Verbose messages about manifest parsing strategies, branch resolution, naive URL fallback logic, and validation internals are now `log.Printf` calls that only appear in debug mode.

4. **Switching `color.Faint` to `output.WithGrayFormat`** — All uses of `color.New(color.Faint)` have been replaced with `output.WithGrayFormat` to follow the azd style guide.

5. **Improving user-facing download output** — The download progress block has been simplified from verbose full-path lines to a clean, scannable format.

### Before
<img width="3617" height="847" alt="image" src="https://github.com/user-attachments/assets/4a238992-99bd-4603-82e1-9f0d2fc4b52a" />


### After
<img width="1088" height="606" alt="image" src="https://github.com/user-attachments/assets/94b9abb3-afcc-441e-a552-a91c812f1c69" />

Verbose logs are available in the .log file generated when `--debug` is used:

```
2026/04/08 23:51:20 Downloading manifest from GitHub: https://github.com/<redacted>/blob/main/samples/python/agentserver-responses/echo-agent-streaming/agent.manifest.yaml
2026/04/08 23:51:20 Run exec: '/home/vscode/.azd/bin/gh --version' , exit code: 0
2026/04/08 23:51:20 Run exec: '/home/vscode/.azd/bin/gh --version' , exit code: 0
2026/04/08 23:51:20 github cli version: 2.89.0
2026/04/08 23:51:20 Attempting to download manifest from 'samples/python/agentserver-responses/echo-agent-streaming/agent.manifest.yaml' in repository '<redacted>', branch 'main'
2026/04/08 23:51:20 Naive GitHub URL parsing failed to download manifest
2026/04/08 23:51:20 Proceeding with full parsing and download logic...
2026/04/08 23:51:21 Downloaded manifest from branch: main
2026/04/08 23:51:21 Run exec: '/home/vscode/.azd/bin/gh api https://api.github.com/repos/<redacted>/contents/samples/python/agentserver-responses/echo-agent-streaming/agent.manifest.yaml?ref=<redacted> -H Accept: application/vnd.github.v3.raw' , exit code: 0
2026/04/08 23:51:21 The manifest does not contain parameters that need to be configured.
2026/04/08 23:51:21 Downloading full directory for container agent
2026/04/08 23:51:21 Downloading parent directory 'samples/python/agentserver-responses/echo-agent-streaming' from repository '<redacted>', branch 'main'
2026/04/08 23:51:21 Run exec: '/home/vscode/.azd/bin/gh api https://api.github.com/repos/<redacted>/contents/samples/python/agentserver-responses/echo-agent-streaming?ref=<redacted>' , exit code: 0
2026/04/08 23:51:21 Downloading file: samples/python/agentserver-responses/echo-agent-streaming/.dockerignore
2026/04/08 23:51:21 Run exec: '/home/vscode/.azd/bin/gh api https://api.github.com/repos/<redacted>/contents/samples/python/agentserver-responses/echo-agent-streaming/.dockerignore?ref=<redacted> -H Accept: application/vnd.github.v3.raw' , exit code: 0
2026/04/08 23:51:21 Downloading file: samples/python/agentserver-responses/echo-agent-streaming/Dockerfile
2026/04/08 23:51:22 Run exec: '/home/vscode/.azd/bin/gh api https://api.github.com/repos/<redacted>/contents/samples/python/agentserver-responses/echo-agent-streaming/Dockerfile?ref=<redacted> -H Accept: application/vnd.github.v3.raw' , exit code: 0
2026/04/08 23:51:22 Downloading file: samples/python/agentserver-responses/echo-agent-streaming/README.md
2026/04/08 23:51:22 Run exec: '/home/vscode/.azd/bin/gh api https://api.github.com/repos/<redacted>/contents/samples/python/agentserver-responses/echo-agent-streaming/README.md?ref=<redacted> -H Accept: application/vnd.github.v3.raw' , exit code: 0
2026/04/08 23:51:22 Downloading file: samples/python/agentserver-responses/echo-agent-streaming/agent.manifest.yaml
2026/04/08 23:51:22 Run exec: '/home/vscode/.azd/bin/gh api https://api.github.com/repos/<redacted>/contents/samples/python/agentserver-responses/echo-agent-streaming/agent.manifest.yaml?ref=<redacted> -H Accept: application/vnd.github.v3.raw' , exit code: 0
2026/04/08 23:51:22 Downloading file: samples/python/agentserver-responses/echo-agent-streaming/agent.yaml
2026/04/08 23:51:23 Run exec: '/home/vscode/.azd/bin/gh api https://api.github.com/repos/<redacted>/contents/samples/python/agentserver-responses/echo-agent-streaming/agent.yaml?ref=<redacted> -H Accept: application/vnd.github.v3.raw' , exit code: 0
2026/04/08 23:51:23 Downloading file: samples/python/agentserver-responses/echo-agent-streaming/main.py
2026/04/08 23:51:23 Run exec: '/home/vscode/.azd/bin/gh api https://api.github.com/repos/<redacted>/contents/samples/python/agentserver-responses/echo-agent-streaming/main.py?ref=<redacted> -H Accept: application/vnd.github.v3.raw' , exit code: 0
2026/04/08 23:51:23 Downloading file: samples/python/agentserver-responses/echo-agent-streaming/requirements.txt
2026/04/08 23:51:23 Run exec: '/home/vscode/.azd/bin/gh api https://api.github.com/repos/<redacted>/contents/samples/python/agentserver-responses/echo-agent-streaming/requirements.txt?ref=<redacted> -H Accept: application/vnd.github.v3.raw' , exit code: 0
```

## Changes

- `internal/cmd/debug.go` — Redirect `log.SetOutput` to `io.Discard` by default; route to log file when `--debug` is active.
- `internal/cmd/init.go` — Convert ~20 verbose `fmt.Printf` calls to `log.Printf`; simplify user-facing messages; use `output.WithGrayFormat`; show indented filenames instead of full paths.
- `internal/cmd/banner.go` — Replace `color.Faint` with `output.WithGrayFormat`.
- `internal/cmd/init_from_templates_helpers.go` — Replace `color.Faint` with `output.WithGrayFormat`.
- `internal/pkg/agents/registry_api/helpers.go` — Move "no parameters" info message to debug log.