### PR TITLE
fix: prompt user to select agent queue for AzDO pipeline config

### DIFF
--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -29,17 +29,17 @@ func createBuildDefinitionVariable(value string, isSecret bool, allowOverride bo
 
 // selectAgentQueue picks the agent queue to use from the provided list.
 // Auto-selects if only one queue exists, prompts the user if multiple.
-// Queues with nil or empty names are filtered out.
+// Queues with nil IDs or nil/empty names are filtered out.
 func selectAgentQueue(
 	ctx context.Context,
 	projectId string,
 	queues []taskagent.TaskAgentQueue,
 	console input.Console,
 ) (*taskagent.TaskAgentQueue, error) {
-	// Filter out queues with nil or empty names
+	// Filter out queues with nil IDs or nil/empty names
 	valid := make([]taskagent.TaskAgentQueue, 0, len(queues))
 	for _, q := range queues {
-		if q.Name != nil && *q.Name != "" {
+		if q.Id != nil && q.Name != nil && *q.Name != "" {
 			valid = append(valid, q)
 		}
 	}

--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -50,11 +50,16 @@ func selectAgentQueue(
 	}
 
 	idx, err := console.Select(ctx, input.ConsoleOptions{
-		Message: "Choose an agent queue for the pipeline",
-		Options: options,
+		Message:      "Choose an agent queue for the pipeline",
+		Options:      options,
+		DefaultValue: options[0],
 	})
 	if err != nil {
 		return nil, fmt.Errorf("selecting agent queue: %w", err)
+	}
+
+	if idx < 0 || idx >= len(queues) {
+		return nil, fmt.Errorf("selecting agent queue: invalid queue index %d for %d queues", idx, len(queues))
 	}
 
 	return &queues[idx], nil

--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -29,23 +29,32 @@ func createBuildDefinitionVariable(value string, isSecret bool, allowOverride bo
 
 // selectAgentQueue picks the agent queue to use from the provided list.
 // Auto-selects if only one queue exists, prompts the user if multiple.
+// Queues with nil or empty names are filtered out.
 func selectAgentQueue(
 	ctx context.Context,
 	projectId string,
 	queues []taskagent.TaskAgentQueue,
 	console input.Console,
 ) (*taskagent.TaskAgentQueue, error) {
-	if len(queues) == 0 {
+	// Filter out queues with nil or empty names
+	valid := make([]taskagent.TaskAgentQueue, 0, len(queues))
+	for _, q := range queues {
+		if q.Name != nil && *q.Name != "" {
+			valid = append(valid, q)
+		}
+	}
+
+	if len(valid) == 0 {
 		return nil, fmt.Errorf("no agent queues available in project %s", projectId)
 	}
 
-	if len(queues) == 1 {
-		console.Message(ctx, fmt.Sprintf("Using agent queue: %s", *queues[0].Name))
-		return &queues[0], nil
+	if len(valid) == 1 {
+		console.Message(ctx, fmt.Sprintf("Using agent queue: %s", *valid[0].Name))
+		return &valid[0], nil
 	}
 
-	options := make([]string, 0, len(queues))
-	for _, q := range queues {
+	options := make([]string, 0, len(valid))
+	for _, q := range valid {
 		options = append(options, *q.Name)
 	}
 
@@ -58,11 +67,11 @@ func selectAgentQueue(
 		return nil, fmt.Errorf("selecting agent queue: %w", err)
 	}
 
-	if idx < 0 || idx >= len(queues) {
-		return nil, fmt.Errorf("selecting agent queue: invalid queue index %d for %d queues", idx, len(queues))
+	if idx < 0 || idx >= len(valid) {
+		return nil, fmt.Errorf("selecting agent queue: invalid queue index %d for %d queues", idx, len(valid))
 	}
 
-	return &queues[idx], nil
+	return &valid[idx], nil
 }
 
 // getAgentQueue returns the agent queue to associate with the pipeline.

--- a/cli/azd/pkg/azdo/pipeline.go
+++ b/cli/azd/pkg/azdo/pipeline.go
@@ -27,29 +27,67 @@ func createBuildDefinitionVariable(value string, isSecret bool, allowOverride bo
 	}
 }
 
-// returns the default agent queue. This is used to associate a Pipeline with a default agent pool queue
+// selectAgentQueue picks the agent queue to use from the provided list.
+// Auto-selects if only one queue exists, prompts the user if multiple.
+func selectAgentQueue(
+	ctx context.Context,
+	projectId string,
+	queues []taskagent.TaskAgentQueue,
+	console input.Console,
+) (*taskagent.TaskAgentQueue, error) {
+	if len(queues) == 0 {
+		return nil, fmt.Errorf("no agent queues available in project %s", projectId)
+	}
+
+	if len(queues) == 1 {
+		console.Message(ctx, fmt.Sprintf("Using agent queue: %s", *queues[0].Name))
+		return &queues[0], nil
+	}
+
+	options := make([]string, 0, len(queues))
+	for _, q := range queues {
+		options = append(options, *q.Name)
+	}
+
+	idx, err := console.Select(ctx, input.ConsoleOptions{
+		Message: "Choose an agent queue for the pipeline",
+		Options: options,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("selecting agent queue: %w", err)
+	}
+
+	return &queues[idx], nil
+}
+
+// getAgentQueue returns the agent queue to associate with the pipeline.
+// It queries all usable queues and auto-selects if only one is available,
+// or prompts the user to choose if multiple queues exist.
 func getAgentQueue(
 	ctx context.Context,
 	projectId string,
 	connection *azuredevops.Connection,
+	console input.Console,
 ) (*taskagent.TaskAgentQueue, error) {
 	client, err := taskagent.NewClient(ctx, connection)
 	if err != nil {
 		return nil, err
 	}
-	getAgentQueuesArgs := taskagent.GetAgentQueuesArgs{
-		Project: &projectId,
-	}
-	queues, err := client.GetAgentQueues(ctx, getAgentQueuesArgs)
+
+	actionFilter := taskagent.TaskAgentQueueActionFilterValues.Use
+	queues, err := client.GetAgentQueues(ctx, taskagent.GetAgentQueuesArgs{
+		Project:      &projectId,
+		ActionFilter: &actionFilter,
+	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("listing agent queues: %w", err)
 	}
-	for _, queue := range *queues {
-		if *queue.Name == "Default" {
-			return &queue, nil
-		}
+
+	if queues == nil {
+		return nil, fmt.Errorf("no agent queues available in project %s", projectId)
 	}
-	return nil, fmt.Errorf("could not find a default agent queue in project %s", projectId)
+
+	return selectAgentQueue(ctx, projectId, *queues, console)
 }
 
 // find pipeline by name
@@ -128,7 +166,7 @@ func CreatePipeline(
 		return definition, nil
 	}
 
-	queue, err := getAgentQueue(ctx, projectId, connection)
+	queue, err := getAgentQueue(ctx, projectId, connection, console)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/pkg/azdo/pipeline_test.go
+++ b/cli/azd/pkg/azdo/pipeline_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azdo
+
+import (
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/taskagent"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_selectAgentQueue(t *testing.T) {
+	t.Run("no queues returns error", func(t *testing.T) {
+		mockConsole := mockinput.NewMockConsole()
+
+		queue, err := selectAgentQueue(t.Context(), "project-1", nil, mockConsole)
+		assert.Nil(t, queue)
+		assert.ErrorContains(t, err, "no agent queues available in project project-1")
+	})
+
+	t.Run("empty queues returns error", func(t *testing.T) {
+		mockConsole := mockinput.NewMockConsole()
+
+		queue, err := selectAgentQueue(t.Context(), "project-1", []taskagent.TaskAgentQueue{}, mockConsole)
+		assert.Nil(t, queue)
+		assert.ErrorContains(t, err, "no agent queues available in project project-1")
+	})
+
+	t.Run("single queue auto-selects", func(t *testing.T) {
+		mockConsole := mockinput.NewMockConsole()
+		queueName := "Azure Pipelines"
+		queueId := 1
+		queues := []taskagent.TaskAgentQueue{
+			{Id: &queueId, Name: &queueName},
+		}
+
+		queue, err := selectAgentQueue(t.Context(), "project-1", queues, mockConsole)
+		require.NoError(t, err)
+		require.NotNil(t, queue)
+		assert.Equal(t, "Azure Pipelines", *queue.Name)
+		assert.Equal(t, 1, *queue.Id)
+	})
+
+	t.Run("multiple queues prompts user", func(t *testing.T) {
+		mockConsole := mockinput.NewMockConsole()
+		mockConsole.WhenSelect(func(options input.ConsoleOptions) bool {
+			return options.Message == "Choose an agent queue for the pipeline"
+		}).Respond(1) // select second queue
+
+		name1 := "Default"
+		id1 := 1
+		name2 := "Azure Pipelines"
+		id2 := 2
+		queues := []taskagent.TaskAgentQueue{
+			{Id: &id1, Name: &name1},
+			{Id: &id2, Name: &name2},
+		}
+
+		queue, err := selectAgentQueue(t.Context(), "project-1", queues, mockConsole)
+		require.NoError(t, err)
+		require.NotNil(t, queue)
+		assert.Equal(t, "Azure Pipelines", *queue.Name)
+		assert.Equal(t, 2, *queue.Id)
+	})
+
+	t.Run("multiple queues selects first", func(t *testing.T) {
+		mockConsole := mockinput.NewMockConsole()
+		mockConsole.WhenSelect(func(options input.ConsoleOptions) bool {
+			return options.Message == "Choose an agent queue for the pipeline"
+		}).Respond(0) // select first queue
+
+		name1 := "Default"
+		id1 := 1
+		name2 := "Azure Pipelines"
+		id2 := 2
+		queues := []taskagent.TaskAgentQueue{
+			{Id: &id1, Name: &name1},
+			{Id: &id2, Name: &name2},
+		}
+
+		queue, err := selectAgentQueue(t.Context(), "project-1", queues, mockConsole)
+		require.NoError(t, err)
+		require.NotNil(t, queue)
+		assert.Equal(t, "Default", *queue.Name)
+		assert.Equal(t, 1, *queue.Id)
+	})
+}

--- a/cli/azd/pkg/azdo/pipeline_test.go
+++ b/cli/azd/pkg/azdo/pipeline_test.go
@@ -30,6 +30,34 @@ func Test_selectAgentQueue(t *testing.T) {
 		assert.ErrorContains(t, err, "no agent queues available in project project-1")
 	})
 
+	t.Run("queues with nil names are filtered out", func(t *testing.T) {
+		mockConsole := mockinput.NewMockConsole()
+		queueId := 1
+		queues := []taskagent.TaskAgentQueue{
+			{Id: &queueId, Name: nil},
+		}
+
+		queue, err := selectAgentQueue(t.Context(), "project-1", queues, mockConsole)
+		assert.Nil(t, queue)
+		assert.ErrorContains(t, err, "no agent queues available in project project-1")
+	})
+
+	t.Run("nil name queues filtered leaving one valid", func(t *testing.T) {
+		mockConsole := mockinput.NewMockConsole()
+		id1 := 1
+		id2 := 2
+		validName := "Azure Pipelines"
+		queues := []taskagent.TaskAgentQueue{
+			{Id: &id1, Name: nil},
+			{Id: &id2, Name: &validName},
+		}
+
+		queue, err := selectAgentQueue(t.Context(), "project-1", queues, mockConsole)
+		require.NoError(t, err)
+		require.NotNil(t, queue)
+		assert.Equal(t, "Azure Pipelines", *queue.Name)
+	})
+
 	t.Run("single queue auto-selects", func(t *testing.T) {
 		mockConsole := mockinput.NewMockConsole()
 		queueName := "Azure Pipelines"

--- a/cli/azd/pkg/azdo/pipeline_test.go
+++ b/cli/azd/pkg/azdo/pipeline_test.go
@@ -4,6 +4,8 @@
 package azdo
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -13,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_selectAgentQueue(t *testing.T) {
+func TestSelectAgentQueue(t *testing.T) {
 	t.Run("no queues returns error", func(t *testing.T) {
 		mockConsole := mockinput.NewMockConsole()
 
@@ -35,6 +37,18 @@ func Test_selectAgentQueue(t *testing.T) {
 		queueId := 1
 		queues := []taskagent.TaskAgentQueue{
 			{Id: &queueId, Name: nil},
+		}
+
+		queue, err := selectAgentQueue(t.Context(), "project-1", queues, mockConsole)
+		assert.Nil(t, queue)
+		assert.ErrorContains(t, err, "no agent queues available in project project-1")
+	})
+
+	t.Run("queues with nil id are filtered out", func(t *testing.T) {
+		mockConsole := mockinput.NewMockConsole()
+		name := "Default"
+		queues := []taskagent.TaskAgentQueue{
+			{Id: nil, Name: &name},
 		}
 
 		queue, err := selectAgentQueue(t.Context(), "project-1", queues, mockConsole)
@@ -76,7 +90,7 @@ func Test_selectAgentQueue(t *testing.T) {
 	t.Run("multiple queues prompts user", func(t *testing.T) {
 		mockConsole := mockinput.NewMockConsole()
 		mockConsole.WhenSelect(func(options input.ConsoleOptions) bool {
-			return options.Message == "Choose an agent queue for the pipeline"
+			return strings.Contains(options.Message, "agent queue")
 		}).Respond(1) // select second queue
 
 		name1 := "Default"
@@ -98,7 +112,7 @@ func Test_selectAgentQueue(t *testing.T) {
 	t.Run("multiple queues selects first", func(t *testing.T) {
 		mockConsole := mockinput.NewMockConsole()
 		mockConsole.WhenSelect(func(options input.ConsoleOptions) bool {
-			return options.Message == "Choose an agent queue for the pipeline"
+			return strings.Contains(options.Message, "agent queue")
 		}).Respond(0) // select first queue
 
 		name1 := "Default"
@@ -115,5 +129,28 @@ func Test_selectAgentQueue(t *testing.T) {
 		require.NotNil(t, queue)
 		assert.Equal(t, "Default", *queue.Name)
 		assert.Equal(t, 1, *queue.Id)
+	})
+
+	t.Run("select error is wrapped", func(t *testing.T) {
+		mockConsole := mockinput.NewMockConsole()
+		mockConsole.WhenSelect(func(options input.ConsoleOptions) bool {
+			return strings.Contains(options.Message, "agent queue")
+		}).RespondFn(func(_ input.ConsoleOptions) (any, error) {
+			return 0, fmt.Errorf("user cancelled")
+		})
+
+		name1 := "Default"
+		id1 := 1
+		name2 := "Azure Pipelines"
+		id2 := 2
+		queues := []taskagent.TaskAgentQueue{
+			{Id: &id1, Name: &name1},
+			{Id: &id2, Name: &name2},
+		}
+
+		queue, err := selectAgentQueue(t.Context(), "project-1", queues, mockConsole)
+		assert.Nil(t, queue)
+		assert.ErrorContains(t, err, "selecting agent queue")
+		assert.ErrorContains(t, err, "user cancelled")
 	})
 }


### PR DESCRIPTION
## Fix: Agent Queue Selection for AzDO Pipeline Config

Fixes #4248

### Problem

`azd pipeline config --provider azdo` fails with `could not find a default agent queue in project` because the queue name is hardcoded to `"Default"`. Users with queues named differently (e.g., `"Azure Pipelines"`) cannot proceed.

### Solution

Instead of hardcoding the queue name, we now:

1. **Query all usable queues** — Uses `ActionFilter: Use` to filter to queues the user has permission to use
2. **Auto-select if only one** — If there's exactly one queue, use it automatically (with an informational message)
3. **Prompt if multiple** — Uses `console.Select()` to let the user pick, following the same pattern as AzDo project selection in `project.go`
4. **Clear error if none** — Returns a descriptive error if no usable queues exist

### Changes

- **`cli/azd/pkg/azdo/pipeline.go`** — Refactored `getAgentQueue()` and extracted `selectAgentQueue()` for testability
- **`cli/azd/pkg/azdo/pipeline_test.go`** (new) — 5 test cases covering: no queues, empty queues, single auto-select, multiple queues with different selections

### Testing

- All 16 azdo package tests pass
- Full `go build ./...` passes
- `golangci-lint` reports 0 issues