### PR TITLE
Add positional argument support to agent init

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -208,11 +208,18 @@ func newInitCommand(rootFlags *rootFlagsDefinition) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "init [-m <manifest pointer>] [--src <source directory>]",
+		Use:   "init [<path>] [-m <manifest pointer>] [--src <source directory>]",
 		Short: fmt.Sprintf("Initialize a new AI agent project. %s", color.YellowString("(Preview)")),
-		Args:  cobra.NoArgs,
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			printBanner(cmd.OutOrStdout())
+
+			// Resolve optional positional argument into --manifest or --src
+			if len(args) == 1 {
+				if err := applyPositionalArg(args[0], flags, cmd); err != nil {
+					return err
+				}
+			}
 
 			ctx := azdext.WithAccessToken(cmd.Context())
 
@@ -886,6 +893,72 @@ func looksLikeManifest(path string) bool {
 
 	_, hasTemplate := top["template"]
 	return hasTemplate
+}
+
+// resolvePositionalArg classifies a positional argument as either a manifest
+// pointer (URL or existing file) or a source directory (existing directory).
+// It returns (isManifest=true, isSrc=false) for URLs and files,
+// (isManifest=false, isSrc=true) for directories, or an error for
+// unrecognized inputs.
+func resolvePositionalArg(arg string) (isManifest bool, isSrc bool, err error) {
+	// Check for URL first (http/https schemes)
+	if parsed, parseErr := url.Parse(arg); parseErr == nil &&
+		(parsed.Scheme == "http" || parsed.Scheme == "https") {
+		return true, false, nil
+	}
+
+	info, statErr := os.Stat(arg)
+	if statErr == nil {
+		if info.IsDir() {
+			return false, true, nil
+		}
+		return true, false, nil
+	}
+
+	return false, false, exterrors.Validation(
+		exterrors.CodeInvalidPositionalArg,
+		fmt.Sprintf(
+			"'%s' is not a recognized URL, file, or directory",
+			arg,
+		),
+		"provide a valid URL, an existing manifest file path, or an existing directory.\n"+
+			"You can also use explicit flags: --manifest (-m) for a manifest pointer, or --src (-s) for a directory",
+	)
+}
+
+// applyPositionalArg resolves a positional argument and maps it to the
+// appropriate flag, returning an error if the flag was already set explicitly.
+func applyPositionalArg(arg string, flags *initFlags, cmd *cobra.Command) error {
+	isManifest, isSrc, err := resolvePositionalArg(arg)
+	if err != nil {
+		return err
+	}
+
+	if isManifest {
+		if cmd.Flags().Changed("manifest") {
+			return exterrors.Validation(
+				exterrors.CodeConflictingArguments,
+				"cannot pass both a positional argument and --manifest",
+				"use either 'azd ai agent init <path>' or "+
+					"'azd ai agent init -m <manifest>', not both",
+			)
+		}
+		flags.manifestPointer = arg
+	}
+
+	if isSrc {
+		if cmd.Flags().Changed("src") {
+			return exterrors.Validation(
+				exterrors.CodeConflictingArguments,
+				"cannot pass both a positional directory argument and --src",
+				"use either 'azd ai agent init <dir>' or "+
+					"'azd ai agent init --src <dir>', not both",
+			)
+		}
+		flags.src = arg
+	}
+
+	return nil
 }
 
 func (a *InitAction) isGitHubUrl(manifestPointer string) bool {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -896,15 +896,21 @@ func looksLikeManifest(path string) bool {
 }
 
 // resolvePositionalArg classifies a positional argument as either a manifest
-// pointer (URL or existing file) or a source directory (existing directory).
-// It returns (isManifest=true, isSrc=false) for URLs and files,
-// (isManifest=false, isSrc=true) for directories, or an error for
+// pointer (explicit URI or existing file) or a source directory (existing
+// directory). It returns (isManifest=true, isSrc=false) for explicit URIs and
+// files, (isManifest=false, isSrc=true) for directories, or an error for
 // unrecognized inputs.
+//
+// For non-existent paths, a heuristic is applied: .yaml/.yml extensions are
+// treated as manifest pointers, while all other paths are treated as source
+// directories (the downstream init flow creates them via MkdirAll).
 func resolvePositionalArg(arg string) (isManifest bool, isSrc bool, err error) {
-	// Check for URL first (http/https schemes)
-	if parsed, parseErr := url.Parse(arg); parseErr == nil &&
-		(parsed.Scheme == "http" || parsed.Scheme == "https") {
-		return true, false, nil
+	// Check for an explicit URI form first. Requiring "://" avoids
+	// misclassifying Windows drive paths such as C:\...
+	if strings.Contains(arg, "://") {
+		if parsed, parseErr := url.Parse(arg); parseErr == nil && parsed.Scheme != "" {
+			return true, false, nil
+		}
 	}
 
 	info, statErr := os.Stat(arg)
@@ -915,15 +921,14 @@ func resolvePositionalArg(arg string) (isManifest bool, isSrc bool, err error) {
 		return true, false, nil
 	}
 
-	return false, false, exterrors.Validation(
-		exterrors.CodeInvalidPositionalArg,
-		fmt.Sprintf(
-			"'%s' is not a recognized URL, file, or directory",
-			arg,
-		),
-		"provide a valid URL, an existing manifest file path, or an existing directory.\n"+
-			"You can also use explicit flags: --manifest (-m) for a manifest pointer, or --src (-s) for a directory",
-	)
+	// Path does not exist — use file extension heuristic.
+	ext := strings.ToLower(filepath.Ext(arg))
+	if ext == ".yaml" || ext == ".yml" {
+		return true, false, nil
+	}
+
+	// Default to source directory; the downstream flow will create it via MkdirAll.
+	return false, true, nil
 }
 
 // applyPositionalArg resolves a positional argument and maps it to the

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -626,7 +626,6 @@ func TestResolvePositionalArg(t *testing.T) {
 		arg        string
 		isManifest bool
 		isSrc      bool
-		wantErr    bool
 	}{
 		{
 			name:       "https URL is manifest",
@@ -636,6 +635,16 @@ func TestResolvePositionalArg(t *testing.T) {
 		{
 			name:       "http URL is manifest",
 			arg:        "http://example.com/agent.yaml",
+			isManifest: true,
+		},
+		{
+			name:       "azureml registry URL is manifest",
+			arg:        "azureml://registries/myReg/agentmanifests/myManifest",
+			isManifest: true,
+		},
+		{
+			name:       "custom scheme URL is manifest",
+			arg:        "custom://some/resource",
 			isManifest: true,
 		},
 		{
@@ -649,9 +658,19 @@ func TestResolvePositionalArg(t *testing.T) {
 			isSrc: true,
 		},
 		{
-			name:    "non-existent path is error",
-			arg:     filepath.Join(tmpDir, "does-not-exist"),
-			wantErr: true,
+			name:       "non-existent yaml path is manifest",
+			arg:        filepath.Join(tmpDir, "does-not-exist.yaml"),
+			isManifest: true,
+		},
+		{
+			name:       "non-existent yml path is manifest",
+			arg:        filepath.Join(tmpDir, "does-not-exist.yml"),
+			isManifest: true,
+		},
+		{
+			name:  "non-existent path without extension is src",
+			arg:   filepath.Join(tmpDir, "new-project-dir"),
+			isSrc: true,
 		},
 	}
 
@@ -659,16 +678,6 @@ func TestResolvePositionalArg(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			isManifest, isSrc, err := resolvePositionalArg(tt.arg)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
-				// Verify it's an exterrors.Validation error
-				if !strings.Contains(err.Error(), "not a recognized URL, file, or directory") {
-					t.Fatalf("expected validation error message, got: %s", err)
-				}
-				return
-			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -702,8 +711,16 @@ func TestApplyPositionalArg_ConflictWithManifestFlag(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for conflicting positional arg and --manifest flag")
 	}
-	if !strings.Contains(err.Error(), "cannot pass both") {
-		t.Fatalf("expected conflict error message, got: %s", err)
+
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	if !ok {
+		t.Fatalf("expected *azdext.LocalError, got %T", err)
+	}
+	if localErr.Code != exterrors.CodeConflictingArguments {
+		t.Errorf("code = %q, want %q", localErr.Code, exterrors.CodeConflictingArguments)
+	}
+	if !strings.Contains(localErr.Suggestion, "azd ai agent init") {
+		t.Errorf("suggestion should include usage example, got: %s", localErr.Suggestion)
 	}
 }
 
@@ -725,8 +742,16 @@ func TestApplyPositionalArg_ConflictWithSrcFlag(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for conflicting positional arg and --src flag")
 	}
-	if !strings.Contains(err.Error(), "cannot pass both") {
-		t.Fatalf("expected conflict error message, got: %s", err)
+
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	if !ok {
+		t.Fatalf("expected *azdext.LocalError, got %T", err)
+	}
+	if localErr.Code != exterrors.CodeConflictingArguments {
+		t.Errorf("code = %q, want %q", localErr.Code, exterrors.CodeConflictingArguments)
+	}
+	if !strings.Contains(localErr.Suggestion, "azd ai agent init") {
+		t.Errorf("suggestion should include usage example, got: %s", localErr.Suggestion)
 	}
 }
 
@@ -766,5 +791,41 @@ func TestApplyPositionalArg_SetsSrcDir(t *testing.T) {
 	}
 	if flags.src != tmpDir {
 		t.Errorf("src = %q, want %q", flags.src, tmpDir)
+	}
+}
+
+func TestApplyPositionalArg_NonExistentDirSetsSrc(t *testing.T) {
+	t.Parallel()
+
+	newDir := filepath.Join(t.TempDir(), "new-project")
+
+	flags := &initFlags{rootFlagsDefinition: &rootFlagsDefinition{}}
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVarP(&flags.manifestPointer, "manifest", "m", "", "")
+	cmd.Flags().StringVarP(&flags.src, "src", "s", "", "")
+
+	if err := applyPositionalArg(newDir, flags, cmd); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if flags.src != newDir {
+		t.Errorf("src = %q, want %q", flags.src, newDir)
+	}
+}
+
+func TestApplyPositionalArg_NonExistentYamlSetsManifest(t *testing.T) {
+	t.Parallel()
+
+	yamlPath := filepath.Join(t.TempDir(), "agent.yaml")
+
+	flags := &initFlags{rootFlagsDefinition: &rootFlagsDefinition{}}
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVarP(&flags.manifestPointer, "manifest", "m", "", "")
+	cmd.Flags().StringVarP(&flags.src, "src", "s", "", "")
+
+	if err := applyPositionalArg(yamlPath, flags, cmd); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if flags.manifestPointer != yamlPath {
+		t.Errorf("manifestPointer = %q, want %q", flags.manifestPointer, yamlPath)
 	}
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -15,6 +15,7 @@ import (
 	"azureaiagent/internal/pkg/agents/agent_yaml"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/spf13/cobra"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -607,5 +608,163 @@ func TestManifestHasModelResources(t *testing.T) {
 				t.Errorf("manifestHasModelResources() = %v, want %v", result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestResolvePositionalArg(t *testing.T) {
+	t.Parallel()
+
+	// Create a temp directory with a manifest file for testing
+	tmpDir := t.TempDir()
+	manifestPath := filepath.Join(tmpDir, "agent.yaml")
+	if err := os.WriteFile(manifestPath, []byte("name: test\n"), 0600); err != nil {
+		t.Fatalf("failed to create test manifest: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		arg        string
+		isManifest bool
+		isSrc      bool
+		wantErr    bool
+	}{
+		{
+			name:       "https URL is manifest",
+			arg:        "https://github.com/org/repo/blob/main/agent.yaml",
+			isManifest: true,
+		},
+		{
+			name:       "http URL is manifest",
+			arg:        "http://example.com/agent.yaml",
+			isManifest: true,
+		},
+		{
+			name:       "existing file is manifest",
+			arg:        manifestPath,
+			isManifest: true,
+		},
+		{
+			name:  "existing directory is src",
+			arg:   tmpDir,
+			isSrc: true,
+		},
+		{
+			name:    "non-existent path is error",
+			arg:     filepath.Join(tmpDir, "does-not-exist"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			isManifest, isSrc, err := resolvePositionalArg(tt.arg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				// Verify it's an exterrors.Validation error
+				if !strings.Contains(err.Error(), "not a recognized URL, file, or directory") {
+					t.Fatalf("expected validation error message, got: %s", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if isManifest != tt.isManifest {
+				t.Errorf("isManifest = %v, want %v", isManifest, tt.isManifest)
+			}
+			if isSrc != tt.isSrc {
+				t.Errorf("isSrc = %v, want %v", isSrc, tt.isSrc)
+			}
+		})
+	}
+}
+
+func TestApplyPositionalArg_ConflictWithManifestFlag(t *testing.T) {
+	t.Parallel()
+
+	manifestPath := filepath.Join(t.TempDir(), "agent.yaml")
+	if err := os.WriteFile(manifestPath, []byte("name: test\n"), 0600); err != nil {
+		t.Fatalf("failed to create test manifest: %v", err)
+	}
+
+	flags := &initFlags{rootFlagsDefinition: &rootFlagsDefinition{}}
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVarP(&flags.manifestPointer, "manifest", "m", "", "")
+	// Simulate the user having set --manifest explicitly
+	if err := cmd.Flags().Set("manifest", "other.yaml"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+
+	err := applyPositionalArg(manifestPath, flags, cmd)
+	if err == nil {
+		t.Fatal("expected error for conflicting positional arg and --manifest flag")
+	}
+	if !strings.Contains(err.Error(), "cannot pass both") {
+		t.Fatalf("expected conflict error message, got: %s", err)
+	}
+}
+
+func TestApplyPositionalArg_ConflictWithSrcFlag(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	flags := &initFlags{rootFlagsDefinition: &rootFlagsDefinition{}}
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVarP(&flags.src, "src", "s", "", "")
+	cmd.Flags().StringVarP(&flags.manifestPointer, "manifest", "m", "", "")
+	// Simulate the user having set --src explicitly
+	if err := cmd.Flags().Set("src", "other-dir"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+
+	err := applyPositionalArg(tmpDir, flags, cmd)
+	if err == nil {
+		t.Fatal("expected error for conflicting positional arg and --src flag")
+	}
+	if !strings.Contains(err.Error(), "cannot pass both") {
+		t.Fatalf("expected conflict error message, got: %s", err)
+	}
+}
+
+func TestApplyPositionalArg_SetsManifestPointer(t *testing.T) {
+	t.Parallel()
+
+	manifestPath := filepath.Join(t.TempDir(), "agent.yaml")
+	if err := os.WriteFile(manifestPath, []byte("name: test\n"), 0600); err != nil {
+		t.Fatalf("failed to create test manifest: %v", err)
+	}
+
+	flags := &initFlags{rootFlagsDefinition: &rootFlagsDefinition{}}
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVarP(&flags.manifestPointer, "manifest", "m", "", "")
+	cmd.Flags().StringVarP(&flags.src, "src", "s", "", "")
+
+	if err := applyPositionalArg(manifestPath, flags, cmd); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if flags.manifestPointer != manifestPath {
+		t.Errorf("manifestPointer = %q, want %q", flags.manifestPointer, manifestPath)
+	}
+}
+
+func TestApplyPositionalArg_SetsSrcDir(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	flags := &initFlags{rootFlagsDefinition: &rootFlagsDefinition{}}
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVarP(&flags.manifestPointer, "manifest", "m", "", "")
+	cmd.Flags().StringVarP(&flags.src, "src", "s", "", "")
+
+	if err := applyPositionalArg(tmpDir, flags, cmd); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if flags.src != tmpDir {
+		t.Errorf("src = %q, want %q", flags.src, tmpDir)
 	}
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go
@@ -31,6 +31,8 @@ const (
 	CodeTenantMismatch            = "tenant_mismatch"
 	CodeMissingPublishedContainer = "missing_published_container_artifact"
 	CodeModelDeploymentNotFound   = "model_deployment_not_found"
+	CodeConflictingArguments      = "conflicting_arguments"
+	CodeInvalidPositionalArg      = "invalid_positional_arg"
 )
 
 // Error codes commonly used for dependency errors.


### PR DESCRIPTION
Fixes #7510

azd ai agent init <path> now accepts an optional positional argument that is auto-disambiguated between url, manifest file, or directory. 

Explicit flags (--manifest, --src) still take priority. Passing both a positional arg and the corresponding flag produces a clear validation error with a suggestion.

 Before

   ❯ azd ai agent init C:\path\to\my-agent
   ERROR: unknown command "C:\path\to\my-agent" for "agent init"

  After

   ❯ azd ai agent init C:\path\to\my-agent
   # Equivalent to: azd ai agent init --src C:\path\to\my-agent