### PR TITLE
Add validation for missing container registry endpoint in agent service

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go
@@ -42,20 +42,20 @@ const (
 // These are usually paired with [Dependency] when required external
 // resources, services, or environment values are missing or unavailable.
 const (
-	CodeProjectNotFound           = "project_not_found"
-	CodeProjectInitFailed         = "project_init_failed"
-	CodeEnvironmentNotFound       = "environment_not_found"
-	CodeEnvironmentCreationFailed = "environment_creation_failed"
-	CodeEnvironmentValuesFailed   = "environment_values_failed"
-	CodeMissingAiProjectEndpoint  = "missing_ai_project_endpoint"
-	CodeMissingAzureTenantId      = "missing_azure_tenant_id"
-	CodeMissingAiProjectId        = "missing_ai_project_id"
-	CodeMissingAzureSubscription  = "missing_azure_subscription_id"
+	CodeProjectNotFound                  = "project_not_found"
+	CodeProjectInitFailed                = "project_init_failed"
+	CodeEnvironmentNotFound              = "environment_not_found"
+	CodeEnvironmentCreationFailed        = "environment_creation_failed"
+	CodeEnvironmentValuesFailed          = "environment_values_failed"
+	CodeMissingAiProjectEndpoint         = "missing_ai_project_endpoint"
+	CodeMissingAzureTenantId             = "missing_azure_tenant_id"
+	CodeMissingAiProjectId               = "missing_ai_project_id"
+	CodeMissingAzureSubscription         = "missing_azure_subscription_id"
 	CodeMissingAgentEnvVars              = "missing_agent_env_vars"
 	CodeMissingContainerRegistryEndpoint = "missing_container_registry_endpoint"
 	CodeGitHubDownloadFailed             = "github_download_failed"
-	CodeScaffoldTemplateFailed    = "scaffold_template_failed"
-	CodePromptFailed              = "prompt_failed"
+	CodeScaffoldTemplateFailed           = "scaffold_template_failed"
+	CodePromptFailed                     = "prompt_failed"
 )
 
 // Error codes commonly used for auth errors.

--- a/cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go
@@ -51,8 +51,9 @@ const (
 	CodeMissingAzureTenantId      = "missing_azure_tenant_id"
 	CodeMissingAiProjectId        = "missing_ai_project_id"
 	CodeMissingAzureSubscription  = "missing_azure_subscription_id"
-	CodeMissingAgentEnvVars       = "missing_agent_env_vars"
-	CodeGitHubDownloadFailed      = "github_download_failed"
+	CodeMissingAgentEnvVars              = "missing_agent_env_vars"
+	CodeMissingContainerRegistryEndpoint = "missing_container_registry_endpoint"
+	CodeGitHubDownloadFailed             = "github_download_failed"
 	CodeScaffoldTemplateFailed    = "scaffold_template_failed"
 	CodePromptFailed              = "prompt_failed"
 )

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -326,7 +326,7 @@ func (p *AgentServiceTargetProvider) Package(
 	if acrResp == nil || acrResp.Value == "" {
 		return nil, exterrors.Dependency(
 			exterrors.CodeMissingContainerRegistryEndpoint,
-			"AZURE_CONTAINER_REGISTRY_ENDPOINT is required for hosted agents but was not found"+
+			"AZURE_CONTAINER_REGISTRY_ENDPOINT is required: environment variable was not found"+
 				" in the current azd environment",
 			"run 'azd provision' to create infrastructure (including a container registry),"+
 				" or set it manually with"+

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -308,6 +308,32 @@ func (p *AgentServiceTargetProvider) Package(
 		return &azdext.ServicePackageResult{}, nil
 	}
 
+	// Verify ACR endpoint is configured before attempting container operations.
+	// When users leave ACR blank during init, the Bicep template creates one
+	// during 'azd provision'. If provision hasn't run, catch it early with an
+	// actionable message instead of a cryptic RPC error from core azd.
+	acrResp, err := p.azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+		EnvName: p.env.Name,
+		Key:     "AZURE_CONTAINER_REGISTRY_ENDPOINT",
+	})
+	if err != nil {
+		return nil, exterrors.Dependency(
+			exterrors.CodeEnvironmentValuesFailed,
+			fmt.Sprintf("failed to read AZURE_CONTAINER_REGISTRY_ENDPOINT: %s", err),
+			"run 'azd env get-values' to verify environment state",
+		)
+	}
+	if acrResp == nil || acrResp.Value == "" {
+		return nil, exterrors.Dependency(
+			exterrors.CodeMissingContainerRegistryEndpoint,
+			"AZURE_CONTAINER_REGISTRY_ENDPOINT is required for hosted agents but was not found"+
+				" in the current azd environment",
+			"run 'azd provision' to create infrastructure (including a container registry),"+
+				" or set it manually with"+
+				" 'azd env set AZURE_CONTAINER_REGISTRY_ENDPOINT <your-registry>.azurecr.io'",
+		)
+	}
+
 	var packageArtifact *azdext.Artifact
 	var newArtifacts []*azdext.Artifact
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -4,9 +4,19 @@
 package project
 
 import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"azureaiagent/internal/exterrors"
 	"azureaiagent/internal/pkg/agents/agent_api"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
 func TestApplyVnextMetadata(t *testing.T) {
@@ -131,6 +141,182 @@ func TestGetServiceKey_NormalizesToolboxNames(t *testing.T) {
 			got := p.getServiceKey(tt.input)
 			if got != tt.expected {
 				t.Errorf("getServiceKey(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+// --- helpers for Package ACR-validation tests ---
+
+// packageEnvServer is a minimal EnvironmentServiceServer that stubs GetValue
+// and GetCurrent for Package tests.
+type packageEnvServer struct {
+	azdext.UnimplementedEnvironmentServiceServer
+	values  map[string]string
+	getErr  error
+	envName string
+}
+
+func (s *packageEnvServer) GetCurrent(context.Context, *azdext.EmptyRequest) (*azdext.EnvironmentResponse, error) {
+	return &azdext.EnvironmentResponse{
+		Environment: &azdext.Environment{Name: s.envName},
+	}, nil
+}
+
+func (s *packageEnvServer) GetValue(_ context.Context, req *azdext.GetEnvRequest) (*azdext.KeyValueResponse, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	v := s.values[req.Key]
+	return &azdext.KeyValueResponse{Key: req.Key, Value: v}, nil
+}
+
+// newPackageTestClient spins up a gRPC server with the given env server and
+// returns an AzdClient connected to it. Cleanup is handled by t.Cleanup.
+func newPackageTestClient(t *testing.T, envSrv azdext.EnvironmentServiceServer) *azdext.AzdClient {
+	t.Helper()
+
+	srv := grpc.NewServer()
+	azdext.RegisterEnvironmentServiceServer(srv, envSrv)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+	})
+
+	client, err := azdext.NewAzdClient(azdext.WithAddress(lis.Addr().String()))
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	return client
+}
+
+// writeHostedAgentYAML creates a minimal hosted-kind agent.yaml in dir and
+// returns the full path.
+func writeHostedAgentYAML(t *testing.T, dir string) string {
+	t.Helper()
+	p := filepath.Join(dir, "agent.yaml")
+	content := []byte("kind: hosted\nname: test-agent\n")
+	require.NoError(t, os.WriteFile(p, content, 0o644))
+	return p
+}
+
+// writePromptAgentYAML creates a minimal prompt-kind agent.yaml in dir and
+// returns the full path.
+func writePromptAgentYAML(t *testing.T, dir string) string {
+	t.Helper()
+	p := filepath.Join(dir, "agent.yaml")
+	content := []byte("kind: prompt\nname: test-agent\nmodel:\n  id: gpt-4o-mini\n")
+	require.NoError(t, os.WriteFile(p, content, 0o644))
+	return p
+}
+
+func TestPackage_ACREndpointValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		agentKind  string // "hosted" or "prompt"
+		envValues  map[string]string
+		envGetErr  error
+		wantErr    bool
+		wantCode   string
+		wantNotACR bool // when true, expect an error but NOT an ACR-related code
+	}{
+		{
+			name:      "returns error when ACR endpoint is empty",
+			agentKind: "hosted",
+			envValues: map[string]string{},
+			wantErr:   true,
+			wantCode:  exterrors.CodeMissingContainerRegistryEndpoint,
+		},
+		{
+			name:      "returns error when GetValue fails",
+			agentKind: "hosted",
+			envValues: map[string]string{},
+			envGetErr: errors.New("env service unavailable"),
+			wantErr:   true,
+			wantCode:  exterrors.CodeEnvironmentValuesFailed,
+		},
+		{
+			name:      "proceeds past ACR check when endpoint is set",
+			agentKind: "hosted",
+			envValues: map[string]string{
+				"AZURE_CONTAINER_REGISTRY_ENDPOINT": "myregistry.azurecr.io",
+			},
+			// Package will continue past the ACR check and fail later
+			// (no container service stub), but the ACR validation itself passes.
+			wantErr:    true,
+			wantCode:   "",
+			wantNotACR: true,
+		},
+		{
+			name:      "skips ACR check for prompt agents",
+			agentKind: "prompt",
+			envValues: map[string]string{},
+			wantErr:   false,
+			wantCode:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+
+			var agentPath string
+			if tt.agentKind == "hosted" {
+				agentPath = writeHostedAgentYAML(t, dir)
+			} else {
+				agentPath = writePromptAgentYAML(t, dir)
+			}
+
+			envSrv := &packageEnvServer{
+				values:  tt.envValues,
+				getErr:  tt.envGetErr,
+				envName: "test-env",
+			}
+
+			client := newPackageTestClient(t, envSrv)
+
+			provider := &AgentServiceTargetProvider{
+				azdClient:           client,
+				agentDefinitionPath: agentPath,
+				env:                 &azdext.Environment{Name: "test-env"},
+			}
+
+			result, err := provider.Package(
+				t.Context(),
+				&azdext.ServiceConfig{},
+				&azdext.ServiceContext{},
+				func(string) {},
+			)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantNotACR {
+					// Verify the error is NOT the ACR validation error,
+					// confirming the check was passed successfully.
+					var localErr *azdext.LocalError
+					if errors.As(err, &localErr) {
+						require.NotEqual(t, exterrors.CodeMissingContainerRegistryEndpoint, localErr.Code,
+							"expected ACR check to pass, but got ACR missing error")
+						require.NotEqual(t, exterrors.CodeEnvironmentValuesFailed, localErr.Code,
+							"expected ACR check to pass, but got env values error")
+					}
+				} else {
+					var localErr *azdext.LocalError
+					require.True(t, errors.As(err, &localErr), "expected *azdext.LocalError, got %T", err)
+					require.Equal(t, tt.wantCode, localErr.Code)
+				}
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
 			}
 		})
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -201,7 +201,7 @@ func writeHostedAgentYAML(t *testing.T, dir string) string {
 	t.Helper()
 	p := filepath.Join(dir, "agent.yaml")
 	content := []byte("kind: hosted\nname: test-agent\n")
-	require.NoError(t, os.WriteFile(p, content, 0o644))
+	require.NoError(t, os.WriteFile(p, content, 0o600))
 	return p
 }
 
@@ -211,7 +211,7 @@ func writePromptAgentYAML(t *testing.T, dir string) string {
 	t.Helper()
 	p := filepath.Join(dir, "agent.yaml")
 	content := []byte("kind: prompt\nname: test-agent\nmodel:\n  id: gpt-4o-mini\n")
-	require.NoError(t, os.WriteFile(p, content, 0o644))
+	require.NoError(t, os.WriteFile(p, content, 0o600))
 	return p
 }
 


### PR DESCRIPTION
This pull request adds an important validation step to the agent packaging process to ensure that the Azure Container Registry (ACR) endpoint is configured before attempting container operations. This helps prevent confusing errors for users who haven't yet provisioned their environment. Additionally, a new error code is introduced to support this check.

**Container registry validation improvements:**

* [`cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go`](diffhunk://#diff-de3002822a370d78df47a22b93ad4b3c9aa9dd65faa92c654d067850d04cc850R311-R336): Added a check in the `Package` method to verify that the `AZURE_CONTAINER_REGISTRY_ENDPOINT` environment variable is set before proceeding. If it's missing, the user receives a clear, actionable error message explaining how to resolve the issue.

**Error handling updates:**

* [`cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go`](diffhunk://#diff-3c19ec305a83b99e4287275177a21167bf77dda9e50785b661d49c09ae10692dR55): Introduced a new error code, `CodeMissingContainerRegistryEndpoint`, to represent the missing container registry endpoint scenario.

Fixes #7818.