### PR TITLE
Persist explicit session IDs for reuse in subsequent commands.

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
@@ -139,6 +139,9 @@ func resolveStoredID(
 	generateIfMissing bool,
 ) (string, error) {
 	if explicit != "" {
+		// Persist the explicit ID so that subsequent commands (e.g. monitor, invoke)
+		// can find it without the user passing it again.
+		saveContextValue(ctx, azdClient, agentKey, explicit, storeField)
 		return explicit, nil
 	}
 	if forceNew && !generateIfMissing {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -103,12 +104,21 @@ func saveContextValue(
 	}
 	configPath, err := resolveConfigPath(ctx, azdClient)
 	if err != nil {
+		log.Printf("saveContextValue: failed to resolve config path: %v", err)
 		return
 	}
+	if err := saveContextValueToPath(configPath, agentKey, value, storeField); err != nil {
+		log.Printf("saveContextValue: failed to persist %s for %q: %v", storeField, agentKey, err)
+	}
+}
+
+// saveContextValueToPath persists a value into the named field of the local config at configPath.
+// This is the path-based implementation used by saveContextValue and directly in tests.
+func saveContextValueToPath(configPath, agentKey, value, storeField string) error {
 	agentCtx := loadLocalContext(configPath)
 	store := contextMap(agentCtx, storeField)
 	store[agentKey] = value
-	_ = saveLocalContext(agentCtx, configPath)
+	return saveLocalContext(agentCtx, configPath)
 }
 
 // resolveLocalAgentKey builds the storage key for local mode from the azd project config.
@@ -141,7 +151,7 @@ func resolveStoredID(
 	if explicit != "" {
 		// Persist the explicit ID so that subsequent commands (e.g. monitor, invoke)
 		// can find it without the user passing it again.
-		saveContextValue(ctx, azdClient, agentKey, explicit, storeField)
+		persistExplicitID(ctx, azdClient, agentKey, explicit, storeField)
 		return explicit, nil
 	}
 	if forceNew && !generateIfMissing {
@@ -176,7 +186,56 @@ func resolveStoredID(
 	return newID, nil
 }
 
-// contextMap returns the named map from AgentLocalContext, initializing it if nil.
+// persistExplicitID saves a user-provided explicit ID to the local config.
+// Errors are logged for debug visibility but do not block the caller.
+func persistExplicitID(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	agentKey string,
+	value string,
+	storeField string,
+) {
+	saveContextValue(ctx, azdClient, agentKey, value, storeField)
+}
+
+// resolveStoredIDFromPath is a testable variant of resolveStoredID that operates on a
+// config file path directly, removing the need for an azdClient.
+func resolveStoredIDFromPath(
+	configPath string,
+	agentKey string,
+	explicit string,
+	forceNew bool,
+	storeField string,
+	generateIfMissing bool,
+) (string, error) {
+	if explicit != "" {
+		if err := saveContextValueToPath(configPath, agentKey, explicit, storeField); err != nil {
+			log.Printf("resolveStoredIDFromPath: failed to persist explicit %s for %q: %v", storeField, agentKey, err)
+		}
+		return explicit, nil
+	}
+	if forceNew && !generateIfMissing {
+		return "", nil
+	}
+
+	agentCtx := loadLocalContext(configPath)
+	store := contextMap(agentCtx, storeField)
+	if !forceNew {
+		if id, ok := store[agentKey]; ok {
+			return id, nil
+		}
+	}
+
+	if !generateIfMissing {
+		return "", nil
+	}
+
+	newID := uuid.NewString()
+	store[agentKey] = newID
+	_ = saveLocalContext(agentCtx, configPath)
+
+	return newID, nil
+}
 func contextMap(agentCtx *AgentLocalContext, field string) map[string]string {
 	switch field {
 	case "sessions":
@@ -295,7 +354,7 @@ func fetchOpenAPISpec(
 }
 
 // resolveConversationID resolves a Foundry conversation ID.
-// When explicit is provided, it is returned directly.
+// When explicit is provided, it is persisted and returned directly.
 // If no conversation is found (or forceNew is true), it attempts to create one and persist it.
 // Returns empty string when conversation creation fails, allowing invoke to continue without multi-turn memory.
 func resolveConversationID(
@@ -308,6 +367,8 @@ func resolveConversationID(
 	bearerToken string,
 ) (string, error) {
 	if explicit != "" {
+		// Persist the explicit conversation ID so subsequent commands can find it.
+		saveContextValue(ctx, azdClient, agentName, explicit, "conversations")
 		return explicit, nil
 	}
 	configPath, err := resolveConfigPath(ctx, azdClient)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor_test.go
@@ -367,9 +367,6 @@ func TestValidateMonitorFlags_ErrorMessages(t *testing.T) {
 func TestExplicitSessionID_PersistedAndReusable(t *testing.T) {
 	t.Parallel()
 
-	// Simulate the persistence that resolveStoredID now performs when an explicit
-	// session ID is provided. This verifies the round-trip: save an explicit ID,
-	// then load it back (as monitor's resolveMonitorSession would).
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ConfigFile)
 
@@ -380,12 +377,13 @@ func TestExplicitSessionID_PersistedAndReusable(t *testing.T) {
 	agentCtx := loadLocalContext(configPath)
 	assert.Empty(t, agentCtx.Sessions)
 
-	// Simulate what resolveStoredID now does: persist the explicit ID
-	store := contextMap(agentCtx, "sessions")
-	store[agentName] = explicitSID
-	require.NoError(t, saveLocalContext(agentCtx, configPath))
+	// Call resolveStoredIDFromPath with an explicit ID — this is the code path
+	// that resolveStoredID follows when the user passes --session-id.
+	got, err := resolveStoredIDFromPath(configPath, agentName, explicitSID, false, "sessions", false)
+	require.NoError(t, err)
+	assert.Equal(t, explicitSID, got)
 
-	// Reload (as monitor or a subsequent invoke would)
+	// Verify the ID was persisted (as monitor's resolveMonitorSession would load it)
 	loaded := loadLocalContext(configPath)
 	require.NotNil(t, loaded.Sessions)
 	assert.Equal(t, explicitSID, loaded.Sessions[agentName])
@@ -400,10 +398,9 @@ func TestExplicitConversationID_PersistedAndReusable(t *testing.T) {
 	agentName := "my-agent"
 	explicitConvID := "user-provided-conv-id"
 
-	agentCtx := loadLocalContext(configPath)
-	store := contextMap(agentCtx, "conversations")
-	store[agentName] = explicitConvID
-	require.NoError(t, saveLocalContext(agentCtx, configPath))
+	got, err := resolveStoredIDFromPath(configPath, agentName, explicitConvID, false, "conversations", false)
+	require.NoError(t, err)
+	assert.Equal(t, explicitConvID, got)
 
 	loaded := loadLocalContext(configPath)
 	require.NotNil(t, loaded.Conversations)
@@ -418,17 +415,15 @@ func TestExplicitID_OverwritesPreviousValue(t *testing.T) {
 
 	agentName := "my-agent"
 
-	// Save an initial session ID
-	agentCtx := loadLocalContext(configPath)
-	store := contextMap(agentCtx, "sessions")
-	store[agentName] = "old-session-id"
-	require.NoError(t, saveLocalContext(agentCtx, configPath))
+	// Persist an initial session ID via resolveStoredIDFromPath
+	got, err := resolveStoredIDFromPath(configPath, agentName, "old-session-id", false, "sessions", false)
+	require.NoError(t, err)
+	assert.Equal(t, "old-session-id", got)
 
-	// Simulate a second invoke with a different explicit session ID
-	agentCtx = loadLocalContext(configPath)
-	store = contextMap(agentCtx, "sessions")
-	store[agentName] = "new-session-id"
-	require.NoError(t, saveLocalContext(agentCtx, configPath))
+	// Persist a different explicit session ID — should overwrite the previous one
+	got, err = resolveStoredIDFromPath(configPath, agentName, "new-session-id", false, "sessions", false)
+	require.NoError(t, err)
+	assert.Equal(t, "new-session-id", got)
 
 	loaded := loadLocalContext(configPath)
 	assert.Equal(t, "new-session-id", loaded.Sessions[agentName])

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor_test.go
@@ -364,6 +364,76 @@ func TestValidateMonitorFlags_ErrorMessages(t *testing.T) {
 	assert.Contains(t, err.Error(), "badtype")
 }
 
+func TestExplicitSessionID_PersistedAndReusable(t *testing.T) {
+	t.Parallel()
+
+	// Simulate the persistence that resolveStoredID now performs when an explicit
+	// session ID is provided. This verifies the round-trip: save an explicit ID,
+	// then load it back (as monitor's resolveMonitorSession would).
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ConfigFile)
+
+	agentName := "my-agent"
+	explicitSID := "user-provided-session-id"
+
+	// Before: no sessions stored
+	agentCtx := loadLocalContext(configPath)
+	assert.Empty(t, agentCtx.Sessions)
+
+	// Simulate what resolveStoredID now does: persist the explicit ID
+	store := contextMap(agentCtx, "sessions")
+	store[agentName] = explicitSID
+	require.NoError(t, saveLocalContext(agentCtx, configPath))
+
+	// Reload (as monitor or a subsequent invoke would)
+	loaded := loadLocalContext(configPath)
+	require.NotNil(t, loaded.Sessions)
+	assert.Equal(t, explicitSID, loaded.Sessions[agentName])
+}
+
+func TestExplicitConversationID_PersistedAndReusable(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ConfigFile)
+
+	agentName := "my-agent"
+	explicitConvID := "user-provided-conv-id"
+
+	agentCtx := loadLocalContext(configPath)
+	store := contextMap(agentCtx, "conversations")
+	store[agentName] = explicitConvID
+	require.NoError(t, saveLocalContext(agentCtx, configPath))
+
+	loaded := loadLocalContext(configPath)
+	require.NotNil(t, loaded.Conversations)
+	assert.Equal(t, explicitConvID, loaded.Conversations[agentName])
+}
+
+func TestExplicitID_OverwritesPreviousValue(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ConfigFile)
+
+	agentName := "my-agent"
+
+	// Save an initial session ID
+	agentCtx := loadLocalContext(configPath)
+	store := contextMap(agentCtx, "sessions")
+	store[agentName] = "old-session-id"
+	require.NoError(t, saveLocalContext(agentCtx, configPath))
+
+	// Simulate a second invoke with a different explicit session ID
+	agentCtx = loadLocalContext(configPath)
+	store = contextMap(agentCtx, "sessions")
+	store[agentName] = "new-session-id"
+	require.NoError(t, saveLocalContext(agentCtx, configPath))
+
+	loaded := loadLocalContext(configPath)
+	assert.Equal(t, "new-session-id", loaded.Sessions[agentName])
+}
+
 func TestValidateMonitorFlags_SessionDoesNotAffectValidation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #7602

Before: 
Does not save the session when explicitly passed, so monitor fails saying to invoke first. 
```
model-test git:(main) 09:53 azd ai agent invoke --session-id "1234571b-e4d0-4811-ae6d-67faf2c94011" "hello"
Agent:        seattle-hotel-agent (remote)
Message:      "hello"
Session:      1234571b-e4d0-4811-ae6d-67faf2c94011
Conversation: conv_9da3f7bbaed1d2b700xhdNUWasJQgubLV6k7Qe6tTvcywHO60J

Trace ID: ceb08745-e9c0-40e0-a704-dccef21f6045
[seattle-hotel-agent] Hello! How can I assist you today? Are you looking for hotel recommendations in Seattle? If so, could you please provide your check-in and check-out dates? Also, do you have a budget range in mind?

model-test git:(main) 09:54 azd ai agent monitor
ERROR: VNext agents are currently enabled and require a session ID for log streaming.

Suggestion: Specify the session ID using --session, or run `azd ai agent invoke` first to create on
```

After:
```
model-test git:(main) 09:56 azd ai agent invoke --session-id "1234571b-e4d0-4811-ae6d-67faf2c94011" "hello"
Agent:        seattle-hotel-agent (remote)
Message:      "hello"
Session:      1234571b-e4d0-4811-ae6d-67faf2c94011
Conversation: conv_9da3f7bbaed1d2b700xhdNUWasJQgubLV6k7Qe6tTvcywHO60J

Trace ID: 0e0faceb-bd50-4183-8c1c-450df7527dce
[seattle-hotel-agent] Hello! How can I assist you with hotels in Seattle today? Are you looking for a place to stay, or do you have any specific dates in mind for your trip?

model-test git:(main) 10:01 azd ai agent monitor
Streaming session logs for seattle-hotel-agent (session: 1234571b-e4d0-4811-ae6d-67faf2c94011)...
event: log
data: {"timestamp":"2026-04-10T14:01:07.7270399+00:00","session_id":"1234571b-e4d0-4811-ae6d-67faf2c94011","session_state":"Running","agent":"seattle-hotel-agent","last_accessed":"2026-04-10T13:54:02.345+00:00"}
...
```
