### PR TITLE
Extension framework - propagate error suggestions from event handlers and custom service targets

### DIFF
--- a/cli/azd/cmd/middleware/error.go
+++ b/cli/azd/cmd/middleware/error.go
@@ -24,6 +24,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/resource"
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
@@ -172,6 +173,12 @@ func (e *ErrorMiddleware) Run(ctx context.Context, next NextFn) (*actions.Action
 	// Check if error already has a suggestion
 	if _, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
 		// Already has a suggestion, return as-is
+		return actionResult, err
+	}
+
+	// Check if extension error already has a structured suggestion (e.g. LocalError)
+	// Skip the YAML pipeline so it doesn't override the extension's specific guidance
+	if azdext.ErrorSuggestion(err) != "" {
 		return actionResult, err
 	}
 

--- a/cli/azd/cmd/middleware/error.go
+++ b/cli/azd/cmd/middleware/error.go
@@ -176,9 +176,9 @@ func (e *ErrorMiddleware) Run(ctx context.Context, next NextFn) (*actions.Action
 		return actionResult, err
 	}
 
-	// Check if extension error already has a structured suggestion (e.g. LocalError)
-	// Skip the YAML pipeline so it doesn't override the extension's specific guidance
-	if azdext.ErrorSuggestion(err) != "" {
+	// Skip the YAML pipeline for typed extension errors so host-side rules don't
+	// override the extension's structured classification or user guidance.
+	if azdext.IsStructuredError(err) {
 		return actionResult, err
 	}
 

--- a/cli/azd/cmd/middleware/error_test.go
+++ b/cli/azd/cmd/middleware/error_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/errorhandler"
@@ -229,6 +230,65 @@ func Test_ErrorMiddleware_PatternMatchingSuggestion(t *testing.T) {
 	require.True(t, errors.As(err, &suggestionErr), "Expected error to be wrapped with suggestion")
 	require.Contains(t, suggestionErr.Suggestion, "quota")
 	require.NotEmpty(t, suggestionErr.Links, "Expected reference links")
+}
+
+// Test_ErrorMiddleware_ExtensionErrorWithSuggestion_BypassesPipeline verifies that
+// when an extension-supplied error (LocalError or ServiceError) already carries a
+// Suggestion, the YAML error-suggestion pipeline is short-circuited so it doesn't
+// override the extension's specific guidance with a generic one. Regression test
+// for https://github.com/Azure/azure-dev/issues/7706.
+func Test_ErrorMiddleware_ExtensionErrorWithSuggestion_BypassesPipeline(t *testing.T) {
+	t.Parallel()
+
+	mockContext := mocks.NewMockContext(context.Background())
+	cfg := config.NewEmptyConfig()
+	featureManager := alpha.NewFeaturesManagerWithConfig(cfg)
+	global := &internal.GlobalCommandOptions{
+		NoPrompt: true, // skip agentic handling
+	}
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	errorPipeline := errorhandler.NewErrorHandlerPipeline(nil)
+	middleware := NewErrorMiddleware(
+		&Options{Name: "test"},
+		mockContext.Console,
+		nil,
+		global,
+		featureManager,
+		userConfigManager,
+		errorPipeline,
+	)
+
+	// "QuotaExceeded" matches a known pattern in error_suggestions.yaml that would
+	// otherwise wrap into an *ErrorWithSuggestion (proven by
+	// Test_ErrorMiddleware_PatternMatchingSuggestion). The middleware must skip
+	// that wrapping when the extension already supplied a suggestion of its own.
+	extErr := &azdext.LocalError{
+		Message:    "Deployment failed: QuotaExceeded for resource",
+		Code:       "quota_exceeded",
+		Category:   azdext.LocalErrorCategoryUser,
+		Suggestion: "Extension-provided guidance: request a quota increase via the portal.",
+	}
+	nextFn := func(ctx context.Context) (*actions.ActionResult, error) {
+		return nil, extErr
+	}
+
+	result, err := middleware.Run(*mockContext.Context, nextFn)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	// The original LocalError must be returned unchanged — not wrapped in
+	// *ErrorWithSuggestion by the YAML pipeline.
+	var wrapped *internal.ErrorWithSuggestion
+	require.False(
+		t,
+		errors.As(err, &wrapped),
+		"YAML pipeline should not wrap an extension error that already has a Suggestion",
+	)
+	returned, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok, "expected the original *LocalError to be returned")
+	require.Same(t, extErr, returned)
+	require.Equal(t, extErr.Suggestion, azdext.ErrorSuggestion(err))
 }
 
 func Test_ErrorMiddleware_NoPatternMatch(t *testing.T) {

--- a/cli/azd/cmd/middleware/error_test.go
+++ b/cli/azd/cmd/middleware/error_test.go
@@ -291,6 +291,49 @@ func Test_ErrorMiddleware_ExtensionErrorWithSuggestion_BypassesPipeline(t *testi
 	require.Equal(t, extErr.Suggestion, azdext.ErrorSuggestion(err))
 }
 
+func Test_ErrorMiddleware_StructuredExtensionErrorWithoutSuggestion_BypassesPipeline(t *testing.T) {
+	t.Parallel()
+
+	mockContext := mocks.NewMockContext(context.Background())
+	cfg := config.NewEmptyConfig()
+	featureManager := alpha.NewFeaturesManagerWithConfig(cfg)
+	global := &internal.GlobalCommandOptions{
+		NoPrompt: true,
+	}
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	errorPipeline := errorhandler.NewErrorHandlerPipeline(nil)
+	middleware := NewErrorMiddleware(
+		&Options{Name: "test"},
+		mockContext.Console,
+		nil,
+		global,
+		featureManager,
+		userConfigManager,
+		errorPipeline,
+	)
+
+	extErr := &azdext.LocalError{
+		Message:  "Deployment failed: QuotaExceeded for resource",
+		Code:     "quota_exceeded",
+		Category: azdext.LocalErrorCategoryUser,
+	}
+	nextFn := func(ctx context.Context) (*actions.ActionResult, error) {
+		return nil, extErr
+	}
+
+	result, err := middleware.Run(*mockContext.Context, nextFn)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	var wrapped *internal.ErrorWithSuggestion
+	require.False(t, errors.As(err, &wrapped))
+	returned, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	require.Same(t, extErr, returned)
+	require.Empty(t, azdext.ErrorSuggestion(err))
+}
+
 func Test_ErrorMiddleware_NoPatternMatch(t *testing.T) {
 	t.Parallel()
 	mockContext := mocks.NewMockContext(context.Background())

--- a/cli/azd/cmd/middleware/middleware_coverage2_test.go
+++ b/cli/azd/cmd/middleware/middleware_coverage2_test.go
@@ -617,6 +617,34 @@ func TestUxMiddleware_Run_AzdextServiceErrorWithSuggestion(t *testing.T) {
 	require.Nil(t, result)
 }
 
+func TestUxMiddleware_Run_AzdextLocalErrorWithLinks(t *testing.T) {
+	t.Parallel()
+	console := mockinput.NewMockConsole()
+	m := &UxMiddleware{
+		options:         &Options{},
+		console:         console,
+		featuresManager: alpha.NewFeaturesManagerWithConfig(config.NewEmptyConfig()),
+	}
+
+	localErr := &azdext.LocalError{
+		Message: "Extension config missing",
+		Code:    "missing_config",
+		Links: []errorhandler.ErrorLink{{
+			URL:   "https://aka.ms/azd-errors#missing-config",
+			Title: "Missing config help",
+		}},
+	}
+
+	result, err := m.Run(t.Context(), func(_ context.Context) (*actions.ActionResult, error) {
+		return nil, localErr
+	})
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, fmt.Sprint(console.Output()), "https://aka.ms/azd-errors#missing-config")
+	require.NotContains(t, fmt.Sprint(console.Output()), "Suggestion:")
+}
+
 func TestUxMiddleware_Run_AzdextLocalErrorWithoutSuggestion(t *testing.T) {
 	t.Parallel()
 	console := mockinput.NewMockConsole()

--- a/cli/azd/cmd/middleware/ux.go
+++ b/cli/azd/cmd/middleware/ux.go
@@ -68,7 +68,7 @@ func (m *UxMiddleware) Run(ctx context.Context, next NextFn) (*actions.ActionRes
 
 		// Bridge extension errors (LocalError/ServiceError) with suggestions to rich UX.
 		// Covers both CLI extension commands and gRPC service target errors.
-		if suggestion := azdext.ErrorSuggestion(err); suggestion != "" {
+		if suggestion := azdext.ErrorSuggestion(err); suggestion != "" || len(azdext.ErrorLinks(err)) > 0 {
 			message := azdext.ErrorMessage(err)
 			if message == "" {
 				message = err.Error()
@@ -76,6 +76,7 @@ func (m *UxMiddleware) Run(ctx context.Context, next NextFn) (*actions.ActionRes
 			displayErr := &ux.ErrorWithSuggestion{
 				Message:    message,
 				Suggestion: suggestion,
+				Links:      azdext.ErrorLinks(err),
 			}
 			m.console.Message(ctx, "")
 			m.console.MessageUxItem(ctx, displayErr)

--- a/cli/azd/grpc/proto/errors.proto
+++ b/cli/azd/grpc/proto/errors.proto
@@ -30,6 +30,12 @@ message LocalErrorDetail {
   string category = 2;  // Error category (e.g., "user", "validation", "dependency", "internal")
 }
 
+// ErrorLink contains a reference link with a URL and optional title.
+message ErrorLink {
+  string url = 1;    // Link target
+  string title = 2;  // Display text (falls back to the URL when empty)
+}
+
 // ExtensionError is a unified error message that can represent errors from different sources.
 // It provides structured error information for telemetry and error handling.
 message ExtensionError {
@@ -37,6 +43,7 @@ message ExtensionError {
   string message = 2;       // Human-readable error message
   ErrorOrigin origin = 4;   // Where the error originated from
   string suggestion = 5;    // Optional user-facing suggestion for resolving the error
+  repeated ErrorLink links = 6;  // Optional reference links rendered alongside the suggestion
 
   // Source-specific structured details. Only one should be set based on origin.
   oneof source {

--- a/cli/azd/grpc/proto/event.proto
+++ b/cli/azd/grpc/proto/event.proto
@@ -69,6 +69,7 @@ message ProjectHandlerStatus {
   // Status such as "running", "completed", "failed", etc.
   string status = 2;
   // Optional message providing further details.
+  // For backward compatibility with older hosts, populate this even when error is set.
   string message = 3;
   // Optional structured error details (set when status is "failed").
   ExtensionError error = 4;
@@ -83,6 +84,7 @@ message ServiceHandlerStatus {
   // Status such as "running", "completed", "failed", etc.
   string status = 3;
   // Optional message providing further details.
+  // For backward compatibility with older hosts, populate this even when error is set.
   string message = 4;
   // Optional structured error details (set when status is "failed").
   ExtensionError error = 5;

--- a/cli/azd/grpc/proto/event.proto
+++ b/cli/azd/grpc/proto/event.proto
@@ -7,6 +7,7 @@ package azdext;
 option go_package = "github.com/azure/azure-dev/cli/azd/pkg/azdext";
 
 import "models.proto";
+import "errors.proto";
 
 // EventService defines methods for event subscription, invocation, and status updates.
 // Clients can subscribe to events and receive notifications via a bidirectional stream.
@@ -69,6 +70,8 @@ message ProjectHandlerStatus {
   string status = 2;
   // Optional message providing further details.
   string message = 3;
+  // Optional structured error details (set when status is "failed").
+  ExtensionError error = 4;
 }
 
 // Client sends status updates for service events
@@ -81,4 +84,6 @@ message ServiceHandlerStatus {
   string status = 3;
   // Optional message providing further details.
   string message = 4;
+  // Optional structured error details (set when status is "failed").
+  ExtensionError error = 5;
 }

--- a/cli/azd/internal/grpcserver/event_service.go
+++ b/cli/azd/internal/grpcserver/event_service.go
@@ -179,6 +179,9 @@ func (s *eventService) createProjectEventHandler(
 			}
 
 			if statusMsg.ProjectHandlerStatus.Status == "failed" {
+				if extErr := azdext.UnwrapError(statusMsg.ProjectHandlerStatus.Error); extErr != nil {
+					return extErr
+				}
 				return fmt.Errorf(
 					"extension %s project hook %s failed: %s",
 					extension.Id,
@@ -297,6 +300,9 @@ func (s *eventService) createServiceEventHandler(
 			}
 
 			if statusMsg.ServiceHandlerStatus.Status == "failed" {
+				if extErr := azdext.UnwrapError(statusMsg.ServiceHandlerStatus.Error); extErr != nil {
+					return extErr
+				}
 				return fmt.Errorf(
 					"extension %s service hook %s.%s failed: %s",
 					extension.Id,

--- a/cli/azd/internal/grpcserver/event_service.go
+++ b/cli/azd/internal/grpcserver/event_service.go
@@ -180,6 +180,12 @@ func (s *eventService) createProjectEventHandler(
 
 			if statusMsg.ProjectHandlerStatus.Status == "failed" {
 				if extErr := azdext.UnwrapError(statusMsg.ProjectHandlerStatus.Error); extErr != nil {
+					log.Printf(
+						"extension %s project hook %s failed with structured error: %v",
+						extension.Id,
+						eventName,
+						extErr,
+					)
 					return extErr
 				}
 				return fmt.Errorf(
@@ -301,6 +307,13 @@ func (s *eventService) createServiceEventHandler(
 
 			if statusMsg.ServiceHandlerStatus.Status == "failed" {
 				if extErr := azdext.UnwrapError(statusMsg.ServiceHandlerStatus.Error); extErr != nil {
+					log.Printf(
+						"extension %s service hook %s.%s failed with structured error: %v",
+						extension.Id,
+						args.Service.Name,
+						eventName,
+						extErr,
+					)
 					return extErr
 				}
 				return fmt.Errorf(

--- a/cli/azd/internal/grpcserver/event_service_test.go
+++ b/cli/azd/internal/grpcserver/event_service_test.go
@@ -5,16 +5,21 @@ package grpcserver
 
 import (
 	"context"
+	"errors"
+	"io"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/errorhandler"
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
 	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
 	"github.com/azure/azure-dev/cli/azd/pkg/grpcbroker"
 	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
+	"github.com/azure/azure-dev/cli/azd/pkg/state"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -87,6 +92,63 @@ func (m *MockBidiStreamingServer[Req, Resp]) SetTrailer(md metadata.MD) {
 // Type aliases for convenience when working with specific message types
 type MockEventStreamingServer = MockBidiStreamingServer[*azdext.EventMessage, *azdext.EventMessage]
 
+type noOpEnvironmentManager struct{}
+
+func (m *noOpEnvironmentManager) Create(ctx context.Context, spec environment.Spec) (*environment.Environment, error) {
+	return nil, nil
+}
+
+func (m *noOpEnvironmentManager) LoadOrInitInteractive(
+	ctx context.Context,
+	name string,
+) (*environment.Environment, error) {
+	return nil, nil
+}
+
+func (m *noOpEnvironmentManager) List(ctx context.Context) ([]*environment.Description, error) {
+	return nil, nil
+}
+
+func (m *noOpEnvironmentManager) Get(ctx context.Context, name string) (*environment.Environment, error) {
+	return nil, nil
+}
+
+func (m *noOpEnvironmentManager) Save(ctx context.Context, env *environment.Environment) error {
+	return nil
+}
+
+func (m *noOpEnvironmentManager) SaveWithOptions(
+	ctx context.Context,
+	env *environment.Environment,
+	options *environment.SaveOptions,
+) error {
+	return nil
+}
+
+func (m *noOpEnvironmentManager) Reload(ctx context.Context, env *environment.Environment) error {
+	return nil
+}
+
+func (m *noOpEnvironmentManager) Delete(ctx context.Context, name string) error {
+	return nil
+}
+
+func (m *noOpEnvironmentManager) EnvPath(env *environment.Environment) string {
+	return ""
+}
+
+func (m *noOpEnvironmentManager) ConfigPath(env *environment.Environment) string {
+	return ""
+}
+
+func (m *noOpEnvironmentManager) InvalidateEnvCache(ctx context.Context, envName string) error {
+	return nil
+}
+
+func (m *noOpEnvironmentManager) GetStateCacheManager() *state.StateCacheManager {
+	return nil
+}
+
 // Test helpers
 func createTestEventService() (*eventService, *MockEventStreamingServer) {
 	mockStream := &MockEventStreamingServer{}
@@ -94,7 +156,7 @@ func createTestEventService() (*eventService, *MockEventStreamingServer) {
 
 	// Create lazy environment manager (mock)
 	lazyEnvManager := lazy.NewLazy(func() (environment.Manager, error) {
-		return nil, nil // Tests don't need actual environment manager
+		return &noOpEnvironmentManager{}, nil
 	})
 
 	// Create lazy project with simple test config
@@ -149,6 +211,67 @@ func createTestExtension() *extensions.Extension {
 		Version:     "1.0.0",
 		// Don't call Initialize() as it causes hangs in tests
 	}
+}
+
+type scriptedEventStream struct {
+	ctx    context.Context
+	recvCh chan *azdext.EventMessage
+	sendFn func(*azdext.EventMessage) error
+}
+
+func (s *scriptedEventStream) Send(msg *azdext.EventMessage) error {
+	return s.sendFn(msg)
+}
+
+func (s *scriptedEventStream) Recv() (*azdext.EventMessage, error) {
+	msg, ok := <-s.recvCh
+	if !ok {
+		return nil, io.EOF
+	}
+
+	return msg, nil
+}
+
+func createBrokerForEventHandler(
+	t *testing.T,
+	extensionID string,
+	responseFn func(*azdext.EventMessage) *azdext.EventMessage,
+) (*grpcbroker.MessageBroker[azdext.EventMessage], context.Context, func()) {
+	t.Helper()
+
+	streamCtx := extensions.WithClaimsContext(context.Background(), &extensions.ExtensionClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject: extensionID,
+		},
+	})
+
+	stream := &scriptedEventStream{
+		ctx:    streamCtx,
+		recvCh: make(chan *azdext.EventMessage, 1),
+	}
+	stream.sendFn = func(msg *azdext.EventMessage) error {
+		if response := responseFn(msg); response != nil {
+			stream.recvCh <- response
+		}
+
+		return nil
+	}
+
+	brokerCtx, cancel := context.WithCancel(streamCtx)
+	broker := grpcbroker.NewMessageBroker(stream, azdext.NewEventMessageEnvelope(), extensionID, nil)
+
+	go func() {
+		_ = broker.Run(brokerCtx)
+	}()
+
+	require.NoError(t, broker.Ready(t.Context()))
+
+	cleanup := func() {
+		close(stream.recvCh)
+		cancel()
+	}
+
+	return broker, streamCtx, cleanup
 }
 
 func TestEventService_handleSubscribeProjectEvent(t *testing.T) {
@@ -331,6 +454,188 @@ func TestEventService_createServiceEventHandler(t *testing.T) {
 
 	// Test that the handler function is created correctly
 	assert.NotNil(t, handler)
+}
+
+func TestEventService_createProjectEventHandler_RoundTripsStructuredError(t *testing.T) {
+	service, _ := createTestEventService()
+	extension := createTestExtension()
+	projectConfig, err := service.lazyProject.GetValue()
+	require.NoError(t, err)
+
+	broker, streamCtx, cleanup := createBrokerForEventHandler(
+		t,
+		extension.Id,
+		func(msg *azdext.EventMessage) *azdext.EventMessage {
+			invoke := msg.GetInvokeProjectHandler()
+			require.NotNil(t, invoke)
+
+			return &azdext.EventMessage{
+				MessageType: &azdext.EventMessage_ProjectHandlerStatus{
+					ProjectHandlerStatus: &azdext.ProjectHandlerStatus{
+						EventName: invoke.EventName,
+						Status:    "failed",
+						Message:   "extension project hook failed",
+						Error: azdext.WrapError(&azdext.LocalError{
+							Message:    "extension project hook failed",
+							Code:       "hook_failed",
+							Category:   azdext.LocalErrorCategoryValidation,
+							Suggestion: "Fix the extension config and retry",
+							Links: []errorhandler.ErrorLink{{
+								URL:   "https://aka.ms/azd-errors#hook-failed",
+								Title: "Hook troubleshooting",
+							}},
+						}),
+					},
+				},
+			}
+		},
+	)
+	defer cleanup()
+
+	handler := service.createProjectEventHandler(streamCtx, extension, "prepackage", broker)
+	err = handler(t.Context(), project.ProjectLifecycleEventArgs{Project: projectConfig})
+	require.Error(t, err)
+
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, "extension project hook failed", localErr.Message)
+	assert.Equal(t, "hook_failed", localErr.Code)
+	assert.Equal(t, azdext.LocalErrorCategoryValidation, localErr.Category)
+	assert.Equal(t, "Fix the extension config and retry", localErr.Suggestion)
+	require.Len(t, localErr.Links, 1)
+	assert.Equal(t, "Hook troubleshooting", localErr.Links[0].Title)
+}
+
+func TestEventService_createProjectEventHandler_BackCompatFailedMessage(t *testing.T) {
+	service, _ := createTestEventService()
+	extension := createTestExtension()
+	projectConfig, err := service.lazyProject.GetValue()
+	require.NoError(t, err)
+
+	broker, streamCtx, cleanup := createBrokerForEventHandler(
+		t,
+		extension.Id,
+		func(msg *azdext.EventMessage) *azdext.EventMessage {
+			invoke := msg.GetInvokeProjectHandler()
+			require.NotNil(t, invoke)
+
+			return &azdext.EventMessage{
+				MessageType: &azdext.EventMessage_ProjectHandlerStatus{
+					ProjectHandlerStatus: &azdext.ProjectHandlerStatus{
+						EventName: invoke.EventName,
+						Status:    "failed",
+						Message:   "old host failure message",
+					},
+				},
+			}
+		},
+	)
+	defer cleanup()
+
+	handler := service.createProjectEventHandler(streamCtx, extension, "prepackage", broker)
+	err = handler(t.Context(), project.ProjectLifecycleEventArgs{Project: projectConfig})
+	require.EqualError(t, err, "extension test.extension project hook prepackage failed: old host failure message")
+}
+
+func TestEventService_createServiceEventHandler_RoundTripsStructuredError(t *testing.T) {
+	service, _ := createTestEventService()
+	extension := createTestExtension()
+	projectConfig, err := service.lazyProject.GetValue()
+	require.NoError(t, err)
+	serviceConfig := projectConfig.Services["api"]
+	require.NotNil(t, serviceConfig)
+
+	broker, streamCtx, cleanup := createBrokerForEventHandler(
+		t,
+		extension.Id,
+		func(msg *azdext.EventMessage) *azdext.EventMessage {
+			invoke := msg.GetInvokeServiceHandler()
+			require.NotNil(t, invoke)
+
+			return &azdext.EventMessage{
+				MessageType: &azdext.EventMessage_ServiceHandlerStatus{
+					ServiceHandlerStatus: &azdext.ServiceHandlerStatus{
+						EventName:   invoke.EventName,
+						ServiceName: invoke.Service.Name,
+						Status:      "failed",
+						Message:     "extension service hook failed",
+						Error: azdext.WrapError(&azdext.ServiceError{
+							Message:     "extension service hook failed",
+							ErrorCode:   "Conflict",
+							StatusCode:  409,
+							ServiceName: "management.azure.com",
+							Suggestion:  "Wait for the active operation to finish",
+							Links: []errorhandler.ErrorLink{{
+								URL:   "https://aka.ms/azd-errors#conflict",
+								Title: "Conflict troubleshooting",
+							}},
+						}),
+					},
+				},
+			}
+		},
+	)
+	defer cleanup()
+
+	handler := service.createServiceEventHandler(streamCtx, serviceConfig, extension, "prepackage", broker)
+	err = handler(t.Context(), project.ServiceLifecycleEventArgs{
+		Project:        projectConfig,
+		Service:        serviceConfig,
+		ServiceContext: project.NewServiceContext(),
+	})
+	require.Error(t, err)
+
+	serviceErr, ok := errors.AsType[*azdext.ServiceError](err)
+	require.True(t, ok)
+	assert.Equal(t, "extension service hook failed", serviceErr.Message)
+	assert.Equal(t, "Conflict", serviceErr.ErrorCode)
+	assert.Equal(t, 409, serviceErr.StatusCode)
+	assert.Equal(t, "management.azure.com", serviceErr.ServiceName)
+	assert.Equal(t, "Wait for the active operation to finish", serviceErr.Suggestion)
+	require.Len(t, serviceErr.Links, 1)
+	assert.Equal(t, "Conflict troubleshooting", serviceErr.Links[0].Title)
+}
+
+func TestEventService_createServiceEventHandler_BackCompatFailedMessage(t *testing.T) {
+	service, _ := createTestEventService()
+	extension := createTestExtension()
+	projectConfig, err := service.lazyProject.GetValue()
+	require.NoError(t, err)
+	serviceConfig := projectConfig.Services["api"]
+	require.NotNil(t, serviceConfig)
+
+	broker, streamCtx, cleanup := createBrokerForEventHandler(
+		t,
+		extension.Id,
+		func(msg *azdext.EventMessage) *azdext.EventMessage {
+			invoke := msg.GetInvokeServiceHandler()
+			require.NotNil(t, invoke)
+
+			return &azdext.EventMessage{
+				MessageType: &azdext.EventMessage_ServiceHandlerStatus{
+					ServiceHandlerStatus: &azdext.ServiceHandlerStatus{
+						EventName:   invoke.EventName,
+						ServiceName: invoke.Service.Name,
+						Status:      "failed",
+						Message:     "old service host failure message",
+					},
+				},
+			}
+		},
+	)
+	defer cleanup()
+
+	handler := service.createServiceEventHandler(streamCtx, serviceConfig, extension, "prepackage", broker)
+	err = handler(t.Context(), project.ServiceLifecycleEventArgs{
+		Project:        projectConfig,
+		Service:        serviceConfig,
+		ServiceContext: project.NewServiceContext(),
+	})
+	require.EqualError(
+		t,
+		err,
+		"extension test.extension service hook api.prepackage failed: old service host failure message",
+	)
 }
 
 func TestEventService_New(t *testing.T) {

--- a/cli/azd/pkg/azdext/errors.pb.go
+++ b/cli/azd/pkg/azdext/errors.pb.go
@@ -194,6 +194,59 @@ func (x *LocalErrorDetail) GetCategory() string {
 	return ""
 }
 
+// ErrorLink contains a reference link with a URL and optional title.
+type ErrorLink struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Url           string                 `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`     // Link target
+	Title         string                 `protobuf:"bytes,2,opt,name=title,proto3" json:"title,omitempty"` // Display text (falls back to the URL when empty)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ErrorLink) Reset() {
+	*x = ErrorLink{}
+	mi := &file_errors_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ErrorLink) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ErrorLink) ProtoMessage() {}
+
+func (x *ErrorLink) ProtoReflect() protoreflect.Message {
+	mi := &file_errors_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ErrorLink.ProtoReflect.Descriptor instead.
+func (*ErrorLink) Descriptor() ([]byte, []int) {
+	return file_errors_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *ErrorLink) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+func (x *ErrorLink) GetTitle() string {
+	if x != nil {
+		return x.Title
+	}
+	return ""
+}
+
 // ExtensionError is a unified error message that can represent errors from different sources.
 // It provides structured error information for telemetry and error handling.
 type ExtensionError struct {
@@ -201,6 +254,7 @@ type ExtensionError struct {
 	Message    string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`                        // Human-readable error message
 	Origin     ErrorOrigin            `protobuf:"varint,4,opt,name=origin,proto3,enum=azdext.ErrorOrigin" json:"origin,omitempty"` // Where the error originated from
 	Suggestion string                 `protobuf:"bytes,5,opt,name=suggestion,proto3" json:"suggestion,omitempty"`                  // Optional user-facing suggestion for resolving the error
+	Links      []*ErrorLink           `protobuf:"bytes,6,rep,name=links,proto3" json:"links,omitempty"`                            // Optional reference links rendered alongside the suggestion
 	// Source-specific structured details. Only one should be set based on origin.
 	//
 	// Types that are valid to be assigned to Source:
@@ -214,7 +268,7 @@ type ExtensionError struct {
 
 func (x *ExtensionError) Reset() {
 	*x = ExtensionError{}
-	mi := &file_errors_proto_msgTypes[2]
+	mi := &file_errors_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -226,7 +280,7 @@ func (x *ExtensionError) String() string {
 func (*ExtensionError) ProtoMessage() {}
 
 func (x *ExtensionError) ProtoReflect() protoreflect.Message {
-	mi := &file_errors_proto_msgTypes[2]
+	mi := &file_errors_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -239,7 +293,7 @@ func (x *ExtensionError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtensionError.ProtoReflect.Descriptor instead.
 func (*ExtensionError) Descriptor() ([]byte, []int) {
-	return file_errors_proto_rawDescGZIP(), []int{2}
+	return file_errors_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *ExtensionError) GetMessage() string {
@@ -261,6 +315,13 @@ func (x *ExtensionError) GetSuggestion() string {
 		return x.Suggestion
 	}
 	return ""
+}
+
+func (x *ExtensionError) GetLinks() []*ErrorLink {
+	if x != nil {
+		return x.Links
+	}
+	return nil
 }
 
 func (x *ExtensionError) GetSource() isExtensionError_Source {
@@ -317,13 +378,17 @@ const file_errors_proto_rawDesc = "" +
 	"\fservice_name\x18\x03 \x01(\tR\vserviceName\"B\n" +
 	"\x10LocalErrorDetail\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\tR\x04code\x12\x1a\n" +
-	"\bcategory\x18\x02 \x01(\tR\bcategory\"\x8d\x02\n" +
+	"\bcategory\x18\x02 \x01(\tR\bcategory\"3\n" +
+	"\tErrorLink\x12\x10\n" +
+	"\x03url\x18\x01 \x01(\tR\x03url\x12\x14\n" +
+	"\x05title\x18\x02 \x01(\tR\x05title\"\xb6\x02\n" +
 	"\x0eExtensionError\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12+\n" +
 	"\x06origin\x18\x04 \x01(\x0e2\x13.azdext.ErrorOriginR\x06origin\x12\x1e\n" +
 	"\n" +
 	"suggestion\x18\x05 \x01(\tR\n" +
-	"suggestion\x12A\n" +
+	"suggestion\x12'\n" +
+	"\x05links\x18\x06 \x03(\v2\x11.azdext.ErrorLinkR\x05links\x12A\n" +
 	"\rservice_error\x18\n" +
 	" \x01(\v2\x1a.azdext.ServiceErrorDetailH\x00R\fserviceError\x12;\n" +
 	"\vlocal_error\x18\v \x01(\v2\x18.azdext.LocalErrorDetailH\x00R\n" +
@@ -348,22 +413,24 @@ func file_errors_proto_rawDescGZIP() []byte {
 }
 
 var file_errors_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_errors_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_errors_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_errors_proto_goTypes = []any{
 	(ErrorOrigin)(0),           // 0: azdext.ErrorOrigin
 	(*ServiceErrorDetail)(nil), // 1: azdext.ServiceErrorDetail
 	(*LocalErrorDetail)(nil),   // 2: azdext.LocalErrorDetail
-	(*ExtensionError)(nil),     // 3: azdext.ExtensionError
+	(*ErrorLink)(nil),          // 3: azdext.ErrorLink
+	(*ExtensionError)(nil),     // 4: azdext.ExtensionError
 }
 var file_errors_proto_depIdxs = []int32{
 	0, // 0: azdext.ExtensionError.origin:type_name -> azdext.ErrorOrigin
-	1, // 1: azdext.ExtensionError.service_error:type_name -> azdext.ServiceErrorDetail
-	2, // 2: azdext.ExtensionError.local_error:type_name -> azdext.LocalErrorDetail
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	3, // 1: azdext.ExtensionError.links:type_name -> azdext.ErrorLink
+	1, // 2: azdext.ExtensionError.service_error:type_name -> azdext.ServiceErrorDetail
+	2, // 3: azdext.ExtensionError.local_error:type_name -> azdext.LocalErrorDetail
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_errors_proto_init() }
@@ -371,7 +438,7 @@ func file_errors_proto_init() {
 	if File_errors_proto != nil {
 		return
 	}
-	file_errors_proto_msgTypes[2].OneofWrappers = []any{
+	file_errors_proto_msgTypes[3].OneofWrappers = []any{
 		(*ExtensionError_ServiceError)(nil),
 		(*ExtensionError_LocalError)(nil),
 	}
@@ -381,7 +448,7 @@ func file_errors_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_errors_proto_rawDesc), len(file_errors_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   3,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/cli/azd/pkg/azdext/event.pb.go
+++ b/cli/azd/pkg/azdext/event.pb.go
@@ -415,6 +415,7 @@ type ProjectHandlerStatus struct {
 	// Status such as "running", "completed", "failed", etc.
 	Status string `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
 	// Optional message providing further details.
+	// For backward compatibility with older hosts, populate this even when error is set.
 	Message string `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
 	// Optional structured error details (set when status is "failed").
 	Error         *ExtensionError `protobuf:"bytes,4,opt,name=error,proto3" json:"error,omitempty"`
@@ -490,6 +491,7 @@ type ServiceHandlerStatus struct {
 	// Status such as "running", "completed", "failed", etc.
 	Status string `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
 	// Optional message providing further details.
+	// For backward compatibility with older hosts, populate this even when error is set.
 	Message string `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`
 	// Optional structured error details (set when status is "failed").
 	Error         *ExtensionError `protobuf:"bytes,5,opt,name=error,proto3" json:"error,omitempty"`

--- a/cli/azd/pkg/azdext/event.pb.go
+++ b/cli/azd/pkg/azdext/event.pb.go
@@ -415,7 +415,9 @@ type ProjectHandlerStatus struct {
 	// Status such as "running", "completed", "failed", etc.
 	Status string `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
 	// Optional message providing further details.
-	Message       string `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
+	Message string `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
+	// Optional structured error details (set when status is "failed").
+	Error         *ExtensionError `protobuf:"bytes,4,opt,name=error,proto3" json:"error,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -471,6 +473,13 @@ func (x *ProjectHandlerStatus) GetMessage() string {
 	return ""
 }
 
+func (x *ProjectHandlerStatus) GetError() *ExtensionError {
+	if x != nil {
+		return x.Error
+	}
+	return nil
+}
+
 // Client sends status updates for service events
 type ServiceHandlerStatus struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -481,7 +490,9 @@ type ServiceHandlerStatus struct {
 	// Status such as "running", "completed", "failed", etc.
 	Status string `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
 	// Optional message providing further details.
-	Message       string `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`
+	Message string `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`
+	// Optional structured error details (set when status is "failed").
+	Error         *ExtensionError `protobuf:"bytes,5,opt,name=error,proto3" json:"error,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -544,11 +555,18 @@ func (x *ServiceHandlerStatus) GetMessage() string {
 	return ""
 }
 
+func (x *ServiceHandlerStatus) GetError() *ExtensionError {
+	if x != nil {
+		return x.Error
+	}
+	return nil
+}
+
 var File_event_proto protoreflect.FileDescriptor
 
 const file_event_proto_rawDesc = "" +
 	"\n" +
-	"\vevent.proto\x12\x06azdext\x1a\fmodels.proto\"\xa8\x04\n" +
+	"\vevent.proto\x12\x06azdext\x1a\fmodels.proto\x1a\ferrors.proto\"\xa8\x04\n" +
 	"\fEventMessage\x12W\n" +
 	"\x17subscribe_project_event\x18\x01 \x01(\v2\x1d.azdext.SubscribeProjectEventH\x00R\x15subscribeProjectEvent\x12T\n" +
 	"\x16invoke_project_handler\x18\x02 \x01(\v2\x1c.azdext.InvokeProjectHandlerH\x00R\x14invokeProjectHandler\x12T\n" +
@@ -574,18 +592,20 @@ const file_event_proto_rawDesc = "" +
 	"event_name\x18\x01 \x01(\tR\teventName\x12/\n" +
 	"\aproject\x18\x02 \x01(\v2\x15.azdext.ProjectConfigR\aproject\x12/\n" +
 	"\aservice\x18\x03 \x01(\v2\x15.azdext.ServiceConfigR\aservice\x12?\n" +
-	"\x0fservice_context\x18\x04 \x01(\v2\x16.azdext.ServiceContextR\x0eserviceContext\"g\n" +
+	"\x0fservice_context\x18\x04 \x01(\v2\x16.azdext.ServiceContextR\x0eserviceContext\"\x95\x01\n" +
 	"\x14ProjectHandlerStatus\x12\x1d\n" +
 	"\n" +
 	"event_name\x18\x01 \x01(\tR\teventName\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12\x18\n" +
-	"\amessage\x18\x03 \x01(\tR\amessage\"\x8a\x01\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\x12,\n" +
+	"\x05error\x18\x04 \x01(\v2\x16.azdext.ExtensionErrorR\x05error\"\xb8\x01\n" +
 	"\x14ServiceHandlerStatus\x12\x1d\n" +
 	"\n" +
 	"event_name\x18\x01 \x01(\tR\teventName\x12!\n" +
 	"\fservice_name\x18\x02 \x01(\tR\vserviceName\x12\x16\n" +
 	"\x06status\x18\x03 \x01(\tR\x06status\x12\x18\n" +
-	"\amessage\x18\x04 \x01(\tR\amessage2M\n" +
+	"\amessage\x18\x04 \x01(\tR\amessage\x12,\n" +
+	"\x05error\x18\x05 \x01(\v2\x16.azdext.ExtensionErrorR\x05error2M\n" +
 	"\fEventService\x12=\n" +
 	"\vEventStream\x12\x14.azdext.EventMessage\x1a\x14.azdext.EventMessage(\x010\x01B/Z-github.com/azure/azure-dev/cli/azd/pkg/azdextb\x06proto3"
 
@@ -613,6 +633,7 @@ var file_event_proto_goTypes = []any{
 	(*ProjectConfig)(nil),         // 7: azdext.ProjectConfig
 	(*ServiceConfig)(nil),         // 8: azdext.ServiceConfig
 	(*ServiceContext)(nil),        // 9: azdext.ServiceContext
+	(*ExtensionError)(nil),        // 10: azdext.ExtensionError
 }
 var file_event_proto_depIdxs = []int32{
 	1,  // 0: azdext.EventMessage.subscribe_project_event:type_name -> azdext.SubscribeProjectEvent
@@ -625,13 +646,15 @@ var file_event_proto_depIdxs = []int32{
 	7,  // 7: azdext.InvokeServiceHandler.project:type_name -> azdext.ProjectConfig
 	8,  // 8: azdext.InvokeServiceHandler.service:type_name -> azdext.ServiceConfig
 	9,  // 9: azdext.InvokeServiceHandler.service_context:type_name -> azdext.ServiceContext
-	0,  // 10: azdext.EventService.EventStream:input_type -> azdext.EventMessage
-	0,  // 11: azdext.EventService.EventStream:output_type -> azdext.EventMessage
-	11, // [11:12] is the sub-list for method output_type
-	10, // [10:11] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	10, // 10: azdext.ProjectHandlerStatus.error:type_name -> azdext.ExtensionError
+	10, // 11: azdext.ServiceHandlerStatus.error:type_name -> azdext.ExtensionError
+	0,  // 12: azdext.EventService.EventStream:input_type -> azdext.EventMessage
+	0,  // 13: azdext.EventService.EventStream:output_type -> azdext.EventMessage
+	13, // [13:14] is the sub-list for method output_type
+	12, // [12:13] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_event_proto_init() }
@@ -640,6 +663,7 @@ func file_event_proto_init() {
 		return
 	}
 	file_models_proto_init()
+	file_errors_proto_init()
 	file_event_proto_msgTypes[0].OneofWrappers = []any{
 		(*EventMessage_SubscribeProjectEvent)(nil),
 		(*EventMessage_InvokeProjectHandler)(nil),

--- a/cli/azd/pkg/azdext/event_manager.go
+++ b/cli/azd/pkg/azdext/event_manager.go
@@ -229,12 +229,14 @@ func (em *EventManager) onInvokeProjectHandler(
 
 	handlerStatus := "completed"
 	handlerMessage := ""
+	var handlerError *ExtensionError
 
 	// Call the project event handler
 	err := handler(ctx, args)
 	if err != nil {
 		handlerStatus = "failed"
 		handlerMessage = err.Error()
+		handlerError = WrapError(err)
 		log.Printf("invokeProjectHandler error for event %s: %v", req.EventName, err)
 	}
 
@@ -245,6 +247,7 @@ func (em *EventManager) onInvokeProjectHandler(
 				EventName: req.EventName,
 				Status:    handlerStatus,
 				Message:   handlerMessage,
+				Error:     handlerError,
 			},
 		},
 	}, nil
@@ -278,12 +281,14 @@ func (em *EventManager) onInvokeServiceHandler(
 
 	handlerStatus := "completed"
 	handlerMessage := ""
+	var handlerError *ExtensionError
 
 	// Call the service event handler
 	err := handler(ctx, args)
 	if err != nil {
 		handlerStatus = "failed"
 		handlerMessage = err.Error()
+		handlerError = WrapError(err)
 		log.Printf("invokeServiceHandler error for event %s: %v", req.EventName, err)
 	}
 
@@ -295,6 +300,7 @@ func (em *EventManager) onInvokeServiceHandler(
 				ServiceName: req.Service.Name,
 				Status:      handlerStatus,
 				Message:     handlerMessage,
+				Error:       handlerError,
 			},
 		},
 	}, nil

--- a/cli/azd/pkg/azdext/event_manager_test.go
+++ b/cli/azd/pkg/azdext/event_manager_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/errorhandler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -376,6 +377,51 @@ func TestEventManager_onInvokeServiceHandler_HandlerError(t *testing.T) {
 	require.NotNil(t, status.Error.GetLocalError())
 	assert.Equal(t, "service_handler_failed", status.Error.GetLocalError().GetCode())
 	assert.Equal(t, string(LocalErrorCategoryUser), status.Error.GetLocalError().GetCategory())
+}
+
+func TestEventManager_onInvokeServiceHandler_ServiceError(t *testing.T) {
+	ctx := context.Background()
+	client := &AzdClient{}
+
+	eventManager := NewEventManager("microsoft.azd.demo", client, nil)
+
+	handlerErr := &ServiceError{
+		Message:     "service handler failed",
+		ErrorCode:   "Conflict",
+		StatusCode:  409,
+		ServiceName: "management.azure.com",
+		Suggestion:  "Wait for the active operation to finish",
+		Links: []errorhandler.ErrorLink{{
+			URL:   "https://aka.ms/azd-errors#conflict",
+			Title: "Conflict troubleshooting",
+		}},
+	}
+	handler := func(ctx context.Context, args *ServiceEventArgs) error {
+		return handlerErr
+	}
+	eventManager.serviceEvents["prepublish"] = handler
+
+	invokeMsg := &InvokeServiceHandler{
+		EventName:      "prepublish",
+		Project:        createTestProjectConfigForEvents(),
+		Service:        createTestServiceConfigForEvents(),
+		ServiceContext: createTestServiceContextForEvents(),
+	}
+
+	resp, err := eventManager.onInvokeServiceHandler(ctx, invokeMsg)
+
+	assert.NoError(t, err)
+	require.NotNil(t, resp)
+	status := resp.GetServiceHandlerStatus()
+	require.NotNil(t, status)
+	require.NotNil(t, status.Error)
+	require.NotNil(t, status.Error.GetServiceError())
+	assert.Equal(t, "Conflict", status.Error.GetServiceError().GetErrorCode())
+	assert.Equal(t, int32(409), status.Error.GetServiceError().GetStatusCode())
+	assert.Equal(t, "management.azure.com", status.Error.GetServiceError().GetServiceName())
+	assert.Equal(t, "Wait for the active operation to finish", status.Error.GetSuggestion())
+	require.Len(t, status.Error.GetLinks(), 1)
+	assert.Equal(t, "Conflict troubleshooting", status.Error.GetLinks()[0].GetTitle())
 }
 
 // Test onInvokeServiceHandler with no registered handler

--- a/cli/azd/pkg/azdext/event_manager_test.go
+++ b/cli/azd/pkg/azdext/event_manager_test.go
@@ -5,7 +5,6 @@ package azdext
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -178,9 +177,16 @@ func TestEventManager_onInvokeProjectHandler_HandlerError(t *testing.T) {
 
 	eventManager := NewEventManager("microsoft.azd.demo", client, nil)
 
-	// Add a test handler that fails
+	// Add a test handler that fails with a structured LocalError so we can verify
+	// the failure response carries the structured error payload, not just a string.
+	handlerErr := &LocalError{
+		Message:    "handler failed",
+		Code:       "handler_failed",
+		Category:   LocalErrorCategoryUser,
+		Suggestion: "Try again with --debug",
+	}
 	handler := func(ctx context.Context, args *ProjectEventArgs) error {
-		return errors.New("handler failed")
+		return handlerErr
 	}
 	eventManager.projectEvents["postbuild"] = handler
 
@@ -202,6 +208,15 @@ func TestEventManager_onInvokeProjectHandler_HandlerError(t *testing.T) {
 	assert.Equal(t, "postbuild", status.EventName)
 	assert.Equal(t, "failed", status.Status)
 	assert.Equal(t, "handler failed", status.Message)
+
+	// Verify the structured ExtensionError is also populated so the host can unwrap
+	// it back into a typed LocalError (preserving the Suggestion and category).
+	require.NotNil(t, status.Error, "expected structured ExtensionError on failed status")
+	assert.Equal(t, "handler failed", status.Error.GetMessage())
+	assert.Equal(t, "Try again with --debug", status.Error.GetSuggestion())
+	require.NotNil(t, status.Error.GetLocalError())
+	assert.Equal(t, "handler_failed", status.Error.GetLocalError().GetCode())
+	assert.Equal(t, string(LocalErrorCategoryUser), status.Error.GetLocalError().GetCategory())
 }
 
 // Test onInvokeProjectHandler with no registered handler
@@ -318,9 +333,16 @@ func TestEventManager_onInvokeServiceHandler_HandlerError(t *testing.T) {
 
 	eventManager := NewEventManager("microsoft.azd.demo", client, nil)
 
-	// Add a test handler that fails
+	// Add a test handler that fails with a structured LocalError so we can verify
+	// the failure response carries the structured error payload, not just a string.
+	handlerErr := &LocalError{
+		Message:    "service handler failed",
+		Code:       "service_handler_failed",
+		Category:   LocalErrorCategoryUser,
+		Suggestion: "Re-run with --debug",
+	}
 	handler := func(ctx context.Context, args *ServiceEventArgs) error {
-		return errors.New("service handler failed")
+		return handlerErr
 	}
 	eventManager.serviceEvents["prepublish"] = handler
 
@@ -345,6 +367,15 @@ func TestEventManager_onInvokeServiceHandler_HandlerError(t *testing.T) {
 	assert.Equal(t, "test-service", status.ServiceName)
 	assert.Equal(t, "failed", status.Status)
 	assert.Equal(t, "service handler failed", status.Message)
+
+	// Verify the structured ExtensionError is also populated so the host can unwrap
+	// it back into a typed LocalError (preserving the Suggestion and category).
+	require.NotNil(t, status.Error, "expected structured ExtensionError on failed status")
+	assert.Equal(t, "service handler failed", status.Error.GetMessage())
+	assert.Equal(t, "Re-run with --debug", status.Error.GetSuggestion())
+	require.NotNil(t, status.Error.GetLocalError())
+	assert.Equal(t, "service_handler_failed", status.Error.GetLocalError().GetCode())
+	assert.Equal(t, string(LocalErrorCategoryUser), status.Error.GetLocalError().GetCategory())
 }
 
 // Test onInvokeServiceHandler with no registered handler

--- a/cli/azd/pkg/azdext/extension_error.go
+++ b/cli/azd/pkg/azdext/extension_error.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/azure/azure-dev/cli/azd/pkg/errorhandler"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -24,6 +25,8 @@ type ServiceError struct {
 	ServiceName string
 	// Suggestion contains optional user-facing remediation guidance.
 	Suggestion string
+	// Links contains optional reference links rendered alongside the suggestion.
+	Links []errorhandler.ErrorLink
 }
 
 // LocalError represents non-service extension errors, such as validation/config failures.
@@ -37,6 +40,8 @@ type LocalError struct {
 	Category LocalErrorCategory
 	// Suggestion contains optional user-facing remediation guidance.
 	Suggestion string
+	// Links contains optional reference links rendered alongside the suggestion.
+	Links []errorhandler.ErrorLink
 }
 
 // Error implements the error interface.
@@ -75,6 +80,7 @@ func WrapError(err error) *ExtensionError {
 	if extServiceErr, ok := errors.AsType[*ServiceError](err); ok {
 		extErr.Message = extServiceErr.Message
 		extErr.Suggestion = extServiceErr.Suggestion
+		extErr.Links = wrapErrorLinks(extServiceErr.Links)
 		extErr.Origin = ErrorOrigin_ERROR_ORIGIN_SERVICE
 		extErr.Source = &ExtensionError_ServiceError{
 			ServiceError: &ServiceErrorDetail{
@@ -91,6 +97,7 @@ func WrapError(err error) *ExtensionError {
 		normalizedCategory := NormalizeLocalErrorCategory(extLocalErr.Category)
 		extErr.Message = extLocalErr.Message
 		extErr.Suggestion = extLocalErr.Suggestion
+		extErr.Links = wrapErrorLinks(extLocalErr.Links)
 		extErr.Origin = ErrorOrigin_ERROR_ORIGIN_LOCAL
 		extErr.Source = &ExtensionError_LocalError{
 			LocalError: &LocalErrorDetail{
@@ -164,9 +171,11 @@ func authLocalErrorCode(st *status.Status) string {
 // for telemetry classification and error handling.
 // It returns the appropriate error type based on the origin field.
 func UnwrapError(msg *ExtensionError) error {
-	if msg == nil || msg.GetMessage() == "" {
+	if msg == nil {
 		return nil
 	}
+
+	links := unwrapErrorLinks(msg.GetLinks())
 
 	// Check for service error details
 	if svcErr := msg.GetServiceError(); svcErr != nil {
@@ -176,6 +185,7 @@ func UnwrapError(msg *ExtensionError) error {
 			StatusCode:  int(svcErr.GetStatusCode()),
 			ServiceName: svcErr.GetServiceName(),
 			Suggestion:  msg.GetSuggestion(),
+			Links:       links,
 		}
 	}
 
@@ -186,6 +196,7 @@ func UnwrapError(msg *ExtensionError) error {
 			Code:       localErr.GetCode(),
 			Category:   normalizedCategory,
 			Suggestion: msg.GetSuggestion(),
+			Links:      links,
 		}
 	}
 
@@ -194,6 +205,7 @@ func UnwrapError(msg *ExtensionError) error {
 			Message:    msg.GetMessage(),
 			Category:   LocalErrorCategoryLocal,
 			Suggestion: msg.GetSuggestion(),
+			Links:      links,
 		}
 	}
 
@@ -201,6 +213,7 @@ func UnwrapError(msg *ExtensionError) error {
 		return &ServiceError{
 			Message:    msg.GetMessage(),
 			Suggestion: msg.GetSuggestion(),
+			Links:      links,
 		}
 	}
 
@@ -208,5 +221,42 @@ func UnwrapError(msg *ExtensionError) error {
 		Message:    msg.GetMessage(),
 		Category:   LocalErrorCategoryLocal,
 		Suggestion: msg.GetSuggestion(),
+		Links:      links,
 	}
+}
+
+func wrapErrorLinks(links []errorhandler.ErrorLink) []*ErrorLink {
+	if len(links) == 0 {
+		return nil
+	}
+
+	protoLinks := make([]*ErrorLink, len(links))
+	for i, link := range links {
+		protoLinks[i] = &ErrorLink{
+			Url:   link.URL,
+			Title: link.Title,
+		}
+	}
+
+	return protoLinks
+}
+
+func unwrapErrorLinks(links []*ErrorLink) []errorhandler.ErrorLink {
+	if len(links) == 0 {
+		return nil
+	}
+
+	unwrapped := make([]errorhandler.ErrorLink, len(links))
+	for i, link := range links {
+		if link == nil {
+			continue
+		}
+
+		unwrapped[i] = errorhandler.ErrorLink{
+			URL:   link.GetUrl(),
+			Title: link.GetTitle(),
+		}
+	}
+
+	return unwrapped
 }

--- a/cli/azd/pkg/azdext/extension_error_test.go
+++ b/cli/azd/pkg/azdext/extension_error_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/azure/azure-dev/cli/azd/pkg/errorhandler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -54,11 +55,18 @@ func TestExtensionError_RoundTrip(t *testing.T) {
 				StatusCode:  429,
 				ServiceName: "openai.azure.com",
 				Suggestion:  "Retry with exponential backoff",
+				Links: []errorhandler.ErrorLink{{
+					URL:   "https://aka.ms/azd-errors#rate-limit",
+					Title: "Rate limit troubleshooting",
+				}},
 			},
 			verify: func(t *testing.T, protoErr *ExtensionError, goErr error) {
 				assert.Equal(t, "Rate limit exceeded", protoErr.GetMessage())
 				assert.Equal(t, "Retry with exponential backoff", protoErr.GetSuggestion())
 				assert.Equal(t, ErrorOrigin_ERROR_ORIGIN_SERVICE, protoErr.GetOrigin())
+				require.Len(t, protoErr.GetLinks(), 1)
+				assert.Equal(t, "https://aka.ms/azd-errors#rate-limit", protoErr.GetLinks()[0].GetUrl())
+				assert.Equal(t, "Rate limit troubleshooting", protoErr.GetLinks()[0].GetTitle())
 
 				svcDetail := protoErr.GetServiceError()
 				require.NotNil(t, svcDetail)
@@ -73,6 +81,9 @@ func TestExtensionError_RoundTrip(t *testing.T) {
 				assert.Equal(t, 429, svcErr.StatusCode)
 				assert.Equal(t, "openai.azure.com", svcErr.ServiceName)
 				assert.Equal(t, "Retry with exponential backoff", svcErr.Suggestion)
+				require.Len(t, svcErr.Links, 1)
+				assert.Equal(t, "https://aka.ms/azd-errors#rate-limit", svcErr.Links[0].URL)
+				assert.Equal(t, "Rate limit troubleshooting", svcErr.Links[0].Title)
 			},
 		},
 		{
@@ -82,10 +93,16 @@ func TestExtensionError_RoundTrip(t *testing.T) {
 				Code:       "invalid_config",
 				Category:   LocalErrorCategoryValidation,
 				Suggestion: "Add the missing required field",
+				Links: []errorhandler.ErrorLink{{
+					URL:   "https://aka.ms/azd-errors#invalid-config",
+					Title: "Invalid config reference",
+				}},
 			},
 			verify: func(t *testing.T, protoErr *ExtensionError, goErr error) {
 				assert.Equal(t, ErrorOrigin_ERROR_ORIGIN_LOCAL, protoErr.GetOrigin())
 				assert.Equal(t, "Add the missing required field", protoErr.GetSuggestion())
+				require.Len(t, protoErr.GetLinks(), 1)
+				assert.Equal(t, "https://aka.ms/azd-errors#invalid-config", protoErr.GetLinks()[0].GetUrl())
 
 				localDetail := protoErr.GetLocalError()
 				require.NotNil(t, localDetail)
@@ -97,6 +114,8 @@ func TestExtensionError_RoundTrip(t *testing.T) {
 				assert.Equal(t, "invalid_config", localErr.Code)
 				assert.Equal(t, LocalErrorCategoryValidation, localErr.Category)
 				assert.Equal(t, "Add the missing required field", localErr.Suggestion)
+				require.Len(t, localErr.Links, 1)
+				assert.Equal(t, "Invalid config reference", localErr.Links[0].Title)
 			},
 		},
 		{
@@ -222,6 +241,35 @@ func TestExtensionError_RoundTrip(t *testing.T) {
 			tt.verify(t, protoErr, goErr)
 		})
 	}
+}
+
+func TestUnwrapError_EmptyMessagePreservesStructuredError(t *testing.T) {
+	protoErr := &ExtensionError{
+		Origin: ErrorOrigin_ERROR_ORIGIN_LOCAL,
+		Source: &ExtensionError_LocalError{
+			LocalError: &LocalErrorDetail{
+				Code:     "empty_message",
+				Category: "validation",
+			},
+		},
+		Suggestion: "Fill in the required setting",
+		Links: []*ErrorLink{{
+			Url:   "https://aka.ms/azd-errors#empty-message",
+			Title: "Validation troubleshooting",
+		}},
+	}
+
+	err := UnwrapError(protoErr)
+	require.Error(t, err)
+
+	localErr, ok := errors.AsType[*LocalError](err)
+	require.True(t, ok)
+	assert.Empty(t, localErr.Message)
+	assert.Equal(t, "empty_message", localErr.Code)
+	assert.Equal(t, LocalErrorCategoryValidation, localErr.Category)
+	assert.Equal(t, "Fill in the required setting", localErr.Suggestion)
+	require.Len(t, localErr.Links, 1)
+	assert.Equal(t, "Validation troubleshooting", localErr.Links[0].Title)
 }
 
 func mustAuthStatusError(code codes.Code, reason, message string) error {

--- a/cli/azd/pkg/azdext/run.go
+++ b/cli/azd/pkg/azdext/run.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/errorhandler"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -131,4 +132,29 @@ func ErrorMessage(err error) string {
 	}
 
 	return ""
+}
+
+// ErrorLinks extracts the Links field from a [LocalError] or [ServiceError].
+// Returns nil if the error has no links.
+func ErrorLinks(err error) []errorhandler.ErrorLink {
+	if localErr, ok := errors.AsType[*LocalError](err); ok && len(localErr.Links) > 0 {
+		return localErr.Links
+	}
+
+	if svcErr, ok := errors.AsType[*ServiceError](err); ok && len(svcErr.Links) > 0 {
+		return svcErr.Links
+	}
+
+	return nil
+}
+
+// IsStructuredError reports whether err is an azd extension local or service error.
+func IsStructuredError(err error) bool {
+	_, localErr := errors.AsType[*LocalError](err)
+	if localErr {
+		return true
+	}
+
+	_, svcErr := errors.AsType[*ServiceError](err)
+	return svcErr
 }

--- a/cli/azd/pkg/azdext/run_coverage_test.go
+++ b/cli/azd/pkg/azdext/run_coverage_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/errorhandler"
 	"github.com/stretchr/testify/require"
 )
 
@@ -143,6 +144,58 @@ func TestErrorMessage(t *testing.T) {
 			require.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestErrorLinks(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected []errorhandler.ErrorLink
+	}{
+		{
+			name: "LocalErrorWithLinks",
+			err: &LocalError{
+				Links: []errorhandler.ErrorLink{{
+					URL:   "https://aka.ms/azd-errors#local",
+					Title: "Local error help",
+				}},
+			},
+			expected: []errorhandler.ErrorLink{{
+				URL:   "https://aka.ms/azd-errors#local",
+				Title: "Local error help",
+			}},
+		},
+		{
+			name: "WrappedServiceErrorWithLinks",
+			err: fmt.Errorf("op: %w", &ServiceError{
+				Links: []errorhandler.ErrorLink{{
+					URL: "https://aka.ms/azd-errors#service",
+				}},
+			}),
+			expected: []errorhandler.ErrorLink{{
+				URL: "https://aka.ms/azd-errors#service",
+			}},
+		},
+		{
+			name:     "GenericError",
+			err:      errors.New("generic"),
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, ErrorLinks(tt.err))
+		})
+	}
+}
+
+func TestIsStructuredError(t *testing.T) {
+	require.True(t, IsStructuredError(&LocalError{}))
+	require.True(t, IsStructuredError(&ServiceError{}))
+	require.True(t, IsStructuredError(fmt.Errorf("wrapped: %w", &LocalError{})))
+	require.False(t, IsStructuredError(errors.New("plain")))
+	require.False(t, IsStructuredError(nil))
 }
 
 func TestVersion_IsSet(t *testing.T) {

--- a/cli/azd/pkg/ext/event_dispatcher.go
+++ b/cli/azd/pkg/ext/event_dispatcher.go
@@ -126,7 +126,7 @@ func (ed *EventDispatcher[T]) RaiseEvent(ctx context.Context, name Event, eventA
 		}
 	}
 
-	// Build final error string if their are any failures
+	// Build final error string if there are any failures
 	if len(handlerErrors) > 0 {
 		// Single error: preserve the original error type for unwrapping.
 		// This lets structured errors (e.g. LocalError, ErrorWithSuggestion)

--- a/cli/azd/pkg/ext/event_dispatcher.go
+++ b/cli/azd/pkg/ext/event_dispatcher.go
@@ -137,15 +137,16 @@ func (ed *EventDispatcher[T]) RaiseEvent(ctx context.Context, name Event, eventA
 
 		// For multiple errors, join them as before
 		lines := make([]string, len(handlerErrors))
-		// If any of the errors have a suggestion, collect them
+		// If any of the errors have a suggestion, collect them.
+		// ErrorWithSuggestion takes precedence — it has an Unwrap() so a nested
+		// extension error's suggestion would otherwise be appended twice.
 		var suggestions []string
 		for i, err := range handlerErrors {
 			lines[i] = err.Error()
 			if errWithSuggestion, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok &&
 				errWithSuggestion.Suggestion != "" {
 				suggestions = append(suggestions, errWithSuggestion.Suggestion)
-			}
-			if s := azdext.ErrorSuggestion(err); s != "" {
+			} else if s := azdext.ErrorSuggestion(err); s != "" {
 				suggestions = append(suggestions, s)
 			}
 		}

--- a/cli/azd/pkg/ext/event_dispatcher.go
+++ b/cli/azd/pkg/ext/event_dispatcher.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 )
 
 type Event string
@@ -127,6 +128,13 @@ func (ed *EventDispatcher[T]) RaiseEvent(ctx context.Context, name Event, eventA
 
 	// Build final error string if their are any failures
 	if len(handlerErrors) > 0 {
+		// Single error: preserve the original error type for unwrapping.
+		// This lets structured errors (e.g. LocalError, ErrorWithSuggestion)
+		// flow through to middleware without losing type information.
+		if len(handlerErrors) == 1 {
+			return handlerErrors[0]
+		}
+
 		// For multiple errors, join them as before
 		lines := make([]string, len(handlerErrors))
 		// If any of the errors have a suggestion, collect them
@@ -136,6 +144,9 @@ func (ed *EventDispatcher[T]) RaiseEvent(ctx context.Context, name Event, eventA
 			if errWithSuggestion, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok &&
 				errWithSuggestion.Suggestion != "" {
 				suggestions = append(suggestions, errWithSuggestion.Suggestion)
+			}
+			if s := azdext.ErrorSuggestion(err); s != "" {
+				suggestions = append(suggestions, s)
 			}
 		}
 		combinedErr := errors.New(strings.Join(lines, ","))

--- a/cli/azd/pkg/ext/event_dispatcher_test.go
+++ b/cli/azd/pkg/ext/event_dispatcher_test.go
@@ -474,7 +474,7 @@ func Test_Workflow_Context_Handler_Cleanup(t *testing.T) {
 
 		// Raise event again - handler should NOT be called
 		step1CallCount = 0
-		err = ed.RaiseEvent(context.Background(), testEvent, testEventArgs{})
+		err = ed.RaiseEvent(t.Context(), testEvent, testEventArgs{})
 		require.NoError(t, err)
 		require.Equal(t, 0, step1CallCount, "Step 1 handler should not be called after cleanup")
 	})
@@ -483,7 +483,7 @@ func Test_Workflow_Context_Handler_Cleanup(t *testing.T) {
 		ed := NewEventDispatcher[testEventArgs](testEvent)
 
 		// Simulate root context with WithoutCancel
-		rootCtx := context.Background()
+		rootCtx := t.Context()
 		nonCancellableRoot := context.WithoutCancel(rootCtx)
 
 		// Step 1: provision

--- a/cli/azd/pkg/ext/event_dispatcher_test.go
+++ b/cli/azd/pkg/ext/event_dispatcher_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,6 +66,57 @@ func Test_Invalid_Event_Names(t *testing.T) {
 			require.ErrorIs(t, err, ErrInvalidEvent)
 		})
 	}
+}
+
+func Test_Single_Error_Preserves_Type(t *testing.T) {
+	// When exactly one handler fails, RaiseEvent must return the original error
+	// untouched so callers can recover the typed error (e.g. *azdext.LocalError or
+	// *internal.ErrorWithSuggestion) and surface its Suggestion. Regression test
+	// for https://github.com/Azure/azure-dev/issues/7706 — flattening the single
+	// error into errors.New(...) silently drops the structured payload.
+
+	t.Run("LocalError preserved with suggestion", func(t *testing.T) {
+		localErr := &azdext.LocalError{
+			Message:    "extension failed",
+			Code:       "boom",
+			Category:   azdext.LocalErrorCategoryUser,
+			Suggestion: "Try again with --debug",
+		}
+		ed := NewEventDispatcher[testEventArgs](testEvent)
+		require.NoError(t, ed.AddHandler(context.Background(), testEvent, func(
+			ctx context.Context, args testEventArgs,
+		) error {
+			return localErr
+		}))
+
+		err := ed.RaiseEvent(context.Background(), testEvent, testEventArgs{})
+		require.Error(t, err)
+
+		got, ok := errors.AsType[*azdext.LocalError](err)
+		require.True(t, ok, "expected *azdext.LocalError to survive RaiseEvent")
+		require.Same(t, localErr, got)
+		require.Equal(t, localErr.Suggestion, azdext.ErrorSuggestion(err))
+	})
+
+	t.Run("ErrorWithSuggestion preserved", func(t *testing.T) {
+		suggErr := &internal.ErrorWithSuggestion{
+			Err:        errors.New("boom"),
+			Suggestion: "Try again",
+		}
+		ed := NewEventDispatcher[testEventArgs](testEvent)
+		require.NoError(t, ed.AddHandler(context.Background(), testEvent, func(
+			ctx context.Context, args testEventArgs,
+		) error {
+			return suggErr
+		}))
+
+		err := ed.RaiseEvent(context.Background(), testEvent, testEventArgs{})
+		require.Error(t, err)
+
+		got, ok := errors.AsType[*internal.ErrorWithSuggestion](err)
+		require.True(t, ok, "expected *ErrorWithSuggestion to survive RaiseEvent")
+		require.Same(t, suggErr, got)
+	})
 }
 
 func Test_Multiple_Errors_With_Suggestions(t *testing.T) {


### PR DESCRIPTION
Resolves #7706

With this PR, extension-authored error suggestions now flow through to the user when an error is raised from a project/service event handler or a custom service target.

<img width="517" height="169" alt="image" src="https://github.com/user-attachments/assets/40a4cd06-f33f-45a2-af40-f83f42274e78" />

### What changed

- Added `links` to `ExtensionError` and round-tripped them through `WrapError` / `UnwrapError`
- Added `Links` to `azdext.LocalError` and `azdext.ServiceError`
- Fixed `UnwrapError` so structured errors with an empty `Message` are still preserved
- Broadened the middleware bypass so typed extension errors skip the YAML suggestion pipeline even when `Suggestion` is empty
- Updated the UX bridge so extension-authored links render on the host
- Added structured-error logging in `event_service.go` without changing the user-facing message
- Documented that hook status `message` should still be populated for compatibility with older hosts

### Follow-up

The broader host-side gRPC actionable error cleanup in `internal/grpcserver/server.go` is tracked separately in:

- #7844