### PR TITLE
feat(ai-agents): show command surfaces agent_endpoint via GetAgent

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/show.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/show.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -108,23 +109,32 @@ func (a *ShowAction) Run(ctx context.Context) error {
 		return err
 	}
 
-	version, err := agentClient.GetAgentVersion(
-		ctx, a.Name, a.Version, DefaultAgentAPIVersion,
-	)
+	version, err := agentClient.GetAgentVersion(ctx, a.Name, a.Version, DefaultAgentAPIVersion)
 	if err != nil {
 		return fmt.Errorf("failed to get agent version: %w", err)
 	}
 
+	var endpoint *agent_api.AgentEndpointInfo
+	if agent, err := agentClient.GetAgent(ctx, a.Name, DefaultAgentAPIVersion); err == nil {
+		endpoint = agent.AgentEndpoint
+	}
+
 	switch a.flags.output {
 	case "table":
-		return printAgentVersionTable(version)
+		return printAgentVersionTable(version, endpoint)
 	default:
-		return printAgentVersionJSON(version)
+		return printAgentVersionJSON(version, endpoint)
 	}
 }
 
-func printAgentVersionJSON(version *agent_api.AgentVersionObject) error {
-	jsonBytes, err := json.MarshalIndent(version, "", "  ")
+type agentShowOutput struct {
+	*agent_api.AgentVersionObject
+	AgentEndpoint *agent_api.AgentEndpointInfo `json:"agent_endpoint,omitempty"`
+}
+
+func printAgentVersionJSON(version *agent_api.AgentVersionObject, endpoint *agent_api.AgentEndpointInfo) error {
+	out := agentShowOutput{AgentVersionObject: version, AgentEndpoint: endpoint}
+	jsonBytes, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal agent version to JSON: %w", err)
 	}
@@ -132,7 +142,7 @@ func printAgentVersionJSON(version *agent_api.AgentVersionObject) error {
 	return nil
 }
 
-func printAgentVersionTable(version *agent_api.AgentVersionObject) error {
+func printAgentVersionTable(version *agent_api.AgentVersionObject, endpoint *agent_api.AgentEndpointInfo) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "FIELD\tVALUE")
 	fmt.Fprintln(w, "-----\t-----")
@@ -167,6 +177,19 @@ func printAgentVersionTable(version *agent_api.AgentVersionObject) error {
 	}
 	for k, v := range version.Metadata {
 		fmt.Fprintf(w, "Metadata[%s]\t%s\n", k, v)
+	}
+	if endpoint != nil {
+		if len(endpoint.Protocols) > 0 {
+			fmt.Fprintf(w, "Endpoint Protocols\t%s\n", strings.Join(endpoint.Protocols, ", "))
+		}
+		for i, scheme := range endpoint.AuthorizationSchemes {
+			label := fmt.Sprintf("Endpoint Auth[%d]", i)
+			if scheme.IsolationKeySource != nil {
+				fmt.Fprintf(w, "%s\t%s (isolation: %s)\n", label, scheme.Type, scheme.IsolationKeySource.Kind)
+			} else {
+				fmt.Fprintf(w, "%s\t%s\n", label, scheme.Type)
+			}
+		}
 	}
 
 	return w.Flush()

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/show_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/show_test.go
@@ -4,7 +4,10 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
+	"os"
 	"testing"
 
 	"azureaiagent/internal/pkg/agents/agent_api"
@@ -12,6 +15,25 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	runErr := fn()
+
+	require.NoError(t, w.Close())
+	os.Stdout = orig
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	require.NoError(t, runErr)
+	return buf.String()
+}
 
 func TestShowCommand_AcceptsPositionalArg(t *testing.T) {
 	cmd := newShowCommand()
@@ -83,7 +105,7 @@ func TestPrintAgentVersionJSON(t *testing.T) {
 		CreatedAt: 1735689600, // 2025-01-01T00:00:00Z
 	}
 
-	err := printAgentVersionJSON(version)
+	err := printAgentVersionJSON(version, nil)
 	require.NoError(t, err)
 }
 
