### PR TITLE
[Agents Extension] Github workflow for extension owner approval check

### DIFF
--- a/.github/scripts/approval-ext-azure-ai-agents.js
+++ b/.github/scripts/approval-ext-azure-ai-agents.js
@@ -1,0 +1,183 @@
+// Required Approval Gate for azure.ai.agents Extension
+//
+// Validates that at least one required approver has approved the current HEAD,
+// or that a valid break-glass override comment exists.
+//
+// See .github/workflows/approval-ext-azure-ai-agents.yml for full documentation.
+module.exports = async ({ github, context, core }) => {
+  const requiredApprovers = [
+    'trangevi',
+    'trrwilson',
+    'therealjohn',
+    'glharper',
+  ];
+
+  const EXTENSION_PATH = 'cli/azd/extensions/azure.ai.agents/';
+  const WORKFLOW_PATH = '.github/workflows/approval-ext-azure-ai-agents.yml';
+  const OVERRIDE_COMMAND = '/agents-extension-approval override';
+
+  const prNumber =
+    context.payload.pull_request?.number ??
+    context.payload.review?.pull_request?.number ??
+    context.payload.issue?.number;
+
+  if (!prNumber) {
+    core.setFailed('Could not determine PR number from event payload.');
+    return;
+  }
+
+  // Helper: fetch PR data and HEAD commit date.
+  async function getPrAndPushDate() {
+    const { data: pr } = await github.rest.pulls.get({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: prNumber,
+    });
+    const { data: headCommit } = await github.rest.repos.getCommit({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: pr.head.sha,
+    });
+    const lastPushDate = new Date(headCommit.commit.committer.date);
+    return { pr, headSha: pr.head.sha, lastPushDate };
+  }
+
+  // Helper: wrap API calls with 403 handling for fork PRs.
+  async function safeCall(fn, description) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (err.status === 403) {
+        core.setFailed(
+          `Insufficient permissions to ${description}. ` +
+          'Fork PRs may not have the required token permissions for this check.'
+        );
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  // --- issue_comment handler (break-glass override, writes commit status) ---
+  if (context.eventName === 'issue_comment') {
+    const comment = (context.payload.comment.body || '').trim();
+    if (comment === OVERRIDE_COMMAND) {
+      const commenter = context.payload.comment.user.login.toLowerCase();
+      if (!requiredApprovers.includes(commenter)) {
+        core.setFailed(
+          `Override denied: ${context.payload.comment.user.login} is not in the required approvers list.`
+        );
+        return;
+      }
+
+      // Validate the override comment was posted after the latest push.
+      const { pr, headSha, lastPushDate } = await getPrAndPushDate();
+      const commentDate = new Date(context.payload.comment.created_at);
+      if (commentDate <= lastPushDate) {
+        core.setFailed(
+          'Override denied: comment was posted before the latest push. ' +
+          'Please post a new override comment after the most recent commit.'
+        );
+        return;
+      }
+
+      // issue_comment runs don't update PR status checks automatically.
+      // Write a commit status directly to the PR head SHA.
+      await github.rest.repos.createCommitStatus({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        sha: headSha,
+        state: 'success',
+        context: 'Required Approval',
+        description: `Override (break-glass) by ${context.payload.comment.user.login}`,
+      });
+      core.info(
+        `Override granted via comment by ${context.payload.comment.user.login}. ` +
+        `Status set on ${headSha}.`
+      );
+      return;
+    }
+  }
+
+  // --- pull_request_review: runtime path-scope check ---
+  // GitHub Actions does not support `paths:` filters on pull_request_review or
+  // issue_comment events. This runtime check compensates for that limitation.
+  if (context.eventName === 'pull_request_review') {
+    const files = await safeCall(
+      () => github.paginate(
+        github.rest.pulls.listFiles,
+        { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
+      ),
+      'list PR files'
+    );
+    if (files === null) return;
+
+    const touchesExtension = files.some(f =>
+      f.filename.startsWith(EXTENSION_PATH) || f.filename === WORKFLOW_PATH
+    );
+    if (!touchesExtension) {
+      core.info('PR does not touch agents extension — skipping approval check.');
+      return;
+    }
+  }
+
+  // --- Check for an existing override comment (break-glass, fallback scan) ---
+  const comments = await safeCall(
+    () => github.paginate(
+      github.rest.issues.listComments,
+      { owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber }
+    ),
+    'list PR comments'
+  );
+  if (comments === null) return;
+
+  const { pr, headSha, lastPushDate } = await getPrAndPushDate();
+
+  const validOverride = comments.find(c =>
+    (c.body || '').trim() === OVERRIDE_COMMAND &&
+    requiredApprovers.includes(c.user.login.toLowerCase()) &&
+    new Date(c.created_at) > lastPushDate
+  );
+  if (validOverride) {
+    core.info(
+      `Override (break-glass) granted via comment by ${validOverride.user.login}.`
+    );
+    return;
+  }
+
+  // --- Check reviews for a valid approval ---
+  const reviews = await safeCall(
+    () => github.paginate(
+      github.rest.pulls.listReviews,
+      { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
+    ),
+    'list PR reviews'
+  );
+  if (reviews === null) return;
+
+  // Collapse reviews per user to the latest state on the current HEAD.
+  // This ensures a CHANGES_REQUESTED after an APPROVED invalidates the
+  // earlier approval (matching GitHub's effective review state).
+  const latestByUser = new Map();
+  for (const r of reviews.filter(r => r.commit_id === headSha)) {
+    const key = r.user.login.toLowerCase();
+    const prev = latestByUser.get(key);
+    if (!prev || new Date(r.submitted_at) > new Date(prev.submitted_at)) {
+      latestByUser.set(key, r);
+    }
+  }
+  const validApprovals = [...latestByUser.values()].filter(
+    r => r.state === 'APPROVED' && requiredApprovers.includes(r.user.login.toLowerCase())
+  );
+
+  if (validApprovals.length > 0) {
+    const names = validApprovals.map(r => r.user.login).join(', ');
+    core.info(`Approved by: ${names}`);
+  } else {
+    core.setFailed(
+      `Requires approval from at least one of: ${requiredApprovers.join(', ')}. ` +
+      'No qualifying approval found on the current commit. ' +
+      'Break-glass: a required approver can post exactly "/agents-extension-approval override" to bypass.'
+    );
+  }
+};

--- a/.github/workflows/approval-ext-azure-ai-agents.yml
+++ b/.github/workflows/approval-ext-azure-ai-agents.yml
@@ -7,8 +7,10 @@
 # - This check is ADDITIVE to GitHub CODEOWNERS — both must be satisfied to merge.
 # - Approval must come from a member of the requiredApprovers list on the current
 #   HEAD commit (stale approvals are rejected after new pushes).
-# - Override: Any user can post "/agents-extension-approval override" as a PR
-#   comment to bypass the approval requirement.
+# - Override (break-glass): A member of the requiredApprovers list can post
+#   "/agents-extension-approval override" as a PR comment to bypass the approval
+#   requirement. The override must be posted after the latest push to be valid.
+#   This is intended as an emergency escape hatch, not routine workflow.
 # - Fork PRs: External contributors from forks have restricted token permissions.
 #   If API calls fail with 403, the check reports a clear error rather than crashing.
 #
@@ -42,8 +44,9 @@ jobs:
   required-approval:
     name: Required Approval
     # For issue_comment, only run if the comment is on a PR and contains the
-    # override phrase. For pull_request_review, run on all PRs (runtime filter
-    # below skips non-extension PRs).
+    # override phrase. The job-level `contains()` is a coarse pre-filter to avoid
+    # spinning up the runner for irrelevant comments; the script enforces exact
+    # match and authorization checks.
     if: |
       github.event_name == 'pull_request' ||
       github.event_name == 'pull_request_review' ||
@@ -75,10 +78,17 @@ jobs:
               return;
             }
 
-            // Check for override comment.
+            // Check for override comment (break-glass, restricted to requiredApprovers).
             if (context.eventName === 'issue_comment') {
               const comment = (context.payload.comment.body || '').trim();
               if (comment === '/agents-extension-approval override') {
+                const commenter = context.payload.comment.user.login.toLowerCase();
+                if (!requiredApprovers.includes(commenter)) {
+                  core.setFailed(
+                    `Override denied: ${context.payload.comment.user.login} is not in the required approvers list.`
+                  );
+                  return;
+                }
                 // issue_comment runs don't update PR status checks automatically.
                 // Write a commit status directly to the PR head SHA.
                 const { data: pr } = await github.rest.pulls.get({
@@ -92,7 +102,7 @@ jobs:
                   sha: pr.head.sha,
                   state: 'success',
                   context: 'Required Approval',
-                  description: `Override by ${context.payload.comment.user.login}`,
+                  description: `Override (break-glass) by ${context.payload.comment.user.login}`,
                 });
                 core.info(
                   `Override granted via comment by ${context.payload.comment.user.login}. ` +
@@ -130,7 +140,8 @@ jobs:
               }
             }
 
-            // Check for an override comment on the PR.
+            // Check for an override comment on the PR (break-glass).
+            // Only honor overrides from required approvers, posted after the latest push.
             let comments;
             try {
               comments = await github.paginate(
@@ -148,15 +159,29 @@ jobs:
               throw err;
             }
 
-            const hasOverride = comments.some(c =>
-              (c.body || '').trim() === '/agents-extension-approval override'
+            // Get the HEAD SHA and commit date for staleness checks.
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const headSha = pr.head.sha;
+
+            const { data: headCommit } = await github.rest.repos.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: headSha,
+            });
+            const lastPushDate = new Date(headCommit.commit.committer.date);
+
+            const validOverride = comments.find(c =>
+              (c.body || '').trim() === '/agents-extension-approval override' &&
+              requiredApprovers.includes(c.user.login.toLowerCase()) &&
+              new Date(c.created_at) > lastPushDate
             );
-            if (hasOverride) {
-              const overrideComment = comments.find(c =>
-                (c.body || '').trim() === '/agents-extension-approval override'
-              );
+            if (validOverride) {
               core.info(
-                `Override granted via comment by ${overrideComment.user.login}.`
+                `Override (break-glass) granted via comment by ${validOverride.user.login}.`
               );
               return;
             }
@@ -179,20 +204,19 @@ jobs:
               throw err;
             }
 
-            // Get the HEAD SHA so we can verify the approval is current.
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            });
-            const headSha = pr.head.sha;
-
-            // Find approvals from required reviewers on the current HEAD commit.
-            const validApprovals = reviews.filter(
-              r =>
-                r.state === 'APPROVED' &&
-                r.commit_id === headSha &&
-                requiredApprovers.includes(r.user.login.toLowerCase())
+            // Collapse reviews per user to the latest state on the current HEAD.
+            // This ensures a CHANGES_REQUESTED after an APPROVED invalidates
+            // the earlier approval (matching GitHub's effective review state).
+            const latestByUser = new Map();
+            for (const r of reviews.filter(r => r.commit_id === headSha)) {
+              const key = r.user.login.toLowerCase();
+              const prev = latestByUser.get(key);
+              if (!prev || new Date(r.submitted_at) > new Date(prev.submitted_at)) {
+                latestByUser.set(key, r);
+              }
+            }
+            const validApprovals = [...latestByUser.values()].filter(
+              r => r.state === 'APPROVED' && requiredApprovers.includes(r.user.login.toLowerCase())
             );
 
             if (validApprovals.length > 0) {
@@ -202,6 +226,6 @@ jobs:
               core.setFailed(
                 `Requires approval from at least one of: ${requiredApprovers.join(', ')}. ` +
                 'No qualifying approval found on the current commit. ' +
-                'To bypass, post a comment containing "/agents-extension-approval override".'
+                'Break-glass: a required approver can post exactly "/agents-extension-approval override" to bypass.'
               );
             }

--- a/.github/workflows/approval-ext-azure-ai-agents.yml
+++ b/.github/workflows/approval-ext-azure-ai-agents.yml
@@ -1,0 +1,96 @@
+name: ext-azure-ai-agents-approval
+
+on:
+  pull_request:
+    paths:
+      - "cli/azd/extensions/azure.ai.agents/**"
+      - ".github/workflows/approval-ext-azure-ai-agents.yml"
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  required-approval:
+    name: Required Approval
+    # Only run for PRs that touch the agents extension.
+    # pull_request is already path-filtered; pull_request_review is not, so we
+    # check at runtime whether the PR has files in the extension path.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check for required team approval
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const requiredApprovers = [
+              'trangevi',
+              'trrwilson',
+              'therealjohn',
+              'glharper',
+            ];
+
+            const prNumber =
+              context.payload.pull_request?.number ??
+              context.payload.review?.pull_request?.number;
+
+            if (!prNumber) {
+              core.setFailed('Could not determine PR number from event payload.');
+              return;
+            }
+
+            // For pull_request_review events (no path filter), check whether the
+            // PR actually touches the agents extension before enforcing approval.
+            if (context.eventName === 'pull_request_review') {
+              const files = await github.paginate(
+                github.rest.pulls.listFiles,
+                { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
+              );
+              const touchesExtension = files.some(f =>
+                f.filename.startsWith('cli/azd/extensions/azure.ai.agents/')
+              );
+              if (!touchesExtension) {
+                core.info('PR does not touch agents extension — skipping approval check.');
+                return;
+              }
+            }
+
+            // Fetch all reviews on the PR.
+            const reviews = await github.paginate(
+              github.rest.pulls.listReviews,
+              { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
+            );
+
+            // Get the HEAD SHA so we can verify the approval is current.
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const headSha = pr.head.sha;
+
+            // Find approvals from required reviewers on the current HEAD commit.
+            const validApprovals = reviews.filter(
+              r =>
+                r.state === 'APPROVED' &&
+                r.commit_id === headSha &&
+                requiredApprovers.includes(r.user.login.toLowerCase())
+            );
+
+            if (validApprovals.length > 0) {
+              const names = validApprovals.map(r => r.user.login).join(', ');
+              core.info(`Approved by: ${names}`);
+            } else {
+              core.setFailed(
+                `Requires approval from at least one of: ${requiredApprovers.join(', ')}. ` +
+                'No qualifying approval found on the current commit.'
+              );
+            }

--- a/.github/workflows/approval-ext-azure-ai-agents.yml
+++ b/.github/workflows/approval-ext-azure-ai-agents.yml
@@ -14,7 +14,8 @@
 # - Fork PRs: External contributors from forks have restricted token permissions.
 #   If API calls fail with 403, the check reports a clear error rather than crashing.
 #
-# To change the required approvers list, update the requiredApprovers array below.
+# To change the required approvers list, update the array in
+# .github/scripts/approval-ext-azure-ai-agents.js.
 
 name: ext-azure-ai-agents-approval
 
@@ -23,8 +24,11 @@ on:
     paths:
       - "cli/azd/extensions/azure.ai.agents/**"
       - ".github/workflows/approval-ext-azure-ai-agents.yml"
+      - ".github/scripts/approval-ext-azure-ai-agents.js"
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
+  # GitHub Actions does not support `paths:` filters on pull_request_review or
+  # issue_comment events. The script performs a runtime path check to compensate.
   pull_request_review:
     types: [submitted]
   issue_comment:
@@ -54,178 +58,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Check for required team approval
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
-            const requiredApprovers = [
-              'trangevi',
-              'trrwilson',
-              'therealjohn',
-              'glharper',
-            ];
-
-            const EXTENSION_PATH = 'cli/azd/extensions/azure.ai.agents/';
-            const WORKFLOW_PATH = '.github/workflows/approval-ext-azure-ai-agents.yml';
-
-            const prNumber =
-              context.payload.pull_request?.number ??
-              context.payload.review?.pull_request?.number ??
-              context.payload.issue?.number;
-
-            if (!prNumber) {
-              core.setFailed('Could not determine PR number from event payload.');
-              return;
-            }
-
-            // Check for override comment (break-glass, restricted to requiredApprovers).
-            if (context.eventName === 'issue_comment') {
-              const comment = (context.payload.comment.body || '').trim();
-              if (comment === '/agents-extension-approval override') {
-                const commenter = context.payload.comment.user.login.toLowerCase();
-                if (!requiredApprovers.includes(commenter)) {
-                  core.setFailed(
-                    `Override denied: ${context.payload.comment.user.login} is not in the required approvers list.`
-                  );
-                  return;
-                }
-                // issue_comment runs don't update PR status checks automatically.
-                // Write a commit status directly to the PR head SHA.
-                const { data: pr } = await github.rest.pulls.get({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: prNumber,
-                });
-                await github.rest.repos.createCommitStatus({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  sha: pr.head.sha,
-                  state: 'success',
-                  context: 'Required Approval',
-                  description: `Override (break-glass) by ${context.payload.comment.user.login}`,
-                });
-                core.info(
-                  `Override granted via comment by ${context.payload.comment.user.login}. ` +
-                  `Status set on ${pr.head.sha}.`
-                );
-                return;
-              }
-            }
-
-            // For pull_request_review events (no path filter), check whether the
-            // PR actually touches the agents extension before enforcing approval.
-            if (context.eventName === 'pull_request_review') {
-              let files;
-              try {
-                files = await github.paginate(
-                  github.rest.pulls.listFiles,
-                  { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
-                );
-              } catch (err) {
-                if (err.status === 403) {
-                  core.setFailed(
-                    'Insufficient permissions to list PR files. ' +
-                    'Fork PRs may not have the required token permissions for this check.'
-                  );
-                  return;
-                }
-                throw err;
-              }
-              const touchesExtension = files.some(f =>
-                f.filename.startsWith(EXTENSION_PATH) || f.filename === WORKFLOW_PATH
-              );
-              if (!touchesExtension) {
-                core.info('PR does not touch agents extension — skipping approval check.');
-                return;
-              }
-            }
-
-            // Check for an override comment on the PR (break-glass).
-            // Only honor overrides from required approvers, posted after the latest push.
-            let comments;
-            try {
-              comments = await github.paginate(
-                github.rest.issues.listComments,
-                { owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber }
-              );
-            } catch (err) {
-              if (err.status === 403) {
-                core.setFailed(
-                  'Insufficient permissions to list PR comments. ' +
-                  'Fork PRs may not have the required token permissions for this check.'
-                );
-                return;
-              }
-              throw err;
-            }
-
-            // Get the HEAD SHA and commit date for staleness checks.
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            });
-            const headSha = pr.head.sha;
-
-            const { data: headCommit } = await github.rest.repos.getCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: headSha,
-            });
-            const lastPushDate = new Date(headCommit.commit.committer.date);
-
-            const validOverride = comments.find(c =>
-              (c.body || '').trim() === '/agents-extension-approval override' &&
-              requiredApprovers.includes(c.user.login.toLowerCase()) &&
-              new Date(c.created_at) > lastPushDate
-            );
-            if (validOverride) {
-              core.info(
-                `Override (break-glass) granted via comment by ${validOverride.user.login}.`
-              );
-              return;
-            }
-
-            // Fetch all reviews on the PR.
-            let reviews;
-            try {
-              reviews = await github.paginate(
-                github.rest.pulls.listReviews,
-                { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
-              );
-            } catch (err) {
-              if (err.status === 403) {
-                core.setFailed(
-                  'Insufficient permissions to list PR reviews. ' +
-                  'Fork PRs may not have the required token permissions for this check.'
-                );
-                return;
-              }
-              throw err;
-            }
-
-            // Collapse reviews per user to the latest state on the current HEAD.
-            // This ensures a CHANGES_REQUESTED after an APPROVED invalidates
-            // the earlier approval (matching GitHub's effective review state).
-            const latestByUser = new Map();
-            for (const r of reviews.filter(r => r.commit_id === headSha)) {
-              const key = r.user.login.toLowerCase();
-              const prev = latestByUser.get(key);
-              if (!prev || new Date(r.submitted_at) > new Date(prev.submitted_at)) {
-                latestByUser.set(key, r);
-              }
-            }
-            const validApprovals = [...latestByUser.values()].filter(
-              r => r.state === 'APPROVED' && requiredApprovers.includes(r.user.login.toLowerCase())
-            );
-
-            if (validApprovals.length > 0) {
-              const names = validApprovals.map(r => r.user.login).join(', ');
-              core.info(`Approved by: ${names}`);
-            } else {
-              core.setFailed(
-                `Requires approval from at least one of: ${requiredApprovers.join(', ')}. ` +
-                'No qualifying approval found on the current commit. ' +
-                'Break-glass: a required approver can post exactly "/agents-extension-approval override" to bypass.'
-              );
-            }
+            const script = require('./.github/scripts/approval-ext-azure-ai-agents.js');
+            await script({ github, context, core });

--- a/.github/workflows/approval-ext-azure-ai-agents.yml
+++ b/.github/workflows/approval-ext-azure-ai-agents.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "cli/azd/extensions/azure.ai.agents/**"
+      - ".github/workflows/approval-ext-azure-ai-agents.yml"
     branches: [main]
     types: [opened, synchronize, reopened]
   pull_request_review:

--- a/.github/workflows/approval-ext-azure-ai-agents.yml
+++ b/.github/workflows/approval-ext-azure-ai-agents.yml
@@ -1,3 +1,19 @@
+# Required Approval Gate for azure.ai.agents Extension
+#
+# Purpose: Ensures at least one designated team member approves PRs that modify
+# the azure.ai.agents extension before they can merge.
+#
+# Behavior:
+# - This check is ADDITIVE to GitHub CODEOWNERS — both must be satisfied to merge.
+# - Approval must come from a member of the requiredApprovers list on the current
+#   HEAD commit (stale approvals are rejected after new pushes).
+# - Override: Any user can post "/agents-extension-approval override" as a PR
+#   comment to bypass the approval requirement.
+# - Fork PRs: External contributors from forks have restricted token permissions.
+#   If API calls fail with 403, the check reports a clear error rather than crashing.
+#
+# To change the required approvers list, update the requiredApprovers array below.
+
 name: ext-azure-ai-agents-approval
 
 on:
@@ -6,29 +22,37 @@ on:
       - "cli/azd/extensions/azure.ai.agents/**"
       - ".github/workflows/approval-ext-azure-ai-agents.yml"
     branches: [main]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   pull_request_review:
     types: [submitted]
+  issue_comment:
+    types: [created]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
   pull-requests: read
+  issues: read
+  statuses: write
 
 jobs:
   required-approval:
     name: Required Approval
-    # Only run for PRs that touch the agents extension.
-    # pull_request is already path-filtered; pull_request_review is not, so we
-    # check at runtime whether the PR has files in the extension path.
+    # For issue_comment, only run if the comment is on a PR and contains the
+    # override phrase. For pull_request_review, run on all PRs (runtime filter
+    # below skips non-extension PRs).
+    if: |
+      github.event_name == 'pull_request' ||
+      github.event_name == 'pull_request_review' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/agents-extension-approval override'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check for required team approval
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const requiredApprovers = [
@@ -38,24 +62,67 @@ jobs:
               'glharper',
             ];
 
+            const EXTENSION_PATH = 'cli/azd/extensions/azure.ai.agents/';
+            const WORKFLOW_PATH = '.github/workflows/approval-ext-azure-ai-agents.yml';
+
             const prNumber =
               context.payload.pull_request?.number ??
-              context.payload.review?.pull_request?.number;
+              context.payload.review?.pull_request?.number ??
+              context.payload.issue?.number;
 
             if (!prNumber) {
               core.setFailed('Could not determine PR number from event payload.');
               return;
             }
 
+            // Check for override comment.
+            if (context.eventName === 'issue_comment') {
+              const comment = (context.payload.comment.body || '').trim();
+              if (comment === '/agents-extension-approval override') {
+                // issue_comment runs don't update PR status checks automatically.
+                // Write a commit status directly to the PR head SHA.
+                const { data: pr } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                });
+                await github.rest.repos.createCommitStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  sha: pr.head.sha,
+                  state: 'success',
+                  context: 'Required Approval',
+                  description: `Override by ${context.payload.comment.user.login}`,
+                });
+                core.info(
+                  `Override granted via comment by ${context.payload.comment.user.login}. ` +
+                  `Status set on ${pr.head.sha}.`
+                );
+                return;
+              }
+            }
+
             // For pull_request_review events (no path filter), check whether the
             // PR actually touches the agents extension before enforcing approval.
             if (context.eventName === 'pull_request_review') {
-              const files = await github.paginate(
-                github.rest.pulls.listFiles,
-                { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
-              );
+              let files;
+              try {
+                files = await github.paginate(
+                  github.rest.pulls.listFiles,
+                  { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
+                );
+              } catch (err) {
+                if (err.status === 403) {
+                  core.setFailed(
+                    'Insufficient permissions to list PR files. ' +
+                    'Fork PRs may not have the required token permissions for this check.'
+                  );
+                  return;
+                }
+                throw err;
+              }
               const touchesExtension = files.some(f =>
-                f.filename.startsWith('cli/azd/extensions/azure.ai.agents/')
+                f.filename.startsWith(EXTENSION_PATH) || f.filename === WORKFLOW_PATH
               );
               if (!touchesExtension) {
                 core.info('PR does not touch agents extension — skipping approval check.');
@@ -63,11 +130,54 @@ jobs:
               }
             }
 
-            // Fetch all reviews on the PR.
-            const reviews = await github.paginate(
-              github.rest.pulls.listReviews,
-              { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
+            // Check for an override comment on the PR.
+            let comments;
+            try {
+              comments = await github.paginate(
+                github.rest.issues.listComments,
+                { owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber }
+              );
+            } catch (err) {
+              if (err.status === 403) {
+                core.setFailed(
+                  'Insufficient permissions to list PR comments. ' +
+                  'Fork PRs may not have the required token permissions for this check.'
+                );
+                return;
+              }
+              throw err;
+            }
+
+            const hasOverride = comments.some(c =>
+              (c.body || '').trim() === '/agents-extension-approval override'
             );
+            if (hasOverride) {
+              const overrideComment = comments.find(c =>
+                (c.body || '').trim() === '/agents-extension-approval override'
+              );
+              core.info(
+                `Override granted via comment by ${overrideComment.user.login}.`
+              );
+              return;
+            }
+
+            // Fetch all reviews on the PR.
+            let reviews;
+            try {
+              reviews = await github.paginate(
+                github.rest.pulls.listReviews,
+                { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
+              );
+            } catch (err) {
+              if (err.status === 403) {
+                core.setFailed(
+                  'Insufficient permissions to list PR reviews. ' +
+                  'Fork PRs may not have the required token permissions for this check.'
+                );
+                return;
+              }
+              throw err;
+            }
 
             // Get the HEAD SHA so we can verify the approval is current.
             const { data: pr } = await github.rest.pulls.get({
@@ -91,6 +201,7 @@ jobs:
             } else {
               core.setFailed(
                 `Requires approval from at least one of: ${requiredApprovers.join(', ')}. ` +
-                'No qualifying approval found on the current commit.'
+                'No qualifying approval found on the current commit. ' +
+                'To bypass, post a comment containing "/agents-extension-approval override".'
               );
             }

--- a/.github/workflows/approval-ext-azure-ai-agents.yml
+++ b/.github/workflows/approval-ext-azure-ai-agents.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - "cli/azd/extensions/azure.ai.agents/**"
-      - ".github/workflows/approval-ext-azure-ai-agents.yml"
     branches: [main]
     types: [opened, synchronize, reopened]
   pull_request_review:


### PR DESCRIPTION
Add github workflow requiring specific user approval. This is an alternative to shrinking the codeowners for the agents extension.

The idea is, we still definitely want reviews from the broader azd team, but we also want to make sure that someone from the extension team is aware of the changes and signs off, particularly as we're getting more people asking to contribute code, in order to make sure that changes being made align with then intended extension direction. And on top of that, last week showed that it's important for azd folks to be able to help us approve PRs when we're down people, which I believe this will still allow via override.