### PR TITLE
fix changelog skill to include azdext version.go

### DIFF
--- a/.github/skills/changelog-generation/SKILL.md
+++ b/.github/skills/changelog-generation/SKILL.md
@@ -45,12 +45,12 @@ Auto-detect scope from the current working directory:
 
 ### Step 2 — Determine Version & Update Files
 
-**Files to update (core):** `cli/azd/CHANGELOG.md`, `cli/version.txt`
+**Files to update (core):** `cli/azd/CHANGELOG.md`, `cli/version.txt`, `cli/azd/pkg/azdext/version.go`
 **Files to update (extension):** `<extension>/CHANGELOG.md`, `<extension>/version.txt`, `<extension>/extension.yaml`
 
 For version derivation rules, see [references/scope-rules.md](references/scope-rules.md) § Version Files.
 
-- **Core**: derive version from the existing unreleased header (strip `-beta.*` and `(Unreleased)`), use today's date. Update `cli/version.txt` to the released version.
+- **Core**: derive version from the existing unreleased header (strip `-beta.*` and `(Unreleased)`), use today's date. Update `cli/version.txt` and `cli/azd/pkg/azdext/version.go` (`Version` constant) to the released version.
 - **Extension**: ask the user for the new version number via `ask_user`. Update both `version.txt` and `extension.yaml` — they must match exactly.
 
 Present the version and date to the user for confirmation before writing any files.

--- a/.github/skills/changelog-generation/references/scope-rules.md
+++ b/.github/skills/changelog-generation/references/scope-rules.md
@@ -7,6 +7,7 @@
 Files to update:
 - `cli/azd/CHANGELOG.md` — add release entry
 - `cli/version.txt` — set to released version
+- `cli/azd/pkg/azdext/version.go` — update `Version` constant to match `cli/version.txt`
 - `.vscode/cspell-github-user-aliases.txt` — if spell check additions needed
 
 **Version derivation:**
@@ -14,7 +15,8 @@ Files to update:
 2. Strip the `-beta.N` suffix and `(Unreleased)` marker.
 3. Format as: `## X.Y.Z (YYYY-MM-DD)` using today's date.
 4. Set `cli/version.txt` to `X.Y.Z`.
-5. If no unreleased header is found in the changelog, ask the user for the release version number via `ask_user`.
+5. Set the `Version` constant in `cli/azd/pkg/azdext/version.go` to `X.Y.Z`.
+6. If no unreleased header is found in the changelog, ask the user for the release version number via `ask_user`.
 
 **Do NOT** update any extension files.
 


### PR DESCRIPTION
The changelog skill didn't know about `cli/azd/pkg/azdext/version.go` (added in #7403). Core releases need to bump the `Version` constant there too.

Found this when PR #7639 bumped `cli/version.txt` to 1.23.15 but left `version.go` at 1.24.0-beta.1.

Updated SKILL.md and scope-rules.md to include `version.go` in the core release file list.

Fixes https://github.com/Azure/azure-dev/issues/7638