### PR TITLE
azdext: add `RegisterFlagOptions` for per-subcommand flag config

### DIFF
--- a/cli/azd/docs/extensions/extension-framework.md
+++ b/cli/azd/docs/extensions/extension-framework.md
@@ -480,6 +480,85 @@ The build process automatically creates binaries for multiple platforms and arch
 > [!NOTE]
 > Build times may vary depending on your hardware and extension complexity.
 
+### Building a Root Command
+
+Go extensions should build their cobra root command using `azdext.NewExtensionRootCommand`. The helper registers the flags and environment-variable handling that `azd` standardizes across all extensions, so extension authors do not need to declare them manually (and avoid name collisions with `azd`'s reserved global flags).
+
+```go
+import "github.com/azure/azure-dev/cli/azd/pkg/azdext"
+
+func NewRootCommand() *cobra.Command {
+  rootCmd, extCtx := azdext.NewExtensionRootCommand(azdext.ExtensionCommandOptions{
+    Name:  "agent",
+    Use:   "agent <command> [options]",
+    Short: "Manage AI agents.",
+  })
+
+  rootCmd.AddCommand(newShowCommand(extCtx))
+  // ... other subcommands
+  return rootCmd
+}
+```
+
+`NewExtensionRootCommand` automatically:
+
+- Registers the standard persistent flags: `--debug`, `--no-prompt`, `-C/--cwd`, `-e/--environment`, `-o/--output`, plus the hidden `--trace-log-file` / `--trace-log-url` flags.
+- Reads the matching `AZD_DEBUG`, `AZD_NO_PROMPT`, `AZD_CWD`, and `AZD_ENVIRONMENT` environment variables that `azd` sets when launching the extension, and applies them when the corresponding flag was not passed explicitly.
+- Honors `--cwd`/`AZD_CWD` by changing the process working directory before the command runs.
+- Extracts W3C trace context from `TRACEPARENT` / `TRACESTATE` and calls `azdext.WithAccessToken` so the command's `cmd.Context()` is ready to use with the gRPC client.
+
+The returned `*ExtensionContext` is the recommended way to read these values inside subcommand `RunE` handlers — do not redeclare any of the standard flags on subcommands.
+
+```go
+type ExtensionContext struct {
+  Debug        bool
+  NoPrompt     bool
+  Cwd          string
+  Environment  string
+  OutputFormat string
+}
+```
+
+Pass `extCtx` into each subcommand factory and read from it inside `RunE`:
+
+```go
+func newShowCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
+  cmd := &cobra.Command{
+    Use: "show",
+    RunE: func(cmd *cobra.Command, args []string) error {
+      if extCtx.NoPrompt {
+        // skip interactive prompts
+      }
+      // use extCtx.Environment, extCtx.OutputFormat, etc.
+      return nil
+    },
+  }
+  return cmd
+}
+```
+
+#### Per-Subcommand Flag Options
+
+The persistent `-o/--output` flag is shared across the whole command tree, but different subcommands often support different output formats (for example a `list` subcommand may support `json` and `table`, while a `version` subcommand only supports `json`). Use `azdext.RegisterFlagOptions` to declare the allowed values and per-command default for any inherited persistent flag without redeclaring it:
+
+```go
+listCmd := &cobra.Command{
+  Use:  "list",
+  RunE: runList,
+}
+azdext.RegisterFlagOptions(listCmd, "output", []string{"json", "table"}, "json")
+```
+
+A single `RegisterFlagOptions` declaration drives all of the following:
+
+- **Help text.** `myext list --help` renders the flag as `-o, --output string   The output format (supported: json, table) (default "json")`.
+- **Metadata.** `azd ext metadata` (and the JSON snapshot extensions ship in their package) populates `flag.validValues` and `flag.default` for the subcommand from the same declaration.
+- **Parse-time validation.** Invocations that pass an unsupported value (e.g. `myext list --output yaml`) are rejected by the SDK with a descriptive error before `RunE` runs.
+- **Shell completion.** Tab-completing `myext list --output ` offers the registered allowed values.
+- **Default substitution.** When the user does not pass `--output`, the SDK writes the per-command default into `extCtx.OutputFormat` before `RunE` runs, so subcommands can read `extCtx.OutputFormat` directly without their own resolution logic.
+
+Sibling and parent commands continue to render the SDK default help text and behavior. The helper generalizes to any inherited persistent flag (passing the flag name as the second argument); it is most commonly used for `--output`.
+
 ### Distributed Tracing
 
 `azd` uses OpenTelemetry and W3C Trace Context for distributed tracing. `azd` sets `TRACEPARENT` in the environment when it launches the extension process.

--- a/cli/azd/docs/extensions/extension-framework.md
+++ b/cli/azd/docs/extensions/extension-framework.md
@@ -546,7 +546,11 @@ listCmd := &cobra.Command{
   Use:  "list",
   RunE: runList,
 }
-azdext.RegisterFlagOptions(listCmd, "output", []string{"json", "table"}, "json")
+azdext.RegisterFlagOptions(listCmd, azdext.FlagOptions{
+  Name:          "output",
+  AllowedValues: []string{"json", "table"},
+  Default:       "json",
+})
 ```
 
 A single `RegisterFlagOptions` declaration drives all of the following:

--- a/cli/azd/pkg/azdext/extension_command.go
+++ b/cli/azd/pkg/azdext/extension_command.go
@@ -8,10 +8,26 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"go.opentelemetry.io/otel/propagation"
+)
+
+const (
+	// flagAllowedValuesAnnotationPrefix is the cobra command annotation prefix
+	// used to record per-command allowed values for an inherited persistent
+	// flag. The full key is "azdext.allowed-values/<flagName>" and the value
+	// is a comma-joined list. See [RegisterFlagOptions].
+	flagAllowedValuesAnnotationPrefix = "azdext.allowed-values/"
+	// flagDefaultAnnotationPrefix records the per-command default value for
+	// an inherited persistent flag. See [RegisterFlagOptions].
+	flagDefaultAnnotationPrefix = "azdext.default/"
+
+	defaultOutputFlagUsage = "The output format"
 )
 
 // ExtensionContext holds parsed global state available to extension commands.
@@ -54,7 +70,9 @@ type ExtensionCommandOptions struct {
 //   - Sets up OpenTelemetry trace context from TRACEPARENT/TRACESTATE env vars
 //   - Calls WithAccessToken() on the command context
 //
-// The returned command has PersistentPreRunE configured to set up the ExtensionContext.
+// The returned command has PersistentPreRunE configured to set up the ExtensionContext
+// and to apply per-command overrides registered via [RegisterFlagOptions]. Extensions
+// must not replace PersistentPreRunE on the root or these behaviors will be lost.
 //
 // NOTE: This function and its companion helpers ([NewListenCommand], [NewMetadataCommand],
 // [NewVersionCommand]) depend on [github.com/spf13/cobra]. If non-cobra CLI frameworks
@@ -84,7 +102,7 @@ func NewExtensionRootCommand(opts ExtensionCommandOptions) (*cobra.Command, *Ext
 	flags.BoolVar(&extCtx.NoPrompt, "no-prompt", false, "Accepts the default value instead of prompting")
 	flags.StringVarP(&extCtx.Cwd, "cwd", "C", "", "Sets the current working directory")
 	flags.StringVarP(&extCtx.Environment, "environment", "e", "", "The name of the environment to use")
-	flags.StringVarP(&extCtx.OutputFormat, "output", "o", "default", "The output format")
+	flags.StringVarP(&extCtx.OutputFormat, "output", "o", "default", defaultOutputFlagUsage)
 
 	// Hidden trace flags
 	var traceLogFile, traceLogURL string
@@ -92,6 +110,26 @@ func NewExtensionRootCommand(opts ExtensionCommandOptions) (*cobra.Command, *Ext
 	flags.StringVar(&traceLogURL, "trace-log-url", "", "Send raw OpenTelemetry trace data to a URL")
 	_ = flags.MarkHidden("trace-log-file")
 	_ = flags.MarkHidden("trace-log-url")
+
+	// Register delegating shell completion for the SDK-managed --output flag.
+	// Cobra keys completion functions by *pflag.Flag pointer globally, so
+	// individual subcommands can't register their own completions for this
+	// inherited flag without conflicting. Instead this single delegating
+	// function consults the executing subcommand's [RegisterFlagOptions]
+	// annotations at completion time.
+	_ = cmd.RegisterFlagCompletionFunc("output", flagOptionsCompletion("output"))
+
+	defaultUsage := cmd.UsageFunc()
+
+	// Wrap UsageFunc only. Cobra's default HelpFunc calls UsageString()
+	// which goes through UsageFunc, so a single layer of mutation here
+	// covers both `--help` rendering and usage-on-error rendering. Wrapping
+	// HelpFunc in addition would cause overrides to be applied twice.
+	cmd.SetUsageFunc(func(usageCmd *cobra.Command) error {
+		restore := applyFlagOverridesForCommand(usageCmd)
+		defer restore()
+		return defaultUsage(usageCmd)
+	})
 
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		// Env-var fallback for flags not explicitly set
@@ -121,6 +159,14 @@ func NewExtensionRootCommand(opts ExtensionCommandOptions) (*cobra.Command, *Ext
 			if v := os.Getenv("AZD_ENVIRONMENT"); v != "" {
 				extCtx.Environment = v
 			}
+		}
+
+		// Apply per-command flag option overrides registered via
+		// RegisterFlagOptions: validate user-supplied values against the
+		// allowed set, and substitute the per-command default when the user
+		// did not pass the flag.
+		if err := applyFlagOptionsForCommand(cmd); err != nil {
+			return err
 		}
 
 		// Change working directory if specified.
@@ -160,4 +206,190 @@ func NewExtensionRootCommand(opts ExtensionCommandOptions) (*cobra.Command, *Ext
 	}
 
 	return cmd, extCtx
+}
+
+// RegisterFlagOptions configures per-subcommand metadata for an inherited
+// persistent flag (typically one registered by [NewExtensionRootCommand], such
+// as -o/--output). When set, the SDK uses this single registration to drive:
+//
+//   - help and usage rendering — the flag's help text is annotated with
+//     "(supported: ...)" and the per-command default is shown
+//   - extension metadata JSON (see [GenerateExtensionMetadata]) — populates
+//     [extensions.Flag.ValidValues] and overrides [extensions.Flag.Default]
+//   - parse-time validation — values not in allowedValues are rejected before
+//     the command's RunE is invoked
+//   - shell completion — allowedValues are suggested for the flag
+//   - default substitution — when the user did not pass the flag, the
+//     bound variable (e.g. [ExtensionContext.OutputFormat]) is set to
+//     defaultValue before RunE runs, so RunE can read it directly without
+//     extra normalization
+//
+// Pass an empty allowedValues to skip validation/completion while still
+// customizing the default. Pass an empty defaultValue to leave the SDK
+// default in place. Calling this multiple times for the same flag overwrites
+// the previous configuration. Passing a nil command or empty flagName is a
+// no-op.
+//
+// Typical usage in an extension subcommand:
+//
+//	cmd := &cobra.Command{Use: "list", RunE: runList}
+//	azdext.RegisterFlagOptions(cmd, "output", []string{"json", "table"}, "json")
+func RegisterFlagOptions(cmd *cobra.Command, flagName string, allowedValues []string, defaultValue string) *cobra.Command {
+	if cmd == nil || flagName == "" {
+		return cmd
+	}
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	if len(allowedValues) > 0 {
+		cmd.Annotations[flagAllowedValuesAnnotationPrefix+flagName] = strings.Join(allowedValues, ",")
+		// Best-effort: register completion if the flag is owned directly by
+		// cmd (not inherited). For inherited persistent flags managed by
+		// [NewExtensionRootCommand], a delegating completion function is
+		// already registered at the root that consults this command's
+		// annotations; RegisterFlagCompletionFunc would error with "already
+		// registered" here, which we deliberately ignore.
+		_ = cmd.RegisterFlagCompletionFunc(
+			flagName,
+			cobra.FixedCompletions(allowedValues, cobra.ShellCompDirectiveNoFileComp),
+		)
+	} else {
+		delete(cmd.Annotations, flagAllowedValuesAnnotationPrefix+flagName)
+	}
+	if defaultValue != "" {
+		cmd.Annotations[flagDefaultAnnotationPrefix+flagName] = defaultValue
+	} else {
+		delete(cmd.Annotations, flagDefaultAnnotationPrefix+flagName)
+	}
+	return cmd
+}
+
+// flagOverride holds the per-command configuration recorded by
+// [RegisterFlagOptions] for a single inherited flag.
+type flagOverride struct {
+	AllowedValues []string
+	Default       string
+}
+
+// flagOptionsCompletion returns a cobra completion function for flagName that
+// resolves allowed values from the executing command's [RegisterFlagOptions]
+// annotations. Used as a delegating completion for SDK-managed inherited
+// persistent flags (notably --output): cobra keys completion funcs by
+// *pflag.Flag pointer, which is shared across the tree for inherited flags,
+// so per-subcommand completions can't be registered directly.
+func flagOptionsCompletion(flagName string) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		if ov, ok := flagOverridesForCommand(cmd)[flagName]; ok && len(ov.AllowedValues) > 0 {
+			return ov.AllowedValues, cobra.ShellCompDirectiveNoFileComp
+		}
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+}
+
+// flagOverridesForCommand returns the per-command flag overrides recorded on
+// cmd via [RegisterFlagOptions], keyed by flag name. Returns nil when none
+// are registered.
+func flagOverridesForCommand(cmd *cobra.Command) map[string]flagOverride {
+	if cmd == nil || cmd.Annotations == nil {
+		return nil
+	}
+	out := map[string]flagOverride{}
+	for key, val := range cmd.Annotations {
+		switch {
+		case strings.HasPrefix(key, flagAllowedValuesAnnotationPrefix):
+			name := strings.TrimPrefix(key, flagAllowedValuesAnnotationPrefix)
+			o := out[name]
+			if val != "" {
+				o.AllowedValues = strings.Split(val, ",")
+			}
+			out[name] = o
+		case strings.HasPrefix(key, flagDefaultAnnotationPrefix):
+			name := strings.TrimPrefix(key, flagDefaultAnnotationPrefix)
+			o := out[name]
+			o.Default = val
+			out[name] = o
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// applyFlagOverridesForCommand transiently mutates the inherited persistent
+// flags referenced by cmd's per-command overrides so help/usage rendering
+// reflects the per-command supported values and default. Returns a restore
+// function that callers must defer to undo the mutation.
+func applyFlagOverridesForCommand(cmd *cobra.Command) func() {
+	overrides := flagOverridesForCommand(cmd)
+	if len(overrides) == 0 || cmd == nil {
+		return func() {}
+	}
+	type saved struct {
+		flag         *pflag.Flag
+		origUsage    string
+		origDefValue string
+	}
+	var savedFlags []saved
+	for name, ov := range overrides {
+		flag := cmd.Flags().Lookup(name)
+		if flag == nil {
+			continue
+		}
+		savedFlags = append(savedFlags, saved{flag, flag.Usage, flag.DefValue})
+		if len(ov.AllowedValues) > 0 {
+			flag.Usage = fmt.Sprintf("%s (supported: %s)", flag.Usage, strings.Join(ov.AllowedValues, ", "))
+		}
+		if ov.Default != "" {
+			flag.DefValue = ov.Default
+		}
+	}
+	return func() {
+		for _, s := range savedFlags {
+			s.flag.Usage = s.origUsage
+			s.flag.DefValue = s.origDefValue
+		}
+	}
+}
+
+// applyFlagOptionsForCommand validates and defaults the inherited persistent
+// flags configured via [RegisterFlagOptions] for the executing command. It is
+// invoked from the root command's PersistentPreRunE so it runs once before
+// the leaf command's RunE.
+//
+// For each registered override:
+//   - If the user supplied a value (cmd.Flags().Changed) and an allowedValues
+//     set is configured, the value is checked and a descriptive error is
+//     returned for unsupported values.
+//   - If the user did not supply a value and a per-command default is
+//     configured, the flag is set to that default. Because the SDK persistent
+//     flags are bound to fields on [ExtensionContext], this also updates the
+//     extension context value (e.g. [ExtensionContext.OutputFormat]).
+func applyFlagOptionsForCommand(cmd *cobra.Command) error {
+	overrides := flagOverridesForCommand(cmd)
+	for name, ov := range overrides {
+		flag := cmd.Flags().Lookup(name)
+		if flag == nil {
+			continue
+		}
+		if cmd.Flags().Changed(name) {
+			if len(ov.AllowedValues) == 0 {
+				continue
+			}
+			current := flag.Value.String()
+			if !slices.Contains(ov.AllowedValues, current) {
+				return fmt.Errorf(
+					"invalid value %q for --%s (supported: %s)",
+					current, name, strings.Join(ov.AllowedValues, ", "),
+				)
+			}
+			continue
+		}
+		if ov.Default != "" {
+			if err := cmd.Flags().Set(name, ov.Default); err != nil {
+				return fmt.Errorf("apply default for --%s: %w", name, err)
+			}
+		}
+	}
+	return nil
 }

--- a/cli/azd/pkg/azdext/extension_command.go
+++ b/cli/azd/pkg/azdext/extension_command.go
@@ -5,6 +5,7 @@ package azdext
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,8 +20,8 @@ import (
 
 const (
 	// flagAllowedValuesAnnotationPrefix prefixes cobra annotation keys that
-	// record per-command allowed values for an inherited flag. The value is
-	// a comma-joined list. See [RegisterFlagOptions].
+	// record per-command allowed values for an inherited flag. The value is a
+	// JSON-encoded []string. See [RegisterFlagOptions].
 	flagAllowedValuesAnnotationPrefix = "azdext.allowed-values/"
 	// flagDefaultAnnotationPrefix prefixes cobra annotation keys that record
 	// the per-command default for an inherited flag. See [RegisterFlagOptions].
@@ -265,7 +266,11 @@ func RegisterFlagOptions(cmd *cobra.Command, opts FlagOptions) *cobra.Command {
 		cmd.Annotations = map[string]string{}
 	}
 	if len(opts.AllowedValues) > 0 {
-		cmd.Annotations[flagAllowedValuesAnnotationPrefix+opts.Name] = strings.Join(opts.AllowedValues, ",")
+		encoded, err := json.Marshal(opts.AllowedValues)
+		if err != nil {
+			panic(fmt.Sprintf("azdext.RegisterFlagOptions: encode allowed values for flag %q: %v", opts.Name, err))
+		}
+		cmd.Annotations[flagAllowedValuesAnnotationPrefix+opts.Name] = string(encoded)
 	} else {
 		delete(cmd.Annotations, flagAllowedValuesAnnotationPrefix+opts.Name)
 	}
@@ -312,7 +317,10 @@ func flagOverridesForCommand(cmd *cobra.Command) map[string]flagOverride {
 			name := strings.TrimPrefix(key, flagAllowedValuesAnnotationPrefix)
 			o := out[name]
 			if val != "" {
-				o.AllowedValues = strings.Split(val, ",")
+				var values []string
+				if err := json.Unmarshal([]byte(val), &values); err == nil {
+					o.AllowedValues = values
+				}
 			}
 			out[name] = o
 		case strings.HasPrefix(key, flagDefaultAnnotationPrefix):
@@ -388,9 +396,14 @@ func applyFlagOptionsForCommand(cmd *cobra.Command) error {
 			continue
 		}
 		if ov.Default != "" {
-			if err := cmd.Flags().Set(name, ov.Default); err != nil {
+			// Use flag.Value.Set directly and preserve flag.Changed so callers
+			// of cmd.Flags().Changed(name) can still distinguish "user-supplied"
+			// from "SDK-substituted default".
+			wasChanged := flag.Changed
+			if err := flag.Value.Set(ov.Default); err != nil {
 				return fmt.Errorf("apply default for --%s: %w", name, err)
 			}
+			flag.Changed = wasChanged
 		}
 	}
 	return nil

--- a/cli/azd/pkg/azdext/extension_command.go
+++ b/cli/azd/pkg/azdext/extension_command.go
@@ -18,13 +18,12 @@ import (
 )
 
 const (
-	// flagAllowedValuesAnnotationPrefix is the cobra command annotation prefix
-	// used to record per-command allowed values for an inherited persistent
-	// flag. The full key is "azdext.allowed-values/<flagName>" and the value
-	// is a comma-joined list. See [RegisterFlagOptions].
+	// flagAllowedValuesAnnotationPrefix prefixes cobra annotation keys that
+	// record per-command allowed values for an inherited flag. The value is
+	// a comma-joined list. See [RegisterFlagOptions].
 	flagAllowedValuesAnnotationPrefix = "azdext.allowed-values/"
-	// flagDefaultAnnotationPrefix records the per-command default value for
-	// an inherited persistent flag. See [RegisterFlagOptions].
+	// flagDefaultAnnotationPrefix prefixes cobra annotation keys that record
+	// the per-command default for an inherited flag. See [RegisterFlagOptions].
 	flagDefaultAnnotationPrefix = "azdext.default/"
 
 	defaultOutputFlagUsage = "The output format"
@@ -111,20 +110,19 @@ func NewExtensionRootCommand(opts ExtensionCommandOptions) (*cobra.Command, *Ext
 	_ = flags.MarkHidden("trace-log-file")
 	_ = flags.MarkHidden("trace-log-url")
 
-	// Register delegating shell completion for the SDK-managed --output flag.
-	// Cobra keys completion functions by *pflag.Flag pointer globally, so
-	// individual subcommands can't register their own completions for this
-	// inherited flag without conflicting. Instead this single delegating
-	// function consults the executing subcommand's [RegisterFlagOptions]
-	// annotations at completion time.
+	// Delegating completion for the SDK-managed --output flag. Cobra keys
+	// completion funcs by *pflag.Flag pointer, so subcommands can't register
+	// their own for an inherited flag; this delegate reads the executing
+	// subcommand's [RegisterFlagOptions] annotations at completion time.
+	// Other inherited string flags (--environment, --cwd) can be added if
+	// extensions need to constrain them.
 	_ = cmd.RegisterFlagCompletionFunc("output", flagOptionsCompletion("output"))
 
 	defaultUsage := cmd.UsageFunc()
 
-	// Wrap UsageFunc only. Cobra's default HelpFunc calls UsageString()
-	// which goes through UsageFunc, so a single layer of mutation here
-	// covers both `--help` rendering and usage-on-error rendering. Wrapping
-	// HelpFunc in addition would cause overrides to be applied twice.
+	// Wrap UsageFunc only — cobra's default HelpFunc calls UsageString
+	// which goes through UsageFunc, so wrapping both would double-apply
+	// the per-command help overrides.
 	cmd.SetUsageFunc(func(usageCmd *cobra.Command) error {
 		restore := applyFlagOverridesForCommand(usageCmd)
 		defer restore()
@@ -161,10 +159,7 @@ func NewExtensionRootCommand(opts ExtensionCommandOptions) (*cobra.Command, *Ext
 			}
 		}
 
-		// Apply per-command flag option overrides registered via
-		// RegisterFlagOptions: validate user-supplied values against the
-		// allowed set, and substitute the per-command default when the user
-		// did not pass the flag.
+		// Validate and apply per-command overrides from [RegisterFlagOptions].
 		if err := applyFlagOptionsForCommand(cmd); err != nil {
 			return err
 		}
@@ -208,58 +203,76 @@ func NewExtensionRootCommand(opts ExtensionCommandOptions) (*cobra.Command, *Ext
 	return cmd, extCtx
 }
 
-// RegisterFlagOptions configures per-subcommand metadata for an inherited
-// persistent flag (typically one registered by [NewExtensionRootCommand], such
-// as -o/--output). When set, the SDK uses this single registration to drive:
+// FlagOptions describes per-subcommand configuration for an inherited
+// persistent flag. See [RegisterFlagOptions] for the effects each field
+// drives.
+type FlagOptions struct {
+	// Name is the flag name without leading dashes (e.g. "output"). Required.
+	Name string
+
+	// AllowedValues, when non-empty, restricts accepted values, drives
+	// "(supported: ...)" help text, populates metadata ValidValues, and
+	// powers shell completion.
+	AllowedValues []string
+
+	// Default, when non-empty, becomes the per-subcommand default: shown in
+	// help, surfaced in metadata, and substituted into the bound variable
+	// (e.g. [ExtensionContext.OutputFormat]) when the user does not pass
+	// the flag.
+	Default string
+}
+
+// RegisterFlagOptions configures per-subcommand behavior for an inherited
+// persistent flag (typically one registered by [NewExtensionRootCommand],
+// such as -o/--output). One declaration drives:
 //
-//   - help and usage rendering — the flag's help text is annotated with
-//     "(supported: ...)" and the per-command default is shown
-//   - extension metadata JSON (see [GenerateExtensionMetadata]) — populates
-//     [extensions.Flag.ValidValues] and overrides [extensions.Flag.Default]
-//   - parse-time validation — values not in allowedValues are rejected before
-//     the command's RunE is invoked
-//   - shell completion — allowedValues are suggested for the flag
-//   - default substitution — when the user did not pass the flag, the
-//     bound variable (e.g. [ExtensionContext.OutputFormat]) is set to
-//     defaultValue before RunE runs, so RunE can read it directly without
-//     extra normalization
+//   - help/usage rendering — flag usage gets "(supported: ...)" appended and
+//     shows the per-command default
+//   - extension metadata (see [GenerateExtensionMetadata]) — populates the
+//     flag's ValidValues field and overrides its Default field
+//   - parse-time validation — values outside AllowedValues are rejected
+//     before the command's RunE runs
+//   - shell completion — AllowedValues are suggested for the flag
+//   - default substitution — when the user does not pass the flag, the
+//     bound variable is set to Default before RunE runs
 //
-// Pass an empty allowedValues to skip validation/completion while still
-// customizing the default. Pass an empty defaultValue to leave the SDK
-// default in place. Calling this multiple times for the same flag overwrites
-// the previous configuration. Passing a nil command or empty flagName is a
-// no-op.
+// Empty AllowedValues skips validation/completion. Empty Default leaves the
+// SDK default in place. Repeat calls for the same flag overwrite. A nil
+// command or empty Name is a no-op.
 //
-// Typical usage in an extension subcommand:
+// Panics if Default is set but not in a non-empty AllowedValues, since this
+// would silently bypass validation.
+//
+// Typical usage:
 //
 //	cmd := &cobra.Command{Use: "list", RunE: runList}
-//	azdext.RegisterFlagOptions(cmd, "output", []string{"json", "table"}, "json")
-func RegisterFlagOptions(cmd *cobra.Command, flagName string, allowedValues []string, defaultValue string) *cobra.Command {
-	if cmd == nil || flagName == "" {
+//	azdext.RegisterFlagOptions(cmd, azdext.FlagOptions{
+//	    Name:          "output",
+//	    AllowedValues: []string{"json", "table"},
+//	    Default:       "json",
+//	})
+func RegisterFlagOptions(cmd *cobra.Command, opts FlagOptions) *cobra.Command {
+	if cmd == nil || opts.Name == "" {
 		return cmd
+	}
+	if opts.Default != "" && len(opts.AllowedValues) > 0 && !slices.Contains(opts.AllowedValues, opts.Default) {
+		panic(fmt.Sprintf(
+			"azdext.RegisterFlagOptions: default %q for flag %q is not in allowed values %v",
+			opts.Default, opts.Name, opts.AllowedValues,
+		))
 	}
 	if cmd.Annotations == nil {
 		cmd.Annotations = map[string]string{}
 	}
-	if len(allowedValues) > 0 {
-		cmd.Annotations[flagAllowedValuesAnnotationPrefix+flagName] = strings.Join(allowedValues, ",")
-		// Best-effort: register completion if the flag is owned directly by
-		// cmd (not inherited). For inherited persistent flags managed by
-		// [NewExtensionRootCommand], a delegating completion function is
-		// already registered at the root that consults this command's
-		// annotations; RegisterFlagCompletionFunc would error with "already
-		// registered" here, which we deliberately ignore.
-		_ = cmd.RegisterFlagCompletionFunc(
-			flagName,
-			cobra.FixedCompletions(allowedValues, cobra.ShellCompDirectiveNoFileComp),
-		)
+	if len(opts.AllowedValues) > 0 {
+		cmd.Annotations[flagAllowedValuesAnnotationPrefix+opts.Name] = strings.Join(opts.AllowedValues, ",")
 	} else {
-		delete(cmd.Annotations, flagAllowedValuesAnnotationPrefix+flagName)
+		delete(cmd.Annotations, flagAllowedValuesAnnotationPrefix+opts.Name)
 	}
-	if defaultValue != "" {
-		cmd.Annotations[flagDefaultAnnotationPrefix+flagName] = defaultValue
+	if opts.Default != "" {
+		cmd.Annotations[flagDefaultAnnotationPrefix+opts.Name] = opts.Default
 	} else {
-		delete(cmd.Annotations, flagDefaultAnnotationPrefix+flagName)
+		delete(cmd.Annotations, flagDefaultAnnotationPrefix+opts.Name)
 	}
 	return cmd
 }
@@ -271,12 +284,11 @@ type flagOverride struct {
 	Default       string
 }
 
-// flagOptionsCompletion returns a cobra completion function for flagName that
-// resolves allowed values from the executing command's [RegisterFlagOptions]
-// annotations. Used as a delegating completion for SDK-managed inherited
-// persistent flags (notably --output): cobra keys completion funcs by
-// *pflag.Flag pointer, which is shared across the tree for inherited flags,
-// so per-subcommand completions can't be registered directly.
+// flagOptionsCompletion returns a delegating completion func for flagName
+// that resolves allowed values from the executing command's
+// [RegisterFlagOptions] annotations at completion time. Used so completions
+// for SDK-managed inherited flags can vary per subcommand (cobra keys flag
+// completions by *pflag.Flag pointer, which is shared for inherited flags).
 func flagOptionsCompletion(flagName string) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		if ov, ok := flagOverridesForCommand(cmd)[flagName]; ok && len(ov.AllowedValues) > 0 {
@@ -316,10 +328,9 @@ func flagOverridesForCommand(cmd *cobra.Command) map[string]flagOverride {
 	return out
 }
 
-// applyFlagOverridesForCommand transiently mutates the inherited persistent
-// flags referenced by cmd's per-command overrides so help/usage rendering
-// reflects the per-command supported values and default. Returns a restore
-// function that callers must defer to undo the mutation.
+// applyFlagOverridesForCommand transiently mutates flag Usage/DefValue so
+// help/usage rendering reflects cmd's per-command [RegisterFlagOptions]
+// overrides. Returns a restore func that callers must defer.
 func applyFlagOverridesForCommand(cmd *cobra.Command) func() {
 	overrides := flagOverridesForCommand(cmd)
 	if len(overrides) == 0 || cmd == nil {
@@ -352,19 +363,10 @@ func applyFlagOverridesForCommand(cmd *cobra.Command) func() {
 	}
 }
 
-// applyFlagOptionsForCommand validates and defaults the inherited persistent
-// flags configured via [RegisterFlagOptions] for the executing command. It is
-// invoked from the root command's PersistentPreRunE so it runs once before
-// the leaf command's RunE.
-//
-// For each registered override:
-//   - If the user supplied a value (cmd.Flags().Changed) and an allowedValues
-//     set is configured, the value is checked and a descriptive error is
-//     returned for unsupported values.
-//   - If the user did not supply a value and a per-command default is
-//     configured, the flag is set to that default. Because the SDK persistent
-//     flags are bound to fields on [ExtensionContext], this also updates the
-//     extension context value (e.g. [ExtensionContext.OutputFormat]).
+// applyFlagOptionsForCommand applies [RegisterFlagOptions] overrides for cmd:
+// rejects user-supplied values not in AllowedValues, and substitutes Default
+// when the flag was not passed. Run from the root PersistentPreRunE so the
+// substituted value reaches the bound [ExtensionContext] field before RunE.
 func applyFlagOptionsForCommand(cmd *cobra.Command) error {
 	overrides := flagOverridesForCommand(cmd)
 	for name, ov := range overrides {

--- a/cli/azd/pkg/azdext/extension_command.go
+++ b/cli/azd/pkg/azdext/extension_command.go
@@ -70,15 +70,19 @@ type ExtensionCommandOptions struct {
 //   - Sets up OpenTelemetry trace context from TRACEPARENT/TRACESTATE env vars
 //   - Calls WithAccessToken() on the command context
 //
-// The returned command has PersistentPreRunE configured to set up the ExtensionContext
-// and to apply per-command overrides registered via [RegisterFlagOptions]. Extensions
-// must not replace PersistentPreRunE on the root or these behaviors will be lost.
+// Sets [cobra.EnableTraverseRunHooks] = true so the SDK's PersistentPreRunE runs
+// even when subcommands define their own. Per-command flag overrides registered
+// via [RegisterFlagOptions] are applied before subcommand pre-runs see them.
 //
 // NOTE: This function and its companion helpers ([NewListenCommand], [NewMetadataCommand],
 // [NewVersionCommand]) depend on [github.com/spf13/cobra]. If non-cobra CLI frameworks
 // gain adoption among extension authors, these symbols are candidates for extraction into
 // an azdext/cobra sub-package so the core SDK remains framework-agnostic.
 func NewExtensionRootCommand(opts ExtensionCommandOptions) (*cobra.Command, *ExtensionContext) {
+	// Run every PersistentPreRunE in the chain (root → leaf) so subcommands
+	// can add their own without losing SDK setup.
+	cobra.EnableTraverseRunHooks = true
+
 	extCtx := &ExtensionContext{}
 
 	use := opts.Use
@@ -213,13 +217,13 @@ type FlagOptions struct {
 
 	// AllowedValues, when non-empty, restricts accepted values, drives
 	// "(supported: ...)" help text, populates metadata ValidValues, and
-	// powers shell completion.
+	// powers shell completion. Matched case-sensitively; order is preserved.
 	AllowedValues []string
 
 	// Default, when non-empty, becomes the per-subcommand default: shown in
 	// help, surfaced in metadata, and substituted into the bound variable
 	// (e.g. [ExtensionContext.OutputFormat]) when the user does not pass
-	// the flag.
+	// the flag. Substitution preserves cmd.Flags().Changed(name) == false.
 	Default string
 }
 
@@ -239,10 +243,12 @@ type FlagOptions struct {
 //
 // Empty AllowedValues skips validation/completion. Empty Default leaves the
 // SDK default in place. Repeat calls for the same flag overwrite. A nil
-// command or empty Name is a no-op.
+// command is a no-op.
 //
-// Panics if Default is set but not in a non-empty AllowedValues, since this
-// would silently bypass validation.
+// Panics if Name is empty, or if Default is set but not in a non-empty
+// AllowedValues. Returns an error from PersistentPreRunE if Name does not
+// match any flag visible to the executing command (typo guard; inherited
+// flags only become visible after the command is attached to its parent).
 //
 // Typical usage:
 //
@@ -253,8 +259,11 @@ type FlagOptions struct {
 //	    Default:       "json",
 //	})
 func RegisterFlagOptions(cmd *cobra.Command, opts FlagOptions) *cobra.Command {
-	if cmd == nil || opts.Name == "" {
+	if cmd == nil {
 		return cmd
+	}
+	if opts.Name == "" {
+		panic("azdext.RegisterFlagOptions: FlagOptions.Name is required")
 	}
 	if opts.Default != "" && len(opts.AllowedValues) > 0 && !slices.Contains(opts.AllowedValues, opts.Default) {
 		panic(fmt.Sprintf(
@@ -339,6 +348,7 @@ func flagOverridesForCommand(cmd *cobra.Command) map[string]flagOverride {
 // applyFlagOverridesForCommand transiently mutates flag Usage/DefValue so
 // help/usage rendering reflects cmd's per-command [RegisterFlagOptions]
 // overrides. Returns a restore func that callers must defer.
+// Not safe for concurrent UsageFunc invocations; cobra renders help serially.
 func applyFlagOverridesForCommand(cmd *cobra.Command) func() {
 	overrides := flagOverridesForCommand(cmd)
 	if len(overrides) == 0 || cmd == nil {
@@ -380,7 +390,11 @@ func applyFlagOptionsForCommand(cmd *cobra.Command) error {
 	for name, ov := range overrides {
 		flag := cmd.Flags().Lookup(name)
 		if flag == nil {
-			continue
+			// Typo guard: inherited flags only become visible after the
+			// command is attached to its parent, so we check at execute time.
+			return fmt.Errorf(
+				"azdext.RegisterFlagOptions: flag %q is not defined on command %q", name, cmd.CommandPath(),
+			)
 		}
 		if cmd.Flags().Changed(name) {
 			if len(ov.AllowedValues) == 0 {
@@ -396,9 +410,8 @@ func applyFlagOptionsForCommand(cmd *cobra.Command) error {
 			continue
 		}
 		if ov.Default != "" {
-			// Use flag.Value.Set directly and preserve flag.Changed so callers
-			// of cmd.Flags().Changed(name) can still distinguish "user-supplied"
-			// from "SDK-substituted default".
+			// Set the value directly and preserve flag.Changed so callers
+			// can still distinguish user-supplied from SDK-substituted.
 			wasChanged := flag.Changed
 			if err := flag.Value.Set(ov.Default); err != nil {
 				return fmt.Errorf("apply default for --%s: %w", name, err)

--- a/cli/azd/pkg/azdext/extension_commands_test.go
+++ b/cli/azd/pkg/azdext/extension_commands_test.go
@@ -13,6 +13,148 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRegisterFlagOptions_HelpRendering(t *testing.T) {
+	root, _ := NewExtensionRootCommand(ExtensionCommandOptions{Name: "test"})
+	showCmd := RegisterFlagOptions(&cobra.Command{
+		Use:   "show",
+		Short: "show",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}, "output", []string{"json", "table"}, "json")
+	versionCmd := RegisterFlagOptions(&cobra.Command{
+		Use:   "version",
+		Short: "version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}, "output", []string{"json"}, "json")
+	root.AddCommand(showCmd, versionCmd)
+
+	showHelp := captureStdout(t, func() {
+		root.SetArgs([]string{"show", "--help"})
+		err := root.Execute()
+		require.NoError(t, err)
+	})
+	require.Contains(t, string(showHelp), `The output format (supported: json, table)`)
+	require.Contains(t, string(showHelp), `(default "json")`)
+
+	versionHelp := captureStdout(t, func() {
+		root.SetArgs([]string{"version", "--help"})
+		err := root.Execute()
+		require.NoError(t, err)
+	})
+	require.Contains(t, string(versionHelp), `The output format (supported: json)`)
+	require.NotContains(t, string(versionHelp), `supported: json, table`)
+
+	rootHelp := captureStdout(t, func() {
+		root.SetArgs([]string{"--help"})
+		err := root.Execute()
+		require.NoError(t, err)
+	})
+	require.Contains(t, string(rootHelp), defaultOutputFlagUsage)
+	require.NotContains(t, string(rootHelp), `supported: json, table`)
+}
+
+func TestRegisterFlagOptions_RejectsInvalidValue(t *testing.T) {
+	root, extCtx := NewExtensionRootCommand(ExtensionCommandOptions{Name: "test"})
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+
+	root.AddCommand(RegisterFlagOptions(&cobra.Command{
+		Use:  "list",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}, "output", []string{"json", "table"}, "json"))
+
+	root.SetArgs([]string{"list", "--output", "yaml"})
+	err := root.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `invalid value "yaml" for --output`)
+	require.Contains(t, err.Error(), "json, table")
+	// Validation should not have mutated the bound variable past parsing.
+	require.Equal(t, "yaml", extCtx.OutputFormat)
+}
+
+func TestRegisterFlagOptions_AppliesPerCommandDefault(t *testing.T) {
+	root, extCtx := NewExtensionRootCommand(ExtensionCommandOptions{Name: "test"})
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+
+	var observed string
+	root.AddCommand(RegisterFlagOptions(&cobra.Command{
+		Use: "list",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			observed = extCtx.OutputFormat
+			return nil
+		},
+	}, "output", []string{"json", "table"}, "json"))
+
+	root.SetArgs([]string{"list"})
+	require.NoError(t, root.Execute())
+	require.Equal(t, "json", observed)
+	require.Equal(t, "json", extCtx.OutputFormat)
+}
+
+func TestRegisterFlagOptions_AcceptsExplicitAllowedValue(t *testing.T) {
+	root, extCtx := NewExtensionRootCommand(ExtensionCommandOptions{Name: "test"})
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+
+	root.AddCommand(RegisterFlagOptions(&cobra.Command{
+		Use:  "list",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}, "output", []string{"json", "table"}, "json"))
+
+	root.SetArgs([]string{"list", "--output", "table"})
+	require.NoError(t, root.Execute())
+	require.Equal(t, "table", extCtx.OutputFormat)
+}
+
+func TestRegisterFlagOptions_RegistersShellCompletion(t *testing.T) {
+	root, _ := NewExtensionRootCommand(ExtensionCommandOptions{Name: "test"})
+	listCmd := RegisterFlagOptions(&cobra.Command{
+		Use:  "list",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}, "output", []string{"json", "table"}, "json")
+	root.AddCommand(listCmd)
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{cobra.ShellCompRequestCmd, "list", "--output", ""})
+	require.NoError(t, root.Execute())
+
+	out := buf.String()
+	require.Contains(t, out, "json")
+	require.Contains(t, out, "table")
+}
+
+func TestRegisterFlagOptions_NilCommandIsNoOp(t *testing.T) {
+	require.NotPanics(t, func() {
+		RegisterFlagOptions(nil, "output", []string{"json"}, "json")
+	})
+}
+
+func TestRegisterFlagOptions_OnlyDefaultStillSubstitutes(t *testing.T) {
+	root, extCtx := NewExtensionRootCommand(ExtensionCommandOptions{Name: "test"})
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+
+	root.AddCommand(RegisterFlagOptions(&cobra.Command{
+		Use:  "list",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}, "output", nil, "json"))
+
+	root.SetArgs([]string{"list"})
+	require.NoError(t, root.Execute())
+	require.Equal(t, "json", extCtx.OutputFormat)
+
+	// With no allowed values configured, any value is accepted.
+	root.SetArgs([]string{"list", "--output", "anything"})
+	require.NoError(t, root.Execute())
+	require.Equal(t, "anything", extCtx.OutputFormat)
+}
+
 func TestExtensionCommands_NewListenCommand(t *testing.T) {
 	t.Run("CreatesHiddenCommand", func(t *testing.T) {
 		cmd := NewListenCommand(nil)

--- a/cli/azd/pkg/azdext/extension_commands_test.go
+++ b/cli/azd/pkg/azdext/extension_commands_test.go
@@ -149,6 +149,31 @@ func TestRegisterFlagOptions_NilCommandIsNoOp(t *testing.T) {
 	})
 }
 
+func TestRegisterFlagOptions_PanicsOnEmptyName(t *testing.T) {
+	require.PanicsWithValue(t,
+		"azdext.RegisterFlagOptions: FlagOptions.Name is required",
+		func() {
+			RegisterFlagOptions(&cobra.Command{Use: "list"}, FlagOptions{Name: ""})
+		},
+	)
+}
+
+func TestRegisterFlagOptions_RejectsUnknownFlagAtExecute(t *testing.T) {
+	root, _ := NewExtensionRootCommand(ExtensionCommandOptions{Name: "test"})
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+
+	root.AddCommand(RegisterFlagOptions(&cobra.Command{
+		Use:  "list",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}, FlagOptions{Name: "ouput", AllowedValues: []string{"json"}, Default: "json"})) // typo
+
+	root.SetArgs([]string{"list"})
+	err := root.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `flag "ouput" is not defined`)
+}
+
 func TestRegisterFlagOptions_PanicsOnDefaultNotInAllowed(t *testing.T) {
 	require.PanicsWithValue(t,
 		`azdext.RegisterFlagOptions: default "yaml" for flag "output" is not in allowed values [json table]`,
@@ -180,6 +205,29 @@ func TestRegisterFlagOptions_OnlyDefaultStillSubstitutes(t *testing.T) {
 	root.SetArgs([]string{"list", "--output", "anything"})
 	require.NoError(t, root.Execute())
 	require.Equal(t, "anything", extCtx.OutputFormat)
+}
+
+func TestRegisterFlagOptions_RunsAlongsideSubcommandPersistentPreRunE(t *testing.T) {
+	// EnableTraverseRunHooks contract: subcommand PersistentPreRunE coexists with the SDK's.
+	root, extCtx := NewExtensionRootCommand(ExtensionCommandOptions{Name: "test"})
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+
+	subRan := false
+	listCmd := RegisterFlagOptions(&cobra.Command{
+		Use: "list",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			subRan = true
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}, FlagOptions{Name: "output", AllowedValues: []string{"json", "table"}, Default: "json"})
+	root.AddCommand(listCmd)
+
+	root.SetArgs([]string{"list"})
+	require.NoError(t, root.Execute())
+	require.True(t, subRan, "subcommand PersistentPreRunE must still run")
+	require.Equal(t, "json", extCtx.OutputFormat, "SDK default substitution must still happen")
 }
 
 func TestExtensionCommands_NewListenCommand(t *testing.T) {

--- a/cli/azd/pkg/azdext/extension_commands_test.go
+++ b/cli/azd/pkg/azdext/extension_commands_test.go
@@ -81,18 +81,32 @@ func TestRegisterFlagOptions_AppliesPerCommandDefault(t *testing.T) {
 	root.SilenceErrors = true
 
 	var observed string
-	root.AddCommand(RegisterFlagOptions(&cobra.Command{
+	var changedAfterDefault, changedAfterExplicit bool
+	listCmd := RegisterFlagOptions(&cobra.Command{
 		Use: "list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			observed = extCtx.OutputFormat
+			changedAfterDefault = cmd.Flags().Changed("output")
 			return nil
 		},
-	}, FlagOptions{Name: "output", AllowedValues: []string{"json", "table"}, Default: "json"}))
+	}, FlagOptions{Name: "output", AllowedValues: []string{"json", "table"}, Default: "json"})
+	root.AddCommand(listCmd)
 
 	root.SetArgs([]string{"list"})
 	require.NoError(t, root.Execute())
 	require.Equal(t, "json", observed)
 	require.Equal(t, "json", extCtx.OutputFormat)
+	// Substituting the default must not flip Changed; callers rely on it to
+	// distinguish user-supplied values from SDK defaults.
+	require.False(t, changedAfterDefault, "Changed must remain false when SDK substituted the default")
+
+	listCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		changedAfterExplicit = cmd.Flags().Changed("output")
+		return nil
+	}
+	root.SetArgs([]string{"list", "--output", "table"})
+	require.NoError(t, root.Execute())
+	require.True(t, changedAfterExplicit, "Changed must be true when user supplied the flag")
 }
 
 func TestRegisterFlagOptions_AcceptsExplicitAllowedValue(t *testing.T) {

--- a/cli/azd/pkg/azdext/extension_commands_test.go
+++ b/cli/azd/pkg/azdext/extension_commands_test.go
@@ -21,14 +21,14 @@ func TestRegisterFlagOptions_HelpRendering(t *testing.T) {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return nil
 		},
-	}, "output", []string{"json", "table"}, "json")
+	}, FlagOptions{Name: "output", AllowedValues: []string{"json", "table"}, Default: "json"})
 	versionCmd := RegisterFlagOptions(&cobra.Command{
 		Use:   "version",
 		Short: "version",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return nil
 		},
-	}, "output", []string{"json"}, "json")
+	}, FlagOptions{Name: "output", AllowedValues: []string{"json"}, Default: "json"})
 	root.AddCommand(showCmd, versionCmd)
 
 	showHelp := captureStdout(t, func() {
@@ -64,7 +64,7 @@ func TestRegisterFlagOptions_RejectsInvalidValue(t *testing.T) {
 	root.AddCommand(RegisterFlagOptions(&cobra.Command{
 		Use:  "list",
 		RunE: func(cmd *cobra.Command, args []string) error { return nil },
-	}, "output", []string{"json", "table"}, "json"))
+	}, FlagOptions{Name: "output", AllowedValues: []string{"json", "table"}, Default: "json"}))
 
 	root.SetArgs([]string{"list", "--output", "yaml"})
 	err := root.Execute()
@@ -87,7 +87,7 @@ func TestRegisterFlagOptions_AppliesPerCommandDefault(t *testing.T) {
 			observed = extCtx.OutputFormat
 			return nil
 		},
-	}, "output", []string{"json", "table"}, "json"))
+	}, FlagOptions{Name: "output", AllowedValues: []string{"json", "table"}, Default: "json"}))
 
 	root.SetArgs([]string{"list"})
 	require.NoError(t, root.Execute())
@@ -103,7 +103,7 @@ func TestRegisterFlagOptions_AcceptsExplicitAllowedValue(t *testing.T) {
 	root.AddCommand(RegisterFlagOptions(&cobra.Command{
 		Use:  "list",
 		RunE: func(cmd *cobra.Command, args []string) error { return nil },
-	}, "output", []string{"json", "table"}, "json"))
+	}, FlagOptions{Name: "output", AllowedValues: []string{"json", "table"}, Default: "json"}))
 
 	root.SetArgs([]string{"list", "--output", "table"})
 	require.NoError(t, root.Execute())
@@ -115,7 +115,7 @@ func TestRegisterFlagOptions_RegistersShellCompletion(t *testing.T) {
 	listCmd := RegisterFlagOptions(&cobra.Command{
 		Use:  "list",
 		RunE: func(cmd *cobra.Command, args []string) error { return nil },
-	}, "output", []string{"json", "table"}, "json")
+	}, FlagOptions{Name: "output", AllowedValues: []string{"json", "table"}, Default: "json"})
 	root.AddCommand(listCmd)
 
 	var buf bytes.Buffer
@@ -131,8 +131,21 @@ func TestRegisterFlagOptions_RegistersShellCompletion(t *testing.T) {
 
 func TestRegisterFlagOptions_NilCommandIsNoOp(t *testing.T) {
 	require.NotPanics(t, func() {
-		RegisterFlagOptions(nil, "output", []string{"json"}, "json")
+		RegisterFlagOptions(nil, FlagOptions{Name: "output", AllowedValues: []string{"json"}, Default: "json"})
 	})
+}
+
+func TestRegisterFlagOptions_PanicsOnDefaultNotInAllowed(t *testing.T) {
+	require.PanicsWithValue(t,
+		`azdext.RegisterFlagOptions: default "yaml" for flag "output" is not in allowed values [json table]`,
+		func() {
+			RegisterFlagOptions(&cobra.Command{Use: "list"}, FlagOptions{
+				Name:          "output",
+				AllowedValues: []string{"json", "table"},
+				Default:       "yaml",
+			})
+		},
+	)
 }
 
 func TestRegisterFlagOptions_OnlyDefaultStillSubstitutes(t *testing.T) {
@@ -143,7 +156,7 @@ func TestRegisterFlagOptions_OnlyDefaultStillSubstitutes(t *testing.T) {
 	root.AddCommand(RegisterFlagOptions(&cobra.Command{
 		Use:  "list",
 		RunE: func(cmd *cobra.Command, args []string) error { return nil },
-	}, "output", nil, "json"))
+	}, FlagOptions{Name: "output", Default: "json"}))
 
 	root.SetArgs([]string{"list"})
 	require.NoError(t, root.Execute())

--- a/cli/azd/pkg/azdext/metadata_generator.go
+++ b/cli/azd/pkg/azdext/metadata_generator.go
@@ -129,6 +129,12 @@ func generateFlags(cmd *cobra.Command) []extensions.Flag {
 	// Ensure the default help flag is initialized (Cobra adds it lazily during execution)
 	cmd.InitDefaultHelpFlag()
 
+	// Per-command flag overrides registered via [RegisterFlagOptions]. These
+	// drive ValidValues and override Default in the emitted metadata so JSON
+	// consumers (azd, IDEs, IntelliSense) see the same per-command
+	// information that --help renders.
+	overrides := flagOverridesForCommand(cmd)
+
 	var flags []extensions.Flag
 
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
@@ -146,6 +152,15 @@ func generateFlags(cmd *cobra.Command) []extensions.Flag {
 
 		if flag.Deprecated != "" {
 			flagMeta.Deprecated = flag.Deprecated
+		}
+
+		if ov, ok := overrides[flag.Name]; ok {
+			if len(ov.AllowedValues) > 0 {
+				flagMeta.ValidValues = ov.AllowedValues
+			}
+			if ov.Default != "" {
+				flagMeta.Default = ov.Default
+			}
 		}
 
 		flags = append(flags, flagMeta)

--- a/cli/azd/pkg/azdext/metadata_generator_test.go
+++ b/cli/azd/pkg/azdext/metadata_generator_test.go
@@ -336,3 +336,41 @@ func TestGenerateExtensionMetadata_SkipsEmptyCommands(t *testing.T) {
 		assert.NotEmpty(t, cmd.Name, "Command name should not be empty")
 	}
 }
+
+func TestGenerateExtensionMetadata_FlagOptionsOverride(t *testing.T) {
+	rootCmd, _ := NewExtensionRootCommand(ExtensionCommandOptions{Name: "test-ext"})
+
+	listCmd := RegisterFlagOptions(&cobra.Command{
+		Use:   "list",
+		Short: "List things",
+		RunE:  func(cmd *cobra.Command, args []string) error { return nil },
+	}, "output", []string{"json", "table"}, "json")
+
+	plainCmd := &cobra.Command{
+		Use:   "plain",
+		Short: "Plain command without override",
+		RunE:  func(cmd *cobra.Command, args []string) error { return nil },
+	}
+
+	rootCmd.AddCommand(listCmd, plainCmd)
+
+	metadata := GenerateExtensionMetadata("1.0", "test.extension", rootCmd)
+
+	listMeta := findCommand(metadata.Commands, "list")
+	require.NotNil(t, listMeta)
+	listOutput := findFlag(listMeta.Flags, "output")
+	require.NotNil(t, listOutput)
+	// The metadata description stays clean; ValidValues carries the allowed
+	// set so JSON consumers can render or validate it as they prefer.
+	assert.Equal(t, defaultOutputFlagUsage, listOutput.Description)
+	assert.Equal(t, []string{"json", "table"}, listOutput.ValidValues)
+	assert.Equal(t, "json", listOutput.Default)
+
+	plainMeta := findCommand(metadata.Commands, "plain")
+	require.NotNil(t, plainMeta)
+	plainOutput := findFlag(plainMeta.Flags, "output")
+	require.NotNil(t, plainOutput)
+	assert.Equal(t, defaultOutputFlagUsage, plainOutput.Description)
+	assert.Empty(t, plainOutput.ValidValues)
+	assert.Equal(t, "default", plainOutput.Default)
+}

--- a/cli/azd/pkg/azdext/metadata_generator_test.go
+++ b/cli/azd/pkg/azdext/metadata_generator_test.go
@@ -344,7 +344,7 @@ func TestGenerateExtensionMetadata_FlagOptionsOverride(t *testing.T) {
 		Use:   "list",
 		Short: "List things",
 		RunE:  func(cmd *cobra.Command, args []string) error { return nil },
-	}, "output", []string{"json", "table"}, "json")
+	}, FlagOptions{Name: "output", AllowedValues: []string{"json", "table"}, Default: "json"})
 
 	plainCmd := &cobra.Command{
 		Use:   "plain",


### PR DESCRIPTION
Closes #7824.

## Summary

Extensions built with [`azdext.NewExtensionRootCommand`](https://github.com/Azure/azure-dev/pull/6856) inherit a single SDK-owned `-o/--output` persistent flag, which until now meant every subcommand rendered the same generic help text and had no way to declare its own allowed values, default, validation, or completion.

This PR adds a new SDK helper that lets a subcommand declare per-command flag options for any inherited persistent flag in one place:

```go
azdext.RegisterFlagOptions(listCmd, azdext.FlagOptions{
    Name:          "output",
    AllowedValues: []string{"json", "table"},
    Default:       "json",
})
```

<img width="544" height="352" alt="image" src="https://github.com/user-attachments/assets/e30c510f-8f3d-4244-a37e-ae67cf702444" />

A single declaration drives:

1. **Help text** rendered for that subcommand (`--output string   The output format (supported: json, table) (default "json")`).
2. **Extension metadata** — `Flag.ValidValues` and `Flag.Default` populated by `GenerateExtensionMetadata`.
3. **Parse-time validation** — root `PersistentPreRunE` rejects unsupported values with a descriptive error before `RunE` runs.
4. **Shell completion** — a single delegating completion func registered on the SDK-managed inherited flag returns the per-command allowed values.
5. **Default substitution** — when the flag is omitted, the SDK writes the per-command default into `extCtx.OutputFormat` so subcommands can read it directly.

Generalizes to any inherited persistent flag via `FlagOptions.Name`; not hardcoded to `--output`. Stores config in cobra annotations under `azdext.allowed-values/<name>` and `azdext.default/<name>`. Panics at registration time if `Default` is set but not present in a non-empty `AllowedValues` — surfaces extension-author misconfiguration immediately rather than at runtime.

## Why a new API instead of redeclaring the flag

Redeclaring a local `--output` on each subcommand collides with the inherited persistent flag and breaks once azd enforces its reserved-flag set. `RegisterFlagOptions` keeps the SDK as the single owner of the flag while still letting extensions express per-command intent declaratively.

## Implementation notes

- Validation and default substitution run from the root command's `PersistentPreRunE`. Cobra's "closest ancestor wins" semantics mean extensions must not replace `PersistentPreRunE` on the root — called out in the godoc.
- Help rendering wraps `UsageFunc` only. Cobra's default `HelpFunc` calls `UsageString()` → `UsageFunc`, so wrapping both layers caused double-application of the override.
- Shell completion is registered once on the root via a delegating function. Cobra keys flag completion by `*pflag.Flag` pointer, which is shared across the tree for inherited flags, so per-subcommand registration would conflict.