### PR TITLE
Exempt ARM-allow-listed types from reserved-name preflight check and fix duplicated warnings

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -434,6 +434,7 @@ overrides:
       - ONENOTE
       - VISIO
       - WEBREFERENCES
+      - sharepointonline
 ignorePaths:
   - "**/*_test.go"
   - "**/mock*.go"

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -115,6 +115,64 @@ var azureReservedResourceNameContainsMatches = []string{
 
 const azureReservedResourceNamePrefixMatch = "LOGIN"
 
+// azureReservedResourceNameExemptTypes lists resource type prefixes for which
+// the reserved-word check is skipped. ARM does not enforce the reserved-word
+// rule on these types — either because they have no public endpoint, or because
+// their names are FQDN/convention-shaped by design (e.g. DNS zones, VM
+// extensions named "Publisher.Type").
+//
+// Each entry matches the exact type or any descendant child type
+// (case-insensitive). One entry like "Microsoft.Network/privateDnsZones"
+// covers the parent zone plus every record/link child without enumerating them.
+var azureReservedResourceNameExemptTypes = []string{
+	// FQDN-shaped names.
+	"Microsoft.Network/privateDnsZones",
+	"Microsoft.Network/dnsZones",
+	"Microsoft.Network/dnsForwardingRulesets",
+	"Microsoft.Network/dnsResolvers",
+	"Microsoft.Network/firewallPolicies",
+
+	// Internal-only names (no public endpoint).
+	"Microsoft.Resources/resourceGroups",
+	"Microsoft.Resources/deployments",
+	"Microsoft.Resources/deploymentScripts",
+	"Microsoft.Authorization/roleAssignments",
+	"Microsoft.Authorization/roleDefinitions",
+	"Microsoft.Authorization/policyAssignments",
+	"Microsoft.Authorization/policyDefinitions",
+	"Microsoft.Authorization/policySetDefinitions",
+	"Microsoft.Authorization/locks",
+	"Microsoft.Insights/diagnosticSettings",
+
+	// User-labeled child resources (e.g. NSG rule "AllowMicrosoftContainerRegistryOutbound").
+	"Microsoft.Network/networkSecurityGroups",
+	"Microsoft.KeyVault/vaults/secrets",
+	"Microsoft.KeyVault/vaults/keys",
+	"Microsoft.KeyVault/vaults/certificates",
+	"Microsoft.KeyVault/vaults/accessPolicies",
+	"Microsoft.OperationalInsights/workspaces/dataSources",
+
+	// Convention-named resources (names mirror a publisher, connector, or service tag).
+	"Microsoft.Compute/virtualMachines/extensions", // e.g. "Microsoft.Insights.LogAnalyticsAgent"
+	"Microsoft.Compute/virtualMachineScaleSets/extensions",
+	"Microsoft.Web/connections",                             // e.g. "office365", "sharepointonline"
+	"Microsoft.Network/virtualNetworks/subnets/delegations", // e.g. "Microsoft.Web/serverFarms"
+}
+
+// isReservedNameCheckExempt reports whether the reserved-word check should be
+// skipped for the given resource type. Matching is case-insensitive and applies
+// to the type itself or any descendant child type.
+func isReservedNameCheckExempt(resourceType string) bool {
+	normalized := strings.ToLower(resourceType)
+	for _, exempt := range azureReservedResourceNameExemptTypes {
+		exemptLower := strings.ToLower(exempt)
+		if normalized == exemptLower || strings.HasPrefix(normalized, exemptLower+"/") {
+			return true
+		}
+	}
+	return false
+}
+
 // BicepProvider exposes infrastructure provisioning using Azure Bicep templates
 type BicepProvider struct {
 	// Options that are available after Initialize()
@@ -2489,6 +2547,9 @@ func (p *BicepProvider) checkReservedResourceNames(
 	const docsLink = "https://learn.microsoft.com/azure/azure-resource-manager/templates/error-reserved-resource-name"
 
 	for _, resource := range valCtx.SnapshotResources {
+		if isReservedNameCheckExempt(resource.Type) {
+			continue
+		}
 		for _, v := range findReservedResourceNameViolations(resource.Name) {
 			resourceName := output.WithHighLightFormat("%q", resource.Name)
 			resourceType := output.WithGrayFormat("(%s)", resource.Type)
@@ -2711,11 +2772,18 @@ type reservedNameViolation struct {
 	matchType    string
 }
 
-// findReservedResourceNameViolations returns every reserved-word violation found
-// across the `/`-delimited segments of resourceName. A single segment can
-// produce multiple violations (for example "LoginMicrosoftApp" triggers both
-// the LOGIN prefix and the MICROSOFT substring rule), so all matches are
-// returned to avoid fix-rerun cycles during preflight.
+// findReservedResourceNameViolations returns every reserved-word violation
+// found in resourceName. A single resource can produce multiple violations
+// (for example "LoginMicrosoftApp" triggers both the LOGIN prefix and the
+// MICROSOFT substring rule), so all matches are returned to avoid fix-rerun
+// cycles during preflight.
+//
+// Only the trailing `/`-delimited segment of the name is evaluated. For child
+// resources, ARM emits the name as `<parent>/<child>` (and `<grandparent>/...`
+// for deeper children), but the parent is also enumerated separately in the
+// snapshot and is checked on its own pass — re-scanning the parent prefix
+// under each child would duplicate warnings whenever a parent name contains a
+// reserved word.
 func findReservedResourceNameViolations(resourceName string) []reservedNameViolation {
 	// Skip names that are unresolved ARM template expressions (e.g. "[guid(...)]").
 	// These are evaluated at deployment time and the literal text inside the expression
@@ -2725,40 +2793,43 @@ func findReservedResourceNameViolations(resourceName string) []reservedNameViola
 		return nil
 	}
 
+	// Evaluate only the trailing path segment so child resources don't re-flag
+	// reserved words already reported on their parents.
+	segment := resourceName
+	if idx := strings.LastIndex(resourceName, "/"); idx >= 0 {
+		segment = resourceName[idx+1:]
+	}
+	if segment == "" {
+		return nil
+	}
+
 	var violations []reservedNameViolation
-	for segment := range strings.SplitSeq(resourceName, "/") {
-		if segment == "" {
-			continue
-		}
+	normalized := strings.ToUpper(segment)
+	if _, found := azureReservedResourceNameExactMatches[normalized]; found {
+		// An exact match subsumes any prefix/substring match on the same segment,
+		// so skip the remaining checks to avoid duplicate reports.
+		return []reservedNameViolation{{
+			segment:      segment,
+			reservedWord: normalized,
+			matchType:    "exactly matches",
+		}}
+	}
 
-		normalized := strings.ToUpper(segment)
-		if _, found := azureReservedResourceNameExactMatches[normalized]; found {
-			// An exact match subsumes any prefix/substring match on the same segment,
-			// so skip the remaining checks to avoid duplicate reports.
+	if strings.HasPrefix(normalized, azureReservedResourceNamePrefixMatch) {
+		violations = append(violations, reservedNameViolation{
+			segment:      segment,
+			reservedWord: azureReservedResourceNamePrefixMatch,
+			matchType:    "starts with",
+		})
+	}
+
+	for _, reservedWord := range azureReservedResourceNameContainsMatches {
+		if strings.Contains(normalized, reservedWord) {
 			violations = append(violations, reservedNameViolation{
 				segment:      segment,
-				reservedWord: normalized,
-				matchType:    "exactly matches",
+				reservedWord: reservedWord,
+				matchType:    "contains",
 			})
-			continue
-		}
-
-		if strings.HasPrefix(normalized, azureReservedResourceNamePrefixMatch) {
-			violations = append(violations, reservedNameViolation{
-				segment:      segment,
-				reservedWord: azureReservedResourceNamePrefixMatch,
-				matchType:    "starts with",
-			})
-		}
-
-		for _, reservedWord := range azureReservedResourceNameContainsMatches {
-			if strings.Contains(normalized, reservedWord) {
-				violations = append(violations, reservedNameViolation{
-					segment:      segment,
-					reservedWord: reservedWord,
-					matchType:    "contains",
-				})
-			}
 		}
 	}
 

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_reserved_names_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_reserved_names_test.go
@@ -49,7 +49,7 @@ func TestFindReservedResourceNameViolations(t *testing.T) {
 			},
 		},
 		{
-			name:         "checks individual resource name segments",
+			name:         "checks last segment only — earlier segments are scanned via parent resource",
 			resourceName: "ai-account/AZURE",
 			want: []reservedNameViolation{
 				{segment: "AZURE", reservedWord: "AZURE", matchType: "exactly matches"},
@@ -71,11 +71,26 @@ func TestFindReservedResourceNameViolations(t *testing.T) {
 			},
 		},
 		{
-			name:         "reports violations across multiple segments",
+			// A reserved word in a parent segment is reported only once — when
+			// the parent resource is enumerated separately in the snapshot. The
+			// child compound name does not duplicate it on its own pass.
+			name:         "ignores reserved words in parent segments of a compound child name",
 			resourceName: "Azure/LoginPortal",
 			want: []reservedNameViolation{
-				{segment: "Azure", reservedWord: "AZURE", matchType: "exactly matches"},
 				{segment: "LoginPortal", reservedWord: "LOGIN", matchType: "starts with"},
+			},
+		},
+		{
+			// Reproduces the issue #7805 child-link case. Even ignoring the
+			// type-level exemption, only the trailing link segment is scanned.
+			name:         "child link compound name only scans the link segment",
+			resourceName: "privatelink.search.windows.net/privatelink.search.windows.net-link",
+			want: []reservedNameViolation{
+				{
+					segment:      "privatelink.search.windows.net-link",
+					reservedWord: "WINDOWS",
+					matchType:    "contains",
+				},
 			},
 		},
 		{
@@ -124,6 +139,124 @@ func TestCheckReservedResourceNames(t *testing.T) {
 				Name: "[guid('/subscriptions/sub-id/resourceGroups/rg-learn-agent-dev/providers/" +
 					"Microsoft.ContainerRegistry/registries/cr123', principalId, roleDefId)]",
 			},
+			// --- Issue #7805 false-positives: exempt resource types should
+			// produce no warnings even when the name contains "WINDOWS".
+			{
+				Type: "Microsoft.Network/privateDnsZones",
+				Name: "privatelink.search.windows.net",
+			},
+			{
+				Type: "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+				Name: "privatelink.search.windows.net/privatelink.search.windows.net-link",
+			},
+			{
+				Type: "Microsoft.Network/privateDnsZones/A",
+				Name: "privatelink.redis.cache.windows.net/myrecord",
+			},
+			{
+				Type: "Microsoft.Network/dnsZones",
+				Name: "contoso.windows.net",
+			},
+			{
+				Type: "Microsoft.Network/dnsForwardingRulesets/forwardingRules",
+				Name: "ruleset/forward-windows-net",
+			},
+			{
+				Type: "Microsoft.Network/dnsResolvers/inboundEndpoints",
+				Name: "resolver/windows-inbound",
+			},
+			{
+				Type: "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
+				Name: "policy/AllowMicrosoftServices",
+			},
+			{
+				// Internal-only names are exempt: nested deployments commonly
+				// embed reserved words like "microsoft" in their names.
+				Type: "Microsoft.Resources/deployments",
+				Name: "deploy-microsoft-graph",
+			},
+			{
+				Type: "Microsoft.Authorization/roleDefinitions",
+				Name: "MicrosoftAdminRole",
+			},
+			{
+				Type: "Microsoft.Authorization/policyAssignments",
+				Name: "audit-microsoft-services",
+			},
+			{
+				Type: "Microsoft.Authorization/locks",
+				Name: "DoNotDeleteMicrosoftSubscriptionLock",
+			},
+			{
+				Type: "Microsoft.Insights/diagnosticSettings",
+				Name: "audit-microsoft-events",
+			},
+			// Reproduces the false positive seen in the official azd sample
+			// `Azure-Samples/azure-search-openai-demo` — NSG security rules
+			// frequently encode Azure service-tag names like
+			// "MicrosoftContainerRegistry" in their labels.
+			{
+				Type: "Microsoft.Network/networkSecurityGroups/securityRules",
+				Name: "myNsg/AllowMicrosoftContainerRegistryOutbound",
+			},
+			// Resource group names are commonly derived from the user's azd
+			// environment name (e.g. `rg-${environmentName}`); a project named
+			// "microsoft-graph-svc" must not produce an unfixable warning.
+			{
+				Type: "Microsoft.Resources/resourceGroups",
+				Name: "rg-microsoft-graph-svc",
+			},
+			// Key Vault item children: user-labeled, no endpoint enforcement.
+			{
+				Type: "Microsoft.KeyVault/vaults/secrets",
+				Name: "kv/microsoft-graph-client-secret",
+			},
+			{
+				Type: "Microsoft.KeyVault/vaults/keys",
+				Name: "kv/windows-signing-key",
+			},
+			{
+				Type: "Microsoft.KeyVault/vaults/certificates",
+				Name: "kv/microsoftAuthCert",
+			},
+			{
+				Type: "Microsoft.KeyVault/vaults/accessPolicies",
+				Name: "kv/MicrosoftAdminPolicy",
+			},
+			// VM extension names follow the publisher.type convention; the
+			// official Microsoft Sentinel azd template uses
+			// "Microsoft.Insights.LogAnalyticsAgent".
+			{
+				Type: "Microsoft.Compute/virtualMachines/extensions",
+				Name: "myVm/Microsoft.Insights.LogAnalyticsAgent",
+			},
+			// Logic Apps API connection: the resource name mirrors the
+			// connector type by convention, including the literal "office365"
+			// (which would otherwise hit the OFFICE365 reserved-word rule).
+			{
+				Type: "Microsoft.Web/connections",
+				Name: "office365",
+			},
+			// Log Analytics workspace data source: user-labeled config child
+			// frequently named after Windows perf counters.
+			{
+				Type: "Microsoft.OperationalInsights/workspaces/dataSources",
+				Name: "myWorkspace/windowsPerfCounter1",
+			},
+			// Subnet delegations are named after the delegated provider's
+			// service tag (e.g. "Microsoft.Web/serverFarms"); every Microsoft
+			// delegation hits the MICROSOFT rule.
+			{
+				Type: "Microsoft.Network/virtualNetworks/subnets/delegations",
+				Name: "vnet/snet/Microsoft.Web.serverFarms",
+			},
+			{
+				// Case-insensitive type matching: ARM resource types are
+				// case-insensitive, so a lower-cased provider should still be
+				// recognized as exempt.
+				Type: "microsoft.network/privatednszones",
+				Name: "another.windows.net",
+			},
 		},
 	})
 
@@ -152,4 +285,197 @@ func TestCheckReservedResourceNames(t *testing.T) {
 	require.Contains(t, results[3].Message, `"LoginMicrosoftApp"`)
 	require.Contains(t, results[3].Message, "contains")
 	require.Contains(t, results[3].Message, `"MICROSOFT"`)
+}
+
+func TestIsReservedNameCheckExempt(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType string
+		want         bool
+	}{
+		{
+			name:         "exact exempt parent type",
+			resourceType: "Microsoft.Network/privateDnsZones",
+			want:         true,
+		},
+		{
+			name:         "exempt child via prefix match",
+			resourceType: "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+			want:         true,
+		},
+		{
+			name:         "exempt grandchild via prefix match",
+			resourceType: "Microsoft.Network/privateDnsZones/A/foo",
+			want:         true,
+		},
+		{
+			name:         "case-insensitive comparison",
+			resourceType: "microsoft.network/privatednszones",
+			want:         true,
+		},
+		{
+			name:         "public dnsZones exempt",
+			resourceType: "Microsoft.Network/dnsZones",
+			want:         true,
+		},
+		{
+			name:         "dns forwarding rulesets exempt",
+			resourceType: "Microsoft.Network/dnsForwardingRulesets/forwardingRules",
+			want:         true,
+		},
+		{
+			name:         "dns resolvers inbound exempt",
+			resourceType: "Microsoft.Network/dnsResolvers/inboundEndpoints",
+			want:         true,
+		},
+		{
+			name:         "firewall policy parent exempt",
+			resourceType: "Microsoft.Network/firewallPolicies",
+			want:         true,
+		},
+		{
+			name:         "firewall policy rule collection groups exempt via prefix",
+			resourceType: "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
+			want:         true,
+		},
+		{
+			name:         "nested deployments exempt",
+			resourceType: "Microsoft.Resources/deployments",
+			want:         true,
+		},
+		{
+			name:         "deployment scripts exempt",
+			resourceType: "Microsoft.Resources/deploymentScripts",
+			want:         true,
+		},
+		{
+			name:         "role assignments exempt",
+			resourceType: "Microsoft.Authorization/roleAssignments",
+			want:         true,
+		},
+		{
+			name:         "policy set definitions exempt",
+			resourceType: "Microsoft.Authorization/policySetDefinitions",
+			want:         true,
+		},
+		{
+			name:         "authorization locks exempt",
+			resourceType: "Microsoft.Authorization/locks",
+			want:         true,
+		},
+		{
+			name:         "diagnostic settings exempt",
+			resourceType: "Microsoft.Insights/diagnosticSettings",
+			want:         true,
+		},
+		{
+			name:         "resource groups exempt",
+			resourceType: "Microsoft.Resources/resourceGroups",
+			want:         true,
+		},
+		{
+			name:         "NSG security rules exempt via parent prefix",
+			resourceType: "Microsoft.Network/networkSecurityGroups/securityRules",
+			want:         true,
+		},
+		{
+			name:         "key vault secrets exempt",
+			resourceType: "Microsoft.KeyVault/vaults/secrets",
+			want:         true,
+		},
+		{
+			name:         "key vault keys exempt",
+			resourceType: "Microsoft.KeyVault/vaults/keys",
+			want:         true,
+		},
+		{
+			name:         "key vault certificates exempt",
+			resourceType: "Microsoft.KeyVault/vaults/certificates",
+			want:         true,
+		},
+		{
+			name:         "key vault accessPolicies exempt",
+			resourceType: "Microsoft.KeyVault/vaults/accessPolicies",
+			want:         true,
+		},
+		{
+			name:         "VM extension exempt (publisher.type names)",
+			resourceType: "Microsoft.Compute/virtualMachines/extensions",
+			want:         true,
+		},
+		{
+			name:         "VMSS extension exempt",
+			resourceType: "Microsoft.Compute/virtualMachineScaleSets/extensions",
+			want:         true,
+		},
+		{
+			name:         "Logic Apps API connection exempt (e.g. office365)",
+			resourceType: "Microsoft.Web/connections",
+			want:         true,
+		},
+		{
+			name:         "Log Analytics workspace data source exempt",
+			resourceType: "Microsoft.OperationalInsights/workspaces/dataSources",
+			want:         true,
+		},
+		{
+			name:         "subnet delegation exempt",
+			resourceType: "Microsoft.Network/virtualNetworks/subnets/delegations",
+			want:         true,
+		},
+		{
+			// VM parent is NOT exempt — only the per-extension child names are.
+			name:         "VM parent NOT exempt",
+			resourceType: "Microsoft.Compute/virtualMachines",
+			want:         false,
+		},
+		{
+			// VNet parent is NOT exempt — only the per-delegation child names are.
+			name:         "VNet parent NOT exempt",
+			resourceType: "Microsoft.Network/virtualNetworks",
+			want:         false,
+		},
+		{
+			// Parent KeyVault is NOT exempt — vault names are FQDNs
+			// (<name>.vault.azure.net) and ARM enforces reserved-word checks.
+			name:         "key vault parent NOT exempt",
+			resourceType: "Microsoft.KeyVault/vaults",
+			want:         false,
+		},
+		{
+			// NSG names themselves are user-labeled (no FQDN, no public
+			// endpoint), so the parent type is exempt too.
+			name:         "NSG parent exempt",
+			resourceType: "Microsoft.Network/networkSecurityGroups",
+			want:         true,
+		},
+		{
+			name:         "NSG security rule child exempt via prefix",
+			resourceType: "Microsoft.Network/networkSecurityGroups/securityRules",
+			want:         true,
+		},
+		{
+			name:         "non-exempt type: storage accounts",
+			resourceType: "Microsoft.Storage/storageAccounts",
+			want:         false,
+		},
+		{
+			name:         "non-exempt type: web sites",
+			resourceType: "Microsoft.Web/sites",
+			want:         false,
+		},
+		{
+			// Type prefix without "/" boundary should not match (no false
+			// matches via substring).
+			name:         "prefix without slash boundary not exempt",
+			resourceType: "Microsoft.Network/privateDnsZonesAndMore",
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isReservedNameCheckExempt(tt.resourceType))
+		})
+	}
 }


### PR DESCRIPTION
Fixes #7805

### Problem

The [reserved keywords validate checks](https://github.com/Azure/azure-dev/pull/7746) emit false-positive warnings on resource types where ARM **does not** enforce the reserved-word rule, such as Private Link resources.

Two distinct bugs:

1. **No exception list for ARM-allow-listed resource types.** The [reserved-name docs][docs] scope the rule to "resources with an accessible endpoint." DNS zones, RGs, deployments, policy assignments, etc. are all accepted server-side regardless of name.

2. **Compound child names produce duplicate warnings.** Bicep lists each child separately with a compound `parent/child` name. The original code split on `/` and scanned every segment, so reserved words in the parent re-fired on every child too.

[docs]: https://learn.microsoft.com/azure/azure-resource-manager/templates/error-reserved-resource-name

### Fix

This PR introduces a denylist (`azureReservedResourceNameExemptTypes`) of resource types to skip enforcing the reserved name rule.

Second, this PR rewrites `findReservedResourceNameViolations` to only scan the trailing `/`-segment of each resource name. Because Bicep enumerates the parent as its own resource, the parent's name is already evaluated separately, and re-scanning the parent prefix on every child only
duplicated warnings without finding anything new.

**Without fix**
<img width="652" height="212" alt="image" src="https://github.com/user-attachments/assets/dd3a36dc-6d97-4f90-8c0f-638eb44a7bbc" />

**With fix**

<img width="647" height="155" alt="image" src="https://github.com/user-attachments/assets/fbbf5b8f-9bd9-4898-94ab-8255acb6239c" />

#### Exempt resource types

This list was formed by analyzing Awesome Azd template bicep files.

**FQDN-shaped names**
- `Microsoft.Network/privateDnsZones`, `dnsZones`, `dnsForwardingRulesets`, `dnsResolvers`, `firewallPolicies`

**Internal-only names (no public endpoint)**
- `Microsoft.Resources/resourceGroups`, `deployments`, `deploymentScripts`
- `Microsoft.Authorization/{roleAssignments, roleDefinitions, policyAssignments, policyDefinitions, policySetDefinitions, locks}`
- `Microsoft.Insights/diagnosticSettings`

**User-labeled child resources**
- `Microsoft.Network/networkSecurityGroups` (covers parent + `securityRules`)
- `Microsoft.KeyVault/vaults/{secrets, keys, certificates, accessPolicies}`
- `Microsoft.OperationalInsights/workspaces/dataSources`

**Convention-named (publisher / connector / service tag)**
- `Microsoft.Compute/virtualMachines/extensions` *(e.g. `Microsoft.Insights.LogAnalyticsAgent`)*
- `Microsoft.Compute/virtualMachineScaleSets/extensions`
- `Microsoft.Web/connections` *(e.g. `office365`, `sharepointonline`)*
- `Microsoft.Network/virtualNetworks/subnets/delegations` *(e.g. `Microsoft.Web/serverFarms`)*

#### Why a denylist

A denylist was used instead of an allowlist because there is no public catalog of which resource types ARM actually enforces the rule on, so either approach will be wrong sometimes.

A denylist miss is a noisy false positive that the user reports and we fix. An allowlist miss is silent: the warning never fires and the user only learns the name is invalid when ARM rejects the deployment a minute later, so the gap can persist indefinitely with no signal.
