### PR TITLE
update config set of error handling to auto fix and rerun

### DIFF
--- a/cli/azd/cmd/middleware/error.go
+++ b/cli/azd/cmd/middleware/error.go
@@ -320,6 +320,8 @@ func (e *ErrorMiddleware) Run(ctx context.Context, next NextFn) (*actions.Action
 			// Unlike the explain/guidance path (which auto-retries when the user
 			// explicitly chose actionFixAndRetry), the category-fix path asks for
 			// retry confirmation because the user only chose "fix" — not "fix and retry".
+			// The saved copilot.errorHandling.fix=allow preference bypasses this prompt
+			// and auto-retries.
 			shouldRetry, err := e.promptRetryAfterFix(ctx)
 			if err != nil {
 				span.SetStatus(codes.Error, "agent.retry.failed")
@@ -543,13 +545,36 @@ func (e *ErrorMiddleware) promptNextAction(
 
 // promptRetryAfterFix asks the user if the agent applied a fix and they want to retry the command.
 func (e *ErrorMiddleware) promptRetryAfterFix(ctx context.Context) (bool, error) {
+	userConfig, err := e.userConfigManager.Load()
+	if err != nil {
+		return false, fmt.Errorf("failed to load user config: %w", err)
+	}
+
+	// Saved "always fix" preference → auto-retry the command after fix.
+	if val, ok := userConfig.GetString(
+		agentcopilot.ConfigKeyErrorHandlingFix); ok && val == "allow" {
+		e.console.Message(ctx, output.WithWarningFormat(
+			"\n%s auto-fix and retry is enabled. To change, run %s.",
+			agentcopilot.DisplayTitle,
+			output.WithHighLightFormat(
+				fmt.Sprintf("azd config unset %s",
+					agentcopilot.ConfigKeyErrorHandlingFix)),
+		))
+		return true, nil
+	}
+
 	choices := []*uxlib.SelectChoice{
 		{Value: "retry", Label: "Retry the command"},
 		{Value: "exit", Label: "Exit"},
 	}
 
 	selector := uxlib.NewSelect(&uxlib.SelectOptions{
-		Message:         "How would you like to proceed?",
+		Message: "How would you like to proceed?",
+		HelpMessage: fmt.Sprintf(
+			"To always auto-fix and retry, run %s.",
+			output.WithHighLightFormat(
+				fmt.Sprintf("azd config set %s allow",
+					agentcopilot.ConfigKeyErrorHandlingFix))),
 		Choices:         choices,
 		EnableFiltering: new(false),
 		DisplayCount:    len(choices),

--- a/cli/azd/cmd/middleware/error.go
+++ b/cli/azd/cmd/middleware/error.go
@@ -488,18 +488,17 @@ func (e *ErrorMiddleware) promptNextAction(
 			"failed to load user config: %w", err)
 	}
 
-	// Saved "always fix" preference → auto-approve fix only (user still
-	// controls retry via the category-fix path or interactive prompt).
+	// Saved "always fix" preference → auto-approve fix and rerun the command.
 	if val, ok := userConfig.GetString(
 		agentcopilot.ConfigKeyErrorHandlingFix); ok && val == "allow" {
 		e.console.Message(ctx, output.WithWarningFormat(
-			"\n%s auto-fix is enabled. To change, run %s.",
+			"\n%s auto-fix and rerun is enabled. To change, run %s.",
 			agentcopilot.DisplayTitle,
 			output.WithHighLightFormat(
 				fmt.Sprintf("azd config unset %s",
 					agentcopilot.ConfigKeyErrorHandlingFix)),
 		))
-		return actionFixOnly, nil
+		return actionFixAndRetry, nil
 	}
 
 	choices := []*uxlib.SelectChoice{

--- a/cli/azd/cmd/middleware/error.go
+++ b/cli/azd/cmd/middleware/error.go
@@ -540,7 +540,18 @@ func (e *ErrorMiddleware) promptNextAction(
 		return actionExit, fmt.Errorf("invalid choice selected")
 	}
 
-	return nextAction(choices[*choiceIndex].Value), nil
+	selected := nextAction(choices[*choiceIndex].Value)
+
+	// Print hint about persisting the choice (only fix_and_retry has a saved equivalent).
+	if selected == actionFixAndRetry {
+		e.console.Message(ctx, output.WithGrayFormat(
+			"Tip: To always auto-fix and retry, run: %s",
+			output.WithHighLightFormat(
+				fmt.Sprintf("azd config set %s allow", agentcopilot.ConfigKeyErrorHandlingFix)),
+		))
+	}
+
+	return selected, nil
 }
 
 // promptRetryAfterFix asks the user if the agent applied a fix and they want to retry the command.
@@ -590,5 +601,16 @@ func (e *ErrorMiddleware) promptRetryAfterFix(ctx context.Context) (bool, error)
 		return false, fmt.Errorf("invalid retry choice selected")
 	}
 
-	return choices[*choiceIndex].Value == "retry", nil
+	shouldRetry := choices[*choiceIndex].Value == "retry"
+
+	// Print hint about persisting the choice (only retry has a saved equivalent).
+	if shouldRetry {
+		e.console.Message(ctx, output.WithGrayFormat(
+			"Tip: To always auto retry after fix, run: %s",
+			output.WithHighLightFormat(
+				fmt.Sprintf("azd config set %s allow", agentcopilot.ConfigKeyErrorHandlingFix)),
+		))
+	}
+
+	return shouldRetry, nil
 }

--- a/cli/azd/cmd/middleware/error.go
+++ b/cli/azd/cmd/middleware/error.go
@@ -492,7 +492,7 @@ func (e *ErrorMiddleware) promptNextAction(
 	if val, ok := userConfig.GetString(
 		agentcopilot.ConfigKeyErrorHandlingFix); ok && val == "allow" {
 		e.console.Message(ctx, output.WithWarningFormat(
-			"\n%s auto-fix and rerun is enabled. To change, run %s.",
+			"\n%s auto-fix and retry is enabled. To change, run %s.",
 			agentcopilot.DisplayTitle,
 			output.WithHighLightFormat(
 				fmt.Sprintf("azd config unset %s",
@@ -517,7 +517,7 @@ func (e *ErrorMiddleware) promptNextAction(
 	selector := uxlib.NewSelect(&uxlib.SelectOptions{
 		Message: "How would you like to proceed?",
 		HelpMessage: fmt.Sprintf(
-			"To always allow fixes, run %s.",
+			"To always auto-fix and retry, run %s.",
 			output.WithHighLightFormat(
 				fmt.Sprintf("azd config set %s allow",
 					agentcopilot.ConfigKeyErrorHandlingFix))),

--- a/cli/azd/cmd/middleware/error_test.go
+++ b/cli/azd/cmd/middleware/error_test.go
@@ -718,7 +718,7 @@ func Test_ErrorMiddleware_MaxRetry_FirstIterationSkipsCounter(t *testing.T) {
 	require.NotNil(t, result)
 }
 
-func Test_PromptNextAction_SavedAllow_ReturnsFixOnly(t *testing.T) {
+func Test_PromptNextAction_SavedAllow_ReturnsFixAndRetry(t *testing.T) {
 	t.Parallel()
 
 	cfg := configWithKeys(agentcopilot.ConfigKeyErrorHandlingFix, "allow")
@@ -731,8 +731,8 @@ func Test_PromptNextAction_SavedAllow_ReturnsFixOnly(t *testing.T) {
 
 	action, err := m.promptNextAction(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, actionFixOnly, action,
-		"saved 'allow' preference should return actionFixOnly, not actionFixAndRetry")
+	require.Equal(t, actionFixAndRetry, action,
+		"saved 'allow' preference should return actionFixAndRetry to auto-rerun the command")
 }
 
 func Test_PromptNextAction_ConfigLoadError(t *testing.T) {

--- a/cli/azd/cmd/middleware/error_test.go
+++ b/cli/azd/cmd/middleware/error_test.go
@@ -750,3 +750,36 @@ func Test_PromptNextAction_ConfigLoadError(t *testing.T) {
 	require.Contains(t, err.Error(), "io error")
 	require.Equal(t, actionExit, action)
 }
+
+func Test_PromptRetryAfterFix_SavedAllow_ReturnsTrue(t *testing.T) {
+	t.Parallel()
+
+	cfg := configWithKeys(agentcopilot.ConfigKeyErrorHandlingFix, "allow")
+	ucm := &mockUserConfigManager{cfg: cfg}
+
+	m := &ErrorMiddleware{
+		console:           mockinput.NewMockConsole(),
+		userConfigManager: ucm,
+	}
+
+	shouldRetry, err := m.promptRetryAfterFix(t.Context())
+	require.NoError(t, err)
+	require.True(t, shouldRetry,
+		"saved 'allow' preference should bypass the retry prompt and auto-retry")
+}
+
+func Test_PromptRetryAfterFix_ConfigLoadError(t *testing.T) {
+	t.Parallel()
+
+	ucm := &mockUserConfigManager{cfg: nil, err: errors.New("io error")}
+
+	m := &ErrorMiddleware{
+		console:           mockinput.NewMockConsole(),
+		userConfigManager: ucm,
+	}
+
+	shouldRetry, err := m.promptRetryAfterFix(t.Context())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "io error")
+	require.False(t, shouldRetry)
+}


### PR DESCRIPTION
Update error handling so that when copilot.errorHandling.fix is set to allow, the command is automatically retried after the fix is applied (actionFixAndRetry), instead of just applying the fix without rerun (actionFixOnly).

Also updates help text and warning messages to use consistent 'auto-fix and retry' terminology.

Closes #7769