### PR TITLE
Implement FlexibleTimestamp for modified_time in JSON

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/files.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/files.go
@@ -501,7 +501,7 @@ func printFileListTable(fileList *agent_api.SessionFileList) error {
 		}
 		modified := ""
 		if f.LastModified != nil {
-			modified = *f.LastModified
+			modified = f.LastModified.String()
 		}
 		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\n", f.Name, f.Path, fileType, f.Size, modified)
 	}
@@ -798,7 +798,7 @@ func printFileInfoTable(f *agent_api.SessionFileInfo) error {
 	}
 	modified := ""
 	if f.LastModified != nil {
-		modified = *f.LastModified
+		modified = f.LastModified.String()
 	}
 	fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\n", f.Name, f.Path, fileType, f.Size, modified)
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/files_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/files_test.go
@@ -143,7 +143,7 @@ func TestFilesMkdirCommand_HasFlags(t *testing.T) {
 }
 
 func TestPrintFileListJSON(t *testing.T) {
-	modified := "2025-01-01T00:00:00Z"
+	modified := agent_api.FlexibleTimestamp("2025-01-01T00:00:00Z")
 	fileList := &agent_api.SessionFileList{
 		Path: "/data",
 		Entries: []agent_api.SessionFileInfo{
@@ -167,7 +167,7 @@ func TestPrintFileListJSON(t *testing.T) {
 }
 
 func TestPrintFileListTable(t *testing.T) {
-	modified := "2025-01-01T00:00:00Z"
+	modified := agent_api.FlexibleTimestamp("2025-01-01T00:00:00Z")
 	fileList := &agent_api.SessionFileList{
 		Path: "/data",
 		Entries: []agent_api.SessionFileInfo{

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
@@ -715,8 +715,8 @@ type StructuredOutputDefinition struct {
 }
 
 // FlexibleTimestamp is a string that can be unmarshalled from either a JSON
-// string or a JSON number (Unix epoch seconds). This handles APIs that may
-// return modified_time as either format.
+// string or a JSON number (Unix epoch seconds or milliseconds). This handles
+// APIs that may return modified_time as either format.
 type FlexibleTimestamp string
 
 // UnmarshalJSON unmarshals FlexibleTimestamp from either a JSON string or a
@@ -729,15 +729,24 @@ func (ft *FlexibleTimestamp) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	// Try number (Unix epoch seconds, or milliseconds if > 1e12).
+	// Try number (Unix epoch seconds or milliseconds).
 	var n float64
 	if err := json.Unmarshal(data, &n); err == nil {
-		if n > 1e12 {
-			n /= 1000
-		}
+		// Interpret as seconds first.
 		sec, frac := math.Modf(n)
 		t := time.Unix(int64(sec), int64(frac*1e9)).UTC()
-		*ft = FlexibleTimestamp(t.Format(time.RFC3339))
+
+		// If the result is far in the future, the value is
+		// likely in milliseconds.
+		if t.Year() > 3000 {
+			ms := int64(n)
+			t = time.Unix(
+				ms/1000,
+				(ms%1000)*int64(time.Millisecond),
+			).UTC()
+		}
+
+		*ft = FlexibleTimestamp(t.Format(time.RFC3339Nano))
 		return nil
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
@@ -3,6 +3,13 @@
 
 package agent_api
 
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"time"
+)
+
 // AgentProtocol represents the protocol types supported by agents
 type AgentProtocol string
 
@@ -707,14 +714,54 @@ type StructuredOutputDefinition struct {
 	Strict      *bool          `json:"strict"`
 }
 
+// FlexibleTimestamp is a string that can be unmarshalled from either a JSON
+// string or a JSON number (Unix epoch seconds). This handles APIs that may
+// return modified_time as either format.
+type FlexibleTimestamp string
+
+// UnmarshalJSON unmarshals FlexibleTimestamp from either a JSON string or a
+// JSON number (Unix epoch seconds or milliseconds).
+func (ft *FlexibleTimestamp) UnmarshalJSON(data []byte) error {
+	// Try string first (the common/expected case).
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*ft = FlexibleTimestamp(s)
+		return nil
+	}
+
+	// Try number (Unix epoch seconds, or milliseconds if > 1e12).
+	var n float64
+	if err := json.Unmarshal(data, &n); err == nil {
+		if n > 1e12 {
+			n /= 1000
+		}
+		sec, frac := math.Modf(n)
+		t := time.Unix(int64(sec), int64(frac*1e9)).UTC()
+		*ft = FlexibleTimestamp(t.Format(time.RFC3339))
+		return nil
+	}
+
+	return fmt.Errorf("modified_time: expected string or number, got %s", string(data))
+}
+
+// MarshalJSON marshals FlexibleTimestamp as a JSON string.
+func (ft FlexibleTimestamp) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(ft))
+}
+
+// String returns the string representation of FlexibleTimestamp.
+func (ft FlexibleTimestamp) String() string {
+	return string(ft)
+}
+
 // SessionFileInfo represents a file or directory entry in a session.
 type SessionFileInfo struct {
-	Name         string  `json:"name"`
-	Path         string  `json:"path"`
-	IsDirectory  bool    `json:"is_dir"`
-	Size         int64   `json:"size,omitempty"`
-	Mode         int     `json:"mode,omitempty"`
-	LastModified *string `json:"modified_time,omitempty"`
+	Name         string             `json:"name"`
+	Path         string             `json:"path"`
+	IsDirectory  bool               `json:"is_dir"`
+	Size         int64              `json:"size,omitempty"`
+	Mode         int                `json:"mode,omitempty"`
+	LastModified *FlexibleTimestamp `json:"modified_time,omitempty"`
 }
 
 // SessionFileList represents the response from listing session files.

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
@@ -867,8 +867,27 @@ func TestFlexibleTimestamp_UnmarshalNumber(t *testing.T) {
 	if err := json.Unmarshal([]byte(raw), &got); err != nil {
 		t.Fatalf("unmarshal numeric timestamp: %v", err)
 	}
-	if got.LastModified == nil || got.LastModified.String() != "2023-11-14T22:13:20Z" {
-		t.Errorf("LastModified = %v, want 2023-11-14T22:13:20Z", got.LastModified)
+	if got.LastModified == nil ||
+		got.LastModified.String() != "2023-11-14T22:13:20Z" {
+		t.Errorf(
+			"LastModified = %v, want 2023-11-14T22:13:20Z",
+			got.LastModified,
+		)
+	}
+
+	// Verify round-trip: re-marshalling produces an RFC3339 string.
+	data, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal numeric timestamp: %v", err)
+	}
+	if !strings.Contains(
+		string(data),
+		`"modified_time":"2023-11-14T22:13:20Z"`,
+	) {
+		t.Errorf(
+			"marshalled JSON = %s, want RFC3339 string",
+			string(data),
+		)
 	}
 }
 
@@ -883,22 +902,44 @@ func TestFlexibleTimestamp_UnmarshalNumberInEntries(t *testing.T) {
 	if len(got.Entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(got.Entries))
 	}
-	if got.Entries[0].LastModified == nil || got.Entries[0].LastModified.String() != "2023-11-14T22:13:20Z" {
-		t.Errorf("entry LastModified = %v, want 2023-11-14T22:13:20Z", got.Entries[0].LastModified)
+	if got.Entries[0].LastModified == nil ||
+		got.Entries[0].LastModified.String() != "2023-11-14T22:13:20Z" {
+		t.Errorf(
+			"entry LastModified = %v, want 2023-11-14T22:13:20Z",
+			got.Entries[0].LastModified,
+		)
 	}
 }
 
 func TestFlexibleTimestamp_UnmarshalMilliseconds(t *testing.T) {
 	t.Parallel()
 
-	// 1700000000000 ms == 1700000000 s == 2023-11-14T22:13:20Z
-	raw := `{"name":"f.txt","path":"/f.txt","is_dir":false,"modified_time":1700000000000}`
+	// 1700000000123 ms == 2023-11-14T22:13:20.123Z
+	raw := `{"name":"f.txt","path":"/f.txt","is_dir":false,"modified_time":1700000000123}`
 	var got SessionFileInfo
 	if err := json.Unmarshal([]byte(raw), &got); err != nil {
 		t.Fatalf("unmarshal millisecond timestamp: %v", err)
 	}
-	if got.LastModified == nil || got.LastModified.String() != "2023-11-14T22:13:20Z" {
-		t.Errorf("LastModified = %v, want 2023-11-14T22:13:20Z", got.LastModified)
+	want := "2023-11-14T22:13:20.123Z"
+	if got.LastModified == nil ||
+		got.LastModified.String() != want {
+		t.Errorf(
+			"LastModified = %v, want %s",
+			got.LastModified, want,
+		)
+	}
+
+	// Verify round-trip preserves millisecond precision.
+	data, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal millisecond timestamp: %v", err)
+	}
+	wantJSON := `"modified_time":"2023-11-14T22:13:20.123Z"`
+	if !strings.Contains(string(data), wantJSON) {
+		t.Errorf(
+			"marshalled JSON = %s, want %s",
+			string(data), wantJSON,
+		)
 	}
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
@@ -811,7 +811,7 @@ func TestSessionFileInfo_RoundTrip(t *testing.T) {
 		IsDirectory:  false,
 		Size:         2048,
 		Mode:         0644,
-		LastModified: new("2024-06-15T10:30:00Z"),
+		LastModified: new(FlexibleTimestamp("2024-06-15T10:30:00Z")),
 	}
 
 	data, err := json.Marshal(original)
@@ -840,8 +840,65 @@ func TestSessionFileInfo_RoundTrip(t *testing.T) {
 	if got.Size != 2048 {
 		t.Errorf("Size = %d, want %d", got.Size, int64(2048))
 	}
-	if got.LastModified == nil || *got.LastModified != "2024-06-15T10:30:00Z" {
+	if got.LastModified == nil || got.LastModified.String() != "2024-06-15T10:30:00Z" {
 		t.Error("LastModified mismatch")
+	}
+}
+
+func TestFlexibleTimestamp_UnmarshalString(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"name":"f.txt","path":"/f.txt","is_dir":false,"modified_time":"2025-03-01T12:00:00Z"}`
+	var got SessionFileInfo
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unmarshal string timestamp: %v", err)
+	}
+	if got.LastModified == nil || got.LastModified.String() != "2025-03-01T12:00:00Z" {
+		t.Errorf("LastModified = %v, want 2025-03-01T12:00:00Z", got.LastModified)
+	}
+}
+
+func TestFlexibleTimestamp_UnmarshalNumber(t *testing.T) {
+	t.Parallel()
+
+	// 1700000000 == 2023-11-14T22:13:20Z
+	raw := `{"name":"f.txt","path":"/f.txt","is_dir":false,"modified_time":1700000000}`
+	var got SessionFileInfo
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unmarshal numeric timestamp: %v", err)
+	}
+	if got.LastModified == nil || got.LastModified.String() != "2023-11-14T22:13:20Z" {
+		t.Errorf("LastModified = %v, want 2023-11-14T22:13:20Z", got.LastModified)
+	}
+}
+
+func TestFlexibleTimestamp_UnmarshalNumberInEntries(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"path":"/","entries":[{"name":"a","path":"/a","is_dir":false,"modified_time":1700000000}]}`
+	var got SessionFileList
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unmarshal entries with numeric timestamp: %v", err)
+	}
+	if len(got.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got.Entries))
+	}
+	if got.Entries[0].LastModified == nil || got.Entries[0].LastModified.String() != "2023-11-14T22:13:20Z" {
+		t.Errorf("entry LastModified = %v, want 2023-11-14T22:13:20Z", got.Entries[0].LastModified)
+	}
+}
+
+func TestFlexibleTimestamp_UnmarshalMilliseconds(t *testing.T) {
+	t.Parallel()
+
+	// 1700000000000 ms == 1700000000 s == 2023-11-14T22:13:20Z
+	raw := `{"name":"f.txt","path":"/f.txt","is_dir":false,"modified_time":1700000000000}`
+	var got SessionFileInfo
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unmarshal millisecond timestamp: %v", err)
+	}
+	if got.LastModified == nil || got.LastModified.String() != "2023-11-14T22:13:20Z" {
+		t.Errorf("LastModified = %v, want 2023-11-14T22:13:20Z", got.LastModified)
 	}
 }
 


