### PR TITLE
fix: use project root as boundary for hook path containment

### DIFF
--- a/cli/azd/cmd/hooks.go
+++ b/cli/azd/cmd/hooks.go
@@ -332,7 +332,7 @@ func (hra *hooksRunAction) execHook(
 		hookName: {hook},
 	}
 
-	hooksManager := ext.NewHooksManager(cwd, hra.commandRunner)
+	hooksManager := ext.NewHooksManager(cwd, hra.projectConfig.Path, hra.commandRunner)
 	hooksRunner := ext.NewHooksRunner(
 		hooksManager, hra.commandRunner, hra.envManager, hra.console, cwd, hooksMap, hra.env, hra.serviceLocator)
 
@@ -357,7 +357,7 @@ func (hra *hooksRunAction) validateAndWarnHooks(ctx context.Context) error {
 			return
 		}
 
-		hooksManager := ext.NewHooksManager(cwd, hra.commandRunner)
+		hooksManager := ext.NewHooksManager(cwd, hra.projectConfig.Path, hra.commandRunner)
 		validationResult := hooksManager.ValidateHooks(ctx, hooks)
 
 		for _, warning := range validationResult.Warnings {

--- a/cli/azd/cmd/hooks.go
+++ b/cli/azd/cmd/hooks.go
@@ -332,7 +332,9 @@ func (hra *hooksRunAction) execHook(
 		hookName: {hook},
 	}
 
-	hooksManager := ext.NewHooksManager(cwd, hra.projectConfig.Path, hra.commandRunner)
+	hooksManager := ext.NewHooksManager(ext.HooksManagerOptions{
+		Cwd: cwd, ProjectDir: hra.projectConfig.Path,
+	}, hra.commandRunner)
 	hooksRunner := ext.NewHooksRunner(
 		hooksManager, hra.commandRunner, hra.envManager, hra.console, cwd, hooksMap, hra.env, hra.serviceLocator)
 
@@ -357,7 +359,9 @@ func (hra *hooksRunAction) validateAndWarnHooks(ctx context.Context) error {
 			return
 		}
 
-		hooksManager := ext.NewHooksManager(cwd, hra.projectConfig.Path, hra.commandRunner)
+		hooksManager := ext.NewHooksManager(ext.HooksManagerOptions{
+			Cwd: cwd, ProjectDir: hra.projectConfig.Path,
+		}, hra.commandRunner)
 		validationResult := hooksManager.ValidateHooks(ctx, hooks)
 
 		for _, warning := range validationResult.Warnings {

--- a/cli/azd/cmd/middleware/hooks.go
+++ b/cli/azd/cmd/middleware/hooks.go
@@ -84,7 +84,9 @@ func (m *HooksMiddleware) registerCommandHooks(
 		return next(ctx)
 	}
 
-	hooksManager := ext.NewHooksManager(m.projectConfig.Path, m.projectConfig.Path, m.commandRunner)
+	hooksManager := ext.NewHooksManager(ext.HooksManagerOptions{
+		Cwd: m.projectConfig.Path, ProjectDir: m.projectConfig.Path,
+	}, m.commandRunner)
 	hooksRunner := ext.NewHooksRunner(
 		hooksManager,
 		m.commandRunner,
@@ -142,7 +144,9 @@ func (m *HooksMiddleware) registerServiceHooks(ctx context.Context) error {
 			continue
 		}
 
-		serviceHooksManager := ext.NewHooksManager(service.Path(), m.projectConfig.Path, m.commandRunner)
+		serviceHooksManager := ext.NewHooksManager(ext.HooksManagerOptions{
+			Cwd: service.Path(), ProjectDir: m.projectConfig.Path,
+		}, m.commandRunner)
 		serviceHooksRunner := ext.NewHooksRunner(
 			serviceHooksManager,
 			m.commandRunner,
@@ -206,7 +210,9 @@ func (m *HooksMiddleware) validateHooks(ctx context.Context, projectConfig *proj
 			return
 		}
 
-		hooksManager := ext.NewHooksManager(cwd, projectConfig.Path, m.commandRunner)
+		hooksManager := ext.NewHooksManager(ext.HooksManagerOptions{
+			Cwd: cwd, ProjectDir: projectConfig.Path,
+		}, m.commandRunner)
 		validationResult := hooksManager.ValidateHooks(ctx, hooks)
 
 		for _, warning := range validationResult.Warnings {

--- a/cli/azd/cmd/middleware/hooks.go
+++ b/cli/azd/cmd/middleware/hooks.go
@@ -84,7 +84,7 @@ func (m *HooksMiddleware) registerCommandHooks(
 		return next(ctx)
 	}
 
-	hooksManager := ext.NewHooksManager(m.projectConfig.Path, m.commandRunner)
+	hooksManager := ext.NewHooksManager(m.projectConfig.Path, m.projectConfig.Path, m.commandRunner)
 	hooksRunner := ext.NewHooksRunner(
 		hooksManager,
 		m.commandRunner,
@@ -142,7 +142,7 @@ func (m *HooksMiddleware) registerServiceHooks(ctx context.Context) error {
 			continue
 		}
 
-		serviceHooksManager := ext.NewHooksManager(service.Path(), m.commandRunner)
+		serviceHooksManager := ext.NewHooksManager(service.Path(), m.projectConfig.Path, m.commandRunner)
 		serviceHooksRunner := ext.NewHooksRunner(
 			serviceHooksManager,
 			m.commandRunner,
@@ -206,7 +206,7 @@ func (m *HooksMiddleware) validateHooks(ctx context.Context, projectConfig *proj
 			return
 		}
 
-		hooksManager := ext.NewHooksManager(cwd, m.commandRunner)
+		hooksManager := ext.NewHooksManager(cwd, projectConfig.Path, m.commandRunner)
 		validationResult := hooksManager.ValidateHooks(ctx, hooks)
 
 		for _, warning := range validationResult.Warnings {

--- a/cli/azd/internal/cmd/provision.go
+++ b/cli/azd/internal/cmd/provision.go
@@ -535,7 +535,7 @@ func (p *ProvisionAction) runLayerProvisionWithHooks(
 		return actionFn()
 	}
 
-	hooksManager := ext.NewHooksManager(layerPath, p.commandRunner)
+	hooksManager := ext.NewHooksManager(layerPath, p.projectConfig.Path, p.commandRunner)
 	hooksRunner := ext.NewHooksRunner(
 		hooksManager,
 		p.commandRunner,

--- a/cli/azd/internal/cmd/provision.go
+++ b/cli/azd/internal/cmd/provision.go
@@ -535,7 +535,9 @@ func (p *ProvisionAction) runLayerProvisionWithHooks(
 		return actionFn()
 	}
 
-	hooksManager := ext.NewHooksManager(layerPath, p.projectConfig.Path, p.commandRunner)
+	hooksManager := ext.NewHooksManager(ext.HooksManagerOptions{
+		Cwd: layerPath, ProjectDir: p.projectConfig.Path,
+	}, p.commandRunner)
 	hooksRunner := ext.NewHooksRunner(
 		hooksManager,
 		p.commandRunner,

--- a/cli/azd/pkg/ext/executor_dispatch_test.go
+++ b/cli/azd/pkg/ext/executor_dispatch_test.go
@@ -1,0 +1,220 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package ext
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/tools/language"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHookConfig_ExecutorDispatch verifies that every valid combination
+// of Kind, Run, and Dir resolves to the correct executor Kind after
+// validate(). The Kind string is the key passed to
+// serviceLocator.ResolveNamed() in execHook() to select the executor.
+func TestHookConfig_ExecutorDispatch(t *testing.T) {
+	t.Parallel()
+
+	// expectedOSDefault is the Kind assigned to inline scripts when
+	// no explicit Kind or Shell is set.
+	expectedOSDefault := language.HookKindBash
+	if runtime.GOOS == "windows" {
+		expectedOSDefault = language.HookKindPowerShell
+	}
+
+	tests := []struct {
+		name         string
+		kind         language.HookKind // explicit Kind (empty = infer)
+		run          string
+		dir          string   // explicit Dir (empty = infer)
+		createFiles  []string // paths relative to tmpDir
+		expectedKind language.HookKind
+	}{
+		// ── Explicit Kind always wins ──────────────────────────
+		{
+			name:         "ExplicitKindPython_RunPy",
+			kind:         language.HookKindPython,
+			run:          "main.py",
+			createFiles:  []string{"main.py"},
+			expectedKind: language.HookKindPython,
+		},
+		{
+			name:         "ExplicitKindBash_RunSh",
+			kind:         language.HookKindBash,
+			run:          "deploy.sh",
+			createFiles:  []string{"deploy.sh"},
+			expectedKind: language.HookKindBash,
+		},
+		{
+			name:         "ExplicitKindOverridesExtension",
+			kind:         language.HookKindJavaScript,
+			run:          "main.py",
+			createFiles:  []string{"main.py"},
+			expectedKind: language.HookKindJavaScript,
+		},
+
+		// ── Run only (no dir, no kind) — infer from extension ─
+		{
+			name:         "RunOnly_Py",
+			run:          "main.py",
+			createFiles:  []string{"main.py"},
+			expectedKind: language.HookKindPython,
+		},
+		{
+			name:         "RunOnly_Sh",
+			run:          "deploy.sh",
+			createFiles:  []string{"deploy.sh"},
+			expectedKind: language.HookKindBash,
+		},
+		{
+			name:         "RunOnly_Ps1",
+			run:          "deploy.ps1",
+			createFiles:  []string{"deploy.ps1"},
+			expectedKind: language.HookKindPowerShell,
+		},
+		{
+			name:         "RunOnly_Js",
+			run:          "index.js",
+			createFiles:  []string{"index.js"},
+			expectedKind: language.HookKindJavaScript,
+		},
+		{
+			name:         "RunOnly_Ts",
+			run:          "index.ts",
+			createFiles:  []string{"index.ts"},
+			expectedKind: language.HookKindTypeScript,
+		},
+		{
+			name:         "RunOnly_Cs",
+			run:          "Program.cs",
+			createFiles:  []string{"Program.cs"},
+			expectedKind: language.HookKindDotNet,
+		},
+
+		// ── Dir + Run (no kind) — infer from extension ────────
+		{
+			name:         "DirRun_Py",
+			run:          "main.py",
+			dir:          filepath.Join("hooks", "pre"),
+			createFiles:  []string{filepath.Join("hooks", "pre", "main.py")},
+			expectedKind: language.HookKindPython,
+		},
+		{
+			name:         "DirRun_Sh",
+			run:          "deploy.sh",
+			dir:          filepath.Join("hooks", "pre"),
+			createFiles:  []string{filepath.Join("hooks", "pre", "deploy.sh")},
+			expectedKind: language.HookKindBash,
+		},
+		{
+			name:         "DirRun_Ps1",
+			run:          "deploy.ps1",
+			dir:          filepath.Join("hooks", "pre"),
+			createFiles:  []string{filepath.Join("hooks", "pre", "deploy.ps1")},
+			expectedKind: language.HookKindPowerShell,
+		},
+		{
+			name:         "DirRun_Js",
+			run:          "index.js",
+			dir:          filepath.Join("hooks", "pre"),
+			createFiles:  []string{filepath.Join("hooks", "pre", "index.js")},
+			expectedKind: language.HookKindJavaScript,
+		},
+		{
+			name:         "DirRun_Ts",
+			run:          "index.ts",
+			dir:          filepath.Join("hooks", "pre"),
+			createFiles:  []string{filepath.Join("hooks", "pre", "index.ts")},
+			expectedKind: language.HookKindTypeScript,
+		},
+		{
+			name:         "DirRun_Cs",
+			run:          "Program.cs",
+			dir:          filepath.Join("hooks", "pre"),
+			createFiles:  []string{filepath.Join("hooks", "pre", "Program.cs")},
+			expectedKind: language.HookKindDotNet,
+		},
+
+		// ── Dir + Run with subdirectory path in run ───────────
+		{
+			name:         "DirRun_NestedPy",
+			run:          filepath.Join("src", "main.py"),
+			dir:          "hooks",
+			createFiles:  []string{filepath.Join("hooks", "src", "main.py")},
+			expectedKind: language.HookKindPython,
+		},
+
+		// ── Inline scripts (no file) — default to OS shell ────
+		{
+			name:         "Inline_NoFile",
+			run:          "echo hello",
+			expectedKind: expectedOSDefault,
+		},
+		{
+			name:         "Inline_DirSet_NoFile",
+			run:          "echo hello",
+			dir:          filepath.Join("hooks", "pre"),
+			expectedKind: expectedOSDefault,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+
+			for _, f := range tt.createFiles {
+				fullPath := filepath.Join(tmpDir, f)
+				require.NoError(t,
+					os.MkdirAll(filepath.Dir(fullPath), 0o755))
+				require.NoError(t,
+					os.WriteFile(fullPath, []byte("# placeholder"), 0o600))
+			}
+
+			config := HookConfig{
+				Name:     "test",
+				Run:      tt.run,
+				Dir:      tt.dir,
+				Kind:     tt.kind,
+				inputCwd: tmpDir,
+			}
+
+			err := config.validate()
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedKind, config.Kind,
+				"expected Kind %q but got %q for ResolveNamed() executor lookup",
+				tt.expectedKind, config.Kind)
+		})
+	}
+}
+
+// TestHookKind_ExecutorRegistrationNames verifies that the string
+// representation of each HookKind matches the key used when
+// registering executors in the IoC container. These are the exact
+// strings passed to serviceLocator.ResolveNamed() in execHook().
+// If someone renames a constant, this test ensures the IoC
+// lookup string stays in sync.
+func TestHookKind_ExecutorRegistrationNames(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "sh", string(language.HookKindBash),
+		"Bash executor registration key")
+	assert.Equal(t, "pwsh", string(language.HookKindPowerShell),
+		"PowerShell executor registration key")
+	assert.Equal(t, "python", string(language.HookKindPython),
+		"Python executor registration key")
+	assert.Equal(t, "js", string(language.HookKindJavaScript),
+		"JavaScript executor registration key")
+	assert.Equal(t, "ts", string(language.HookKindTypeScript),
+		"TypeScript executor registration key")
+	assert.Equal(t, "dotnet", string(language.HookKindDotNet),
+		"DotNet executor registration key")
+}

--- a/cli/azd/pkg/ext/hooks_manager.go
+++ b/cli/azd/pkg/ext/hooks_manager.go
@@ -27,13 +27,18 @@ type HookFilterPredicateFn func(scriptName string, hookConfig *HookConfig) bool
 // commands. Hooks can be invoked at the project or service level.
 type HooksManager struct {
 	cwd           string
+	projectDir    string
 	commandRunner exec.CommandRunner
 }
 
 // NewHooks creates a new instance of CommandHooks
-// When `cwd` is empty defaults to current shell working directory
+// When `cwd` is empty defaults to current shell working directory.
+// `projectDir` is the project root directory (where azure.yaml
+// lives), used as the security boundary for path containment.
+// When empty, `cwd` is used as the boundary.
 func NewHooksManager(
 	cwd string,
+	projectDir string,
 	commandRunner exec.CommandRunner,
 ) *HooksManager {
 	if cwd == "" {
@@ -45,8 +50,13 @@ func NewHooksManager(
 		cwd = osWd
 	}
 
+	if projectDir == "" {
+		projectDir = cwd
+	}
+
 	return &HooksManager{
 		cwd:           cwd,
+		projectDir:    projectDir,
 		commandRunner: commandRunner,
 	}
 }
@@ -116,6 +126,7 @@ func (h *HooksManager) filterConfigs(
 
 			hook.Name = scriptName
 			hook.cwd = h.cwd
+			hook.projectDir = h.projectDir
 
 			if err := hook.validate(); err != nil {
 				return nil, fmt.Errorf("hook configuration for '%s' is invalid, %w", scriptName, err)
@@ -162,6 +173,9 @@ func (h *HooksManager) ValidateHooks(ctx context.Context, allHooks map[string][]
 			// Set the working directory for validation
 			if hookConfig.cwd == "" {
 				hookConfig.cwd = h.cwd
+			}
+			if hookConfig.projectDir == "" {
+				hookConfig.projectDir = h.projectDir
 			}
 
 			// Only perform shell detection for warning purposes, not full validation
@@ -290,6 +304,9 @@ func (h *HooksManager) validateRuntimes(
 
 			if cfg.cwd == "" {
 				cfg.cwd = h.cwd
+			}
+			if cfg.projectDir == "" {
+				cfg.projectDir = h.projectDir
 			}
 
 			// Set the hook name so that any temp scripts

--- a/cli/azd/pkg/ext/hooks_manager.go
+++ b/cli/azd/pkg/ext/hooks_manager.go
@@ -23,6 +23,12 @@ import (
 
 type HookFilterPredicateFn func(scriptName string, hookConfig *HookConfig) bool
 
+// HooksManagerOptions configures a new [HooksManager].
+type HooksManagerOptions struct {
+	Cwd        string // Working directory for resolving relative hook paths
+	ProjectDir string // Project root (azure.yaml location) for security boundary
+}
+
 // HooksManager enables support to invoke lifecycle hooks before & after
 // commands. Hooks can be invoked at the project or service level.
 type HooksManager struct {
@@ -32,15 +38,16 @@ type HooksManager struct {
 }
 
 // NewHooksManager creates a new [HooksManager] instance.
-// When `cwd` is empty defaults to current shell working directory.
-// `projectDir` is the project root directory (where azure.yaml
-// lives), used as the security boundary for path containment.
-// When empty, `cwd` is used as the boundary.
+// When [HooksManagerOptions.Cwd] is empty defaults to current shell
+// working directory.
+// [HooksManagerOptions.ProjectDir] is the project root directory
+// (where azure.yaml lives), used as the security boundary for path
+// containment. When empty, Cwd is used as the boundary.
 func NewHooksManager(
-	cwd string,
-	projectDir string,
+	options HooksManagerOptions,
 	commandRunner exec.CommandRunner,
 ) *HooksManager {
+	cwd := options.Cwd
 	if cwd == "" {
 		osWd, err := os.Getwd()
 		if err != nil {
@@ -50,6 +57,7 @@ func NewHooksManager(
 		cwd = osWd
 	}
 
+	projectDir := options.ProjectDir
 	if projectDir == "" {
 		projectDir = cwd
 	}

--- a/cli/azd/pkg/ext/hooks_manager.go
+++ b/cli/azd/pkg/ext/hooks_manager.go
@@ -31,7 +31,7 @@ type HooksManager struct {
 	commandRunner exec.CommandRunner
 }
 
-// NewHooks creates a new instance of CommandHooks
+// NewHooksManager creates a new [HooksManager] instance.
 // When `cwd` is empty defaults to current shell working directory.
 // `projectDir` is the project root directory (where azure.yaml
 // lives), used as the security boundary for path containment.

--- a/cli/azd/pkg/ext/hooks_manager.go
+++ b/cli/azd/pkg/ext/hooks_manager.go
@@ -188,15 +188,46 @@ func (h *HooksManager) ValidateHooks(ctx context.Context, allHooks map[string][]
 
 			// Only perform shell detection for warning purposes, not full validation
 			if !hookConfig.validated && hookConfig.Run != "" {
-				// Check if it's an inline script (no file exists)
-				relativeCheckPath := strings.ReplaceAll(hookConfig.Run, "/", string(os.PathSeparator))
+				// Check if it's an inline script (no file exists).
+				// Mirror the Dir-aware resolution from parseRunTarget
+				// so dir+run combinations are correctly detected as
+				// file-based hooks.
+				relativeCheckPath := strings.ReplaceAll(
+					hookConfig.Run, "/", string(os.PathSeparator),
+				)
 				fullCheckPath := relativeCheckPath
 				if hookConfig.inputCwd != "" {
-					fullCheckPath = filepath.Join(hookConfig.inputCwd, relativeCheckPath)
+					if filepath.IsAbs(relativeCheckPath) {
+						fullCheckPath = relativeCheckPath
+					} else if hookConfig.Dir != "" {
+						dir := hookConfig.Dir
+						if !filepath.IsAbs(dir) {
+							dir = filepath.Join(
+								hookConfig.inputCwd, dir,
+							)
+						}
+						candidate := filepath.Join(
+							dir, relativeCheckPath,
+						)
+						info, sErr := os.Stat(candidate)
+						if sErr == nil && !info.IsDir() {
+							fullCheckPath = candidate
+						} else {
+							fullCheckPath = filepath.Join(
+								hookConfig.inputCwd,
+								relativeCheckPath,
+							)
+						}
+					} else {
+						fullCheckPath = filepath.Join(
+							hookConfig.inputCwd,
+							relativeCheckPath,
+						)
+					}
 				}
 
 				_, err := os.Stat(fullCheckPath)
-				isInlineScript := err != nil // File doesn't exist, so it's inline
+				isInlineScript := err != nil
 
 				// If no kind/shell and it's an inline script, set
 				// OS default Kind for warning purposes.

--- a/cli/azd/pkg/ext/hooks_manager.go
+++ b/cli/azd/pkg/ext/hooks_manager.go
@@ -125,7 +125,7 @@ func (h *HooksManager) filterConfigs(
 			}
 
 			hook.Name = scriptName
-			hook.cwd = h.cwd
+			hook.inputCwd = h.cwd
 			hook.projectDir = h.projectDir
 
 			if err := hook.validate(); err != nil {
@@ -171,8 +171,8 @@ func (h *HooksManager) ValidateHooks(ctx context.Context, allHooks map[string][]
 	for _, hookConfigs := range allHooks {
 		for _, hookConfig := range hookConfigs {
 			// Set the working directory for validation
-			if hookConfig.cwd == "" {
-				hookConfig.cwd = h.cwd
+			if hookConfig.inputCwd == "" {
+				hookConfig.inputCwd = h.cwd
 			}
 			if hookConfig.projectDir == "" {
 				hookConfig.projectDir = h.projectDir
@@ -183,8 +183,8 @@ func (h *HooksManager) ValidateHooks(ctx context.Context, allHooks map[string][]
 				// Check if it's an inline script (no file exists)
 				relativeCheckPath := strings.ReplaceAll(hookConfig.Run, "/", string(os.PathSeparator))
 				fullCheckPath := relativeCheckPath
-				if hookConfig.cwd != "" {
-					fullCheckPath = filepath.Join(hookConfig.cwd, relativeCheckPath)
+				if hookConfig.inputCwd != "" {
+					fullCheckPath = filepath.Join(hookConfig.inputCwd, relativeCheckPath)
 				}
 
 				_, err := os.Stat(fullCheckPath)
@@ -302,8 +302,8 @@ func (h *HooksManager) validateRuntimes(
 				cfg = cfg.Posix
 			}
 
-			if cfg.cwd == "" {
-				cfg.cwd = h.cwd
+			if cfg.inputCwd == "" {
+				cfg.inputCwd = h.cwd
 			}
 			if cfg.projectDir == "" {
 				cfg.projectDir = h.projectDir

--- a/cli/azd/pkg/ext/hooks_manager.go
+++ b/cli/azd/pkg/ext/hooks_manager.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"os"
 	osexec "os/exec"
-	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -168,86 +167,48 @@ func (h *HooksManager) ValidateHooks(ctx context.Context, allHooks map[string][]
 	hasPowerShellHooks := false
 	hasDefaultShellHooks := false
 
-	// Two-pass validation is required because:
-	// 1. First pass: Set shell defaults and detect inline scripts for each hook configuration
-	// 2. Second pass: Generate warnings only after all hooks have been processed and we know
-	//    the complete state (e.g., whether ANY hook uses PowerShell or default shell)
-	// We cannot merge these loops because warnings depend on global state across all hooks.
-
-	// First pass: perform lightweight validation to set flags like usingDefaultShell
-	// without creating temporary files (which full validation does)
-	for _, hookConfigs := range allHooks {
+	// validate() is the sole authority for Kind assignment.
+	// Run it on every hook first, then read the resolved
+	// state for warning purposes.
+	for hookName, hookConfigs := range allHooks {
 		for _, hookConfig := range hookConfigs {
-			// Set the working directory for validation
-			if hookConfig.inputCwd == "" {
-				hookConfig.inputCwd = h.cwd
-			}
-			if hookConfig.projectDir == "" {
-				hookConfig.projectDir = h.projectDir
+			if hookConfig == nil {
+				continue
 			}
 
-			// Only perform shell detection for warning purposes, not full validation
-			if !hookConfig.validated && hookConfig.Run != "" {
-				// Check if it's an inline script (no file exists).
-				// Mirror the Dir-aware resolution from parseRunTarget
-				// so dir+run combinations are correctly detected as
-				// file-based hooks.
-				relativeCheckPath := strings.ReplaceAll(
-					hookConfig.Run, "/", string(os.PathSeparator),
-				)
-				fullCheckPath := relativeCheckPath
-				if hookConfig.inputCwd != "" {
-					if filepath.IsAbs(relativeCheckPath) {
-						fullCheckPath = relativeCheckPath
-					} else if hookConfig.Dir != "" {
-						dir := hookConfig.Dir
-						if !filepath.IsAbs(dir) {
-							dir = filepath.Join(
-								hookConfig.inputCwd, dir,
-							)
-						}
-						candidate := filepath.Join(
-							dir, relativeCheckPath,
-						)
-						info, sErr := os.Stat(candidate)
-						if sErr == nil && !info.IsDir() {
-							fullCheckPath = candidate
-						} else {
-							fullCheckPath = filepath.Join(
-								hookConfig.inputCwd,
-								relativeCheckPath,
-							)
-						}
-					} else {
-						fullCheckPath = filepath.Join(
-							hookConfig.inputCwd,
-							relativeCheckPath,
-						)
-					}
-				}
-
-				_, err := os.Stat(fullCheckPath)
-				isInlineScript := err != nil
-
-				// If no kind/shell and it's an inline script, set
-				// OS default Kind for warning purposes.
-				if hookConfig.Shell == "" &&
-					hookConfig.Kind == language.HookKindUnknown &&
-					isInlineScript {
-					hookConfig.Kind = defaultKindForOS()
-					hookConfig.usingDefaultShell = true
-				}
+			// Apply OS-specific override if present.
+			cfg := hookConfig
+			if runtime.GOOS == "windows" &&
+				cfg.Windows != nil {
+				cfg = cfg.Windows
+			} else if (runtime.GOOS == "linux" ||
+				runtime.GOOS == "darwin") &&
+				cfg.Posix != nil {
+				cfg = cfg.Posix
 			}
-		}
-	}
 
-	// Second pass: check all hooks for warning conditions using the state set in first pass
-	for _, hookConfigs := range allHooks {
-		for _, hookConfig := range hookConfigs {
-			if hookConfig.IsPowerShellHook() {
+			if cfg.inputCwd == "" {
+				cfg.inputCwd = h.cwd
+			}
+			if cfg.projectDir == "" {
+				cfg.projectDir = h.projectDir
+			}
+			if cfg.Name == "" {
+				cfg.Name = hookName
+			}
+
+			// validate() resolves Kind from file extension,
+			// explicit config, or OS default for inline
+			// scripts. Validation errors are surfaced by
+			// GetAll / GetByParams; skip the hook here.
+			if err := cfg.validate(); err != nil {
+				continue
+			}
+
+			if cfg.IsPowerShellHook() {
 				hasPowerShellHooks = true
 			}
-			if hookConfig.IsUsingDefaultShell() {
+			if cfg.IsUsingDefaultShell() {
 				hasDefaultShellHooks = true
 			}
 		}

--- a/cli/azd/pkg/ext/hooks_manager_test.go
+++ b/cli/azd/pkg/ext/hooks_manager_test.go
@@ -40,7 +40,7 @@ func Test_GetAllHookConfigs(t *testing.T) {
 		ensureScriptsExist(t, hooksMap)
 
 		mockCommandRunner := mockexec.NewMockCommandRunner()
-		hooksManager := NewHooksManager(tempDir, tempDir, mockCommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: tempDir, ProjectDir: tempDir}, mockCommandRunner)
 		validHooks, err := hooksManager.GetAll(hooksMap)
 
 		require.Len(t, validHooks, len(hooksMap))
@@ -67,7 +67,7 @@ func Test_GetAllHookConfigs(t *testing.T) {
 		ensureScriptsExist(t, hooksMap)
 
 		mockCommandRunner := mockexec.NewMockCommandRunner()
-		hooksManager := NewHooksManager(tempDir, tempDir, mockCommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: tempDir, ProjectDir: tempDir}, mockCommandRunner)
 		validHooks, err := hooksManager.GetAll(hooksMap)
 
 		require.Nil(t, validHooks)
@@ -81,7 +81,7 @@ func Test_GetAllHookConfigs(t *testing.T) {
 		}
 
 		mockCommandRunner := mockexec.NewMockCommandRunner()
-		hooksManager := NewHooksManager(tempDir, tempDir, mockCommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: tempDir, ProjectDir: tempDir}, mockCommandRunner)
 		validHooks, err := hooksManager.GetAll(hooksMap)
 
 		require.NoError(t, err)
@@ -111,7 +111,7 @@ func Test_GetByParams(t *testing.T) {
 		ensureScriptsExist(t, hooksMap)
 
 		mockCommandRunner := mockexec.NewMockCommandRunner()
-		hooksManager := NewHooksManager(tempDir, tempDir, mockCommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: tempDir, ProjectDir: tempDir}, mockCommandRunner)
 		validHooks, err := hooksManager.GetByParams(hooksMap, HookTypePre, "init")
 
 		require.Len(t, validHooks, 1)
@@ -139,7 +139,7 @@ func Test_GetByParams(t *testing.T) {
 		ensureScriptsExist(t, hooksMap)
 
 		mockCommandRunner := mockexec.NewMockCommandRunner()
-		hooksManager := NewHooksManager(tempDir, tempDir, mockCommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: tempDir, ProjectDir: tempDir}, mockCommandRunner)
 		validHooks, err := hooksManager.GetByParams(hooksMap, HookTypePre, "init")
 
 		require.Nil(t, validHooks)
@@ -220,7 +220,7 @@ func Test_ValidateHooks_PythonInstalled(t *testing.T) {
 		return strings.Contains(cmd, "--version")
 	}).Respond(exec.RunResult{Stdout: "Python 3.12.0"})
 
-	mgr := NewHooksManager(tempDir, tempDir, mockRunner)
+	mgr := NewHooksManager(HooksManagerOptions{Cwd: tempDir, ProjectDir: tempDir}, mockRunner)
 	result := mgr.ValidateHooks(t.Context(), hooksMap)
 
 	// No runtime warnings should be present.
@@ -260,7 +260,7 @@ func Test_ValidateHooks_PythonNotInstalled(t *testing.T) {
 	mockRunner.MockToolInPath("python", osexec.ErrNotFound)
 	mockRunner.MockToolInPath("python3", osexec.ErrNotFound)
 
-	mgr := NewHooksManager(tempDir, tempDir, mockRunner)
+	mgr := NewHooksManager(HooksManagerOptions{Cwd: tempDir, ProjectDir: tempDir}, mockRunner)
 	result := mgr.ValidateHooks(t.Context(), hooksMap)
 
 	// Expect a warning about missing Python.
@@ -318,7 +318,7 @@ func Test_ValidateHooks_ShellHookNoValidation(t *testing.T) {
 	// pwsh available so PowerShell warning doesn't fire.
 	mockRunner.MockToolInPath("pwsh", nil)
 
-	mgr := NewHooksManager(tempDir, tempDir, mockRunner)
+	mgr := NewHooksManager(HooksManagerOptions{Cwd: tempDir, ProjectDir: tempDir}, mockRunner)
 	result := mgr.ValidateHooks(t.Context(), hooksMap)
 
 	// No runtime warnings for Bash/PowerShell hooks.
@@ -370,7 +370,7 @@ func Test_ValidateHooks_MixedHooks(t *testing.T) {
 	// pwsh available — no PowerShell warning.
 	mockRunner.MockToolInPath("pwsh", nil)
 
-	mgr := NewHooksManager(tempDir, tempDir, mockRunner)
+	mgr := NewHooksManager(HooksManagerOptions{Cwd: tempDir, ProjectDir: tempDir}, mockRunner)
 	result := mgr.ValidateHooks(t.Context(), hooksMap)
 
 	// Exactly one runtime warning (Python), no shell warnings.

--- a/cli/azd/pkg/ext/hooks_manager_test.go
+++ b/cli/azd/pkg/ext/hooks_manager_test.go
@@ -179,7 +179,7 @@ func Test_HookConfig_DefaultShell(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Clone the config to avoid modifying the test case
 			config := *tt.hookConfig
-			config.cwd = t.TempDir()
+			config.inputCwd = t.TempDir()
 
 			err := config.validate()
 			require.NoError(t, err)

--- a/cli/azd/pkg/ext/hooks_manager_test.go
+++ b/cli/azd/pkg/ext/hooks_manager_test.go
@@ -40,7 +40,7 @@ func Test_GetAllHookConfigs(t *testing.T) {
 		ensureScriptsExist(t, hooksMap)
 
 		mockCommandRunner := mockexec.NewMockCommandRunner()
-		hooksManager := NewHooksManager(tempDir, mockCommandRunner)
+		hooksManager := NewHooksManager(tempDir, tempDir, mockCommandRunner)
 		validHooks, err := hooksManager.GetAll(hooksMap)
 
 		require.Len(t, validHooks, len(hooksMap))
@@ -67,7 +67,7 @@ func Test_GetAllHookConfigs(t *testing.T) {
 		ensureScriptsExist(t, hooksMap)
 
 		mockCommandRunner := mockexec.NewMockCommandRunner()
-		hooksManager := NewHooksManager(tempDir, mockCommandRunner)
+		hooksManager := NewHooksManager(tempDir, tempDir, mockCommandRunner)
 		validHooks, err := hooksManager.GetAll(hooksMap)
 
 		require.Nil(t, validHooks)
@@ -81,7 +81,7 @@ func Test_GetAllHookConfigs(t *testing.T) {
 		}
 
 		mockCommandRunner := mockexec.NewMockCommandRunner()
-		hooksManager := NewHooksManager(tempDir, mockCommandRunner)
+		hooksManager := NewHooksManager(tempDir, tempDir, mockCommandRunner)
 		validHooks, err := hooksManager.GetAll(hooksMap)
 
 		require.NoError(t, err)
@@ -111,7 +111,7 @@ func Test_GetByParams(t *testing.T) {
 		ensureScriptsExist(t, hooksMap)
 
 		mockCommandRunner := mockexec.NewMockCommandRunner()
-		hooksManager := NewHooksManager(tempDir, mockCommandRunner)
+		hooksManager := NewHooksManager(tempDir, tempDir, mockCommandRunner)
 		validHooks, err := hooksManager.GetByParams(hooksMap, HookTypePre, "init")
 
 		require.Len(t, validHooks, 1)
@@ -139,7 +139,7 @@ func Test_GetByParams(t *testing.T) {
 		ensureScriptsExist(t, hooksMap)
 
 		mockCommandRunner := mockexec.NewMockCommandRunner()
-		hooksManager := NewHooksManager(tempDir, mockCommandRunner)
+		hooksManager := NewHooksManager(tempDir, tempDir, mockCommandRunner)
 		validHooks, err := hooksManager.GetByParams(hooksMap, HookTypePre, "init")
 
 		require.Nil(t, validHooks)
@@ -220,7 +220,7 @@ func Test_ValidateHooks_PythonInstalled(t *testing.T) {
 		return strings.Contains(cmd, "--version")
 	}).Respond(exec.RunResult{Stdout: "Python 3.12.0"})
 
-	mgr := NewHooksManager(tempDir, mockRunner)
+	mgr := NewHooksManager(tempDir, tempDir, mockRunner)
 	result := mgr.ValidateHooks(t.Context(), hooksMap)
 
 	// No runtime warnings should be present.
@@ -260,7 +260,7 @@ func Test_ValidateHooks_PythonNotInstalled(t *testing.T) {
 	mockRunner.MockToolInPath("python", osexec.ErrNotFound)
 	mockRunner.MockToolInPath("python3", osexec.ErrNotFound)
 
-	mgr := NewHooksManager(tempDir, mockRunner)
+	mgr := NewHooksManager(tempDir, tempDir, mockRunner)
 	result := mgr.ValidateHooks(t.Context(), hooksMap)
 
 	// Expect a warning about missing Python.
@@ -318,7 +318,7 @@ func Test_ValidateHooks_ShellHookNoValidation(t *testing.T) {
 	// pwsh available so PowerShell warning doesn't fire.
 	mockRunner.MockToolInPath("pwsh", nil)
 
-	mgr := NewHooksManager(tempDir, mockRunner)
+	mgr := NewHooksManager(tempDir, tempDir, mockRunner)
 	result := mgr.ValidateHooks(t.Context(), hooksMap)
 
 	// No runtime warnings for Bash/PowerShell hooks.
@@ -370,7 +370,7 @@ func Test_ValidateHooks_MixedHooks(t *testing.T) {
 	// pwsh available — no PowerShell warning.
 	mockRunner.MockToolInPath("pwsh", nil)
 
-	mgr := NewHooksManager(tempDir, mockRunner)
+	mgr := NewHooksManager(tempDir, tempDir, mockRunner)
 	result := mgr.ValidateHooks(t.Context(), hooksMap)
 
 	// Exactly one runtime warning (Python), no shell warnings.

--- a/cli/azd/pkg/ext/hooks_manager_test.go
+++ b/cli/azd/pkg/ext/hooks_manager_test.go
@@ -562,6 +562,138 @@ func Test_ValidateHooks_MixedHooks(t *testing.T) {
 	require.Contains(t, err.Error(), "Python")
 }
 
+// Test_ValidateHooks_KindResolution exercises ValidateHooks with
+// dir+run combinations for all 6 hook kinds plus inline and
+// run-only variants. Each sub-test creates the required file
+// structure, calls ValidateHooks, and verifies the resolved Kind.
+func Test_ValidateHooks_KindResolution(t *testing.T) {
+	tests := []struct {
+		name         string
+		dir          string
+		run          string
+		fileName     string // relative path to create under tempDir
+		expectedKind language.HookKind
+		isDefault    bool
+	}{
+		{
+			name:         "dir+run Python",
+			dir:          "hooks/pre",
+			run:          "main.py",
+			fileName:     "hooks/pre/main.py",
+			expectedKind: language.HookKindPython,
+		},
+		{
+			name:         "dir+run Bash",
+			dir:          "hooks/pre",
+			run:          "deploy.sh",
+			fileName:     "hooks/pre/deploy.sh",
+			expectedKind: language.HookKindBash,
+		},
+		{
+			name:         "dir+run PowerShell",
+			dir:          "hooks/pre",
+			run:          "deploy.ps1",
+			fileName:     "hooks/pre/deploy.ps1",
+			expectedKind: language.HookKindPowerShell,
+		},
+		{
+			name:         "dir+run JavaScript",
+			dir:          "hooks/pre",
+			run:          "index.js",
+			fileName:     "hooks/pre/index.js",
+			expectedKind: language.HookKindJavaScript,
+		},
+		{
+			name:         "dir+run TypeScript",
+			dir:          "hooks/pre",
+			run:          "index.ts",
+			fileName:     "hooks/pre/index.ts",
+			expectedKind: language.HookKindTypeScript,
+		},
+		{
+			name:         "dir+run DotNet",
+			dir:          "hooks/pre",
+			run:          "Program.cs",
+			fileName:     "hooks/pre/Program.cs",
+			expectedKind: language.HookKindDotNet,
+		},
+		{
+			name:         "inline script no dir no file",
+			run:          "echo hello",
+			expectedKind: defaultKindForOS(),
+			isDefault:    true,
+		},
+		{
+			name:         "run-only Python no dir",
+			run:          "hooks/pre/main.py",
+			fileName:     "hooks/pre/main.py",
+			expectedKind: language.HookKindPython,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			if tt.fileName != "" {
+				fullPath := filepath.Join(
+					tempDir, tt.fileName,
+				)
+				require.NoError(t, os.MkdirAll(
+					filepath.Dir(fullPath),
+					osutil.PermissionDirectory,
+				))
+				require.NoError(t, os.WriteFile(
+					fullPath,
+					[]byte("// placeholder"),
+					osutil.PermissionExecutableFile,
+				))
+			}
+
+			hooksMap := map[string][]*HookConfig{
+				"preprovision": {{
+					Dir: tt.dir,
+					Run: tt.run,
+				}},
+			}
+
+			mockRunner := mockexec.NewMockCommandRunner()
+			// Ensure pwsh check doesn't interfere.
+			mockRunner.MockToolInPath("pwsh", nil)
+			// Mock Python as available so validateRuntimes
+			// doesn't panic for Python hook sub-tests.
+			mockRunner.MockToolInPath("py", nil)
+			mockRunner.When(func(
+				args exec.RunArgs, cmd string,
+			) bool {
+				return strings.Contains(cmd, "--version")
+			}).Respond(exec.RunResult{
+				Stdout: "Python 3.12.0",
+			})
+
+			mgr := NewHooksManager(
+				HooksManagerOptions{
+					Cwd:        tempDir,
+					ProjectDir: tempDir,
+				},
+				mockRunner,
+			)
+			_ = mgr.ValidateHooks(t.Context(), hooksMap)
+
+			hook := hooksMap["preprovision"][0]
+			require.Equal(t,
+				tt.expectedKind, hook.Kind,
+				"Kind mismatch",
+			)
+			require.Equal(t,
+				tt.isDefault,
+				hook.IsUsingDefaultShell(),
+				"IsUsingDefaultShell mismatch",
+			)
+		})
+	}
+}
+
 func ensureScriptsExist(t *testing.T, configs map[string][]*HookConfig) {
 	for _, hooks := range configs {
 		for _, hook := range hooks {

--- a/cli/azd/pkg/ext/hooks_manager_test.go
+++ b/cli/azd/pkg/ext/hooks_manager_test.go
@@ -285,6 +285,179 @@ func Test_ValidateHooks_PythonNotInstalled(t *testing.T) {
 	require.Contains(t, err.Error(), "Python")
 }
 
+func Test_ValidateHooks_DirRunPython(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create hooks/pre/main.py so the dir+run combination
+	// is detected as a file-based hook.
+	scriptDir := filepath.Join(tempDir, "hooks", "pre")
+	require.NoError(t,
+		os.MkdirAll(scriptDir, osutil.PermissionDirectory))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(scriptDir, "main.py"),
+		[]byte("print('hello')"),
+		osutil.PermissionExecutableFile,
+	))
+
+	hooksMap := map[string][]*HookConfig{
+		"preprovision": {{
+			Dir: "hooks/pre",
+			Run: "main.py",
+		}},
+	}
+
+	mockRunner := mockexec.NewMockCommandRunner()
+	mockRunner.MockToolInPath("py", nil)
+	mockRunner.When(func(args exec.RunArgs, cmd string) bool {
+		return strings.Contains(cmd, "--version")
+	}).Respond(exec.RunResult{Stdout: "Python 3.12.0"})
+
+	mgr := NewHooksManager(
+		HooksManagerOptions{
+			Cwd:        tempDir,
+			ProjectDir: tempDir,
+		},
+		mockRunner,
+	)
+	result := mgr.ValidateHooks(t.Context(), hooksMap)
+
+	// Kind must be Python — not the OS default shell.
+	hook := hooksMap["preprovision"][0]
+	require.Equal(t, language.HookKindPython, hook.Kind,
+		"dir+run Python file must resolve to HookKindPython")
+	require.False(t, hook.IsUsingDefaultShell(),
+		"file-based hook must not use default shell")
+
+	for _, w := range result.Warnings {
+		require.NotContains(t, w.Message, "PowerShell",
+			"no PowerShell warning for Python hook")
+	}
+}
+
+func Test_ValidateHooks_DirRunJavaScript(t *testing.T) {
+	tempDir := t.TempDir()
+
+	scriptDir := filepath.Join(tempDir, "hooks", "pre")
+	require.NoError(t,
+		os.MkdirAll(scriptDir, osutil.PermissionDirectory))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(scriptDir, "index.js"),
+		[]byte("console.log('hello')"),
+		osutil.PermissionExecutableFile,
+	))
+
+	hooksMap := map[string][]*HookConfig{
+		"preprovision": {{
+			Dir: "hooks/pre",
+			Run: "index.js",
+		}},
+	}
+
+	mockRunner := mockexec.NewMockCommandRunner()
+	mgr := NewHooksManager(
+		HooksManagerOptions{
+			Cwd:        tempDir,
+			ProjectDir: tempDir,
+		},
+		mockRunner,
+	)
+	result := mgr.ValidateHooks(t.Context(), hooksMap)
+
+	hook := hooksMap["preprovision"][0]
+	require.Equal(t, language.HookKindJavaScript, hook.Kind,
+		"dir+run JS file must resolve to HookKindJavaScript")
+	require.False(t, hook.IsUsingDefaultShell(),
+		"file-based hook must not use default shell")
+
+	for _, w := range result.Warnings {
+		require.NotContains(t, w.Message, "PowerShell",
+			"no PowerShell warning for JS hook")
+	}
+	require.Empty(t, result.Warnings,
+		"no warnings expected for JS hook")
+}
+
+func Test_ValidateHooks_DirRunNoFileInline(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Dir exists but the run value is an inline command,
+	// not a file on disk.
+	scriptDir := filepath.Join(tempDir, "hooks", "pre")
+	require.NoError(t,
+		os.MkdirAll(scriptDir, osutil.PermissionDirectory))
+
+	hooksMap := map[string][]*HookConfig{
+		"preprovision": {{
+			Dir: "hooks/pre",
+			Run: "echo hello",
+		}},
+	}
+
+	mockRunner := mockexec.NewMockCommandRunner()
+	mockRunner.MockToolInPath("pwsh", nil)
+
+	mgr := NewHooksManager(
+		HooksManagerOptions{
+			Cwd:        tempDir,
+			ProjectDir: tempDir,
+		},
+		mockRunner,
+	)
+	_ = mgr.ValidateHooks(t.Context(), hooksMap)
+
+	hook := hooksMap["preprovision"][0]
+	require.Equal(t, defaultKindForOS(), hook.Kind,
+		"inline script must use OS default shell")
+	require.True(t, hook.IsUsingDefaultShell(),
+		"inline script must be flagged as default shell")
+}
+
+func Test_ValidateHooks_RunOnlyPython(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create hooks/pre/main.py referenced directly via run.
+	scriptDir := filepath.Join(tempDir, "hooks", "pre")
+	require.NoError(t,
+		os.MkdirAll(scriptDir, osutil.PermissionDirectory))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(scriptDir, "main.py"),
+		[]byte("print('hello')"),
+		osutil.PermissionExecutableFile,
+	))
+
+	hooksMap := map[string][]*HookConfig{
+		"preprovision": {{
+			Run: "hooks/pre/main.py",
+		}},
+	}
+
+	mockRunner := mockexec.NewMockCommandRunner()
+	mockRunner.MockToolInPath("py", nil)
+	mockRunner.When(func(args exec.RunArgs, cmd string) bool {
+		return strings.Contains(cmd, "--version")
+	}).Respond(exec.RunResult{Stdout: "Python 3.12.0"})
+
+	mgr := NewHooksManager(
+		HooksManagerOptions{
+			Cwd:        tempDir,
+			ProjectDir: tempDir,
+		},
+		mockRunner,
+	)
+	result := mgr.ValidateHooks(t.Context(), hooksMap)
+
+	hook := hooksMap["preprovision"][0]
+	require.Equal(t, language.HookKindPython, hook.Kind,
+		"run-only Python file must resolve to HookKindPython")
+	require.False(t, hook.IsUsingDefaultShell(),
+		"file-based hook must not use default shell")
+
+	for _, w := range result.Warnings {
+		require.NotContains(t, w.Message, "Python",
+			"no Python warning when runtime is available")
+	}
+}
+
 func Test_ValidateHooks_ShellHookNoValidation(t *testing.T) {
 	tempDir := t.TempDir()
 	ostest.Chdir(t, tempDir)

--- a/cli/azd/pkg/ext/hooks_runner.go
+++ b/cli/azd/pkg/ext/hooks_runner.go
@@ -159,7 +159,10 @@ func (h *HooksRunner) execHook(
 		cwd = h.cwd // fallback (shouldn't happen after validate)
 	}
 
-	boundaryDir := hookConfig.cwd
+	boundaryDir := hookConfig.projectDir
+	if boundaryDir == "" {
+		boundaryDir = hookConfig.cwd
+	}
 	if boundaryDir == "" {
 		boundaryDir = h.cwd
 	}

--- a/cli/azd/pkg/ext/hooks_runner.go
+++ b/cli/azd/pkg/ext/hooks_runner.go
@@ -161,7 +161,7 @@ func (h *HooksRunner) execHook(
 
 	boundaryDir := hookConfig.projectDir
 	if boundaryDir == "" {
-		boundaryDir = hookConfig.cwd
+		boundaryDir = hookConfig.inputCwd
 	}
 	if boundaryDir == "" {
 		boundaryDir = h.cwd
@@ -176,7 +176,7 @@ func (h *HooksRunner) execHook(
 		Cwd:          cwd,
 		EnvVars:      envVars,
 		BoundaryDir:  boundaryDir,
-		InlineScript: hookConfig.script,
+		InlineScript: hookConfig.inlineScript,
 		HookName:     hookConfig.Name,
 	}
 

--- a/cli/azd/pkg/ext/hooks_runner_test.go
+++ b/cli/azd/pkg/ext/hooks_runner_test.go
@@ -93,7 +93,7 @@ func Test_Hooks_Execute(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -131,7 +131,7 @@ func Test_Hooks_Execute(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -169,7 +169,7 @@ func Test_Hooks_Execute(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -201,7 +201,7 @@ func Test_Hooks_Execute(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -252,7 +252,7 @@ func Test_Hooks_Execute(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -330,7 +330,7 @@ func Test_Hooks_Validation(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager, mockContext.CommandRunner, envManager,
 			mockContext.Console, cwd, hooksMap, env, mockContext.Container,
@@ -362,7 +362,7 @@ func Test_Hooks_Validation(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager, mockContext.CommandRunner, envManager,
 			mockContext.Console, cwd, hooksMap, env, mockContext.Container,
@@ -392,7 +392,7 @@ func Test_Hooks_Validation(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager, mockContext.CommandRunner, envManager,
 			mockContext.Console, cwd, hooksMap, env, mockContext.Container,
@@ -413,7 +413,7 @@ func Test_Hooks_Validation(t *testing.T) {
 
 		mockContext := mocks.NewMockContext(context.Background())
 		registerHookExecutors(mockContext)
-		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager, mockContext.CommandRunner, envManager,
 			mockContext.Console, cwd, hooksMap, env, mockContext.Container,
@@ -477,7 +477,7 @@ func Test_ExecHook_NonShellHooks(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -533,7 +533,7 @@ func Test_ExecHook_NonShellHooks(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -589,7 +589,7 @@ func Test_ExecHook_NonShellHooks(t *testing.T) {
 			return exec.NewRunResult(1, "", ""), fmt.Errorf("python not found")
 		})
 
-		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -651,7 +651,7 @@ func Test_ExecHook_NonShellHooks(t *testing.T) {
 			return exec.NewRunResult(1, "", "error"), fmt.Errorf("script failed")
 		})
 
-		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -720,7 +720,7 @@ func Test_ExecHook_NonShellHooks(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -834,9 +834,7 @@ func Test_ExecHook_DirRunResolution(t *testing.T) {
 			},
 		)
 
-		hooksManager := NewHooksManager(
-			cwd, cwd, mockContext.CommandRunner,
-		)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -925,9 +923,7 @@ func Test_ExecHook_DirRunResolution(t *testing.T) {
 			},
 		)
 
-		hooksManager := NewHooksManager(
-			cwd, cwd, mockContext.CommandRunner,
-		)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -1024,9 +1020,7 @@ func Test_ExecHook_DirRunResolution(t *testing.T) {
 			},
 		)
 
-		hooksManager := NewHooksManager(
-			cwd, cwd, mockContext.CommandRunner,
-		)
+		hooksManager := NewHooksManager(HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,

--- a/cli/azd/pkg/ext/hooks_runner_test.go
+++ b/cli/azd/pkg/ext/hooks_runner_test.go
@@ -93,7 +93,7 @@ func Test_Hooks_Execute(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -131,7 +131,7 @@ func Test_Hooks_Execute(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -169,7 +169,7 @@ func Test_Hooks_Execute(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -201,7 +201,7 @@ func Test_Hooks_Execute(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -252,7 +252,7 @@ func Test_Hooks_Execute(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -330,7 +330,7 @@ func Test_Hooks_Validation(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager, mockContext.CommandRunner, envManager,
 			mockContext.Console, cwd, hooksMap, env, mockContext.Container,
@@ -362,7 +362,7 @@ func Test_Hooks_Validation(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager, mockContext.CommandRunner, envManager,
 			mockContext.Console, cwd, hooksMap, env, mockContext.Container,
@@ -392,7 +392,7 @@ func Test_Hooks_Validation(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager, mockContext.CommandRunner, envManager,
 			mockContext.Console, cwd, hooksMap, env, mockContext.Container,
@@ -413,7 +413,7 @@ func Test_Hooks_Validation(t *testing.T) {
 
 		mockContext := mocks.NewMockContext(context.Background())
 		registerHookExecutors(mockContext)
-		hooksManager := NewHooksManager(cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager, mockContext.CommandRunner, envManager,
 			mockContext.Console, cwd, hooksMap, env, mockContext.Container,
@@ -477,7 +477,7 @@ func Test_ExecHook_NonShellHooks(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -533,7 +533,7 @@ func Test_ExecHook_NonShellHooks(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -589,7 +589,7 @@ func Test_ExecHook_NonShellHooks(t *testing.T) {
 			return exec.NewRunResult(1, "", ""), fmt.Errorf("python not found")
 		})
 
-		hooksManager := NewHooksManager(cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -651,7 +651,7 @@ func Test_ExecHook_NonShellHooks(t *testing.T) {
 			return exec.NewRunResult(1, "", "error"), fmt.Errorf("script failed")
 		})
 
-		hooksManager := NewHooksManager(cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -720,7 +720,7 @@ func Test_ExecHook_NonShellHooks(t *testing.T) {
 			return exec.NewRunResult(0, "", ""), nil
 		})
 
-		hooksManager := NewHooksManager(cwd, mockContext.CommandRunner)
+		hooksManager := NewHooksManager(cwd, cwd, mockContext.CommandRunner)
 		runner := NewHooksRunner(
 			hooksManager,
 			mockContext.CommandRunner,
@@ -835,7 +835,7 @@ func Test_ExecHook_DirRunResolution(t *testing.T) {
 		)
 
 		hooksManager := NewHooksManager(
-			cwd, mockContext.CommandRunner,
+			cwd, cwd, mockContext.CommandRunner,
 		)
 		runner := NewHooksRunner(
 			hooksManager,
@@ -926,7 +926,7 @@ func Test_ExecHook_DirRunResolution(t *testing.T) {
 		)
 
 		hooksManager := NewHooksManager(
-			cwd, mockContext.CommandRunner,
+			cwd, cwd, mockContext.CommandRunner,
 		)
 		runner := NewHooksRunner(
 			hooksManager,
@@ -1025,7 +1025,7 @@ func Test_ExecHook_DirRunResolution(t *testing.T) {
 		)
 
 		hooksManager := NewHooksManager(
-			cwd, mockContext.CommandRunner,
+			cwd, cwd, mockContext.CommandRunner,
 		)
 		runner := NewHooksRunner(
 			hooksManager,

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -264,7 +264,13 @@ func (hc *HookConfig) validate() error {
 	// paths (e.g. the service directory for service hooks).
 	cwdDir := hc.cwd
 	if cwdDir == "" {
-		cwdDir, _ = os.Getwd()
+		var err error
+		cwdDir, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf(
+				"resolving working directory: %w", err,
+			)
+		}
 	}
 
 	// boundaryDir is the project root used for path
@@ -314,50 +320,70 @@ func (hc *HookConfig) validate() error {
 		}
 	}
 
-	// Validate that resolvedDir stays within the project root
-	// to prevent path traversal via ".." in Dir.
-	absDir, absErr := filepath.Abs(hc.resolvedDir)
-	if absErr != nil {
-		return fmt.Errorf(
-			"resolving hook directory: %w", absErr,
-		)
-	}
-	absBoundary, absErr := filepath.Abs(boundaryDir)
-	if absErr != nil {
-		return fmt.Errorf(
-			"resolving boundary directory: %w", absErr,
-		)
-	}
-	if !osutil.IsPathContained(absBoundary, absDir) {
-		return fmt.Errorf(
-			"hook directory %q escapes project root %q",
-			hc.Dir, boundaryDir,
-		)
-	}
-	hc.resolvedDir = absDir
-
-	// Validate that resolvedScriptPath stays within the project
-	// root to prevent path traversal via ".." in Run.
-	if hc.resolvedScriptPath != "" {
-		absScript, scriptErr := filepath.Abs(
-			hc.resolvedScriptPath,
-		)
-		if scriptErr != nil {
+	// Inline hooks (hc.script != "") are saved to an OS temp
+	// file for execution and may run from external layer paths,
+	// so they are exempt from containment checks. Only
+	// file-based hooks (hc.path != "") are validated against the
+	// project root boundary.
+	if hc.path != "" {
+		// Validate that resolvedDir stays within the project
+		// root to prevent path traversal via ".." in Dir.
+		absDir, absErr := filepath.Abs(hc.resolvedDir)
+		if absErr != nil {
 			return fmt.Errorf(
-				"resolving hook script path: %w",
-				scriptErr,
+				"resolving hook directory: %w", absErr,
 			)
 		}
-		if !osutil.IsPathContained(
-			absBoundary, absScript,
-		) {
+		absBoundary, absErr := filepath.Abs(boundaryDir)
+		if absErr != nil {
 			return fmt.Errorf(
-				"hook script path %q escapes "+
+				"resolving boundary directory: %w",
+				absErr,
+			)
+		}
+		if !osutil.IsPathContained(absBoundary, absDir) {
+			return fmt.Errorf(
+				"hook directory %q escapes "+
 					"project root %q",
-				hc.Run, boundaryDir,
+				hc.Dir, boundaryDir,
 			)
 		}
-		hc.resolvedScriptPath = absScript
+		hc.resolvedDir = absDir
+
+		// Validate that resolvedScriptPath stays within
+		// the project root to prevent path traversal via
+		// ".." in Run.
+		if hc.resolvedScriptPath != "" {
+			absScript, scriptErr := filepath.Abs(
+				hc.resolvedScriptPath,
+			)
+			if scriptErr != nil {
+				return fmt.Errorf(
+					"resolving hook script path: %w",
+					scriptErr,
+				)
+			}
+			if !osutil.IsPathContained(
+				absBoundary, absScript,
+			) {
+				return fmt.Errorf(
+					"hook script path %q escapes "+
+						"project root %q",
+					hc.Run, boundaryDir,
+				)
+			}
+			hc.resolvedScriptPath = absScript
+		}
+	} else {
+		// Inline hooks: resolve to absolute path but skip
+		// containment validation.
+		absDir, absErr := filepath.Abs(hc.resolvedDir)
+		if absErr != nil {
+			return fmt.Errorf(
+				"resolving hook directory: %w", absErr,
+			)
+		}
+		hc.resolvedDir = absDir
 	}
 
 	hc.validated = true

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -138,6 +138,19 @@ type HookConfig struct {
 // the script location (inline vs. file path) and ensures that Kind
 // is always resolved to a concrete [language.HookKind] value.
 //
+// The pipeline (parseRunTarget → resolveKind → resolvePaths →
+// enforceContainment) is kind-agnostic: all 6 hook kinds are treated
+// uniformly. The only structural distinction is shell vs. non-shell
+// ([language.HookKind.IsShell]):
+//
+//   - Shell hooks support inline scripts and use inputCwd as-is.
+//   - Non-shell hooks require a file on disk and auto-infer Dir
+//     from the script location for project-relative tooling
+//     (venvs, node_modules, etc.).
+//
+// Kind-specific validation (runtime availability, dependency
+// discovery) lives in each executor's Prepare() method, not here.
+//
 // Kind resolution priority:
 //  1. Explicit Kind field
 //  2. Explicit Shell field (deprecated alias, mapped to Kind)
@@ -238,6 +251,19 @@ func (hc *HookConfig) parseRunTarget() (bool, error) {
 // or Shell fields, the file extension, or the OS default shell.
 // It also infers Dir for non-shell file hooks when Dir was not
 // explicitly set by the user.
+//
+// This method is intentionally kind-agnostic: it branches only on
+// [language.HookKind.IsShell] (shell vs. non-shell), never on
+// individual kind values. The shell vs. non-shell distinction maps
+// to structural differences in how hooks execute:
+//
+//   - Shell hooks: support inline scripts, no Dir auto-inference.
+//   - Non-shell hooks: require a file, Dir inferred from script path
+//     so project-relative tooling (venvs, node_modules) resolves
+//     correctly.
+//
+// Kind-specific validation (e.g. checking Python/Node installation)
+// is deferred to each executor's Prepare() method.
 func (hc *HookConfig) resolveKind(dirExplicit bool) error {
 	// Kind resolution — priority:
 	// 1. explicit Kind  2. Shell alias
@@ -303,6 +329,10 @@ func (hc *HookConfig) resolveKind(dirExplicit bool) error {
 // from the hook's Dir, relativeScriptPath, and inputCwd fields.
 // After this method, resolvedDir and resolvedScriptPath are the
 // single source of truth for hook execution paths.
+//
+// Kind-agnostic: the only distinction is shell vs. non-shell — non-
+// shell hooks derive cwd from the script directory when Dir is not
+// explicitly set, so project-relative tooling works correctly.
 func (hc *HookConfig) resolvePaths(dirExplicit bool) error {
 	// cwdDir is the working directory for resolving relative
 	// paths (e.g. the service directory for service hooks).
@@ -363,6 +393,10 @@ func (hc *HookConfig) resolvePaths(dirExplicit bool) error {
 // enforceContainment validates that file-based hooks do not escape
 // the project root via ".." in Dir or Run. Inline hooks are exempt
 // because they are saved to an OS temp file for execution.
+//
+// Kind-agnostic: containment rules apply identically to all 6 hook
+// kinds. The only structural difference is that inline scripts (any
+// shell kind) skip the boundary check.
 func (hc *HookConfig) enforceContainment() error {
 	if hc.relativeScriptPath == "" {
 		// Inline hooks: resolve to absolute path but skip

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -77,6 +77,10 @@ type HookConfig struct {
 	validated bool
 	// Stores the working directory set for this hook config
 	cwd string
+	// projectDir is the project root directory (where azure.yaml
+	// lives). Used as the security boundary for path containment
+	// checks. When empty, cwd is used as the boundary instead.
+	projectDir string
 	// When set, contains the inline script content to execute
 	script string
 	// Indicates if the shell was automatically detected based on OS (used for warnings)
@@ -256,43 +260,54 @@ func (hc *HookConfig) validate() error {
 	// the single source of truth for hook execution paths.
 	// execHook() should read these directly.
 
-	boundaryDir := hc.cwd
+	// cwdDir is the working directory for resolving relative
+	// paths (e.g. the service directory for service hooks).
+	cwdDir := hc.cwd
+	if cwdDir == "" {
+		cwdDir, _ = os.Getwd()
+	}
+
+	// boundaryDir is the project root used for path
+	// containment validation. For service-level hooks this
+	// is the project root (where azure.yaml lives), which
+	// may differ from cwdDir (the service directory).
+	boundaryDir := hc.projectDir
 	if boundaryDir == "" {
-		boundaryDir, _ = os.Getwd()
+		boundaryDir = cwdDir
 	}
 
 	// Resolve working directory.
 	if hc.Dir != "" {
 		dir := hc.Dir
 		if !filepath.IsAbs(dir) {
-			dir = filepath.Join(boundaryDir, dir)
+			dir = filepath.Join(cwdDir, dir)
 		}
 		hc.resolvedDir = dir
 	} else if hc.path != "" && !hc.Kind.IsShell() {
 		// Non-shell hooks: derive cwd from script directory so
 		// project-relative tooling (venvs, node_modules) works.
 		hc.resolvedDir = filepath.Dir(
-			filepath.Join(boundaryDir, hc.path),
+			filepath.Join(cwdDir, hc.path),
 		)
 	} else {
-		hc.resolvedDir = boundaryDir
+		hc.resolvedDir = cwdDir
 	}
 
 	// Resolve script path to absolute.
 	if hc.path != "" {
 		if dirExplicit && !filepath.IsAbs(hc.path) {
 			// Dir was explicitly set — run path is relative
-			// to Dir, not boundaryDir alone.
+			// to Dir, not cwdDir alone.
 			dir := hc.Dir
 			if !filepath.IsAbs(dir) {
-				dir = filepath.Join(boundaryDir, dir)
+				dir = filepath.Join(cwdDir, dir)
 			}
 			hc.resolvedScriptPath = filepath.Join(
 				dir, hc.path,
 			)
 		} else if !filepath.IsAbs(hc.path) {
 			hc.resolvedScriptPath = filepath.Join(
-				boundaryDir, hc.path,
+				cwdDir, hc.path,
 			)
 		} else {
 			hc.resolvedScriptPath = hc.path

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -71,18 +71,25 @@ type InvokeFn func() error
 // based on the hook's Kind — including Bash, PowerShell, Python,
 // and future executor types (JS, TS, DotNet).
 type HookConfig struct {
-	// When set, contains the resolved file path relative to the project or service
-	path string
+	// relativeScriptPath holds the file path relative to the
+	// project or service directory. Set by parseRunTarget when
+	// Run references an existing file. Empty for inline scripts.
+	relativeScriptPath string
 	// Stores a value whether or not this hook config has been previously validated
 	validated bool
-	// Stores the working directory set for this hook config
-	cwd string
+	// inputCwd is the working directory injected by the hooks
+	// manager (e.g. the service directory for service hooks).
+	// Distinguished from resolvedDir, which is the final
+	// absolute working directory computed during validate().
+	inputCwd string
 	// projectDir is the project root directory (where azure.yaml
 	// lives). Used as the security boundary for path containment
-	// checks. When empty, cwd is used as the boundary instead.
+	// checks. When empty, inputCwd is used as the boundary.
 	projectDir string
-	// When set, contains the inline script content to execute
-	script string
+	// inlineScript holds the inline script content to execute.
+	// Set by parseRunTarget when Run does not reference an
+	// existing file. Empty for file-based hooks.
+	inlineScript string
 	// Indicates if the shell was automatically detected based on OS (used for warnings)
 	usingDefaultShell bool
 	// resolvedScriptPath is the absolute path to the script file,
@@ -148,6 +155,29 @@ func (hc *HookConfig) validate() error {
 		return ErrRunRequired
 	}
 
+	dirExplicit, err := hc.parseRunTarget()
+	if err != nil {
+		return err
+	}
+	if err := hc.resolveKind(dirExplicit); err != nil {
+		return err
+	}
+	if err := hc.resolvePaths(dirExplicit); err != nil {
+		return err
+	}
+	if err := hc.enforceContainment(); err != nil {
+		return err
+	}
+
+	hc.validated = true
+	return nil
+}
+
+// parseRunTarget normalizes the Run field and determines whether it
+// references an existing file or an inline script. It sets
+// relativeScriptPath (for file-based hooks) or inlineScript (for
+// inline hooks) and returns whether Dir was explicitly provided.
+func (hc *HookConfig) parseRunTarget() (bool, error) {
 	// Record whether Dir was explicitly provided by the user
 	// before any auto-inference fills it in.
 	dirExplicit := hc.Dir != ""
@@ -158,18 +188,18 @@ func (hc *HookConfig) validate() error {
 
 	// Resolve the full path for the os.Stat check. When Dir is
 	// explicitly set and run is relative, we try Dir first and
-	// fall back to cwd (project root). This supports both:
+	// fall back to inputCwd (project root). This supports both:
 	//   run: main.py        + dir: hooks/preprovision
 	//   run: hooks/deploy.py + dir: custom_workdir
 	fullCheckPath := relativeCheckPath
 	foundViaDir := false
-	if hc.cwd != "" {
+	if hc.inputCwd != "" {
 		if filepath.IsAbs(relativeCheckPath) {
 			fullCheckPath = relativeCheckPath
 		} else if dirExplicit {
 			dir := hc.Dir
 			if !filepath.IsAbs(dir) {
-				dir = filepath.Join(hc.cwd, dir)
+				dir = filepath.Join(hc.inputCwd, dir)
 			}
 			dirPath := filepath.Join(
 				dir, relativeCheckPath,
@@ -180,41 +210,52 @@ func (hc *HookConfig) validate() error {
 				foundViaDir = true
 			} else {
 				fullCheckPath = filepath.Join(
-					hc.cwd, relativeCheckPath,
+					hc.inputCwd, relativeCheckPath,
 				)
 			}
 		} else {
 			fullCheckPath = filepath.Join(
-				hc.cwd, relativeCheckPath,
+				hc.inputCwd, relativeCheckPath,
 			)
 		}
 	}
 
 	stats, err := os.Stat(fullCheckPath)
 	if err == nil && !stats.IsDir() {
-		hc.path = relativeCheckPath
+		hc.relativeScriptPath = relativeCheckPath
 		if foundViaDir {
 			dirExplicit = true
 		}
 	} else {
-		hc.script = hc.Run
+		hc.inlineScript = hc.Run
 		dirExplicit = false
 	}
 
+	return dirExplicit, nil
+}
+
+// resolveKind resolves the hook's Kind field from the explicit Kind
+// or Shell fields, the file extension, or the OS default shell.
+// It also infers Dir for non-shell file hooks when Dir was not
+// explicitly set by the user.
+func (hc *HookConfig) resolveKind(dirExplicit bool) error {
 	// Kind resolution — priority:
 	// 1. explicit Kind  2. Shell alias
 	// 3. file extension  4. OS default for inline scripts
 	if hc.Kind == language.HookKindUnknown && hc.Shell != "" {
 		hc.Kind = language.HookKind(hc.Shell)
 	}
-	if hc.Kind == language.HookKindUnknown && hc.path != "" {
-		hc.Kind = language.InferKindFromPath(hc.path)
+	if hc.Kind == language.HookKindUnknown &&
+		hc.relativeScriptPath != "" {
+		hc.Kind = language.InferKindFromPath(
+			hc.relativeScriptPath,
+		)
 	}
 
-	// Reject inline scripts for non-shell executors. Only Bash and
-	// PowerShell executors support inline script content; other
-	// executors require a file on disk.
-	if hc.script != "" &&
+	// Reject inline scripts for non-shell executors. Only Bash
+	// and PowerShell executors support inline script content;
+	// other executors require a file on disk.
+	if hc.inlineScript != "" &&
 		hc.Kind != language.HookKindUnknown &&
 		!hc.Kind.IsShell() {
 		return fmt.Errorf(
@@ -232,14 +273,14 @@ func (hc *HookConfig) validate() error {
 		!hc.Kind.IsShell() {
 		// Auto-infer Dir from the script's directory when not
 		// explicitly set by the user.
-		if hc.Dir == "" && hc.path != "" {
-			hc.Dir = filepath.Dir(hc.path)
+		if !dirExplicit && hc.relativeScriptPath != "" {
+			hc.Dir = filepath.Dir(hc.relativeScriptPath)
 		}
 	} else {
 		// For inline scripts with no resolved kind, default to
 		// the OS-appropriate shell kind.
 		if hc.Kind == language.HookKindUnknown &&
-			hc.script != "" {
+			hc.inlineScript != "" {
 			hc.Kind = defaultKindForOS()
 			hc.usingDefaultShell = true
 		}
@@ -249,20 +290,23 @@ func (hc *HookConfig) validate() error {
 			return fmt.Errorf(
 				"script with file extension '%s' is not "+
 					"valid. %w.",
-				filepath.Ext(hc.path),
+				filepath.Ext(hc.relativeScriptPath),
 				ErrUnsupportedScriptType,
 			)
 		}
 	}
 
-	// ── Resolve absolute paths ──────────────────────────────
-	// After this point, resolvedDir and resolvedScriptPath are
-	// the single source of truth for hook execution paths.
-	// execHook() should read these directly.
+	return nil
+}
 
+// resolvePaths computes absolute resolvedDir and resolvedScriptPath
+// from the hook's Dir, relativeScriptPath, and inputCwd fields.
+// After this method, resolvedDir and resolvedScriptPath are the
+// single source of truth for hook execution paths.
+func (hc *HookConfig) resolvePaths(dirExplicit bool) error {
 	// cwdDir is the working directory for resolving relative
 	// paths (e.g. the service directory for service hooks).
-	cwdDir := hc.cwd
+	cwdDir := hc.inputCwd
 	if cwdDir == "" {
 		var err error
 		cwdDir, err = os.Getwd()
@@ -273,15 +317,6 @@ func (hc *HookConfig) validate() error {
 		}
 	}
 
-	// boundaryDir is the project root used for path
-	// containment validation. For service-level hooks this
-	// is the project root (where azure.yaml lives), which
-	// may differ from cwdDir (the service directory).
-	boundaryDir := hc.projectDir
-	if boundaryDir == "" {
-		boundaryDir = cwdDir
-	}
-
 	// Resolve working directory.
 	if hc.Dir != "" {
 		dir := hc.Dir
@@ -289,19 +324,21 @@ func (hc *HookConfig) validate() error {
 			dir = filepath.Join(cwdDir, dir)
 		}
 		hc.resolvedDir = dir
-	} else if hc.path != "" && !hc.Kind.IsShell() {
+	} else if hc.relativeScriptPath != "" &&
+		!hc.Kind.IsShell() {
 		// Non-shell hooks: derive cwd from script directory so
 		// project-relative tooling (venvs, node_modules) works.
 		hc.resolvedDir = filepath.Dir(
-			filepath.Join(cwdDir, hc.path),
+			filepath.Join(cwdDir, hc.relativeScriptPath),
 		)
 	} else {
 		hc.resolvedDir = cwdDir
 	}
 
 	// Resolve script path to absolute.
-	if hc.path != "" {
-		if dirExplicit && !filepath.IsAbs(hc.path) {
+	if hc.relativeScriptPath != "" {
+		if dirExplicit &&
+			!filepath.IsAbs(hc.relativeScriptPath) {
 			// Dir was explicitly set — run path is relative
 			// to Dir, not cwdDir alone.
 			dir := hc.Dir
@@ -309,72 +346,25 @@ func (hc *HookConfig) validate() error {
 				dir = filepath.Join(cwdDir, dir)
 			}
 			hc.resolvedScriptPath = filepath.Join(
-				dir, hc.path,
+				dir, hc.relativeScriptPath,
 			)
-		} else if !filepath.IsAbs(hc.path) {
+		} else if !filepath.IsAbs(hc.relativeScriptPath) {
 			hc.resolvedScriptPath = filepath.Join(
-				cwdDir, hc.path,
+				cwdDir, hc.relativeScriptPath,
 			)
 		} else {
-			hc.resolvedScriptPath = hc.path
+			hc.resolvedScriptPath = hc.relativeScriptPath
 		}
 	}
 
-	// Inline hooks (hc.script != "") are saved to an OS temp
-	// file for execution and may run from external layer paths,
-	// so they are exempt from containment checks. Only
-	// file-based hooks (hc.path != "") are validated against the
-	// project root boundary.
-	if hc.path != "" {
-		// Validate that resolvedDir stays within the project
-		// root to prevent path traversal via ".." in Dir.
-		absDir, absErr := filepath.Abs(hc.resolvedDir)
-		if absErr != nil {
-			return fmt.Errorf(
-				"resolving hook directory: %w", absErr,
-			)
-		}
-		absBoundary, absErr := filepath.Abs(boundaryDir)
-		if absErr != nil {
-			return fmt.Errorf(
-				"resolving boundary directory: %w",
-				absErr,
-			)
-		}
-		if !osutil.IsPathContained(absBoundary, absDir) {
-			return fmt.Errorf(
-				"hook directory %q escapes "+
-					"project root %q",
-				hc.Dir, boundaryDir,
-			)
-		}
-		hc.resolvedDir = absDir
+	return nil
+}
 
-		// Validate that resolvedScriptPath stays within
-		// the project root to prevent path traversal via
-		// ".." in Run.
-		if hc.resolvedScriptPath != "" {
-			absScript, scriptErr := filepath.Abs(
-				hc.resolvedScriptPath,
-			)
-			if scriptErr != nil {
-				return fmt.Errorf(
-					"resolving hook script path: %w",
-					scriptErr,
-				)
-			}
-			if !osutil.IsPathContained(
-				absBoundary, absScript,
-			) {
-				return fmt.Errorf(
-					"hook script path %q escapes "+
-						"project root %q",
-					hc.Run, boundaryDir,
-				)
-			}
-			hc.resolvedScriptPath = absScript
-		}
-	} else {
+// enforceContainment validates that file-based hooks do not escape
+// the project root via ".." in Dir or Run. Inline hooks are exempt
+// because they are saved to an OS temp file for execution.
+func (hc *HookConfig) enforceContainment() error {
+	if hc.relativeScriptPath == "" {
 		// Inline hooks: resolve to absolute path but skip
 		// containment validation.
 		absDir, absErr := filepath.Abs(hc.resolvedDir)
@@ -384,9 +374,75 @@ func (hc *HookConfig) validate() error {
 			)
 		}
 		hc.resolvedDir = absDir
+		return nil
 	}
 
-	hc.validated = true
+	// boundaryDir is the project root used for path
+	// containment validation. For service-level hooks this
+	// is the project root (where azure.yaml lives), which
+	// may differ from inputCwd (the service directory).
+	boundaryDir := hc.projectDir
+	if boundaryDir == "" {
+		boundaryDir = hc.inputCwd
+	}
+	if boundaryDir == "" {
+		var err error
+		boundaryDir, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf(
+				"resolving working directory: %w", err,
+			)
+		}
+	}
+
+	// Validate that resolvedDir stays within the project
+	// root to prevent path traversal via ".." in Dir.
+	absDir, absErr := filepath.Abs(hc.resolvedDir)
+	if absErr != nil {
+		return fmt.Errorf(
+			"resolving hook directory: %w", absErr,
+		)
+	}
+	absBoundary, absErr := filepath.Abs(boundaryDir)
+	if absErr != nil {
+		return fmt.Errorf(
+			"resolving boundary directory: %w",
+			absErr,
+		)
+	}
+	if !osutil.IsPathContained(absBoundary, absDir) {
+		return fmt.Errorf(
+			"hook directory %q escapes "+
+				"project root %q",
+			hc.Dir, boundaryDir,
+		)
+	}
+	hc.resolvedDir = absDir
+
+	// Validate that resolvedScriptPath stays within
+	// the project root to prevent path traversal via
+	// ".." in Run.
+	if hc.resolvedScriptPath != "" {
+		absScript, scriptErr := filepath.Abs(
+			hc.resolvedScriptPath,
+		)
+		if scriptErr != nil {
+			return fmt.Errorf(
+				"resolving hook script path: %w",
+				scriptErr,
+			)
+		}
+		if !osutil.IsPathContained(
+			absBoundary, absScript,
+		) {
+			return fmt.Errorf(
+				"hook script path %q escapes "+
+					"project root %q",
+				hc.Run, boundaryDir,
+			)
+		}
+		hc.resolvedScriptPath = absScript
+	}
 
 	return nil
 }

--- a/cli/azd/pkg/ext/models.go
+++ b/cli/azd/pkg/ext/models.go
@@ -208,7 +208,7 @@ func (hc *HookConfig) validate() error {
 		hc.Kind = language.HookKind(hc.Shell)
 	}
 	if hc.Kind == language.HookKindUnknown && hc.path != "" {
-		hc.Kind = language.InferKindFromPath(hc.Run)
+		hc.Kind = language.InferKindFromPath(hc.path)
 	}
 
 	// Reject inline scripts for non-shell executors. Only Bash and

--- a/cli/azd/pkg/ext/models_test.go
+++ b/cli/azd/pkg/ext/models_test.go
@@ -764,3 +764,197 @@ func TestHookConfig_ValidatePathTraversal(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "escapes project root")
 }
+
+// TestHookConfig_ServiceHookRelativePathWithinProject verifies that
+// service-level hooks with relative paths that reference parent
+// directories are accepted when they resolve within the project
+// root. This is the regression scenario from issue #7666 where a
+// service in src/logicApp has hooks at ../../hooks/prepackage.ps1.
+func TestHookConfig_ServiceHookRelativePathWithinProject(
+	t *testing.T,
+) {
+	// Structure:
+	//   projectRoot/
+	//     hooks/prepackage.sh
+	//     hooks/prepackage.ps1
+	//     hooks/prepackage.py
+	//     hooks/prepackage.js
+	//     hooks/prepackage.ts
+	//     hooks/prepackage.cs
+	//     src/logicApp/  (service cwd)
+	projectRoot := t.TempDir()
+	serviceCwd := filepath.Join(
+		projectRoot, "src", "logicApp",
+	)
+	hooksDir := filepath.Join(projectRoot, "hooks")
+
+	require.NoError(t, os.MkdirAll(serviceCwd, 0o755))
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+	// Create script files for all hook kinds.
+	scripts := []string{
+		"prepackage.sh",
+		"prepackage.ps1",
+		"prepackage.py",
+		"prepackage.js",
+		"prepackage.ts",
+		"prepackage.cs",
+	}
+	for _, s := range scripts {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(hooksDir, s), nil, 0o600,
+		))
+	}
+
+	tests := []struct {
+		name string
+		run  string
+		kind language.HookKind
+	}{
+		{
+			name: "BashHookFromService",
+			run: filepath.Join(
+				"..", "..", "hooks", "prepackage.sh",
+			),
+			kind: language.HookKindBash,
+		},
+		{
+			name: "PowerShellHookFromService",
+			run: filepath.Join(
+				"..", "..", "hooks", "prepackage.ps1",
+			),
+			kind: language.HookKindPowerShell,
+		},
+		{
+			name: "PythonHookFromService",
+			run: filepath.Join(
+				"..", "..", "hooks", "prepackage.py",
+			),
+			kind: language.HookKindPython,
+		},
+		{
+			name: "JavaScriptHookFromService",
+			run: filepath.Join(
+				"..", "..", "hooks", "prepackage.js",
+			),
+			kind: language.HookKindJavaScript,
+		},
+		{
+			name: "TypeScriptHookFromService",
+			run: filepath.Join(
+				"..", "..", "hooks", "prepackage.ts",
+			),
+			kind: language.HookKindTypeScript,
+		},
+		{
+			name: "DotNetHookFromService",
+			run: filepath.Join(
+				"..", "..", "hooks", "prepackage.cs",
+			),
+			kind: language.HookKindDotNet,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := HookConfig{
+				Name:       "prepackage",
+				Run:        tt.run,
+				cwd:        serviceCwd,
+				projectDir: projectRoot,
+			}
+
+			err := config.validate()
+			require.NoError(t, err,
+				"hook within project root must not "+
+					"be rejected")
+			require.Equal(t, tt.kind, config.Kind)
+		})
+	}
+}
+
+// TestHookConfig_ServiceHookEscapesProjectRoot verifies that
+// service-level hooks that escape the project root are still
+// rejected even when projectDir is set separately from cwd.
+func TestHookConfig_ServiceHookEscapesProjectRoot(
+	t *testing.T,
+) {
+	projectRoot := t.TempDir()
+	serviceCwd := filepath.Join(
+		projectRoot, "src", "logicApp",
+	)
+	require.NoError(t, os.MkdirAll(serviceCwd, 0o755))
+
+	// Script file outside the project root — the
+	// boundary check must reject this.
+	outsideDir := t.TempDir()
+	scriptPath := filepath.Join(outsideDir, "evil.sh")
+	require.NoError(t, os.WriteFile(
+		scriptPath, nil, 0o600,
+	))
+
+	config := HookConfig{
+		Name:       "prepackage",
+		Shell:      string(language.HookKindBash),
+		Run:        scriptPath,
+		cwd:        serviceCwd,
+		projectDir: projectRoot,
+	}
+
+	err := config.validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "escapes project root")
+}
+
+// TestHookConfig_ProjectDirFallbackToCwd verifies that when
+// projectDir is empty, cwd is used as the boundary (preserving
+// backward compatibility).
+func TestHookConfig_ProjectDirFallbackToCwd(t *testing.T) {
+	cwd := t.TempDir()
+
+	config := HookConfig{
+		Name:  "test",
+		Shell: string(language.HookKindBash),
+		Run:   "echo hello",
+		Dir:   filepath.Join("..", "..", "escape"),
+		cwd:   cwd,
+		// projectDir intentionally empty
+	}
+
+	err := config.validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "escapes project root")
+}
+
+// TestHookConfig_ServiceDirWithinProjectBoundary verifies that
+// an explicit Dir field that resolves within the project root is
+// accepted for service-level hooks with a separate projectDir.
+func TestHookConfig_ServiceDirWithinProjectBoundary(
+	t *testing.T,
+) {
+	projectRoot := t.TempDir()
+	serviceCwd := filepath.Join(
+		projectRoot, "src", "logicApp",
+	)
+	require.NoError(t, os.MkdirAll(serviceCwd, 0o755))
+
+	scriptDir := filepath.Join(projectRoot, "hooks")
+	require.NoError(t, os.MkdirAll(scriptDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(scriptDir, "deploy.sh"),
+		nil, 0o600,
+	))
+
+	config := HookConfig{
+		Name:       "predeploy",
+		Shell:      string(language.HookKindBash),
+		Run:        "deploy.sh",
+		Dir:        filepath.Join("..", "..", "hooks"),
+		cwd:        serviceCwd,
+		projectDir: projectRoot,
+	}
+
+	err := config.validate()
+	require.NoError(t, err,
+		"Dir within project root must be accepted")
+}

--- a/cli/azd/pkg/ext/models_test.go
+++ b/cli/azd/pkg/ext/models_test.go
@@ -266,7 +266,7 @@ func TestHookConfig_ValidateKindResolution(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config := tt.config
 			cwd := t.TempDir()
-			config.cwd = cwd
+			config.inputCwd = cwd
 
 			if tt.createFile != "" {
 				filePath := filepath.Join(cwd, tt.createFile)
@@ -365,7 +365,7 @@ func TestHookConfig_ValidateDirInference(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config := tt.config
 			cwd := t.TempDir()
-			config.cwd = cwd
+			config.inputCwd = cwd
 
 			if tt.createFile != "" {
 				filePath := filepath.Join(cwd, tt.createFile)
@@ -390,8 +390,8 @@ func TestHookConfig_ValidateDirRunResolution(t *testing.T) {
 		name         string
 		config       HookConfig
 		createFiles  []string // paths relative to cwd
-		expectPath   string   // expected hc.path (empty = inline)
-		expectScript string   // expected hc.script (empty = file)
+		expectPath   string   // expected hc.relativeScriptPath (empty = inline)
+		expectScript string   // expected hc.inlineScript (empty = file)
 		expectError  string
 	}{
 		{
@@ -497,7 +497,7 @@ func TestHookConfig_ValidateDirRunResolution(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config := tt.config
 			cwd := t.TempDir()
-			config.cwd = cwd
+			config.inputCwd = cwd
 
 			for _, f := range tt.createFiles {
 				fp := filepath.Join(cwd, f)
@@ -521,11 +521,11 @@ func TestHookConfig_ValidateDirRunResolution(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(
-				t, tt.expectPath, config.path,
+				t, tt.expectPath, config.relativeScriptPath,
 				"path mismatch",
 			)
 			require.Equal(
-				t, tt.expectScript, config.script,
+				t, tt.expectScript, config.inlineScript,
 				"script mismatch",
 			)
 		})
@@ -548,18 +548,18 @@ func TestHookConfig_ValidateDirRunAbsolutePath(t *testing.T) {
 	)
 
 	config := HookConfig{
-		Name: "test",
-		Kind: language.HookKindPython,
-		Run:  absScript,
-		Dir:  filepath.Join("hooks", "preprovision"),
-		cwd:  cwd,
+		Name:     "test",
+		Kind:     language.HookKindPython,
+		Run:      absScript,
+		Dir:      filepath.Join("hooks", "preprovision"),
+		inputCwd: cwd,
 	}
 
 	err := config.validate()
 	require.NoError(t, err)
 	// Absolute run paths are resolved without Dir prefix.
-	require.Equal(t, absScript, config.path)
-	require.Equal(t, "", config.script)
+	require.Equal(t, absScript, config.relativeScriptPath)
+	require.Equal(t, "", config.inlineScript)
 }
 
 func TestHookKind_IsShell(t *testing.T) {
@@ -676,7 +676,7 @@ func TestHookConfig_ResolvedPaths(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config := tt.config
 			cwd := t.TempDir()
-			config.cwd = cwd
+			config.inputCwd = cwd
 
 			for _, f := range tt.createFiles {
 				fp := filepath.Join(cwd, f)
@@ -762,10 +762,10 @@ func TestHookConfig_ValidatePathTraversal(t *testing.T) {
 	)
 
 	config := HookConfig{
-		Name:  "test",
-		Shell: string(language.HookKindBash),
-		Run:   scriptPath,
-		cwd:   cwd,
+		Name:     "test",
+		Shell:    string(language.HookKindBash),
+		Run:      scriptPath,
+		inputCwd: cwd,
 	}
 
 	err := config.validate()
@@ -868,7 +868,7 @@ func TestHookConfig_ServiceHookRelativePathWithinProject(
 			config := HookConfig{
 				Name:       "prepackage",
 				Run:        tt.run,
-				cwd:        serviceCwd,
+				inputCwd:   serviceCwd,
 				projectDir: projectRoot,
 			}
 
@@ -905,7 +905,7 @@ func TestHookConfig_ServiceHookEscapesProjectRoot(
 		Name:       "prepackage",
 		Shell:      string(language.HookKindBash),
 		Run:        scriptPath,
-		cwd:        serviceCwd,
+		inputCwd:   serviceCwd,
 		projectDir: projectRoot,
 	}
 
@@ -930,10 +930,10 @@ func TestHookConfig_ProjectDirFallbackToCwd(t *testing.T) {
 	)
 
 	config := HookConfig{
-		Name:  "test",
-		Shell: string(language.HookKindBash),
-		Run:   scriptPath,
-		cwd:   cwd,
+		Name:     "test",
+		Shell:    string(language.HookKindBash),
+		Run:      scriptPath,
+		inputCwd: cwd,
 		// projectDir intentionally empty
 	}
 
@@ -966,7 +966,7 @@ func TestHookConfig_ServiceDirWithinProjectBoundary(
 		Shell:      string(language.HookKindBash),
 		Run:        "deploy.sh",
 		Dir:        filepath.Join("..", "..", "hooks"),
-		cwd:        serviceCwd,
+		inputCwd:   serviceCwd,
 		projectDir: projectRoot,
 	}
 
@@ -1023,7 +1023,7 @@ func TestHookConfig_InlineHookContainmentExempt(t *testing.T) {
 				Shell:      string(language.HookKindBash),
 				Run:        "echo shared",
 				Dir:        tt.dir,
-				cwd:        tt.cwdDir,
+				inputCwd:   tt.cwdDir,
 				projectDir: projectRoot,
 			}
 
@@ -1112,7 +1112,7 @@ func TestHookConfig_FileBasedContainmentEnforced(t *testing.T) {
 				Shell:      string(language.HookKindBash),
 				Run:        tt.run,
 				Dir:        tt.dir,
-				cwd:        tt.cwd,
+				inputCwd:   tt.cwd,
 				projectDir: projectRoot,
 			}
 
@@ -1162,7 +1162,7 @@ func TestHookConfig_AllKindsInsideProject(t *testing.T) {
 				Name:       "prebuild",
 				Run:        k.file,
 				Dir:        "hooks",
-				cwd:        projectRoot,
+				inputCwd:   projectRoot,
 				projectDir: projectRoot,
 			}
 
@@ -1196,7 +1196,7 @@ func TestHookConfig_AllKindsInlineExempt(t *testing.T) {
 				Name:       "preshared",
 				Kind:       k.kind,
 				Run:        "echo layer",
-				cwd:        externalLayer,
+				inputCwd:   externalLayer,
 				projectDir: projectRoot,
 			}
 
@@ -1226,7 +1226,7 @@ func TestHookConfig_InlineDirSetRunNotSet(t *testing.T) {
 		Shell:      string(language.HookKindBash),
 		Run:        "echo build",
 		Dir:        externalDir,
-		cwd:        projectRoot,
+		inputCwd:   projectRoot,
 		projectDir: projectRoot,
 	}
 
@@ -1296,10 +1296,10 @@ func TestHookConfig_DirRunKindInference(t *testing.T) {
 			))
 
 			config := HookConfig{
-				Name: "preprovision",
-				Run:  tt.run,
-				Dir:  filepath.Join("hooks", "pre"),
-				cwd:  cwd,
+				Name:     "preprovision",
+				Run:      tt.run,
+				Dir:      filepath.Join("hooks", "pre"),
+				inputCwd: cwd,
 			}
 
 			err := config.validate()

--- a/cli/azd/pkg/ext/models_test.go
+++ b/cli/azd/pkg/ext/models_test.go
@@ -748,15 +748,23 @@ func TestHookConfig_ResolvedPaths(t *testing.T) {
 }
 
 // TestHookConfig_ValidatePathTraversal verifies that validate()
-// rejects Dir values that escape the project root via "..".
+// rejects Dir values that escape the project root via ".." for
+// file-based hooks, while inline hooks are exempt.
 func TestHookConfig_ValidatePathTraversal(t *testing.T) {
 	cwd := t.TempDir()
+
+	// File-based hook with Dir escaping project root — must fail.
+	escapeDir := filepath.Join(cwd, "..", "..", "escape")
+	require.NoError(t, os.MkdirAll(escapeDir, 0o755))
+	scriptPath := filepath.Join(escapeDir, "evil.sh")
+	require.NoError(
+		t, os.WriteFile(scriptPath, nil, 0o600),
+	)
 
 	config := HookConfig{
 		Name:  "test",
 		Shell: string(language.HookKindBash),
-		Run:   "echo hello",
-		Dir:   filepath.Join("..", "..", "escape"),
+		Run:   scriptPath,
 		cwd:   cwd,
 	}
 
@@ -908,15 +916,23 @@ func TestHookConfig_ServiceHookEscapesProjectRoot(
 
 // TestHookConfig_ProjectDirFallbackToCwd verifies that when
 // projectDir is empty, cwd is used as the boundary (preserving
-// backward compatibility).
+// backward compatibility). Uses a file-based hook so the
+// containment check is actually enforced.
 func TestHookConfig_ProjectDirFallbackToCwd(t *testing.T) {
 	cwd := t.TempDir()
+
+	// Create a script outside cwd to trigger containment.
+	escapeDir := filepath.Join(cwd, "..", "..", "escape")
+	require.NoError(t, os.MkdirAll(escapeDir, 0o755))
+	scriptPath := filepath.Join(escapeDir, "evil.sh")
+	require.NoError(
+		t, os.WriteFile(scriptPath, nil, 0o600),
+	)
 
 	config := HookConfig{
 		Name:  "test",
 		Shell: string(language.HookKindBash),
-		Run:   "echo hello",
-		Dir:   filepath.Join("..", "..", "escape"),
+		Run:   scriptPath,
 		cwd:   cwd,
 		// projectDir intentionally empty
 	}
@@ -957,6 +973,268 @@ func TestHookConfig_ServiceDirWithinProjectBoundary(
 	err := config.validate()
 	require.NoError(t, err,
 		"Dir within project root must be accepted")
+}
+
+// TestHookConfig_InlineHookContainmentExempt verifies that inline
+// hooks (where Run does not resolve to a file on disk) are exempt
+// from both the directory and script path containment checks.
+// This is critical for layer hooks whose cwd is an external temp
+// directory outside the project root.
+func TestHookConfig_InlineHookContainmentExempt(t *testing.T) {
+	projectRoot := t.TempDir()
+
+	tests := []struct {
+		name string
+		// cwd for the hook; may be outside projectRoot
+		cwdDir string
+		// explicit Dir field; may be outside projectRoot
+		dir string
+		// should validate succeed?
+		expectPass bool
+	}{
+		{
+			name:       "InlineCwdInsideProject",
+			cwdDir:     projectRoot,
+			expectPass: true,
+		},
+		{
+			name:       "InlineCwdOutsideProject",
+			cwdDir:     t.TempDir(), // separate temp dir
+			expectPass: true,
+		},
+		{
+			name:       "InlineExplicitDirOutsideProject",
+			cwdDir:     projectRoot,
+			dir:        t.TempDir(), // absolute external dir
+			expectPass: true,
+		},
+		{
+			name:       "InlineBothCwdAndDirOutside",
+			cwdDir:     t.TempDir(),
+			dir:        t.TempDir(),
+			expectPass: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := HookConfig{
+				Name:       "preshared",
+				Shell:      string(language.HookKindBash),
+				Run:        "echo shared",
+				Dir:        tt.dir,
+				cwd:        tt.cwdDir,
+				projectDir: projectRoot,
+			}
+
+			err := config.validate()
+			if tt.expectPass {
+				require.NoError(t, err,
+					"inline hooks must be exempt "+
+						"from containment checks")
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+// TestHookConfig_FileBasedContainmentEnforced verifies that
+// file-based hooks enforce the project root containment boundary
+// for both the script path and the working directory.
+func TestHookConfig_FileBasedContainmentEnforced(t *testing.T) {
+	projectRoot := t.TempDir()
+	outsideDir := t.TempDir()
+
+	// Create a script inside the project root.
+	hooksDir := filepath.Join(projectRoot, "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(hooksDir, "deploy.sh"),
+		nil, 0o600,
+	))
+
+	// Create a script outside the project root.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outsideDir, "evil.sh"),
+		nil, 0o600,
+	))
+
+	// Ensure the nested service dir exists.
+	serviceCwd := filepath.Join(
+		projectRoot, "src", "logicApp",
+	)
+	require.NoError(t, os.MkdirAll(serviceCwd, 0o755))
+
+	tests := []struct {
+		name       string
+		run        string
+		dir        string
+		cwd        string
+		expectErr  string
+		expectPass bool
+	}{
+		{
+			name:       "ScriptInsideProjectRoot",
+			run:        filepath.Join("hooks", "deploy.sh"),
+			cwd:        projectRoot,
+			expectPass: true,
+		},
+		{
+			name: "AbsScriptOutsideProjectRoot",
+			run: filepath.Join(
+				outsideDir, "evil.sh",
+			),
+			cwd:       projectRoot,
+			expectErr: "escapes project root",
+		},
+		{
+			name:      "DirOutsideProjectRoot",
+			run:       "evil.sh",
+			dir:       outsideDir,
+			cwd:       projectRoot,
+			expectErr: "escapes project root",
+		},
+		{
+			name: "RelativePathResolvesWithinProject",
+			run: filepath.Join(
+				"..", "..", "hooks", "deploy.sh",
+			),
+			cwd:        serviceCwd,
+			expectPass: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := HookConfig{
+				Name:       "predeploy",
+				Shell:      string(language.HookKindBash),
+				Run:        tt.run,
+				Dir:        tt.dir,
+				cwd:        tt.cwd,
+				projectDir: projectRoot,
+			}
+
+			err := config.validate()
+			if tt.expectPass {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(
+					t, err.Error(), tt.expectErr,
+				)
+			}
+		})
+	}
+}
+
+// TestHookConfig_AllKindsInsideProject verifies that all six
+// hook kinds pass validation when the script is inside the
+// project root with Dir + Run set.
+func TestHookConfig_AllKindsInsideProject(t *testing.T) {
+	projectRoot := t.TempDir()
+	hooksDir := filepath.Join(projectRoot, "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+	kinds := []struct {
+		file string
+		kind language.HookKind
+	}{
+		{"build.sh", language.HookKindBash},
+		{"build.ps1", language.HookKindPowerShell},
+		{"main.py", language.HookKindPython},
+		{"index.js", language.HookKindJavaScript},
+		{"index.ts", language.HookKindTypeScript},
+		{"Program.cs", language.HookKindDotNet},
+	}
+
+	for _, k := range kinds {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(hooksDir, k.file),
+			nil, 0o600,
+		))
+	}
+
+	for _, k := range kinds {
+		t.Run(string(k.kind), func(t *testing.T) {
+			config := HookConfig{
+				Name:       "prebuild",
+				Run:        k.file,
+				Dir:        "hooks",
+				cwd:        projectRoot,
+				projectDir: projectRoot,
+			}
+
+			err := config.validate()
+			require.NoError(t, err)
+			require.Equal(t, k.kind, config.Kind)
+		})
+	}
+}
+
+// TestHookConfig_AllKindsInlineExempt verifies that inline
+// scripts for both shell kinds pass validation even when cwd is
+// outside the project root (layer scenario). Non-shell kinds
+// reject inline scripts (tested elsewhere), so only Bash and
+// PowerShell are exercised here.
+func TestHookConfig_AllKindsInlineExempt(t *testing.T) {
+	projectRoot := t.TempDir()
+	externalLayer := t.TempDir()
+
+	shellKinds := []struct {
+		name string
+		kind language.HookKind
+	}{
+		{"Bash", language.HookKindBash},
+		{"PowerShell", language.HookKindPowerShell},
+	}
+
+	for _, k := range shellKinds {
+		t.Run(k.name, func(t *testing.T) {
+			config := HookConfig{
+				Name:       "preshared",
+				Kind:       k.kind,
+				Run:        "echo layer",
+				cwd:        externalLayer,
+				projectDir: projectRoot,
+			}
+
+			err := config.validate()
+			require.NoError(t, err,
+				"inline %s hook must be exempt "+
+					"from containment", k.kind)
+			require.Equal(t, k.kind, config.Kind)
+			// resolvedDir should be the external layer
+			absLayer, _ := filepath.Abs(externalLayer)
+			require.Equal(
+				t, absLayer, config.resolvedDir,
+			)
+		})
+	}
+}
+
+// TestHookConfig_InlineDirSetRunNotSet verifies that when Dir is
+// set but Run resolves to an inline script, the hook is still
+// exempt from containment checks.
+func TestHookConfig_InlineDirSetRunNotSet(t *testing.T) {
+	projectRoot := t.TempDir()
+	externalDir := t.TempDir()
+
+	config := HookConfig{
+		Name:       "prepackage",
+		Shell:      string(language.HookKindBash),
+		Run:        "echo build",
+		Dir:        externalDir,
+		cwd:        projectRoot,
+		projectDir: projectRoot,
+	}
+
+	err := config.validate()
+	require.NoError(t, err,
+		"inline hook with explicit Dir must be exempt")
+	absDir, _ := filepath.Abs(externalDir)
+	require.Equal(t, absDir, config.resolvedDir)
 }
 
 // TestHookConfig_DirRunKindInference verifies that when both Dir

--- a/cli/azd/pkg/ext/models_test.go
+++ b/cli/azd/pkg/ext/models_test.go
@@ -958,3 +958,93 @@ func TestHookConfig_ServiceDirWithinProjectBoundary(
 	require.NoError(t, err,
 		"Dir within project root must be accepted")
 }
+
+// TestHookConfig_DirRunKindInference verifies that when both Dir
+// and Run are set without an explicit Kind, validate() correctly
+// infers the hook kind from the file extension and resolves the
+// script path to the actual file on disk.
+func TestHookConfig_DirRunKindInference(t *testing.T) {
+	tests := []struct {
+		name         string
+		run          string
+		expectedKind language.HookKind
+	}{
+		{
+			name:         "Bash",
+			run:          "build.sh",
+			expectedKind: language.HookKindBash,
+		},
+		{
+			name:         "PowerShell",
+			run:          "build.ps1",
+			expectedKind: language.HookKindPowerShell,
+		},
+		{
+			name:         "Python",
+			run:          "main.py",
+			expectedKind: language.HookKindPython,
+		},
+		{
+			name:         "JavaScript",
+			run:          "index.js",
+			expectedKind: language.HookKindJavaScript,
+		},
+		{
+			name:         "TypeScript",
+			run:          "index.ts",
+			expectedKind: language.HookKindTypeScript,
+		},
+		{
+			name:         "DotNet",
+			run:          "Program.cs",
+			expectedKind: language.HookKindDotNet,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cwd := t.TempDir()
+
+			hookDir := filepath.Join(
+				cwd, "hooks", "pre",
+			)
+			require.NoError(
+				t,
+				os.MkdirAll(hookDir, 0o755),
+			)
+			require.NoError(t, os.WriteFile(
+				filepath.Join(hookDir, tt.run),
+				nil, 0o600,
+			))
+
+			config := HookConfig{
+				Name: "preprovision",
+				Run:  tt.run,
+				Dir:  filepath.Join("hooks", "pre"),
+				cwd:  cwd,
+			}
+
+			err := config.validate()
+			require.NoError(t, err)
+
+			require.Equal(
+				t,
+				tt.expectedKind,
+				config.Kind,
+				"Kind should be inferred from "+
+					"file extension",
+			)
+
+			expectedScript := filepath.Join(
+				hookDir, tt.run,
+			)
+			require.Equal(
+				t,
+				expectedScript,
+				config.resolvedScriptPath,
+				"resolvedScriptPath should point "+
+					"to the actual file",
+			)
+		})
+	}
+}

--- a/cli/azd/pkg/ext/python_hooks_e2e_test.go
+++ b/cli/azd/pkg/ext/python_hooks_e2e_test.go
@@ -73,7 +73,7 @@ func buildRunner(
 	envManager.On("Reload", mock.Anything, env).Return(nil)
 
 	hooksManager := NewHooksManager(
-		cwd, cwd, mockCtx.CommandRunner,
+		HooksManagerOptions{Cwd: cwd, ProjectDir: cwd}, mockCtx.CommandRunner,
 	)
 
 	return NewHooksRunner(

--- a/cli/azd/pkg/ext/python_hooks_e2e_test.go
+++ b/cli/azd/pkg/ext/python_hooks_e2e_test.go
@@ -73,7 +73,7 @@ func buildRunner(
 	envManager.On("Reload", mock.Anything, env).Return(nil)
 
 	hooksManager := NewHooksManager(
-		cwd, mockCtx.CommandRunner,
+		cwd, cwd, mockCtx.CommandRunner,
 	)
 
 	return NewHooksRunner(


### PR DESCRIPTION
## What Changed

Service-level hooks that reference shared scripts via relative paths (e.g., `../../hooks/prepackage.ps1`) no longer fail with "hook script path escapes project root." This was a regression in 1.23.15 introduced by PR #7451 (multi-language hooks Phase 1).

Additionally, hook kind inference now works correctly when both `dir` and `run` fields are set — previously the system would default to PowerShell on Windows instead of inferring the correct executor from the file extension.

**Before (broken):**
- A service at `src/logicApp/` with a hook pointing to `../../hooks/script.ps1` would fail because the security boundary was the service directory, not the project root.
- A hook with `dir: hooks/pre` and `run: main.py` (no explicit `kind`) would default to PowerShell instead of Python.

**After (fixed):**
- The containment boundary is the project root (where `azure.yaml` lives). Service hooks can reach shared scripts via relative paths. Paths that escape the project root are still rejected.
- Hook kind is correctly inferred from the resolved file extension, not the raw `run` value.
- Inline hooks (script content in YAML) are exempt from containment checks since they execute from OS temp files.

## How It Works

PR #7451 conflated two concepts into a single `cwd` variable: the working directory for resolving relative paths and the security boundary for path containment checks. This PR introduces a separate `projectDir` field on `HookConfig` that always points to the project root. Path resolution still uses `cwd` (which may be a service subdirectory), but containment validation checks against `projectDir`.

For inline hooks (defined directly in YAML rather than as file references), both containment checks are skipped entirely — these hooks are saved to OS temp files for execution, so their script path and working directory are expected to be outside the project root.

The kind inference fix changes `InferKindFromPath(hc.Run)` to `InferKindFromPath(hc.path)`, ensuring the resolved file path (with extension) is used instead of the raw user input.

## Issue References

Resolves #7666
Resolves #7691

## Notes

Comprehensive test coverage added across three commits:
- All 6 hook kinds (bash, powershell, python, js, ts, dotnet) tested for path containment and kind inference
- Inline hook exemption tested with cwd inside and outside project root
- File-based containment enforcement tested for scripts inside, outside, and at relative boundary
- Backward compatibility verified when `projectDir` is unset (falls back to `cwd`)