### PR TITLE
Add support for experiment name

### DIFF
--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_get.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_get.go
@@ -298,6 +298,9 @@ func printJobDetails(d *jobDetails) {
 		fmt.Fprintf(w, "Display Name:\t%s\n", props.DisplayName)
 	}
 	fmt.Fprintf(w, "Status:\t%s\n", statusIndicator(props.Status))
+	if props.ExperimentName != "" {
+		fmt.Fprintf(w, "Experiment:\t%s\n", props.ExperimentName)
+	}
 	if props.Description != "" {
 		fmt.Fprintf(w, "Description:\t%s\n", props.Description)
 	}

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_submit.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_submit.go
@@ -131,6 +131,7 @@ func newJobSubmitCommand() *cobra.Command {
 func buildJobResource(def *utils.JobDefinition) *models.JobResource {
 	job := models.CommandJob{
 		JobType:                   "Command",
+		ExperimentName:            def.ExperimentName,
 		DisplayName:               def.DisplayName,
 		Description:               def.Description,
 		Command:                   def.Command,

--- a/cli/azd/extensions/azure.ai.customtraining/internal/utils/yaml_parser.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/utils/yaml_parser.go
@@ -18,6 +18,7 @@ type JobDefinition struct {
 	Type                 string                      `yaml:"type"`
 	Name                 string                      `yaml:"name"`
 	DisplayName          string                      `yaml:"display_name"`
+	ExperimentName       string                      `yaml:"experiment_name"`
 	Description          string                      `yaml:"description"`
 	Command              string                      `yaml:"command" validate:"required"`
 	Environment          string                      `yaml:"environment" validate:"required"`

--- a/cli/azd/extensions/azure.ai.customtraining/pkg/models/job.go
+++ b/cli/azd/extensions/azure.ai.customtraining/pkg/models/job.go
@@ -15,6 +15,7 @@ type JobResource struct {
 // CommandJob represents the properties of a Foundry command job.
 type CommandJob struct {
 	JobType                   string                 `json:"jobType"`
+	ExperimentName            string                 `json:"experimentName,omitempty"`
 	DisplayName               string                 `json:"displayName,omitempty" table:"DISPLAY NAME"`
 	Description               string                 `json:"description,omitempty"`
 	Status                    string                 `json:"status,omitempty" table:"STATUS"`


### PR DESCRIPTION
### Notes
- This is an optional field. Customers can use this to track their experiments.

### Testing

- Submit
<img width="1032" height="653" alt="image" src="https://github.com/user-attachments/assets/1becd392-2b8f-45b5-b75d-8d2692526125" />

- Show
<img width="1087" height="712" alt="image" src="https://github.com/user-attachments/assets/75dc1562-2761-41f9-b6bc-08fe1af4e5fe" />
