### PR TITLE
fix: eliminate failing/flaky tests in devcontainer/non-CI environments

### DIFF
--- a/cli/azd/cmd/final_coverage3_test.go
+++ b/cli/azd/cmd/final_coverage3_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net/http"
 	"os"
 	"testing"
 
@@ -85,6 +86,18 @@ func (r *noopCommandRunner) ToolInPath(_ string) error {
 	return errors.New("not found")
 }
 
+// failingTransport is an http.RoundTripper that always returns an error.
+type failingTransport struct{}
+
+func (ft *failingTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return nil, errors.New("test: network disabled")
+}
+
+// failingHTTPClient returns an *http.Client that fails all requests.
+func failingHTTPClient() *http.Client {
+	return &http.Client{Transport: &failingTransport{}}
+}
+
 // ===========================================================================
 // updateAction.Run tests
 // ===========================================================================
@@ -131,6 +144,7 @@ func newTestUpdateAction(
 		writer:        writer,
 		configManager: cfgMgr,
 		commandRunner: cmdRunner,
+		httpClient:    failingHTTPClient(),
 	}
 }
 

--- a/cli/azd/cmd/update.go
+++ b/cli/azd/cmd/update.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/internal"
@@ -69,6 +70,7 @@ type updateAction struct {
 	writer        io.Writer
 	configManager config.UserConfigManager
 	commandRunner exec.CommandRunner
+	httpClient    *http.Client // nil uses default; tests inject a failing client
 }
 
 func newUpdateAction(
@@ -176,7 +178,7 @@ func (a *updateAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		}, nil
 	}
 
