### PR TITLE
fix: deploy with separate locations for models and other foundry projects

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -654,11 +654,18 @@ func loadAzureContext(
 		envValueMap[value.Key] = value.Value
 	}
 
+	// Use AZURE_AI_DEPLOYMENTS_LOCATION for Scope.Location (used for model filtering).
+	// Fall back to AZURE_LOCATION for backward compatibility with older environments.
+	location := envValueMap["AZURE_AI_DEPLOYMENTS_LOCATION"]
+	if location == "" {
+		location = envValueMap["AZURE_LOCATION"]
+	}
+
 	return &azdext.AzureContext{
 		Scope: &azdext.AzureScope{
 			TenantId:       envValueMap["AZURE_TENANT_ID"],
 			SubscriptionId: envValueMap["AZURE_SUBSCRIPTION_ID"],
-			Location:       envValueMap["AZURE_LOCATION"],
+			Location:       location,
 		},
 		Resources: []string{},
 	}, nil
@@ -728,7 +735,9 @@ func ensureSubscription(
 }
 
 // ensureLocation prompts for an Azure location if not already set in the AzureContext.
-// Both init flows use this.
+// Both init flows use this. Sets both AZURE_LOCATION (resource group) and
+// AZURE_AI_DEPLOYMENTS_LOCATION (AI/model resources) to the same value as a default.
+// If the user later picks a different model region, only AZURE_AI_DEPLOYMENTS_LOCATION changes.
 func ensureLocation(
 	ctx context.Context,
 	azdClient *azdext.AzdClient,
@@ -738,7 +747,8 @@ func ensureLocation(
 	allowedLocations := supportedRegionsForInit()
 
 	if azureContext.Scope.Location != "" && locationAllowed(azureContext.Scope.Location, allowedLocations) {
-		return nil
+		// Location already set and valid — ensure AZURE_AI_DEPLOYMENTS_LOCATION is also set
+		return setEnvValue(ctx, azdClient, envName, "AZURE_AI_DEPLOYMENTS_LOCATION", azureContext.Scope.Location)
 	}
 	if azureContext.Scope.Location != "" {
 		fmt.Printf("%s", output.WithWarningFormat(
@@ -757,7 +767,11 @@ func ensureLocation(
 
 	azureContext.Scope.Location = locationName
 
-	return setEnvValue(ctx, azdClient, envName, "AZURE_LOCATION", azureContext.Scope.Location)
+	if err := setEnvValue(ctx, azdClient, envName, "AZURE_LOCATION", azureContext.Scope.Location); err != nil {
+		return err
+	}
+
+	return setEnvValue(ctx, azdClient, envName, "AZURE_AI_DEPLOYMENTS_LOCATION", azureContext.Scope.Location)
 }
 
 // ensureSubscriptionAndLocation ensures both subscription and location are set.
@@ -1085,10 +1099,22 @@ func selectFoundryProject(
 
 	selectedProject := projects[selectedIdx]
 
-	// Set location from the selected project
+	// Set AI deployments location from the selected project.
+	// The project's location determines where AI models and resources are deployed.
+	previousLocation := azureContext.Scope.Location
 	azureContext.Scope.Location = selectedProject.Location
-	if err := setEnvValue(ctx, azdClient, envName, "AZURE_LOCATION", selectedProject.Location); err != nil {
-		return nil, fmt.Errorf("failed to set AZURE_LOCATION: %w", err)
+	if err := setEnvValue(
+		ctx, azdClient, envName, "AZURE_AI_DEPLOYMENTS_LOCATION", selectedProject.Location,
+	); err != nil {
+		return nil, fmt.Errorf("failed to set AZURE_AI_DEPLOYMENTS_LOCATION: %w", err)
+	}
+
+	// Seed AZURE_LOCATION (resource group location) if not already set.
+	// Default to co-locating with the project; user can override before deploying.
+	if previousLocation == "" {
+		if err := setEnvValue(ctx, azdClient, envName, "AZURE_LOCATION", selectedProject.Location); err != nil {
+			return nil, fmt.Errorf("failed to set AZURE_LOCATION: %w", err)
+		}
 	}
 
 	// Configure all Foundry project environment variables

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go
@@ -83,11 +83,11 @@ func (a *modelSelector) updateEnvLocation(ctx context.Context, selectedLocation 
 
 	_, err := a.azdClient.Environment().SetValue(ctx, &azdext.SetEnvRequest{
 		EnvName: envName,
-		Key:     "AZURE_LOCATION",
+		Key:     "AZURE_AI_DEPLOYMENTS_LOCATION",
 		Value:   selectedLocation,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to update AZURE_LOCATION in azd environment: %w", err)
+		return fmt.Errorf("failed to update AZURE_AI_DEPLOYMENTS_LOCATION in azd environment: %w", err)
 	}
 
 	if a.azureContext == nil {
@@ -98,7 +98,9 @@ func (a *modelSelector) updateEnvLocation(ctx context.Context, selectedLocation 
 	}
 	a.azureContext.Scope.Location = selectedLocation
 
-	fmt.Println(output.WithSuccessFormat("Updated AZURE_LOCATION to '%s' in your azd environment.", selectedLocation))
+	fmt.Println(output.WithSuccessFormat(
+		"Updated AZURE_AI_DEPLOYMENTS_LOCATION to '%s' in your azd environment.", selectedLocation,
+	))
 	return nil
 }
 


### PR DESCRIPTION
This pull request updates how Azure location environment variables are handled for AI/model resources and resource groups, improving clarity and flexibility in regional configuration. The main focus is on distinguishing between the deployment location for AI resources and the general resource group location, ensuring both are set appropriately and allowing for independent changes when needed.

**Environment variable handling improvements:**

* The logic for setting the Azure location in `loadAzureContext` now prefers `AZURE_AI_DEPLOYMENTS_LOCATION` for AI/model resource deployments, falling back to `AZURE_LOCATION` for backward compatibility. (`cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go`)
* The `ensureLocation` function now sets both `AZURE_LOCATION` (for resource groups) and `AZURE_AI_DEPLOYMENTS_LOCATION` (for AI/model resources) to the same value by default, but allows `AZURE_AI_DEPLOYMENTS_LOCATION` to be changed independently later. (`cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go`) [[1]](diffhunk://#diff-46e6dfc85715f4b765bd87dc4e2d258ae6a74dcaf785775e3b0dc9cf8590d5acL731-R740) [[2]](diffhunk://#diff-46e6dfc85715f4b765bd87dc4e2d258ae6a74dcaf785775e3b0dc9cf8590d5acL741-R751) [[3]](diffhunk://#diff-46e6dfc85715f4b765bd87dc4e2d258ae6a74dcaf785775e3b0dc9cf8590d5acL760-R774)

**Project selection and environment updates:**

* When selecting a Foundry project, the deployment location for AI resources is set using `AZURE_AI_DEPLOYMENTS_LOCATION`, and `AZURE_LOCATION` is seeded only if not already set, allowing the user to override it before deployment. (`cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go`)
* In the model selector, updates now target `AZURE_AI_DEPLOYMENTS_LOCATION` instead of `AZURE_LOCATION`, and the success message reflects this change. (`cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go`) [[1]](diffhunk://#diff-bd59534c3f4023c2639c0421684fff0e5aa83ee2c33be97bc7234117fc44a9f6L86-R90) [[2]](diffhunk://#diff-bd59534c3f4023c2639c0421684fff0e5aa83ee2c33be97bc7234117fc44a9f6L101-R103)

Matching bicep updates: https://github.com/Azure-Samples/azd-ai-starter-basic/pull/58
Fixes #7670 