### PR TITLE
Pass `buildArgs` to ACR remote build task

### DIFF
--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -356,42 +356,13 @@ func (ch *ContainerHelper) Build(
 	dockerOptions := getDockerOptionsWithDefaults(serviceConfig.Docker)
 	resolveDockerPaths(serviceConfig, &dockerOptions)
 
-	resolveParameters := func(source []string) ([]string, error) {
-		result := make([]string, len(source))
-		for i, arg := range source {
-			evaluatedString, err := apphost.EvalString(arg, func(match string) (string, error) {
-				path := match
-				value, has := env.Config.GetString(path)
-				if !has {
-					return "", fmt.Errorf("parameter %s not found", path)
-				}
-				return value, nil
-			})
-			if err != nil {
-				return nil, err
-			}
-			result[i] = evaluatedString
-		}
-		return result, nil
-	}
-
-	dockerBuildArgs := []string{}
-	for _, arg := range dockerOptions.BuildArgs {
-		buildArgValue, err := arg.Envsubst(env.Getenv)
-		if err != nil {
-			return nil, fmt.Errorf("substituting environment variables in build args: %w", err)
-		}
-
-		dockerBuildArgs = append(dockerBuildArgs, buildArgValue)
-	}
-
-	// resolve parameters for build args and secrets
-	resolvedBuildArgs, err := resolveParameters(dockerBuildArgs)
+	resolvedBuildArgs, err := resolveDockerBuildArgs(dockerOptions.BuildArgs, env)
 	if err != nil {
 		return nil, err
 	}
 
-	resolvedBuildEnv, err := resolveParameters(dockerOptions.BuildEnv)
+	// resolve parameters for build args and secrets
+	resolvedBuildEnv, err := resolveDockerParameters(dockerOptions.BuildEnv, env)
 	if err != nil {
 		return nil, err
 	}
@@ -523,6 +494,40 @@ func (ch *ContainerHelper) Build(
 			},
 		}},
 	}, nil