@@ -165,8 +187,83 @@ func TestPrintAgentVersionTable(t *testing.T) {
 		},
 	}
 
-	err := printAgentVersionTable(version)
+	err := printAgentVersionTable(version, nil)
 	require.NoError(t, err)
+}
+
+func TestPrintAgentVersionJSON_WithEndpoint(t *testing.T) {
+	version := &agent_api.AgentVersionObject{
+		Object:  "agent.version",
+		ID:      "ver-ep",
+		Name:    "ep-agent",
+		Version: "1",
+	}
+	endpoint := &agent_api.AgentEndpointInfo{
+		Protocols: []string{"responses", "a2a"},
+		AuthorizationSchemes: []agent_api.AuthorizationScheme{
+			{
+				Type: "EntraIDAuth",
+				IsolationKeySource: &agent_api.IsolationKeySource{Kind: "ProjectScopedManagedIdentity"},
+			},
+		},
+	}
+
+	out := captureStdout(t, func() error { return printAgentVersionJSON(version, endpoint) })
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+
+	ep, ok := result["agent_endpoint"].(map[string]any)
+	require.True(t, ok, "agent_endpoint missing in JSON output")
+	protocols := ep["protocols"].([]any)
+	assert.ElementsMatch(t, []any{"responses", "a2a"}, protocols)
+	schemes := ep["authorization_schemes"].([]any)
+	require.Len(t, schemes, 1)
+	scheme := schemes[0].(map[string]any)
+	assert.Equal(t, "EntraIDAuth", scheme["type"])
+	assert.Equal(t, "ProjectScopedManagedIdentity", scheme["isolation_key_source"].(map[string]any)["kind"])
+}
+
+func TestPrintAgentVersionJSON_NilEndpointOmitsField(t *testing.T) {
+	version := &agent_api.AgentVersionObject{
+		Object:  "agent.version",
+		ID:      "ver-no-ep",
+		Name:    "no-ep-agent",
+		Version: "1",
+	}
+
+	out := captureStdout(t, func() error { return printAgentVersionJSON(version, nil) })
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	_, hasEndpoint := result["agent_endpoint"]
+	assert.False(t, hasEndpoint, "agent_endpoint should be omitted when nil")
+}
+
+func TestPrintAgentVersionTable_WithEndpoint(t *testing.T) {
+	version := &agent_api.AgentVersionObject{
+		Object:  "agent.version",
+		ID:      "ver-ep",
+		Name:    "ep-agent",
+		Version: "1",
+	}
+	endpoint := &agent_api.AgentEndpointInfo{
+		Protocols: []string{"responses", "a2a"},
+		AuthorizationSchemes: []agent_api.AuthorizationScheme{
+			{Type: "EntraIDAuth", IsolationKeySource: &agent_api.IsolationKeySource{Kind: "ProjectScopedManagedIdentity"}},
+			{Type: "ApiKeyAuth"},
+		},
+	}
+
+	out := captureStdout(t, func() error { return printAgentVersionTable(version, endpoint) })
+
+	assert.Contains(t, out, "Endpoint Protocols")
+	assert.Contains(t, out, "responses, a2a")
+	assert.Contains(t, out, "Endpoint Auth[0]")
+	assert.Contains(t, out, "EntraIDAuth")
+	assert.Contains(t, out, "isolation: ProjectScopedManagedIdentity")
+	assert.Contains(t, out, "Endpoint Auth[1]")
+	assert.Contains(t, out, "ApiKeyAuth")
 }
 
 func TestPrintAgentVersionTable_MinimalFields(t *testing.T) {
@@ -177,6 +274,6 @@ func TestPrintAgentVersionTable_MinimalFields(t *testing.T) {
 		Version: "1",
 	}
 
-	err := printAgentVersionTable(version)
+	err := printAgentVersionTable(version, nil)
 	require.NoError(t, err)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
@@ -192,6 +192,24 @@ type AgentObject struct {
 	Versions struct {
 		Latest AgentVersionObject `json:"latest"`
 	} `json:"versions"`
+	AgentEndpoint *AgentEndpointInfo `json:"agent_endpoint,omitempty"`
+}
+
+// AgentEndpointInfo describes the public endpoint of an agent.
+type AgentEndpointInfo struct {
+	Protocols            []string              `json:"protocols,omitempty"`
+	AuthorizationSchemes []AuthorizationScheme `json:"authorization_schemes,omitempty"`
+}
+
+// AuthorizationScheme describes one authentication mechanism accepted by an agent endpoint.
+type AuthorizationScheme struct {
+	Type               string              `json:"type"`
+	IsolationKeySource *IsolationKeySource `json:"isolation_key_source,omitempty"`
+}
+
+// IsolationKeySource indicates how per-caller isolation keys are derived.
+type IsolationKeySource struct {
+	Kind string `json:"kind"`
 }
 
 // CommonListObjectProperties represents common properties for list responses

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
@@ -5,6 +5,7 @@ package agent_api
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -79,6 +80,12 @@ func TestAgentObject_RoundTrip(t *testing.T) {
 				CreatedAt:   1700000000,
 			},
 		},
