### PR TITLE
Handle existing AI project selection in model configuration

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -805,6 +805,13 @@ func (a *InitAction) configureModelChoice(
 			if selectedProject == nil {
 				return nil, fmt.Errorf("foundry project not found: %s", a.flags.projectResourceId)
 			}
+
+			// Signal Bicep to skip project/role/connection provisioning for this existing project
+			if err := setEnvValue(
+				ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "true",
+			); err != nil {
+				return nil, err
+			}
 		} else {
 			// Prompt user to pick an existing Foundry project or create new resources
 			projectChoices := []*azdext.SelectChoice{
@@ -848,7 +855,19 @@ func (a *InitAction) configureModelChoice(
 					_, _ = color.New(color.Faint).Println(
 						"No existing Foundry project was selected. Falling back to creating new resources.",
 					)
+					if err := setEnvValue(
+						ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false",
+					); err != nil {
+						return nil, err
+					}
 					if err := ensureLocation(ctx, a.azdClient, a.azureContext, a.environment.Name); err != nil {
+						return nil, err
+					}
+				} else {
+					// Signal Bicep to skip project/role/connection provisioning for this existing project
+					if err := setEnvValue(
+						ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "true",
+					); err != nil {
 						return nil, err
 					}
 				}
@@ -861,6 +880,13 @@ func (a *InitAction) configureModelChoice(
 					return nil, err
 				}
 				a.credential = newCred
+
+				// Creating new resources — clear any stale existing-project flag
+				if err := setEnvValue(
+					ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false",
+				); err != nil {
+					return nil, err
+				}
 			}
 		}
 
@@ -918,7 +944,9 @@ func (a *InitAction) configureModelChoice(
 
 		if selectedProject != nil {
 			// Signal Bicep to skip project/role/connection provisioning for this existing project
-			if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "true"); err != nil {
+			if err := setEnvValue(
+				ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "true",
+			); err != nil {
 				return nil, err
 			}
 		} else {
@@ -926,6 +954,12 @@ func (a *InitAction) configureModelChoice(
 			fmt.Println(output.WithGrayFormat(
 				"No existing Foundry project was selected. Falling back to deploying a new model.",
 			))
+			// Clear any stale existing-project flag from a previous init
+			if err := setEnvValue(
+				ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false",
+			); err != nil {
+				return nil, err
+			}
 			if err := ensureLocation(ctx, a.azdClient, a.azureContext, a.environment.Name); err != nil {
 				return nil, err
 			}
@@ -941,6 +975,13 @@ func (a *InitAction) configureModelChoice(
 			return nil, err
 		}
 		a.credential = newCred
+
+		// Deploying new resources — clear any stale existing-project flag
+		if err := setEnvValue(
+			ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false",
+		); err != nil {
+			return nil, err
+		}
 	}
 
 	// Now process models — getModelDeploymentDetails will branch based on AZURE_AI_PROJECT_ID

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -916,7 +916,12 @@ func (a *InitAction) configureModelChoice(
 			return nil, err
 		}
 
-		if selectedProject == nil {
+		if selectedProject != nil {
+			// Signal Bicep to skip project/role/connection provisioning for this existing project
+			if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "true"); err != nil {
+				return nil, err
+			}
+		} else {
 			// No existing project selected (no projects found or user chose "Create new") → fall back to "deploy new" path
 			fmt.Println(output.WithGrayFormat(
 				"No existing Foundry project was selected. Falling back to deploying a new model.",

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
@@ -162,6 +162,7 @@ type testEnvironmentServiceServer struct {
 	azdext.UnimplementedEnvironmentServiceServer
 	environments map[string]*azdext.Environment
 	current      *azdext.Environment
+	values       map[string]map[string]string // envName -> key -> value
 }
 
 func (s *testEnvironmentServiceServer) GetCurrent(context.Context, *azdext.EmptyRequest) (*azdext.EnvironmentResponse, error) {
@@ -172,13 +173,41 @@ func (s *testEnvironmentServiceServer) GetCurrent(context.Context, *azdext.Empty
 	return &azdext.EnvironmentResponse{Environment: s.current}, nil
 }
 
-func (s *testEnvironmentServiceServer) Get(_ context.Context, req *azdext.GetEnvironmentRequest) (*azdext.EnvironmentResponse, error) {
+func (s *testEnvironmentServiceServer) Get(
+	_ context.Context, req *azdext.GetEnvironmentRequest,
+) (*azdext.EnvironmentResponse, error) {
 	env, ok := s.environments[req.Name]
 	if !ok {
 		return nil, status.Error(codes.NotFound, "environment not found")
 	}
 
 	return &azdext.EnvironmentResponse{Environment: env}, nil
+}
+
+func (s *testEnvironmentServiceServer) SetValue(
+	_ context.Context, req *azdext.SetEnvRequest,
+) (*azdext.EmptyResponse, error) {
+	if s.values == nil {
+		s.values = make(map[string]map[string]string)
+	}
+	if s.values[req.EnvName] == nil {
+		s.values[req.EnvName] = make(map[string]string)
+	}
+	s.values[req.EnvName][req.Key] = req.Value
+	return &azdext.EmptyResponse{}, nil
+}
+
+func (s *testEnvironmentServiceServer) GetValue(
+	_ context.Context, req *azdext.GetEnvRequest,
+) (*azdext.KeyValueResponse, error) {
+	if s.values != nil {
+		if envVals, ok := s.values[req.EnvName]; ok {
+			if val, ok := envVals[req.Key]; ok {
+				return &azdext.KeyValueResponse{Value: val}, nil
+			}
+		}
+	}
+	return nil, status.Error(codes.NotFound, "key not found")
 }
 
 type testWorkflowServiceServer struct {
@@ -486,4 +515,36 @@ func TestNormalizeLoginServer(t *testing.T) {
 			require.Equal(t, tt.want, normalizeLoginServer(tt.input))
 		})
 	}
+}
+
+func TestSetEnvValue_PersistsKeyValue(t *testing.T) {
+	t.Parallel()
+
+	envServer := &testEnvironmentServiceServer{
+		environments: map[string]*azdext.Environment{
+			"test-env": {Name: "test-env"},
+		},
+	}
+	workflowServer := &testWorkflowServiceServer{}
+	azdClient := newTestAzdClient(t, envServer, workflowServer)
+
+	const envName = "test-env"
+
+	// Set a value
+	err := setEnvValue(
+		t.Context(), azdClient, envName, "USE_EXISTING_AI_PROJECT", "true",
+	)
+	require.NoError(t, err)
+
+	// Verify it was stored
+	require.Equal(t, "true", envServer.values[envName]["USE_EXISTING_AI_PROJECT"])
+
+	// Overwrite with "false" (simulating re-init choosing "create new")
+	err = setEnvValue(
+		t.Context(), azdClient, envName, "USE_EXISTING_AI_PROJECT", "false",
+	)
+	require.NoError(t, err)
+
+	// Verify the value was updated
+	require.Equal(t, "false", envServer.values[envName]["USE_EXISTING_AI_PROJECT"])
 }


### PR DESCRIPTION
This pull request updates the logic for handling existing Azure AI projects during the initialization process. Now, when an existing project is selected, an environment variable is set to signal downstream tools to skip unnecessary provisioning steps.

Project selection and provisioning logic:

* Updated the conditional in `configureModelChoice` (in `init.go`) to check for an existing project and, if found, set the `USE_EXISTING_AI_PROJECT` environment variable to `"true"`, signaling Bicep to skip project/role/connection provisioning for existing projects.

matching PR for bicep: https://github.com/Azure-Samples/azd-ai-starter-basic/pull/56

Fixes #7842 