### PR TITLE
Simplify "update available" banner and include link to release notes

### DIFF
--- a/cli/azd/cmd/update.go
+++ b/cli/azd/cmd/update.go
@@ -201,8 +201,8 @@ func (a *updateAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 				Err: fmt.Errorf("daily builds aren't available via %s", installedBy),
 				Suggestion: fmt.Sprintf(
 					"Uninstall first with: %s\nThen install daily with: "+
-						"powershell -ex AllSigned -c \"Invoke-RestMethod 'https://aka.ms/install-azd.ps1'"+
-						" -OutFile 'install-azd.ps1'; ./install-azd.ps1 -Version 'daily'\"",
+						"powershell -ex AllSigned -c \"& ([scriptblock]::Create("+
+						"(Invoke-RestMethod 'https://aka.ms/install-azd.ps1'))) -Version 'daily'\"",
 					uninstallCmd),
 			},
 		}

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -262,29 +262,24 @@ func createDailyLogFile() (*os.File, error) {
 }
 
 // platformUpgradeHint returns the platform-specific update action for azd,
-// tailored to the given release channel. Only the script-based installers
-// (install-azd.sh / install-azd.ps1) distribute daily builds, so channel only
-// affects those paths. Package managers (winget/choco/brew) don't publish
-// daily builds — users on those paths are assumed to be on the stable channel.
+// tailored to the current OS, installer, and release channel.
 func platformUpgradeHint(channel update.Channel) update.UpdateHint {
-	installedBy := installer.InstalledBy()
+	return platformUpgradeHintFor(runtime.GOOS, installer.InstalledBy(), channel)
+}
+
+// platformUpgradeHintFor is the testable core of platformUpgradeHint. Only the
+// script-based installers (install-azd.sh / install-azd.ps1) distribute daily
+// builds, so channel only affects those paths. Package managers
+// (winget/choco/brew) don't publish daily builds — users on those paths are
+// assumed to be on the stable channel.
+func platformUpgradeHintFor(goos string, installedBy installer.InstallType, channel update.Channel) update.UpdateHint {
 	isDaily := channel == update.ChannelDaily
 
-	if runtime.GOOS == "windows" {
+	switch goos {
+	case "windows":
 		switch installedBy {
 		case installer.InstallTypePs:
-			var cmd string
-			if isDaily {
-				//nolint:lll
-				cmd = "powershell -ex AllSigned -c \"& ([scriptblock]::Create((Invoke-RestMethod 'https://aka.ms/install-azd.ps1'))) -Version 'daily'\""
-			} else {
-				//nolint:lll
-				cmd = "powershell -ex AllSigned -c \"Invoke-RestMethod 'https://aka.ms/install-azd.ps1' | Invoke-Expression\""
-			}
-			return update.RunUpdateHint(
-				cmd,
-				update.WithDetails(scriptInstallerDetails("https://aka.ms/azd/upgrade/windows")),
-			)
+			return psInstallerHint(isDaily, "https://aka.ms/azd/upgrade/windows")
 		case installer.InstallTypeWinget:
 			return update.RunUpdateHint("winget upgrade Microsoft.Azd")
 		case installer.InstallTypeChoco:
@@ -292,39 +287,48 @@ func platformUpgradeHint(channel update.Channel) update.UpdateHint {
 		default:
 			return update.VisitUpdateHint("https://aka.ms/azd/upgrade/windows")
 		}
-	} else if runtime.GOOS == "linux" {
+	case "linux":
 		switch installedBy {
 		case installer.InstallTypeSh:
-			cmd := "curl -fsSL https://aka.ms/install-azd.sh | bash"
-			if isDaily {
-				cmd = "curl -fsSL https://aka.ms/install-azd.sh | bash -s -- --version daily"
-			}
-			return update.RunUpdateHint(
-				cmd,
-				update.WithDetails(scriptInstallerDetails("https://aka.ms/azd/upgrade/linux")),
-			)
+			return shInstallerHint(isDaily, "https://aka.ms/azd/upgrade/linux")
 		default:
 			return update.VisitUpdateHint("https://aka.ms/azd/upgrade/linux")
 		}
-	} else if runtime.GOOS == "darwin" {
+	case "darwin":
 		switch installedBy {
 		case installer.InstallTypeBrew:
 			return update.RunUpdateHint("brew uninstall azd && brew install --cask azure/azd/azd")
 		case installer.InstallTypeSh:
-			cmd := "curl -fsSL https://aka.ms/install-azd.sh | bash"
-			if isDaily {
-				cmd = "curl -fsSL https://aka.ms/install-azd.sh | bash -s -- --version daily"
-			}
-			return update.RunUpdateHint(
-				cmd,
-				update.WithDetails(scriptInstallerDetails("https://aka.ms/azd/upgrade/mac")),
-			)
+			return shInstallerHint(isDaily, "https://aka.ms/azd/upgrade/mac")
 		default:
 			return update.VisitUpdateHint("https://aka.ms/azd/upgrade/mac")
 		}
 	}
 
 	return update.VisitUpdateHint("https://aka.ms/azd/upgrade")
+}
+
+// shInstallerHint builds the curl-based upgrade command shared by Linux and
+// macOS install-azd.sh installs.
+func shInstallerHint(isDaily bool, docsURL string) update.UpdateHint {
+	cmd := "curl -fsSL https://aka.ms/install-azd.sh | bash"
+	if isDaily {
+		cmd = "curl -fsSL https://aka.ms/install-azd.sh | bash -s -- --version daily"
+	}
+	return update.RunUpdateHint(cmd, update.WithDetails(scriptInstallerDetails(docsURL)))
+}
+
+// psInstallerHint builds the PowerShell-based upgrade command for Windows
+// install-azd.ps1 installs. The daily form uses an in-memory scriptblock to
+// avoid leaving a stray install-azd.ps1 in the user's cwd.
+func psInstallerHint(isDaily bool, docsURL string) update.UpdateHint {
+	//nolint:lll
+	cmd := "powershell -ex AllSigned -c \"Invoke-RestMethod 'https://aka.ms/install-azd.ps1' | Invoke-Expression\""
+	if isDaily {
+		//nolint:lll
+		cmd = "powershell -ex AllSigned -c \"& ([scriptblock]::Create((Invoke-RestMethod 'https://aka.ms/install-azd.ps1'))) -Version 'daily'\""
+	}
+	return update.RunUpdateHint(cmd, update.WithDetails(scriptInstallerDetails(docsURL)))
 }
 
 // scriptInstallerDetails returns the caveat shown alongside script-based

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -276,7 +276,7 @@ func platformUpgradeHint(channel update.Channel) update.UpdateHint {
 			var cmd string
 			if isDaily {
 				//nolint:lll
-				cmd = "powershell -ex AllSigned -c \"Invoke-RestMethod 'https://aka.ms/install-azd.ps1' -OutFile 'install-azd.ps1'; ./install-azd.ps1 -Version 'daily'\""
+				cmd = "powershell -ex AllSigned -c \"& ([scriptblock]::Create((Invoke-RestMethod 'https://aka.ms/install-azd.ps1'))) -Version 'daily'\""
 			} else {
 				//nolint:lll
 				cmd = "powershell -ex AllSigned -c \"Invoke-RestMethod 'https://aka.ms/install-azd.ps1' | Invoke-Expression\""

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -104,34 +104,25 @@ func main() {
 		} else if versionInfo.HasUpdate {
 			currentVersionStr := internal.VersionInfo().Version.String()
 			latestVersionStr := versionInfo.Version
-			if versionInfo.BuildNumber > 0 {
-				latestVersionStr = fmt.Sprintf("%s (build %d)", versionInfo.Version, versionInfo.BuildNumber)
-			}
 
-			fmt.Fprintln(
-				os.Stderr,
-				output.WithWarningFormat(
-					"WARNING: your version of azd is out of date, you have %s and the latest %s version is %s",
-					currentVersionStr, versionInfo.Channel, latestVersionStr))
-			fmt.Fprintln(os.Stderr)
-
-			// Show "azd update" hint if the user has update config set,
-			// otherwise show the original platform-specific upgrade instructions.
+			// Determine the update hint to show.
+			updateHint := update.RunUpdateHint("azd update")
 			configMgr := config.NewUserConfigManager(config.NewFileConfigManager(config.NewManager()))
 			userCfg, cfgErr := configMgr.Load()
 			if cfgErr != nil {
 				userCfg = config.NewEmptyConfig()
 			}
-			if update.HasUpdateConfig(userCfg) {
-				fmt.Fprintln(
-					os.Stderr,
-					output.WithWarningFormat("To update to the latest version, run: azd update"))
-			} else {
-				upgradeText := platformUpgradeText()
-				fmt.Fprintln(
-					os.Stderr,
-					output.WithWarningFormat("To update to the latest version, %s", upgradeText))
+			if !update.HasUpdateConfig(userCfg) {
+				updateHint = platformUpgradeHint()
 			}
+
+			banner := update.RenderUpdateBanner(update.BannerParams{
+				CurrentVersion: currentVersionStr,
+				LatestVersion:  latestVersionStr,
+				Channel:        versionInfo.Channel,
+				UpdateHint:     updateHint,
+			})
+			fmt.Fprintln(os.Stderr, banner)
 		}
 	}
 
@@ -270,43 +261,61 @@ func createDailyLogFile() (*os.File, error) {
 	return logFile, nil
 }
 
-// platformUpgradeText returns the original platform-specific upgrade instructions.
-func platformUpgradeText() string {
+// platformUpgradeHint returns the platform-specific update action for azd.
+func platformUpgradeHint() update.UpdateHint {
 	installedBy := installer.InstalledBy()
 
 	if runtime.GOOS == "windows" {
 		switch installedBy {
 		case installer.InstallTypePs:
 			//nolint:lll
-			return "run:\npowershell -ex AllSigned -c \"Invoke-RestMethod 'https://aka.ms/install-azd.ps1' | Invoke-Expression\"\n\nIf the install script was run with custom parameters, ensure that the same parameters are used for the upgrade. For advanced install instructions, see: https://aka.ms/azd/upgrade/windows"
+			return update.RunUpdateHint(
+				"powershell -ex AllSigned -c \"Invoke-RestMethod 'https://aka.ms/install-azd.ps1' | Invoke-Expression\"",
+				update.WithDetails(scriptInstallerDetails("https://aka.ms/azd/upgrade/windows")),
+			)
 		case installer.InstallTypeWinget:
-			return "run:\nwinget upgrade Microsoft.Azd"
+			return update.RunUpdateHint("winget upgrade Microsoft.Azd")
 		case installer.InstallTypeChoco:
-			return "run:\nchoco upgrade azd"
+			return update.RunUpdateHint("choco upgrade azd")
 		default:
-			return "visit https://aka.ms/azd/upgrade/windows"
+			return update.VisitUpdateHint("https://aka.ms/azd/upgrade/windows")
 		}
 	} else if runtime.GOOS == "linux" {
 		switch installedBy {
 		case installer.InstallTypeSh:
-			//nolint:lll
-			return "run:\ncurl -fsSL https://aka.ms/install-azd.sh | bash\n\nIf the install script was run with custom parameters, ensure that the same parameters are used for the upgrade. For advanced install instructions, see: https://aka.ms/azd/upgrade/linux"
+			return update.RunUpdateHint(
+				"curl -fsSL https://aka.ms/install-azd.sh | bash",
+				update.WithDetails(scriptInstallerDetails("https://aka.ms/azd/upgrade/linux")),
+			)
 		default:
-			return "visit https://aka.ms/azd/upgrade/linux"
+			return update.VisitUpdateHint("https://aka.ms/azd/upgrade/linux")
 		}
 	} else if runtime.GOOS == "darwin" {
 		switch installedBy {
 		case installer.InstallTypeBrew:
-			return "run:\nbrew uninstall azd && brew install --cask azure/azd/azd"
+			return update.RunUpdateHint("brew uninstall azd && brew install --cask azure/azd/azd")
 		case installer.InstallTypeSh:
-			//nolint:lll
-			return "run:\ncurl -fsSL https://aka.ms/install-azd.sh | bash\n\nIf the install script was run with custom parameters, ensure that the same parameters are used for the upgrade. For advanced install instructions, see: https://aka.ms/azd/upgrade/mac"
+			return update.RunUpdateHint(
+				"curl -fsSL https://aka.ms/install-azd.sh | bash",
+				update.WithDetails(scriptInstallerDetails("https://aka.ms/azd/upgrade/mac")),
+			)
 		default:
-			return "visit https://aka.ms/azd/upgrade/mac"
+			return update.VisitUpdateHint("https://aka.ms/azd/upgrade/mac")
 		}
 	}
 
-	return "visit https://aka.ms/azd/upgrade"
+	return update.VisitUpdateHint("https://aka.ms/azd/upgrade")
+}
+
+// scriptInstallerDetails returns the caveat shown alongside script-based
+// install commands, noting that custom install parameters are not preserved
+// by the default one-liner and pointing at platform-specific advanced docs.
+func scriptInstallerDetails(docsURL string) string {
+	return fmt.Sprintf(
+		"If the install script was run with custom parameters, ensure that the same parameters "+
+			"are used for the upgrade. For advanced install instructions, see: %s",
+		output.WithHyperlink(docsURL, docsURL),
+	)
 }
 
 func startBackgroundUploadProcess() error {

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -113,7 +113,7 @@ func main() {
 				userCfg = config.NewEmptyConfig()
 			}
 			if !update.HasUpdateConfig(userCfg) {
-				updateHint = platformUpgradeHint()
+				updateHint = platformUpgradeHint(versionInfo.Channel)
 			}
 
 			banner := update.RenderUpdateBanner(update.BannerParams{
@@ -261,16 +261,28 @@ func createDailyLogFile() (*os.File, error) {
 	return logFile, nil
 }
 
-// platformUpgradeHint returns the platform-specific update action for azd.
-func platformUpgradeHint() update.UpdateHint {
+// platformUpgradeHint returns the platform-specific update action for azd,
+// tailored to the given release channel. Only the script-based installers
+// (install-azd.sh / install-azd.ps1) distribute daily builds, so channel only
+// affects those paths. Package managers (winget/choco/brew) don't publish
+// daily builds — users on those paths are assumed to be on the stable channel.
+func platformUpgradeHint(channel update.Channel) update.UpdateHint {
 	installedBy := installer.InstalledBy()
+	isDaily := channel == update.ChannelDaily
 
 	if runtime.GOOS == "windows" {
 		switch installedBy {
 		case installer.InstallTypePs:
-			//nolint:lll
+			var cmd string
+			if isDaily {
+				//nolint:lll
+				cmd = "powershell -ex AllSigned -c \"Invoke-RestMethod 'https://aka.ms/install-azd.ps1' -OutFile 'install-azd.ps1'; ./install-azd.ps1 -Version 'daily'\""
+			} else {
+				//nolint:lll
+				cmd = "powershell -ex AllSigned -c \"Invoke-RestMethod 'https://aka.ms/install-azd.ps1' | Invoke-Expression\""
+			}
 			return update.RunUpdateHint(
-				"powershell -ex AllSigned -c \"Invoke-RestMethod 'https://aka.ms/install-azd.ps1' | Invoke-Expression\"",
+				cmd,
 				update.WithDetails(scriptInstallerDetails("https://aka.ms/azd/upgrade/windows")),
 			)
 		case installer.InstallTypeWinget:
@@ -283,8 +295,12 @@ func platformUpgradeHint() update.UpdateHint {
 	} else if runtime.GOOS == "linux" {
 		switch installedBy {
 		case installer.InstallTypeSh:
+			cmd := "curl -fsSL https://aka.ms/install-azd.sh | bash"
+			if isDaily {
+				cmd = "curl -fsSL https://aka.ms/install-azd.sh | bash -s -- --version daily"
+			}
 			return update.RunUpdateHint(
-				"curl -fsSL https://aka.ms/install-azd.sh | bash",
+				cmd,
 				update.WithDetails(scriptInstallerDetails("https://aka.ms/azd/upgrade/linux")),
 			)
 		default:
@@ -295,8 +311,12 @@ func platformUpgradeHint() update.UpdateHint {
 		case installer.InstallTypeBrew:
 			return update.RunUpdateHint("brew uninstall azd && brew install --cask azure/azd/azd")
 		case installer.InstallTypeSh:
+			cmd := "curl -fsSL https://aka.ms/install-azd.sh | bash"
+			if isDaily {
+				cmd = "curl -fsSL https://aka.ms/install-azd.sh | bash -s -- --version daily"
+			}
 			return update.RunUpdateHint(
-				"curl -fsSL https://aka.ms/install-azd.sh | bash",
+				cmd,
 				update.WithDetails(scriptInstallerDetails("https://aka.ms/azd/upgrade/mac")),
 			)
 		default:
@@ -312,8 +332,7 @@ func platformUpgradeHint() update.UpdateHint {
 // by the default one-liner and pointing at platform-specific advanced docs.
 func scriptInstallerDetails(docsURL string) string {
 	return fmt.Sprintf(
-		"If the install script was run with custom parameters, ensure that the same parameters "+
-			"are used for the upgrade. For advanced install instructions, see: %s",
+		"If you installed azd with custom options, use the same options when updating. See %s for details.",
 		output.WithHyperlink(docsURL, docsURL),
 	)
 }

--- a/cli/azd/main_test.go
+++ b/cli/azd/main_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/installer"
+	"github.com/azure/azure-dev/cli/azd/pkg/update"
+	"github.com/fatih/color"
+	"github.com/stretchr/testify/assert"
+)
+
+// disableTerminalFormatting suppresses ANSI hyperlink and color escape codes
+// so substring assertions on the rendered banner are deterministic regardless
+// of whether `go test` is attached to a TTY. See
+// pkg/update/banner_test.go:disableTerminalFormatting for the rationale on
+// why color.NoColor is set directly instead of via NO_COLOR.
+func disableTerminalFormatting(t *testing.T) {
+	t.Helper()
+	t.Setenv("AZD_FORCE_TTY", "false")
+	prev := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = prev })
+}
+
+func TestPlatformUpgradeHintFor(t *testing.T) {
+	disableTerminalFormatting(t)
+
+	const detailsMarker = "If you installed azd with custom options"
+
+	tests := []struct {
+		name        string
+		goos        string
+		installedBy installer.InstallType
+		channel     update.Channel
+		// wantContains are substrings expected in the rendered banner's
+		// "To update, ..." line and any details paragraph.
+		wantContains []string
+		// wantNotContains guards against accidental inclusion of the
+		// details paragraph for hint types that shouldn't carry one.
+		wantNotContains []string
+	}{
+		// Windows
+		{
+			name:        "windows/ps/stable",
+			goos:        "windows",
+			installedBy: installer.InstallTypePs,
+			channel:     update.ChannelStable,
+			wantContains: []string{
+				"To update, run",
+				"Invoke-RestMethod 'https://aka.ms/install-azd.ps1' | Invoke-Expression",
+				detailsMarker,
+				"https://aka.ms/azd/upgrade/windows",
+			},
+		},
+		{
+			name:        "windows/ps/daily uses scriptblock and -Version daily",
+			goos:        "windows",
+			installedBy: installer.InstallTypePs,
+			channel:     update.ChannelDaily,
+			wantContains: []string{
+				"[scriptblock]::Create((Invoke-RestMethod 'https://aka.ms/install-azd.ps1'))) -Version 'daily'",
+				detailsMarker,
+				"https://aka.ms/azd/upgrade/windows",
+			},
+		},
+		{
+			name:            "windows/winget ignores channel",
+			goos:            "windows",
+			installedBy:     installer.InstallTypeWinget,
+			channel:         update.ChannelDaily,
+			wantContains:    []string{"To update, run", "winget upgrade Microsoft.Azd"},
+			wantNotContains: []string{detailsMarker},
+		},
+		{
+			name:            "windows/choco ignores channel",
+			goos:            "windows",
+			installedBy:     installer.InstallTypeChoco,
+			channel:         update.ChannelDaily,
+			wantContains:    []string{"choco upgrade azd"},
+			wantNotContains: []string{detailsMarker},
+		},
+		{
+			name:         "windows/unknown falls back to docs",
+			goos:         "windows",
+			installedBy:  installer.InstallTypeUnknown,
+			channel:      update.ChannelStable,
+			wantContains: []string{"To update, visit", "https://aka.ms/azd/upgrade/windows"},
+		},
+		// Linux
+		{
+			name:        "linux/sh/stable",
+			goos:        "linux",
+			installedBy: installer.InstallTypeSh,
+			channel:     update.ChannelStable,
+			wantContains: []string{
+				"curl -fsSL https://aka.ms/install-azd.sh | bash",
+				detailsMarker,
+				"https://aka.ms/azd/upgrade/linux",
+			},
+			wantNotContains: []string{"--version daily"},
+		},
+		{
+			name:        "linux/sh/daily appends --version daily",
+			goos:        "linux",
+			installedBy: installer.InstallTypeSh,
+			channel:     update.ChannelDaily,
+			wantContains: []string{
+				"curl -fsSL https://aka.ms/install-azd.sh | bash -s -- --version daily",
+				detailsMarker,
+				"https://aka.ms/azd/upgrade/linux",
+			},
+		},
+		{
+			name:         "linux/unknown falls back to docs",
+			goos:         "linux",
+			installedBy:  installer.InstallTypeUnknown,
+			channel:      update.ChannelStable,
+			wantContains: []string{"To update, visit", "https://aka.ms/azd/upgrade/linux"},
+		},
+		// Darwin
+		{
+			name:            "darwin/brew ignores channel",
+			goos:            "darwin",
+			installedBy:     installer.InstallTypeBrew,
+			channel:         update.ChannelDaily,
+			wantContains:    []string{"brew uninstall azd && brew install --cask azure/azd/azd"},
+			wantNotContains: []string{detailsMarker},
+		},
+		{
+			name:        "darwin/sh/stable",
+			goos:        "darwin",
+			installedBy: installer.InstallTypeSh,
+			channel:     update.ChannelStable,
+			wantContains: []string{
+				"curl -fsSL https://aka.ms/install-azd.sh | bash",
+				detailsMarker,
+				"https://aka.ms/azd/upgrade/mac",
+			},
+			wantNotContains: []string{"--version daily"},
+		},
+		{
+			name:        "darwin/sh/daily appends --version daily",
+			goos:        "darwin",
+			installedBy: installer.InstallTypeSh,
+			channel:     update.ChannelDaily,
+			wantContains: []string{
+				"curl -fsSL https://aka.ms/install-azd.sh | bash -s -- --version daily",
+				detailsMarker,
+				"https://aka.ms/azd/upgrade/mac",
+			},
+		},
+		{
+			name:         "darwin/unknown falls back to docs",
+			goos:         "darwin",
+			installedBy:  installer.InstallTypeUnknown,
+			channel:      update.ChannelStable,
+			wantContains: []string{"To update, visit", "https://aka.ms/azd/upgrade/mac"},
+		},
+		// Unrecognized OS
+		{
+			name:         "unknown OS falls back to generic docs",
+			goos:         "plan9",
+			installedBy:  installer.InstallTypeUnknown,
+			channel:      update.ChannelStable,
+			wantContains: []string{"To update, visit", "https://aka.ms/azd/upgrade"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hint := platformUpgradeHintFor(tt.goos, tt.installedBy, tt.channel)
+			rendered := update.RenderUpdateBanner(update.BannerParams{
+				CurrentVersion: "1.0.0",
+				LatestVersion:  "1.1.0",
+				Channel:        tt.channel,
+				UpdateHint:     hint,
+			})
+			for _, want := range tt.wantContains {
+				assert.Contains(t, rendered, want)
+			}
+			for _, dontWant := range tt.wantNotContains {
+				assert.NotContains(t, rendered, dontWant)
+			}
+		})
+	}
+}

--- a/cli/azd/pkg/update/banner.go
+++ b/cli/azd/pkg/update/banner.go
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package update
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+)
+
+const (
+	// stableReleaseNotesURL is the release notes URL template for stable versions.
+	stableReleaseNotesURL = "https://github.com/Azure/azure-dev/releases/tag/azure-dev-cli_%s"
+	// dailyReleaseNotesURL points to the main branch commits for daily builds.
+	dailyReleaseNotesURL = "https://github.com/Azure/azure-dev/commits/main"
+)
+
+// BannerParams holds the data needed to render an update banner.
+type BannerParams struct {
+	CurrentVersion string
+	LatestVersion  string
+	Channel        Channel
+	UpdateHint     UpdateHint
+}
+
+type updateHintKind int
+
+// Zero-value (hintKindNone) represents an unset hint so the banner renders
+// without any "To update, ..." line.
+const (
+	hintKindNone updateHintKind = iota
+	hintKindRun
+	hintKindVisit
+)
+
+// UpdateHint describes how a user should update azd. Construct one with
+// RunUpdateHint or VisitUpdateHint.
+type UpdateHint struct {
+	kind    updateHintKind
+	value   string
+	details string
+}
+
+// HintOption configures an UpdateHint.
+type HintOption func(*UpdateHint)
+
+// WithDetails attaches supplemental instructions that are rendered on a
+// separate paragraph below the main update line (e.g. a caveat about custom
+// install parameters or a link to advanced install docs).
+func WithDetails(details string) HintOption {
+	return func(h *UpdateHint) { h.details = details }
+}
+
+// RunUpdateHint returns an update hint that renders a shell command.
+func RunUpdateHint(command string, opts ...HintOption) UpdateHint {
+	return newHint(hintKindRun, command, opts)
+}
+
+// VisitUpdateHint returns an update hint that renders a documentation URL.
+func VisitUpdateHint(url string, opts ...HintOption) UpdateHint {
+	return newHint(hintKindVisit, url, opts)
+}
+
+func newHint(kind updateHintKind, value string, opts []HintOption) UpdateHint {
+	h := UpdateHint{kind: kind, value: value}
+	for _, opt := range opts {
+		opt(&h)
+	}
+	return h
+}
+
+// RenderUpdateBanner returns the formatted update notification string, including
+// color/formatting escape codes, ready to be printed to stderr.
+func RenderUpdateBanner(p BannerParams) string {
+	var sb strings.Builder
+	releaseNotes := p.releaseNotesLink()
+	sb.WriteString(output.WithWarningFormat("Update available: " + p.versionDisplay()))
+	fmt.Fprintf(&sb, " (%s)", output.WithHyperlink(releaseNotes.url, releaseNotes.label))
+
+	if hint := formatUpdateHint(p.UpdateHint); hint != "" {
+		sb.WriteString("\n")
+		sb.WriteString(hint)
+	}
+	if p.UpdateHint.details != "" {
+		sb.WriteString("\n\n")
+		sb.WriteString(p.UpdateHint.details)
+	}
+
+	return sb.String()
+}
+
+func (p BannerParams) versionDisplay() string {
+	if p.Channel == ChannelDaily {
+		return p.LatestVersion
+	}
+
+	return fmt.Sprintf("%s -> %s", p.CurrentVersion, p.LatestVersion)
+}
+
+type releaseNotesLink struct {
+	label string
+	url   string
+}
+
+func (p BannerParams) releaseNotesLink() releaseNotesLink {
+	// Daily builds don't have per-build GitHub releases, so link to the main
+	// branch commit history instead. Stable releases have a tag of the form
+	// `azure-dev-cli_<semver>` (e.g. azure-dev-cli_1.13.1).
+	if p.Channel == ChannelDaily {
+		return releaseNotesLink{
+			label: "Recent Changes",
+			url:   dailyReleaseNotesURL,
+		}
+	}
+
+	return releaseNotesLink{
+		label: "Release Notes",
+		url:   fmt.Sprintf(stableReleaseNotesURL, p.LatestVersion),
+	}
+}
+
+// formatUpdateHint renders the primary update instruction line.
+func formatUpdateHint(h UpdateHint) string {
+	switch h.kind {
+	case hintKindRun:
+		return fmt.Sprintf("To update, run `%s`", output.WithHighLightFormat(h.value))
+	case hintKindVisit:
+		return fmt.Sprintf("To update, visit %s", output.WithHyperlink(h.value, h.value))
+	default:
+		return ""
+	}
+}

--- a/cli/azd/pkg/update/banner.go
+++ b/cli/azd/pkg/update/banner.go
@@ -110,13 +110,13 @@ func (p BannerParams) releaseNotesLink() releaseNotesLink {
 	// `azure-dev-cli_<semver>` (e.g. azure-dev-cli_1.13.1).
 	if p.Channel == ChannelDaily {
 		return releaseNotesLink{
-			label: "Recent Changes",
+			label: "Recent changes",
 			url:   dailyReleaseNotesURL,
 		}
 	}
 
 	return releaseNotesLink{
-		label: "Release Notes",
+		label: "Release notes",
 		url:   fmt.Sprintf(stableReleaseNotesURL, p.LatestVersion),
 	}
 }

--- a/cli/azd/pkg/update/banner_test.go
+++ b/cli/azd/pkg/update/banner_test.go
@@ -10,8 +10,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// disableTerminalFormatting disables terminal hyperlink escape sequences
+// (AZD_FORCE_TTY=false) and color codes (NO_COLOR=1) so banner assertions
+// match plain-string substrings regardless of whether `go test` is run in an
+// interactive terminal.
+//
+// t.Setenv is not compatible with t.Parallel(), so tests that call this
+// helper must not be parallelized. Banner tests are sub-millisecond so this
+// is an acceptable trade-off.
+func disableTerminalFormatting(t *testing.T) {
+	t.Helper()
+	t.Setenv("AZD_FORCE_TTY", "false")
+	t.Setenv("NO_COLOR", "1")
+}
+
 func TestRenderUpdateBanner(t *testing.T) {
-	t.Parallel()
+	disableTerminalFormatting(t)
 
 	params := BannerParams{
 		CurrentVersion: "1.11.0",
@@ -27,7 +41,6 @@ func TestRenderUpdateBanner(t *testing.T) {
 		"Update available:",
 		"1.11.0 -> 1.13.1",
 		"To update, run `azd update`",
-		// WithHyperlink falls back to plain URL in non-terminal test environments.
 		"github.com/Azure/azure-dev/releases/tag/azure-dev-cli_1.13.1",
 	} {
 		assert.Contains(t, result, s, "expected banner to contain %q", s)
@@ -39,10 +52,9 @@ func TestRenderUpdateBanner(t *testing.T) {
 }
 
 func TestRenderUpdateBanner_PlatformCommand(t *testing.T) {
-	t.Parallel()
+	disableTerminalFormatting(t)
 
 	t.Run("run_hint_with_details", func(t *testing.T) {
-		t.Parallel()
 		params := BannerParams{
 			CurrentVersion: "1.11.0",
 			LatestVersion:  "1.13.1",
@@ -59,7 +71,6 @@ func TestRenderUpdateBanner_PlatformCommand(t *testing.T) {
 	})
 
 	t.Run("handles_visit_url", func(t *testing.T) {
-		t.Parallel()
 		visitParams := BannerParams{
 			CurrentVersion: "1.11.0",
 			LatestVersion:  "1.13.1",
@@ -72,7 +83,7 @@ func TestRenderUpdateBanner_PlatformCommand(t *testing.T) {
 }
 
 func TestRenderUpdateBanner_DailyChannel(t *testing.T) {
-	t.Parallel()
+	disableTerminalFormatting(t)
 
 	// Daily version strings already embed the build number (e.g.
 	// "1.24.0-daily.6168094"), so no extra formatting is needed.
@@ -92,7 +103,7 @@ func TestRenderUpdateBanner_DailyChannel(t *testing.T) {
 }
 
 func TestFormatUpdateHint(t *testing.T) {
-	t.Parallel()
+	disableTerminalFormatting(t)
 
 	tests := []struct {
 		name     string
@@ -125,8 +136,6 @@ func TestFormatUpdateHint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			got := formatUpdateHint(tt.input)
 			for _, s := range tt.contains {
 				assert.Contains(t, got, s, "expected hint to contain %q", s)
@@ -136,11 +145,13 @@ func TestFormatUpdateHint(t *testing.T) {
 }
 
 func TestFormatUpdateHint_EmptyRendersNothing(t *testing.T) {
-	t.Parallel()
+	disableTerminalFormatting(t)
 	assert.Empty(t, formatUpdateHint(UpdateHint{}))
 }
 
 func TestReleaseNotesLink(t *testing.T) {
+	// Pure string construction — no color/hyperlink output involved, so this
+	// test doesn't need disableTerminalFormatting and can run in parallel.
 	t.Parallel()
 
 	tests := []struct {

--- a/cli/azd/pkg/update/banner_test.go
+++ b/cli/azd/pkg/update/banner_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package update
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderUpdateBanner(t *testing.T) {
+	t.Parallel()
+
+	params := BannerParams{
+		CurrentVersion: "1.11.0",
+		LatestVersion:  "1.13.1",
+		Channel:        ChannelStable,
+		UpdateHint:     RunUpdateHint("azd update"),
+	}
+
+	result := RenderUpdateBanner(params)
+	require.NotEmpty(t, result)
+
+	for _, s := range []string{
+		"Update available:",
+		"1.11.0 -> 1.13.1",
+		"To update, run `azd update`",
+		// WithHyperlink falls back to plain URL in non-terminal test environments.
+		"github.com/Azure/azure-dev/releases/tag/azure-dev-cli_1.13.1",
+	} {
+		assert.Contains(t, result, s, "expected banner to contain %q", s)
+	}
+
+	// The legacy phrasing should not appear after the refactor.
+	assert.NotContains(t, result, "WARNING:")
+	assert.NotContains(t, result, "out of date")
+}
+
+func TestRenderUpdateBanner_PlatformCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("run_hint_with_details", func(t *testing.T) {
+		t.Parallel()
+		params := BannerParams{
+			CurrentVersion: "1.11.0",
+			LatestVersion:  "1.13.1",
+			Channel:        ChannelStable,
+			UpdateHint: RunUpdateHint(
+				"curl -fsSL https://aka.ms/install-azd.sh | bash",
+				WithDetails("If you installed azd with custom options, see https://aka.ms/azd/upgrade/linux for details."),
+			),
+		}
+		result := RenderUpdateBanner(params)
+		assert.Contains(t, result, "To update, run `curl -fsSL https://aka.ms/install-azd.sh | bash`")
+		assert.Contains(t, result, "If you installed azd with custom options")
+		assert.Contains(t, result, "https://aka.ms/azd/upgrade/linux")
+	})
+
+	t.Run("handles_visit_url", func(t *testing.T) {
+		t.Parallel()
+		visitParams := BannerParams{
+			CurrentVersion: "1.11.0",
+			LatestVersion:  "1.13.1",
+			Channel:        ChannelStable,
+			UpdateHint:     VisitUpdateHint("https://aka.ms/azd/upgrade/linux"),
+		}
+		result := RenderUpdateBanner(visitParams)
+		assert.Contains(t, result, "To update, visit https://aka.ms/azd/upgrade/linux")
+	})
+}
+
+func TestRenderUpdateBanner_DailyChannel(t *testing.T) {
+	t.Parallel()
+
+	// Daily version strings already embed the build number (e.g.
+	// "1.24.0-daily.6168094"), so no extra formatting is needed.
+	params := BannerParams{
+		CurrentVersion: "1.11.0",
+		LatestVersion:  "1.24.0-daily.6168094",
+		Channel:        ChannelDaily,
+		UpdateHint:     RunUpdateHint("azd update"),
+	}
+
+	result := RenderUpdateBanner(params)
+	assert.Contains(t, result, "Update available:")
+	assert.Contains(t, result, "1.24.0-daily.6168094")
+	assert.Contains(t, result, "github.com/Azure/azure-dev/commits/main/")
+	// Daily banner omits the "current -> latest" format.
+	assert.NotContains(t, result, "1.11.0 ->")
+}
+
+func TestFormatUpdateHint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    UpdateHint
+		contains []string
+	}{
+		{
+			name:     "simple_command",
+			input:    RunUpdateHint("azd update"),
+			contains: []string{"To update, run `azd update`"},
+		},
+		{
+			name:  "shell_command",
+			input: RunUpdateHint("curl -fsSL https://aka.ms/install-azd.sh | bash"),
+			contains: []string{
+				"To update, run `curl -fsSL https://aka.ms/install-azd.sh | bash`",
+			},
+		},
+		{
+			name:     "visit_url",
+			input:    VisitUpdateHint("https://aka.ms/azd/upgrade/linux"),
+			contains: []string{"To update, visit https://aka.ms/azd/upgrade/linux"},
+		},
+		{
+			name:     "winget_command",
+			input:    RunUpdateHint("winget upgrade Microsoft.Azd"),
+			contains: []string{"To update, run `winget upgrade Microsoft.Azd`"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := formatUpdateHint(tt.input)
+			for _, s := range tt.contains {
+				assert.Contains(t, got, s, "expected hint to contain %q", s)
+			}
+		})
+	}
+}
+
+func TestFormatUpdateHint_EmptyRendersNothing(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, formatUpdateHint(UpdateHint{}))
+}
+
+func TestReleaseNotesLink(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		params   BannerParams
+		expected releaseNotesLink
+	}{
+		{
+			name: "stable_links_to_release_tag",
+			params: BannerParams{
+				LatestVersion: "1.13.1",
+				Channel:       ChannelStable,
+			},
+			expected: releaseNotesLink{
+				label: "Release Notes",
+				url:   "https://github.com/Azure/azure-dev/releases/tag/azure-dev-cli_1.13.1",
+			},
+		},
+		{
+			name: "daily_links_to_commits",
+			params: BannerParams{
+				LatestVersion: "1.24.0-daily.6168094",
+				Channel:       ChannelDaily,
+			},
+			expected: releaseNotesLink{
+				label: "Recent Changes",
+				url:   "https://github.com/Azure/azure-dev/commits/main",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.params.releaseNotesLink()
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/cli/azd/pkg/update/banner_test.go
+++ b/cli/azd/pkg/update/banner_test.go
@@ -166,7 +166,7 @@ func TestReleaseNotesLink(t *testing.T) {
 				Channel:       ChannelStable,
 			},
 			expected: releaseNotesLink{
-				label: "Release Notes",
+				label: "Release notes",
 				url:   "https://github.com/Azure/azure-dev/releases/tag/azure-dev-cli_1.13.1",
 			},
 		},
@@ -177,7 +177,7 @@ func TestReleaseNotesLink(t *testing.T) {
 				Channel:       ChannelDaily,
 			},
 			expected: releaseNotesLink{
-				label: "Recent Changes",
+				label: "Recent changes",
 				url:   "https://github.com/Azure/azure-dev/commits/main",
 			},
 		},

--- a/cli/azd/pkg/update/banner_test.go
+++ b/cli/azd/pkg/update/banner_test.go
@@ -6,14 +6,20 @@ package update
 import (
 	"testing"
 
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// disableTerminalFormatting disables terminal hyperlink escape sequences
-// (AZD_FORCE_TTY=false) and color codes (NO_COLOR=1) so banner assertions
-// match plain-string substrings regardless of whether `go test` is run in an
-// interactive terminal.
+// disableTerminalFormatting disables terminal hyperlink escape sequences and
+// ANSI color codes so banner assertions match plain-string substrings
+// regardless of whether `go test` runs attached to a TTY.
+//
+//   - AZD_FORCE_TTY=false suppresses hyperlink OSC-8 sequences from
+//     output.WithHyperlink, which reads the env var at call time.
+//   - color.NoColor is set directly because fatih/color initializes its
+//     NoColor package-level var once at init time; setting NO_COLOR via
+//     t.Setenv after init has no effect.
 //
 // t.Setenv is not compatible with t.Parallel(), so tests that call this
 // helper must not be parallelized. Banner tests are sub-millisecond so this
@@ -21,7 +27,9 @@ import (
 func disableTerminalFormatting(t *testing.T) {
 	t.Helper()
 	t.Setenv("AZD_FORCE_TTY", "false")
-	t.Setenv("NO_COLOR", "1")
+	prev := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = prev })
 }
 
 func TestRenderUpdateBanner(t *testing.T) {
@@ -46,7 +54,7 @@ func TestRenderUpdateBanner(t *testing.T) {
 		assert.Contains(t, result, s, "expected banner to contain %q", s)
 	}
 
-	// The legacy phrasing should not appear after the refactor.
+	// Old wording should not appear.
 	assert.NotContains(t, result, "WARNING:")
 	assert.NotContains(t, result, "out of date")
 }
@@ -85,8 +93,7 @@ func TestRenderUpdateBanner_PlatformCommand(t *testing.T) {
 func TestRenderUpdateBanner_DailyChannel(t *testing.T) {
 	disableTerminalFormatting(t)
 
-	// Daily version strings already embed the build number (e.g.
-	// "1.24.0-daily.6168094"), so no extra formatting is needed.
+	// Daily versions already include the build number.
 	params := BannerParams{
 		CurrentVersion: "1.11.0",
 		LatestVersion:  "1.24.0-daily.6168094",
@@ -98,7 +105,7 @@ func TestRenderUpdateBanner_DailyChannel(t *testing.T) {
 	assert.Contains(t, result, "Update available:")
 	assert.Contains(t, result, "1.24.0-daily.6168094")
 	assert.Contains(t, result, "github.com/Azure/azure-dev/commits/main")
-	// Daily banner omits the "current -> latest" format.
+	// Daily banners omit "current -> latest".
 	assert.NotContains(t, result, "1.11.0 ->")
 }
 
@@ -150,8 +157,7 @@ func TestFormatUpdateHint_EmptyRendersNothing(t *testing.T) {
 }
 
 func TestReleaseNotesLink(t *testing.T) {
-	// Pure string construction — no color/hyperlink output involved, so this
-	// test doesn't need disableTerminalFormatting and can run in parallel.
+	// Pure string construction, so no formatting setup is needed.
 	t.Parallel()
 
 	tests := []struct {

--- a/cli/azd/pkg/update/banner_test.go
+++ b/cli/azd/pkg/update/banner_test.go
@@ -86,7 +86,7 @@ func TestRenderUpdateBanner_DailyChannel(t *testing.T) {
 	result := RenderUpdateBanner(params)
 	assert.Contains(t, result, "Update available:")
 	assert.Contains(t, result, "1.24.0-daily.6168094")
-	assert.Contains(t, result, "github.com/Azure/azure-dev/commits/main/")
+	assert.Contains(t, result, "github.com/Azure/azure-dev/commits/main")
 	// Daily banner omits the "current -> latest" format.
 	assert.NotContains(t, result, "1.11.0 ->")
 }

--- a/cli/installer/README.md
+++ b/cli/installer/README.md
@@ -165,7 +165,7 @@ The `daily` feed is periodically updated with builds from the latest source code
 ##### Install
 
 ```pwsh
-powershell -ex AllSigned -c "Invoke-RestMethod 'https://aka.ms/install-azd.ps1' -OutFile 'install-azd.ps1'; ./install-azd.ps1 -Version 'daily'"
+powershell -ex AllSigned -c "& ([scriptblock]::Create((Invoke-RestMethod 'https://aka.ms/install-azd.ps1'))) -Version 'daily'"
 ```
 
 ##### Uninstall or switch to another version


### PR DESCRIPTION
Resolves #4948

This PR redesigns the "update available" banner shown on CLI exit so the message is less verbose  and more neutral sounding.

The updated banner now also links to the release notes or changes, depending on the update channel:

| Channel | Link label | URL |
|---|---|---|
| Stable | `Release notes` | `https://github.com/Azure/azure-dev/releases/tag/azure-dev-cli_<version>` |
| Daily | `Recent changes` | `https://github.com/Azure/azure-dev/commits/main` (daily builds don't have GitHub releases) |

In addition, the guidance for daily builds (when `azd update` is ineligible) is enhanced to include flags like `--version daily` for `install-azd.sh` and `-Version 'daily'` for `install-azd.ps1`.

The daily PowerShell command also switched from `-OutFile 'install-azd.ps1'; ./install-azd.ps1 -Version 'daily'` to an in-memory scriptblock form so it no longer leaves a stray `install-azd.ps1` in the user's cwd (https://github.com/Azure/azure-dev/pull/7767#discussion_r3097715866). The same form is used anywhere the command is suggested (`cli/azd/main.go`, `cli/azd/cmd/update.go`, `cli/installer/README.md`).

## Screenshots
### Old update banner

<img width="1439" height="165" alt="image" src="https://github.com/user-attachments/assets/ec9dd103-2a68-4b63-9998-095e6d2ad0b1" />

<img width="2225" height="224" alt="image" src="https://github.com/user-attachments/assets/e68b5236-4d9c-47a9-b9b9-668f992ff498" />

------

### Stable channel, `azd update` ineligible

<img width="1559" height="318" alt="image" src="https://github.com/user-attachments/assets/54582ad1-e705-4b5d-996b-1a50cd513269" />

### Stable channel, `azd update` eligible

<img width="947" height="126" alt="image" src="https://github.com/user-attachments/assets/db9b3a13-9282-40ef-b64b-7213237f27a7" />

### Daily channel, `azd update` ineligible

<img width="1728" height="317" alt="image" src="https://github.com/user-attachments/assets/186a5464-7261-4ee8-9818-52d13dbdae77" />

### Daily channel, `azd update` eligible

<img width="1168" height="129" alt="image" src="https://github.com/user-attachments/assets/db632f1e-db39-4e88-9b36-ac0fa5c9b88d" />