### PR TITLE
fix: replace spaces with underscores in service name env var keys

### DIFF
--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -247,7 +247,7 @@ func (e *Environment) SetLocation(location string) {
 }
 
 // Key returns the environment key name for the given name.
-// The name is uppercased, and whitespace (including tabs and Unicode spaces)
+// The name is converted to uppercase, and whitespace (including tabs and Unicode spaces)
 // and hyphens are replaced with underscores. Other characters (e.g., dots,
 // slashes) are passed through unchanged.
 func Key(name string) string {

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -246,8 +246,13 @@ func (e *Environment) SetLocation(location string) {
 }
 
 // Key returns the environment key name for the given name.
+// Spaces and hyphens are replaced with underscores to produce valid
+// environment variable names (e.g., "api and frontend" → "API_AND_FRONTEND").
 func Key(name string) string {
-	return strings.ReplaceAll(strings.ToUpper(name), "-", "_")
+	upper := strings.ToUpper(name)
+	upper = strings.ReplaceAll(upper, " ", "_")
+	upper = strings.ReplaceAll(upper, "-", "_")
+	return upper
 }
 
 // GetServiceProperty is shorthand for Getenv(SERVICE_$SERVICE_NAME_$PROPERTY_NAME)

--- a/cli/azd/pkg/environment/environment.go
+++ b/cli/azd/pkg/environment/environment.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"maps"
 
@@ -246,11 +247,17 @@ func (e *Environment) SetLocation(location string) {
 }
 
 // Key returns the environment key name for the given name.
-// Spaces and hyphens are replaced with underscores to produce valid
-// environment variable names (e.g., "api and frontend" → "API_AND_FRONTEND").
+// The name is uppercased, and whitespace (including tabs and Unicode spaces)
+// and hyphens are replaced with underscores. Other characters (e.g., dots,
+// slashes) are passed through unchanged.
 func Key(name string) string {
 	upper := strings.ToUpper(name)
-	upper = strings.ReplaceAll(upper, " ", "_")
+	upper = strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return '_'
+		}
+		return r
+	}, upper)
 	upper = strings.ReplaceAll(upper, "-", "_")
 	return upper
 }

--- a/cli/azd/pkg/environment/environment_test.go
+++ b/cli/azd/pkg/environment/environment_test.go
@@ -273,3 +273,42 @@ func createEnvManager(mockContext *mocks.MockContext, root string) (Manager, *az
 
 	return newManagerForTest(azdCtx, mockContext.Console, localDataStore, nil), azdCtx
 }
