### PR TITLE
Unify host gRPC error transport with a structured ActionableErrorDetail

### DIFF
--- a/cli/azd/grpc/proto/errors.proto
+++ b/cli/azd/grpc/proto/errors.proto
@@ -36,6 +36,20 @@ message ErrorLink {
   string title = 2;  // Display text (falls back to the URL when empty)
 }
 
+// ActionableErrorDetail carries user-facing remediation metadata in gRPC status details.
+// It is used for host-originated errors so clients can preserve suggestions and links
+// without parsing status message text.
+//
+// Direction: host -> extension only. Extensions returning errors to the host should use
+// LocalError / ServiceError (transported via ExtensionError) instead.
+//
+// The user-facing error message lives in google.rpc.Status.message; this detail does not
+// duplicate it.
+message ActionableErrorDetail {
+  string suggestion = 1;         // Optional user-facing suggestion for resolving the error
+  repeated ErrorLink links = 2;  // Optional reference links rendered alongside the suggestion
+}
+
 // ExtensionError is a unified error message that can represent errors from different sources.
 // It provides structured error information for telemetry and error handling.
 message ExtensionError {

--- a/cli/azd/grpc/proto/errors.proto
+++ b/cli/azd/grpc/proto/errors.proto
@@ -52,6 +52,9 @@ message ActionableErrorDetail {
 
 // ExtensionError is a unified error message that can represent errors from different sources.
 // It provides structured error information for telemetry and error handling.
+//
+// Direction: extension -> host only. Counterpart of host's ActionableErrorDetail, which carries
+// host-originated remediation metadata in the opposite direction.
 message ExtensionError {
   reserved 1, 3;            // Reserved for future use; do not reuse.
   string message = 2;       // Human-readable error message

--- a/cli/azd/internal/grpcserver/errors.go
+++ b/cli/azd/internal/grpcserver/errors.go
@@ -6,6 +6,7 @@ package grpcserver
 import (
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
@@ -98,6 +99,7 @@ func withAuthErrorInfo(st *status.Status, err error) *status.Status {
 		Domain: azdext.AuthErrorDomain,
 	})
 	if detailErr != nil {
+		log.Printf("failed to attach auth ErrorInfo to gRPC status: %v", detailErr)
 		return st
 	}
 
@@ -114,6 +116,7 @@ func withActionableErrorDetail(st *status.Status, err *internal.ErrorWithSuggest
 		Links:      azdext.WrapErrorLinks(err.Links),
 	})
 	if detailErr != nil {
+		log.Printf("failed to attach ActionableErrorDetail to gRPC status: %v", detailErr)
 		return st
 	}
 

--- a/cli/azd/internal/grpcserver/errors.go
+++ b/cli/azd/internal/grpcserver/errors.go
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package grpcserver
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/auth"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// mapHostError serializes a host-originated Go error into a gRPC status error for transport
+// to extensions.
+//
+// This is the gRPC serialization boundary: the original error chain (e.g. *auth.AuthFailedError)
+// is intentionally not preserved across the wire — only the structured details defined here.
+//
+// Auth-related errors are reported with codes.Unauthenticated and an azd.auth ErrorInfo detail
+// (preserving AADSTS<code> reasons from Entra). ErrorWithSuggestion errors carry an
+// ActionableErrorDetail so consumers receive suggestion + links structurally.
+//
+// status.Message is always err.Error() (or ErrorWithSuggestion.Message when set). Suggestion
+// text is never concatenated into status.Message; consumers must read ActionableErrorDetail
+// for remediation guidance.
+func mapHostError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	suggestionErr, hasSuggestion := errors.AsType[*internal.ErrorWithSuggestion](err)
+	isAuthErr := isAuthError(err)
+	if !hasSuggestion && !isAuthErr {
+		return err
+	}
+
+	code := codes.Unknown
+	if st, ok := azdext.GRPCStatusFromError(err); ok {
+		code = st.Code()
+	}
+	if isAuthErr {
+		code = codes.Unauthenticated
+	}
+
+	st := status.New(code, statusMessage(err, suggestionErr))
+	if isAuthErr {
+		st = withAuthErrorInfo(st, err)
+	}
+	if hasSuggestion {
+		st = withActionableErrorDetail(st, suggestionErr)
+	}
+
+	return st.Err()
+}
+
+// statusMessage returns the user-facing message that should populate status.Message.
+// When the source is an ErrorWithSuggestion with an explicit Message, that wins. Otherwise,
+// if err is already a gRPC status error, use its Message (avoids nesting "rpc error: ..."
+// prefixes in the new status). Falls back to err.Error(). Suggestion text is never appended.
+func statusMessage(err error, suggestionErr *internal.ErrorWithSuggestion) string {
+	if suggestionErr != nil && suggestionErr.Message != "" {
+		return suggestionErr.Message
+	}
+	if st, ok := azdext.GRPCStatusFromError(err); ok {
+		return st.Message()
+	}
+	return err.Error()
+}
+
+// isAuthError reports whether err's chain contains a known auth-failure type that should be
+// surfaced over gRPC as codes.Unauthenticated.
+func isAuthError(err error) bool {
+	if errors.Is(err, auth.ErrNoCurrentUser) {
+		return true
+	}
+	if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*auth.AuthFailedError](err); ok {
+		return true
+	}
+	return false
+}
+
+func withAuthErrorInfo(st *status.Status, err error) *status.Status {
+	reason := grpcAuthReason(err)
+	if reason == "" {
+		return st
+	}
+
+	withDetails, detailErr := st.WithDetails(&errdetails.ErrorInfo{
+		Reason: reason,
+		Domain: azdext.AuthErrorDomain,
+	})
+	if detailErr != nil {
+		return st
+	}
+
+	return withDetails
+}
+
+func withActionableErrorDetail(st *status.Status, err *internal.ErrorWithSuggestion) *status.Status {
+	if err.Suggestion == "" && len(err.Links) == 0 {
+		return st
+	}
+
+	withDetails, detailErr := st.WithDetails(&azdext.ActionableErrorDetail{
+		Suggestion: err.Suggestion,
+		Links:      azdext.WrapErrorLinks(err.Links),
+	})
+	if detailErr != nil {
+		return st
+	}
+
+	return withDetails
+}
+
+func grpcAuthReason(err error) string {
+	if errors.Is(err, auth.ErrNoCurrentUser) {
+		return azdext.AuthErrorReasonNotLoggedIn
+	}
+
+	// Pass through the originating AAD error code (e.g., "AADSTS530084") when available.
+	// This preserves Entra's own semantics rather than redefining them on azd's side.
+	if authFailed, ok := errors.AsType[*auth.AuthFailedError](err); ok {
+		if authFailed.Parsed != nil && len(authFailed.Parsed.ErrorCodes) > 0 {
+			return fmt.Sprintf("AADSTS%d", authFailed.Parsed.ErrorCodes[0])
+		}
+	}
+
+	if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {
+		return azdext.AuthErrorReasonLoginRequired
+	}
+
+	return ""
+}

--- a/cli/azd/internal/grpcserver/prompt_service_test.go
+++ b/cli/azd/internal/grpcserver/prompt_service_test.go
@@ -665,9 +665,15 @@ func Test_PromptService_PromptSubscription_ErrorWithSuggestion(t *testing.T) {
 	})
 
 	require.Error(t, err)
