### PR TITLE
fix: Fix links to extension assets in documentation

### DIFF
--- a/cli/azd/docs/extensions/extension-framework-services.md
+++ b/cli/azd/docs/extensions/extension-framework-services.md
@@ -391,9 +391,9 @@ func (p *RustFrameworkServiceProvider) Initialize(ctx context.Context, serviceCo
 
 You can find a complete working example in the azd demo extension:
 
-- Extension manifest: [`extensions/microsoft.azd.demo/extension.yaml`](../extensions/microsoft.azd.demo/extension.yaml)
-- Framework service implementation: [`extensions/microsoft.azd.demo/internal/project/framework_service_demo.go`](../extensions/microsoft.azd.demo/internal/project/framework_service_demo.go)
-- Registration: [`extensions/microsoft.azd.demo/internal/cmd/listen.go`](../extensions/microsoft.azd.demo/internal/cmd/listen.go)
+- Extension manifest: [`extensions/microsoft.azd.demo/extension.yaml`](../../extensions/microsoft.azd.demo/extension.yaml)
+- Framework service implementation: [`extensions/microsoft.azd.demo/internal/project/framework_service_demo.go`](../../extensions/microsoft.azd.demo/internal/project/framework_service_demo.go)
+- Registration: [`extensions/microsoft.azd.demo/internal/cmd/listen.go`](../../extensions/microsoft.azd.demo/internal/cmd/listen.go)
 
 ## Troubleshooting
 

--- a/cli/azd/docs/extensions/extension-framework.md
+++ b/cli/azd/docs/extensions/extension-framework.md
@@ -1215,7 +1215,7 @@ For extensions built using Go, the `azdext` package provides an `AzdClient` whic
 
 #### Other Languages
 
-For extensions authored in other programming languages, the [gRPC proto files](../grpc/proto/) can be used to generate clients in your preferred language.
+For extensions authored in other programming languages, the [gRPC proto files](../../grpc/proto/) can be used to generate clients in your preferred language.
 
 ### How to set `azd` access token on requests
 
@@ -1350,9 +1350,9 @@ if err := host.Run(ctx); err != nil {
 
 `azd` leverages gRPC for the communication protocol between Core `azd` and extensions. gRPC client & server components are automatically generated from profile files.
 
-- Proto files @ [grpc/proto](../grpc/proto/)
-- Generated files @ [pkg/azdext](../pkg/azdext)
-- Make file @ [Makefile](../Makefile)
+- Proto files @ [grpc/proto](../../grpc/proto/)
+- Generated files @ [pkg/azdext](../../pkg/azdext)
+- Make file @ [Makefile](../../Makefile)
 
 To re-generate gRPC clients:
 
@@ -1389,7 +1389,7 @@ The following are a list of available gRPC services for extension developer to i
 
 This service manages project configuration retrieval and related operations, including project and service-level configuration management.
 
-> See [project.proto](../grpc/proto/project.proto) for more details.
+> See [project.proto](../../grpc/proto/project.proto) for more details.
 
 #### Get
 
@@ -1521,7 +1521,7 @@ Removes a service configuration value or section at the specified path from serv
 
 This service handles environment management including retrieval, selection, and key-value operations.
 
-> See [environment.proto](../grpc/proto/environment.proto) for more details.
+> See [environment.proto](../../grpc/proto/environment.proto) for more details.
 
 #### GetCurrent
 
@@ -1643,7 +1643,7 @@ Removes a config value at a given path.
 
 This service manages user-specific configuration retrieval and updates.
 
-> See [user_config.proto](../grpc/proto/user_config.proto) for more details.
+> See [user_config.proto](../../grpc/proto/user_config.proto) for more details.
 
 #### Get
 
@@ -1705,7 +1705,7 @@ Removes a user configuration value.
 
 This service provides operations for deployment retrieval and context management.
 
-> See [deployment.proto](../grpc/proto/deployment.proto) for more details.
+> See [deployment.proto](../../grpc/proto/deployment.proto) for more details.
 
 #### GetDeployment
 
@@ -1743,7 +1743,7 @@ Retrieves the current deployment context.
 
 This service manages user prompt interactions for subscriptions, locations, resources, and confirmations.
 
-> See [prompt.proto](../grpc/proto/prompt.proto) for more details.
+> See [prompt.proto](../../grpc/proto/prompt.proto) for more details.
 
 #### PromptSubscription
 
@@ -1968,7 +1968,7 @@ Prompts the user to select a location for a specific model and shows quota avail
 
 This service provides non-interactive AI catalog, deployment resolution, and quota usage primitives.
 
-> See [ai_model.proto](../grpc/proto/ai_model.proto) for more details.
+> See [ai_model.proto](../../grpc/proto/ai_model.proto) for more details.
 
 #### ListModels
 
@@ -2133,7 +2133,7 @@ Clients can subscribe to events and receive notifications via a bidirectional st
   - Invoke event handlers.
   - Send status updates regarding event processing.
 
-> See [event.proto](../grpc/proto/event.proto) for more details.
+> See [event.proto](../../grpc/proto/event.proto) for more details.
 
 #### Message Types
 
@@ -2264,7 +2264,7 @@ host := azdext.NewExtensionHost(azdClient).
 
 This service provides container build, package, and publish operations for extensions that need to work with containers but don't want to implement the full complexity of Docker CLI integration, registry authentication, etc.
 
-> See [container.proto](../grpc/proto/container.proto) for more details.
+> See [container.proto](../../grpc/proto/container.proto) for more details.
 
 #### Build
 
@@ -2378,7 +2378,7 @@ fmt.Printf("Container published successfully with %d artifacts\n", len(publishRe
 
 This service handles language and framework-specific operations like restore, build, and package for services. Extensions can register framework service providers to handle custom languages or override default behavior.
 
-> See [framework_service.proto](../grpc/proto/framework_service.proto) for more details.
+> See [framework_service.proto](../../grpc/proto/framework_service.proto) for more details.
 
 #### Provider Interface
 
@@ -2500,7 +2500,7 @@ func main() {
 
 This service handles the full deployment lifecycle for services, including packaging, publishing, and deploying to Azure resources. Extensions can register service target providers for custom deployment scenarios.
 
-> See [service_target.proto](../grpc/proto/service_target.proto) for more details.
+> See [service_target.proto](../../grpc/proto/service_target.proto) for more details.
 
 #### Provider Interface
 
@@ -2616,7 +2616,7 @@ func main() {
 
 This service manages composability resources in an azd project.
 
-> See [compose.proto](../grpc/proto/compose.proto) for more details.
+> See [compose.proto](../../grpc/proto/compose.proto) for more details.
 
 #### ListResources
 
@@ -2673,7 +2673,7 @@ Adds a new composability resource to the project.
 
 This service executes workflows defined within the project.
 
-> See [workflow.proto](../grpc/proto/workflow.proto) for more details.
+> See [workflow.proto](../../grpc/proto/workflow.proto) for more details.
 
 #### Run
 
@@ -2690,7 +2690,7 @@ Executes a workflow consisting of sequential steps.
 
 This service provides information about the currently logged-in user or identity.
 
-> See [account.proto](../grpc/proto/account.proto) for more details.
+> See [account.proto](../../grpc/proto/account.proto) for more details.
 
 #### ListSubscriptions
 
@@ -2828,7 +2828,7 @@ func getSubscriptionDetails(ctx context.Context, azdClient *azdext.AzdClient, su
 
 This service provides Copilot agent capabilities to extensions. Sessions are created lazily on the first `SendMessage` call and can be reused across multiple calls. Sessions run in headless/autopilot mode by default when invoked via gRPC, suppressing all console output.
 
-> See [copilot.proto](../grpc/proto/copilot.proto) for more details.
+> See [copilot.proto](../../grpc/proto/copilot.proto) for more details.
 
 #### Initialize
 

--- a/cli/azd/docs/extensions/extension-framework.md
+++ b/cli/azd/docs/extensions/extension-framework.md
@@ -907,7 +907,7 @@ Once PR has been merged the extension updates are now live in the official `azd`
 
 Each extension must declare an `extension.yaml` file that describes the metadata for the extension and the capabilities that it supports. This metadata is used within the extension registry to provide details to developers when searching for and installing extensions.
 
-A [JSON schema](../extensions/extension.schema.json) is available to support authoring extension manifests.
+A [JSON schema](../../extensions/extension.schema.json) is available to support authoring extension manifests.
 
 #### Schema Properties
 
@@ -1097,7 +1097,7 @@ examples:
     usage: azd demo prompt
 ```
 
-The following is an example of an [extension manifest](../extensions/microsoft.azd.demo/extension.yaml).
+The following is an example of an [extension manifest](../../extensions/microsoft.azd.demo/extension.yaml).
 
 ```yaml
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/extension.schema.json


### PR DESCRIPTION
This fixes a few relative links to extension assets on [Adding Custom Language Frameworks with Extensions](https://github.com/Azure/azure-dev/blob/main/cli/azd/docs/extensions/extension-framework-services.md#example-complete-rust-framework-service) and [Extension Framework](https://github.com/Azure/azure-dev/blob/main/cli/azd/docs/extensions/extension-framework.md#extension-manifest).

_I'm assuming that the docs are only published in GitHub (where the links are broken) and that they aren't published somewhere else where the old links are correct._