+
+func TestKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"simple", "web", "WEB"},
+		{"withHyphens", "my-web-app", "MY_WEB_APP"},
+		{"withSpaces", "api and frontend", "API_AND_FRONTEND"},
+		{"spacesAndHyphens", "my api-service", "MY_API_SERVICE"},
+		{"uppercase", "MyApp", "MYAPP"},
+		{"multipleSpaces", "my  app", "MY__APP"},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Key(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestServicePropertyRoundTripWithSpaces(t *testing.T) {
+	env := NewWithValues("test-env", nil)
+
+	env.SetServiceProperty("api and frontend", "IMAGE_NAME", "myimage:latest")
+	val := env.GetServiceProperty("api and frontend", "IMAGE_NAME")
+	require.Equal(t, "myimage:latest", val)
+
+	// Verify the env var key uses underscores, not spaces
+	rawVal := env.Getenv("SERVICE_API_AND_FRONTEND_IMAGE_NAME")
+	require.Equal(t, "myimage:latest", rawVal)
+
+	// Verify no space-containing key exists
+	rawBadVal := env.Getenv("SERVICE_API AND FRONTEND_IMAGE_NAME")
+	require.Empty(t, rawBadVal)
+}

--- a/cli/azd/pkg/environment/environment_test.go
+++ b/cli/azd/pkg/environment/environment_test.go
@@ -286,6 +286,8 @@ func TestKey(t *testing.T) {
 		{"spacesAndHyphens", "my api-service", "MY_API_SERVICE"},
 		{"uppercase", "MyApp", "MYAPP"},
 		{"multipleSpaces", "my  app", "MY__APP"},
+		{"withTab", "api\tfrontend", "API_FRONTEND"},
+		{"withNewline", "api\nfrontend", "API_FRONTEND"},
 		{"empty", "", ""},
 	}
 

--- a/cli/azd/pkg/project/service_target_appservice.go
+++ b/cli/azd/pkg/project/service_target_appservice.go
@@ -339,10 +339,9 @@ func (st *appServiceTarget) determineDeploymentTargets(
 
 // slotEnvVarNameForService returns the environment variable name for setting the deployment slot
 // for a given service. The format is AZD_DEPLOY_{SERVICE_NAME}_SLOT_NAME where the service name
-// is uppercase and any hyphens are replaced with underscores.
+// is normalized via environment.Key (uppercase, spaces/hyphens → underscores).
 func slotEnvVarNameForService(serviceName string) string {
-	normalizedName := strings.ToUpper(strings.ReplaceAll(serviceName, "-", "_"))
-	return fmt.Sprintf("AZD_DEPLOY_%s_SLOT_NAME", normalizedName)
+	return fmt.Sprintf("AZD_DEPLOY_%s_SLOT_NAME", environment.Key(serviceName))
 }
 
 // Gets the exposed endpoints for the App Service, including any deployment slots

--- a/cli/azd/pkg/project/service_targets_coverage3_test.go
+++ b/cli/azd/pkg/project/service_targets_coverage3_test.go
@@ -41,6 +41,8 @@ func Test_slotEnvVarNameForService_Coverage3(t *testing.T) {
 		{"withHyphens", "my-web-app", "AZD_DEPLOY_MY_WEB_APP_SLOT_NAME"},
 		{"uppercase", "MyApp", "AZD_DEPLOY_MYAPP_SLOT_NAME"},
 		{"mixed", "my-App-2", "AZD_DEPLOY_MY_APP_2_SLOT_NAME"},
+		{"withSpaces", "api and frontend", "AZD_DEPLOY_API_AND_FRONTEND_SLOT_NAME"},
+		{"spacesAndHyphens", "my api-service", "AZD_DEPLOY_MY_API_SERVICE_SLOT_NAME"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fixes #4996 — Service names with spaces in `azure.yaml` (e.g., `"api and frontend"`) produced invalid environment variable names like `SERVICE_API AND FRONTEND_IMAGE_NAME`.

## Root Cause

`environment.Key()` only replaced hyphens (`-`) with underscores but did not handle spaces. The `slotEnvVarNameForService()` function in appservice.go duplicated this same logic with the same gap.

## Changes

| File | Change |
|------|--------|
| `pkg/environment/environment.go` | `Key()` now replaces both spaces and hyphens with underscores |
| `pkg/project/service_target_appservice.go` | `slotEnvVarNameForService()` centralized to use `environment.Key()` |
| `pkg/environment/environment_test.go` | 9 new tests: `TestKey` (7 cases) + `TestServicePropertyRoundTripWithSpaces` |
| `pkg/project/service_targets_coverage3_test.go` | 2 new test cases for spaces in slot env var names |

## Telemetry

Queried Kusto (`ddazureclients/DevCLI`) — found 2 `"Resource has invalid name"` errors in the last 180 days related to this pattern. Low frequency since most templates avoid spaces, but when it hits the error is confusing.

## Before/After

```
# Before
SERVICE_API AND FRONTEND_IMAGE_NAME    ❌ invalid env var
AZD_DEPLOY_API AND FRONTEND_SLOT_NAME  ❌ invalid env var

# After
SERVICE_API_AND_FRONTEND_IMAGE_NAME    ✅
AZD_DEPLOY_API_AND_FRONTEND_SLOT_NAME  ✅
```