+		AgentEndpoint: &AgentEndpointInfo{
+			Protocols: []string{"responses", "a2a"},
+			AuthorizationSchemes: []AuthorizationScheme{
+				{Type: "Entra", IsolationKeySource: &IsolationKeySource{Kind: "Entra"}},
+			},
+		},
 	}
 
 	data, err := json.Marshal(original)
@@ -87,7 +94,10 @@ func TestAgentObject_RoundTrip(t *testing.T) {
 	}
 
 	s := string(data)
-	for _, field := range []string{`"object"`, `"id"`, `"name"`, `"versions"`, `"latest"`} {
+	for _, field := range []string{
+		`"object"`, `"id"`, `"name"`, `"versions"`, `"latest"`,
+		`"agent_endpoint"`, `"protocols"`, `"authorization_schemes"`,
+	} {
 		if !strings.Contains(s, field) {
 			t.Errorf("expected JSON to contain %s", field)
 		}
@@ -106,6 +116,17 @@ func TestAgentObject_RoundTrip(t *testing.T) {
 	}
 	if got.Versions.Latest.CreatedAt != 1700000000 {
 		t.Errorf("Latest.CreatedAt = %d, want %d", got.Versions.Latest.CreatedAt, int64(1700000000))
+	}
+	if got.AgentEndpoint == nil {
+		t.Fatalf("AgentEndpoint = nil, want non-nil")
+	}
+	if !slices.Contains(got.AgentEndpoint.Protocols, "responses") {
+		t.Errorf("AgentEndpoint.Protocols = %v, want to contain %q", got.AgentEndpoint.Protocols, "responses")
+	}
+	if len(got.AgentEndpoint.AuthorizationSchemes) != 1 ||
+		got.AgentEndpoint.AuthorizationSchemes[0].Type != "Entra" {
+		t.Errorf("AgentEndpoint.AuthorizationSchemes = %+v, want one entry of type Entra",
+			got.AgentEndpoint.AuthorizationSchemes)
 	}
 }
 


### PR DESCRIPTION
Updates `azd ai agent show` to surface the `agent_endpoint` block (protocols, authorization_schemes) which the per-version API route never returns.

### Approach
- Continue calling `GetAgentVersion` for the env-tracked version (preserves prior version-selection behavior).
- Additionally call `GetAgent` to fetch the agent-level `agent_endpoint` and merge it into the JSON/table output.
- If `GetAgent` fails, the command still succeeds with the version body alone (`agent_endpoint` is omitted from output).
