### PR TITLE
azd down: warn before deleting resource groups not created by azd

### DIFF
--- a/cli/azd/pkg/azapi/resource_service.go
+++ b/cli/azd/pkg/azapi/resource_service.go
@@ -27,9 +27,10 @@ type Resource struct {
 }
 
 type ResourceGroup struct {
-	Id       string `json:"id"`
-	Name     string `json:"name"`
-	Location string `json:"location"`
+	Id       string            `json:"id"`
+	Name     string            `json:"name"`
+	Location string            `json:"location"`
+	Tags     map[string]string `json:"tags,omitempty"`
 }
 
 type ResourceExtended struct {
@@ -336,10 +337,21 @@ func (rs *ResourceService) GetResourceGroup(
 		return nil, fmt.Errorf("getting resource group %q in subscription %q: %w", resourceGroupName, subscriptionId, err)
 	}
 
+	var tags map[string]string
+	if len(resp.Tags) > 0 {
+		tags = make(map[string]string, len(resp.Tags))
+		for k, v := range resp.Tags {
+			if v != nil {
+				tags[k] = *v
+			}
+		}
+	}
+
 	return &ResourceGroup{
 		Id:       convert.ToValueWithDefault(resp.ID, ""),
 		Name:     convert.ToValueWithDefault(resp.Name, ""),
 		Location: convert.ToValueWithDefault(resp.Location, ""),
+		Tags:     tags,
 	}, nil
 }
 

--- a/cli/azd/pkg/azapi/resource_service_coverage3_test.go
+++ b/cli/azd/pkg/azapi/resource_service_coverage3_test.go
@@ -139,6 +139,53 @@ func Test_ResourceService_ListResourceGroupResources_Coverage3(t *testing.T) {
 	})
 }
 
