### PR TITLE
feat: Add warnings for role assignment issues in RBAC checks

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/project/agent_identity_rbac.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agent_identity_rbac.go
@@ -341,15 +341,13 @@ func ensureSingleAgentRBAC(
 	if err != nil {
 		if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok &&
 			respErr.StatusCode == http.StatusForbidden {
-			// Write to stderr with warning color so it survives azd's deployment preview capture.
-			fmt.Fprintf(os.Stderr, "%s\n",
-				output.WithWarningFormat(
-					"Could not assign 'Azure AI User' to agent identity '%s' (403 Forbidden).\n"+
-						"    The agent may not have access to the Foundry Project until this role is assigned.\n"+
-						"    Re-run after granting role assignment write, or set AZD_AGENT_SKIP_ROLE_ASSIGNMENTS=true.",
-					agentName,
-				),
-			)
+			// Write with warning color so it appears as a yellow warning, not a red error.
+			fmt.Printf("%s\n", output.WithWarningFormat(
+				"Could not assign 'Azure AI User' to agent identity '%s' (403 Forbidden).\n"+
+					"    The agent may not have access to the Foundry Project until this role is assigned.\n"+
+					"    Re-run after granting role assignment write, or set AZD_AGENT_SKIP_ROLE_ASSIGNMENTS=true.",
+				agentName,
+			))
 			return nil
 		}
 		return fmt.Errorf("failed to assign Azure AI User role: %w", err)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agent_identity_rbac.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agent_identity_rbac.go
@@ -5,9 +5,11 @@ package project
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"maps"
+	"net/http"
 	"os"
 	"slices"
 	"strconv"
@@ -17,6 +19,7 @@ import (
 
 	"azureaiagent/internal/exterrors"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
@@ -335,6 +338,17 @@ func ensureSingleAgentRBAC(
 		armauthorization.PrincipalTypeServicePrincipal,
 	)
 	if err != nil {
+		if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok &&
+			respErr.StatusCode == http.StatusForbidden {
+			// Write to stderr so this survives azd's deployment preview capture of stdout.
+			fmt.Fprintf(os.Stderr,
+				"(!) Warning: Could not assign 'Azure AI User' to agent identity '%s' (403 Forbidden).\n"+
+					"    The agent may not have access to the Foundry Project until this role is assigned.\n"+
+					"    Re-run after granting role assignment write, or set AZD_AGENT_SKIP_ROLE_ASSIGNMENTS=true.\n",
+				agentName,
+			)
+			return nil
+		}
 		return fmt.Errorf("failed to assign Azure AI User role: %w", err)
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agent_identity_rbac.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agent_identity_rbac.go
@@ -341,12 +341,26 @@ func ensureSingleAgentRBAC(
 	if err != nil {
 		if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok &&
 			respErr.StatusCode == http.StatusForbidden {
+			manualRemediationCommand := fmt.Sprintf(
+				"az role assignment create --assignee-object-id %s --assignee-principal-type ServicePrincipal --role %s --scope %s",
+				strconv.Quote(principalID),
+				strconv.Quote("Azure AI User"),
+				strconv.Quote(info.ProjectScope),
+			)
+
 			// Write with warning color so it appears as a yellow warning, not a red error.
 			fmt.Printf("%s\n", output.WithWarningFormat(
 				"Could not assign 'Azure AI User' to agent identity '%s' (403 Forbidden).\n"+
 					"    The agent may not have access to the Foundry Project until this role is assigned.\n"+
+					"    Principal ID: %s\n"+
+					"    Foundry Project scope: %s\n"+
+					"    To remediate manually, run:\n"+
+					"      %s\n"+
 					"    Re-run after granting role assignment write, or set AZD_AGENT_SKIP_ROLE_ASSIGNMENTS=true.",
 				agentName,
+				principalID,
+				info.ProjectScope,
+				manualRemediationCommand,
 			))
 			return nil
 		}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agent_identity_rbac.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agent_identity_rbac.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/google/uuid"
 )
 
@@ -340,12 +341,14 @@ func ensureSingleAgentRBAC(
 	if err != nil {
 		if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok &&
 			respErr.StatusCode == http.StatusForbidden {
-			// Write to stderr so this survives azd's deployment preview capture of stdout.
-			fmt.Fprintf(os.Stderr,
-				"(!) Warning: Could not assign 'Azure AI User' to agent identity '%s' (403 Forbidden).\n"+
-					"    The agent may not have access to the Foundry Project until this role is assigned.\n"+
-					"    Re-run after granting role assignment write, or set AZD_AGENT_SKIP_ROLE_ASSIGNMENTS=true.\n",
-				agentName,
+			// Write to stderr with warning color so it survives azd's deployment preview capture.
+			fmt.Fprintf(os.Stderr, "%s\n",
+				output.WithWarningFormat(
+					"Could not assign 'Azure AI User' to agent identity '%s' (403 Forbidden).\n"+
+						"    The agent may not have access to the Foundry Project until this role is assigned.\n"+
+						"    Re-run after granting role assignment write, or set AZD_AGENT_SKIP_ROLE_ASSIGNMENTS=true.",
+					agentName,
+				),
 			)
 			return nil
 		}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check.go
@@ -92,7 +92,8 @@ var sufficientRoleAssignWriteRoles = []string{
 //   - Container Registry Tasks Contributor OR Container Registry Repository Contributor
 //     on the ACR (to build images via remote build and push container images)
 //
-// Returns nil if all checks pass, or a structured error with suggestions on failure.
+// Missing roles are reported as warnings rather than errors so that deployment can proceed.
+// The developer may need to obtain the missing roles separately for full functionality.
 func CheckDeveloperRBAC(ctx context.Context, azdClient *azdext.AzdClient) error {
 	azdEnvClient := azdClient.Environment()
 	cEnvResponse, err := azdEnvClient.GetCurrent(ctx, &azdext.EmptyRequest{})
@@ -190,8 +191,9 @@ func CheckDeveloperRBAC(ctx context.Context, azdClient *azdext.AzdClient) error 
 					userProfile.DisplayName, info.AccountName, info.ProjectName,
 					principalID, info.ProjectScope,
 				))
+			} else {
+				fmt.Printf("  ⚠ Azure AI User auto-assign failed (non-auth error): %s — continuing\n", assignErr)
 			}
-			fmt.Printf("  ⚠ Azure AI User auto-assign failed (non-auth error): %s — continuing\n", assignErr)
 		} else {
 			fmt.Println("  ✓ Azure AI User auto-assigned to developer identity")
 		}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check.go
@@ -8,10 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
-
-	"azureaiagent/internal/exterrors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -185,16 +182,14 @@ func CheckDeveloperRBAC(ctx context.Context, azdClient *azdext.AzdClient) error 
 			// may not be able to interact with agents until this role is assigned.
 			if respErr, ok := errors.AsType[*azcore.ResponseError](assignErr); ok &&
 				respErr.StatusCode == http.StatusForbidden {
-				fmt.Fprintf(os.Stderr, "%s\n",
-					output.WithWarningFormat(
-						"Your identity (%s) does not have the 'Azure AI User' role on the Foundry Project %s/%s "+
-							"and auto-assign was denied.\n"+
-							"    Ask a subscription Owner or User Access Administrator to assign the role:\n"+
-							"      az role assignment create --assignee %s --role \"Azure AI User\" --scope %q",
-						userProfile.DisplayName, info.AccountName, info.ProjectName,
-						principalID, info.ProjectScope,
-					),
-				)
+				fmt.Printf("%s\n", output.WithWarningFormat(
+					"Your identity (%s) does not have the 'Azure AI User' role on the Foundry Project %s/%s "+
+						"and auto-assign was denied.\n"+
+						"    Ask a subscription Owner or User Access Administrator to assign the role:\n"+
+						"      az role assignment create --assignee %s --role \"Azure AI User\" --scope %q",
+					userProfile.DisplayName, info.AccountName, info.ProjectName,
+					principalID, info.ProjectScope,
+				))
 			}
 			fmt.Printf("  ⚠ Azure AI User auto-assign failed (non-auth error): %s — continuing\n", assignErr)
 		} else {
@@ -213,23 +208,21 @@ func CheckDeveloperRBAC(ctx context.Context, azdClient *azdext.AzdClient) error 
 	} else if !hasRoleWrite {
 		// Warn rather than fail hard: deployment can still proceed, but the postdeploy
 		// step that assigns 'Azure AI User' to agent service principals may return 403.
-		// Write to stderr with warning color so the message survives azd's deployment preview capture.
-		fmt.Fprintf(os.Stderr, "%s\n",
-			output.WithWarningFormat(
-				"Role assignment write not available on Foundry Project %s/%s.\n"+
-					"    The postdeploy step will attempt to assign 'Azure AI User' to agent service principals,\n"+
-					"    but may fail with a 403. To grant this permission, assign one of these roles:\n"+
-					"      • Owner\n"+
-					"      • User Access Administrator\n"+
-					"      • Role Based Access Control Administrator\n"+
-					"      • Azure AI Project Manager\n"+
-					"      • Azure AI Account Owner\n"+
-					"      az role assignment create --assignee %s "+
-					"--role \"Role Based Access Control Administrator\" --scope %q\n"+
-					"    Or, if roles are managed externally: AZD_AGENT_SKIP_ROLE_ASSIGNMENTS=true",
-				info.AccountName, info.ProjectName, principalID, info.ProjectScope,
-			),
-		)
+		// Write with warning color so it appears as a yellow warning, not a red error.
+		fmt.Printf("%s\n", output.WithWarningFormat(
+			"Role assignment write not available on Foundry Project %s/%s.\n"+
+				"    The postdeploy step will attempt to assign 'Azure AI User' to agent service principals,\n"+
+				"    but may fail with a 403. To grant this permission, assign one of these roles:\n"+
+				"      • Owner\n"+
+				"      • User Access Administrator\n"+
+				"      • Role Based Access Control Administrator\n"+
+				"      • Azure AI Project Manager\n"+
+				"      • Azure AI Account Owner\n"+
+				"      az role assignment create --assignee %s "+
+				"--role \"Role Based Access Control Administrator\" --scope %q\n"+
+				"    Or, if roles are managed externally: AZD_AGENT_SKIP_ROLE_ASSIGNMENTS=true",
+			info.AccountName, info.ProjectName, principalID, info.ProjectScope,
+		))
 	} else {
 		fmt.Println("  ✓ Role assignment write on Foundry Project")
 	}
@@ -271,43 +264,33 @@ func CheckDeveloperRBAC(ctx context.Context, azdClient *azdext.AzdClient) error 
 	if !hasACRAccess {
 		acrName := strings.TrimSuffix(normalizeLoginServer(acrEndpoint), ".azurecr.io")
 		if isAbac {
-			return exterrors.Auth(
-				exterrors.CodeDeveloperMissingACRRole,
-				fmt.Sprintf(
-					"your identity (%s) does not have the required role on the ABAC-mode Container Registry '%s' "+
-						"to push container images",
-					userProfile.DisplayName, acrName,
-				),
-				fmt.Sprintf(
-					"ask a subscription Owner or User Access Administrator to assign one of these roles "+
-						"to your identity on the Container Registry scope:\n"+
-						"  • Owner (broad access)\n"+
-						"  • Container Registry Repository Writer (ABAC push)\n"+
-						"  • Container Registry Repository Contributor (superset of Writer)\n\n"+
-						"  az role assignment create --assignee %s "+
-						"--role \"Container Registry Repository Writer\" --scope %q",
-					principalID, acrResourceID,
-				),
-			)
-		}
-		return exterrors.Auth(
-			exterrors.CodeDeveloperMissingACRRole,
-			fmt.Sprintf(
-				"your identity (%s) does not have the required role on the Container Registry '%s' "+
-					"to build and push container images",
+			fmt.Printf("%s\n", output.WithWarningFormat(
+				"Your identity (%s) does not have the required role on the ABAC-mode Container Registry '%s' "+
+					"to push container images.\n"+
+					"    Ask a subscription Owner or User Access Administrator to assign one of these roles:\n"+
+					"      • Owner (broad access)\n"+
+					"      • Container Registry Repository Writer (ABAC push)\n"+
+					"      • Container Registry Repository Contributor (superset of Writer)\n\n"+
+					"      az role assignment create --assignee %s "+
+					"--role \"Container Registry Repository Writer\" --scope %q",
 				userProfile.DisplayName, acrName,
-			),
-			fmt.Sprintf(
-				"ask a subscription Owner or User Access Administrator to assign one of these roles "+
-					"to your identity on the Container Registry scope:\n"+
-					"  • Owner or Contributor (broad access)\n"+
-					"  • AcrPush (push and pull images)\n"+
-					"  • Container Registry Tasks Contributor (remote build)\n"+
-					"  • Container Registry Repository Contributor (repository operations)\n\n"+
-					"  az role assignment create --assignee %s --role \"AcrPush\" --scope %q",
 				principalID, acrResourceID,
-			),
-		)
+			))
+		} else {
+			fmt.Printf("%s\n", output.WithWarningFormat(
+				"Your identity (%s) does not have the required role on the Container Registry '%s' "+
+					"to build and push container images.\n"+
+					"    Ask a subscription Owner or User Access Administrator to assign one of these roles:\n"+
+					"      • Owner or Contributor (broad access)\n"+
+					"      • AcrPush (push and pull images)\n"+
+					"      • Container Registry Tasks Contributor (remote build)\n"+
+					"      • Container Registry Repository Contributor (repository operations)\n\n"+
+					"      az role assignment create --assignee %s --role \"AcrPush\" --scope %q",
+				userProfile.DisplayName, acrName,
+				principalID, acrResourceID,
+			))
+		}
+		return nil
 	}
 
 	if isAbac {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	"azureaiagent/internal/exterrors"
@@ -18,6 +19,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/graphsdk"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
 const (
@@ -179,20 +181,17 @@ func CheckDeveloperRBAC(ctx context.Context, azdClient *azdext.AzdClient) error 
 			"Azure AI User → Foundry Project", info.ProjectScope,
 			armauthorization.PrincipalTypeUser,
 		); assignErr != nil {
-			// Only treat 403 as a hard RBAC failure — transient errors (throttling, network) are non-blocking.
+			// Warn rather than fail hard on 403 — deployment can proceed, but the developer
+			// may not be able to interact with agents until this role is assigned.
 			if respErr, ok := errors.AsType[*azcore.ResponseError](assignErr); ok &&
 				respErr.StatusCode == http.StatusForbidden {
-				return exterrors.Auth(
-					exterrors.CodeDeveloperMissingAIUserRole,
-					fmt.Sprintf(
-						"your identity (%s) does not have the 'Azure AI User' role on the Foundry Project %s/%s "+
-							"and auto-assign was denied: %s",
-						userProfile.DisplayName, info.AccountName, info.ProjectName, assignErr,
-					),
-					fmt.Sprintf(
-						"ask a subscription Owner or User Access Administrator to assign the 'Azure AI User' role "+
-							"to your identity on the Foundry Project scope:\n"+
-							"  az role assignment create --assignee %s --role \"Azure AI User\" --scope %q",
+				fmt.Fprintf(os.Stderr, "%s\n",
+					output.WithWarningFormat(
+						"Your identity (%s) does not have the 'Azure AI User' role on the Foundry Project %s/%s "+
+							"and auto-assign was denied.\n"+
+							"    Ask a subscription Owner or User Access Administrator to assign the role:\n"+
+							"      az role assignment create --assignee %s --role \"Azure AI User\" --scope %q",
+						userProfile.DisplayName, info.AccountName, info.ProjectName,
 						principalID, info.ProjectScope,
 					),
 				)
@@ -214,19 +213,22 @@ func CheckDeveloperRBAC(ctx context.Context, azdClient *azdext.AzdClient) error 
 	} else if !hasRoleWrite {
 		// Warn rather than fail hard: deployment can still proceed, but the postdeploy
 		// step that assigns 'Azure AI User' to agent service principals may return 403.
-		fmt.Printf(
-			"  (!) Warning: Role assignment write not available on Foundry Project %s/%s.\n"+
-				"    The postdeploy step will attempt to assign 'Azure AI User' to agent service principals,\n"+
-				"    but may fail with a 403. To grant this permission, assign one of these roles:\n"+
-				"      • Owner\n"+
-				"      • User Access Administrator\n"+
-				"      • Role Based Access Control Administrator\n"+
-				"      • Azure AI Project Manager\n"+
-				"      • Azure AI Account Owner\n"+
-				"      az role assignment create --assignee %s "+
-				"--role \"Role Based Access Control Administrator\" --scope %q\n"+
-				"    Or, if roles are managed externally: AZD_AGENT_SKIP_ROLE_ASSIGNMENTS=true\n",
-			info.AccountName, info.ProjectName, principalID, info.ProjectScope,
+		// Write to stderr with warning color so the message survives azd's deployment preview capture.
+		fmt.Fprintf(os.Stderr, "%s\n",
+			output.WithWarningFormat(
+				"Role assignment write not available on Foundry Project %s/%s.\n"+
+					"    The postdeploy step will attempt to assign 'Azure AI User' to agent service principals,\n"+
+					"    but may fail with a 403. To grant this permission, assign one of these roles:\n"+
+					"      • Owner\n"+
+					"      • User Access Administrator\n"+
+					"      • Role Based Access Control Administrator\n"+
+					"      • Azure AI Project Manager\n"+
+					"      • Azure AI Account Owner\n"+
+					"      az role assignment create --assignee %s "+
+					"--role \"Role Based Access Control Administrator\" --scope %q\n"+
+					"    Or, if roles are managed externally: AZD_AGENT_SKIP_ROLE_ASSIGNMENTS=true",
+				info.AccountName, info.ProjectName, principalID, info.ProjectScope,
+			),
 		)
 	} else {
 		fmt.Println("  ✓ Role assignment write on Foundry Project")

--- a/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check.go
@@ -212,28 +212,21 @@ func CheckDeveloperRBAC(ctx context.Context, azdClient *azdext.AzdClient) error 
 	if err != nil {
 		fmt.Printf("  ⚠ Could not check role-assignment-write capability: %s\n", err)
 	} else if !hasRoleWrite {
-		return exterrors.Auth(
-			exterrors.CodeDeveloperMissingRoleAssignWriteRole,
-			fmt.Sprintf(
-				"your identity (%s) does not have the permission to write role assignments on the "+
-					"Foundry Project %s/%s — this is required for the postdeploy step to assign "+
-					"'Azure AI User' to agent service principals",
-				userProfile.DisplayName, info.AccountName, info.ProjectName,
-			),
-			fmt.Sprintf(
-				"ask a subscription Owner or User Access Administrator to assign one of these roles "+
-					"to your identity on the Foundry Project scope:\n"+
-					"  • Owner\n"+
-					"  • User Access Administrator\n"+
-					"  • Role Based Access Control Administrator\n"+
-					"  • Azure AI Project Manager\n"+
-					"  • Azure AI Account Owner\n\n"+
-					"  az role assignment create --assignee %s "+
-					"--role \"Role Based Access Control Administrator\" --scope %q\n\n"+
-					"Alternatively, if role assignments are managed externally:\n"+
-					"  AZD_AGENT_SKIP_ROLE_ASSIGNMENTS=true",
-				principalID, info.ProjectScope,
-			),
+		// Warn rather than fail hard: deployment can still proceed, but the postdeploy
+		// step that assigns 'Azure AI User' to agent service principals may return 403.
+		fmt.Printf(
+			"  (!) Warning: Role assignment write not available on Foundry Project %s/%s.\n"+
+				"    The postdeploy step will attempt to assign 'Azure AI User' to agent service principals,\n"+
+				"    but may fail with a 403. To grant this permission, assign one of these roles:\n"+
+				"      • Owner\n"+
+				"      • User Access Administrator\n"+
+				"      • Role Based Access Control Administrator\n"+
+				"      • Azure AI Project Manager\n"+
+				"      • Azure AI Account Owner\n"+
+				"      az role assignment create --assignee %s "+
+				"--role \"Role Based Access Control Administrator\" --scope %q\n"+
+				"    Or, if roles are managed externally: AZD_AGENT_SKIP_ROLE_ASSIGNMENTS=true\n",
+			info.AccountName, info.ProjectName, principalID, info.ProjectScope,
 		)
 	} else {
 		fmt.Println("  ✓ Role assignment write on Foundry Project")


### PR DESCRIPTION
Dont block deployment of agents on permissions, just warn the user. Fixes #7810