-	// Verify that the suggestion text is included in the error message (wrapped by interceptor)
-	require.Contains(t, err.Error(), "azd auth login")
+	// Status message carries only the underlying error; suggestion travels via ActionableErrorDetail.
 	require.Contains(t, err.Error(), "AADSTS70043")
+	require.NotContains(t, err.Error(), "azd auth login",
+		"suggestion text must not be concatenated into status.Message")
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	actionable := azdext.ActionableErrorDetailFromStatus(st)
+	require.NotNil(t, actionable)
+	require.Contains(t, actionable.GetSuggestion(), "azd auth login")
 	mockPrompter.AssertExpectations(t)
 }
 
@@ -697,9 +703,15 @@ func Test_PromptService_PromptResourceGroup_ErrorWithSuggestion(t *testing.T) {
 	})
 
 	require.Error(t, err)
-	// Verify that the suggestion text is included in the error message (wrapped by interceptor)
-	require.Contains(t, err.Error(), "azd auth login")
+	// Status message carries only the underlying error; suggestion travels via ActionableErrorDetail.
 	require.Contains(t, err.Error(), "AADSTS70043")
+	require.NotContains(t, err.Error(), "azd auth login",
+		"suggestion text must not be concatenated into status.Message")
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	actionable := azdext.ActionableErrorDetailFromStatus(st)
+	require.NotNil(t, actionable)
+	require.Contains(t, actionable.GetSuggestion(), "azd auth login")
 	mockPrompter.AssertExpectations(t)
 }
 

--- a/cli/azd/internal/grpcserver/server.go
+++ b/cli/azd/internal/grpcserver/server.go
@@ -6,16 +6,12 @@ package grpcserver
 import (
 	"context"
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"log"
 	"net"
 
-	"github.com/azure/azure-dev/cli/azd/internal"
-	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -159,9 +155,9 @@ func (s *Server) Stop() error {
 	return nil
 }
 
-// errorWrappingInterceptor wraps ErrorWithSuggestion errors to include their suggestion text
-// in the error message. This ensures that helpful suggestions (like "run azd auth login")
-// are preserved when errors are transmitted over gRPC, where only the error message string is sent.
+// errorWrappingInterceptor maps host errors into gRPC status errors with structured details
+// (auth ErrorInfo, ActionableErrorDetail) so extensions can preserve actionable guidance
+// without parsing status message text. See [mapHostError] for the contract.
 func (s *Server) errorWrappingInterceptor() grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
@@ -171,15 +167,13 @@ func (s *Server) errorWrappingInterceptor() grpc.UnaryServerInterceptor {
 	) (any, error) {
 		resp, err := handler(ctx, req)
 		if err != nil {
-			err = wrapErrorWithSuggestion(err)
+			err = mapHostError(err)
 		}
 		return resp, err
 	}
 }
 
 // errorWrappingStreamInterceptor is the streaming counterpart of errorWrappingInterceptor.