+func Test_ResourceService_GetResourceGroup_Tags(t *testing.T) {
+	t.Run("WithTags", func(t *testing.T) {
+		mockCtx := mocks.NewMockContext(t.Context())
+		rs := NewResourceService(mockCtx.SubscriptionCredentialProvider, mockCtx.ArmClientOptions)
+		mockCtx.HttpClient.When(func(req *http.Request) bool {
+			return req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/resourcegroups/my-rg")
+		}).RespondFn(func(req *http.Request) (*http.Response, error) {
+			return mocks.CreateHttpResponseWithBody(req, http.StatusOK,
+				armresources.ResourceGroup{
+					ID:       new("/subscriptions/SUB/resourceGroups/my-rg"),
+					Name:     new("my-rg"),
+					Location: new("eastus"),
+					Tags: map[string]*string{
+						"azd-env-name": new("my-env"),
+						"other-tag":    new("value"),
+					},
+				})
+		})
+
+		rg, err := rs.GetResourceGroup(*mockCtx.Context, "SUB", "my-rg")
+		require.NoError(t, err)
+		assert.Equal(t, "my-rg", rg.Name)
+		assert.Equal(t, "my-env", rg.Tags["azd-env-name"])
+		assert.Equal(t, "value", rg.Tags["other-tag"])
+	})
+
+	t.Run("WithoutTags", func(t *testing.T) {
+		mockCtx := mocks.NewMockContext(t.Context())
+		rs := NewResourceService(mockCtx.SubscriptionCredentialProvider, mockCtx.ArmClientOptions)
+		mockCtx.HttpClient.When(func(req *http.Request) bool {
+			return req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/resourcegroups/no-tags")
+		}).RespondFn(func(req *http.Request) (*http.Response, error) {
+			return mocks.CreateHttpResponseWithBody(req, http.StatusOK,
+				armresources.ResourceGroup{
+					ID:       new("/subscriptions/SUB/resourceGroups/no-tags"),
+					Name:     new("no-tags"),
+					Location: new("eastus"),
+				})
+		})
+
+		rg, err := rs.GetResourceGroup(*mockCtx.Context, "SUB", "no-tags")
+		require.NoError(t, err)
+		assert.Equal(t, "no-tags", rg.Name)
+		assert.Nil(t, rg.Tags)
+	})
+}
+
 func Test_ResourceService_ListResourceGroup_Coverage3(t *testing.T) {
 	t.Run("WithTagFilter", func(t *testing.T) {
 		mockCtx := mocks.NewMockContext(t.Context())

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -41,6 +41,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/errorhandler"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -1156,9 +1157,38 @@ func (p *BicepProvider) Destroy(
 
 		p.console.StopSpinner(ctx, "", input.StepDone)
 
-		// Prompt for confirmation before deleting resources
-		if err := p.promptDeletion(ctx, options, groupedResources, len(resourcesToDelete)); err != nil {
-			return nil, err
+		// For resource-group-scoped deployments, check if the resource group was created by azd.
+		// If not, warn the user that deleting the RG will remove ALL resources, including those
+		// not deployed by azd.
+		if targetScope == azure.DeploymentScopeResourceGroup {
+			rgName := p.env.Getenv(environment.ResourceGroupEnvVarName)
+			// warnExternalResourceGroup returns (userAlreadyConfirmed, error).
+			// When true, user confirmed via the external-RG warning so we skip promptDeletion.
+			// When false with nil error, the RG is azd-owned and normal prompt applies.
+			userAlreadyConfirmed, err := p.warnExternalResourceGroup(
+				ctx, options, rgName, groupedResources, len(resourcesToDelete),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("checking resource group ownership: %w", err)
+			}
+
+			// If the external-RG warning was already confirmed, skip the regular
+			// deletion prompt to avoid double-prompting the user.
+			if !userAlreadyConfirmed {
+				// Prompt for confirmation before deleting resources
+				if err := p.promptDeletion(
+					ctx, options, groupedResources, len(resourcesToDelete),
+				); err != nil {
+					return nil, err
+				}
+			}
+		} else {
+			// Prompt for confirmation before deleting resources
+			if err := p.promptDeletion(
+				ctx, options, groupedResources, len(resourcesToDelete),
+			); err != nil {
+				return nil, err
+			}
 		}
 
 		p.console.Message(ctx, output.WithGrayFormat("Deleting your resources can take some time.\n"))
@@ -1368,6 +1398,85 @@ func (p *BicepProvider) promptDeletion(
 	}
 
 	return nil
+}
+
+// warnExternalResourceGroup checks if a resource group was created by azd (has azd-env-name tag
+// matching the current environment). If the RG was not created by azd, it warns the user and asks
+// for explicit confirmation before proceeding with deletion, since deleting the RG will remove ALL
+// resources inside it, including any that were not deployed by azd.
+//
+// Returns (userAlreadyConfirmed=true, nil) if the user confirmed deletion through this warning
+// or if --force is set — the caller should skip promptDeletion to avoid double-prompting.
+// Returns (false, nil) if no warning was needed (RG is azd-owned).
+// Returns (false, error) if the user denied or an error occurred.
+func (p *BicepProvider) warnExternalResourceGroup(
+	ctx context.Context,
+	options provisioning.DestroyOptions,
+	resourceGroupName string,
+	groupedResources map[string][]*azapi.Resource,
+	resourceCount int,
+) (bool, error) {
+	if options.Force() {
+		return true, nil
+	}
+
+	if resourceGroupName == "" {
+		return false, nil
+	}
+
+	rg, err := p.resourceService.GetResourceGroup(ctx, p.env.GetSubscriptionId(), resourceGroupName)
+	if err != nil {
+		// Fail closed: if we can't determine ownership, treat it as external and warn.
+		// This prevents accidental deletion when the API call fails transiently.
+		log.Printf(
+			"warnExternalResourceGroup: failed to get resource group %q, treating as external: %v",
+			resourceGroupName, err,
+		)
+	}
+
+	// If the RG has the azd-env-name tag matching the current environment, azd created it
+	if rg != nil {
+		if envTag, hasTag := rg.Tags[azure.TagKeyAzdEnvName]; hasTag && envTag == p.env.Name() {
+			return false, nil
+		}
+	}
+
+	p.console.MessageUxItem(ctx, &ux.WarningMessage{
+		Description: fmt.Sprintf(
+			"Resource group %s was not created by azd.",
+			output.WithHighLightFormat(resourceGroupName),
+		),
+	})
+	p.console.Message(ctx, fmt.Sprintf(
+		"  Deleting this resource group will remove %s inside it,\n"+
+			"  including any that were not deployed by azd.\n",
+		output.WithErrorFormat("ALL resources"),
+	))
+
+	p.console.MessageUxItem(ctx, &ux.MultilineMessage{
+		Lines: p.generateResourcesToDelete(ctx, groupedResources)},
+	)
+
+	confirmDelete, err := p.console.Confirm(ctx, input.ConsoleOptions{
+		Message: fmt.Sprintf(
+			"Do you still want to delete the entire resource group %s?",
+			output.WithHighLightFormat(resourceGroupName),
+		),
+		DefaultValue: false,
+	})
+	if err != nil {
+		return false, fmt.Errorf("prompting for resource group deletion: %w", err)
+	}
+
+	if !confirmDelete {
+		return false, &errorhandler.ErrorWithSuggestion{
+			Err:        errors.New("user denied delete confirmation"),
+			Message:    "Resource group was not deleted.",
+			Suggestion: "Re-run with --force to skip this check, or delete resources manually in the Azure Portal.",
+		}
+	}
+
+	return true, nil
 }
 
 // destroyDeployment deletes the azure resources within the deployment and voids the deployment state.

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -250,6 +250,144 @@ func TestBicepDestroyLogAnalyticsWorkspace(t *testing.T) {
 	})
 }
 
+func TestWarnExternalResourceGroup(t *testing.T) {
+	setupProvider := func(t *testing.T, mockContext *mocks.MockContext) *BicepProvider {
+		t.Helper()
+		env := environment.NewWithValues("test-env", map[string]string{
+			environment.SubscriptionIdEnvVarName: "SUBSCRIPTION_ID",
+		})
+		resourceService := azapi.NewResourceService(
+			mockContext.SubscriptionCredentialProvider, mockContext.ArmClientOptions,
+		)
+		return &BicepProvider{
+			env:             env,
+			console:         mockContext.Console,
+			resourceService: resourceService,
+		}
+	}
+
+	mockRGResponse := func(
+		mockContext *mocks.MockContext, rgName string, tags map[string]*string,
+	) {
+		mockContext.HttpClient.When(func(req *http.Request) bool {
+			return req.Method == http.MethodGet &&
+				strings.Contains(req.URL.Path, "/resourcegroups/"+rgName)
+		}).RespondFn(func(req *http.Request) (*http.Response, error) {
+			return mocks.CreateHttpResponseWithBody(req, http.StatusOK,
+				armresources.ResourceGroup{
+					ID:       new("/subscriptions/SUBSCRIPTION_ID/resourceGroups/" + rgName),
+					Name:     new(rgName),
+					Location: new("eastus"),
+					Tags:     tags,
+				})
+		})
+	}
+
+	t.Run("SkipsWhenForced", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(t.Context())
+		provider := setupProvider(t, mockContext)
+		options := provisioning.NewDestroyOptions(true, false)
+
+		confirmed, err := provider.warnExternalResourceGroup(
+			*mockContext.Context, options, "my-rg", nil, 0,
+		)
+		require.NoError(t, err)
+		assert.True(t, confirmed)
+	})
+
+	t.Run("NoWarningWhenRGHasMatchingTag", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(t.Context())
+		mockRGResponse(mockContext, "my-rg", map[string]*string{
+			"azd-env-name": new("test-env"),
+		})
+		provider := setupProvider(t, mockContext)
+		options := provisioning.NewDestroyOptions(false, false)
+
+		confirmed, err := provider.warnExternalResourceGroup(
+			*mockContext.Context, options, "my-rg", nil, 0,
+		)
+		require.NoError(t, err)
+		assert.False(t, confirmed)
+	})
+
+	t.Run("WarnsWhenRGHasMismatchedTag", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(t.Context())
+		mockRGResponse(mockContext, "my-rg", map[string]*string{
+			"azd-env-name": new("other-env"),
+		})
+		provider := setupProvider(t, mockContext)
+		options := provisioning.NewDestroyOptions(false, false)
+
+		mockContext.Console.WhenConfirm(func(options input.ConsoleOptions) bool {
+			return true
+		}).Respond(false)
+
+		_, err := provider.warnExternalResourceGroup(
+			*mockContext.Context, options, "my-rg", nil, 0,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "user denied delete confirmation")
+	})
+
+	t.Run("WarnsAndDeniesWhenRGHasNoTag", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(t.Context())
+		mockRGResponse(mockContext, "my-rg", nil)
+		provider := setupProvider(t, mockContext)
+		options := provisioning.NewDestroyOptions(false, false)
+
+		mockContext.Console.WhenConfirm(func(options input.ConsoleOptions) bool {
+			// Verify DefaultValue is false — this is what --no-prompt uses to deny by default
+			assert.False(t, options.DefaultValue.(bool))
+			return true
+		}).Respond(false)
+
+		_, err := provider.warnExternalResourceGroup(
+			*mockContext.Context, options, "my-rg", nil, 0,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "user denied delete confirmation")
+	})
+
+	t.Run("ProceedsWhenUserConfirms", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(t.Context())
+		mockRGResponse(mockContext, "my-rg", nil)
+		provider := setupProvider(t, mockContext)
+		options := provisioning.NewDestroyOptions(false, false)
+
+		mockContext.Console.WhenConfirm(func(options input.ConsoleOptions) bool {
+			return true
+		}).Respond(true)
+
+		confirmed, err := provider.warnExternalResourceGroup(
+			*mockContext.Context, options, "my-rg", nil, 0,
+		)
+		require.NoError(t, err)
+		assert.True(t, confirmed)
+	})
+
+	t.Run("FailsClosedWhenGetRGErrors", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(t.Context())
+		mockContext.HttpClient.When(func(req *http.Request) bool {
+			return req.Method == http.MethodGet &&
+				strings.Contains(req.URL.Path, "/resourcegroups/my-rg")
+		}).RespondFn(func(req *http.Request) (*http.Response, error) {
+			return mocks.CreateEmptyHttpResponse(req, http.StatusInternalServerError)
+		})
+		provider := setupProvider(t, mockContext)
+		options := provisioning.NewDestroyOptions(false, false)
+
+		mockContext.Console.WhenConfirm(func(options input.ConsoleOptions) bool {
+			return true
+		}).Respond(false)
+
+		_, err := provider.warnExternalResourceGroup(
+			*mockContext.Context, options, "my-rg", nil, 0,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "user denied delete confirmation")
+	})
+}
+
 func TestDeploymentForResourceGroup(t *testing.T) {
 	mockContext := mocks.NewMockContext(t.Context())
 


### PR DESCRIPTION
Fixes #4785

`azd down` with RG-scoped deployments deletes the entire resource group even if azd didn't create it. This adds a tag check before deletion.

Checks the `azd-env-name` tag on the RG. If missing or mismatched, warns the user and asks for confirmation before proceeding.

- Matching tag: no extra prompt
- Missing/mismatched tag: warning + confirm
- --force: skips warning
- --no-prompt: defaults to deny

Unit tests added for the warning flow (force skip, matching tag, mismatched tag, no-tag denial, user confirms, API error fail-closed).

### Testing

**RG without azd-env-name tag (warns + user says No):**
```
$ /tmp/azd-local down

Deleting all resources and deployed code on Azure (azd down)
Local application code is not deleted when running 'azd down'.

  WARNING: Resource group rg-scope-test-existing was not created by azd.
  Deleting this resource group will remove ALL resources inside it,
  including any that were not deployed by azd.

  Resource(s) to be deleted:

  Resource Group: rg-scope-test-existing
    • Storage account: strgtest2ak6x4tiv2omg

? Do you still want to delete the entire resource group rg-scope-test-existing? No

ERROR: Resource group was not deleted.

Suggestion: Re-run with --force to skip this check, or delete resources manually in the Azure Portal.

user denied delete confirmation
```

**RG without azd-env-name tag (warns + user says Yes):**
```
$ /tmp/azd-local down

Deleting all resources and deployed code on Azure (azd down)
Local application code is not deleted when running 'azd down'.

  WARNING: Resource group rg-scope-test-existing was not created by azd.
  Deleting this resource group will remove ALL resources inside it,
  including any that were not deployed by azd.

  Resource(s) to be deleted:

  Resource Group: rg-scope-test-existing
    • Storage account: strgtest2ak6x4tiv2omg

? Do you still want to delete the entire resource group rg-scope-test-existing? Yes
Deleting your resources can take some time.

  (✓) Done: Deleted resource group rg-scope-test-existing

SUCCESS: Your application was removed from Azure in 1 minute 11 seconds.
```

**RG with azd-env-name tag (no warning, normal flow):**
```
$ /tmp/azd-local down

Deleting all resources and deployed code on Azure (azd down)
Local application code is not deleted when running 'azd down'.

  Resource(s) to be deleted:

  Resource Group: rg-scope-test-existing
    • Storage account: strgtest2ak6x4tiv2omg

? Total resources to delete: 2, are you sure you want to continue? Yes
Deleting your resources can take some time.

  (✓) Done: Deleted resource group rg-scope-test-existing

SUCCESS: Your application was removed from Azure in 1 minute 8 seconds.
```

Note: does not support deleting individual resources while keeping the RG. Consistent with sub-scoped deployments.