-	mgr := update.NewManager(a.commandRunner, nil)
+	mgr := update.NewManager(a.commandRunner, a.httpClient)
 
 	// Block update in CI/CD environments
 	if resource.IsRunningOnCI() {

--- a/cli/azd/pkg/azdext/security_validation.go
+++ b/cli/azd/pkg/azdext/security_validation.go
@@ -183,12 +183,22 @@ func ValidateScriptName(name string) error {
 // Container environment detection
 // ---------------------------------------------------------------------------
 
-// containerEnvVars maps environment variables to the container runtime they indicate.
-var containerEnvVars = map[string]string{
-	"CODESPACES":              "codespaces",
-	"KUBERNETES_SERVICE_HOST": "kubernetes",
-	"REMOTE_CONTAINERS":       "devcontainer",
-	"REMOTE_CONTAINERS_IPC":   "devcontainer",
+// containerEnvVar associates an environment variable with the container
+// runtime it indicates. Order matters: when multiple variables are present
+// (e.g., a Codespace running inside a devcontainer), entries earlier in the
+// list take precedence so detection is deterministic.
+type containerEnvVar struct {
+	envKey  string
+	runtime string
+}
+
+// containerEnvVars lists the environment variables checked for container
+// detection, in priority order.
+var containerEnvVars = []containerEnvVar{
+	{"CODESPACES", "codespaces"},
+	{"KUBERNETES_SERVICE_HOST", "kubernetes"},
+	{"REMOTE_CONTAINERS", "devcontainer"},
+	{"REMOTE_CONTAINERS_IPC", "devcontainer"},
 }
 
 // IsContainerEnvironment reports whether the current process is running inside
@@ -203,8 +213,8 @@ var containerEnvVars = map[string]string{
 // security decisions.
 func IsContainerEnvironment() bool {
 	// Check well-known environment variables.
-	for envKey := range containerEnvVars {
-		if v := os.Getenv(envKey); v != "" {
+	for _, e := range containerEnvVars {
+		if v := os.Getenv(e.envKey); v != "" {
 			return true
 		}
 	}
@@ -218,13 +228,15 @@ func IsContainerEnvironment() bool {
 }
 
 // ContainerRuntime returns the detected container runtime name, or an empty
-// string if no container environment is detected.
+// string if no container environment is detected. When multiple container
+// environment variables are set, the first match in containerEnvVars order
+// wins, ensuring deterministic results.
 //
 // Possible return values: "codespaces", "kubernetes", "devcontainer", "docker", "".
 func ContainerRuntime() string {
-	for envKey, runtime := range containerEnvVars {
-		if v := os.Getenv(envKey); v != "" {
-			return runtime
+	for _, e := range containerEnvVars {
+		if v := os.Getenv(e.envKey); v != "" {
+			return e.runtime
 		}
 	}
 

--- a/cli/azd/pkg/azdext/security_validation_test.go
+++ b/cli/azd/pkg/azdext/security_validation_test.go
@@ -263,8 +263,8 @@ func TestIsContainerEnvironment_EnvVars(t *testing.T) {
 			// Clear all container env vars so only the one under test is active.
 			// This prevents false positives when running inside a devcontainer
 			// or Codespace where other vars are already set.
-			for envKey := range containerEnvVars {
-				t.Setenv(envKey, "")
+			for _, e := range containerEnvVars {
+				t.Setenv(e.envKey, "")
 			}
 			t.Setenv(tc.envKey, "true")
 
@@ -282,10 +282,10 @@ func TestIsContainerEnvironment_EnvVars(t *testing.T) {
 
 func TestIsContainerEnvironment_NoContainerEnv(t *testing.T) {
 	// Clear all container-related env vars.
-	for envKey := range containerEnvVars {
-		if v := os.Getenv(envKey); v != "" {
-			t.Setenv(envKey, "")
-			os.Unsetenv(envKey)
+	for _, e := range containerEnvVars {
+		if v := os.Getenv(e.envKey); v != "" {
+			t.Setenv(e.envKey, "")
+			os.Unsetenv(e.envKey)
 		}
 	}
 

--- a/cli/azd/pkg/azdext/security_validation_test.go
+++ b/cli/azd/pkg/azdext/security_validation_test.go
@@ -260,8 +260,12 @@ func TestIsContainerEnvironment_EnvVars(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.envKey, func(t *testing.T) {
-			// Ensure the env var is clean before/after.
-			orig := os.Getenv(tc.envKey)
+			// Clear all container env vars so only the one under test is active.
+			// This prevents false positives when running inside a devcontainer
+			// or Codespace where other vars are already set.
+			for envKey := range containerEnvVars {
+				t.Setenv(envKey, "")
+			}
 			t.Setenv(tc.envKey, "true")
 
 			if !IsContainerEnvironment() {
@@ -271,13 +275,6 @@ func TestIsContainerEnvironment_EnvVars(t *testing.T) {
 			rt := ContainerRuntime()
 			if rt != tc.runtime {
 				t.Errorf("ContainerRuntime() = %q with %s set, want %q", rt, tc.envKey, tc.runtime)
-			}
-
-			// Restore and verify negative case.
-			if orig == "" {
-				os.Unsetenv(tc.envKey)
-			} else {
-				os.Setenv(tc.envKey, orig)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

Two test suites fail when run locally in devcontainers but pass in CI:

1. **`TestIsContainerEnvironment_EnvVars`** — Ambient env vars like `REMOTE_CONTAINERS` (set in devcontainers) interfere with assertions because Go map iteration is non-deterministic. When testing `CODESPACES`, `ContainerRuntime()` may find `REMOTE_CONTAINERS` first and return `"devcontainer"` instead of `"codespaces"`.

2. **`Test_UpdateAction_Run_SwitchChannel_CheckForUpdateError`** / **`Test_UpdateAction_Run_NoChannelNoConfigFlags`** — These expect `Run()` to return an error via `noopCommandRunner`, but `CheckForUpdate` uses an HTTP client (not the command runner). In CI, `IsRunningOnCI()` short-circuits before reaching `CheckForUpdate`, masking the bug. Locally, the real HTTP call succeeds and `Run()` returns nil.

## Fix

- **Container env tests**: Clear all container env vars via `t.Setenv` before each subtest so only the target var is active.
- **Update action tests**: Add `httpClient` field to `updateAction` (nil = default) and inject a `failingTransport` in tests so `CheckForUpdate` fails deterministically without network access.