### PR TITLE
Standardize `no-prompt` required input behavior 

### DIFF
--- a/cli/azd/cmd/deeper_coverage3_test.go
+++ b/cli/azd/cmd/deeper_coverage3_test.go
@@ -137,6 +137,10 @@ func (m *mockPrompter) PromptResourceGroupFrom(
 	return args.String(0), args.Error(1)
 }
 
+func (m *mockPrompter) IsNoPromptMode() bool {
+	return false
+}
+
 type mockEnvSetSecretSubscriptionResolver struct {
 	mock.Mock
 }

--- a/cli/azd/internal/grpcserver/prompt_interactive_coverage3_test.go
+++ b/cli/azd/internal/grpcserver/prompt_interactive_coverage3_test.go
@@ -122,7 +122,7 @@ func TestPromptService_Confirm_NoPrompt_NoDefault(t *testing.T) {
 		},
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no default response")
+	requirePromptRequiredError(t, err, "continue?")
 }
 
 // --- Select tests ---
@@ -169,7 +169,7 @@ func TestPromptService_Select_NoPrompt_NoDefault(t *testing.T) {
 		},
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no default selection")
+	requirePromptRequiredError(t, err, "choose:")
 }
 
 // --- MultiSelect tests ---
@@ -247,7 +247,7 @@ func TestPromptService_Prompt_NoPrompt_RequiredNoDefault(t *testing.T) {
 		},
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no default response")
+	requirePromptRequiredError(t, err, "enter:")
 }
 
 func TestPromptService_Prompt_NoPrompt_RequiredWithDefault(t *testing.T) {
@@ -300,6 +300,14 @@ func TestPromptService_PromptSubscription_Error(t *testing.T) {
 	_, err := svc.PromptSubscription(t.Context(), &azdext.PromptSubscriptionRequest{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no subscriptions")
+}
+
+func TestPromptService_PromptSubscription_NoPrompt_DefaultMessage(t *testing.T) {
+	t.Parallel()
+	svc := newTestPromptService(&mockPromptService{}, true)
+	_, err := svc.PromptSubscription(t.Context(), &azdext.PromptSubscriptionRequest{})
+	require.Error(t, err)
+	requirePromptRequiredError(t, err, "Select subscription")
 }
 
 // --- PromptLocation tests ---
@@ -382,6 +390,14 @@ func TestPromptService_PromptLocation_Error(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestPromptService_PromptLocation_NoPrompt(t *testing.T) {
+	t.Parallel()
+	svc := newTestPromptService(&mockPromptService{}, true)
+	_, err := svc.PromptLocation(t.Context(), &azdext.PromptLocationRequest{})
+	require.Error(t, err)
+	requirePromptRequiredError(t, err, "Select location")
+}
+
 // --- PromptResourceGroup tests ---
 
 func TestPromptService_PromptResourceGroup_NilAzureContext(t *testing.T) {
@@ -436,6 +452,14 @@ func TestPromptService_PromptResourceGroup_Error(t *testing.T) {
 		},
 	})
 	require.Error(t, err)
+}
+
+func TestPromptService_PromptResourceGroup_NoPrompt_DefaultMessage(t *testing.T) {
+	t.Parallel()
+	svc := newTestPromptService(&mockPromptService{}, true)
+	_, err := svc.PromptResourceGroup(t.Context(), &azdext.PromptResourceGroupRequest{})
+	require.Error(t, err)
+	requirePromptRequiredError(t, err, "Select resource group")
 }
 
 // --- PromptSubscriptionResource tests ---
@@ -503,6 +527,18 @@ func TestPromptService_PromptSubscriptionResource_Error(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestPromptService_PromptSubscriptionResource_NoPrompt_DefaultResourceMessage(t *testing.T) {
+	t.Parallel()
+	svc := newTestPromptService(&mockPromptService{}, true)
+	_, err := svc.PromptSubscriptionResource(t.Context(), &azdext.PromptSubscriptionResourceRequest{
+		Options: &azdext.PromptResourceOptions{
+			ResourceTypeDisplayName: "OpenAI account",
+		},
+	})
+	require.Error(t, err)
+	requirePromptRequiredError(t, err, "Select OpenAI account")
+}
+
 // --- PromptResourceGroupResource tests ---
 
 func TestPromptService_PromptResourceGroupResource_NilAzureContext(t *testing.T) {
@@ -510,6 +546,20 @@ func TestPromptService_PromptResourceGroupResource_NilAzureContext(t *testing.T)
 	svc := newTestPromptService(&mockPromptService{}, false)
 	_, err := svc.PromptResourceGroupResource(t.Context(), &azdext.PromptResourceGroupResourceRequest{})
 	require.Error(t, err)
+}
+
+func TestPromptService_PromptResourceGroupResource_NoPrompt_UsesSelectOptionsMessage(t *testing.T) {
+	t.Parallel()
+	svc := newTestPromptService(&mockPromptService{}, true)
+	_, err := svc.PromptResourceGroupResource(t.Context(), &azdext.PromptResourceGroupResourceRequest{
+		Options: &azdext.PromptResourceOptions{
+			SelectOptions: &azdext.PromptResourceSelectOptions{
+				Message: "Select existing web app",
+			},
+		},
+	})
+	require.Error(t, err)
+	requirePromptRequiredError(t, err, "Select existing web app")
 }
 
 func TestPromptService_PromptResourceGroupResource_Success(t *testing.T) {

--- a/cli/azd/internal/grpcserver/prompt_service.go
+++ b/cli/azd/internal/grpcserver/prompt_service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/ai"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
 	"github.com/azure/azure-dev/cli/azd/pkg/ux"
@@ -54,7 +55,9 @@ func (s *promptService) Confirm(ctx context.Context, req *azdext.ConfirmRequest)
 
 	if s.globalOptions.NoPrompt {
 		if req.Options.DefaultValue == nil {
-			return nil, fmt.Errorf("no default response for prompt '%s'", req.Options.Message)
+			return nil, &input.PromptRequiredError{
+				PromptMessage: req.Options.Message,
+			}
 		} else {
 			return &azdext.ConfirmResponse{
 				Value: req.Options.DefaultValue,
@@ -91,7 +94,9 @@ func (s *promptService) Select(ctx context.Context, req *azdext.SelectRequest) (
 
 	if s.globalOptions.NoPrompt {
 		if req.Options.SelectedIndex == nil {
-			return nil, fmt.Errorf("no default selection for prompt '%s'", req.Options.Message)
+			return nil, &input.PromptRequiredError{
+				PromptMessage: req.Options.Message,
+			}
 		} else {
 			return &azdext.SelectResponse{
 				Value: req.Options.SelectedIndex,
@@ -196,7 +201,9 @@ func (s *promptService) MultiSelect(
 func (s *promptService) Prompt(ctx context.Context, req *azdext.PromptRequest) (*azdext.PromptResponse, error) {
 	if s.globalOptions.NoPrompt {
 		if req.Options.Required && req.Options.DefaultValue == "" {
-			return nil, fmt.Errorf("no default response for prompt '%s'", req.Options.Message)
+			return nil, &input.PromptRequiredError{
+				PromptMessage: req.Options.Message,
+			}
 		} else {
 			return &azdext.PromptResponse{
 				Value: req.Options.DefaultValue,

--- a/cli/azd/internal/grpcserver/prompt_service.go
+++ b/cli/azd/internal/grpcserver/prompt_service.go
@@ -242,7 +242,10 @@ func (s *promptService) PromptSubscription(
 	ctx context.Context,
 	req *azdext.PromptSubscriptionRequest,
 ) (*azdext.PromptSubscriptionResponse, error) {
-	// Delegate to prompt service which handles --no-prompt mode
+	if s.globalOptions.NoPrompt {
+		return nil, &input.PromptRequiredError{PromptMessage: promptSubscriptionMessage(req)}
+	}
+
 	release, err := s.acquirePromptLock(ctx)
 	if err != nil {
 		return nil, err
@@ -274,7 +277,10 @@ func (s *promptService) PromptLocation(
 	ctx context.Context,
 	req *azdext.PromptLocationRequest,
 ) (*azdext.PromptLocationResponse, error) {
-	// Delegate to prompt service which handles --no-prompt mode
+	if s.globalOptions.NoPrompt {
+		return nil, &input.PromptRequiredError{PromptMessage: "Select location"}
+	}
+
 	release, err := s.acquirePromptLock(ctx)
 	if err != nil {
 		return nil, err
@@ -313,7 +319,10 @@ func (s *promptService) PromptResourceGroup(
 	ctx context.Context,
 	req *azdext.PromptResourceGroupRequest,
 ) (*azdext.PromptResourceGroupResponse, error) {
-	// Delegate to prompt service which handles --no-prompt mode
+	if s.globalOptions.NoPrompt {
+		return nil, &input.PromptRequiredError{PromptMessage: promptResourceGroupMessage(req)}
+	}
+
 	release, err := s.acquirePromptLock(ctx)
 	if err != nil {
 		return nil, err
@@ -347,7 +356,10 @@ func (s *promptService) PromptSubscriptionResource(
 	ctx context.Context,
 	req *azdext.PromptSubscriptionResourceRequest,
 ) (*azdext.PromptSubscriptionResourceResponse, error) {
-	// Delegate to prompt service which handles --no-prompt mode
+	if s.globalOptions.NoPrompt {
+		return nil, &input.PromptRequiredError{PromptMessage: promptResourceMessage(req.Options)}
+	}
+
 	release, err := s.acquirePromptLock(ctx)
 	if err != nil {
 		return nil, err
@@ -381,7 +393,10 @@ func (s *promptService) PromptResourceGroupResource(
 	ctx context.Context,
 	req *azdext.PromptResourceGroupResourceRequest,
 ) (*azdext.PromptResourceGroupResourceResponse, error) {
-	// Delegate to prompt service which handles --no-prompt mode
+	if s.globalOptions.NoPrompt {
+		return nil, &input.PromptRequiredError{PromptMessage: promptResourceMessage(req.Options)}
+	}
+
 	release, err := s.acquirePromptLock(ctx)
 	if err != nil {
 		return nil, err
@@ -477,6 +492,44 @@ func createResourceOptions(options *azdext.PromptResourceOptions) prompt.Resourc
 	}
 
 	return resourceOptions
+}
+
+func promptSubscriptionMessage(req *azdext.PromptSubscriptionRequest) string {
+	if req != nil && req.Message != "" {
+		return req.Message
+	}
+
+	return "Select subscription"
+}
+
+func promptResourceGroupMessage(req *azdext.PromptResourceGroupRequest) string {
+	if req != nil &&
+		req.Options != nil &&
+		req.Options.SelectOptions != nil &&
+		req.Options.SelectOptions.Message != "" {
+		return req.Options.SelectOptions.Message
+	}
+
+	return "Select resource group"
+}
+
+func promptResourceMessage(options *azdext.PromptResourceOptions) string {
+	if options != nil &&
+		options.SelectOptions != nil &&
+		options.SelectOptions.Message != "" {
+		return options.SelectOptions.Message
+	}
+
+	resourceName := "resource"
+	if options != nil {
+		if options.ResourceTypeDisplayName != "" {
+			resourceName = options.ResourceTypeDisplayName
+		} else if options.ResourceType != "" {
+			resourceName = options.ResourceType
+		}
+	}
+
+	return fmt.Sprintf("Select %s", resourceName)
 }
 
 func createResourceGroupOptions(options *azdext.PromptResourceGroupOptions) *prompt.ResourceGroupOptions {

--- a/cli/azd/internal/grpcserver/prompt_service.go
+++ b/cli/azd/internal/grpcserver/prompt_service.go
@@ -432,7 +432,7 @@ func (s *promptService) createAzureContext(wire *azdext.AzureContext) (*prompt.A
 
 	resourceList := prompt.NewAzureResourceList(s.resourceService, resources)
 
-	return prompt.NewAzureContext(s.prompter, scope, resourceList), nil
+	return prompt.NewAzureContext(s.prompter, scope, resourceList, s.globalOptions), nil
 }
 
 func createResourceOptions(options *azdext.PromptResourceOptions) prompt.ResourceOptions {

--- a/cli/azd/internal/grpcserver/prompt_service.go
+++ b/cli/azd/internal/grpcserver/prompt_service.go
@@ -454,7 +454,7 @@ func (s *promptService) createAzureContext(wire *azdext.AzureContext) (*prompt.A
 
 	resourceList := prompt.NewAzureResourceList(s.resourceService, resources)
 
-	return prompt.NewAzureContext(s.prompter, scope, resourceList, s.globalOptions), nil
+	return prompt.NewAzureContext(s.prompter, scope, resourceList, s.globalOptions.NoPrompt), nil
 }
 
 func createResourceOptions(options *azdext.PromptResourceOptions) prompt.ResourceOptions {

--- a/cli/azd/internal/grpcserver/prompt_service_test.go
+++ b/cli/azd/internal/grpcserver/prompt_service_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
 	"github.com/azure/azure-dev/cli/azd/pkg/ux"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockprompt"
@@ -51,7 +52,7 @@ func Test_PromptService_Confirm_NoPromptWithoutDefault(t *testing.T) {
 	})
 
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no default response")
+	requirePromptRequiredError(t, err, "Continue?")
 }
 
 func Test_PromptService_Select_NoPromptWithDefault(t *testing.T) {
@@ -88,7 +89,7 @@ func Test_PromptService_Select_NoPromptWithoutDefault(t *testing.T) {
 	})
 
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no default selection")
+	requirePromptRequiredError(t, err, "Choose option:")
 }
 
 func Test_PromptService_MultiSelect_NoPrompt(t *testing.T) {
@@ -140,7 +141,7 @@ func Test_PromptService_Prompt_NoPromptRequiredWithoutDefault(t *testing.T) {
 	})
 
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no default response")
+	requirePromptRequiredError(t, err, "Enter name:")
 }
 
 func Test_PromptService_Prompt_NoPromptNotRequiredWithoutDefault(t *testing.T) {
@@ -156,6 +157,17 @@ func Test_PromptService_Prompt_NoPromptNotRequiredWithoutDefault(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, "", resp.Value)
+}
+
+func requirePromptRequiredError(t *testing.T, err error, expectedPromptMessage string) *input.PromptRequiredError {
+	t.Helper()
+
+	promptErr, ok := errors.AsType[*input.PromptRequiredError](err)
+	require.True(t, ok)
+	require.Empty(t, promptErr.Inputs)
+	require.Equal(t, expectedPromptMessage, promptErr.PromptMessage)
+
+	return promptErr
 }
 
 func Test_PromptService_PromptSubscription(t *testing.T) {

--- a/cli/azd/pkg/contracts/envelope.go
+++ b/cli/azd/pkg/contracts/envelope.go
@@ -16,3 +16,13 @@ type EventEnvelope struct {
 	Timestamp time.Time     `json:"timestamp"`
 	Data      any           `json:"data"`
 }
+
+// ErrorEnvelope is the standard envelope for error returns.
+type ErrorEnvelope[D any] struct {
+	// Code is a machine-readable error code.
+	Code string `json:"code"`
+	// Message is a human-readable error message.
+	Message string `json:"message"`
+	// Details contains additional error details.
+	Details D `json:"details"`
+}

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -372,6 +372,9 @@ func EnsureSubscriptionAndLocation(
 ) error {
 	subId := env.GetSubscriptionId()
 	if subId == "" {
+		if prompter.IsNoPromptMode() {
+			return fmt.Errorf("subscription ID is required in no-prompt mode. Set AZURE_SUBSCRIPTION_ID environment variable")
+		}
 		subscriptionId, err := prompter.PromptSubscription(ctx, "Select an Azure Subscription to use:")
 		if err != nil {
 			return err
@@ -390,6 +393,9 @@ func EnsureSubscriptionAndLocation(
 
 	location := env.GetLocation()
 	if env.GetLocation() == "" {
+		if prompter.IsNoPromptMode() {
+			return fmt.Errorf("location is required in no-prompt mode. Set AZURE_LOCATION environment variable")
+		}
 		loc, err := prompter.PromptLocation(
 			ctx,
 			env.GetSubscriptionId(),
@@ -416,6 +422,9 @@ func EnsureSubscription(
 ) error {
 	subId := env.GetSubscriptionId()
 	if subId == "" {
+		if prompter.IsNoPromptMode() {
+			return fmt.Errorf("subscription ID is required in no-prompt mode. Set AZURE_SUBSCRIPTION_ID environment variable")
+		}
 		subscriptionId, err := prompter.PromptSubscription(ctx, "Select an Azure Subscription to use:")
 		if err != nil {
 			return err

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -373,7 +373,19 @@ func EnsureSubscriptionAndLocation(
 	subId := env.GetSubscriptionId()
 	if subId == "" {
 		if prompter.IsNoPromptMode() {
-			return fmt.Errorf("subscription ID is required in no-prompt mode. Set AZURE_SUBSCRIPTION_ID environment variable")
+			return &input.PromptRequiredError{
+				Inputs: []input.RequiredInput{
+					{
+						Name: "subscription",
+						Sources: []input.InputSource{
+							{
+								Kind: input.InputSourceEnvironment,
+								Name: environment.SubscriptionIdEnvVarName,
+							},
+						},
+					},
+				},
+			}
 		}
 		subscriptionId, err := prompter.PromptSubscription(ctx, "Select an Azure Subscription to use:")
 		if err != nil {
@@ -394,7 +406,19 @@ func EnsureSubscriptionAndLocation(
 	location := env.GetLocation()
 	if env.GetLocation() == "" {
 		if prompter.IsNoPromptMode() {
-			return fmt.Errorf("location is required in no-prompt mode. Set AZURE_LOCATION environment variable")
+			return &input.PromptRequiredError{
+				Inputs: []input.RequiredInput{
+					{
+						Name: "location",
+						Sources: []input.InputSource{
+							{
+								Kind: input.InputSourceEnvironment,
+								Name: environment.LocationEnvVarName,
+							},
+						},
+					},
+				},
+			}
 		}
 		loc, err := prompter.PromptLocation(
 			ctx,
@@ -423,7 +447,19 @@ func EnsureSubscription(
 	subId := env.GetSubscriptionId()
 	if subId == "" {
 		if prompter.IsNoPromptMode() {
-			return fmt.Errorf("subscription ID is required in no-prompt mode. Set AZURE_SUBSCRIPTION_ID environment variable")
+			return &input.PromptRequiredError{
+				Inputs: []input.RequiredInput{
+					{
+						Name: "subscription",
+						Sources: []input.InputSource{
+							{
+								Kind: input.InputSourceEnvironment,
+								Name: environment.SubscriptionIdEnvVarName,
+							},
+						},
+					},
+				},
+			}
 		}
 		subscriptionId, err := prompter.PromptSubscription(ctx, "Select an Azure Subscription to use:")
 		if err != nil {

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -5,6 +5,7 @@ package provisioning_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -22,6 +23,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazapi"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockenv"
 	"github.com/benbjohnson/clock"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -220,6 +222,125 @@ func TestManagerDestroyWithNegativeConfirmation(t *testing.T) {
 	require.Nil(t, destroyResult)
 	require.NotNil(t, err)
 	require.Contains(t, mockContext.Console.Output(), "Are you sure you want to destroy?")
+}
+
+func TestEnsureSubscriptionAndLocation_NoPromptMissingSubscriptionReturnsPromptRequiredError(t *testing.T) {
+	env := environment.NewWithValues("test-env", nil)
+
+	err := provisioning.EnsureSubscriptionAndLocation(
+		context.Background(),
+		&mockenv.MockEnvManager{},
+		env,
+		noPromptPrompter{},
+		provisioning.EnsureSubscriptionAndLocationOptions{},
+	)
+	promptErr := requirePromptRequiredError(t, err, input.RequiredInput{
+		Name: "subscription",
+		Sources: []input.InputSource{
+			{
+				Kind: input.InputSourceEnvironment,
+				Name: environment.SubscriptionIdEnvVarName,
+			},
+		},
+	})
+
+	require.Contains(t, promptErr.ToString(""), environment.SubscriptionIdEnvVarName)
+}
+
+func TestEnsureSubscriptionAndLocation_NoPromptMissingLocationReturnsPromptRequiredError(t *testing.T) {
+	env := environment.NewWithValues("test-env", map[string]string{
+		environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
+	})
+	envManager := &mockenv.MockEnvManager{}
+	envManager.On("Save", mock.Anything, env).Return(nil).Once()
+
+	err := provisioning.EnsureSubscriptionAndLocation(
+		context.Background(),
+		envManager,
+		env,
+		noPromptPrompter{},
+		provisioning.EnsureSubscriptionAndLocationOptions{},
+	)
+	promptErr := requirePromptRequiredError(t, err, input.RequiredInput{
+		Name: "location",
+		Sources: []input.InputSource{
+			{
+				Kind: input.InputSourceEnvironment,
+				Name: environment.LocationEnvVarName,
+			},
+		},
+	})
+
+	require.Contains(t, promptErr.ToString(""), environment.LocationEnvVarName)
+	envManager.AssertExpectations(t)
+}
+
+func TestEnsureSubscription_NoPromptMissingSubscriptionReturnsPromptRequiredError(t *testing.T) {
+	env := environment.NewWithValues("test-env", nil)
+
+	err := provisioning.EnsureSubscription(
+		context.Background(),
+		&mockenv.MockEnvManager{},
+		env,
+		noPromptPrompter{},
+	)
+	requirePromptRequiredError(t, err, input.RequiredInput{
+		Name: "subscription",
+		Sources: []input.InputSource{
+			{
+				Kind: input.InputSourceEnvironment,
+				Name: environment.SubscriptionIdEnvVarName,
+			},
+		},
+	})
+}
+
+type noPromptPrompter struct{}
+
+func (p noPromptPrompter) PromptSubscription(ctx context.Context, msg string) (string, error) {
+	panic("unexpected PromptSubscription call")
+}
+
+func (p noPromptPrompter) PromptLocation(
+	ctx context.Context,
+	subId string,
+	msg string,
+	filter prompt.LocationFilterPredicate,
+	defaultLocation *string,
+) (string, error) {
+	panic("unexpected PromptLocation call")
+}
+
+func (p noPromptPrompter) PromptResourceGroup(ctx context.Context, options prompt.PromptResourceOptions) (string, error) {
+	panic("unexpected PromptResourceGroup call")
+}
+
+func (p noPromptPrompter) PromptResourceGroupFrom(
+	ctx context.Context,
+	subscriptionId string,
+	location string,
+	options prompt.PromptResourceGroupFromOptions,
+) (string, error) {
+	panic("unexpected PromptResourceGroupFrom call")
+}
+
+func (p noPromptPrompter) IsNoPromptMode() bool {
+	return true
+}
+
+func requirePromptRequiredError(
+	t *testing.T,
+	err error,
+	expectedInput input.RequiredInput,
+) *input.PromptRequiredError {
+	t.Helper()
+
+	promptErr, ok := errors.AsType[*input.PromptRequiredError](err)
+	require.True(t, ok)
+	require.Equal(t, []input.RequiredInput{expectedInput}, promptErr.Inputs)
+	require.Contains(t, promptErr.ToString(""), input.DefaultPromptRequiredMessage)
+
+	return promptErr
 }
 
 func registerContainerDependencies(mockContext *mocks.MockContext, env *environment.Environment) {

--- a/cli/azd/pkg/input/asker.go
+++ b/cli/azd/pkg/input/asker.go
@@ -31,13 +31,13 @@ func askOneNoPrompt(p survey.Prompt, response any) error {
 	switch v := p.(type) {
 	case *survey.Input:
 		if v.Default == "" {
-			return fmt.Errorf("no default response for prompt '%s'", v.Message)
+			return promptRequiredForPrompt(v.Message)
 		}
 
 		*(response.(*string)) = v.Default
 	case *survey.Select:
 		if v.Default == nil {
-			return fmt.Errorf("no default response for prompt '%s'", v.Message)
+			return promptRequiredForPrompt(v.Message)
 		}
 
 		switch ptr := response.(type) {
@@ -60,9 +60,11 @@ func askOneNoPrompt(p survey.Prompt, response any) error {
 		}
 	case *survey.Confirm:
 		*(response.(*bool)) = v.Default
+	case *survey.Password:
+		return promptRequiredForPrompt(v.Message)
 	case *survey.MultiSelect:
 		if v.Default == nil {
-			return fmt.Errorf("no default response for prompt '%s'", v.Message)
+			return promptRequiredForPrompt(v.Message)
 		}
 		defValue, err := v.Default.([]string)
 		if !err {
@@ -74,6 +76,12 @@ func askOneNoPrompt(p survey.Prompt, response any) error {
 	}
 
 	return nil
+}
+
+func promptRequiredForPrompt(promptMessage string) error {
+	return &PromptRequiredError{
+		PromptMessage: promptMessage,
+	}
 }
 
 func withShowCursor(o *survey.AskOptions) error {

--- a/cli/azd/pkg/input/asker_test.go
+++ b/cli/azd/pkg/input/asker_test.go
@@ -5,6 +5,7 @@ package input
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -48,7 +49,9 @@ func Test_askOneNoPrompt_Input(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.errContains)
+				promptErr, ok := errors.AsType[*PromptRequiredError](err)
+				require.True(t, ok)
+				require.Equal(t, tt.message, promptErr.PromptMessage)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.wantResult, result)
@@ -100,7 +103,13 @@ func Test_askOneNoPrompt_Select_IntResponse(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.errContains)
+				if tt.errContains == "no default response" {
+					promptErr, ok := errors.AsType[*PromptRequiredError](err)
+					require.True(t, ok)
+					require.Equal(t, prompt.Message, promptErr.PromptMessage)
+				} else {
+					require.Contains(t, err.Error(), tt.errContains)
+				}
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.wantIdx, result)
@@ -203,7 +212,13 @@ func Test_askOneNoPrompt_MultiSelect(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.errContains)
+				if tt.errContains == "no default response" {
+					promptErr, ok := errors.AsType[*PromptRequiredError](err)
+					require.True(t, ok)
+					require.Equal(t, prompt.Message, promptErr.PromptMessage)
+				} else {
+					require.Contains(t, err.Error(), tt.errContains)
+				}
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.wantResult, result)
@@ -212,8 +227,20 @@ func Test_askOneNoPrompt_MultiSelect(t *testing.T) {
 	}
 }
 
-func Test_askOneNoPrompt_UnknownType_Panics(t *testing.T) {
+func Test_askOneNoPrompt_Password_ReturnsPromptRequiredError(t *testing.T) {
 	prompt := &survey.Password{Message: "Secret:"}
+	var result string
+
+	err := askOneNoPrompt(prompt, &result)
+
+	require.Error(t, err)
+	promptErr, ok := errors.AsType[*PromptRequiredError](err)
+	require.True(t, ok)
+	require.Equal(t, "Secret:", promptErr.PromptMessage)
+}
+
+func Test_askOneNoPrompt_UnknownType_Panics(t *testing.T) {
+	prompt := &survey.Editor{Message: "Edit:"}
 	var result string
 
 	require.Panics(t, func() {

--- a/cli/azd/pkg/input/prompt_required_error.go
+++ b/cli/azd/pkg/input/prompt_required_error.go
@@ -44,12 +44,15 @@ type RequiredInput struct {
 }
 
 // PromptRequiredError is returned when --no-prompt mode prevents collecting required inputs interactively.
+//
+// Either Inputs or PromptMessage is set, but not both.
 type PromptRequiredError struct {
+	// Inputs is the list of required inputs that are missing.
+	Inputs []RequiredInput
 	// Message is the headline used for structured missing-input output.
 	Message string
-	Inputs  []RequiredInput
 
-	// PromptMessage is the original prompt text and is only used when Inputs is empty.
+	// PromptMessage is the prompt text that would have been displayed to the user if interactive prompts were allowed.
 	PromptMessage string
 }
 

--- a/cli/azd/pkg/input/prompt_required_error.go
+++ b/cli/azd/pkg/input/prompt_required_error.go
@@ -1,0 +1,183 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package input
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// DefaultPromptRequiredMessage is the default headline used when a command cannot continue without prompting.
+const DefaultPromptRequiredMessage = "This command cannot continue (interactive prompts disabled)"
+
+const (
+	promptRequiredCode              = "promptRequired"
+	promptRequiredMissingInputsType = "missingRequiredInputs"
+)
+
+// InputSourceKind identifies the kind of source that can satisfy a required input.
+type InputSourceKind string
+
+const (
+	InputSourceFlag        InputSourceKind = "flag"
+	InputSourceEnvironment InputSourceKind = "environment"
+	InputSourceConfig      InputSourceKind = "config"
+)
+
+// InputSource describes one way a required input can be supplied.
+type InputSource struct {
+	Kind         InputSourceKind `json:"kind"`
+	Name         string          `json:"name"`
+	ExampleValue string          `json:"exampleValue,omitempty"`
+}
+
+// RequiredInput describes a missing input and the supported sources that can provide it.
+type RequiredInput struct {
+	Name        string        `json:"name"`
+	Description string        `json:"description,omitempty"`
+	Sources     []InputSource `json:"sources,omitempty"`
+}
+
+// PromptRequiredError is returned when --no-prompt mode prevents collecting required inputs interactively.
+type PromptRequiredError struct {
+	Message string
+	Inputs  []RequiredInput
+}
+
+// Error implements the error interface.
+func (e *PromptRequiredError) Error() string {
+	return "prompt required"
+}
+
+// ToString returns a formatted message with the missing inputs and short remediation guidance.
+func (e *PromptRequiredError) ToString(currentIndentation string) string {
+	var buf strings.Builder
+	separator := "──────────────────────────────────────────────────────────────"
+
+	message := e.Message
+	if message == "" {
+		message = DefaultPromptRequiredMessage
+	}
+
+	buf.WriteString(separator + "\n")
+	buf.WriteString(message + "\n")
+	buf.WriteString(separator + "\n\n")
+
+	switch len(e.Inputs) {
+	case 0:
+		buf.WriteString("Required input is missing.\n")
+	case 1:
+		buf.WriteString("1 required input is missing.\n")
+	default:
+		buf.WriteString(fmt.Sprintf("%d required inputs are missing.\n", len(e.Inputs)))
+	}
+
+	if len(e.Inputs) > 0 {
+		buf.WriteString("\nMissing required inputs:\n\n")
+	}
+
+	for _, input := range e.Inputs {
+		buf.WriteString(fmt.Sprintf("• %s\n", input.Name))
+
+		if len(input.Sources) > 0 {
+			buf.WriteString("    Provide one of:\n")
+			for _, source := range input.Sources {
+				buf.WriteString(fmt.Sprintf("      %s: %s\n", sourceKindLabel(source.Kind), source.Name))
+			}
+		}
+
+		if input.Description != "" {
+			buf.WriteString(fmt.Sprintf("    Description: %s\n", input.Description))
+		}
+
+		buf.WriteString("\n")
+	}
+
+	if e.hasEnvironmentSource() {
+		exampleSources := e.environmentSourcesWithExamples()
+		if len(exampleSources) == 0 {
+			buf.WriteString("Example:\n")
+			buf.WriteString("  azd env set <ENV_VAR_NAME> <value>\n\n")
+		} else {
+			if len(exampleSources) == 1 {
+				buf.WriteString("Example:\n")
+			} else {
+				buf.WriteString("Examples:\n")
+			}
+			for _, source := range exampleSources {
+				buf.WriteString(fmt.Sprintf("  azd env set %s %s\n", source.Name, source.ExampleValue))
+			}
+			buf.WriteString("\n")
+		}
+	}
+
+	return buf.String()
+}
+
+// MarshalJSON implements json.Marshaler.
+func (e *PromptRequiredError) MarshalJSON() ([]byte, error) {
+	message := e.Message
+	if message == "" {
+		message = DefaultPromptRequiredMessage
+	}
+
+	return json.Marshal(struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+		Details struct {
+			Type   string          `json:"type"`
+			Inputs []RequiredInput `json:"inputs"`
+		} `json:"details"`
+	}{
+		Code:    promptRequiredCode,
+		Message: message,
+		Details: struct {
+			Type   string          `json:"type"`
+			Inputs []RequiredInput `json:"inputs"`
+		}{
+			Type:   promptRequiredMissingInputsType,
+			Inputs: e.Inputs,
+		},
+	})
+}
+
+func (e *PromptRequiredError) hasEnvironmentSource() bool {
+	for _, input := range e.Inputs {
+		for _, source := range input.Sources {
+			if source.Kind == InputSourceEnvironment {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (e *PromptRequiredError) environmentSourcesWithExamples() []InputSource {
+	var sources []InputSource
+
+	for _, input := range e.Inputs {
+		for _, source := range input.Sources {
+			if source.Kind == InputSourceEnvironment && source.ExampleValue != "" {
+				sources = append(sources, source)
+			}
+		}
+	}
+
+	return sources
+}
+
+func sourceKindLabel(kind InputSourceKind) string {
+	switch kind {
+	case InputSourceFlag:
+		return "Flag"
+	case InputSourceEnvironment:
+		return "Environment"
+	case InputSourceConfig:
+		return "Config"
+	default:
+		return "Source"
+	}
+}

--- a/cli/azd/pkg/input/prompt_required_error.go
+++ b/cli/azd/pkg/input/prompt_required_error.go
@@ -7,14 +7,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/contracts"
 )
 
 // DefaultPromptRequiredMessage is the default headline used when a command cannot continue without prompting.
 const DefaultPromptRequiredMessage = "This command cannot continue (interactive prompts disabled)"
 
 const (
-	promptRequiredCode              = "promptRequired"
-	promptRequiredMissingInputsType = "missingRequiredInputs"
+	promptRequiredCode                    = "promptRequired"
+	promptRequiredMissingInputsType       = "missingRequiredInputs"
+	promptRequiredInteractiveRequiredType = "interactiveRequired"
 )
 
 // InputSourceKind identifies the kind of source that can satisfy a required input.
@@ -42,8 +45,12 @@ type RequiredInput struct {
 
 // PromptRequiredError is returned when --no-prompt mode prevents collecting required inputs interactively.
 type PromptRequiredError struct {
+	// Message is the headline used for structured missing-input output.
 	Message string
 	Inputs  []RequiredInput
+
+	// PromptMessage is the original prompt text and is only used when Inputs is empty.
+	PromptMessage string
 }
 
 // Error implements the error interface.
@@ -53,16 +60,15 @@ func (e *PromptRequiredError) Error() string {
 
 // ToString returns a formatted message with the missing inputs and short remediation guidance.
 func (e *PromptRequiredError) ToString(currentIndentation string) string {
+	if len(e.Inputs) == 0 && e.PromptMessage != "" {
+		return e.promptMessageToString()
+	}
+
 	var buf strings.Builder
 	separator := "──────────────────────────────────────────────────────────────"
 
-	message := e.Message
-	if message == "" {
-		message = DefaultPromptRequiredMessage
-	}
-
 	buf.WriteString(separator + "\n")
-	buf.WriteString(message + "\n")
+	buf.WriteString(e.message() + "\n")
 	buf.WriteString(separator + "\n\n")
 
 	switch len(e.Inputs) {
@@ -118,29 +124,44 @@ func (e *PromptRequiredError) ToString(currentIndentation string) string {
 
 // MarshalJSON implements json.Marshaler.
 func (e *PromptRequiredError) MarshalJSON() ([]byte, error) {
-	message := e.Message
-	if message == "" {
-		message = DefaultPromptRequiredMessage
+	type details struct {
+		Type          string          `json:"type"`
+		PromptMessage string          `json:"promptMessage,omitempty"`
+		Inputs        []RequiredInput `json:"inputs,omitempty"`
 	}
 
-	return json.Marshal(struct {
-		Code    string `json:"code"`
-		Message string `json:"message"`
-		Details struct {
-			Type   string          `json:"type"`
-			Inputs []RequiredInput `json:"inputs"`
-		} `json:"details"`
-	}{
+	d := details{Inputs: e.Inputs}
+	if len(e.Inputs) == 0 && e.PromptMessage != "" {
+		d.Type = promptRequiredInteractiveRequiredType
+		d.PromptMessage = e.PromptMessage
+	} else {
+		d.Type = promptRequiredMissingInputsType
+	}
+
+	return json.Marshal(contracts.ErrorEnvelope[details]{
 		Code:    promptRequiredCode,
-		Message: message,
-		Details: struct {
-			Type   string          `json:"type"`
-			Inputs []RequiredInput `json:"inputs"`
-		}{
-			Type:   promptRequiredMissingInputsType,
-			Inputs: e.Inputs,
-		},
+		Message: e.message(),
+		Details: d,
 	})
+}
+
+func (e *PromptRequiredError) message() string {
+	if e.Message == "" {
+		return DefaultPromptRequiredMessage
+	}
+
+	return e.Message
+}
+
+func (e *PromptRequiredError) promptMessageToString() string {
+	var buf strings.Builder
+
+	buf.WriteString("The following prompt requires user input:\n\n")
+	buf.WriteString(fmt.Sprintf("  ? %s\n\n", e.PromptMessage))
+	buf.WriteString("This prompt cannot be answered non-interactively. ")
+	buf.WriteString("To proceed, run this command in interactive mode.\n")
+
+	return buf.String()
 }
 
 func (e *PromptRequiredError) hasEnvironmentSource() bool {

--- a/cli/azd/pkg/input/prompt_required_error_test.go
+++ b/cli/azd/pkg/input/prompt_required_error_test.go
@@ -110,6 +110,23 @@ func TestPromptRequiredError_ToString_UsesDescription(t *testing.T) {
 	require.Equal(t, expectedOutput, err.ToString(""))
 }
 
+func TestPromptRequiredError_ToString_UsesPromptMessageWhenInputsMissing(t *testing.T) {
+	err := &PromptRequiredError{
+		PromptMessage: "Enter name:",
+	}
+
+	expectedOutput := strings.Join([]string{
+		"The following prompt requires user input:",
+		"",
+		"  ? Enter name:",
+		"",
+		"This prompt cannot be answered non-interactively. To proceed, run this command in interactive mode.",
+		"",
+	}, "\n")
+
+	require.Equal(t, expectedOutput, err.ToString(""))
+}
+
 func TestPromptRequiredError_MarshalJSON(t *testing.T) {
 	err := &PromptRequiredError{
 		Message: DefaultPromptRequiredMessage,
@@ -165,4 +182,24 @@ func TestPromptRequiredError_MarshalJSON_UsesDefaultMessageWhenEmpty(t *testing.
 	}
 	require.NoError(t, json.Unmarshal(data, &payload))
 	require.Equal(t, DefaultPromptRequiredMessage, payload.Message)
+}
+
+func TestPromptRequiredError_MarshalJSON_IncludesPromptMessageWhenInputsMissing(t *testing.T) {
+	err := &PromptRequiredError{
+		PromptMessage: "Enter name:",
+	}
+
+	data, marshalErr := err.MarshalJSON()
+	require.NoError(t, marshalErr)
+
+	var payload struct {
+		Message string `json:"message"`
+		Details struct {
+			PromptMessage string `json:"promptMessage"`
+		} `json:"details"`
+	}
+	require.NoError(t, json.Unmarshal(data, &payload))
+
+	require.Equal(t, DefaultPromptRequiredMessage, payload.Message)
+	require.Equal(t, "Enter name:", payload.Details.PromptMessage)
 }

--- a/cli/azd/pkg/input/prompt_required_error_test.go
+++ b/cli/azd/pkg/input/prompt_required_error_test.go
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package input
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPromptRequiredError_Error(t *testing.T) {
+	err := &PromptRequiredError{Message: DefaultPromptRequiredMessage}
+
+	require.Equal(t, "prompt required", err.Error())
+}
+
+func TestPromptRequiredError_ToString_UsesGenericEnvExample(t *testing.T) {
+	err := &PromptRequiredError{
+		Message: DefaultPromptRequiredMessage,
+		Inputs: []RequiredInput{
+			{
+				Name: "subscription",
+				Sources: []InputSource{
+					{
+						Kind: InputSourceFlag,
+						Name: "--subscription",
+					},
+					{
+						Kind: InputSourceEnvironment,
+						Name: "AZURE_SUBSCRIPTION_ID",
+					},
+				},
+			},
+		},
+	}
+
+	output := err.ToString("")
+	require.Contains(t, output, DefaultPromptRequiredMessage)
+	require.Contains(t, output, "1 required input is missing")
+	require.Contains(t, output, "• subscription")
+	require.Contains(t, output, "Flag: --subscription")
+	require.Contains(t, output, "Environment: AZURE_SUBSCRIPTION_ID")
+	require.Contains(t, output, "Example:")
+	require.Contains(t, output, "azd env set <ENV_VAR_NAME> <value>")
+}
+
+func TestPromptRequiredError_ToString_UsesConcreteEnvExamples(t *testing.T) {
+	err := &PromptRequiredError{
+		Message: DefaultPromptRequiredMessage,
+		Inputs: []RequiredInput{
+			{
+				Name: "location",
+				Sources: []InputSource{
+					{
+						Kind:         InputSourceEnvironment,
+						Name:         "AZURE_LOCATION",
+						ExampleValue: "westus2",
+					},
+				},
+			},
+			{
+				Name: "resource group",
+				Sources: []InputSource{
+					{
+						Kind:         InputSourceEnvironment,
+						Name:         "AZURE_RESOURCE_GROUP",
+						ExampleValue: "my-app-rg",
+					},
+				},
+			},
+		},
+	}
+
+	output := err.ToString("")
+	require.Contains(t, output, "Examples:")
+	require.Contains(t, output, "azd env set AZURE_LOCATION westus2")
+	require.Contains(t, output, "azd env set AZURE_RESOURCE_GROUP my-app-rg")
+	require.NotContains(t, output, "azd env set <ENV_VAR_NAME> <value>")
+}
+
+func TestPromptRequiredError_ToString_UsesDescription(t *testing.T) {
+	err := &PromptRequiredError{
+		Message: DefaultPromptRequiredMessage,
+		Inputs: []RequiredInput{
+			{
+				Name:        "OpenAI account",
+				Description: "OpenAI account must be selected to continue.",
+			},
+		},
+	}
+
+	expectedOutput := strings.Join([]string{
+		strings.Repeat("─", 62),
+		DefaultPromptRequiredMessage,
+		strings.Repeat("─", 62),
+		"",
+		"1 required input is missing.",
+		"",
+		"Missing required inputs:",
+		"",
+		"• OpenAI account",
+		"    Description: OpenAI account must be selected to continue.",
+		"",
+		"",
+	}, "\n")
+
+	require.Equal(t, expectedOutput, err.ToString(""))
+}
+
+func TestPromptRequiredError_MarshalJSON(t *testing.T) {
+	err := &PromptRequiredError{
+		Message: DefaultPromptRequiredMessage,
+		Inputs: []RequiredInput{
+			{
+				Name: "subscription",
+				Sources: []InputSource{
+					{
+						Kind: InputSourceEnvironment,
+						Name: "AZURE_SUBSCRIPTION_ID",
+					},
+					{
+						Kind:         InputSourceFlag,
+						Name:         "--subscription",
+						ExampleValue: "<subscription-id>",
+					},
+				},
+			},
+		},
+	}
+
+	data, marshalErr := err.MarshalJSON()
+	require.NoError(t, marshalErr)
+
+	var payload struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+		Details struct {
+			Type   string          `json:"type"`
+			Inputs []RequiredInput `json:"inputs"`
+		} `json:"details"`
+	}
+	require.NoError(t, json.Unmarshal(data, &payload))
+
+	require.Equal(t, promptRequiredCode, payload.Code)
+	require.Equal(t, DefaultPromptRequiredMessage, payload.Message)
+	require.Equal(t, promptRequiredMissingInputsType, payload.Details.Type)
+	require.Equal(t, err.Inputs, payload.Details.Inputs)
+}
+
+func TestPromptRequiredError_MarshalJSON_UsesDefaultMessageWhenEmpty(t *testing.T) {
+	err := &PromptRequiredError{
+		Inputs: []RequiredInput{
+			{Name: "subscription"},
+		},
+	}
+
+	data, marshalErr := err.MarshalJSON()
+	require.NoError(t, marshalErr)
+
+	var payload struct {
+		Message string `json:"message"`
+	}
+	require.NoError(t, json.Unmarshal(data, &payload))
+	require.Equal(t, DefaultPromptRequiredMessage, payload.Message)
+}

--- a/cli/azd/pkg/pipeline/pipeline_manager_test.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager_test.go
@@ -942,6 +942,11 @@ func (m *mockPrompter) PromptSubscription(ctx context.Context, msg string) (subs
 	return "00000000-0000-0000-0000-000000000000", nil
 }
 
+// IsNoPromptMode implements prompt.Prompter.
+func (m *mockPrompter) IsNoPromptMode() bool {
+	return false
+}
+
 type mockUserConfigManager struct {
 }
 

--- a/cli/azd/pkg/prompt/azure_context_test.go
+++ b/cli/azd/pkg/prompt/azure_context_test.go
@@ -23,7 +23,7 @@ var (
 
 func TestAzureContext_EnsureSubscription(t *testing.T) {
 	mockPromptService := &MockPromptService{}
-	azureContext := NewAzureContext(mockPromptService, AzureScope{}, nil)
+	azureContext := NewAzureContext(mockPromptService, AzureScope{}, nil, nil)
 
 	mockPromptService.On("PromptSubscription", mockContextType, mockSelectOptionsType).
 		Return(&account.Subscription{
@@ -44,7 +44,7 @@ func TestAzureContext_EnsureSubscription_NoPrompt(t *testing.T) {
 	azureContext := NewAzureContext(mockPromptService, AzureScope{
 		SubscriptionId: "test-subscription-id",
 		TenantId:       "test-tenant-id",
-	}, nil)
+	}, nil, nil)
 
 	err := azureContext.EnsureSubscription(context.Background())
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestAzureContext_EnsureSubscription_NoPrompt(t *testing.T) {
 
 func TestAzureContext_EnsureSubscription_Error(t *testing.T) {
 	mockPromptService := &MockPromptService{}
-	azureContext := NewAzureContext(mockPromptService, AzureScope{}, nil)
+	azureContext := NewAzureContext(mockPromptService, AzureScope{}, nil, nil)
 
 	mockPromptService.On("PromptSubscription", mockContextType, mockSelectOptionsType).
 		Return(nil, fmt.Errorf("subscription error"))
@@ -71,7 +71,7 @@ func TestAzureContext_EnsureResourceGroup(t *testing.T) {
 	mockPromptService := &MockPromptService{}
 	azureContext := NewAzureContext(mockPromptService, AzureScope{
 		SubscriptionId: "test-subscription-id",
-	}, nil)
+	}, nil, nil)
 
 	mockPromptService.On("PromptResourceGroup", mockContextType, mockAzureContextType, mockResourceGroupOptions).
 		Return(&azapi.ResourceGroup{
@@ -90,7 +90,7 @@ func TestAzureContext_EnsureResourceGroup_NoPrompt(t *testing.T) {
 	azureContext := NewAzureContext(mockPromptService, AzureScope{
 		SubscriptionId: "test-subscription-id",
 		ResourceGroup:  "test-resource-group",
-	}, nil)
+	}, nil, nil)
 
 	err := azureContext.EnsureResourceGroup(context.Background())
 	require.NoError(t, err)
@@ -103,7 +103,7 @@ func TestAzureContext_EnsureResourceGroup_Error(t *testing.T) {
 	mockPromptService := &MockPromptService{}
 	azureContext := NewAzureContext(mockPromptService, AzureScope{
 		SubscriptionId: "test-subscription-id",
-	}, nil)
+	}, nil, nil)
 
 	mockPromptService.On("PromptResourceGroup", mockContextType, mockAzureContextType, mockResourceGroupOptions).
 		Return(nil, fmt.Errorf("resource group error"))
@@ -117,7 +117,7 @@ func TestAzureContext_EnsureLocation(t *testing.T) {
 	mockPromptService := &MockPromptService{}
 	azureContext := NewAzureContext(mockPromptService, AzureScope{
 		SubscriptionId: "test-subscription-id",
-	}, nil)
+	}, nil, nil)
 
 	mockPromptService.On("PromptLocation", mockContextType, mockAzureContextType, mockSelectOptionsType).
 		Return(&account.Location{
@@ -136,7 +136,7 @@ func TestAzureContext_EnsureLocation_NoPrompt(t *testing.T) {
 	azureContext := NewAzureContext(mockPromptService, AzureScope{
 		SubscriptionId: "test-subscription-id",
 		Location:       "test-location",
-	}, nil)
+	}, nil, nil)
 
 	err := azureContext.EnsureLocation(context.Background())
 	require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestAzureContext_EnsureLocation_Error(t *testing.T) {
 	mockPromptService := &MockPromptService{}
 	azureContext := NewAzureContext(mockPromptService, AzureScope{
 		SubscriptionId: "test-subscription-id",
-	}, nil)
+	}, nil, nil)
 
 	mockPromptService.On("PromptLocation", mockContextType, mockAzureContextType, mockSelectOptionsType).
 		Return(nil, fmt.Errorf("location error"))

--- a/cli/azd/pkg/prompt/azure_context_test.go
+++ b/cli/azd/pkg/prompt/azure_context_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -41,15 +43,15 @@ func TestAzureContext_EnsureSubscription(t *testing.T) {
 
 func TestAzureContext_EnsureSubscription_NoPrompt(t *testing.T) {
 	mockPromptService := &MockPromptService{}
-	azureContext := NewAzureContext(mockPromptService, AzureScope{
-		SubscriptionId: "test-subscription-id",
-		TenantId:       "test-tenant-id",
-	}, nil, false)
+	azureContext := NewAzureContext(mockPromptService, AzureScope{}, nil, true)
 
 	err := azureContext.EnsureSubscription(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, "test-subscription-id", azureContext.Scope.SubscriptionId)
-	require.Equal(t, "test-tenant-id", azureContext.Scope.TenantId)
+	require.Error(t, err)
+
+	var promptErr *input.PromptRequiredError
+	require.ErrorAs(t, err, &promptErr)
+	require.Len(t, promptErr.Inputs, 1)
+	require.Contains(t, promptErr.ToString(""), environment.SubscriptionIdEnvVarName)
 
 	mockPromptService.AssertNotCalled(t, "PromptSubscription", mock.Anything, mock.Anything)
 }
@@ -89,12 +91,15 @@ func TestAzureContext_EnsureResourceGroup_NoPrompt(t *testing.T) {
 	mockPromptService := &MockPromptService{}
 	azureContext := NewAzureContext(mockPromptService, AzureScope{
 		SubscriptionId: "test-subscription-id",
-		ResourceGroup:  "test-resource-group",
-	}, nil, false)
+	}, nil, true)
 
 	err := azureContext.EnsureResourceGroup(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, "test-resource-group", azureContext.Scope.ResourceGroup)
+	require.Error(t, err)
+
+	var promptErr *input.PromptRequiredError
+	require.ErrorAs(t, err, &promptErr)
+	require.Len(t, promptErr.Inputs, 1)
+	require.Contains(t, promptErr.ToString(""), environment.ResourceGroupEnvVarName)
 
 	mockPromptService.AssertNotCalled(t, "PromptResourceGroup", mock.Anything, mock.Anything, mock.Anything)
 }
@@ -135,12 +140,14 @@ func TestAzureContext_EnsureLocation_NoPrompt(t *testing.T) {
 	mockPromptService := &MockPromptService{}
 	azureContext := NewAzureContext(mockPromptService, AzureScope{
 		SubscriptionId: "test-subscription-id",
-		Location:       "test-location",
-	}, nil, false)
+	}, nil, true)
 
 	err := azureContext.EnsureLocation(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, "test-location", azureContext.Scope.Location)
+	require.Error(t, err)
+
+	var promptErr *input.PromptRequiredError
+	require.ErrorAs(t, err, &promptErr)
+	require.Contains(t, promptErr.ToString(""), environment.LocationEnvVarName)
 
 	mockPromptService.AssertNotCalled(t, "PromptLocation", mock.Anything, mock.Anything, mock.Anything)
 }

--- a/cli/azd/pkg/prompt/azure_context_test.go
+++ b/cli/azd/pkg/prompt/azure_context_test.go
@@ -23,7 +23,7 @@ var (
 
 func TestAzureContext_EnsureSubscription(t *testing.T) {
 	mockPromptService := &MockPromptService{}
-	azureContext := NewAzureContext(mockPromptService, AzureScope{}, nil, nil)
+	azureContext := NewAzureContext(mockPromptService, AzureScope{}, nil, false)
 
 	mockPromptService.On("PromptSubscription", mockContextType, mockSelectOptionsType).
 		Return(&account.Subscription{
@@ -44,7 +44,7 @@ func TestAzureContext_EnsureSubscription_NoPrompt(t *testing.T) {
 	azureContext := NewAzureContext(mockPromptService, AzureScope{
 		SubscriptionId: "test-subscription-id",
 		TenantId:       "test-tenant-id",
-	}, nil, nil)
+	}, nil, false)
 
 	err := azureContext.EnsureSubscription(context.Background())
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestAzureContext_EnsureSubscription_NoPrompt(t *testing.T) {
 
 func TestAzureContext_EnsureSubscription_Error(t *testing.T) {
 	mockPromptService := &MockPromptService{}
-	azureContext := NewAzureContext(mockPromptService, AzureScope{}, nil, nil)
+	azureContext := NewAzureContext(mockPromptService, AzureScope{}, nil, false)
 
 	mockPromptService.On("PromptSubscription", mockContextType, mockSelectOptionsType).
 		Return(nil, fmt.Errorf("subscription error"))
@@ -71,7 +71,7 @@ func TestAzureContext_EnsureResourceGroup(t *testing.T) {
 	mockPromptService := &MockPromptService{}
 	azureContext := NewAzureContext(mockPromptService, AzureScope{
 		SubscriptionId: "test-subscription-id",
-	}, nil, nil)
+	}, nil, false)
 
 	mockPromptService.On("PromptResourceGroup", mockContextType, mockAzureContextType, mockResourceGroupOptions).
 		Return(&azapi.ResourceGroup{
@@ -90,7 +90,7 @@ func TestAzureContext_EnsureResourceGroup_NoPrompt(t *testing.T) {
 	azureContext := NewAzureContext(mockPromptService, AzureScope{
 		SubscriptionId: "test-subscription-id",
 		ResourceGroup:  "test-resource-group",
-	}, nil, nil)
+	}, nil, false)
 
 	err := azureContext.EnsureResourceGroup(context.Background())
 	require.NoError(t, err)
@@ -103,7 +103,7 @@ func TestAzureContext_EnsureResourceGroup_Error(t *testing.T) {
 	mockPromptService := &MockPromptService{}
 	azureContext := NewAzureContext(mockPromptService, AzureScope{
 		SubscriptionId: "test-subscription-id",
-	}, nil, nil)
+	}, nil, false)
 
 	mockPromptService.On("PromptResourceGroup", mockContextType, mockAzureContextType, mockResourceGroupOptions).
 		Return(nil, fmt.Errorf("resource group error"))
@@ -117,7 +117,7 @@ func TestAzureContext_EnsureLocation(t *testing.T) {
 	mockPromptService := &MockPromptService{}
 	azureContext := NewAzureContext(mockPromptService, AzureScope{
 		SubscriptionId: "test-subscription-id",
-	}, nil, nil)
+	}, nil, false)
 
 	mockPromptService.On("PromptLocation", mockContextType, mockAzureContextType, mockSelectOptionsType).
 		Return(&account.Location{
@@ -136,7 +136,7 @@ func TestAzureContext_EnsureLocation_NoPrompt(t *testing.T) {
 	azureContext := NewAzureContext(mockPromptService, AzureScope{
 		SubscriptionId: "test-subscription-id",
 		Location:       "test-location",
-	}, nil, nil)
+	}, nil, false)
 
 	err := azureContext.EnsureLocation(context.Background())
 	require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestAzureContext_EnsureLocation_Error(t *testing.T) {
 	mockPromptService := &MockPromptService{}
 	azureContext := NewAzureContext(mockPromptService, AzureScope{
 		SubscriptionId: "test-subscription-id",
-	}, nil, nil)
+	}, nil, false)
 
 	mockPromptService.On("PromptLocation", mockContextType, mockAzureContextType, mockSelectOptionsType).
 		Return(nil, fmt.Errorf("location error"))

--- a/cli/azd/pkg/prompt/prompt_models.go
+++ b/cli/azd/pkg/prompt/prompt_models.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
 )
 
 // Azure Scope contains the high level metadata about an Azure deployment.
@@ -151,6 +154,7 @@ type AzureContext struct {
 	Scope         AzureScope
 	Resources     *AzureResourceList
 	promptService PromptService
+	globalOptions *internal.GlobalCommandOptions
 }
 
 // NewEmptyAzureContext creates a new empty Azure context.
@@ -166,26 +170,46 @@ func NewAzureContext(
 	promptService PromptService,
 	scope AzureScope,
 	resourceList *AzureResourceList,
+	globalOptions *internal.GlobalCommandOptions,
 ) *AzureContext {
 	return &AzureContext{
 		Scope:         scope,
 		Resources:     resourceList,
 		promptService: promptService,
+		globalOptions: globalOptions,
 	}
 }
 
 // EnsureSubscription ensures that the Azure context has a subscription.
 // If the subscription is not set, the user is prompted to select a subscription.
 func (pc *AzureContext) EnsureSubscription(ctx context.Context) error {
-	if pc.Scope.SubscriptionId == "" {
-		subscription, err := pc.promptService.PromptSubscription(ctx, nil)
-		if err != nil {
-			return err
-		}
-
-		pc.Scope.TenantId = subscription.TenantId
-		pc.Scope.SubscriptionId = subscription.Id
+	if pc.Scope.SubscriptionId != "" {
+		return nil
 	}
+
+	if pc.globalOptions != nil && pc.globalOptions.NoPrompt {
+		return &input.PromptRequiredError{
+			Inputs: []input.RequiredInput{
+				{
+					Name: "subscription",
+					Sources: []input.InputSource{
+						{
+							Kind: input.InputSourceEnvironment,
+							Name: environment.SubscriptionIdEnvVarName,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	subscription, err := pc.promptService.PromptSubscription(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	pc.Scope.TenantId = subscription.TenantId
+	pc.Scope.SubscriptionId = subscription.Id
 
 	return nil
 }
@@ -193,14 +217,33 @@ func (pc *AzureContext) EnsureSubscription(ctx context.Context) error {
 // EnsureResourceGroup ensures that the Azure context has a resource group.
 // If the resource group is not set, the user is prompted to select a resource group.
 func (pc *AzureContext) EnsureResourceGroup(ctx context.Context) error {
-	if pc.Scope.ResourceGroup == "" {
-		resourceGroup, err := pc.promptService.PromptResourceGroup(ctx, pc, nil)
-		if err != nil {
-			return err
-		}
-
-		pc.Scope.ResourceGroup = resourceGroup.Name
+	if pc.Scope.ResourceGroup != "" {
+		return nil
 	}
+
+	if pc.globalOptions != nil && pc.globalOptions.NoPrompt {
+		return &input.PromptRequiredError{
+			Inputs: []input.RequiredInput{
+				{
+					Name:        "resource group",
+					Description: "The name of the resource group to use for the deployment",
+					Sources: []input.InputSource{
+						{
+							Kind: input.InputSourceEnvironment,
+							Name: environment.ResourceGroupEnvVarName,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	resourceGroup, err := pc.promptService.PromptResourceGroup(ctx, pc, nil)
+	if err != nil {
+		return err
+	}
+
+	pc.Scope.ResourceGroup = resourceGroup.Name
 
 	return nil
 }
@@ -208,14 +251,32 @@ func (pc *AzureContext) EnsureResourceGroup(ctx context.Context) error {
 // EnsureLocation ensures that the Azure context has a location.
 // If the location is not set, the user is prompted to select a location.
 func (pc *AzureContext) EnsureLocation(ctx context.Context) error {
-	if pc.Scope.Location == "" {
-		location, err := pc.promptService.PromptLocation(ctx, pc, nil)
-		if err != nil {
-			return err
-		}
-
-		pc.Scope.Location = location.Name
+	if pc.Scope.Location != "" {
+		return nil
 	}
+
+	if pc.globalOptions != nil && pc.globalOptions.NoPrompt {
+		return &input.PromptRequiredError{
+			Inputs: []input.RequiredInput{
+				{
+					Name: "location",
+					Sources: []input.InputSource{
+						{
+							Kind: input.InputSourceEnvironment,
+							Name: environment.LocationEnvVarName,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	location, err := pc.promptService.PromptLocation(ctx, pc, nil)
+	if err != nil {
+		return err
+	}
+
+	pc.Scope.Location = location.Name
 
 	return nil
 }

--- a/cli/azd/pkg/prompt/prompt_models.go
+++ b/cli/azd/pkg/prompt/prompt_models.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -154,7 +153,7 @@ type AzureContext struct {
 	Scope         AzureScope
 	Resources     *AzureResourceList
 	promptService PromptService
-	globalOptions *internal.GlobalCommandOptions
+	noPrompt      bool
 }
 
 // NewEmptyAzureContext creates a new empty Azure context.
@@ -170,13 +169,13 @@ func NewAzureContext(
 	promptService PromptService,
 	scope AzureScope,
 	resourceList *AzureResourceList,
-	globalOptions *internal.GlobalCommandOptions,
+	noPrompt bool,
 ) *AzureContext {
 	return &AzureContext{
 		Scope:         scope,
 		Resources:     resourceList,
 		promptService: promptService,
-		globalOptions: globalOptions,
+		noPrompt:      noPrompt,
 	}
 }
 
@@ -187,7 +186,7 @@ func (pc *AzureContext) EnsureSubscription(ctx context.Context) error {
 		return nil
 	}
 
-	if pc.globalOptions != nil && pc.globalOptions.NoPrompt {
+	if pc.noPrompt {
 		return &input.PromptRequiredError{
 			Inputs: []input.RequiredInput{
 				{
@@ -221,7 +220,7 @@ func (pc *AzureContext) EnsureResourceGroup(ctx context.Context) error {
 		return nil
 	}
 
-	if pc.globalOptions != nil && pc.globalOptions.NoPrompt {
+	if pc.noPrompt {
 		return &input.PromptRequiredError{
 			Inputs: []input.RequiredInput{
 				{
@@ -255,7 +254,7 @@ func (pc *AzureContext) EnsureLocation(ctx context.Context) error {
 		return nil
 	}
 
-	if pc.globalOptions != nil && pc.globalOptions.NoPrompt {
+	if pc.noPrompt {
 		return &input.PromptRequiredError{
 			Inputs: []input.RequiredInput{
 				{

--- a/cli/azd/pkg/prompt/prompt_service.go
+++ b/cli/azd/pkg/prompt/prompt_service.go
@@ -15,7 +15,6 @@ import (
 	"dario.cat/mergo"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
@@ -192,7 +191,6 @@ type promptService struct {
 	userConfigManager   config.UserConfigManager
 	resourceService     ResourceService
 	subscriptionManager SubscriptionManager
-	globalOptions       *internal.GlobalCommandOptions
 }
 
 // NewPromptService creates a new prompt service.
@@ -202,7 +200,6 @@ func NewPromptService(
 	userConfigManager config.UserConfigManager,
 	subscriptionManager SubscriptionManager,
 	resourceService ResourceService,
-	globalOptions *internal.GlobalCommandOptions,
 ) PromptService {
 	return &promptService{
 		authManager:         authManager,
@@ -210,7 +207,6 @@ func NewPromptService(
 		userConfigManager:   userConfigManager,
 		subscriptionManager: subscriptionManager,
 		resourceService:     resourceService,
-		globalOptions:       globalOptions,
 	}
 }
 
@@ -531,19 +527,6 @@ func (ps *promptService) PromptSubscriptionResource(
 		return nil, err
 	}
 
-	// Handle --no-prompt mode
-	if ps.globalOptions.NoPrompt {
-		return nil, &input.PromptRequiredError{
-			Message: input.DefaultPromptRequiredMessage,
-			Inputs: []input.RequiredInput{
-				{
-					Name:        resourceName,
-					Description: fmt.Sprintf("%s must be selected to continue.", resourceName),
-				},
-			},
-		}
-	}
-
 	allowNewResource := mergedSelectorOptions.AllowNewResource != nil && *mergedSelectorOptions.AllowNewResource
 
 	resource, err := PromptCustomResource(ctx, CustomResourceOptions[azapi.ResourceExtended]{
@@ -680,19 +663,6 @@ func (ps *promptService) PromptResourceGroupResource(
 
 	if err := mergo.Merge(mergedSelectorOptions, defaultSelectorOptions, mergo.WithoutDereference); err != nil {
 		return nil, err
-	}
-
-	// Handle --no-prompt mode
-	if ps.globalOptions.NoPrompt {
-		return nil, &input.PromptRequiredError{
-			Message: input.DefaultPromptRequiredMessage,
-			Inputs: []input.RequiredInput{
-				{
-					Name:        resourceName,
-					Description: fmt.Sprintf("%s must be selected to continue.", resourceName),
-				},
-			},
-		}
 	}
 
 	allowNewResource := mergedSelectorOptions.AllowNewResource != nil && *mergedSelectorOptions.AllowNewResource

--- a/cli/azd/pkg/prompt/prompt_service.go
+++ b/cli/azd/pkg/prompt/prompt_service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/ux"
@@ -253,7 +254,19 @@ func (ps *promptService) PromptSubscription(
 
 	// Handle --no-prompt mode
 	if ps.globalOptions.NoPrompt {
-		return nil, fmt.Errorf("missing input: AZURE_SUBSCRIPTION_ID must be set")
+		return nil, &input.PromptRequiredError{
+			Inputs: []input.RequiredInput{
+				{
+					Name: "subscription",
+					Sources: []input.InputSource{
+						{
+							Kind: input.InputSourceEnvironment,
+							Name: environment.SubscriptionIdEnvVarName,
+						},
+					},
+				},
+			},
+		}
 	}
 
 	return PromptCustomResource(ctx, CustomResourceOptions[account.Subscription]{
@@ -327,7 +340,19 @@ func (ps *promptService) PromptLocation(
 
 	// Handle --no-prompt mode
 	if ps.globalOptions.NoPrompt {
-		return nil, fmt.Errorf("missing input: AZURE_LOCATION must b set")
+		return nil, &input.PromptRequiredError{
+			Inputs: []input.RequiredInput{
+				{
+					Name: "location",
+					Sources: []input.InputSource{
+						{
+							Kind: input.InputSourceEnvironment,
+							Name: environment.LocationEnvVarName,
+						},
+					},
+				},
+			},
+		}
 	}
 
 	return PromptCustomResource(ctx, CustomResourceOptions[account.Location]{
@@ -441,9 +466,19 @@ func (ps *promptService) PromptResourceGroup(
 	// Handle --no-prompt mode
 	if ps.globalOptions.NoPrompt {
 		if azureContext.Scope.ResourceGroup == "" {
-			return nil, fmt.Errorf(
-				"resource group selection required but cannot prompt in --no-prompt mode. " +
-					"Specify AZURE_RESOURCE_GROUP")
+			return nil, &input.PromptRequiredError{
+				Inputs: []input.RequiredInput{
+					{
+						Name: "resource group",
+						Sources: []input.InputSource{
+							{
+								Kind: input.InputSourceEnvironment,
+								Name: environment.ResourceGroupEnvVarName,
+							},
+						},
+					},
+				},
+			}
 		}
 
 		// Load resource groups and find the one specified in context
@@ -572,10 +607,15 @@ func (ps *promptService) PromptSubscriptionResource(
 
 	// Handle --no-prompt mode
 	if ps.globalOptions.NoPrompt {
-		return nil, fmt.Errorf(
-			"%s selection required but cannot prompt in --no-prompt mode. "+
-				"Please specify the resource using an environment variable or configuration file",
-			resourceName)
+		return nil, &input.PromptRequiredError{
+			Message: input.DefaultPromptRequiredMessage,
+			Inputs: []input.RequiredInput{
+				{
+					Name:        resourceName,
+					Description: fmt.Sprintf("%s must be selected to continue.", resourceName),
+				},
+			},
+		}
 	}
 
 	allowNewResource := mergedSelectorOptions.AllowNewResource != nil && *mergedSelectorOptions.AllowNewResource
@@ -718,10 +758,15 @@ func (ps *promptService) PromptResourceGroupResource(
 
 	// Handle --no-prompt mode
 	if ps.globalOptions.NoPrompt {
-		return nil, fmt.Errorf(
-			"%s selection required but cannot prompt in --no-prompt mode. "+
-				"Please specify the resource using an environment variable or configuration file",
-			resourceName)
+		return nil, &input.PromptRequiredError{
+			Message: input.DefaultPromptRequiredMessage,
+			Inputs: []input.RequiredInput{
+				{
+					Name:        resourceName,
+					Description: fmt.Sprintf("%s must be selected to continue.", resourceName),
+				},
+			},
+		}
 	}
 
 	allowNewResource := mergedSelectorOptions.AllowNewResource != nil && *mergedSelectorOptions.AllowNewResource

--- a/cli/azd/pkg/prompt/prompt_service.go
+++ b/cli/azd/pkg/prompt/prompt_service.go
@@ -253,50 +253,7 @@ func (ps *promptService) PromptSubscription(
 
 	// Handle --no-prompt mode
 	if ps.globalOptions.NoPrompt {
-		// Load subscriptions for both default lookup and auto-selection
-		subscriptionList, err := ps.subscriptionManager.GetSubscriptions(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load subscriptions: %w", err)
-		}
-
-		// If a default subscription is configured, use it
-		if defaultSubscriptionId != "" {
-			for _, subscription := range subscriptionList {
-				if strings.EqualFold(subscription.Id, defaultSubscriptionId) {
-					return &subscription, nil
-				}
-			}
-
-			if hideId {
-				return nil, fmt.Errorf(
-					"default subscription not found. " +
-						"Update your default subscription using " +
-						"'azd config set defaults.subscription <subscription-id>'")
-			}
-
-			return nil, fmt.Errorf(
-				"default subscription '%s' not found. "+
-					"Update your default subscription using "+
-					"'azd config set defaults.subscription <subscription-id>'",
-				defaultSubscriptionId)
-		}
-
-		// No default configured — try auto-selecting if exactly one subscription exists
-		switch len(subscriptionList) {
-		case 0:
-			return nil, fmt.Errorf(
-				"no Azure subscriptions found for the current account. " +
-					"Verify that you're logged into the correct Azure account and tenant, " +
-					"and that your account has one or more active subscriptions. " +
-					"If needed, run 'azd auth login' to sign in.")
-		case 1:
-			ps.console.Message(ctx, formatAutoSelectedSubscriptionMessage(&subscriptionList[0], hideId))
-			return &subscriptionList[0], nil
-		default:
-			return nil, fmt.Errorf(
-				"multiple Azure subscriptions found but running in non-interactive mode. " +
-					"Set a default subscription using 'azd config set defaults.subscription <subscription-id>'")
-		}
+		return nil, fmt.Errorf("missing input: AZURE_SUBSCRIPTION_ID must be set")
 	}
 
 	return PromptCustomResource(ctx, CustomResourceOptions[account.Subscription]{
@@ -370,32 +327,7 @@ func (ps *promptService) PromptLocation(
 
 	// Handle --no-prompt mode
 	if ps.globalOptions.NoPrompt {
-		// Default location always exists (fallback to eastus2), so we can use it
-		// Load locations and find the default
-		locationList, err := ps.subscriptionManager.GetLocations(
-			ctx,
-			azureContext.Scope.SubscriptionId,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load locations: %w", err)
-		}
-
-		locationList = filterLocationOptions(locationList, mergedOptions.AllowedValues)
-
-		for _, location := range locationList {
-			if strings.EqualFold(location.Name, defaultLocation) {
-				return &account.Location{
-					Name:                location.Name,
-					DisplayName:         location.DisplayName,
-					RegionalDisplayName: location.RegionalDisplayName,
-				}, nil
-			}
-		}
-
-		return nil, fmt.Errorf(
-			"default location '%s' not found in the available location options. "+
-				"Update your default location using 'azd config set defaults.location <location-name>'",
-			defaultLocation)
+		return nil, fmt.Errorf("missing input: AZURE_LOCATION must b set")
 	}
 
 	return PromptCustomResource(ctx, CustomResourceOptions[account.Location]{
@@ -511,7 +443,7 @@ func (ps *promptService) PromptResourceGroup(
 		if azureContext.Scope.ResourceGroup == "" {
 			return nil, fmt.Errorf(
 				"resource group selection required but cannot prompt in --no-prompt mode. " +
-					"Specify a resource group explicitly in your configuration or environment")
+					"Specify AZURE_RESOURCE_GROUP")
 		}
 
 		// Load resource groups and find the one specified in context

--- a/cli/azd/pkg/prompt/prompt_service.go
+++ b/cli/azd/pkg/prompt/prompt_service.go
@@ -20,7 +20,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
-	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/ux"
@@ -252,23 +251,6 @@ func (ps *promptService) PromptSubscription(
 
 	hideId := isDemoModeEnabled()
 
-	// Handle --no-prompt mode
-	if ps.globalOptions.NoPrompt {
-		return nil, &input.PromptRequiredError{
-			Inputs: []input.RequiredInput{
-				{
-					Name: "subscription",
-					Sources: []input.InputSource{
-						{
-							Kind: input.InputSourceEnvironment,
-							Name: environment.SubscriptionIdEnvVarName,
-						},
-					},
-				},
-			},
-		}
-	}
-
 	return PromptCustomResource(ctx, CustomResourceOptions[account.Subscription]{
 		SelectorOptions: mergedOptions,
 		LoadData: func(ctx context.Context) ([]*account.Subscription, error) {
@@ -335,23 +317,6 @@ func (ps *promptService) PromptLocation(
 		userLocation, exists := userConfig.GetString("defaults.location")
 		if exists && userLocation != "" {
 			defaultLocation = userLocation
-		}
-	}
-
-	// Handle --no-prompt mode
-	if ps.globalOptions.NoPrompt {
-		return nil, &input.PromptRequiredError{
-			Inputs: []input.RequiredInput{
-				{
-					Name: "location",
-					Sources: []input.InputSource{
-						{
-							Kind: input.InputSourceEnvironment,
-							Name: environment.LocationEnvVarName,
-						},
-					},
-				},
-			},
 		}
 	}
 
@@ -461,45 +426,6 @@ func (ps *promptService) PromptResourceGroup(
 
 	if err := mergo.Merge(mergedSelectorOptions, defaultSelectorOptions, mergo.WithoutDereference); err != nil {
 		return nil, err
-	}
-
-	// Handle --no-prompt mode
-	if ps.globalOptions.NoPrompt {
-		if azureContext.Scope.ResourceGroup == "" {
-			return nil, &input.PromptRequiredError{
-				Inputs: []input.RequiredInput{
-					{
-						Name: "resource group",
-						Sources: []input.InputSource{
-							{
-								Kind: input.InputSourceEnvironment,
-								Name: environment.ResourceGroupEnvVarName,
-							},
-						},
-					},
-				},
-			}
-		}
-
-		// Load resource groups and find the one specified in context
-		resourceGroupList, err := ps.resourceService.ListResourceGroup(ctx, azureContext.Scope.SubscriptionId, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load resource groups: %w", err)
-		}
-
-		for _, resourceGroup := range resourceGroupList {
-			if resourceGroup.Name == azureContext.Scope.ResourceGroup {
-				return &azapi.ResourceGroup{
-					Id:       resourceGroup.Id,
-					Name:     resourceGroup.Name,
-					Location: resourceGroup.Location,
-				}, nil
-			}
-		}
-
-		return nil, fmt.Errorf(
-			"resource group '%s' not found in subscription",
-			azureContext.Scope.ResourceGroup)
 	}
 
 	return PromptCustomResource(ctx, CustomResourceOptions[azapi.ResourceGroup]{

--- a/cli/azd/pkg/prompt/prompt_service_test.go
+++ b/cli/azd/pkg/prompt/prompt_service_test.go
@@ -5,13 +5,15 @@ package prompt
 
 import (
 	"context"
-	"strings"
+	"errors"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockaccount"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockauth"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazapi"
@@ -77,97 +79,6 @@ func Test_PromptService_PromptSubscription(t *testing.T) {
 	require.NotNil(t, promptService)
 }
 
-func Test_PromptService_PromptSubscription_NoPrompt_AutoSelect(t *testing.T) {
-	tests := []struct {
-		name          string
-		subscriptions []account.Subscription
-		defaultSubId  string
-		wantErr       bool
-		errContains   string
-		wantSubId     string
-	}{
-		{
-			name: "single subscription auto-selected",
-			subscriptions: []account.Subscription{
-				{Id: "sub-1", TenantId: "tenant-1", Name: "My Only Sub"},
-			},
-			wantSubId: "sub-1",
-		},
-		{
-			name:          "no subscriptions returns error",
-			subscriptions: []account.Subscription{},
-			wantErr:       true,
-			errContains:   "no Azure subscriptions found for the current account",
-		},
-		{
-			name: "multiple subscriptions without default returns error",
-			subscriptions: []account.Subscription{
-				{Id: "sub-1", TenantId: "tenant-1", Name: "Sub 1"},
-				{Id: "sub-2", TenantId: "tenant-2", Name: "Sub 2"},
-			},
-			wantErr:     true,
-			errContains: "multiple Azure subscriptions found",
-		},
-		{
-			name: "default subscription used when set",
-			subscriptions: []account.Subscription{
-				{Id: "sub-1", TenantId: "tenant-1", Name: "Sub 1"},
-				{Id: "sub-2", TenantId: "tenant-2", Name: "Sub 2"},
-			},
-			defaultSubId: "sub-2",
-			wantSubId:    "sub-2",
-		},
-		{
-			name: "default subscription not found returns error",
-			subscriptions: []account.Subscription{
-				{Id: "sub-1", TenantId: "tenant-1", Name: "Sub 1"},
-			},
-			defaultSubId: "sub-nonexistent",
-			wantErr:      true,
-			errContains:  "not found",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := config.NewEmptyConfig()
-			if tt.defaultSubId != "" {
-				err := cfg.Set("defaults.subscription", tt.defaultSubId)
-				require.NoError(t, err)
-			}
-			ucm := newInMemoryUserConfigManager(cfg)
-
-			authManager := &mockauth.MockAuthManager{}
-			subscriptionManager := &mockaccount.MockSubscriptionManager{}
-			resourceService := &mockazapi.MockResourceService{}
-			mockConsole := mockinput.NewMockConsole()
-			mockConsole.SetNoPromptMode(true)
-
-			subscriptionManager.
-				On("GetSubscriptions", mock.Anything).
-				Return(tt.subscriptions, nil)
-
-			globalOptions := &internal.GlobalCommandOptions{
-				NoPrompt: true,
-			}
-
-			ps := NewPromptService(
-				authManager, mockConsole, ucm, subscriptionManager, resourceService, globalOptions,
-			)
-
-			result, err := ps.PromptSubscription(context.Background(), nil)
-			if tt.wantErr {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.errContains)
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, result)
-				require.Equal(t, tt.wantSubId, result.Id)
-			}
-		})
-	}
-}
-
 func TestFormatSubscriptionDisplayName_DemoModeHidesId(t *testing.T) {
 	displayName := formatSubscriptionDisplayName(&account.Subscription{
 		Id:   "/subscriptions/sub-1",
@@ -177,9 +88,7 @@ func TestFormatSubscriptionDisplayName_DemoModeHidesId(t *testing.T) {
 	require.Equal(t, "Subscription 1", displayName)
 }
 
-func TestPromptSubscription_NoPrompt_AutoSelect_DemoModeRedactsOutput(t *testing.T) {
-	t.Setenv("AZD_DEMO_MODE", "true")
-
+func TestPromptSubscription_NoPrompt_ReturnsPromptRequiredError(t *testing.T) {
 	ucm := newInMemoryUserConfigManager(nil)
 	authManager := &mockauth.MockAuthManager{}
 	subscriptionManager := &mockaccount.MockSubscriptionManager{}
@@ -202,21 +111,20 @@ func TestPromptSubscription_NoPrompt_AutoSelect_DemoModeRedactsOutput(t *testing
 		&internal.GlobalCommandOptions{NoPrompt: true},
 	)
 
-	result, err := ps.PromptSubscription(context.Background(), nil)
-	require.NoError(t, err)
-	require.Equal(t, "sub-1", result.Id)
-	require.Len(t, mockConsole.Output(), 1)
-	require.Equal(t, "Auto-selected subscription: My Only Sub", mockConsole.Output()[0])
+	_, err := ps.PromptSubscription(context.Background(), nil)
+	requirePromptRequiredError(t, err, input.RequiredInput{
+		Name: "subscription",
+		Sources: []input.InputSource{
+			{
+				Kind: input.InputSourceEnvironment,
+				Name: environment.SubscriptionIdEnvVarName,
+			},
+		},
+	})
 }
 
-func TestPromptSubscription_NoPrompt_DefaultNotFound_DemoModeRedactsId(t *testing.T) {
-	t.Setenv("AZD_DEMO_MODE", "true")
-
-	cfg := config.NewEmptyConfig()
-	err := cfg.Set("defaults.subscription", "sub-secret")
-	require.NoError(t, err)
-
-	ucm := newInMemoryUserConfigManager(cfg)
+func TestPromptLocation_NoPrompt_ReturnsPromptRequiredError(t *testing.T) {
+	ucm := newInMemoryUserConfigManager(nil)
 	authManager := &mockauth.MockAuthManager{}
 	subscriptionManager := &mockaccount.MockSubscriptionManager{}
 	resourceService := &mockazapi.MockResourceService{}
@@ -238,18 +146,22 @@ func TestPromptSubscription_NoPrompt_DefaultNotFound_DemoModeRedactsId(t *testin
 		&internal.GlobalCommandOptions{NoPrompt: true},
 	)
 
-	_, err = ps.PromptSubscription(context.Background(), nil)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "default subscription not found")
-	require.False(t, strings.Contains(err.Error(), "sub-secret"))
+	_, err := ps.PromptLocation(context.Background(), &AzureContext{
+		Scope: AzureScope{SubscriptionId: "sub-123"},
+	}, nil)
+	requirePromptRequiredError(t, err, input.RequiredInput{
+		Name: "location",
+		Sources: []input.InputSource{
+			{
+				Kind: input.InputSourceEnvironment,
+				Name: environment.LocationEnvVarName,
+			},
+		},
+	})
 }
 
-func TestPromptLocation_NoPrompt_FiltersAllowedValues(t *testing.T) {
-	cfg := config.NewEmptyConfig()
-	err := cfg.Set("defaults.location", "westus3")
-	require.NoError(t, err)
-
-	ucm := newInMemoryUserConfigManager(cfg)
+func TestPromptResourceGroup_NoPrompt_ReturnsPromptRequiredError(t *testing.T) {
+	ucm := newInMemoryUserConfigManager(nil)
 	authManager := &mockauth.MockAuthManager{}
 	subscriptionManager := &mockaccount.MockSubscriptionManager{}
 	resourceService := &mockazapi.MockResourceService{}
@@ -272,35 +184,27 @@ func TestPromptLocation_NoPrompt_FiltersAllowedValues(t *testing.T) {
 		&internal.GlobalCommandOptions{NoPrompt: true},
 	)
 
-	location, err := ps.PromptLocation(context.Background(), &AzureContext{
+	_, err := ps.PromptResourceGroup(context.Background(), &AzureContext{
 		Scope: AzureScope{SubscriptionId: "sub-123"},
-	}, &SelectOptions{
-		AllowedValues: []string{"westus3"},
+	}, nil)
+	requirePromptRequiredError(t, err, input.RequiredInput{
+		Name: "resource group",
+		Sources: []input.InputSource{
+			{
+				Kind: input.InputSourceEnvironment,
+				Name: environment.ResourceGroupEnvVarName,
+			},
+		},
 	})
-
-	require.NoError(t, err)
-	require.Equal(t, "westus3", location.Name)
-	subscriptionManager.AssertExpectations(t)
 }
 
-func TestPromptLocation_NoPrompt_FiltersAllowedValuesCaseInsensitive(t *testing.T) {
-	cfg := config.NewEmptyConfig()
-	err := cfg.Set("defaults.location", "WESTUS3")
-	require.NoError(t, err)
-
-	ucm := newInMemoryUserConfigManager(cfg)
+func TestPromptSubscriptionResource_NoPrompt_ReturnsPromptRequiredError(t *testing.T) {
+	ucm := newInMemoryUserConfigManager(nil)
 	authManager := &mockauth.MockAuthManager{}
 	subscriptionManager := &mockaccount.MockSubscriptionManager{}
 	resourceService := &mockazapi.MockResourceService{}
 	mockConsole := mockinput.NewMockConsole()
 	mockConsole.SetNoPromptMode(true)
-
-	subscriptionManager.
-		On("GetLocations", mock.Anything, "sub-123").
-		Return([]account.Location{
-			{Name: "eastus2", DisplayName: "East US 2", RegionalDisplayName: "(US) East US 2"},
-			{Name: "westus3", DisplayName: "West US 3", RegionalDisplayName: "(US) West US 3"},
-		}, nil)
 
 	ps := NewPromptService(
 		authManager,
@@ -311,91 +215,27 @@ func TestPromptLocation_NoPrompt_FiltersAllowedValuesCaseInsensitive(t *testing.
 		&internal.GlobalCommandOptions{NoPrompt: true},
 	)
 
-	location, err := ps.PromptLocation(context.Background(), &AzureContext{
+	_, err := ps.PromptSubscriptionResource(context.Background(), &AzureContext{
 		Scope: AzureScope{SubscriptionId: "sub-123"},
-	}, &SelectOptions{
-		AllowedValues: []string{"WestUS3"},
+	}, ResourceOptions{
+		ResourceTypeDisplayName: "OpenAI account",
 	})
-
-	require.NoError(t, err)
-	require.Equal(t, "westus3", location.Name)
-	subscriptionManager.AssertExpectations(t)
+	requirePromptRequiredError(t, err, input.RequiredInput{
+		Name:        "OpenAI account",
+		Description: "OpenAI account must be selected to continue.",
+	})
 }
 
-func TestPromptLocation_NoPrompt_DefaultFilteredOut(t *testing.T) {
-	cfg := config.NewEmptyConfig()
-	err := cfg.Set("defaults.location", "westus3")
-	require.NoError(t, err)
+func requirePromptRequiredError(
+	t *testing.T,
+	err error,
+	expectedInput input.RequiredInput,
+) *input.PromptRequiredError {
+	t.Helper()
 
-	ucm := newInMemoryUserConfigManager(cfg)
-	authManager := &mockauth.MockAuthManager{}
-	subscriptionManager := &mockaccount.MockSubscriptionManager{}
-	resourceService := &mockazapi.MockResourceService{}
-	mockConsole := mockinput.NewMockConsole()
-	mockConsole.SetNoPromptMode(true)
+	promptErr, ok := errors.AsType[*input.PromptRequiredError](err)
+	require.True(t, ok)
+	require.Equal(t, []input.RequiredInput{expectedInput}, promptErr.Inputs)
 
-	subscriptionManager.
-		On("GetLocations", mock.Anything, "sub-123").
-		Return([]account.Location{
-			{Name: "eastus2", DisplayName: "East US 2", RegionalDisplayName: "(US) East US 2"},
-			{Name: "westus3", DisplayName: "West US 3", RegionalDisplayName: "(US) West US 3"},
-		}, nil)
-
-	ps := NewPromptService(
-		authManager,
-		mockConsole,
-		ucm,
-		subscriptionManager,
-		resourceService,
-		&internal.GlobalCommandOptions{NoPrompt: true},
-	)
-
-	_, err = ps.PromptLocation(context.Background(), &AzureContext{
-		Scope: AzureScope{SubscriptionId: "sub-123"},
-	}, &SelectOptions{
-		AllowedValues: []string{"eastus2"},
-	})
-
-	require.Error(t, err)
-	require.ErrorContains(t, err, "default location 'westus3' not found in the available location options")
-	subscriptionManager.AssertExpectations(t)
-}
-
-func TestPromptLocation_NoPrompt_IgnoresEmptyAllowedValues(t *testing.T) {
-	cfg := config.NewEmptyConfig()
-	err := cfg.Set("defaults.location", "westus3")
-	require.NoError(t, err)
-
-	ucm := newInMemoryUserConfigManager(cfg)
-	authManager := &mockauth.MockAuthManager{}
-	subscriptionManager := &mockaccount.MockSubscriptionManager{}
-	resourceService := &mockazapi.MockResourceService{}
-	mockConsole := mockinput.NewMockConsole()
-	mockConsole.SetNoPromptMode(true)
-
-	subscriptionManager.
-		On("GetLocations", mock.Anything, "sub-123").
-		Return([]account.Location{
-			{Name: "eastus2", DisplayName: "East US 2", RegionalDisplayName: "(US) East US 2"},
-			{Name: "westus3", DisplayName: "West US 3", RegionalDisplayName: "(US) West US 3"},
-		}, nil)
-
-	ps := NewPromptService(
-		authManager,
-		mockConsole,
-		ucm,
-		subscriptionManager,
-		resourceService,
-		&internal.GlobalCommandOptions{NoPrompt: true},
-	)
-
-	location, err := ps.PromptLocation(context.Background(), &AzureContext{
-		Scope: AzureScope{SubscriptionId: "sub-123"},
-	}, &SelectOptions{
-		AllowedValues: []string{" ", ""},
-	})
-
-	require.NoError(t, err)
-	require.Equal(t, "westus3", location.Name)
-	subscriptionManager.AssertExpectations(t)
+	return promptErr
 }

--- a/cli/azd/pkg/prompt/prompt_service_test.go
+++ b/cli/azd/pkg/prompt/prompt_service_test.go
@@ -4,16 +4,11 @@
 package prompt
 
 import (
-	"context"
-	"errors"
 	"testing"
 
-	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
-	"github.com/azure/azure-dev/cli/azd/pkg/environment"
-	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockaccount"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockauth"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockazapi"
@@ -69,13 +64,7 @@ func Test_PromptService_PromptSubscription(t *testing.T) {
 			},
 		}, nil)
 
-	globalOptions := &internal.GlobalCommandOptions{
-		NoPrompt: false,
-	}
-
-	promptService := NewPromptService(
-		authManager, mockConsole, ucm, subscriptionManager, resourceService, globalOptions,
-	)
+	promptService := NewPromptService(authManager, mockConsole, ucm, subscriptionManager, resourceService)
 	require.NotNil(t, promptService)
 }
 
@@ -86,156 +75,4 @@ func TestFormatSubscriptionDisplayName_DemoModeHidesId(t *testing.T) {
 	}, true)
 
 	require.Equal(t, "Subscription 1", displayName)
-}
-
-func TestPromptSubscription_NoPrompt_ReturnsPromptRequiredError(t *testing.T) {
-	ucm := newInMemoryUserConfigManager(nil)
-	authManager := &mockauth.MockAuthManager{}
-	subscriptionManager := &mockaccount.MockSubscriptionManager{}
-	resourceService := &mockazapi.MockResourceService{}
-	mockConsole := mockinput.NewMockConsole()
-	mockConsole.SetNoPromptMode(true)
-
-	subscriptionManager.
-		On("GetSubscriptions", mock.Anything).
-		Return([]account.Subscription{
-			{Id: "sub-1", TenantId: "tenant-1", Name: "My Only Sub"},
-		}, nil)
-
-	ps := NewPromptService(
-		authManager,
-		mockConsole,
-		ucm,
-		subscriptionManager,
-		resourceService,
-		&internal.GlobalCommandOptions{NoPrompt: true},
-	)
-
-	_, err := ps.PromptSubscription(context.Background(), nil)
-	requirePromptRequiredError(t, err, input.RequiredInput{
-		Name: "subscription",
-		Sources: []input.InputSource{
-			{
-				Kind: input.InputSourceEnvironment,
-				Name: environment.SubscriptionIdEnvVarName,
-			},
-		},
-	})
-}
-
-func TestPromptLocation_NoPrompt_ReturnsPromptRequiredError(t *testing.T) {
-	ucm := newInMemoryUserConfigManager(nil)
-	authManager := &mockauth.MockAuthManager{}
-	subscriptionManager := &mockaccount.MockSubscriptionManager{}
-	resourceService := &mockazapi.MockResourceService{}
-	mockConsole := mockinput.NewMockConsole()
-	mockConsole.SetNoPromptMode(true)
-
-	subscriptionManager.
-		On("GetSubscriptions", mock.Anything).
-		Return([]account.Subscription{
-			{Id: "sub-1", TenantId: "tenant-1", Name: "Sub 1"},
-		}, nil)
-
-	ps := NewPromptService(
-		authManager,
-		mockConsole,
-		ucm,
-		subscriptionManager,
-		resourceService,
-		&internal.GlobalCommandOptions{NoPrompt: true},
-	)
-
-	_, err := ps.PromptLocation(context.Background(), &AzureContext{
-		Scope: AzureScope{SubscriptionId: "sub-123"},
-	}, nil)
-	requirePromptRequiredError(t, err, input.RequiredInput{
-		Name: "location",
-		Sources: []input.InputSource{
-			{
-				Kind: input.InputSourceEnvironment,
-				Name: environment.LocationEnvVarName,
-			},
-		},
-	})
-}
-
-func TestPromptResourceGroup_NoPrompt_ReturnsPromptRequiredError(t *testing.T) {
-	ucm := newInMemoryUserConfigManager(nil)
-	authManager := &mockauth.MockAuthManager{}
-	subscriptionManager := &mockaccount.MockSubscriptionManager{}
-	resourceService := &mockazapi.MockResourceService{}
-	mockConsole := mockinput.NewMockConsole()
-	mockConsole.SetNoPromptMode(true)
-
-	subscriptionManager.
-		On("GetLocations", mock.Anything, "sub-123").
-		Return([]account.Location{
-			{Name: "eastus2", DisplayName: "East US 2", RegionalDisplayName: "(US) East US 2"},
-			{Name: "westus3", DisplayName: "West US 3", RegionalDisplayName: "(US) West US 3"},
-		}, nil)
-
-	ps := NewPromptService(
-		authManager,
-		mockConsole,
-		ucm,
-		subscriptionManager,
-		resourceService,
-		&internal.GlobalCommandOptions{NoPrompt: true},
-	)
-
-	_, err := ps.PromptResourceGroup(context.Background(), &AzureContext{
-		Scope: AzureScope{SubscriptionId: "sub-123"},
-	}, nil)
-	requirePromptRequiredError(t, err, input.RequiredInput{
-		Name: "resource group",
-		Sources: []input.InputSource{
-			{
-				Kind: input.InputSourceEnvironment,
-				Name: environment.ResourceGroupEnvVarName,
-			},
-		},
-	})
-}
-
-func TestPromptSubscriptionResource_NoPrompt_ReturnsPromptRequiredError(t *testing.T) {
-	ucm := newInMemoryUserConfigManager(nil)
-	authManager := &mockauth.MockAuthManager{}
-	subscriptionManager := &mockaccount.MockSubscriptionManager{}
-	resourceService := &mockazapi.MockResourceService{}
-	mockConsole := mockinput.NewMockConsole()
-	mockConsole.SetNoPromptMode(true)
-
-	ps := NewPromptService(
-		authManager,
-		mockConsole,
-		ucm,
-		subscriptionManager,
-		resourceService,
-		&internal.GlobalCommandOptions{NoPrompt: true},
-	)
-
-	_, err := ps.PromptSubscriptionResource(context.Background(), &AzureContext{
-		Scope: AzureScope{SubscriptionId: "sub-123"},
-	}, ResourceOptions{
-		ResourceTypeDisplayName: "OpenAI account",
-	})
-	requirePromptRequiredError(t, err, input.RequiredInput{
-		Name:        "OpenAI account",
-		Description: "OpenAI account must be selected to continue.",
-	})
-}
-
-func requirePromptRequiredError(
-	t *testing.T,
-	err error,
-	expectedInput input.RequiredInput,
-) *input.PromptRequiredError {
-	t.Helper()
-
-	promptErr, ok := errors.AsType[*input.PromptRequiredError](err)
-	require.True(t, ok)
-	require.Equal(t, []input.RequiredInput{expectedInput}, promptErr.Inputs)
-
-	return promptErr
 }

--- a/cli/azd/pkg/prompt/prompter.go
+++ b/cli/azd/pkg/prompt/prompter.go
@@ -41,6 +41,9 @@ type Prompter interface {
 	// PromptResourceGroupFrom is like PromptResourceGroup, but it takes an existing subscription ID and location.
 	PromptResourceGroupFrom(
 		ctx context.Context, subscriptionId string, location string, options PromptResourceGroupFromOptions) (string, error)
+
+	// IsNoPromptMode returns true when --no-prompt is active and interactive prompts are disabled.
+	IsNoPromptMode() bool
 }
 
 type DefaultPrompter struct {
@@ -279,4 +282,8 @@ func (p *DefaultPrompter) getSubscriptionOptions(ctx context.Context) ([]string,
 	}
 
 	return subscriptionOptions, subscriptions, defaultSubscription, nil
+}
+
+func (p *DefaultPrompter) IsNoPromptMode() bool {
+	return p.console.IsNoPromptMode()
 }


### PR DESCRIPTION
This change standardizes handling and reporting of interactive input when `--no-prompt` is enabled.

## What changed

 - added a shared `input.PromptRequiredError` for no-prompt failures
 - updated prompt-service, provisioning, prompt-model, and asker paths to use the shared error instead of ad hoc strings
 - adjusted behavior in `pkg/prompt/prompt_service.go` to require input for missing subscription, location, and resource group selection
 - adjusted behavior in `pkg/infra/provisioning/manager.go` to require input for missing subscription and location selection

## Why

Previously, `no-prompt` handling was inconsistent throughout the system. This change aligns handling to a standard behavior, and provides failed cases with consistent human-readable and JSON output.

This accomplishes the goal in #7743 of making `no-prompt` work for true non-interactive work: CI and agents, and fixes the underlying concerns raised in #7390.

## Validation

 - go test ./cmd -run 'TestFigSpec|TestUsage'
 - golangci-lint run ./...
 - go test ./... -short

Fixes #7743