### PR TITLE
Rename EnvironmentID to EnvironmentImageReference

### DIFF
--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_get.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_get.go
@@ -312,7 +312,7 @@ func printJobDetails(d *jobDetails) {
 
 	// Environment & Code
 	w = tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(w, "Environment:\t%s\n", valueOrDash(props.EnvironmentID))
+	fmt.Fprintf(w, "Environment:\t%s\n", valueOrDash(props.EnvironmentImageReference))
 
 	// Show code ID from job props, or fall back to run history inputs
 	codeID := props.CodeID
@@ -455,11 +455,11 @@ func printComputeSection(d *jobDetails) {
 func printInputsSection(inputs map[string]models.JobInput, history *models.RunHistory) {
 	// Merge: job inputs + any extra inputs from run history not in the job response
 	type mergedInput struct {
-		Name     string
-		Type     string
-		Mode     string
-		Value    string // URI or literal value
-		AssetID  string // from run history
+		Name    string
+		Type    string
+		Mode    string
+		Value   string // URI or literal value
+		AssetID string // from run history
 	}
 
 	seen := make(map[string]bool)

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_submit.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_submit.go
@@ -130,14 +130,14 @@ func newJobSubmitCommand() *cobra.Command {
 // buildJobResource converts a parsed YAML JobDefinition into the REST API payload.
 func buildJobResource(def *utils.JobDefinition) *models.JobResource {
 	job := models.CommandJob{
-		JobType:              "Command",
-		DisplayName:          def.DisplayName,
-		Description:          def.Description,
-		Command:              def.Command,
-		EnvironmentID:        def.Environment,
-		ComputeID:            def.Compute,
-		CodeID:               def.Code,
-		EnvironmentVariables: def.EnvironmentVariables,
+		JobType:                   "Command",
+		DisplayName:               def.DisplayName,
+		Description:               def.Description,
+		Command:                   def.Command,
+		EnvironmentImageReference: def.Environment,
+		ComputeID:                 def.Compute,
+		CodeID:                    def.Code,
+		EnvironmentVariables:      def.EnvironmentVariables,
 	}
 
 	if job.DisplayName == "" {

--- a/cli/azd/extensions/azure.ai.customtraining/pkg/models/job.go
+++ b/cli/azd/extensions/azure.ai.customtraining/pkg/models/job.go
@@ -14,24 +14,24 @@ type JobResource struct {
 
 // CommandJob represents the properties of a Foundry command job.
 type CommandJob struct {
-	JobType              string                `json:"jobType"`
-	DisplayName          string                `json:"displayName,omitempty" table:"DISPLAY NAME"`
-	Description          string                `json:"description,omitempty"`
-	Status               string                `json:"status,omitempty" table:"STATUS"`
-	Command              string                `json:"command,omitempty"`
-	EnvironmentID        string                `json:"environmentId,omitempty"`
-	CodeID               string                `json:"codeId,omitempty"`
-	ComputeID            string                `json:"computeId,omitempty"`
-	Inputs               map[string]JobInput   `json:"inputs,omitempty"`
-	Outputs              map[string]JobOutput  `json:"outputs,omitempty"`
-	Distribution         *Distribution         `json:"distribution,omitempty"`
-	Resources            *ResourceConfig       `json:"resources,omitempty"`
-	Limits               *CommandJobLimits     `json:"limits,omitempty"`
-	EnvironmentVariables map[string]string     `json:"environmentVariables,omitempty"`
-	QueueSettings        *QueueSettings        `json:"queueSettings,omitempty"`
-	IsArchived           bool                  `json:"isArchived,omitempty"`
-	CreatedDateTime      string                `json:"createdDateTime,omitempty"`
-	Services             map[string]interface{} `json:"services,omitempty"`
+	JobType                   string                 `json:"jobType"`
+	DisplayName               string                 `json:"displayName,omitempty" table:"DISPLAY NAME"`
+	Description               string                 `json:"description,omitempty"`
+	Status                    string                 `json:"status,omitempty" table:"STATUS"`
+	Command                   string                 `json:"command,omitempty"`
+	EnvironmentImageReference string                 `json:"environmentImageReference,omitempty"`
+	CodeID                    string                 `json:"codeId,omitempty"`
+	ComputeID                 string                 `json:"computeId,omitempty"`
+	Inputs                    map[string]JobInput    `json:"inputs,omitempty"`
+	Outputs                   map[string]JobOutput   `json:"outputs,omitempty"`
+	Distribution              *Distribution          `json:"distribution,omitempty"`
+	Resources                 *ResourceConfig        `json:"resources,omitempty"`
+	Limits                    *CommandJobLimits      `json:"limits,omitempty"`
+	EnvironmentVariables      map[string]string      `json:"environmentVariables,omitempty"`
+	QueueSettings             *QueueSettings         `json:"queueSettings,omitempty"`
+	IsArchived                bool                   `json:"isArchived,omitempty"`
+	CreatedDateTime           string                 `json:"createdDateTime,omitempty"`
+	Services                  map[string]interface{} `json:"services,omitempty"`
 }
 
 // TerminalStatuses contains job statuses that indicate the job has finished.


### PR DESCRIPTION
### Testing
#### Before
<img width="2337" height="314" alt="image" src="https://github.com/user-attachments/assets/055b5681-21d8-4c67-a1f6-729651faccbc" />

#### After the fix
- Submit command: 
<img width="2193" height="1372" alt="image" src="https://github.com/user-attachments/assets/68a91da7-f14b-4251-bebd-5840840ceec1" />

Job submitted: https://eastus2euap.ai.azure.com/nextgen/r/csA7805pQa-VMt_Nw-7-9A,shared-finetuning-rg,,fdp-command-job-CANARY,fdp-command-job-UMI-CANARY-proj/build/train/custom-jobs/frank_carpet_xrjsssmt28/details?flight=horizon_train%2Chorizon_compute%2Chorizon_intcdn

- YAML ref:
<img width="1580" height="585" alt="image" src="https://github.com/user-attachments/assets/8eb81c64-6afe-4b75-b4f6-18727cea4f65" />

- Show command:
<img width="1106" height="588" alt="image" src="https://github.com/user-attachments/assets/2809f6d3-3fc9-4b2f-8448-67eae1f1d0e3" />