### PR DESCRIPTION
This pull request improves the handling of file modification timestamps in the agent API by introducing a new `FlexibleTimestamp` type. This allows the system to robustly parse and serialize timestamps provided either as strings or as Unix epoch numbers (in seconds or milliseconds), addressing inconsistencies in upstream API responses. The changes also update all relevant usages and add comprehensive tests for the new logic.

**Flexible timestamp handling:**

* Introduced the `FlexibleTimestamp` type in `models.go`, which can unmarshal JSON timestamps provided as strings or numbers (seconds or milliseconds), and always serializes as an RFC3339 string. Includes custom `UnmarshalJSON`, `MarshalJSON`, and `String` methods.
* Updated the `SessionFileInfo` struct to use `*FlexibleTimestamp` for the `LastModified` field instead of `*string`.

**Code and test updates:**

* Refactored all usages of `LastModified` in the CLI and tests (`files.go`, `files_test.go`, `models_test.go`) to use the new `FlexibleTimestamp` type and its `.String()` method where needed. [[1]](diffhunk://#diff-7ab85165356870dbb74d3bd7b502b5ecbeeff3a911f04379757858c575ec8a29L504-R504) [[2]](diffhunk://#diff-7ab85165356870dbb74d3bd7b502b5ecbeeff3a911f04379757858c575ec8a29L801-R801) [[3]](diffhunk://#diff-87ef4e7908ea08f8cb39d8c9389907ef57378e90f32093624054d374e688065dL146-R146) [[4]](diffhunk://#diff-87ef4e7908ea08f8cb39d8c9389907ef57378e90f32093624054d374e688065dL170-R170) [[5]](diffhunk://#diff-73785b4ba3b189ec5ab67837873172dff2a582e6bcdefef54355f1ca1e250bd7L814-R814) [[6]](diffhunk://#diff-73785b4ba3b189ec5ab67837873172dff2a582e6bcdefef54355f1ca1e250bd7L843-R904)
* Added extensive tests for `FlexibleTimestamp` covering string, numeric (seconds), and numeric (milliseconds) formats to ensure correct parsing and round-trip serialization.

**Dependency and import updates:**

* Added imports for `encoding/json`, `fmt`, `math`, and `time` in `models.go` to support the new timestamp logic.

Fixes #7802 