+}
+
+func resolveDockerBuildArgs(buildArgs []osutil.ExpandableString, env *environment.Environment) ([]string, error) {
+	dockerBuildArgs := []string{}
+	for _, arg := range buildArgs {
+		buildArgValue, err := arg.Envsubst(env.Getenv)
+		if err != nil {
+			return nil, fmt.Errorf("substituting environment variables in build args: %w", err)
+		}
+
+		dockerBuildArgs = append(dockerBuildArgs, buildArgValue)
+	}
+
+	return resolveDockerParameters(dockerBuildArgs, env)
+}
+
+func resolveDockerParameters(source []string, env *environment.Environment) ([]string, error) {
+	result := make([]string, len(source))
+	for i, arg := range source {
+		evaluatedString, err := apphost.EvalString(arg, func(match string) (string, error) {
+			path := match
+			value, has := env.Config.GetString(path)
+			if !has {
+				return "", fmt.Errorf("parameter %s not found", path)
+			}
+			return value, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		result[i] = evaluatedString
+	}
+
+	return result, nil
 }
 
 func (ch *ContainerHelper) Package(
@@ -812,6 +817,24 @@ func (ch *ContainerHelper) runRemoteBuild(
 		return "", fmt.Errorf("remote build only supports the linux/amd64 platform")
 	}
 
+	resolvedBuildArgs, err := resolveDockerBuildArgs(dockerOptions.BuildArgs, env)
+	if err != nil {
+		return "", err
+	}
+
+	resolvedBuildEnv, err := resolveDockerParameters(dockerOptions.BuildEnv, env)
+	if err != nil {
+		return "", err
+	}
+
+	acrBuildArgs, err := dockerBuildArgsToAcrArguments(
+		resolvedBuildArgs,
+		dockerBuildArgEnvResolver(env, resolvedBuildEnv),
+	)
+	if err != nil {
+		return "", err
+	}
+
 	progress.SetProgress(NewServiceProgress("Packing remote build context"))
 
 	contextPath, dockerPath, err := containerregistry.PackRemoteBuildSource(ctx, dockerOptions.Context, dockerOptions.Path)
@@ -872,6 +895,9 @@ func (ch *ContainerHelper) runRemoteBuild(
 			Architecture: to.Ptr(armcontainerregistry.ArchitectureAmd64),
 		},
 	}
+	if len(acrBuildArgs) > 0 {
+		buildRequest.Arguments = acrBuildArgs
+	}
 
 	previewerWriter := ch.console.ShowPreviewer(ctx,
 		&input.ShowPreviewerOptions{
@@ -887,6 +913,75 @@ func (ch *ContainerHelper) runRemoteBuild(
 	}
 
 	return imageName, nil
+}
+
+func dockerBuildArgsToAcrArguments(
+	buildArgs []string,
+	lookupEnv func(string) (string, bool),
+) ([]*armcontainerregistry.Argument, error) {
+	if len(buildArgs) == 0 {
+		return nil, nil
+	}
+
+	acrArgs := make([]*armcontainerregistry.Argument, 0, len(buildArgs))
+	for i, arg := range buildArgs {
+		name, value, hasValue := strings.Cut(arg, "=")
+		if name == "" {
+			return nil, fmt.Errorf("docker build arg at index %d has an empty name", i)
+		}
+
+		if !hasValue {
+			var ok bool
+			value, ok = lookupEnv(name)
+			if !ok {
+				return nil, fmt.Errorf(
+					"resolving docker build arg %q for remote build: environment variable is not set; "+
+						"use %s=<value> or set %s",
+					name,
+					name,
+					name,
+				)
+			}
+		}
+
+		acrArgs = append(acrArgs, &armcontainerregistry.Argument{
+			Name:     new(name),
+			Value:    new(value),
+			IsSecret: new(false),
+		})
+	}
+
+	return acrArgs, nil
+}
+
+func dockerBuildArgEnvResolver(
+	env *environment.Environment,
+	buildEnv []string,
+) func(string) (string, bool) {
+	effectiveEnv := map[string]string{}
+	for _, envVar := range os.Environ() {
+		key, value, ok := strings.Cut(envVar, "=")
+		if ok {
+			effectiveEnv[key] = value
+		}
+	}
+	for _, envVar := range env.Environ() {
+		key, value, ok := strings.Cut(envVar, "=")
+		if ok {
+			effectiveEnv[key] = value
+		}
+	}
+	for _, envVar := range buildEnv {
+		key, value, ok := strings.Cut(envVar, "=")
+		if ok {
+			effectiveEnv[key] = value
+		}
+	}
+
+	return func(key string) (string, bool) {
+		value, ok := effectiveEnv[key]
+		return value, ok
+	}
 }
 
 // runDotnetPublish builds and publishes the container image using `dotnet publish`. It returns the full remote image name.

--- a/cli/azd/pkg/project/container_helper.go
+++ b/cli/azd/pkg/project/container_helper.go
@@ -361,7 +361,7 @@ func (ch *ContainerHelper) Build(
 		return nil, err
 	}
 
-	// resolve parameters for build args and secrets
+	// resolve parameters for build env
 	resolvedBuildEnv, err := resolveDockerParameters(dockerOptions.BuildEnv, env)
 	if err != nil {
 		return nil, err
@@ -497,7 +497,7 @@ func (ch *ContainerHelper) Build(
 }
 
 func resolveDockerBuildArgs(buildArgs []osutil.ExpandableString, env *environment.Environment) ([]string, error) {
-	dockerBuildArgs := []string{}
+	dockerBuildArgs := make([]string, 0, len(buildArgs))
 	for _, arg := range buildArgs {
 		buildArgValue, err := arg.Envsubst(env.Getenv)
 		if err != nil {
@@ -936,7 +936,7 @@ func dockerBuildArgsToAcrArguments(
 			if !ok {
 				return nil, fmt.Errorf(
 					"resolving docker build arg %q for remote build: environment variable is not set; "+
-						"use %s=<value> or set %s",
+						"use %s=<value> or set environment variable %s",
 					name,
 					name,
 					name,

--- a/cli/azd/pkg/project/container_helper_test.go
+++ b/cli/azd/pkg/project/container_helper_test.go
@@ -5,9 +5,13 @@ package project
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +21,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
+	"github.com/azure/azure-dev/cli/azd/pkg/containerregistry"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
@@ -378,6 +383,256 @@ func Test_ContainerHelper_RemoteImageTag_WithImageOverride(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_ResolveDockerBuildArgs(t *testing.T) {
+	env := environment.NewWithValues("dev", map[string]string{
+		"FROM_ENV": "env-value",
+	})
+	require.NoError(t, env.Config.Set("infra.parameters.param", "param-value"))
+
+	args, err := resolveDockerBuildArgs([]osutil.ExpandableString{
+		osutil.NewExpandableString("FROM_ENV=${FROM_ENV}"),
+		osutil.NewExpandableString("FROM_PARAM={infra.parameters.param}"),
+	}, env)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"FROM_ENV=env-value",
+		"FROM_PARAM=param-value",
+	}, args)
+}
+
+func Test_DockerBuildArgsToAcrArguments(t *testing.T) {
+	lookupEnv := func(key string) (string, bool) {
+		values := map[string]string{
+			"FROM_ENV": "env-value",
+		}
+		value, ok := values[key]
+		return value, ok
+	}
+
+	args, err := dockerBuildArgsToAcrArguments([]string{
+		"EXPLICIT=value",
+		"MULTI=a=b",
+		"FROM_ENV",
+	}, lookupEnv)
+
+	require.NoError(t, err)
+	require.Len(t, args, 3)
+	require.Equal(t, map[string]string{
+		"EXPLICIT": "value",
+		"MULTI":    "a=b",
+		"FROM_ENV": "env-value",
+	}, acrArgumentsToMap(t, args))
+	for _, arg := range args {
+		require.NotNil(t, arg.IsSecret)
+		require.False(t, *arg.IsSecret)
+	}
+}
+
+func Test_DockerBuildArgsToAcrArguments_MissingShorthandEnv(t *testing.T) {
+	_, err := dockerBuildArgsToAcrArguments([]string{"MISSING"}, func(string) (string, bool) {
+		return "", false
+	})
+
+	require.ErrorContains(t, err, `environment variable is not set`)
+	require.ErrorContains(t, err, `MISSING=<value>`)
+}
+
+func Test_DockerBuildArgsToAcrArguments_EmptyName(t *testing.T) {
+	_, err := dockerBuildArgsToAcrArguments([]string{"=value"}, func(string) (string, bool) {
+		return "", false
+	})
+
+	require.ErrorContains(t, err, "empty name")
+}
+
+func Test_DockerBuildArgEnvResolver(t *testing.T) {
+	t.Setenv("FROM_OS", "os-value")
+	t.Setenv("OVERRIDDEN", "os-value")
+
+	env := environment.NewWithValues("dev", map[string]string{
+		"FROM_ENV":   "env-value",
+		"OVERRIDDEN": "env-value",
+	})
+
+	lookup := dockerBuildArgEnvResolver(env, []string{
+		"FROM_BUILD_ENV=build-env-value",
+		"OVERRIDDEN=build-env-value",
+		"EMPTY=",
+	})
+
+	value, ok := lookup("FROM_OS")
+	require.True(t, ok)
+	require.Equal(t, "os-value", value)
+
+	value, ok = lookup("FROM_ENV")
+	require.True(t, ok)
+	require.Equal(t, "env-value", value)
+
+	value, ok = lookup("FROM_BUILD_ENV")
+	require.True(t, ok)
+	require.Equal(t, "build-env-value", value)
+
+	value, ok = lookup("OVERRIDDEN")
+	require.True(t, ok)
+	require.Equal(t, "build-env-value", value)
+
+	value, ok = lookup("EMPTY")
+	require.True(t, ok)
+	require.Equal(t, "", value)
+}
+
+func Test_ContainerHelper_RunRemoteBuild_PassesBuildArgs(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+	env := environment.NewWithValues("dev", map[string]string{
+		"FROM_ENV": "env-value",
+	})
+	require.NoError(t, env.Config.Set("infra.parameters.param", "param-value"))
+
+	var scheduleRunBody []byte
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.Contains(request.URL.Path, "listBuildSourceUploadUrl")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		uploadURL := "https://upload.example.com/container/source.tar.gz?sig=abc"
+		return mocks.CreateHttpResponseWithBody(
+			request, http.StatusOK, armcontainerregistry.SourceUploadDefinition{
+				UploadURL:    &uploadURL,
+				RelativePath: new("source.tar.gz"),
+			},
+		)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.Contains(request.URL.Path, "/container/source.tar.gz")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		_, _ = io.Copy(io.Discard, request.Body)
+		response, err := mocks.CreateEmptyHttpResponse(request, http.StatusCreated)
+		if err != nil {
+			return nil, err
+		}
+		response.Header.Set("ETag", `"0x8D4BCC2E4835CD0"`)
+		return response, nil
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.Contains(request.URL.Path, "scheduleRun")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		var err error
+		scheduleRunBody, err = io.ReadAll(request.Body)
+		require.NoError(t, err)
+
+		return mocks.CreateHttpResponseWithBody(
+			request, http.StatusBadRequest, map[string]any{
+				"error": map[string]string{
+					"code":    "BadRequest",
+					"message": "stop after capturing request",
+				},
+			},
+		)
+	})
+
+	mockContainerRegistryService := &mockContainerRegistryService{}
+	mockContainerRegistryService.On(
+		"FindContainerRegistryResourceGroup",
+		mock.Anything,
+		"SUBSCRIPTION_ID",
+		"contoso",
+	).Return("REGISTRY_RG", nil)
+
+	dockerCli := docker.NewCli(mockContext.CommandRunner)
+	dotnetCli := dotnet.NewCli(mockContext.CommandRunner)
+	containerHelper := NewContainerHelper(
+		clock.NewMock(),
+		mockContainerRegistryService,
+		containerregistry.NewRemoteBuildManager(mockContext.SubscriptionCredentialProvider, mockContext.ArmClientOptions),
+		mockContext.CommandRunner,
+		dockerCli,
+		dotnetCli,
+		mockContext.Console,
+		cloud.AzurePublic(),
+	)
+
+	projectRoot := t.TempDir()
+	servicePath := filepath.Join(projectRoot, "src", "api")
+	require.NoError(t, os.MkdirAll(servicePath, osutil.PermissionDirectory))
+	require.NoError(t, os.WriteFile(filepath.Join(servicePath, "Dockerfile"), []byte("FROM scratch"), 0600))
+
+	serviceConfig := createTestServiceConfig("./src/api", ContainerAppTarget, ServiceLanguageTypeScript)
+	serviceConfig.Project.Path = projectRoot
+	serviceConfig.Docker.Registry = osutil.NewExpandableString("contoso.azurecr.io")
+	serviceConfig.Docker.RemoteBuild = true
+	serviceConfig.Docker.BuildArgs = []osutil.ExpandableString{
+		osutil.NewExpandableString("EXPLICIT=value"),
+		osutil.NewExpandableString("MULTI=a=b"),
+		osutil.NewExpandableString("FROM_ENV"),
+		osutil.NewExpandableString("FROM_BUILD_ENV"),
+		osutil.NewExpandableString("FROM_PARAM={infra.parameters.param}"),
+	}
+	serviceConfig.Docker.BuildEnv = []string{
+		"FROM_BUILD_ENV=build-env-value",
+	}
+
+	targetResource := environment.NewTargetResource(
+		"SUBSCRIPTION_ID",
+		"RESOURCE_GROUP",
+		"CONTAINER_APP",
+		"Microsoft.App/containerApps",
+	)
+
+	_, err := logProgress(
+		t, func(progress *async.Progress[ServiceProgress]) (string, error) {
+			return containerHelper.runRemoteBuild(
+				*mockContext.Context, serviceConfig, targetResource, env, progress, &imageOverride{})
+		},
+	)
+
+	require.Error(t, err)
+	require.NotEmpty(t, scheduleRunBody)
+
+	var requestBody struct {
+		Arguments []struct {
+			Name     string `json:"name"`
+			Value    string `json:"value"`
+			IsSecret bool   `json:"isSecret"`
+		} `json:"arguments"`
+	}
+	require.NoError(t, json.Unmarshal(scheduleRunBody, &requestBody))
+	require.Equal(t, map[string]string{
+		"EXPLICIT":       "value",
+		"MULTI":          "a=b",
+		"FROM_ENV":       "env-value",
+		"FROM_BUILD_ENV": "build-env-value",
+		"FROM_PARAM":     "param-value",
+	}, acrRequestArgumentsToMap(requestBody.Arguments))
+	for _, arg := range requestBody.Arguments {
+		require.False(t, arg.IsSecret)
+	}
+}
+
+func acrArgumentsToMap(t *testing.T, args []*armcontainerregistry.Argument) map[string]string {
+	t.Helper()
+
+	result := map[string]string{}
+	for _, arg := range args {
+		require.NotNil(t, arg.Name)
+		require.NotNil(t, arg.Value)
+		result[*arg.Name] = *arg.Value
+	}
+
+	return result
+}
+
+func acrRequestArgumentsToMap(args []struct {
+	Name     string `json:"name"`
+	Value    string `json:"value"`
+	IsSecret bool   `json:"isSecret"`
+}) map[string]string {
+	result := map[string]string{}
+	for _, arg := range args {
+		result[arg.Name] = arg.Value
+	}
+
+	return result
 }
 
 func Test_ContainerHelper_Resolve_RegistryName(t *testing.T) {


### PR DESCRIPTION
Fixes #7990

## Summary

When a service was configured with `docker.remoteBuild: true`, any `buildArgs` (and `buildEnv`) declared in `azure.yaml` were silently dropped — `runRemoteBuild` constructed the ACR `DockerBuildRequest` without populating its `Arguments` field, so the remote build behaved as if no build args were ever set.

## Changes

- `runRemoteBuild` now resolves `dockerOptions.BuildArgs` and `dockerOptions.BuildEnv` using the same logic as the local Docker build path, then attaches the result to `DockerBuildRequest.Arguments` as `armcontainerregistry.Argument` values (`IsSecret: false`).
- Extracted the shared resolution logic into two helpers so local and remote build paths stay in sync:
  - `resolveDockerBuildArgs` — applies `Envsubst` then parameter resolution.
  - `resolveDockerParameters` — resolves `{infra.parameters.*}` placeholders via `apphost.EvalString`.
- Added `dockerBuildArgsToAcrArguments` to convert `NAME=value` strings to ACR `Argument`s. For shorthand `NAME` entries (no `=`), the value is looked up from a layered env source: `os.Environ` → `env.Environ()` → resolved `buildEnv` (later sources override earlier ones), matching how Docker resolves build args from the surrounding environment. Returns a clear error when a shorthand entry is unset.

## Validation

Tested deploying modified version of [hello-azd template](https://github.com/Azure-Samples/hello-azd) that alters appearance based on whether build args are passed, and confirmed with both `remoteBuild` set to `true` and `false`:

<img width="1215" height="657" alt="image" src="https://github.com/user-attachments/assets/5f6cd6d1-e36a-42b9-9931-de1e26304074" />
