### PR TITLE
update readme to use brew --cask install

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ powershell -ex AllSigned -c "Invoke-RestMethod 'https://aka.ms/install-azd.ps1' 
 ### macOS
 
 ```bash
-brew install azure/azd/azd
+brew install --cask azure/azd/azd
 ```
 
 > **Note:** If upgrading from a non-Homebrew installation, remove the existing `azd` binary first.

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -297,7 +297,7 @@ func platformUpgradeText() string {
 	} else if runtime.GOOS == "darwin" {
 		switch installedBy {
 		case installer.InstallTypeBrew:
-			return "run:\nbrew uninstall --cask azure/azd/azd && brew install --cask azure/azd/azd"
+			return "run:\nbrew uninstall azure/azd/azd && brew install azure/azd/azd"
 		case installer.InstallTypeSh:
 			//nolint:lll
 			return "run:\ncurl -fsSL https://aka.ms/install-azd.sh | bash\n\nIf the install script was run with custom parameters, ensure that the same parameters are used for the upgrade. For advanced install instructions, see: https://aka.ms/azd/upgrade/mac"

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -297,7 +297,7 @@ func platformUpgradeText() string {
 	} else if runtime.GOOS == "darwin" {
 		switch installedBy {
 		case installer.InstallTypeBrew:
-			return "run:\nbrew uninstall azd && brew install --cask azure/azd/azd"
+			return "run:\nbrew uninstall --cask azure/azd/azd && brew install --cask azure/azd/azd"
 		case installer.InstallTypeSh:
 			//nolint:lll
 			return "run:\ncurl -fsSL https://aka.ms/install-azd.sh | bash\n\nIf the install script was run with custom parameters, ensure that the same parameters are used for the upgrade. For advanced install instructions, see: https://aka.ms/azd/upgrade/mac"

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -297,7 +297,7 @@ func platformUpgradeText() string {
 	} else if runtime.GOOS == "darwin" {
 		switch installedBy {
 		case installer.InstallTypeBrew:
-			return "run:\nbrew uninstall azd && brew install azure/azd/azd"
+			return "run:\nbrew uninstall azd && brew install --cask azure/azd/azd"
 		case installer.InstallTypeSh:
 			//nolint:lll
 			return "run:\ncurl -fsSL https://aka.ms/install-azd.sh | bash\n\nIf the install script was run with custom parameters, ensure that the same parameters are used for the upgrade. For advanced install instructions, see: https://aka.ms/azd/upgrade/mac"

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -297,7 +297,7 @@ func platformUpgradeText() string {
 	} else if runtime.GOOS == "darwin" {
 		switch installedBy {
 		case installer.InstallTypeBrew:
-			return "run:\nbrew uninstall azure/azd/azd && brew install azure/azd/azd"
+			return "run:\nbrew uninstall azd && brew install azure/azd/azd"
 		case installer.InstallTypeSh:
 			//nolint:lll
 			return "run:\ncurl -fsSL https://aka.ms/install-azd.sh | bash\n\nIf the install script was run with custom parameters, ensure that the same parameters are used for the upgrade. For advanced install instructions, see: https://aka.ms/azd/upgrade/mac"

--- a/cli/installer/README.md
+++ b/cli/installer/README.md
@@ -35,7 +35,7 @@ See [MSI configuration](#msi-configuration) for advanced install scenarios.
 #### Homebrew (recommended)
 
 ```bash
-brew install azure/azd/azd
+brew install --cask azure/azd/azd
 ```
 
 If using `brew` to upgrade `azd` from a version not installed using `brew`, remove the existing version of `azd` using the uninstall script (if installed to the default location) or by deleting the `azd` binary manually.


### PR DESCRIPTION
While implementing azd update feature, @danieljurek and I were discussing about using brew cask for azd instead of formula. Update readme and installation commend to use cask. 