### PR TITLE
Add userAssignedIdentityId support for command jobs

### DIFF
--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_submit.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_submit.go
@@ -136,6 +136,7 @@ func buildJobResource(def *utils.JobDefinition) *models.JobResource {
 		Command:                   def.Command,
 		EnvironmentImageReference: def.Environment,
 		ComputeID:                 def.Compute,
+		UserAssignedIdentityID:    def.Identity,
 		CodeID:                    def.Code,
 		EnvironmentVariables:      def.EnvironmentVariables,
 	}

--- a/cli/azd/extensions/azure.ai.customtraining/internal/utils/yaml_parser.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/utils/yaml_parser.go
@@ -30,6 +30,7 @@ type JobDefinition struct {
 	InstanceCount        int                         `yaml:"instance_count"`
 	ProcessPerNode       int                         `yaml:"process_per_node"`
 	EnvironmentVariables map[string]string           `yaml:"environment_variables"`
+	Identity             string                      `yaml:"identity"`
 	Timeout              string                      `yaml:"timeout"`
 	Tags                 map[string]string           `yaml:"tags"`
 }

--- a/cli/azd/extensions/azure.ai.customtraining/pkg/models/job.go
+++ b/cli/azd/extensions/azure.ai.customtraining/pkg/models/job.go
@@ -22,6 +22,7 @@ type CommandJob struct {
 	EnvironmentImageReference string                 `json:"environmentImageReference,omitempty"`
 	CodeID                    string                 `json:"codeId,omitempty"`
 	ComputeID                 string                 `json:"computeId,omitempty"`
+	UserAssignedIdentityID    string                 `json:"userAssignedIdentityId,omitempty"`
 	Inputs                    map[string]JobInput    `json:"inputs,omitempty"`
 	Outputs                   map[string]JobOutput   `json:"outputs,omitempty"`
 	Distribution              *Distribution          `json:"distribution,omitempty"`


### PR DESCRIPTION
1. MI has been moved out of env vars. So it was leading to this error:
```
Error Code: ScriptExecution.StreamAccess.Unexpected
Native Error: error in streaming from input data sources
        StreamError(Unknown("An unexpected error occurred while resolving AccessToken: CredentialUnavailableError: ManagedIdentityCredential authentication unavailable. The requested identity has not been assigned to this resource. Error: Unexpected response \"{'error': 'invalid_request', 'error_description': 'Identity not found'}\"", None))
=> An unexpected error occurred while resolving AccessToken: CredentialUnavailableError: ManagedIdentityCredential authentication unavailable. The requested identity has not been assigned to this resource. Error: Unexpected response "{'error': 'invalid_request', 'error_description': 'Identity not found'}"
        Unknown("An unexpected error occurred while resolving AccessToken: CredentialUnavailableError: ManagedIdentityCredential authentication unavailable. The requested identity has not been assigned to this resource. Error: Unexpected response \"{'er
```
2. Now job submission succeeds: https://eastus2euap.ai.azure.com/nextgen/r/csA7805pQa-VMt_Nw-7-9A,shared-finetuning-rg,,fdp-command-job-CANARY,fdp-command-job-UMI-CANARY-proj/build/train/custom-jobs/olden_plastic_y4lv5tn3rs/details?flight=horizon_train%2Chorizon_compute%2Chorizon_intcdn