### PR TITLE
fix: reduce CI pipeline warnings (Phase 1 & 2)

### DIFF
--- a/cli/installer/windows-actions/actions.vcxproj
+++ b/cli/installer/windows-actions/actions.vcxproj
@@ -54,22 +54,18 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <RuntimeLibrary Condition="'$(Configuration)'=='Debug'">MultiThreadedDebug</RuntimeLibrary>
       <RuntimeLibrary Condition="'$(Configuration)'=='Release'">MultiThreaded</RuntimeLibrary>
-      <ControlFlowGuard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <SDLCheck Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</SDLCheck>
       <SDLCheck Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</SDLCheck>
-      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/ZH:SHA_256 /GUARD:CF %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/ZH:SHA_256 /GUARD:CF %(AdditionalOptions)</AdditionalOptions>
-      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Level3</WarningLevel>
-      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Level3</WarningLevel>
-      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/ZH:SHA_256 /GUARD:CF %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/ZH:SHA_256 /GUARD:CF %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)'=='Release'">/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
+      <WarningLevel Condition="'$(Configuration)'=='Release'">Level3</WarningLevel>
+      <AdditionalOptions Condition="'$(Configuration)'=='Debug'">/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>msi.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>actions.def</ModuleDefinitionFile>
       <SubSystem>Windows</SubSystem>
       <CETCompat Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</CETCompat>
-      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/GUARD:CF %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/cli/installer/windows-actions/actions.vcxproj
+++ b/cli/installer/windows-actions/actions.vcxproj
@@ -65,7 +65,7 @@
       <AdditionalDependencies>msi.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>actions.def</ModuleDefinitionFile>
       <SubSystem>Windows</SubSystem>
-      <ControlFlowGuard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Guard</ControlFlowGuard>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <CETCompat Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</CETCompat>
     </Link>
   </ItemDefinitionGroup>

--- a/cli/installer/windows-actions/actions.vcxproj
+++ b/cli/installer/windows-actions/actions.vcxproj
@@ -65,6 +65,7 @@
       <AdditionalDependencies>msi.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>actions.def</ModuleDefinitionFile>
       <SubSystem>Windows</SubSystem>
+      <ControlFlowGuard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Guard</ControlFlowGuard>
       <CETCompat Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</CETCompat>
     </Link>
   </ItemDefinitionGroup>

--- a/cli/installer/windows/azd.wixproj
+++ b/cli/installer/windows/azd.wixproj
@@ -23,7 +23,11 @@
             ProductVersion=$(ProductVersion);
             ReleaseBuild=$(ReleaseBuild);
         </DefineConstants>
-        <SuppressIces Condition="'$(Platform)' == 'arm' Or '$(Platform)' == 'arm64'">ICE39</SuppressIces>
+        <!-- ICE40: REINSTALLMODE=amus is intentional — forces overwrite of unversioned files (azd.exe). -->
+        <!-- ICE105: Per-user default with optional per-machine (ALLUSERS=2) requires both HKCU and HKLM -->
+        <!--         registry entries — HKLM search (azd.wxs:74) and conditional HKLM write (azd.wxs:104-105). -->
+        <SuppressIces>ICE40;ICE105</SuppressIces>
+        <SuppressIces Condition="'$(Platform)' == 'arm' Or '$(Platform)' == 'arm64'">$(SuppressIces);ICE39</SuppressIces>
         <DefineSolutionProperties>false</DefineSolutionProperties>
         <WixTargetsPath Condition="'$(WixTargetsPath)' == ''">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
     </PropertyGroup>

--- a/eng/pipelines/templates/stages/code-coverage-upload.yml
+++ b/eng/pipelines/templates/stages/code-coverage-upload.yml
@@ -84,11 +84,11 @@ stages:
             workingDirectory: $(Build.SourcesDirectory)/cli/azd
           displayName: Check code coverage threshold
 
-      - task: PublishCodeCoverageResults@1
+      - task: PublishCodeCoverageResults@2
         condition: succeededOrFailed()
         inputs:
-          codeCoverageTool: Cobertura
           summaryFileLocation: '$(Build.SourcesDirectory)/**/coverage.xml'
+          pathToSources: '$(Build.SourcesDirectory)'
         displayName: Publish Code Coverage to DevOps
 
       - pwsh: |


### PR DESCRIPTION
## Summary

Resolves #7781

Addresses [#4668](https://github.com/Azure/azure-dev/issues/4668) — reduces CI pipeline warnings by ~22 (from 114 total).

Full analysis: [Azure/azure-dev-pr#1780](https://github.com/Azure/azure-dev-pr/issues/1780)

## Changes

### Phase 1: Deprecated Task Upgrade (2 warnings)
- **`eng/pipelines/templates/stages/code-coverage-upload.yml`**: Upgrade `PublishCodeCoverageResults@1` → `@2`
  - Remove `codeCoverageTool` input (v2 auto-detects format)
  - Add `pathToSources` for proper source mapping in HTML reports

### Phase 2a: MSI Compiler Flag Fix (16 warnings)
- **`cli/installer/windows-actions/actions.vcxproj`**: Replace raw `/GUARD:CF` in `<AdditionalOptions>` with the MSBuild `<ControlFlowGuard>Guard</ControlFlowGuard>` property
  - Eliminates 16 `D9002: ignoring unknown option` warnings (`/GU`, `/GD`, `/G:`, `/GC`)
  - The raw flag was being parsed as separate `/G` sub-options by the compiler
  - The MSBuild property correctly enables CFG for both compiler and linker

### Phase 2b: WiX ICE Warning Suppression (4 warnings)
- **`cli/installer/windows/azd.wixproj`**: Suppress `ICE40` and `ICE105` with detailed rationale comments
  - **ICE40**: `REINSTALLMODE=amus` is intentionally set to force overwrite of unversioned files (`azd.exe`)
  - **ICE105**: Per-user default install (`ALLUSERS=2`, `InstallScope="perUser"`) with optional per-machine requires both HKCU and HKLM registry entries

## Testing

These are build infrastructure changes (pipeline YAML, MSBuild project, WiX project) — no Go code changes. Verification requires a CI pipeline run to confirm warnings are eliminated.

## Remaining Phases

| Phase | Issue | Category | Warnings |
|-------|-------|----------|----------|
| 1 & 2 | #7781 | Deprecated task + MSI/WiX | 22 | ✅ This PR |
| 3 | #7783 | Disk space cleanup | 71 |
| 4 | #7784 | 1ES Guardian/Terrapin | 18 |
| 5 | #7785 | Network isolation | 3 |
