### PR TITLE
Provide error suggestions for `AADSTS530084` and include auth error details when emitted as `ErrorWithSuggestion` in telemetry

### DIFF
--- a/cli/azd/cmd/auth_login.go
+++ b/cli/azd/cmd/auth_login.go
@@ -314,10 +314,10 @@ func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		// We print any non-setup related errors to stderr.
 		// We always return a zero exit code.
 		token, err := la.verifyLoggedIn(ctx)
-		_, loginExpiryError := errors.AsType[*auth.ReLoginRequiredError](err)
+		_, authInteractionErr := errors.AsType[auth.AuthInteractionError](err)
 		if err != nil &&
 			!errors.Is(err, auth.ErrNoCurrentUser) &&
-			!loginExpiryError {
+			!authInteractionErr {
 			fmt.Fprintln(la.console.Handles().Stderr, err.Error())
 		}
 

--- a/cli/azd/cmd/auth_login.go
+++ b/cli/azd/cmd/auth_login.go
@@ -314,10 +314,12 @@ func (la *loginAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		// We print any non-setup related errors to stderr.
 		// We always return a zero exit code.
 		token, err := la.verifyLoggedIn(ctx)
-		_, authInteractionErr := errors.AsType[auth.AuthInteractionError](err)
+		// An *internal.ErrorWithSuggestion already carries actionable, user-facing guidance
+		// surfaced through the login result; avoid double-printing the raw error.
+		_, hasSuggestion := errors.AsType[*internal.ErrorWithSuggestion](err)
 		if err != nil &&
 			!errors.Is(err, auth.ErrNoCurrentUser) &&
-			!authInteractionErr {
+			!hasSuggestion {
 			fmt.Fprintln(la.console.Handles().Stderr, err.Error())
 		}
 

--- a/cli/azd/cmd/auth_status.go
+++ b/cli/azd/cmd/auth_status.go
@@ -81,10 +81,10 @@ func (a *authStatusAction) Run(ctx context.Context) (*actions.ActionResult, erro
 
 	// get user account information
 	details, err := a.authManager.LogInDetails(ctx)
-	_, loginExpiryError := errors.AsType[*auth.ReLoginRequiredError](err)
+	_, authInteractionErr := errors.AsType[auth.AuthInteractionError](err)
 	if err != nil {
 		if !errors.Is(err, auth.ErrNoCurrentUser) &&
-			!loginExpiryError {
+			!authInteractionErr {
 			// print a useful message for unknown errors
 			fmt.Fprintln(a.console.Handles().Stderr, err.Error())
 		}

--- a/cli/azd/cmd/auth_status.go
+++ b/cli/azd/cmd/auth_status.go
@@ -81,10 +81,12 @@ func (a *authStatusAction) Run(ctx context.Context) (*actions.ActionResult, erro
 
 	// get user account information
 	details, err := a.authManager.LogInDetails(ctx)
-	_, authInteractionErr := errors.AsType[auth.AuthInteractionError](err)
+	// An *internal.ErrorWithSuggestion already carries actionable, user-facing guidance
+	// surfaced through the status result; avoid double-printing the raw error.
+	_, hasSuggestion := errors.AsType[*internal.ErrorWithSuggestion](err)
 	if err != nil {
 		if !errors.Is(err, auth.ErrNoCurrentUser) &&
-			!authInteractionErr {
+			!hasSuggestion {
 			// print a useful message for unknown errors
 			fmt.Fprintln(a.console.Handles().Stderr, err.Error())
 		}

--- a/cli/azd/internal/cmd/errors.go
+++ b/cli/azd/internal/cmd/errors.go
@@ -48,6 +48,8 @@ func MapError(err error, span tracing.Span) {
 	if updateErr, ok := errors.AsType[*update.UpdateError](err); ok {
 		errCode = updateErr.Code
 	} else if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {
+		// Auth interaction errors are classified by concrete type rather than the shared AuthInteractionError interface
+		// because each type has a distinct telemetry code.
 		errCode = "auth.login_required"
 		errDetails = append(errDetails, fields.ErrCategory.String("auth"))
 	} else if _, ok := errors.AsType[*auth.TokenProtectionBlockedError](err); ok {

--- a/cli/azd/internal/cmd/errors.go
+++ b/cli/azd/internal/cmd/errors.go
@@ -50,6 +50,9 @@ func MapError(err error, span tracing.Span) {
 	} else if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {
 		errCode = "auth.login_required"
 		errDetails = append(errDetails, fields.ErrCategory.String("auth"))
+	} else if _, ok := errors.AsType[*auth.TokenProtectionBlockedError](err); ok {
+		errCode = "auth.token_protection_blocked"
+		errDetails = append(errDetails, fields.ErrCategory.String("auth"))
 	} else if errWithSuggestion, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
 		errCode = "error.suggestion"
 		span.SetAttributes(fields.ErrType.String(classifySuggestionType(errWithSuggestion.Unwrap())))
@@ -307,6 +310,10 @@ func classifySuggestionType(err error) string {
 
 	if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {
 		return "auth.login_required"
+	}
+
+	if _, ok := errors.AsType[*auth.TokenProtectionBlockedError](err); ok {
+		return "auth.token_protection_blocked"
 	}
 
 	if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok {

--- a/cli/azd/internal/cmd/errors.go
+++ b/cli/azd/internal/cmd/errors.go
@@ -52,7 +52,11 @@ func MapError(err error, span tracing.Span) {
 		errDetails = append(errDetails, fields.ErrCategory.String("auth"))
 	} else if errWithSuggestion, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
 		errCode = "error.suggestion"
-		span.SetAttributes(fields.ErrType.String(classifySuggestionType(errWithSuggestion.Unwrap())))
+		innerErr := errWithSuggestion.Unwrap()
+		span.SetAttributes(fields.ErrType.String(classifySuggestionType(innerErr)))
+		if authFailedErr, ok := errors.AsType[*auth.AuthFailedError](innerErr); ok {
+			errDetails = append(errDetails, authFailedTelemetryDetails(authFailedErr)...)
+		}
 	} else if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok {
 		serviceName := "other"
 		statusCode := -1
@@ -173,18 +177,7 @@ func MapError(err error, span tracing.Span) {
 			errDetails = append(errDetails, fields.ToolName.String(strings.Join(toolCheckErr.ToolNames, ",")))
 		}
 	} else if authFailedErr, ok := errors.AsType[*auth.AuthFailedError](err); ok {
-		errDetails = append(errDetails, fields.ServiceName.String("aad"))
-		if authFailedErr.Parsed != nil {
-			codes := make([]string, 0, len(authFailedErr.Parsed.ErrorCodes))
-			for _, code := range authFailedErr.Parsed.ErrorCodes {
-				codes = append(codes, fmt.Sprintf("%d", code))
-			}
-			serviceErr := strings.Join(codes, ",")
-			errDetails = append(errDetails,
-				fields.ServiceStatusCode.String(authFailedErr.Parsed.Error),
-				fields.ServiceErrorCode.String(serviceErr),
-				fields.ServiceCorrelationId.String(authFailedErr.Parsed.CorrelationId))
-		}
+		errDetails = append(errDetails, authFailedTelemetryDetails(authFailedErr)...)
 		errCode = "service.aad.failed"
 	} else if errors.Is(err, auth.ErrNoCurrentUser) {
 		errCode = "auth.not_logged_in"
@@ -214,6 +207,24 @@ func MapError(err error, span tracing.Span) {
 	}
 
 	span.SetStatus(codes.Error, errCode)
+}
+
+func authFailedTelemetryDetails(authFailedErr *auth.AuthFailedError) []attribute.KeyValue {
+	errDetails := []attribute.KeyValue{fields.ServiceName.String("aad")}
+	if authFailedErr == nil || authFailedErr.Parsed == nil {
+		return errDetails
+	}
+
+	codes := make([]string, 0, len(authFailedErr.Parsed.ErrorCodes))
+	for _, code := range authFailedErr.Parsed.ErrorCodes {
+		codes = append(codes, fmt.Sprintf("%d", code))
+	}
+
+	return append(errDetails,
+		fields.ServiceStatusCode.String(authFailedErr.Parsed.Error),
+		fields.ServiceErrorCode.String(strings.Join(codes, ",")),
+		fields.ServiceCorrelationId.String(authFailedErr.Parsed.CorrelationId),
+	)
 }
 
 // classifySentinel checks if the error matches a known sentinel

--- a/cli/azd/internal/cmd/errors.go
+++ b/cli/azd/internal/cmd/errors.go
@@ -48,12 +48,7 @@ func MapError(err error, span tracing.Span) {
 	if updateErr, ok := errors.AsType[*update.UpdateError](err); ok {
 		errCode = updateErr.Code
 	} else if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {
-		// Auth interaction errors are classified by concrete type rather than the shared AuthInteractionError interface
-		// because each type has a distinct telemetry code.
 		errCode = "auth.login_required"
-		errDetails = append(errDetails, fields.ErrCategory.String("auth"))
-	} else if _, ok := errors.AsType[*auth.TokenProtectionBlockedError](err); ok {
-		errCode = "auth.token_protection_blocked"
 		errDetails = append(errDetails, fields.ErrCategory.String("auth"))
 	} else if errWithSuggestion, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
 		errCode = "error.suggestion"
@@ -312,10 +307,6 @@ func classifySuggestionType(err error) string {
 
 	if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {
 		return "auth.login_required"
-	}
-
-	if _, ok := errors.AsType[*auth.TokenProtectionBlockedError](err); ok {
-		return "auth.token_protection_blocked"
 	}
 
 	if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok {

--- a/cli/azd/internal/cmd/errors_test.go
+++ b/cli/azd/internal/cmd/errors_test.go
@@ -212,6 +212,16 @@ func Test_MapError(t *testing.T) {
 			},
 		},
 		{
+			name: "WithTokenProtectionBlockedError",
+			err: &internal.ErrorWithSuggestion{
+				Err: &auth.TokenProtectionBlockedError{},
+			},
+			wantErrReason: "auth.token_protection_blocked",
+			wantErrDetails: []attribute.KeyValue{
+				fields.ErrorKey(fields.ErrCategory.Key).String("auth"),
+			},
+		},
+		{
 			name:          "WithAzidentityAuthenticationFailedError",
 			err:           &azidentity.AuthenticationFailedError{},
 			wantErrReason: "auth.identity_failed",

--- a/cli/azd/internal/cmd/errors_test.go
+++ b/cli/azd/internal/cmd/errors_test.go
@@ -216,16 +216,21 @@ func Test_MapError(t *testing.T) {
 			err: &internal.ErrorWithSuggestion{
 				Err: &auth.AuthFailedError{
 					Parsed: &auth.AadErrorResponse{
-						Error:      "invalid_grant",
-						ErrorCodes: []int{530084},
+						Error:         "invalid_grant",
+						ErrorCodes:    []int{530084},
+						CorrelationId: "blocked-token-protection",
 					},
 				},
 			},
 			// AADSTS530084 surfaced via the suggestion wrapper still classifies as the generic
-			// AAD service failure for telemetry, matching pre-existing AuthFailedError behavior.
+			// AAD service failure for telemetry, and should preserve the wrapped AAD details.
 			wantErrReason: "error.suggestion",
 			wantErrDetails: []attribute.KeyValue{
 				fields.ErrType.String("service.aad.failed"),
+				fields.ErrorKey(fields.ServiceName.Key).String("aad"),
+				fields.ErrorKey(fields.ServiceErrorCode.Key).String("530084"),
+				fields.ErrorKey(fields.ServiceStatusCode.Key).String("invalid_grant"),
+				fields.ErrorKey(fields.ServiceCorrelationId.Key).String("blocked-token-protection"),
 			},
 		},
 		{

--- a/cli/azd/internal/cmd/errors_test.go
+++ b/cli/azd/internal/cmd/errors_test.go
@@ -212,13 +212,20 @@ func Test_MapError(t *testing.T) {
 			},
 		},
 		{
-			name: "WithTokenProtectionBlockedError",
+			name: "WithTokenProtectionBlockedAuthFailedError",
 			err: &internal.ErrorWithSuggestion{
-				Err: &auth.TokenProtectionBlockedError{},
+				Err: &auth.AuthFailedError{
+					Parsed: &auth.AadErrorResponse{
+						Error:      "invalid_grant",
+						ErrorCodes: []int{530084},
+					},
+				},
 			},
-			wantErrReason: "auth.token_protection_blocked",
+			// AADSTS530084 surfaced via the suggestion wrapper still classifies as the generic
+			// AAD service failure for telemetry, matching pre-existing AuthFailedError behavior.
+			wantErrReason: "error.suggestion",
 			wantErrDetails: []attribute.KeyValue{
-				fields.ErrorKey(fields.ErrCategory.Key).String("auth"),
+				fields.ErrType.String("service.aad.failed"),
 			},
 		},
 		{

--- a/cli/azd/internal/grpcserver/server.go
+++ b/cli/azd/internal/grpcserver/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -268,9 +269,9 @@ func (s *authenticatedStream) Context() context.Context {
 // This ensures that helpful suggestions (like "run azd auth login") are preserved
 // when errors are transmitted over gRPC, where only the error message string is sent.
 //
-// Auth-related errors are returned with gRPC auth-adjacent status codes so extensions can
-// distinguish failures that can be fixed by re-authentication from policy blocks that require
-// administrator action.
+// Auth-related errors are returned with codes.Unauthenticated and a structured
+// ErrorInfo reason so extensions can reliably classify them as auth failures
+// while still distinguishing the remediation path.
 func wrapErrorWithSuggestion(err error) error {
 	if err == nil {
 		return nil
@@ -278,29 +279,54 @@ func wrapErrorWithSuggestion(err error) error {
 
 	_, authInteractionErr := errors.AsType[auth.AuthInteractionError](err)
 	isAuthErr := errors.Is(err, auth.ErrNoCurrentUser) || authInteractionErr
-	authCode := grpcAuthCode(err)
 
 	if suggestionErr, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
 		msg := fmt.Sprintf("%s\n%s", err.Error(), suggestionErr.Suggestion)
 		if isAuthErr {
-			return status.Error(authCode, msg)
+			return grpcAuthStatus(err, msg)
 		}
 		return fmt.Errorf("%w\n%s", err, suggestionErr.Suggestion)
 	}
 
 	if isAuthErr {
-		return status.Error(authCode, err.Error())
+		return grpcAuthStatus(err, err.Error())
 	}
 
 	return err
 }
 
-func grpcAuthCode(err error) codes.Code {
-	if _, ok := errors.AsType[*auth.TokenProtectionBlockedError](err); ok {
-		return codes.PermissionDenied
+func grpcAuthStatus(err error, msg string) error {
+	st := status.New(codes.Unauthenticated, msg)
+	reason := grpcAuthReason(err)
+	if reason == "" {
+		return st.Err()
 	}
 
-	return codes.Unauthenticated
+	withDetails, detailErr := st.WithDetails(&errdetails.ErrorInfo{
+		Reason: reason,
+		Domain: azdext.AuthErrorDomain,
+	})
+	if detailErr != nil {
+		return st.Err()
+	}
+
+	return withDetails.Err()
+}
+
+func grpcAuthReason(err error) string {
+	if errors.Is(err, auth.ErrNoCurrentUser) {
+		return azdext.AuthErrorReasonNotLoggedIn
+	}
+
+	if _, ok := errors.AsType[*auth.TokenProtectionBlockedError](err); ok {
+		return azdext.AuthErrorReasonTokenProtectionBlocked
+	}
+
+	if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {
+		return azdext.AuthErrorReasonLoginRequired
+	}
+
+	return ""
 }
 
 func generateSigningKey() ([]byte, error) {

--- a/cli/azd/internal/grpcserver/server.go
+++ b/cli/azd/internal/grpcserver/server.go
@@ -268,8 +268,9 @@ func (s *authenticatedStream) Context() context.Context {
 // This ensures that helpful suggestions (like "run azd auth login") are preserved
 // when errors are transmitted over gRPC, where only the error message string is sent.
 //
-// Auth-related errors (any auth.AuthInteractionError, ErrNoCurrentUser) are returned with
-// codes.Unauthenticated so that extensions can detect auth failures via gRPC status code.
+// Auth-related errors are returned with gRPC auth-adjacent status codes so extensions can
+// distinguish failures that can be fixed by re-authentication from policy blocks that require
+// administrator action.
 func wrapErrorWithSuggestion(err error) error {
 	if err == nil {
 		return nil
@@ -277,20 +278,29 @@ func wrapErrorWithSuggestion(err error) error {
 
 	_, authInteractionErr := errors.AsType[auth.AuthInteractionError](err)
 	isAuthErr := errors.Is(err, auth.ErrNoCurrentUser) || authInteractionErr
+	authCode := grpcAuthCode(err)
 
 	if suggestionErr, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
 		msg := fmt.Sprintf("%s\n%s", err.Error(), suggestionErr.Suggestion)
 		if isAuthErr {
-			return status.Error(codes.Unauthenticated, msg)
+			return status.Error(authCode, msg)
 		}
 		return fmt.Errorf("%w\n%s", err, suggestionErr.Suggestion)
 	}
 
 	if isAuthErr {
-		return status.Error(codes.Unauthenticated, err.Error())
+		return status.Error(authCode, err.Error())
 	}
 
 	return err
+}
+
+func grpcAuthCode(err error) codes.Code {
+	if _, ok := errors.AsType[*auth.TokenProtectionBlockedError](err); ok {
+		return codes.PermissionDenied
+	}
+
+	return codes.Unauthenticated
 }
 
 func generateSigningKey() ([]byte, error) {

--- a/cli/azd/internal/grpcserver/server.go
+++ b/cli/azd/internal/grpcserver/server.go
@@ -268,15 +268,15 @@ func (s *authenticatedStream) Context() context.Context {
 // This ensures that helpful suggestions (like "run azd auth login") are preserved
 // when errors are transmitted over gRPC, where only the error message string is sent.
 //
-// Auth-related errors (ReLoginRequiredError, ErrNoCurrentUser) are returned with
+// Auth-related errors (any auth.AuthInteractionError, ErrNoCurrentUser) are returned with
 // codes.Unauthenticated so that extensions can detect auth failures via gRPC status code.
 func wrapErrorWithSuggestion(err error) error {
 	if err == nil {
 		return nil
 	}
 
-	_, loginErr := errors.AsType[*auth.ReLoginRequiredError](err)
-	isAuthErr := errors.Is(err, auth.ErrNoCurrentUser) || loginErr
+	_, authInteractionErr := errors.AsType[auth.AuthInteractionError](err)
+	isAuthErr := errors.Is(err, auth.ErrNoCurrentUser) || authInteractionErr
 
 	if suggestionErr, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
 		msg := fmt.Sprintf("%s\n%s", err.Error(), suggestionErr.Suggestion)

--- a/cli/azd/internal/grpcserver/server.go
+++ b/cli/azd/internal/grpcserver/server.go
@@ -277,8 +277,7 @@ func wrapErrorWithSuggestion(err error) error {
 		return nil
 	}
 
-	_, authInteractionErr := errors.AsType[auth.AuthInteractionError](err)
-	isAuthErr := errors.Is(err, auth.ErrNoCurrentUser) || authInteractionErr
+	isAuthErr := isAuthError(err)
 
 	if suggestionErr, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
 		msg := fmt.Sprintf("%s\n%s", err.Error(), suggestionErr.Suggestion)
@@ -293,6 +292,21 @@ func wrapErrorWithSuggestion(err error) error {
 	}
 
 	return err
+}
+
+// isAuthError reports whether err's chain contains a known auth-failure type that should be
+// surfaced over gRPC as codes.Unauthenticated.
+func isAuthError(err error) bool {
+	if errors.Is(err, auth.ErrNoCurrentUser) {
+		return true
+	}
+	if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*auth.AuthFailedError](err); ok {
+		return true
+	}
+	return false
 }
 
 func grpcAuthStatus(err error, msg string) error {
@@ -318,8 +332,12 @@ func grpcAuthReason(err error) string {
 		return azdext.AuthErrorReasonNotLoggedIn
 	}
 
-	if _, ok := errors.AsType[*auth.TokenProtectionBlockedError](err); ok {
-		return azdext.AuthErrorReasonTokenProtectionBlocked
+	// Pass through the originating AAD error code (e.g., "AADSTS530084") when available.
+	// This preserves Entra's own semantics rather than redefining them on azd's side.
+	if authFailed, ok := errors.AsType[*auth.AuthFailedError](err); ok {
+		if authFailed.Parsed != nil && len(authFailed.Parsed.ErrorCodes) > 0 {
+			return fmt.Sprintf("AADSTS%d", authFailed.Parsed.ErrorCodes[0])
+		}
 	}
 
 	if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {

--- a/cli/azd/internal/grpcserver/server_coverage3_test.go
+++ b/cli/azd/internal/grpcserver/server_coverage3_test.go
@@ -77,6 +77,16 @@ func TestWrapErrorWithSuggestion_ReLoginRequired(t *testing.T) {
 	require.Equal(t, codes.Unauthenticated, st.Code())
 }
 
+func TestWrapErrorWithSuggestion_TokenProtectionBlocked(t *testing.T) {
+	t.Parallel()
+	err := fmt.Errorf("token protection: %w", &auth.TokenProtectionBlockedError{})
+
+	wrapped := wrapErrorWithSuggestion(err)
+	st, ok := status.FromError(wrapped)
+	require.True(t, ok)
+	require.Equal(t, codes.PermissionDenied, st.Code())
+}
+
 func TestWrapErrorWithSuggestion_AuthErrorWithSuggestion(t *testing.T) {
 	t.Parallel()
 	inner := auth.ErrNoCurrentUser

--- a/cli/azd/internal/grpcserver/server_coverage3_test.go
+++ b/cli/azd/internal/grpcserver/server_coverage3_test.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -84,7 +86,13 @@ func TestWrapErrorWithSuggestion_TokenProtectionBlocked(t *testing.T) {
 	wrapped := wrapErrorWithSuggestion(err)
 	st, ok := status.FromError(wrapped)
 	require.True(t, ok)
-	require.Equal(t, codes.PermissionDenied, st.Code())
+	require.Equal(t, codes.Unauthenticated, st.Code())
+	details := st.Details()
+	require.Len(t, details, 1)
+	info, ok := details[0].(*errdetails.ErrorInfo)
+	require.True(t, ok)
+	require.Equal(t, azdext.AuthErrorDomain, info.Domain)
+	require.Equal(t, azdext.AuthErrorReasonTokenProtectionBlocked, info.Reason)
 }
 
 func TestWrapErrorWithSuggestion_AuthErrorWithSuggestion(t *testing.T) {

--- a/cli/azd/internal/grpcserver/server_coverage3_test.go
+++ b/cli/azd/internal/grpcserver/server_coverage3_test.go
@@ -81,7 +81,18 @@ func TestWrapErrorWithSuggestion_ReLoginRequired(t *testing.T) {
 
 func TestWrapErrorWithSuggestion_TokenProtectionBlocked(t *testing.T) {
 	t.Parallel()
-	err := fmt.Errorf("token protection: %w", &auth.TokenProtectionBlockedError{})
+	authFailed := &auth.AuthFailedError{
+		Parsed: &auth.AadErrorResponse{
+			Error:      "invalid_grant",
+			ErrorCodes: []int{530084},
+		},
+	}
+	// In production the wrapper is built by newActionableAuthError; mirror that shape here so
+	// wrapErrorWithSuggestion classifies the wrapped *AuthFailedError as an auth interaction.
+	err := fmt.Errorf("token protection: %w", &internal.ErrorWithSuggestion{
+		Err:        authFailed,
+		Suggestion: "Contact your IT administrator or request a policy exception.",
+	})
 
 	wrapped := wrapErrorWithSuggestion(err)
 	st, ok := status.FromError(wrapped)
@@ -92,7 +103,7 @@ func TestWrapErrorWithSuggestion_TokenProtectionBlocked(t *testing.T) {
 	info, ok := details[0].(*errdetails.ErrorInfo)
 	require.True(t, ok)
 	require.Equal(t, azdext.AuthErrorDomain, info.Domain)
-	require.Equal(t, azdext.AuthErrorReasonTokenProtectionBlocked, info.Reason)
+	require.Equal(t, "AADSTS530084", info.Reason)
 }
 
 func TestWrapErrorWithSuggestion_AuthErrorWithSuggestion(t *testing.T) {

--- a/cli/azd/internal/grpcserver/server_test.go
+++ b/cli/azd/internal/grpcserver/server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -237,6 +238,7 @@ func Test_wrapErrorWithSuggestion(t *testing.T) {
 		wantContain      string
 		wantSameInstance bool
 		wantGrpcCode     codes.Code
+		wantAuthReason   string
 	}{
 		{
 			name:    "nil error returns nil",
@@ -266,16 +268,18 @@ func Test_wrapErrorWithSuggestion(t *testing.T) {
 			wantContain: "azd auth login",
 		},
 		{
-			name:         "ErrNoCurrentUser returns Unauthenticated",
-			err:          auth.ErrNoCurrentUser,
-			wantContain:  "not logged in",
-			wantGrpcCode: codes.Unauthenticated,
+			name:           "ErrNoCurrentUser returns Unauthenticated",
+			err:            auth.ErrNoCurrentUser,
+			wantContain:    "not logged in",
+			wantGrpcCode:   codes.Unauthenticated,
+			wantAuthReason: azdext.AuthErrorReasonNotLoggedIn,
 		},
 		{
-			name:         "wrapped ErrNoCurrentUser returns Unauthenticated",
-			err:          fmt.Errorf("failed to list subscriptions: %w", auth.ErrNoCurrentUser),
-			wantContain:  "not logged in",
-			wantGrpcCode: codes.Unauthenticated,
+			name:           "wrapped ErrNoCurrentUser returns Unauthenticated",
+			err:            fmt.Errorf("failed to list subscriptions: %w", auth.ErrNoCurrentUser),
+			wantContain:    "not logged in",
+			wantGrpcCode:   codes.Unauthenticated,
+			wantAuthReason: azdext.AuthErrorReasonNotLoggedIn,
 		},
 		{
 			name: "ReLoginRequiredError with suggestion returns Unauthenticated",
@@ -283,17 +287,19 @@ func Test_wrapErrorWithSuggestion(t *testing.T) {
 				Err:        &auth.ReLoginRequiredError{},
 				Suggestion: "login expired, run `azd auth login` to acquire a new token.",
 			},
-			wantContain:  "azd auth login",
-			wantGrpcCode: codes.Unauthenticated,
+			wantContain:    "azd auth login",
+			wantGrpcCode:   codes.Unauthenticated,
+			wantAuthReason: azdext.AuthErrorReasonLoginRequired,
 		},
 		{
-			name: "TokenProtectionBlockedError with suggestion returns PermissionDenied",
+			name: "TokenProtectionBlockedError with suggestion returns Unauthenticated",
 			err: &internal.ErrorWithSuggestion{
 				Err:        &auth.TokenProtectionBlockedError{},
 				Suggestion: "Contact your IT administrator or request a policy exception.",
 			},
-			wantContain:  "policy exception",
-			wantGrpcCode: codes.PermissionDenied,
+			wantContain:    "policy exception",
+			wantGrpcCode:   codes.Unauthenticated,
+			wantAuthReason: azdext.AuthErrorReasonTokenProtectionBlocked,
 		},
 	}
 
@@ -313,6 +319,14 @@ func Test_wrapErrorWithSuggestion(t *testing.T) {
 				st, ok := status.FromError(result)
 				require.True(t, ok, "expected gRPC status error")
 				require.Equal(t, tt.wantGrpcCode, st.Code())
+				if tt.wantAuthReason != "" {
+					details := st.Details()
+					require.Len(t, details, 1)
+					info, ok := details[0].(*errdetails.ErrorInfo)
+					require.True(t, ok, "expected ErrorInfo detail")
+					require.Equal(t, azdext.AuthErrorDomain, info.Domain)
+					require.Equal(t, tt.wantAuthReason, info.Reason)
+				}
 			}
 		})
 	}

--- a/cli/azd/internal/grpcserver/server_test.go
+++ b/cli/azd/internal/grpcserver/server_test.go
@@ -286,6 +286,15 @@ func Test_wrapErrorWithSuggestion(t *testing.T) {
 			wantContain:  "azd auth login",
 			wantGrpcCode: codes.Unauthenticated,
 		},
+		{
+			name: "TokenProtectionBlockedError with suggestion returns PermissionDenied",
+			err: &internal.ErrorWithSuggestion{
+				Err:        &auth.TokenProtectionBlockedError{},
+				Suggestion: "Contact your IT administrator or request a policy exception.",
+			},
+			wantContain:  "policy exception",
+			wantGrpcCode: codes.PermissionDenied,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cli/azd/internal/grpcserver/server_test.go
+++ b/cli/azd/internal/grpcserver/server_test.go
@@ -294,12 +294,17 @@ func Test_wrapErrorWithSuggestion(t *testing.T) {
 		{
 			name: "TokenProtectionBlockedError with suggestion returns Unauthenticated",
 			err: &internal.ErrorWithSuggestion{
-				Err:        &auth.TokenProtectionBlockedError{},
+				Err: &auth.AuthFailedError{
+					Parsed: &auth.AadErrorResponse{
+						Error:      "invalid_grant",
+						ErrorCodes: []int{530084},
+					},
+				},
 				Suggestion: "Contact your IT administrator or request a policy exception.",
 			},
 			wantContain:    "policy exception",
 			wantGrpcCode:   codes.Unauthenticated,
-			wantAuthReason: azdext.AuthErrorReasonTokenProtectionBlocked,
+			wantAuthReason: "AADSTS530084",
 		},
 	}
 

--- a/cli/azd/pkg/auth/azd_credential.go
+++ b/cli/azd/pkg/auth/azd_credential.go
@@ -75,7 +75,7 @@ func (c *azdCredential) GetToken(ctx context.Context, options policy.TokenReques
 		c.cacheTracer.LogSnapshotOnce(failurePhase)
 
 		if authFailed, ok := errors.AsType[*AuthFailedError](err); ok {
-			if loginErr, ok := newReLoginRequiredError(authFailed.Parsed, options.Scopes, c.cloud, tenantID); ok {
+			if loginErr, ok := newActionableAuthError(authFailed.Parsed, options.Scopes, c.cloud, tenantID); ok {
 				log.Println(authFailed.httpErrorDetails())
 
 				if options.Claims != "" {

--- a/cli/azd/pkg/auth/azd_credential.go
+++ b/cli/azd/pkg/auth/azd_credential.go
@@ -75,7 +75,7 @@ func (c *azdCredential) GetToken(ctx context.Context, options policy.TokenReques
 		c.cacheTracer.LogSnapshotOnce(failurePhase)
 
 		if authFailed, ok := errors.AsType[*AuthFailedError](err); ok {
-			if loginErr, ok := newActionableAuthError(authFailed.Parsed, options.Scopes, c.cloud, tenantID); ok {
+			if loginErr, ok := newActionableAuthError(authFailed.Parsed, options.Scopes, c.cloud, tenantID, authFailed); ok {
 				log.Println(authFailed.httpErrorDetails())
 
 				if options.Claims != "" {

--- a/cli/azd/pkg/auth/claims_test.go
+++ b/cli/azd/pkg/auth/claims_test.go
@@ -436,7 +436,7 @@ func TestNewReLoginRequiredError(t *testing.T) {
 
 	t.Run("nil_response_returns_false", func(t *testing.T) {
 		t.Parallel()
-		err, ok := newReLoginRequiredError(
+		err, ok := newActionableAuthError(
 			nil, nil, cloud.AzurePublic(), "")
 		assert.Nil(t, err)
 		assert.False(t, ok)
@@ -448,7 +448,7 @@ func TestNewReLoginRequiredError(t *testing.T) {
 			Error:            "server_error",
 			ErrorDescription: "something else",
 		}
-		err, ok := newReLoginRequiredError(
+		err, ok := newActionableAuthError(
 			resp, nil, cloud.AzurePublic(), "")
 		assert.Nil(t, err)
 		assert.False(t, ok)
@@ -460,7 +460,7 @@ func TestNewReLoginRequiredError(t *testing.T) {
 			Error:            "invalid_grant",
 			ErrorDescription: "AADSTS700082: expired",
 		}
-		err, ok := newReLoginRequiredError(
+		err, ok := newActionableAuthError(
 			resp,
 			[]string{"https://management.azure.com//.default"},
 			cloud.AzurePublic(),
@@ -477,7 +477,7 @@ func TestNewReLoginRequiredError(t *testing.T) {
 			Error:            "interaction_required",
 			ErrorDescription: "need consent",
 		}
-		err, ok := newReLoginRequiredError(
+		err, ok := newActionableAuthError(
 			resp,
 			[]string{"https://management.azure.com//.default"},
 			cloud.AzurePublic(),
@@ -493,7 +493,7 @@ func TestNewReLoginRequiredError(t *testing.T) {
 			Error:            "invalid_grant",
 			ErrorDescription: "expired",
 		}
-		err, ok := newReLoginRequiredError(
+		err, ok := newActionableAuthError(
 			resp,
 			[]string{
 				"https://management.azure.com//.default",
@@ -514,7 +514,7 @@ func TestNewReLoginRequiredError(t *testing.T) {
 			ErrorDescription: "AADSTS70043: expired",
 			ErrorCodes:       []int{70043},
 		}
-		err, ok := newReLoginRequiredError(
+		err, ok := newActionableAuthError(
 			resp, nil, cloud.AzurePublic(), "")
 		assert.True(t, ok)
 		require.Error(t, err)
@@ -527,7 +527,7 @@ func TestNewReLoginRequiredError(t *testing.T) {
 			ErrorDescription: "AADSTS700082: expired",
 			ErrorCodes:       []int{700082},
 		}
-		err, ok := newReLoginRequiredError(resp, nil, cloud.AzurePublic(), "")
+		err, ok := newActionableAuthError(resp, nil, cloud.AzurePublic(), "")
 		assert.True(t, ok)
 		require.Error(t, err)
 
@@ -543,7 +543,7 @@ func TestNewReLoginRequiredError(t *testing.T) {
 			ErrorDescription: "conditional access",
 			ErrorCodes:       []int{50005},
 		}
-		err, ok := newReLoginRequiredError(
+		err, ok := newActionableAuthError(
 			resp, nil, cloud.AzurePublic(), "")
 		assert.True(t, ok)
 		require.Error(t, err)
@@ -557,7 +557,7 @@ func TestNewReLoginRequiredError(t *testing.T) {
 			ErrorCodes:       []int{70043},
 		}
 		tenantID := "72f988bf-86f1-41af-91ab-2d7cd011db47"
-		err, ok := newReLoginRequiredError(
+		err, ok := newActionableAuthError(
 			resp, nil, cloud.AzurePublic(), tenantID)
 		assert.True(t, ok)
 		require.Error(t, err)

--- a/cli/azd/pkg/auth/claims_test.go
+++ b/cli/azd/pkg/auth/claims_test.go
@@ -431,7 +431,7 @@ func TestReLoginRequiredError_NonRetriable(t *testing.T) {
 	e.NonRetriable() // marker — should not panic
 }
 
-func TestNewReLoginRequiredError(t *testing.T) {
+func TestNewActionableAuthError_ClaimsScenarios(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil_response_returns_false", func(t *testing.T) {
@@ -533,6 +533,7 @@ func TestNewReLoginRequiredError(t *testing.T) {
 
 		var errWithSuggestion *internal.ErrorWithSuggestion
 		require.True(t, errors.As(err, &errWithSuggestion))
+		assert.Equal(t, "Login expired.", errWithSuggestion.Message)
 		assert.Contains(t, errWithSuggestion.Suggestion, "login expired")
 	})
 
@@ -547,6 +548,13 @@ func TestNewReLoginRequiredError(t *testing.T) {
 			resp, nil, cloud.AzurePublic(), "")
 		assert.True(t, ok)
 		require.Error(t, err)
+
+		errWithSuggestion, ok := errors.AsType[*internal.ErrorWithSuggestion](err)
+		require.True(t, ok)
+		assert.Equal(t, "Reauthentication required.", errWithSuggestion.Message)
+		require.Len(t, errWithSuggestion.Links, 1)
+		assert.Equal(t, "https://aka.ms/azd/troubleshoot/conditional-access-policy", errWithSuggestion.Links[0].URL)
+		assert.Equal(t, "Conditional Access policy troubleshooting", errWithSuggestion.Links[0].Title)
 	})
 
 	t.Run("tenant_id_included_in_suggestion", func(t *testing.T) {

--- a/cli/azd/pkg/auth/claims_test.go
+++ b/cli/azd/pkg/auth/claims_test.go
@@ -437,7 +437,7 @@ func TestNewActionableAuthError_ClaimsScenarios(t *testing.T) {
 	t.Run("nil_response_returns_false", func(t *testing.T) {
 		t.Parallel()
 		err, ok := newActionableAuthError(
-			nil, nil, cloud.AzurePublic(), "")
+			nil, nil, cloud.AzurePublic(), "", nil)
 		assert.Nil(t, err)
 		assert.False(t, ok)
 	})
@@ -449,7 +449,7 @@ func TestNewActionableAuthError_ClaimsScenarios(t *testing.T) {
 			ErrorDescription: "something else",
 		}
 		err, ok := newActionableAuthError(
-			resp, nil, cloud.AzurePublic(), "")
+			resp, nil, cloud.AzurePublic(), "", nil)
 		assert.Nil(t, err)
 		assert.False(t, ok)
 	})
@@ -465,6 +465,7 @@ func TestNewActionableAuthError_ClaimsScenarios(t *testing.T) {
 			[]string{"https://management.azure.com//.default"},
 			cloud.AzurePublic(),
 			"",
+			nil,
 		)
 		assert.True(t, ok)
 		require.Error(t, err)
@@ -482,6 +483,7 @@ func TestNewActionableAuthError_ClaimsScenarios(t *testing.T) {
 			[]string{"https://management.azure.com//.default"},
 			cloud.AzurePublic(),
 			"",
+			nil,
 		)
 		assert.True(t, ok)
 		require.Error(t, err)
@@ -501,6 +503,7 @@ func TestNewActionableAuthError_ClaimsScenarios(t *testing.T) {
 			},
 			cloud.AzurePublic(),
 			"",
+			nil,
 		)
 		assert.True(t, ok)
 		require.Error(t, err)
@@ -515,7 +518,7 @@ func TestNewActionableAuthError_ClaimsScenarios(t *testing.T) {
 			ErrorCodes:       []int{70043},
 		}
 		err, ok := newActionableAuthError(
-			resp, nil, cloud.AzurePublic(), "")
+			resp, nil, cloud.AzurePublic(), "", nil)
 		assert.True(t, ok)
 		require.Error(t, err)
 	})
@@ -527,7 +530,7 @@ func TestNewActionableAuthError_ClaimsScenarios(t *testing.T) {
 			ErrorDescription: "AADSTS700082: expired",
 			ErrorCodes:       []int{700082},
 		}
-		err, ok := newActionableAuthError(resp, nil, cloud.AzurePublic(), "")
+		err, ok := newActionableAuthError(resp, nil, cloud.AzurePublic(), "", nil)
 		assert.True(t, ok)
 		require.Error(t, err)
 
@@ -545,7 +548,7 @@ func TestNewActionableAuthError_ClaimsScenarios(t *testing.T) {
 			ErrorCodes:       []int{50005},
 		}
 		err, ok := newActionableAuthError(
-			resp, nil, cloud.AzurePublic(), "")
+			resp, nil, cloud.AzurePublic(), "", nil)
 		assert.True(t, ok)
 		require.Error(t, err)
 
@@ -566,7 +569,7 @@ func TestNewActionableAuthError_ClaimsScenarios(t *testing.T) {
 		}
 		tenantID := "72f988bf-86f1-41af-91ab-2d7cd011db47"
 		err, ok := newActionableAuthError(
-			resp, nil, cloud.AzurePublic(), tenantID)
+			resp, nil, cloud.AzurePublic(), tenantID, nil)
 		assert.True(t, ok)
 		require.Error(t, err)
 

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -46,9 +46,16 @@ type TokenProtectionBlockedError struct {
 	errText string
 }
 
-// newReLoginRequiredError returns an error if the response indicates that the user needs to reauthenticate.
-// If it is not a reauthentication error, it returns false.
-func newReLoginRequiredError(
+// newActionableAuthError inspects an AAD error response and, if it matches a known
+// pattern that azd can surface with actionable guidance, returns a wrapped error and true.
+//
+// The returned error may be a *ReLoginRequiredError (the user should rerun `azd auth login`)
+// or a *TokenProtectionBlockedError (Conditional Access token protection blocked the request
+// and re-authenticating will not help). Callers must not assume the result always implies
+// re-authentication — inspect the underlying error type if behavior needs to differ.
+//
+// If the response does not match a known pattern, it returns (nil, false).
+func newActionableAuthError(
 	response *AadErrorResponse,
 	scopes []string,
 	cloud *cloud.Cloud,

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -41,18 +41,35 @@ type ReLoginRequiredError struct {
 
 // TokenProtectionBlockedError indicates that the token request was blocked by
 // an organization's Conditional Access token protection policy (AADSTS530084), and until #7704 is addressed,
-// re-authenticating with azd won't help.
+// re-running `azd auth login` won't help.
 type TokenProtectionBlockedError struct {
 	errText string
 }
+
+// AuthInteractionError marks AAD-classified, non-retriable errors that carry
+// user-facing guidance via *internal.ErrorWithSuggestion. Callers that just need
+// to know "this is an actionable auth failure" (e.g., gRPC status mapping or
+// suppressing the raw error in `azd auth status` / `--only-check-status` flows)
+// should type-assert against this interface so future variants don't require
+// touching every callsite.
+//
+// The interface is sealed via an unexported marker method; only types declared
+// in this package may implement it.
+type AuthInteractionError interface {
+	error
+	isAuthInteractionError()
+}
+
+func (*ReLoginRequiredError) isAuthInteractionError()        {}
+func (*TokenProtectionBlockedError) isAuthInteractionError() {}
 
 // newActionableAuthError inspects an AAD error response and, if it matches a known
 // pattern that azd can surface with actionable guidance, returns a wrapped error and true.
 //
 // The returned error may be a *ReLoginRequiredError (the user should rerun `azd auth login`)
 // or a *TokenProtectionBlockedError (Conditional Access token protection blocked the request
-// and re-authenticating will not help). Callers must not assume the result always implies
-// re-authentication — inspect the underlying error type if behavior needs to differ.
+// and re-running `azd auth login` will not help). Callers must not assume the result always
+// implies the user can simply log in again — inspect the underlying error type if behavior needs to differ.
 //
 // If the response does not match a known pattern, it returns (nil, false).
 func newActionableAuthError(

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -12,10 +12,12 @@ import (
 	"log"
 	"net/http"
 	"slices"
+	"strings"
 
 	msal "github.com/AzureAD/microsoft-authentication-library-for-go/apps/errors"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
+	"github.com/azure/azure-dev/cli/azd/pkg/errorhandler"
 )
 
 // ErrNoCurrentUser indicates that the current user is not logged in.
@@ -37,6 +39,13 @@ type ReLoginRequiredError struct {
 	helpLink string
 }
 
+// TokenProtectionBlockedError indicates that the token request was blocked by
+// an organization's Conditional Access token protection policy (AADSTS530084)
+// and reauthenticating with azd won't help.
+type TokenProtectionBlockedError struct {
+	errText string
+}
+
 // newReLoginRequiredError returns an error if the response indicates that the user needs to reauthenticate.
 // If it is not a reauthentication error, it returns false.
 func newReLoginRequiredError(
@@ -47,6 +56,10 @@ func newReLoginRequiredError(
 ) (error, bool) {
 	if response == nil {
 		return nil, false
+	}
+
+	if err, ok := newTokenProtectionBlockedError(response, scopes); ok {
+		return err, true
 	}
 
 	//nolint:lll
@@ -69,6 +82,50 @@ func newReLoginRequiredError(
 	}
 
 	return nil, false
+}
+
+const (
+	conditionalAccessDocsLink = "https://aka.ms/TBCADocs"
+	tokenProtectionFAQLink    = "https://aka.ms/TokenProtectionFAQ#troubleshooting"
+)
+
+func newTokenProtectionBlockedError(response *AadErrorResponse, scopes []string) (error, bool) {
+	if response == nil {
+		return nil, false
+	}
+
+	if !slices.Contains(response.ErrorCodes, 530084) {
+		return nil, false
+	}
+
+	message := "A Conditional Access token protection policy blocked this token request."
+	if usesGraphScope(scopes) {
+		message = "A Conditional Access token protection policy blocked this Microsoft Graph token request."
+	}
+
+	return &internal.ErrorWithSuggestion{
+		Err: &TokenProtectionBlockedError{
+			errText: response.ErrorDescription,
+		},
+		Message:    message,
+		Suggestion: "Contact your IT administrator or request a policy exception.",
+		Links: []errorhandler.ErrorLink{
+			{
+				URL:   conditionalAccessDocsLink,
+				Title: "Conditional Access token protection guidance",
+			},
+			{
+				URL:   tokenProtectionFAQLink,
+				Title: "Token protection FAQ",
+			},
+		},
+	}, true
+}
+
+func usesGraphScope(scopes []string) bool {
+	return slices.ContainsFunc(scopes, func(scope string) bool {
+		return strings.HasPrefix(scope, "https://graph.microsoft.com/")
+	})
 }
 
 func (e *ReLoginRequiredError) init(
@@ -111,8 +168,16 @@ func (e *ReLoginRequiredError) Error() string {
 	return e.errText
 }
 
+func (e *TokenProtectionBlockedError) Error() string {
+	return e.errText
+}
+
 // Marker method to indicate this as non-retriable when executed within an armruntime pipeline
 func (e *ReLoginRequiredError) NonRetriable() {
+}
+
+// Marker method to indicate this as non-retriable when executed within an armruntime pipeline
+func (e *TokenProtectionBlockedError) NonRetriable() {
 }
 
 const authFailedPrefix string = "failed to authenticate"

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -40,8 +40,8 @@ type ReLoginRequiredError struct {
 }
 
 // TokenProtectionBlockedError indicates that the token request was blocked by
-// an organization's Conditional Access token protection policy (AADSTS530084)
-// and reauthenticating with azd won't help.
+// an organization's Conditional Access token protection policy (AADSTS530084), and until #7704 is addressed,
+// re-authenticating with azd won't help.
 type TokenProtectionBlockedError struct {
 	errText string
 }
@@ -86,7 +86,8 @@ func newReLoginRequiredError(
 
 const (
 	conditionalAccessDocsLink = "https://aka.ms/TBCADocs"
-	tokenProtectionFAQLink    = "https://aka.ms/TokenProtectionFAQ#troubleshooting"
+	// #nosec G101 -- documentation URL, not a credential.
+	tokenProtectionFAQLink = "https://aka.ms/TokenProtectionFAQ#troubleshooting"
 )
 
 func newTokenProtectionBlockedError(response *AadErrorResponse, scopes []string) (error, bool) {

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -36,7 +36,7 @@ type ReLoginRequiredError struct {
 
 	errText string
 
-	helpLink string
+	helpLink *errorhandler.ErrorLink
 }
 
 // TokenProtectionBlockedError indicates that the token request was blocked by
@@ -50,8 +50,8 @@ type TokenProtectionBlockedError struct {
 // user-facing guidance via *internal.ErrorWithSuggestion. Callers that just need
 // to know "this is an actionable auth failure" (e.g., gRPC status mapping or
 // suppressing the raw error in `azd auth status` / `--only-check-status` flows)
-// should type-assert against this interface so future variants don't require
-// touching every call site.
+// should use errors.AsType[AuthInteractionError](err) so future variants don't
+// require touching every call site.
 //
 // The interface is sealed via an unexported marker method; only types declared
 // in this package may implement it.
@@ -96,13 +96,15 @@ func newActionableAuthError(
 		// Note: Do not prefix with "Suggestion:" here — the UX renderer
 		// (ErrorWithSuggestion.ToString) already adds that prefix when displaying.
 		suggestion := fmt.Sprintf("%s, run `%s` to acquire a new token.", err.scenario, err.loginCmd)
-		if err.helpLink != "" {
-			suggestion += fmt.Sprintf(" See %s for more info.", err.helpLink)
-		}
-		return &internal.ErrorWithSuggestion{
+		suggestionErr := &internal.ErrorWithSuggestion{
 			Err:        &err,
+			Message:    scenarioMessage(err.scenario),
 			Suggestion: suggestion,
-		}, true
+		}
+		if err.helpLink != nil {
+			suggestionErr.Links = []errorhandler.ErrorLink{*err.helpLink}
+		}
+		return suggestionErr, true
 	}
 
 	return nil, false
@@ -153,6 +155,14 @@ func usesGraphScope(scopes []string) bool {
 	})
 }
 
+func scenarioMessage(scenario string) string {
+	if scenario == "" {
+		return ""
+	}
+
+	return strings.ToUpper(scenario[:1]) + scenario[1:] + "."
+}
+
 func (e *ReLoginRequiredError) init(
 	response *AadErrorResponse,
 	scopes []string,
@@ -185,7 +195,10 @@ func (e *ReLoginRequiredError) init(
 	// getting tokens if the Entra tenant has Conditional Access Policies set.
 	if slices.Contains(response.ErrorCodes, 50005) {
 		e.loginCmd += " --use-device-code=false"
-		e.helpLink = "https://aka.ms/azd/troubleshoot/conditional-access-policy"
+		e.helpLink = &errorhandler.ErrorLink{
+			URL:   "https://aka.ms/azd/troubleshoot/conditional-access-policy",
+			Title: "Conditional Access policy troubleshooting",
+		}
 	}
 }
 

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -51,7 +51,7 @@ type TokenProtectionBlockedError struct {
 // to know "this is an actionable auth failure" (e.g., gRPC status mapping or
 // suppressing the raw error in `azd auth status` / `--only-check-status` flows)
 // should type-assert against this interface so future variants don't require
-// touching every callsite.
+// touching every call site.
 //
 // The interface is sealed via an unexported marker method; only types declared
 // in this package may implement it.

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -118,11 +118,13 @@ func newTokenProtectionBlockedSuggestion(
 		message = "A Conditional Access token protection policy blocked this Microsoft Graph token request."
 	}
 
-	var inner error = failedErr
-	if inner == nil {
+	var inner error
+	if failedErr == nil {
 		// Defensive: callers should always pass the originating *AuthFailedError, but if not
 		// available, surface the AAD description so the wrapper still carries detail.
 		inner = errors.New(response.ErrorDescription)
+	} else {
+		inner = failedErr
 	}
 
 	return &internal.ErrorWithSuggestion{

--- a/cli/azd/pkg/auth/errors.go
+++ b/cli/azd/pkg/auth/errors.go
@@ -39,37 +39,13 @@ type ReLoginRequiredError struct {
 	helpLink *errorhandler.ErrorLink
 }
 
-// TokenProtectionBlockedError indicates that the token request was blocked by
-// an organization's Conditional Access token protection policy (AADSTS530084), and until #7704 is addressed,
-// re-running `azd auth login` won't help.
-type TokenProtectionBlockedError struct {
-	errText string
-}
-
-// AuthInteractionError marks AAD-classified, non-retriable errors that carry
-// user-facing guidance via *internal.ErrorWithSuggestion. Callers that just need
-// to know "this is an actionable auth failure" (e.g., gRPC status mapping or
-// suppressing the raw error in `azd auth status` / `--only-check-status` flows)
-// should use errors.AsType[AuthInteractionError](err) so future variants don't
-// require touching every call site.
-//
-// The interface is sealed via an unexported marker method; only types declared
-// in this package may implement it.
-type AuthInteractionError interface {
-	error
-	isAuthInteractionError()
-}
-
-func (*ReLoginRequiredError) isAuthInteractionError()        {}
-func (*TokenProtectionBlockedError) isAuthInteractionError() {}
-
 // newActionableAuthError inspects an AAD error response and, if it matches a known
 // pattern that azd can surface with actionable guidance, returns a wrapped error and true.
 //
-// The returned error may be a *ReLoginRequiredError (the user should rerun `azd auth login`)
-// or a *TokenProtectionBlockedError (Conditional Access token protection blocked the request
-// and re-running `azd auth login` will not help). Callers must not assume the result always
-// implies the user can simply log in again — inspect the underlying error type if behavior needs to differ.
+// For Conditional Access token protection (AADSTS530084), the wrapper preserves the original
+// *AuthFailedError as the inner error (via failedErr) so the AAD error semantics are not
+// shadowed by an azd-specific type. Callers that need to distinguish behavior should match on
+// the AAD error code from *AuthFailedError.Parsed.
 //
 // If the response does not match a known pattern, it returns (nil, false).
 func newActionableAuthError(
@@ -77,12 +53,13 @@ func newActionableAuthError(
 	scopes []string,
 	cloud *cloud.Cloud,
 	tenantID string,
+	failedErr *AuthFailedError,
 ) (error, bool) {
 	if response == nil {
 		return nil, false
 	}
 
-	if err, ok := newTokenProtectionBlockedError(response, scopes); ok {
+	if err, ok := newTokenProtectionBlockedSuggestion(response, scopes, failedErr); ok {
 		return err, true
 	}
 
@@ -116,7 +93,18 @@ const (
 	tokenProtectionFAQLink = "https://aka.ms/TokenProtectionFAQ#troubleshooting"
 )
 
-func newTokenProtectionBlockedError(response *AadErrorResponse, scopes []string) (error, bool) {
+// newTokenProtectionBlockedSuggestion returns an *internal.ErrorWithSuggestion that wraps
+// the original *AuthFailedError when the AAD response indicates AADSTS530084 (Conditional
+// Access token protection blocked the request). Until #7704 is addressed, re-running
+// `azd auth login` will not help, so the suggestion directs the user to their IT admin.
+//
+// The inner Err is the original *AuthFailedError so the AAD error code/description remain
+// the source of truth for downstream classification (telemetry, gRPC ErrorInfo, etc.).
+func newTokenProtectionBlockedSuggestion(
+	response *AadErrorResponse,
+	scopes []string,
+	failedErr *AuthFailedError,
+) (error, bool) {
 	if response == nil {
 		return nil, false
 	}
@@ -130,10 +118,15 @@ func newTokenProtectionBlockedError(response *AadErrorResponse, scopes []string)
 		message = "A Conditional Access token protection policy blocked this Microsoft Graph token request."
 	}
 
+	var inner error = failedErr
+	if inner == nil {
+		// Defensive: callers should always pass the originating *AuthFailedError, but if not
+		// available, surface the AAD description so the wrapper still carries detail.
+		inner = errors.New(response.ErrorDescription)
+	}
+
 	return &internal.ErrorWithSuggestion{
-		Err: &TokenProtectionBlockedError{
-			errText: response.ErrorDescription,
-		},
+		Err:        inner,
 		Message:    message,
 		Suggestion: "Contact your IT administrator or request a policy exception.",
 		Links: []errorhandler.ErrorLink{
@@ -206,16 +199,8 @@ func (e *ReLoginRequiredError) Error() string {
 	return e.errText
 }
 
-func (e *TokenProtectionBlockedError) Error() string {
-	return e.errText
-}
-
 // Marker method to indicate this as non-retriable when executed within an armruntime pipeline
 func (e *ReLoginRequiredError) NonRetriable() {
-}
-
-// Marker method to indicate this as non-retriable when executed within an armruntime pipeline
-func (e *TokenProtectionBlockedError) NonRetriable() {
 }
 
 const authFailedPrefix string = "failed to authenticate"
@@ -290,7 +275,13 @@ func (e *AuthFailedError) Unwrap() error {
 
 func (e *AuthFailedError) Error() string {
 	if e.RawResp == nil { // non-http error, simply append inner error
-		return fmt.Sprintf("%s: %s", authFailedPrefix, e.innerErr.Error())
+		if e.innerErr != nil {
+			return fmt.Sprintf("%s: %s", authFailedPrefix, e.innerErr.Error())
+		}
+		if e.Parsed != nil && e.Parsed.ErrorDescription != "" {
+			return fmt.Sprintf("%s: %s", authFailedPrefix, e.Parsed.ErrorDescription)
+		}
+		return authFailedPrefix
 	}
 
 	if e.Parsed == nil { // unable to parse, provide HTTP error details

--- a/cli/azd/pkg/auth/errors_test.go
+++ b/cli/azd/pkg/auth/errors_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	msal "github.com/AzureAD/microsoft-authentication-library-for-go/apps/errors"
+	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
 	"github.com/stretchr/testify/require"
 )
@@ -132,6 +133,138 @@ func TestReLoginRequiredError(t *testing.T) {
 			err, _ := newReLoginRequiredError(tt.resp, LoginScopes(cloud.AzurePublic()), cloud.AzurePublic(), "")
 			got := err.Error()
 			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTokenProtectionBlockedError(t *testing.T) {
+	graphScopes := []string{"https://graph.microsoft.com/.default"}
+	armScopes := LoginScopes(cloud.AzurePublic())
+
+	tests := []struct {
+		name        string
+		resp        *AadErrorResponse
+		scopes      []string
+		want        bool
+		wantMessage string
+	}{
+		{
+			name:   "nil_response",
+			resp:   nil,
+			scopes: armScopes,
+			want:   false,
+		},
+		{
+			name:   "no_token_protection_code",
+			resp:   &AadErrorResponse{Error: "invalid_grant", ErrorCodes: []int{70043}},
+			scopes: armScopes,
+			want:   false,
+		},
+		{
+			name: "token_protection_arm_scope",
+			resp: &AadErrorResponse{
+				Error:            "invalid_grant",
+				ErrorDescription: "AADSTS530084: blocked by token protection",
+				ErrorCodes:       []int{530084},
+			},
+			scopes:      armScopes,
+			want:        true,
+			wantMessage: "A Conditional Access token protection policy blocked this token request.",
+		},
+		{
+			name: "token_protection_graph_scope",
+			resp: &AadErrorResponse{
+				Error:            "invalid_grant",
+				ErrorDescription: "AADSTS530084: blocked by token protection",
+				ErrorCodes:       []int{530084},
+			},
+			scopes:      graphScopes,
+			want:        true,
+			wantMessage: "A Conditional Access token protection policy blocked this Microsoft Graph token request.",
+		},
+		{
+			name: "token_protection_with_other_codes",
+			resp: &AadErrorResponse{
+				Error:            "invalid_grant",
+				ErrorDescription: "AADSTS530084: blocked by token protection",
+				ErrorCodes:       []int{70043, 530084},
+			},
+			scopes:      armScopes,
+			want:        true,
+			wantMessage: "A Conditional Access token protection policy blocked this token request.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err, ok := newTokenProtectionBlockedError(tt.resp, tt.scopes)
+			require.Equal(t, tt.want, ok)
+			if !tt.want {
+				require.Nil(t, err)
+				return
+			}
+
+			require.NotNil(t, err)
+
+			// Underlying error message preserves the AAD error description.
+			require.Equal(t, tt.resp.ErrorDescription, err.Error())
+
+			// Wrapped as ErrorWithSuggestion with the expected scope-aware message and links.
+			ews, ok := errors.AsType[*internal.ErrorWithSuggestion](err)
+			require.True(t, ok, "expected error to be *internal.ErrorWithSuggestion")
+			require.Equal(t, tt.wantMessage, ews.Message)
+			require.Equal(t, "Contact your IT administrator or request a policy exception.", ews.Suggestion)
+			require.Len(t, ews.Links, 2)
+			require.Equal(t, conditionalAccessDocsLink, ews.Links[0].URL)
+			require.NotEmpty(t, ews.Links[0].Title)
+			require.Equal(t, tokenProtectionFAQLink, ews.Links[1].URL)
+			require.NotEmpty(t, ews.Links[1].Title)
+
+			// Inner error must be *TokenProtectionBlockedError and marked non-retriable.
+			inner, ok := errors.AsType[*TokenProtectionBlockedError](err)
+			require.True(t, ok, "expected inner error to be *TokenProtectionBlockedError")
+			require.Equal(t, tt.resp.ErrorDescription, inner.Error())
+			// Calling NonRetriable should not panic — verifies the marker method exists.
+			inner.NonRetriable()
+		})
+	}
+}
+
+func TestNewReLoginRequiredError_TokenProtectionTakesPrecedence(t *testing.T) {
+	// AADSTS530084 paired with invalid_grant should produce a TokenProtectionBlockedError
+	// (not a ReLoginRequiredError), because reauthenticating won't unblock the user.
+	resp := &AadErrorResponse{
+		Error:            "invalid_grant",
+		ErrorDescription: "AADSTS530084: blocked by token protection",
+		ErrorCodes:       []int{530084},
+	}
+
+	err, ok := newReLoginRequiredError(resp, LoginScopes(cloud.AzurePublic()), cloud.AzurePublic(), "")
+	require.True(t, ok)
+	require.NotNil(t, err)
+
+	_, isReLogin := errors.AsType[*ReLoginRequiredError](err)
+	require.False(t, isReLogin, "should not be classified as ReLoginRequiredError")
+
+	_, isTokenProtection := errors.AsType[*TokenProtectionBlockedError](err)
+	require.True(t, isTokenProtection, "should be classified as TokenProtectionBlockedError")
+}
+
+func TestUsesGraphScope(t *testing.T) {
+	tests := []struct {
+		name   string
+		scopes []string
+		want   bool
+	}{
+		{"empty", nil, false},
+		{"arm_only", []string{"https://management.azure.com/.default"}, false},
+		{"graph_default", []string{"https://graph.microsoft.com/.default"}, true},
+		{"graph_specific_scope", []string{"https://graph.microsoft.com/User.Read"}, true},
+		{"mixed", []string{"https://management.azure.com/.default", "https://graph.microsoft.com/.default"}, true},
+		{"graph_substring_not_prefix", []string{"https://example.com/https://graph.microsoft.com/.default"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, usesGraphScope(tt.scopes))
 		})
 	}
 }

--- a/cli/azd/pkg/auth/errors_test.go
+++ b/cli/azd/pkg/auth/errors_test.go
@@ -87,7 +87,7 @@ func TestAuthFailedError(t *testing.T) {
 	}
 }
 
-func TestReLoginRequired(t *testing.T) {
+func TestNewActionableAuthError_RecognizesLoginRequiredErrors(t *testing.T) {
 	tests := []struct {
 		name string
 		resp *AadErrorResponse
@@ -105,7 +105,7 @@ func TestReLoginRequired(t *testing.T) {
 	}
 }
 
-func TestReLoginRequiredError(t *testing.T) {
+func TestNewActionableAuthError_PreservesUnderlyingErrorText(t *testing.T) {
 	tests := []struct {
 		name string
 		resp *AadErrorResponse
@@ -223,13 +223,16 @@ func TestTokenProtectionBlockedError(t *testing.T) {
 			inner, ok := errors.AsType[*TokenProtectionBlockedError](err)
 			require.True(t, ok, "expected inner error to be *TokenProtectionBlockedError")
 			require.Equal(t, tt.resp.ErrorDescription, inner.Error())
+			_, isInteractionErr := errors.AsType[AuthInteractionError](err)
+			require.True(t, isInteractionErr,
+				"TokenProtectionBlockedError should satisfy AuthInteractionError through the ErrorWithSuggestion wrapper")
 			// Calling NonRetriable should not panic — verifies the marker method exists.
 			inner.NonRetriable()
 		})
 	}
 }
 
-func TestNewReLoginRequiredError_TokenProtectionTakesPrecedence(t *testing.T) {
+func TestNewActionableAuthError_TokenProtectionTakesPrecedence(t *testing.T) {
 	// AADSTS530084 paired with invalid_grant should produce a TokenProtectionBlockedError
 	// (not a ReLoginRequiredError), because reauthenticating won't unblock the user.
 	resp := &AadErrorResponse{

--- a/cli/azd/pkg/auth/errors_test.go
+++ b/cli/azd/pkg/auth/errors_test.go
@@ -99,7 +99,7 @@ func TestReLoginRequired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, got := newReLoginRequiredError(tt.resp, LoginScopes(cloud.AzurePublic()), cloud.AzurePublic(), "")
+			_, got := newActionableAuthError(tt.resp, LoginScopes(cloud.AzurePublic()), cloud.AzurePublic(), "")
 			require.Equal(t, tt.want, got)
 		})
 	}
@@ -130,7 +130,7 @@ func TestReLoginRequiredError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err, _ := newReLoginRequiredError(tt.resp, LoginScopes(cloud.AzurePublic()), cloud.AzurePublic(), "")
+			err, _ := newActionableAuthError(tt.resp, LoginScopes(cloud.AzurePublic()), cloud.AzurePublic(), "")
 			got := err.Error()
 			require.Equal(t, tt.want, got)
 		})
@@ -238,7 +238,7 @@ func TestNewReLoginRequiredError_TokenProtectionTakesPrecedence(t *testing.T) {
 		ErrorCodes:       []int{530084},
 	}
 
-	err, ok := newReLoginRequiredError(resp, LoginScopes(cloud.AzurePublic()), cloud.AzurePublic(), "")
+	err, ok := newActionableAuthError(resp, LoginScopes(cloud.AzurePublic()), cloud.AzurePublic(), "")
 	require.True(t, ok)
 	require.NotNil(t, err)
 

--- a/cli/azd/pkg/auth/errors_test.go
+++ b/cli/azd/pkg/auth/errors_test.go
@@ -99,7 +99,7 @@ func TestNewActionableAuthError_RecognizesLoginRequiredErrors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, got := newActionableAuthError(tt.resp, LoginScopes(cloud.AzurePublic()), cloud.AzurePublic(), "")
+			_, got := newActionableAuthError(tt.resp, LoginScopes(cloud.AzurePublic()), cloud.AzurePublic(), "", nil)
 			require.Equal(t, tt.want, got)
 		})
 	}
@@ -130,14 +130,14 @@ func TestNewActionableAuthError_PreservesUnderlyingErrorText(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err, _ := newActionableAuthError(tt.resp, LoginScopes(cloud.AzurePublic()), cloud.AzurePublic(), "")
+			err, _ := newActionableAuthError(tt.resp, LoginScopes(cloud.AzurePublic()), cloud.AzurePublic(), "", nil)
 			got := err.Error()
 			require.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestTokenProtectionBlockedError(t *testing.T) {
+func TestTokenProtectionBlockedSuggestion(t *testing.T) {
 	graphScopes := []string{"https://graph.microsoft.com/.default"}
 	armScopes := LoginScopes(cloud.AzurePublic())
 
@@ -196,7 +196,11 @@ func TestTokenProtectionBlockedError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err, ok := newTokenProtectionBlockedError(tt.resp, tt.scopes)
+			var failed *AuthFailedError
+			if tt.resp != nil {
+				failed = &AuthFailedError{Parsed: tt.resp, innerErr: errors.New(tt.resp.ErrorDescription)}
+			}
+			err, ok := newTokenProtectionBlockedSuggestion(tt.resp, tt.scopes, failed)
 			require.Equal(t, tt.want, ok)
 			if !tt.want {
 				require.Nil(t, err)
@@ -204,9 +208,6 @@ func TestTokenProtectionBlockedError(t *testing.T) {
 			}
 
 			require.NotNil(t, err)
-
-			// Underlying error message preserves the AAD error description.
-			require.Equal(t, tt.resp.ErrorDescription, err.Error())
 
 			// Wrapped as ErrorWithSuggestion with the expected scope-aware message and links.
 			ews, ok := errors.AsType[*internal.ErrorWithSuggestion](err)
@@ -219,37 +220,37 @@ func TestTokenProtectionBlockedError(t *testing.T) {
 			require.Equal(t, tokenProtectionFAQLink, ews.Links[1].URL)
 			require.NotEmpty(t, ews.Links[1].Title)
 
-			// Inner error must be *TokenProtectionBlockedError and marked non-retriable.
-			inner, ok := errors.AsType[*TokenProtectionBlockedError](err)
-			require.True(t, ok, "expected inner error to be *TokenProtectionBlockedError")
-			require.Equal(t, tt.resp.ErrorDescription, inner.Error())
-			_, isInteractionErr := errors.AsType[AuthInteractionError](err)
-			require.True(t, isInteractionErr,
-				"TokenProtectionBlockedError should satisfy AuthInteractionError through the ErrorWithSuggestion wrapper")
-			// Calling NonRetriable should not panic — verifies the marker method exists.
-			inner.NonRetriable()
+			// Inner error is preserved as the originating *AuthFailedError so AAD semantics
+			// (error code, description) flow through unmodified.
+			inner, ok := errors.AsType[*AuthFailedError](err)
+			require.True(t, ok, "expected inner error to be *AuthFailedError")
+			require.NotNil(t, inner.Parsed)
+			require.Contains(t, inner.Parsed.ErrorCodes, 530084)
 		})
 	}
 }
 
 func TestNewActionableAuthError_TokenProtectionTakesPrecedence(t *testing.T) {
-	// AADSTS530084 paired with invalid_grant should produce a TokenProtectionBlockedError
+	// AADSTS530084 paired with invalid_grant should produce a token-protection suggestion
 	// (not a ReLoginRequiredError), because reauthenticating won't unblock the user.
 	resp := &AadErrorResponse{
 		Error:            "invalid_grant",
 		ErrorDescription: "AADSTS530084: blocked by token protection",
 		ErrorCodes:       []int{530084},
 	}
+	failed := &AuthFailedError{Parsed: resp, innerErr: errors.New(resp.ErrorDescription)}
 
-	err, ok := newActionableAuthError(resp, LoginScopes(cloud.AzurePublic()), cloud.AzurePublic(), "")
+	err, ok := newActionableAuthError(resp, LoginScopes(cloud.AzurePublic()), cloud.AzurePublic(), "", failed)
 	require.True(t, ok)
 	require.NotNil(t, err)
 
 	_, isReLogin := errors.AsType[*ReLoginRequiredError](err)
 	require.False(t, isReLogin, "should not be classified as ReLoginRequiredError")
 
-	_, isTokenProtection := errors.AsType[*TokenProtectionBlockedError](err)
-	require.True(t, isTokenProtection, "should be classified as TokenProtectionBlockedError")
+	// The wrapper preserves the originating *AuthFailedError (and its AAD code) as the inner err.
+	inner, ok := errors.AsType[*AuthFailedError](err)
+	require.True(t, ok, "should preserve inner *AuthFailedError")
+	require.Contains(t, inner.Parsed.ErrorCodes, 530084)
 }
 
 func TestUsesGraphScope(t *testing.T) {

--- a/cli/azd/pkg/auth/errors_test.go
+++ b/cli/azd/pkg/auth/errors_test.go
@@ -250,12 +250,14 @@ func TestNewActionableAuthError_TokenProtectionTakesPrecedence(t *testing.T) {
 	// The wrapper preserves the originating *AuthFailedError (and its AAD code) as the inner err.
 	inner, ok := errors.AsType[*AuthFailedError](err)
 	require.True(t, ok, "should preserve inner *AuthFailedError")
+	require.Contains(t, inner.Parsed.ErrorCodes, 530084)
+}
 
 func TestNewTokenProtectionBlockedSuggestion_NilAuthFailedErrorFallsBackToDescription(t *testing.T) {
 	resp := &AadErrorResponse{
 		Error:            "invalid_grant",
-		ErrorDescription: "AADSTS90002: blocked by token protection",
-		ErrorCodes:       []int{90002},
+		ErrorDescription: "AADSTS530084: blocked by token protection",
+		ErrorCodes:       []int{530084},
 	}
 
 	err, ok := newTokenProtectionBlockedSuggestion(resp, LoginScopes(cloud.AzurePublic()), nil)

--- a/cli/azd/pkg/auth/errors_test.go
+++ b/cli/azd/pkg/auth/errors_test.go
@@ -250,7 +250,20 @@ func TestNewActionableAuthError_TokenProtectionTakesPrecedence(t *testing.T) {
 	// The wrapper preserves the originating *AuthFailedError (and its AAD code) as the inner err.
 	inner, ok := errors.AsType[*AuthFailedError](err)
 	require.True(t, ok, "should preserve inner *AuthFailedError")
-	require.Contains(t, inner.Parsed.ErrorCodes, 530084)
+
+func TestNewTokenProtectionBlockedSuggestion_NilAuthFailedErrorFallsBackToDescription(t *testing.T) {
+	resp := &AadErrorResponse{
+		Error:            "invalid_grant",
+		ErrorDescription: "AADSTS90002: blocked by token protection",
+		ErrorCodes:       []int{90002},
+	}
+
+	err, ok := newTokenProtectionBlockedSuggestion(resp, LoginScopes(cloud.AzurePublic()), nil)
+	require.True(t, ok)
+
+	ews, ok := errors.AsType[*internal.ErrorWithSuggestion](err)
+	require.True(t, ok)
+	require.Equal(t, resp.ErrorDescription, ews.Unwrap().Error())
 }
 
 func TestUsesGraphScope(t *testing.T) {

--- a/cli/azd/pkg/azdext/auth_error_reasons.go
+++ b/cli/azd/pkg/azdext/auth_error_reasons.go
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azdext
+
+import (
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/status"
+)
+
+// Auth error metadata constants used in gRPC ErrorInfo for auth-related host APIs.
+const (
+	AuthErrorDomain = "azd.auth"
+)
+
+// Auth error reason codes used in gRPC ErrorInfo.Reason.
+const (
+	AuthErrorReasonNotLoggedIn            = "AUTH_NOT_LOGGED_IN"
+	AuthErrorReasonLoginRequired          = "AUTH_LOGIN_REQUIRED"
+	AuthErrorReasonTokenProtectionBlocked = "AUTH_TOKEN_PROTECTION_BLOCKED"
+)
+
+// AuthErrorReason extracts the ErrorInfo.Reason from a gRPC status when the domain
+// matches [AuthErrorDomain].
+func AuthErrorReason(st *status.Status) string {
+	for _, detail := range st.Details() {
+		info, ok := detail.(*errdetails.ErrorInfo)
+		if ok && info.Domain == AuthErrorDomain {
+			return info.Reason
+		}
+	}
+
+	return ""
+}

--- a/cli/azd/pkg/azdext/auth_error_reasons.go
+++ b/cli/azd/pkg/azdext/auth_error_reasons.go
@@ -15,8 +15,9 @@ const (
 
 // Auth error reason codes used in gRPC ErrorInfo.Reason.
 const (
-	AuthErrorReasonNotLoggedIn            = "AUTH_NOT_LOGGED_IN"
-	AuthErrorReasonLoginRequired          = "AUTH_LOGIN_REQUIRED"
+	AuthErrorReasonNotLoggedIn   = "AUTH_NOT_LOGGED_IN"
+	AuthErrorReasonLoginRequired = "AUTH_LOGIN_REQUIRED"
+	// #nosec G101 -- gRPC auth reason identifier, not a credential.
 	AuthErrorReasonTokenProtectionBlocked = "AUTH_TOKEN_PROTECTION_BLOCKED"
 )
 

--- a/cli/azd/pkg/azdext/auth_error_reasons.go
+++ b/cli/azd/pkg/azdext/auth_error_reasons.go
@@ -14,11 +14,14 @@ const (
 )
 
 // Auth error reason codes used in gRPC ErrorInfo.Reason.
+//
+// For AAD-originated failures, the Reason is the originating Entra error code formatted as
+// "AADSTS<code>" (e.g. "AADSTS530084") so extensions can match on the AAD code directly without
+// azd having to define a synthetic taxonomy. The constants below cover azd-local conditions
+// that have no corresponding Entra code.
 const (
 	AuthErrorReasonNotLoggedIn   = "AUTH_NOT_LOGGED_IN"
 	AuthErrorReasonLoginRequired = "AUTH_LOGIN_REQUIRED"
-	// #nosec G101 -- gRPC auth reason identifier, not a credential.
-	AuthErrorReasonTokenProtectionBlocked = "AUTH_TOKEN_PROTECTION_BLOCKED"
 )
 
 // AuthErrorReason extracts the ErrorInfo.Reason from a gRPC status when the domain

--- a/cli/azd/pkg/azdext/extension_error.go
+++ b/cli/azd/pkg/azdext/extension_error.go
@@ -56,7 +56,7 @@ func (e *ServiceError) Error() string {
 // The function applies detection in priority order:
 //  1. [ServiceError] / [LocalError] — already structured by extension code (highest specificity)
 //  2. [azcore.ResponseError] — Azure SDK HTTP errors
-//  3. gRPC Unauthenticated — auto-classified as auth category (safety net)
+//  3. gRPC Unauthenticated — auto-classified as auth category, preserving auth subtypes from ErrorInfo when present
 //  4. Fallback — unclassified error with original message
 //
 // The counterpart [UnwrapError] is called from the azd host to deserialize
@@ -121,7 +121,8 @@ func WrapError(err error) *ExtensionError {
 
 	// Detect gRPC Unauthenticated errors as an auth safety net.
 	// If the extension didn't already classify the error, this ensures auth failures
-	// from azd host calls are reported with the correct category in telemetry.
+	// from azd host calls are reported with the correct category in telemetry,
+	// and preserves specific auth subtypes when the host attached auth ErrorInfo details.
 	// Use errors.AsType to detect gRPC status errors even when wrapped by fmt.Errorf.
 	if grpcErr, ok := errors.AsType[interface {
 		error
@@ -132,7 +133,7 @@ func WrapError(err error) *ExtensionError {
 			extErr.Message = st.Message()
 			extErr.Source = &ExtensionError_LocalError{
 				LocalError: &LocalErrorDetail{
-					Code:     "auth_failed",
+					Code:     authLocalErrorCode(st),
 					Category: string(LocalErrorCategoryAuth),
 				},
 			}
@@ -141,6 +142,19 @@ func WrapError(err error) *ExtensionError {
 	}
 
 	return extErr
+}
+
+func authLocalErrorCode(st *status.Status) string {
+	switch AuthErrorReason(st) {
+	case AuthErrorReasonNotLoggedIn:
+		return "not_logged_in"
+	case AuthErrorReasonLoginRequired:
+		return "login_required"
+	case AuthErrorReasonTokenProtectionBlocked:
+		return "token_protection_blocked"
+	default:
+		return "auth_failed"
+	}
 }
 
 // UnwrapError converts an ExtensionError proto back to a typed Go error.

--- a/cli/azd/pkg/azdext/extension_error.go
+++ b/cli/azd/pkg/azdext/extension_error.go
@@ -150,11 +150,12 @@ func authLocalErrorCode(st *status.Status) string {
 		return "not_logged_in"
 	case AuthErrorReasonLoginRequired:
 		return "login_required"
-	case AuthErrorReasonTokenProtectionBlocked:
-		return "token_protection_blocked"
-	default:
-		return "auth_failed"
 	}
+
+	// All other reasons (including AAD-originated codes like "AADSTS530084") collapse to a
+	// generic "auth_failed" label. Extensions that need per-AAD-code granularity can read the
+	// raw reason directly from the gRPC ErrorInfo via AuthErrorReason.
+	return "auth_failed"
 }
 
 // UnwrapError converts an ExtensionError proto back to a typed Go error.

--- a/cli/azd/pkg/azdext/extension_error_test.go
+++ b/cli/azd/pkg/azdext/extension_error_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -119,11 +120,75 @@ func TestExtensionError_RoundTrip(t *testing.T) {
 			},
 		},
 		{
-			name:     "GrpcUnauthenticatedError",
-			inputErr: status.Error(codes.Unauthenticated, "not logged in, run `azd auth login` to login"),
+			name: "GrpcUnauthenticatedError",
+			inputErr: mustAuthStatusError(
+				codes.Unauthenticated,
+				AuthErrorReasonNotLoggedIn,
+				"not logged in, run `azd auth login` to login",
+			),
 			verify: func(t *testing.T, protoErr *ExtensionError, goErr error) {
 				assert.Equal(t, ErrorOrigin_ERROR_ORIGIN_LOCAL, protoErr.GetOrigin())
 				assert.Contains(t, protoErr.GetMessage(), "not logged in")
+
+				localDetail := protoErr.GetLocalError()
+				require.NotNil(t, localDetail)
+				assert.Equal(t, "not_logged_in", localDetail.GetCode())
+				assert.Equal(t, "auth", localDetail.GetCategory())
+
+				var localErr *LocalError
+				require.ErrorAs(t, goErr, &localErr)
+				assert.Equal(t, LocalErrorCategoryAuth, localErr.Category)
+				assert.Equal(t, "not_logged_in", localErr.Code)
+			},
+		},
+		{
+			name: "WrappedGrpcUnauthenticatedError",
+			inputErr: fmt.Errorf(
+				"failed to prompt: %w",
+				mustAuthStatusError(
+					codes.Unauthenticated,
+					AuthErrorReasonTokenProtectionBlocked,
+					"AADSTS530084: blocked by token protection",
+				),
+			),
+			verify: func(t *testing.T, protoErr *ExtensionError, goErr error) {
+				assert.Equal(t, ErrorOrigin_ERROR_ORIGIN_LOCAL, protoErr.GetOrigin())
+				assert.Equal(t, "AADSTS530084: blocked by token protection", protoErr.GetMessage())
+
+				localDetail := protoErr.GetLocalError()
+				require.NotNil(t, localDetail)
+				assert.Equal(t, "token_protection_blocked", localDetail.GetCode())
+				assert.Equal(t, "auth", localDetail.GetCategory())
+			},
+		},
+		{
+			name: "GrpcUnauthenticatedLoginRequiredError",
+			inputErr: mustAuthStatusError(
+				codes.Unauthenticated,
+				AuthErrorReasonLoginRequired,
+				"AADSTS70043: token expired\nlogin expired, run `azd auth login`",
+			),
+			verify: func(t *testing.T, protoErr *ExtensionError, goErr error) {
+				assert.Equal(t, ErrorOrigin_ERROR_ORIGIN_LOCAL, protoErr.GetOrigin())
+				assert.Contains(t, protoErr.GetMessage(), "login expired")
+
+				localDetail := protoErr.GetLocalError()
+				require.NotNil(t, localDetail)
+				assert.Equal(t, "login_required", localDetail.GetCode())
+				assert.Equal(t, "auth", localDetail.GetCategory())
+
+				var localErr *LocalError
+				require.ErrorAs(t, goErr, &localErr)
+				assert.Equal(t, LocalErrorCategoryAuth, localErr.Category)
+				assert.Equal(t, "login_required", localErr.Code)
+			},
+		},
+		{
+			name:     "GrpcUnauthenticatedWithoutAuthDetailsFallsBackToAuthFailed",
+			inputErr: status.Error(codes.Unauthenticated, "generic auth problem"),
+			verify: func(t *testing.T, protoErr *ExtensionError, goErr error) {
+				assert.Equal(t, ErrorOrigin_ERROR_ORIGIN_LOCAL, protoErr.GetOrigin())
+				assert.Equal(t, "generic auth problem", protoErr.GetMessage())
 
 				localDetail := protoErr.GetLocalError()
 				require.NotNil(t, localDetail)
@@ -134,19 +199,6 @@ func TestExtensionError_RoundTrip(t *testing.T) {
 				require.ErrorAs(t, goErr, &localErr)
 				assert.Equal(t, LocalErrorCategoryAuth, localErr.Category)
 				assert.Equal(t, "auth_failed", localErr.Code)
-			},
-		},
-		{
-			name:     "WrappedGrpcUnauthenticatedError",
-			inputErr: fmt.Errorf("failed to prompt: %w", status.Error(codes.Unauthenticated, "login expired")),
-			verify: func(t *testing.T, protoErr *ExtensionError, goErr error) {
-				assert.Equal(t, ErrorOrigin_ERROR_ORIGIN_LOCAL, protoErr.GetOrigin())
-				assert.Equal(t, "login expired", protoErr.GetMessage())
-
-				localDetail := protoErr.GetLocalError()
-				require.NotNil(t, localDetail)
-				assert.Equal(t, "auth_failed", localDetail.GetCode())
-				assert.Equal(t, "auth", localDetail.GetCategory())
 			},
 		},
 	}
@@ -168,4 +220,17 @@ func TestExtensionError_RoundTrip(t *testing.T) {
 			tt.verify(t, protoErr, goErr)
 		})
 	}
+}
+
+func mustAuthStatusError(code codes.Code, reason, message string) error {
+	st := status.New(code, message)
+	withDetails, err := st.WithDetails(&errdetails.ErrorInfo{
+		Reason: reason,
+		Domain: AuthErrorDomain,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return withDetails.Err()
 }

--- a/cli/azd/pkg/azdext/extension_error_test.go
+++ b/cli/azd/pkg/azdext/extension_error_test.go
@@ -147,7 +147,7 @@ func TestExtensionError_RoundTrip(t *testing.T) {
 				"failed to prompt: %w",
 				mustAuthStatusError(
 					codes.Unauthenticated,
-					AuthErrorReasonTokenProtectionBlocked,
+					"AADSTS530084",
 					"AADSTS530084: blocked by token protection",
 				),
 			),
@@ -157,7 +157,9 @@ func TestExtensionError_RoundTrip(t *testing.T) {
 
 				localDetail := protoErr.GetLocalError()
 				require.NotNil(t, localDetail)
-				assert.Equal(t, "token_protection_blocked", localDetail.GetCode())
+				// AAD-originated reasons collapse to the generic "auth_failed" code; the raw
+				// "AADSTS530084" reason remains available to extensions via the gRPC ErrorInfo.
+				assert.Equal(t, "auth_failed", localDetail.GetCode())
 				assert.Equal(t, "auth", localDetail.GetCategory())
 			},
 		},


### PR DESCRIPTION
Resolves #7794
Resolves #7884

This PR adds support for handling `AADSTS530084` token protection errors in the authentication error handling logic. Instead of introducing a new azd-specific auth error type, it preserves the original `*auth.AuthFailedError` and wraps it in `*internal.ErrorWithSuggestion` so users still receive clear guidance and documentation links while downstream auth classification continues to use the underlying AAD error semantics.

This PR also preserves auth error details in telemetry when auth failures are wrapped in `*internal.ErrorWithSuggestion`.

Until https://github.com/Azure/azure-dev/issues/7704 is addressed, users won't be able to fix this issue by re-authenticating, so `azd auth login` as a suggestion was omitted.

Simulated error message (using different error code for testing):

<img width="2582" height="284" alt="image" src="https://github.com/user-attachments/assets/20c130de-e268-4e48-811f-2be916e1241e" />
