### PR TITLE
fix: clear ENABLE_VIRTUAL_TERMINAL_INPUT on Windows to fix PowerShell arrow keys

### DIFF
--- a/cli/azd/pkg/ux/internal/console_other.go
+++ b/cli/azd/pkg/ux/internal/console_other.go
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build !windows
+
+package internal
+
+import "os"
+
+// disableVirtualTerminalInput is a no-op on non-Windows platforms.
+// The ENABLE_VIRTUAL_TERMINAL_INPUT console flag only exists on Windows.
+func disableVirtualTerminalInput(_ *os.File) error {
+	return nil
+}

--- a/cli/azd/pkg/ux/internal/console_windows.go
+++ b/cli/azd/pkg/ux/internal/console_windows.go
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build windows
+
+package internal
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32       = syscall.NewLazyDLL("kernel32.dll")
+	getConsoleMode = kernel32.NewProc("GetConsoleMode")
+	setConsoleMode = kernel32.NewProc("SetConsoleMode")
+)
+
+const enableVirtualTerminalInput uint32 = 0x0200
+
+// disableVirtualTerminalInput clears the ENABLE_VIRTUAL_TERMINAL_INPUT flag
+// on the console input handle. When this flag is set (e.g. by PowerShell),
+// Windows translates arrow key presses into ANSI escape sequences instead of
+// delivering them as native virtual key codes. The survey library's Windows
+// ReadRune only handles native VK codes, so leaving VTI enabled causes
+// escape sequence fragments to leak through as individual runes.
+//
+// This is called after survey's SetTermMode (which saves/restores the original
+// console state), so RestoreTermMode will re-enable VTI if it was originally set.
+func disableVirtualTerminalInput(f *os.File) error {
+	handle := f.Fd()
+
+	var mode uint32
+	r, _, err := getConsoleMode.Call(uintptr(handle), uintptr(unsafe.Pointer(&mode))) //nolint:gosec // Win32 API requires unsafe pointer
+	if r == 0 {
+		return err
+	}
+
+	if mode&enableVirtualTerminalInput == 0 {
+		return nil // VTI not enabled, nothing to do
+	}
+
+	newMode := mode &^ enableVirtualTerminalInput
+	r, _, err = setConsoleMode.Call(uintptr(handle), uintptr(newMode))
+	if r == 0 {
+		return err
+	}
+
+	return nil
+}

--- a/cli/azd/pkg/ux/internal/console_windows.go
+++ b/cli/azd/pkg/ux/internal/console_windows.go
@@ -32,7 +32,8 @@ func disableVirtualTerminalInput(f *os.File) error {
 	handle := f.Fd()
 
 	var mode uint32
-	r, _, err := getConsoleMode.Call(uintptr(handle), uintptr(unsafe.Pointer(&mode))) //nolint:gosec // Win32 API requires unsafe pointer
+	//nolint:gosec // Win32 API requires unsafe pointer
+	r, _, err := getConsoleMode.Call(uintptr(handle), uintptr(unsafe.Pointer(&mode)))
 	if r == 0 {
 		return err
 	}

--- a/cli/azd/pkg/ux/internal/input.go
+++ b/cli/azd/pkg/ux/internal/input.go
@@ -97,6 +97,12 @@ func (i *Input) ReadInput(ctx context.Context, config *InputConfig, handler KeyP
 			errChan <- err
 			return
 		}
+		// On Windows, clear ENABLE_VIRTUAL_TERMINAL_INPUT so the console
+		// delivers native virtual key codes instead of ANSI escape sequences.
+		// survey's RestoreTermMode will restore the original console state.
+		if err := disableVirtualTerminalInput(os.Stdin); err != nil {
+			log.Printf("Warning: could not disable virtual terminal input: %v\n", err)
+		}
 		defer func() {
 			if err := rr.RestoreTermMode(); err != nil {
 				log.Printf("Error restoring terminal mode: %v\n", err)


### PR DESCRIPTION
## Alternative approach to #7642

This is a draft PR illustrating an alternative fix for #7641 — clearing the `ENABLE_VIRTUAL_TERMINAL_INPUT` console flag on Windows instead of adding an escape sequence parser.

### Why

The root cause is that PowerShell enables `ENABLE_VIRTUAL_TERMINAL_INPUT` (0x0200) on the console input handle. This makes Windows translate arrow key presses into ANSI escape sequences (`ESC [ A`) instead of delivering native virtual key codes (`VK_UP`). The survey library's Windows `ReadRune()` only handles native VK codes, so the escape fragments leak through as individual runes.

### How

After `survey.SetTermMode()` (which saves the original console state), we additionally clear the VTI flag. The existing `RestoreTermMode()` restores the original state, re-enabling VTI if it was originally set.

### Changes

| File | Change |
|---|---|
| `pkg/ux/internal/console_windows.go` | New — clears `ENABLE_VIRTUAL_TERMINAL_INPUT` via Win32 API |
| `pkg/ux/internal/console_other.go` | New — no-op for non-Windows |
| `pkg/ux/internal/input.go` | 6-line addition to call the helper after `SetTermMode()` |

### Comparison with #7642

| Dimension | #7642 (escape parsing) | This PR (clear VTI) |
|---|---|---|
| **Lines changed** | +362 / -5 | +71 / -0 (mostly comments) |
| **Root cause** | Compensates downstream | Fixes at source |
| **Cross-platform risk** | `[A`–`[D` filter false positive on Linux/macOS | None (Windows-only via build tag) |
| **Maintenance** | State machine + pending buffer | Near-zero |

See the [detailed analysis comment](https://github.com/Azure/azure-dev/pull/7642#issuecomment-4226763834) on #7642.

Fixes #7641