### PR TITLE
test: fix unknown CI failures

### DIFF
--- a/cli/azd/cmd/completion_test.go
+++ b/cli/azd/cmd/completion_test.go
@@ -4,6 +4,8 @@
 package cmd
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -190,7 +192,9 @@ func TestCompletionHelpDescriptions(t *testing.T) {
 func TestCompletionFigAction_Run(t *testing.T) {
 	t.Parallel()
 
+	var stdout bytes.Buffer
 	root := &cobra.Command{Use: "azd", Short: "Azure Developer CLI"}
+	root.SetOut(&stdout)
 	child := &cobra.Command{Use: "init", Short: "Initialize", Run: func(cmd *cobra.Command, args []string) {}}
 	root.AddCommand(child)
 
@@ -199,4 +203,5 @@ func TestCompletionFigAction_Run(t *testing.T) {
 	result, err := action.Run(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, result)
+	require.True(t, strings.HasSuffix(stdout.String(), "\n"))
 }

--- a/cli/azd/cmd/testdata/TestFigSpec.ts
+++ b/cli/azd/cmd/testdata/TestFigSpec.ts
@@ -3546,3 +3546,4 @@ const completionSpec: Fig.Spec = {
 };
 
 export default completionSpec;
+

--- a/cli/azd/internal/figspec/figspec_coverage_test.go
+++ b/cli/azd/internal/figspec/figspec_coverage_test.go
@@ -893,6 +893,7 @@ func TestToTypeScript(t *testing.T) {
 	require.Contains(t, ts, "'init'")
 	require.Contains(t, ts, "'--template'")
 	require.Contains(t, ts, "'--debug'")
+	require.True(t, strings.HasSuffix(ts, "\n"))
 }
 
 func TestToTypeScript_Empty(t *testing.T) {
@@ -903,6 +904,7 @@ func TestToTypeScript_Empty(t *testing.T) {
 	ts, err := spec.ToTypeScript()
 	require.NoError(t, err)
 	require.Contains(t, ts, "name: 'test'")
+	require.True(t, strings.HasSuffix(ts, "\n"))
 }
 
 // ============================================================================

--- a/cli/azd/internal/figspec/typescript_renderer.go
+++ b/cli/azd/internal/figspec/typescript_renderer.go
@@ -22,7 +22,8 @@ const completionSpec: Fig.Spec = {
 {{.Options}}	],
 };
 
-export default completionSpec;`
+export default completionSpec;
+`
 
 	// TypeScript field names used in rendering
 	fieldName        = "name"

--- a/cli/azd/internal/repository/app_init_test.go
+++ b/cli/azd/internal/repository/app_init_test.go
@@ -4,16 +4,12 @@
 package repository
 
 import (
-	"context"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/appdetect"
-	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/stretchr/testify/require"
 )
@@ -271,17 +267,7 @@ func TestInitializer_prjConfigFromDetect(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			i := &Initializer{
-				console: input.NewConsole(
-					false,
-					false,
-					input.Writers{Output: os.Stdout},
-					input.ConsoleHandles{
-						Stderr: os.Stderr,
-						Stdin:  strings.NewReader(strings.Join(tt.interactions, "\n") + "\n"),
-						Stdout: os.Stdout,
-					},
-					nil,
-					nil),
+				console: newCapturedTestConsole(t, tt.interactions),
 			}
 
 			dir := t.TempDir()
@@ -309,13 +295,9 @@ func TestInitializer_prjConfigFromDetect(t *testing.T) {
 			}
 
 			spec, err := i.prjConfigFromDetect(
-				context.Background(),
+				t.Context(),
 				dir,
 				tt.detect)
-
-			// Print extra newline to avoid mangling `go test -v` final test result output while waiting for final stdin,
-			// which may result in incorrect `gotestsum` reporting
-			fmt.Println()
 
 			require.NoError(t, err)
 			require.Equal(t, tt.want, spec)

--- a/cli/azd/internal/repository/detect_confirm_test.go
+++ b/cli/azd/internal/repository/detect_confirm_test.go
@@ -4,15 +4,12 @@
 package repository
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/internal/appdetect"
-	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/stretchr/testify/require"
 )
 
@@ -210,25 +207,11 @@ func Test_detectConfirm_confirm(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &detectConfirm{
-				console: input.NewConsole(
-					false,
-					false,
-					input.Writers{Output: os.Stdout},
-					input.ConsoleHandles{
-						Stderr: os.Stderr,
-						Stdin:  strings.NewReader(strings.Join(tt.interactions, "\n") + "\n"),
-						Stdout: os.Stdout,
-					},
-					nil,
-					nil),
+				console: newCapturedTestConsole(t, tt.interactions),
 			}
 			d.Init(tt.detection, dir)
 
-			err = d.Confirm(context.Background())
-
-			// Print extra newline to avoid mangling `go test -v` final test result output while waiting for final stdin,
-			// which may result in incorrect `gotestsum` reporting
-			fmt.Println()
+			err = d.Confirm(t.Context())
 
 			require.NoError(t, err)
 			require.Equal(t, tt.want, d.Services)

--- a/cli/azd/internal/repository/infra_confirm_test.go
+++ b/cli/azd/internal/repository/infra_confirm_test.go
@@ -4,15 +4,10 @@
 package repository
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/internal/appdetect"
 	"github.com/azure/azure-dev/cli/azd/internal/scaffold"
-	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/stretchr/testify/require"
 )
 
@@ -217,24 +212,10 @@ func TestInitializer_infraSpecFromDetect(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			i := &Initializer{
-				console: input.NewConsole(
-					false,
-					false,
-					input.Writers{Output: os.Stdout},
-					input.ConsoleHandles{
-						Stderr: os.Stderr,
-						Stdin:  strings.NewReader(strings.Join(tt.interactions, "\n") + "\n"),
-						Stdout: os.Stdout,
-					},
-					nil,
-					nil),
+				console: newCapturedTestConsole(t, tt.interactions),
 			}
 
-			spec, err := i.infraSpecFromDetect(context.Background(), tt.detect)
-
-			// Print extra newline to avoid mangling `go test -v` final test result output while waiting for final stdin,
-			// which may result in incorrect `gotestsum` reporting
-			fmt.Println()
+			spec, err := i.infraSpecFromDetect(t.Context(), tt.detect)
 
 			require.NoError(t, err)
 			require.Equal(t, tt.want, spec)

--- a/cli/azd/internal/repository/test_console_test.go
+++ b/cli/azd/internal/repository/test_console_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package repository
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+)
+
+func newCapturedTestConsole(t *testing.T, interactions []string) input.Console {
+	t.Helper()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+
+		if stdout.Len() > 0 {
+			t.Logf("console stdout:\n%s", stdout.String())
+		}
+		if stderr.Len() > 0 {
+			t.Logf("console stderr:\n%s", stderr.String())
+		}
+	})
+
+	return input.NewConsole(
+		false,
+		false,
+		input.Writers{Output: &stdout},
+		input.ConsoleHandles{
+			Stderr: &stderr,
+			Stdin:  strings.NewReader(strings.Join(interactions, "\n") + "\n"),
+			Stdout: &stdout,
+		},
+		nil,
+		nil,
+	)
+}


### PR DESCRIPTION
## Summary
- ensure `azd completion fig` always writes a trailing newline so gotestsum/JUnit does not misparse passing test output as `(unknown)` failures
- capture interactive console output in `internal/repository` tests and only emit it when a test fails
- keep prompt/debug output available for failures without polluting parallel test output

## Problem
CI has been surfacing bogus Unknown failures even when the underlying test passed, for example:

```text
=== FAIL: internal/repository TestInitializer_PromptIfNonEmpty (unknown)
```

The failures were caused by test output interleaving with `go test -json`/gotestsum markers.

## Testing
- `go test ./... -short`

Fixes #7731