### PR TITLE
fix: remove -e shorthand from AI extensions to resolve reserved flag collision

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- Removed `-e` shorthand for `--environment`; use `--environment` instead. This resolves a collision with azd's global `-e/--environment` flag.
+- Removed `-e` shorthand for `--environment`; use `--environment` instead. This resolves a collision with the azd global `-e/--environment` flag.
 
 ## 0.1.23-preview (2026-04-16)
 

--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.1.24-preview (Unreleased)
+
+### Breaking Changes
+
+- Removed `-e` shorthand for `--environment`; use `--environment` instead. This resolves a collision with azd's global `-e/--environment` flag.
+
 ## 0.1.23-preview (2026-04-16)
 
 - [[#7753]](https://github.com/Azure/azure-dev/pull/7753) Fix `azd ai agent init` to pass the current directory as a positional argument to `azd init`, resolving failures caused by a missing `cwd` assumption in the underlying azd call.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -515,7 +515,7 @@ func newInitCommand(rootFlags *rootFlagsDefinition) *cobra.Command {
 	cmd.Flags().StringVarP(&flags.src, "src", "s", "",
 		"Directory to download the agent definition to (defaults to 'src/<agent-id>')")
 
-	cmd.Flags().StringVarP(&flags.env, "environment", "e", "", "The name of the azd environment to use.")
+	cmd.Flags().StringVar(&flags.env, "environment", "", "The name of the azd environment to use.")
 
 	cmd.Flags().StringSliceVar(&flags.protocols, "protocol", nil,
 		"Protocols supported by the agent (e.g., 'responses', 'invocations'). Can be specified multiple times.")

--- a/cli/azd/extensions/azure.ai.finetune/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.finetune/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release History
 
 
+## 0.0.18-preview (Unreleased)
+
+### Breaking Changes
+
+- Removed `-e` shorthand for `--project-endpoint`; use `--project-endpoint` instead. This resolves a collision with azd's global `-e/--environment` flag.
+
 ## 0.0.17-preview (2026-02-20)
 
 - Add multi-grader support for reinforcement fine-tuning

--- a/cli/azd/extensions/azure.ai.finetune/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.finetune/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Breaking Changes
 
-- Removed `-e` shorthand for `--project-endpoint`; use `--project-endpoint` instead. This resolves a collision with azd's global `-e/--environment` flag.
+- Removed `-e` shorthand for `--project-endpoint`; use `--project-endpoint` instead. This resolves a collision with the azd global `-e/--environment` flag.
 
 ## 0.0.17-preview (2026-02-20)
 

--- a/cli/azd/extensions/azure.ai.finetune/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.finetune/internal/cmd/init.go
@@ -146,10 +146,8 @@ func newInitCommand(rootFlags rootFlagsDefinition) *cobra.Command {
 	cmd.Flags().StringVarP(&flags.subscriptionId, "subscription", "s", "",
 		"Azure subscription ID")
 
-	cmd.Flags().StringVarP(&flags.projectEndpoint, "project-endpoint", "e", "",
+	cmd.Flags().StringVar(&flags.projectEndpoint, "project-endpoint", "",
 		"Azure AI Foundry project endpoint URL (e.g., https://account.services.ai.azure.com/api/projects/project-name)")
-	cmd.Flags().Lookup("project-endpoint").ShorthandDeprecated =
-		"use --project-endpoint instead; -e will be removed in a future release"
 
 	cmd.Flags().StringVarP(&flags.src, "working-directory", "w", "",
 		"Local path for project output")

--- a/cli/azd/extensions/azure.ai.finetune/internal/cmd/operations.go
+++ b/cli/azd/extensions/azure.ai.finetune/internal/cmd/operations.go
@@ -41,10 +41,8 @@ func newOperationCommand() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(&flags.subscriptionId, "subscription", "s", "",
 		"Azure subscription ID (enables implicit init if environment not configured)")
-	cmd.PersistentFlags().StringVarP(&flags.projectEndpoint, "project-endpoint", "e", "",
+	cmd.PersistentFlags().StringVar(&flags.projectEndpoint, "project-endpoint", "",
 		"Azure AI Foundry project endpoint URL (e.g., https://account.services.ai.azure.com/api/projects/project-name)")
-	cmd.PersistentFlags().Lookup("project-endpoint").ShorthandDeprecated =
-		"use --project-endpoint instead; -e will be removed in a future release"
 
 	cmd.AddCommand(newOperationSubmitCommand())
 	cmd.AddCommand(newOperationShowCommand())

--- a/cli/azd/extensions/azure.ai.models/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.models/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Release History
 
 
+## 0.0.6-preview (Unreleased)
+
+### Breaking Changes
+
+- Removed `-e` shorthand for `--project-endpoint`; use `--project-endpoint` instead. This resolves a collision with azd's global `-e/--environment` flag.
+
 ## 0.0.5-preview (2026-03-24)
 
-- **Breaking:** Removed `-e` shorthand for `--project-endpoint`; use `--project-endpoint` instead. This resolves a collision with azd's global `-e/--environment` flag.
+- Deprecated `-e` shorthand for `--project-endpoint`; use the full flag name instead
 - Improved error handling for 403 (Forbidden) during `custom create` upload, with guidance on required roles and links to prerequisites and RBAC documentation (#7278)
 
 ## 0.0.4-preview (2026-03-17)

--- a/cli/azd/extensions/azure.ai.models/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.models/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 0.0.5-preview (2026-03-24)
 
-- Deprecated `-e` shorthand for `--project-endpoint`; use the full flag name instead
+- **Breaking:** Removed `-e` shorthand for `--project-endpoint`; use `--project-endpoint` instead. This resolves a collision with azd's global `-e/--environment` flag.
 - Improved error handling for 403 (Forbidden) during `custom create` upload, with guidance on required roles and links to prerequisites and RBAC documentation (#7278)
 
 ## 0.0.4-preview (2026-03-17)

--- a/cli/azd/extensions/azure.ai.models/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.models/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Breaking Changes
 
-- Removed `-e` shorthand for `--project-endpoint`; use `--project-endpoint` instead. This resolves a collision with azd's global `-e/--environment` flag.
+- Removed `-e` shorthand for `--project-endpoint`; use `--project-endpoint` instead. This resolves a collision with the azd global `-e/--environment` flag.
 
 ## 0.0.5-preview (2026-03-24)
 

--- a/cli/azd/extensions/azure.ai.models/internal/cmd/custom.go
+++ b/cli/azd/extensions/azure.ai.models/internal/cmd/custom.go
@@ -36,10 +36,8 @@ func newCustomCommand() *cobra.Command {
 
 	customCmd.PersistentFlags().StringVarP(&flags.subscriptionId, "subscription", "s", "",
 		"Azure subscription ID")
-	customCmd.PersistentFlags().StringVarP(&flags.projectEndpoint, "project-endpoint", "e", "",
+	customCmd.PersistentFlags().StringVar(&flags.projectEndpoint, "project-endpoint", "",
 		"Azure AI Foundry project endpoint URL (e.g., https://account.services.ai.azure.com/api/projects/project-name)")
-	customCmd.PersistentFlags().Lookup("project-endpoint").ShorthandDeprecated =
-		"use --project-endpoint instead; -e will be removed in a future release"
 
 	customCmd.AddCommand(newCustomCreateCommand(flags))
 	customCmd.AddCommand(newCustomListCommand(flags))

--- a/cli/azd/extensions/azure.ai.models/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.models/internal/cmd/init.go
@@ -92,10 +92,8 @@ The init command will:
 	cmd.Flags().StringVarP(&flags.subscriptionId, "subscription", "s", "",
 		"Azure subscription ID")
 
-	cmd.Flags().StringVarP(&flags.projectEndpoint, "project-endpoint", "e", "",
+	cmd.Flags().StringVar(&flags.projectEndpoint, "project-endpoint", "",
 		"Azure AI Foundry project endpoint URL (e.g., https://account.services.ai.azure.com/api/projects/project-name)")
-	cmd.Flags().Lookup("project-endpoint").ShorthandDeprecated =
-		"use --project-endpoint instead; -e will be removed in a future release"
 
 	cmd.Flags().StringVarP(&flags.projectResourceId, "project-resource-id", "p", "",
 		"ARM resource ID of the Foundry project")


### PR DESCRIPTION
## Summary

Completes the migration started in PR #7313 (which deprecated `-e`). Now fully removes the `-e` shorthand for `--project-endpoint` in **azure.ai.models** and **azure.ai.finetune**, and the `-e` shorthand for `--environment` in **azure.ai.agents**, eliminating the collision with azd's reserved global `-e/--environment` flag.

Users must use `--project-endpoint` (or `--environment`) instead.

## Related

- Closes #7271 (`-e` collision bug)
- Companion to #7312 (reserved flags registry)
- Follow-up to #7313 (deprecated `-e`, merged)

## Changes

| File | Change |
|------|--------|
| `extensions/azure.ai.models/internal/cmd/init.go` | `StringVarP` → `StringVar`, removed `ShorthandDeprecated` |
| `extensions/azure.ai.models/internal/cmd/custom.go` | `StringVarP` → `StringVar`, removed `ShorthandDeprecated` |
| `extensions/azure.ai.finetune/internal/cmd/init.go` | `StringVarP` → `StringVar`, removed `ShorthandDeprecated` |
| `extensions/azure.ai.finetune/internal/cmd/operations.go` | `StringVarP` → `StringVar`, removed `ShorthandDeprecated` |
| `extensions/azure.ai.agents/internal/cmd/init.go` | Removed `-e` shorthand from `--environment` flag |
| `extensions/azure.ai.models/CHANGELOG.md` | Updated deprecation entry → removal entry |

## Testing

- All three extensions build clean
- No behavioral change for users already using `--project-endpoint` / `--environment` long form