### PR TITLE
Enhance SSE handling with raw text fallback and tests

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
@@ -689,11 +689,14 @@ func handleInvocationSync(body io.Reader, agentName string) error {
 
 // handleInvocationSSE handles a streaming (200 OK, text/event-stream) invocations response.
 // The invocations protocol has a developer-defined SSE format, so we print data lines as they arrive.
+// As a fallback, lines that are not SSE control lines (event:, id:, : comment, or blank) are
+// printed as raw text output — this supports agents that stream raw text over text/event-stream.
 func handleInvocationSSE(w io.Writer, body io.Reader, agentName string) error {
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
 	var printed bool
+	var lastWasRaw bool
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -728,11 +731,33 @@ func handleInvocationSSE(w io.Writer, body io.Reader, agentName string) error {
 				printed = true
 			}
 			fmt.Fprintln(w, data)
+			lastWasRaw = false
+			continue
 		}
+
+		// Skip SSE control lines and blank lines
+		if line == "" ||
+			strings.HasPrefix(line, "event:") ||
+			strings.HasPrefix(line, "id:") ||
+			strings.HasPrefix(line, ":") {
+			continue
+		}
+
+		// Raw text fallback — agents may stream plain text over text/event-stream
+		if !printed {
+			fmt.Fprintf(w, "[%s] ", agentName)
+			printed = true
+		}
+		fmt.Fprint(w, line)
+		lastWasRaw = true
 	}
 
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("error reading response stream: %w", err)
+	}
+
+	if lastWasRaw {
+		fmt.Fprintln(w)
 	}
 
 	return nil

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
@@ -468,6 +468,30 @@ func TestHandleInvocationSSE(t *testing.T) {
 			agentName:  "agent",
 			wantOutput: "[agent] line1\nline2\nline3\n",
 		},
+		{
+			name:       "raw text without data prefix is printed as fallback",
+			input:      "Hello from agent\n",
+			agentName:  "raw-agent",
+			wantOutput: "[raw-agent] Hello from agent\n",
+		},
+		{
+			name:       "multiple raw text lines are concatenated",
+			input:      "Hello \nworld!\n",
+			agentName:  "raw-agent",
+			wantOutput: "[raw-agent] Hello world!\n",
+		},
+		{
+			name:       "mixed SSE data and raw text",
+			input:      "data: sse-line\nraw-text\n\n",
+			agentName:  "mix-agent",
+			wantOutput: "[mix-agent] sse-line\nraw-text\n",
+		},
+		{
+			name:       "SSE comment lines are skipped",
+			input:      ": this is a comment\ndata: content\n\n",
+			agentName:  "test-agent",
+			wantOutput: "[test-agent] content\n",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This pull request enhances the handling of streaming responses in the agent invocation command by improving support for agents that send raw text over Server-Sent Events (SSE). It also adds comprehensive test coverage for these scenarios. The main changes are grouped below:

**Enhancements to SSE Response Handling:**

* Updated the `handleInvocationSSE` function in `invoke.go` to treat lines that are not SSE control lines (such as `event:`, `id:`, comments, or blank lines) as raw text, printing them directly as output. This ensures compatibility with agents that stream plain text over SSE. [[1]](diffhunk://#diff-4aa7ede0461890ada63862e7c95c3332290a89a835ca1bb6e607e4b376b08812R692-R699) [[2]](diffhunk://#diff-4aa7ede0461890ada63862e7c95c3332290a89a835ca1bb6e607e4b376b08812R734-R762)
* Ensured that a newline is printed after the last raw text line, improving output formatting for raw text streams.

**Test Coverage Improvements:**

* Added multiple test cases to `handleInvocationSSE` in `invoke_test.go` to verify correct handling of raw text, concatenation of multiple lines, mixed SSE and raw text, and skipping of comment lines.

Fixes #7889 