-// It wraps ErrorWithSuggestion errors from stream handlers so that actionable suggestions
-// are preserved in gRPC stream error responses.
 func (s *Server) errorWrappingStreamInterceptor() grpc.StreamServerInterceptor {
 	return func(
 		srv any,
@@ -189,7 +183,7 @@ func (s *Server) errorWrappingStreamInterceptor() grpc.StreamServerInterceptor {
 	) error {
 		err := handler(srv, ss)
 		if err != nil {
-			err = wrapErrorWithSuggestion(err)
+			err = mapHostError(err)
 		}
 		return err
 	}
@@ -266,89 +260,6 @@ type authenticatedStream struct {
 
 func (s *authenticatedStream) Context() context.Context {
 	return s.ctx
-}
-
-// wrapErrorWithSuggestion checks if the error contains an ErrorWithSuggestion and if so,
-// returns a new error that includes the suggestion text in the error message.
-// This ensures that helpful suggestions (like "run azd auth login") are preserved
-// when errors are transmitted over gRPC, where only the error message string is sent.
-//
-// Auth-related errors are returned with codes.Unauthenticated and a structured
-// ErrorInfo reason so extensions can reliably classify them as auth failures
-// while still distinguishing the remediation path.
-func wrapErrorWithSuggestion(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	isAuthErr := isAuthError(err)
-
-	if suggestionErr, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
-		msg := fmt.Sprintf("%s\n%s", err.Error(), suggestionErr.Suggestion)
-		if isAuthErr {
-			return grpcAuthStatus(err, msg)
-		}
-		return fmt.Errorf("%w\n%s", err, suggestionErr.Suggestion)
-	}
-
-	if isAuthErr {
-		return grpcAuthStatus(err, err.Error())
-	}
-
-	return err
-}
-
-// isAuthError reports whether err's chain contains a known auth-failure type that should be
-// surfaced over gRPC as codes.Unauthenticated.
-func isAuthError(err error) bool {
-	if errors.Is(err, auth.ErrNoCurrentUser) {
-		return true
-	}
-	if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {
-		return true
-	}
-	if _, ok := errors.AsType[*auth.AuthFailedError](err); ok {
-		return true
-	}
-	return false
-}
-
-func grpcAuthStatus(err error, msg string) error {
-	st := status.New(codes.Unauthenticated, msg)
-	reason := grpcAuthReason(err)
-	if reason == "" {
-		return st.Err()
-	}
-
-	withDetails, detailErr := st.WithDetails(&errdetails.ErrorInfo{
-		Reason: reason,
-		Domain: azdext.AuthErrorDomain,
-	})
-	if detailErr != nil {
-		return st.Err()
-	}
-
-	return withDetails.Err()
-}
-
-func grpcAuthReason(err error) string {
-	if errors.Is(err, auth.ErrNoCurrentUser) {
-		return azdext.AuthErrorReasonNotLoggedIn
-	}
-
-	// Pass through the originating AAD error code (e.g., "AADSTS530084") when available.
-	// This preserves Entra's own semantics rather than redefining them on azd's side.
-	if authFailed, ok := errors.AsType[*auth.AuthFailedError](err); ok {
-		if authFailed.Parsed != nil && len(authFailed.Parsed.ErrorCodes) > 0 {
-			return fmt.Sprintf("AADSTS%d", authFailed.Parsed.ErrorCodes[0])
-		}
-	}
-
-	if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {
-		return azdext.AuthErrorReasonLoginRequired
-	}
-
-	return ""
 }
 
 func generateSigningKey() ([]byte, error) {

--- a/cli/azd/internal/grpcserver/server_coverage3_test.go
+++ b/cli/azd/internal/grpcserver/server_coverage3_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -34,19 +33,19 @@ func TestAuthenticatedStream_Context(t *testing.T) {
 	require.Equal(t, "value", got.Value(struct{ key string }{key: "test"}))
 }
 
-func TestWrapErrorWithSuggestion_Nil(t *testing.T) {
+func TestMapHostError_Nil(t *testing.T) {
 	t.Parallel()
-	require.Nil(t, wrapErrorWithSuggestion(nil))
+	require.Nil(t, mapHostError(nil))
 }
 
-func TestWrapErrorWithSuggestion_PlainError(t *testing.T) {
+func TestMapHostError_PlainError(t *testing.T) {
 	t.Parallel()
 	err := errors.New("something failed")
-	wrapped := wrapErrorWithSuggestion(err)
+	wrapped := mapHostError(err)
 	require.Equal(t, err, wrapped)
 }
 
-func TestWrapErrorWithSuggestion_WithSuggestion(t *testing.T) {
+func TestMapHostError_WithSuggestion(t *testing.T) {
 	t.Parallel()
 	inner := errors.New("login required")
 	err := &internal.ErrorWithSuggestion{
@@ -54,32 +53,40 @@ func TestWrapErrorWithSuggestion_WithSuggestion(t *testing.T) {
 		Suggestion: "run azd auth login",
 	}
 
-	wrapped := wrapErrorWithSuggestion(err)
-	require.Contains(t, wrapped.Error(), "run azd auth login")
+	wrapped := mapHostError(err)
+	require.Contains(t, wrapped.Error(), "login required")
+	require.NotContains(t, wrapped.Error(), "run azd auth login",
+		"suggestion text must not be concatenated into status.Message")
+
+	st, ok := status.FromError(wrapped)
+	require.True(t, ok)
+	actionable := azdext.ActionableErrorDetailFromStatus(st)
+	require.NotNil(t, actionable)
+	require.Equal(t, "run azd auth login", actionable.GetSuggestion())
 }
 
-func TestWrapErrorWithSuggestion_AuthError(t *testing.T) {
+func TestMapHostError_AuthError(t *testing.T) {
 	t.Parallel()
 	err := auth.ErrNoCurrentUser
-	wrapped := wrapErrorWithSuggestion(err)
+	wrapped := mapHostError(err)
 
 	st, ok := status.FromError(wrapped)
 	require.True(t, ok)
 	require.Equal(t, codes.Unauthenticated, st.Code())
 }
 
-func TestWrapErrorWithSuggestion_ReLoginRequired(t *testing.T) {
+func TestMapHostError_ReLoginRequired(t *testing.T) {
 	t.Parallel()
 	// ReLoginRequiredError has unexported fields; use a simple error wrapping
 	err := fmt.Errorf("re-login: %w", &auth.ReLoginRequiredError{})
 
-	wrapped := wrapErrorWithSuggestion(err)
+	wrapped := mapHostError(err)
 	st, ok := status.FromError(wrapped)
 	require.True(t, ok)
 	require.Equal(t, codes.Unauthenticated, st.Code())
 }
 
-func TestWrapErrorWithSuggestion_TokenProtectionBlocked(t *testing.T) {
+func TestMapHostError_TokenProtectionBlocked(t *testing.T) {
 	t.Parallel()
 	authFailed := &auth.AuthFailedError{
 		Parsed: &auth.AadErrorResponse{
@@ -88,25 +95,25 @@ func TestWrapErrorWithSuggestion_TokenProtectionBlocked(t *testing.T) {
 		},
 	}
 	// In production the wrapper is built by newActionableAuthError; mirror that shape here so
-	// wrapErrorWithSuggestion classifies the wrapped *AuthFailedError as an auth interaction.
+	// mapHostError classifies the wrapped *AuthFailedError as an auth interaction.
 	err := fmt.Errorf("token protection: %w", &internal.ErrorWithSuggestion{
 		Err:        authFailed,
 		Suggestion: "Contact your IT administrator or request a policy exception.",
 	})
 
-	wrapped := wrapErrorWithSuggestion(err)
+	wrapped := mapHostError(err)
 	st, ok := status.FromError(wrapped)
 	require.True(t, ok)
 	require.Equal(t, codes.Unauthenticated, st.Code())
-	details := st.Details()
-	require.Len(t, details, 1)
-	info, ok := details[0].(*errdetails.ErrorInfo)
-	require.True(t, ok)
+	info := requireAuthErrorInfo(t, st)
 	require.Equal(t, azdext.AuthErrorDomain, info.Domain)
 	require.Equal(t, "AADSTS530084", info.Reason)
+	actionable := azdext.ActionableErrorDetailFromStatus(st)
+	require.NotNil(t, actionable)
+	require.Equal(t, "Contact your IT administrator or request a policy exception.", actionable.GetSuggestion())
 }
 
-func TestWrapErrorWithSuggestion_AuthErrorWithSuggestion(t *testing.T) {
+func TestMapHostError_AuthErrorWithSuggestion(t *testing.T) {
 	t.Parallel()
 	inner := auth.ErrNoCurrentUser
 	err := &internal.ErrorWithSuggestion{
@@ -114,11 +121,15 @@ func TestWrapErrorWithSuggestion_AuthErrorWithSuggestion(t *testing.T) {
 		Suggestion: "run azd auth login",
 	}
 
-	wrapped := wrapErrorWithSuggestion(err)
+	wrapped := mapHostError(err)
 	st, ok := status.FromError(wrapped)
 	require.True(t, ok)
 	require.Equal(t, codes.Unauthenticated, st.Code())
-	require.Contains(t, st.Message(), "run azd auth login")
+	require.NotContains(t, st.Message(), "run azd auth login",
+		"suggestion text must not be concatenated into status.Message")
+	actionable := azdext.ActionableErrorDetailFromStatus(st)
+	require.NotNil(t, actionable)
+	require.Equal(t, "run azd auth login", actionable.GetSuggestion())
 }
 
 func TestGenerateSigningKey(t *testing.T) {

--- a/cli/azd/internal/grpcserver/server_test.go
+++ b/cli/azd/internal/grpcserver/server_test.go
@@ -245,6 +245,8 @@ func Test_mapHostError(t *testing.T) {
 		wantAuthReason   string
 		wantSuggestion   string
 		wantLinks        int
+		wantLinkURL      string
+		wantLinkTitle    string
 	}{
 		{
 			name:    "nil error returns nil",
@@ -326,6 +328,8 @@ func Test_mapHostError(t *testing.T) {
 			wantAuthReason: "AADSTS530084",
 			wantSuggestion: "Contact your IT administrator or request a policy exception.",
 			wantLinks:      1,
+			wantLinkURL:    "https://aka.ms/TokenProtectionFAQ#troubleshooting",
+			wantLinkTitle:  "Token protection FAQ",
 		},
 	}
 
@@ -362,6 +366,10 @@ func Test_mapHostError(t *testing.T) {
 				require.NotNil(t, actionable, "expected ActionableErrorDetail")
 				require.Equal(t, tt.wantSuggestion, actionable.GetSuggestion())
 				require.Len(t, actionable.GetLinks(), tt.wantLinks)
+				if tt.wantLinkURL != "" {
+					require.Equal(t, tt.wantLinkURL, actionable.GetLinks()[0].GetUrl())
+					require.Equal(t, tt.wantLinkTitle, actionable.GetLinks()[0].GetTitle())
+				}
 			}
 		})
 	}

--- a/cli/azd/internal/grpcserver/server_test.go
+++ b/cli/azd/internal/grpcserver/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/azure/azure-dev/cli/azd/pkg/errorhandler"
 	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -232,15 +233,18 @@ func Test_Server_StreamInterceptor(t *testing.T) {
 	})
 }
 
-func Test_wrapErrorWithSuggestion(t *testing.T) {
+func Test_mapHostError(t *testing.T) {
 	tests := []struct {
 		name             string
 		err              error
 		wantNil          bool
 		wantContain      string
+		wantNotContain   string
 		wantSameInstance bool
 		wantGrpcCode     codes.Code
 		wantAuthReason   string
+		wantSuggestion   string
+		wantLinks        int
 	}{
 		{
 			name:    "nil error returns nil",
@@ -254,20 +258,24 @@ func Test_wrapErrorWithSuggestion(t *testing.T) {
 			wantSameInstance: true,
 		},
 		{
-			name: "error with suggestion includes suggestion text",
+			name: "error with suggestion preserves suggestion structurally, not in message",
 			err: &internal.ErrorWithSuggestion{
 				Err:        errors.New("authentication failed"),
 				Suggestion: "run `azd auth login` to acquire a new token.",
 			},
-			wantContain: "azd auth login",
+			wantContain:    "authentication failed",
+			wantNotContain: "azd auth login",
+			wantSuggestion: "run `azd auth login` to acquire a new token.",
 		},
 		{
-			name: "wrapped error with suggestion includes suggestion text",
+			name: "wrapped error with suggestion preserves suggestion structurally, not in message",
 			err: fmt.Errorf("failed to prompt: %w", &internal.ErrorWithSuggestion{
 				Err:        errors.New("token expired"),
 				Suggestion: "login expired, run `azd auth login` to acquire a new token.",
 			}),
-			wantContain: "azd auth login",
+			wantContain:    "token expired",
+			wantNotContain: "azd auth login",
+			wantSuggestion: "login expired, run `azd auth login` to acquire a new token.",
 		},
 		{
 			name:           "ErrNoCurrentUser returns Unauthenticated",
@@ -287,11 +295,14 @@ func Test_wrapErrorWithSuggestion(t *testing.T) {
 			name: "ReLoginRequiredError with suggestion returns Unauthenticated",
 			err: &internal.ErrorWithSuggestion{
 				Err:        &auth.ReLoginRequiredError{},
+				Message:    "Re-authentication required.",
 				Suggestion: "login expired, run `azd auth login` to acquire a new token.",
 			},
-			wantContain:    "azd auth login",
+			wantContain:    "Re-authentication required.",
+			wantNotContain: "azd auth login",
 			wantGrpcCode:   codes.Unauthenticated,
 			wantAuthReason: azdext.AuthErrorReasonLoginRequired,
+			wantSuggestion: "login expired, run `azd auth login` to acquire a new token.",
 		},
 		{
 			name: "TokenProtectionBlockedError with suggestion returns Unauthenticated",
@@ -302,23 +313,35 @@ func Test_wrapErrorWithSuggestion(t *testing.T) {
 						ErrorCodes: []int{530084},
 					},
 				},
+				Message:    "A Conditional Access token protection policy blocked this token request.",
 				Suggestion: "Contact your IT administrator or request a policy exception.",
+				Links: []errorhandler.ErrorLink{{
+					URL:   "https://aka.ms/TokenProtectionFAQ#troubleshooting",
+					Title: "Token protection FAQ",
+				}},
 			},
-			wantContain:    "policy exception",
+			wantContain:    "Conditional Access",
+			wantNotContain: "policy exception",
 			wantGrpcCode:   codes.Unauthenticated,
 			wantAuthReason: "AADSTS530084",
+			wantSuggestion: "Contact your IT administrator or request a policy exception.",
+			wantLinks:      1,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := wrapErrorWithSuggestion(tt.err)
+			result := mapHostError(tt.err)
 			if tt.wantNil {
 				require.Nil(t, result)
 				return
 			}
 			require.NotNil(t, result)
 			require.Contains(t, result.Error(), tt.wantContain)
+			if tt.wantNotContain != "" {
+				require.NotContains(t, result.Error(), tt.wantNotContain,
+					"suggestion text must not be concatenated into status.Message")
+			}
 			if tt.wantSameInstance {
 				require.Same(t, tt.err, result, "expected error to be returned unchanged (same instance)")
 			}
@@ -327,14 +350,32 @@ func Test_wrapErrorWithSuggestion(t *testing.T) {
 				require.True(t, ok, "expected gRPC status error")
 				require.Equal(t, tt.wantGrpcCode, st.Code())
 				if tt.wantAuthReason != "" {
-					details := st.Details()
-					require.Len(t, details, 1)
-					info, ok := details[0].(*errdetails.ErrorInfo)
-					require.True(t, ok, "expected ErrorInfo detail")
+					info := requireAuthErrorInfo(t, st)
 					require.Equal(t, azdext.AuthErrorDomain, info.Domain)
 					require.Equal(t, tt.wantAuthReason, info.Reason)
 				}
 			}
+			if tt.wantSuggestion != "" {
+				st, ok := status.FromError(result)
+				require.True(t, ok, "expected gRPC status error")
+				actionable := azdext.ActionableErrorDetailFromStatus(st)
+				require.NotNil(t, actionable, "expected ActionableErrorDetail")
+				require.Equal(t, tt.wantSuggestion, actionable.GetSuggestion())
+				require.Len(t, actionable.GetLinks(), tt.wantLinks)
+			}
 		})
 	}
+}
+
+func requireAuthErrorInfo(t *testing.T, st *status.Status) *errdetails.ErrorInfo {
+	t.Helper()
+
+	for _, detail := range st.Details() {
+		if info, ok := detail.(*errdetails.ErrorInfo); ok {
+			return info
+		}
+	}
+
+	require.FailNow(t, "expected ErrorInfo detail")
+	return nil
 }

--- a/cli/azd/pkg/azdext/errors.pb.go
+++ b/cli/azd/pkg/azdext/errors.pb.go
@@ -310,6 +310,9 @@ func (x *ActionableErrorDetail) GetLinks() []*ErrorLink {
 
 // ExtensionError is a unified error message that can represent errors from different sources.
 // It provides structured error information for telemetry and error handling.
+//
+// Direction: extension -> host only. Counterpart of host's ActionableErrorDetail, which carries
+// host-originated remediation metadata in the opposite direction.
 type ExtensionError struct {
 	state      protoimpl.MessageState `protogen:"open.v1"`
 	Message    string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`                        // Human-readable error message

--- a/cli/azd/pkg/azdext/errors.pb.go
+++ b/cli/azd/pkg/azdext/errors.pb.go
@@ -247,6 +247,67 @@ func (x *ErrorLink) GetTitle() string {
 	return ""
 }
 
+// ActionableErrorDetail carries user-facing remediation metadata in gRPC status details.
+// It is used for host-originated errors so clients can preserve suggestions and links
+// without parsing status message text.
+//
+// Direction: host -> extension only. Extensions returning errors to the host should use
+// LocalError / ServiceError (transported via ExtensionError) instead.
+//
+// The user-facing error message lives in google.rpc.Status.message; this detail does not
+// duplicate it.
+type ActionableErrorDetail struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Suggestion    string                 `protobuf:"bytes,1,opt,name=suggestion,proto3" json:"suggestion,omitempty"` // Optional user-facing suggestion for resolving the error
+	Links         []*ErrorLink           `protobuf:"bytes,2,rep,name=links,proto3" json:"links,omitempty"`           // Optional reference links rendered alongside the suggestion
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ActionableErrorDetail) Reset() {
+	*x = ActionableErrorDetail{}
+	mi := &file_errors_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ActionableErrorDetail) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ActionableErrorDetail) ProtoMessage() {}
+
+func (x *ActionableErrorDetail) ProtoReflect() protoreflect.Message {
+	mi := &file_errors_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ActionableErrorDetail.ProtoReflect.Descriptor instead.
+func (*ActionableErrorDetail) Descriptor() ([]byte, []int) {
+	return file_errors_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ActionableErrorDetail) GetSuggestion() string {
+	if x != nil {
+		return x.Suggestion
+	}
+	return ""
+}
+
+func (x *ActionableErrorDetail) GetLinks() []*ErrorLink {
+	if x != nil {
+		return x.Links
+	}
+	return nil
+}
+
 // ExtensionError is a unified error message that can represent errors from different sources.
 // It provides structured error information for telemetry and error handling.
 type ExtensionError struct {
@@ -268,7 +329,7 @@ type ExtensionError struct {
 
 func (x *ExtensionError) Reset() {
 	*x = ExtensionError{}
-	mi := &file_errors_proto_msgTypes[3]
+	mi := &file_errors_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -280,7 +341,7 @@ func (x *ExtensionError) String() string {
 func (*ExtensionError) ProtoMessage() {}
 
 func (x *ExtensionError) ProtoReflect() protoreflect.Message {
-	mi := &file_errors_proto_msgTypes[3]
+	mi := &file_errors_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -293,7 +354,7 @@ func (x *ExtensionError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtensionError.ProtoReflect.Descriptor instead.
 func (*ExtensionError) Descriptor() ([]byte, []int) {
-	return file_errors_proto_rawDescGZIP(), []int{3}
+	return file_errors_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *ExtensionError) GetMessage() string {
@@ -381,7 +442,12 @@ const file_errors_proto_rawDesc = "" +
 	"\bcategory\x18\x02 \x01(\tR\bcategory\"3\n" +
 	"\tErrorLink\x12\x10\n" +
 	"\x03url\x18\x01 \x01(\tR\x03url\x12\x14\n" +
-	"\x05title\x18\x02 \x01(\tR\x05title\"\xb6\x02\n" +
+	"\x05title\x18\x02 \x01(\tR\x05title\"`\n" +
+	"\x15ActionableErrorDetail\x12\x1e\n" +
+	"\n" +
+	"suggestion\x18\x01 \x01(\tR\n" +
+	"suggestion\x12'\n" +
+	"\x05links\x18\x02 \x03(\v2\x11.azdext.ErrorLinkR\x05links\"\xb6\x02\n" +
 	"\x0eExtensionError\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12+\n" +
 	"\x06origin\x18\x04 \x01(\x0e2\x13.azdext.ErrorOriginR\x06origin\x12\x1e\n" +
@@ -413,24 +479,26 @@ func file_errors_proto_rawDescGZIP() []byte {
 }
 
 var file_errors_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_errors_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_errors_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_errors_proto_goTypes = []any{
-	(ErrorOrigin)(0),           // 0: azdext.ErrorOrigin
-	(*ServiceErrorDetail)(nil), // 1: azdext.ServiceErrorDetail
-	(*LocalErrorDetail)(nil),   // 2: azdext.LocalErrorDetail
-	(*ErrorLink)(nil),          // 3: azdext.ErrorLink
-	(*ExtensionError)(nil),     // 4: azdext.ExtensionError
+	(ErrorOrigin)(0),              // 0: azdext.ErrorOrigin
+	(*ServiceErrorDetail)(nil),    // 1: azdext.ServiceErrorDetail
+	(*LocalErrorDetail)(nil),      // 2: azdext.LocalErrorDetail
+	(*ErrorLink)(nil),             // 3: azdext.ErrorLink
+	(*ActionableErrorDetail)(nil), // 4: azdext.ActionableErrorDetail
+	(*ExtensionError)(nil),        // 5: azdext.ExtensionError
 }
 var file_errors_proto_depIdxs = []int32{
-	0, // 0: azdext.ExtensionError.origin:type_name -> azdext.ErrorOrigin
-	3, // 1: azdext.ExtensionError.links:type_name -> azdext.ErrorLink
-	1, // 2: azdext.ExtensionError.service_error:type_name -> azdext.ServiceErrorDetail
-	2, // 3: azdext.ExtensionError.local_error:type_name -> azdext.LocalErrorDetail
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	3, // 0: azdext.ActionableErrorDetail.links:type_name -> azdext.ErrorLink
+	0, // 1: azdext.ExtensionError.origin:type_name -> azdext.ErrorOrigin
+	3, // 2: azdext.ExtensionError.links:type_name -> azdext.ErrorLink
+	1, // 3: azdext.ExtensionError.service_error:type_name -> azdext.ServiceErrorDetail
+	2, // 4: azdext.ExtensionError.local_error:type_name -> azdext.LocalErrorDetail
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_errors_proto_init() }
@@ -438,7 +506,7 @@ func file_errors_proto_init() {
 	if File_errors_proto != nil {
 		return
 	}
-	file_errors_proto_msgTypes[3].OneofWrappers = []any{
+	file_errors_proto_msgTypes[4].OneofWrappers = []any{
 		(*ExtensionError_ServiceError)(nil),
 		(*ExtensionError_LocalError)(nil),
 	}
@@ -448,7 +516,7 @@ func file_errors_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_errors_proto_rawDesc), len(file_errors_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/cli/azd/pkg/azdext/extension_error.go
+++ b/cli/azd/pkg/azdext/extension_error.go
@@ -61,7 +61,7 @@ func (e *ServiceError) Error() string {
 // The function applies detection in priority order:
 //  1. [ServiceError] / [LocalError] — already structured by extension code (highest specificity)
 //  2. [azcore.ResponseError] — Azure SDK HTTP errors
-//  3. gRPC Unauthenticated — auto-classified as auth category, preserving auth subtypes from ErrorInfo when present
+//  3. gRPC status — host-originated errors carrying ActionableErrorDetail and/or auth ErrorInfo
 //  4. Fallback — unclassified error with original message
 //
 // The counterpart [UnwrapError] is called from the azd host to deserialize
@@ -80,7 +80,7 @@ func WrapError(err error) *ExtensionError {
 	if extServiceErr, ok := errors.AsType[*ServiceError](err); ok {
 		extErr.Message = extServiceErr.Message
 		extErr.Suggestion = extServiceErr.Suggestion
-		extErr.Links = wrapErrorLinks(extServiceErr.Links)
+		extErr.Links = WrapErrorLinks(extServiceErr.Links)
 		extErr.Origin = ErrorOrigin_ERROR_ORIGIN_SERVICE
 		extErr.Source = &ExtensionError_ServiceError{
 			ServiceError: &ServiceErrorDetail{
@@ -97,7 +97,7 @@ func WrapError(err error) *ExtensionError {
 		normalizedCategory := NormalizeLocalErrorCategory(extLocalErr.Category)
 		extErr.Message = extLocalErr.Message
 		extErr.Suggestion = extLocalErr.Suggestion
-		extErr.Links = wrapErrorLinks(extLocalErr.Links)
+		extErr.Links = WrapErrorLinks(extLocalErr.Links)
 		extErr.Origin = ErrorOrigin_ERROR_ORIGIN_LOCAL
 		extErr.Source = &ExtensionError_LocalError{
 			LocalError: &LocalErrorDetail{
@@ -126,29 +126,93 @@ func WrapError(err error) *ExtensionError {
 		return extErr
 	}
 
-	// Detect gRPC Unauthenticated errors as an auth safety net.
-	// If the extension didn't already classify the error, this ensures auth failures
-	// from azd host calls are reported with the correct category in telemetry,
-	// and preserves specific auth subtypes when the host attached auth ErrorInfo details.
-	// Use errors.AsType to detect gRPC status errors even when wrapped by fmt.Errorf.
-	if grpcErr, ok := errors.AsType[interface {
-		error
-		GRPCStatus() *status.Status
-	}](err); ok {
-		if st := grpcErr.GRPCStatus(); st.Code() == codes.Unauthenticated {
-			extErr.Origin = ErrorOrigin_ERROR_ORIGIN_LOCAL
-			extErr.Message = st.Message()
-			extErr.Source = &ExtensionError_LocalError{
-				LocalError: &LocalErrorDetail{
-					Code:     authLocalErrorCode(st),
-					Category: string(LocalErrorCategoryAuth),
-				},
-			}
-			return extErr
-		}
+	if st, ok := GRPCStatusFromError(err); ok {
+		populateExtensionErrorFromStatus(extErr, st)
 	}
 
 	return extErr
+}
+
+// populateExtensionErrorFromStatus shapes extErr from a host-originated gRPC status.
+// It computes (message, suggestion, links, origin, source) in a single pass without
+// the string-equality fallbacks that earlier versions used.
+func populateExtensionErrorFromStatus(extErr *ExtensionError, st *status.Status) {
+	actionable := ActionableErrorDetailFromStatus(st)
+	isAuth := st.Code() == codes.Unauthenticated
+
+	if actionable == nil && !isAuth {
+		// Plain gRPC error with no host metadata; leave extErr as-is so the caller
+		// surfaces the original message via the unspecified origin path.
+		return
+	}
+
+	// status.Message is the canonical user-facing payload for host errors.
+	extErr.Message = st.Message()
+	if actionable != nil {
+		extErr.Suggestion = actionable.GetSuggestion()
+		extErr.Links = actionable.GetLinks()
+	}
+
+	switch {
+	case isAuth:
+		// Auth safety net: classify as auth even when the extension didn't pre-classify.
+		// Preserves the AAD-originated reason (or AUTH_* azd-local reason) via authLocalErrorCode.
+		extErr.Origin = ErrorOrigin_ERROR_ORIGIN_LOCAL
+		extErr.Source = &ExtensionError_LocalError{
+			LocalError: &LocalErrorDetail{
+				Code:     authLocalErrorCode(st),
+				Category: string(LocalErrorCategoryAuth),
+			},
+		}
+	default:
+		// Non-auth host-originated actionable error.
+		extErr.Origin = ErrorOrigin_ERROR_ORIGIN_LOCAL
+		extErr.Source = &ExtensionError_LocalError{
+			LocalError: &LocalErrorDetail{
+				Category: string(LocalErrorCategoryLocal),
+			},
+		}
+	}
+}
+
+// GRPCStatusFromError extracts a *status.Status from err's chain when one is present.
+// Returns (nil, false) if err does not carry a gRPC status.
+func GRPCStatusFromError(err error) (*status.Status, bool) {
+	grpcErr, ok := errors.AsType[interface {
+		error
+		GRPCStatus() *status.Status
+	}](err)
+	if !ok {
+		return nil, false
+	}
+
+	st := grpcErr.GRPCStatus()
+	return st, st != nil
+}
+
+// ActionableErrorDetailFromError extracts host-originated actionable guidance from a gRPC status error.
+func ActionableErrorDetailFromError(err error) *ActionableErrorDetail {
+	st, ok := GRPCStatusFromError(err)
+	if !ok {
+		return nil
+	}
+
+	return ActionableErrorDetailFromStatus(st)
+}
+
+// ActionableErrorDetailFromStatus extracts host-originated actionable guidance from a gRPC status.
+func ActionableErrorDetailFromStatus(st *status.Status) *ActionableErrorDetail {
+	if st == nil {
+		return nil
+	}
+
+	for _, detail := range st.Details() {
+		if actionable, ok := detail.(*ActionableErrorDetail); ok {
+			return actionable
+		}
+	}
+
+	return nil
 }
 
 func authLocalErrorCode(st *status.Status) string {
@@ -175,7 +239,7 @@ func UnwrapError(msg *ExtensionError) error {
 		return nil
 	}
 
-	links := unwrapErrorLinks(msg.GetLinks())
+	links := UnwrapErrorLinks(msg.GetLinks())
 
 	// Check for service error details
 	if svcErr := msg.GetServiceError(); svcErr != nil {
@@ -225,7 +289,8 @@ func UnwrapError(msg *ExtensionError) error {
 	}
 }
 
-func wrapErrorLinks(links []errorhandler.ErrorLink) []*ErrorLink {
+// WrapErrorLinks converts errorhandler.ErrorLink values into proto ErrorLink messages.
+func WrapErrorLinks(links []errorhandler.ErrorLink) []*ErrorLink {
 	if len(links) == 0 {
 		return nil
 	}
@@ -241,7 +306,8 @@ func wrapErrorLinks(links []errorhandler.ErrorLink) []*ErrorLink {
 	return protoLinks
 }
 
-func unwrapErrorLinks(links []*ErrorLink) []errorhandler.ErrorLink {
+// UnwrapErrorLinks converts proto ErrorLink messages back into errorhandler.ErrorLink values.
+func UnwrapErrorLinks(links []*ErrorLink) []errorhandler.ErrorLink {
 	if len(links) == 0 {
 		return nil
 	}

--- a/cli/azd/pkg/azdext/extension_error_test.go
+++ b/cli/azd/pkg/azdext/extension_error_test.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/protoadapt"
 )
 
 func TestExtensionError_RoundTrip(t *testing.T) {
@@ -205,6 +206,74 @@ func TestExtensionError_RoundTrip(t *testing.T) {
 			},
 		},
 		{
+			name: "GrpcUnauthenticatedWithActionableDetail",
+			inputErr: mustStatusErrorWithDetails(
+				codes.Unauthenticated,
+				"A Conditional Access token protection policy blocked this token request.",
+				&errdetails.ErrorInfo{
+					Reason: "AADSTS530084",
+					Domain: AuthErrorDomain,
+				},
+				&ActionableErrorDetail{
+					Suggestion: "Contact your IT administrator or request a policy exception.",
+					Links: []*ErrorLink{{
+						Url:   "https://aka.ms/TokenProtectionFAQ#troubleshooting",
+						Title: "Token protection FAQ",
+					}},
+				},
+			),
+			verify: func(t *testing.T, protoErr *ExtensionError, goErr error) {
+				assert.Equal(t, ErrorOrigin_ERROR_ORIGIN_LOCAL, protoErr.GetOrigin())
+				assert.Equal(t,
+					"A Conditional Access token protection policy blocked this token request.",
+					protoErr.GetMessage())
+				assert.Equal(t, "Contact your IT administrator or request a policy exception.", protoErr.GetSuggestion())
+				require.Len(t, protoErr.GetLinks(), 1)
+				assert.Equal(t, "https://aka.ms/TokenProtectionFAQ#troubleshooting", protoErr.GetLinks()[0].GetUrl())
+
+				localDetail := protoErr.GetLocalError()
+				require.NotNil(t, localDetail)
+				assert.Equal(t, "auth_failed", localDetail.GetCode())
+				assert.Equal(t, "auth", localDetail.GetCategory())
+
+				var localErr *LocalError
+				require.ErrorAs(t, goErr, &localErr)
+				assert.Equal(t, LocalErrorCategoryAuth, localErr.Category)
+				assert.Equal(t, "auth_failed", localErr.Code)
+				assert.Equal(t, "Contact your IT administrator or request a policy exception.", localErr.Suggestion)
+				require.Len(t, localErr.Links, 1)
+			},
+		},
+		{
+			name: "GrpcActionableNonAuthError",
+			inputErr: mustStatusErrorWithDetails(
+				codes.InvalidArgument,
+				"The extension configuration is invalid.",
+				&ActionableErrorDetail{
+					Suggestion: "Fix the extension config and retry.",
+					Links: []*ErrorLink{{
+						Url:   "https://aka.ms/azd-errors#invalid-config",
+						Title: "Invalid config reference",
+					}},
+				},
+			),
+			verify: func(t *testing.T, protoErr *ExtensionError, goErr error) {
+				assert.Equal(t, ErrorOrigin_ERROR_ORIGIN_LOCAL, protoErr.GetOrigin())
+				assert.Equal(t, "The extension configuration is invalid.", protoErr.GetMessage())
+				assert.Equal(t, "Fix the extension config and retry.", protoErr.GetSuggestion())
+				require.Len(t, protoErr.GetLinks(), 1)
+
+				localDetail := protoErr.GetLocalError()
+				require.NotNil(t, localDetail)
+				assert.Equal(t, string(LocalErrorCategoryLocal), localDetail.GetCategory())
+
+				var localErr *LocalError
+				require.ErrorAs(t, goErr, &localErr)
+				assert.Equal(t, LocalErrorCategoryLocal, localErr.Category)
+				assert.Equal(t, "Fix the extension config and retry.", localErr.Suggestion)
+			},
+		},
+		{
 			name:     "GrpcUnauthenticatedWithoutAuthDetailsFallsBackToAuthFailed",
 			inputErr: status.Error(codes.Unauthenticated, "generic auth problem"),
 			verify: func(t *testing.T, protoErr *ExtensionError, goErr error) {
@@ -273,11 +342,15 @@ func TestUnwrapError_EmptyMessagePreservesStructuredError(t *testing.T) {
 }
 
 func mustAuthStatusError(code codes.Code, reason, message string) error {
-	st := status.New(code, message)
-	withDetails, err := st.WithDetails(&errdetails.ErrorInfo{
+	return mustStatusErrorWithDetails(code, message, &errdetails.ErrorInfo{
 		Reason: reason,
 		Domain: AuthErrorDomain,
 	})
+}
+
+func mustStatusErrorWithDetails(code codes.Code, message string, details ...protoadapt.MessageV1) error {
+	st := status.New(code, message)
+	withDetails, err := st.WithDetails(details...)
 	if err != nil {
 		panic(err)
 	}

--- a/cli/azd/pkg/azdext/extension_error_test.go
+++ b/cli/azd/pkg/azdext/extension_error_test.go
@@ -357,3 +357,85 @@ func mustStatusErrorWithDetails(code codes.Code, message string, details ...prot
 
 	return withDetails.Err()
 }
+
+func TestGRPCStatusFromError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil error returns false", func(t *testing.T) {
+		st, ok := GRPCStatusFromError(nil)
+		assert.False(t, ok)
+		assert.Nil(t, st)
+	})
+
+	t.Run("non-gRPC error returns false", func(t *testing.T) {
+		st, ok := GRPCStatusFromError(errors.New("plain error"))
+		assert.False(t, ok)
+		assert.Nil(t, st)
+	})
+
+	t.Run("status error returns status", func(t *testing.T) {
+		original := status.New(codes.NotFound, "missing").Err()
+		st, ok := GRPCStatusFromError(original)
+		require.True(t, ok)
+		require.NotNil(t, st)
+		assert.Equal(t, codes.NotFound, st.Code())
+		assert.Equal(t, "missing", st.Message())
+	})
+
+	t.Run("status error wrapped with fmt.Errorf is unwrapped", func(t *testing.T) {
+		original := status.New(codes.NotFound, "missing").Err()
+		wrapped := fmt.Errorf("context: %w", original)
+		st, ok := GRPCStatusFromError(wrapped)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+}
+
+func TestActionableErrorDetailFromStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil status returns nil", func(t *testing.T) {
+		assert.Nil(t, ActionableErrorDetailFromStatus(nil))
+	})
+
+	t.Run("status without ActionableErrorDetail returns nil", func(t *testing.T) {
+		st := status.New(codes.Unknown, "no details")
+		assert.Nil(t, ActionableErrorDetailFromStatus(st))
+	})
+
+	t.Run("status with ActionableErrorDetail returns it", func(t *testing.T) {
+		err := mustStatusErrorWithDetails(codes.Unknown, "boom", &ActionableErrorDetail{
+			Suggestion: "try harder",
+		})
+		st, _ := status.FromError(err)
+		actionable := ActionableErrorDetailFromStatus(st)
+		require.NotNil(t, actionable)
+		assert.Equal(t, "try harder", actionable.GetSuggestion())
+	})
+}
+
+func TestActionableErrorDetailFromError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil error returns nil", func(t *testing.T) {
+		assert.Nil(t, ActionableErrorDetailFromError(nil))
+	})
+
+	t.Run("non-gRPC error returns nil", func(t *testing.T) {
+		assert.Nil(t, ActionableErrorDetailFromError(errors.New("plain")))
+	})
+
+	t.Run("status error without detail returns nil", func(t *testing.T) {
+		assert.Nil(t, ActionableErrorDetailFromError(status.New(codes.Unknown, "no details").Err()))
+	})
+
+	t.Run("status error with detail returns it (even when wrapped)", func(t *testing.T) {
+		statusErr := mustStatusErrorWithDetails(codes.Unknown, "boom", &ActionableErrorDetail{
+			Suggestion: "try harder",
+		})
+		wrapped := fmt.Errorf("context: %w", statusErr)
+		actionable := ActionableErrorDetailFromError(wrapped)
+		require.NotNil(t, actionable)
+		assert.Equal(t, "try harder", actionable.GetSuggestion())
+	})
+}

--- a/cli/azd/pkg/azdext/provisioning.pb.go
+++ b/cli/azd/pkg/azdext/provisioning.pb.go
@@ -523,6 +523,10 @@ func (*RegisterProvisioningProviderResponse) Descriptor() ([]byte, []int) {
 	return file_provisioning_proto_rawDescGZIP(), []int{2}
 }
 
+// ProvisioningInitializeRequest does not include a separate provider_name field.
+// provider_name is extracted from ProvisioningOptions.provider because Initialize
+// is the first call and Options always contains the provider identity. This
+// matches how the core Manager.newProvider() resolves by Options.Provider.
 type ProvisioningInitializeRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ProjectPath   string                 `protobuf:"bytes,1,opt,name=project_path,json=projectPath,proto3" json:"project_path,omitempty"`

--- a/cli/azd/pkg/azdext/run.go
+++ b/cli/azd/pkg/azdext/run.go
@@ -106,7 +106,7 @@ func printError(err error) {
 	}
 }
 
-// ErrorSuggestion extracts the Suggestion field from a [LocalError] or [ServiceError].
+// ErrorSuggestion extracts the Suggestion field from structured extension or host gRPC errors.
 // Returns an empty string if the error has no suggestion.
 func ErrorSuggestion(err error) string {
 	if localErr, ok := errors.AsType[*LocalError](err); ok && localErr.Suggestion != "" {
@@ -117,11 +117,15 @@ func ErrorSuggestion(err error) string {
 		return svcErr.Suggestion
 	}
 
+	if actionable := ActionableErrorDetailFromError(err); actionable != nil && actionable.GetSuggestion() != "" {
+		return actionable.GetSuggestion()
+	}
+
 	return ""
 }
 
-// ErrorMessage extracts the user-friendly Message field from a [LocalError] or [ServiceError].
-// Returns an empty string if the error is not an extension error type.
+// ErrorMessage extracts the user-friendly message from a [LocalError], [ServiceError],
+// or a host gRPC error carrying an [ActionableErrorDetail]. Returns "" otherwise.
 func ErrorMessage(err error) string {
 	if localErr, ok := errors.AsType[*LocalError](err); ok && localErr.Message != "" {
 		return localErr.Message
@@ -131,10 +135,19 @@ func ErrorMessage(err error) string {
 		return svcErr.Message
 	}
 
+	// Host-originated actionable errors carry the user-facing message in status.Message
+	// (ActionableErrorDetail intentionally does not duplicate it). Only return when an
+	// ActionableErrorDetail is present so we don't claim every random gRPC error is structured.
+	if st, ok := GRPCStatusFromError(err); ok {
+		if ActionableErrorDetailFromStatus(st) != nil && st.Message() != "" {
+			return st.Message()
+		}
+	}
+
 	return ""
 }
 
-// ErrorLinks extracts the Links field from a [LocalError] or [ServiceError].
+// ErrorLinks extracts the Links field from structured extension or host gRPC errors.
 // Returns nil if the error has no links.
 func ErrorLinks(err error) []errorhandler.ErrorLink {
 	if localErr, ok := errors.AsType[*LocalError](err); ok && len(localErr.Links) > 0 {
@@ -143,6 +156,10 @@ func ErrorLinks(err error) []errorhandler.ErrorLink {
 
 	if svcErr, ok := errors.AsType[*ServiceError](err); ok && len(svcErr.Links) > 0 {
 		return svcErr.Links
+	}
+
+	if actionable := ActionableErrorDetailFromError(err); actionable != nil {
+		return UnwrapErrorLinks(actionable.GetLinks())
 	}
 
 	return nil

--- a/cli/azd/pkg/azdext/run_coverage_test.go
+++ b/cli/azd/pkg/azdext/run_coverage_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/errorhandler"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 )
 
 func TestErrorSuggestion(t *testing.T) {
@@ -75,6 +76,13 @@ func TestErrorSuggestion(t *testing.T) {
 			}),
 			expected: "Request a quota increase",
 		},
+		{
+			name: "GrpcActionableError",
+			err: mustStatusErrorWithDetails(codes.InvalidArgument, "invalid config", &ActionableErrorDetail{
+				Suggestion: "Fix the extension config and retry.",
+			}),
+			expected: "Fix the extension config and retry.",
+		},
 	}
 
 	for _, tt := range tests {
@@ -136,6 +144,14 @@ func TestErrorMessage(t *testing.T) {
 			}),
 			expected: "wrapped service",
 		},
+		{
+			name: "GrpcActionableError",
+			err: mustStatusErrorWithDetails(codes.InvalidArgument, "The extension configuration is invalid.",
+				&ActionableErrorDetail{
+					Suggestion: "Fix the extension config and retry.",
+				}),
+			expected: "The extension configuration is invalid.",
+		},
 	}
 
 	for _, tt := range tests {
@@ -180,6 +196,19 @@ func TestErrorLinks(t *testing.T) {
 			name:     "GenericError",
 			err:      errors.New("generic"),
 			expected: nil,
+		},
+		{
+			name: "GrpcActionableError",
+			err: mustStatusErrorWithDetails(codes.InvalidArgument, "invalid config", &ActionableErrorDetail{
+				Links: []*ErrorLink{{
+					Url:   "https://aka.ms/azd-errors#invalid-config",
+					Title: "Invalid config reference",
+				}},
+			}),
+			expected: []errorhandler.ErrorLink{{
+				URL:   "https://aka.ms/azd-errors#invalid-config",
+				Title: "Invalid config reference",
+			}},
 		},
 	}
 


### PR DESCRIPTION
Fixes #7844

This PR replaces the ad-hoc `"<err>\n<suggestion>"` concatenation in the host's gRPC error path with a structured proto detail. Extensions read suggestion and links via the existing public extractors instead of parsing the error string.

This essentially means once extensions upgrade to latest `github.com/azure/azure-dev/cli/azd` in `go.mod`, extensions will be able to render the full error suggestion UX as core azd, e.g.:

<img width="1245" height="252" alt="image" src="https://github.com/user-attachments/assets/e1d84ce2-177a-4161-87d8-b61e3fe7b61f" />


### What changed

- **New proto detail:** `ActionableErrorDetail { suggestion, links }` in `errors.proto`. Host-attached only; extensions returning errors to the host still use `LocalError` / `ServiceError` via `ExtensionError`.
- **Host (`internal/grpcserver`):** new `errors.go` with `mapHostError` (renamed from `wrapErrorWithSuggestion`) and `statusMessage`. `status.Message` is now just `ErrorWithSuggestion.Message` (or `err.Error()`); the `\n<suggestion>` shim is gone. Suggestion and links travel as structured detail.
- **Extension (`pkg/azdext`):** exported `GRPCStatusFromError`, `ActionableErrorDetailFromStatus`, `ActionableErrorDetailFromError`, `WrapErrorLinks`, `UnwrapErrorLinks`. `WrapError` factored through a single-pass `populateExtensionErrorFromStatus`; the `extErr.Message == err.Error()` heuristic is gone. `ErrorSuggestion`, `ErrorMessage`, and `ErrorLinks` also extract from a host-attached `ActionableErrorDetail` so links survive the wire.
- **De-duplication:** removed parallel `grpcStatusFromError` and `wrapErrorLinks` helpers from `internal/grpcserver`; both packages share the exported `azdext` versions.

### Wire shape (after)

Host → extension errors carry:
- `status.Message` — user-facing message (no concatenation)
- `google.rpc.ErrorInfo { Domain="azd.auth", Reason=... }` — auth failures
- `azdext.ActionableErrorDetail { suggestion, links }` — actionable guidance

### Tests

- `Test_mapHostError` asserts the suggestion lands in `ActionableErrorDetail` and *not* in `status.Message`.
- `Test_PromptService_Prompt{Subscription,ResourceGroup}_ErrorWithSuggestion` exercise the full interceptor stack and read suggestion via `ActionableErrorDetailFromStatus`.
- `extension_error_test.go` updated for the new `ActionableErrorDetail` shape.