### PR TITLE
Implement download command for training job

### DIFF
--- a/cli/azd/extensions/azure.ai.customtraining/internal/azcopy/runner.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/azcopy/runner.go
@@ -86,7 +86,28 @@ func (r *Runner) Path() string {
 
 // Copy runs azcopy copy from source to sasURI with real-time progress display.
 // Source can be a local file/directory path or a remote URL (e.g., blob URL with SAS token).
+//
+// Use this when the source is a single blob, a single local file, or when you
+// want azcopy's default folder-preserving behavior. For remote folders/containers
+// where you want the *contents* extracted directly into the destination (no
+// container-name directory wrapping), use CopyContents instead.
 func (r *Runner) Copy(ctx context.Context, source string, sasURI string) error {
+	return r.copy(ctx, source, sasURI, false /*forceContents*/)
+}
+
+// CopyContents runs azcopy copy from a remote folder/container source to sasURI,
+// rewriting the source URL so azcopy copies the *contents* rather than the
+// folder itself. Use this for blob containers (URLs of shape
+// https://account.blob.core.windows.net/<container>?<sas>) so the destination
+// doesn't end up nested under a container-name directory.
+//
+// For local sources or single-blob URLs, use Copy instead.
+func (r *Runner) CopyContents(ctx context.Context, source string, sasURI string) error {
+	return r.copy(ctx, source, sasURI, true /*forceContents*/)
+}
+
+// copy is the shared implementation behind Copy and CopyContents.
+func (r *Runner) copy(ctx context.Context, source, sasURI string, forceContents bool) error {
 	sourceArg := source
 
 	// Only do local path handling for non-URL sources
@@ -98,6 +119,11 @@ func (r *Runner) Copy(ctx context.Context, source string, sasURI string) error {
 		if info.IsDir() {
 			sourceArg = filepath.Join(source, "*")
 		}
+	} else if forceContents {
+		// Caller explicitly asked for contents-of-folder semantics: ensure the
+		// path has a wildcard so azcopy doesn't preserve the container name as
+		// a directory under the destination.
+		sourceArg = forceWildcardRemoteSource(source)
 	} else {
 		// For remote URLs ending with "/" (directory-like), append "*" before the query
 		// string so azcopy copies the contents rather than the folder itself.
@@ -292,6 +318,32 @@ func normalizeRemoteSourceURL(source string) string {
 	if strings.HasSuffix(path, "/") {
 		path += "*"
 	}
+
+	if len(parts) == 2 {
+		return path + "?" + parts[1]
+	}
+	return path
+}
+
+// forceWildcardRemoteSource rewrites a remote source URL to ensure azcopy
+// copies the *contents* of the referenced container/folder rather than
+// preserving the folder/container name as a directory under the destination.
+//
+// Behavior:
+//   - If the URL already contains a wildcard ("/*"), return as-is.
+//   - Otherwise, ensure the path ends with "/*" before any query string.
+//
+// Example:
+//
+//	in:  https://acct.blob.core.windows.net/container?sig=abc
+//	out: https://acct.blob.core.windows.net/container/*?sig=abc
+func forceWildcardRemoteSource(source string) string {
+	if strings.Contains(source, "/*") {
+		return source
+	}
+
+	parts := strings.SplitN(source, "?", 2)
+	path := strings.TrimSuffix(parts[0], "/") + "/*"
 
 	if len(parts) == 2 {
 		return path + "?" + parts[1]

--- a/cli/azd/extensions/azure.ai.customtraining/internal/azcopy/runner.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/azcopy/runner.go
@@ -15,6 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"azure.ai.customtraining/internal/utils"
 )
 
 // Runner manages azcopy execution.
@@ -220,30 +222,11 @@ func printProgress(transferred, total int64, percent float64, startTime time.Tim
 		etaStr = "calculating..."
 	}
 
-	transferredStr := formatBytes(transferred)
-	totalStr := formatBytes(total)
+	transferredStr := utils.FormatBytes(transferred)
+	totalStr := utils.FormatBytes(total)
 
 	fmt.Fprintf(os.Stdout, "\r  %s %.1f%% (%s / %s) | %s | Elapsed: %s | ETA: %s   ",
 		bar, percent, transferredStr, totalStr, speedStr, formatDuration(elapsed), etaStr)
-}
-
-func formatBytes(b int64) string {
-	const (
-		KB = 1024
-		MB = KB * 1024
-		GB = MB * 1024
-	)
-
-	switch {
-	case b >= GB:
-		return fmt.Sprintf("%.1f GB", float64(b)/float64(GB))
-	case b >= MB:
-		return fmt.Sprintf("%.1f MB", float64(b)/float64(MB))
-	case b >= KB:
-		return fmt.Sprintf("%.1f KB", float64(b)/float64(KB))
-	default:
-		return fmt.Sprintf("%d B", b)
-	}
 }
 
 func formatDuration(d time.Duration) string {

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job.go
@@ -38,6 +38,7 @@ func newJobCommand() *cobra.Command {
 	cmd.AddCommand(newJobStreamCommand())
 	cmd.AddCommand(newJobConnectSSHCommand())
 	cmd.AddCommand(newJobSSHProxyCommand())
+	cmd.AddCommand(newJobDownloadCommand())
 
 	return cmd
 }

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
@@ -1,0 +1,505 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"azure.ai.customtraining/internal/azcopy"
+	"azure.ai.customtraining/internal/download"
+	"azure.ai.customtraining/internal/utils"
+	"azure.ai.customtraining/pkg/client"
+	"azure.ai.customtraining/pkg/models"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/spf13/cobra"
+)
+
+// terminalStatuses lists the job statuses where downloads are permitted.
+var terminalStatuses = []string{"Completed", "Failed", "Canceled", "NotResponding", "Paused"}
+
+// defaultOutputName is the sentinel value treated identically to "no output-name flag".
+const defaultOutputName = "default"
+
+func newJobDownloadCommand() *cobra.Command {
+	var (
+		name         string
+		all          bool
+		downloadPath string
+		outputName   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "download",
+		Short: "Download outputs and/or artifacts from a training job",
+		Long: "Download outputs and artifacts of a training job.\n\n" +
+			"Without flags, downloads the job's default artifacts (logs and run files).\n" +
+			"With --output-name, downloads a single named output.\n" +
+			"With --all, downloads every named output plus the default artifacts.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := azdext.WithAccessToken(cmd.Context())
+
+			if name == "" {
+				return fmt.Errorf("--name (-n) is required")
+			}
+
+			// Resolve destination root
+			destRoot := downloadPath
+			if destRoot == "" {
+				cwd, err := os.Getwd()
+				if err != nil {
+					return fmt.Errorf("failed to resolve current directory: %w", err)
+				}
+				destRoot = cwd
+			}
+			if err := os.MkdirAll(destRoot, 0o755); err != nil {
+				return fmt.Errorf("failed to create download path: %w", err)
+			}
+
+			apiClient, err := newDownloadClient(ctx)
+			if err != nil {
+				return err
+			}
+			apiClient.SetDebugBody(rootFlags.Debug)
+
+			// Step 1 — GET job, check status
+			job, err := apiClient.GetJob(ctx, name)
+			if err != nil {
+				return fmt.Errorf("failed to get job: %w", err)
+			}
+			status := job.Properties.Status
+			if !isTerminalStatus(status) {
+				return fmt.Errorf(
+					"This job is in state %s. Download is allowed only in states %v",
+					status, terminalStatuses,
+				)
+			}
+
+			// Determine mode
+			wantNamed := outputName != "" && outputName != defaultOutputName
+			wantAll := all
+			wantDefault := !wantAll && !wantNamed // covers no flags and output-name=default
+
+			azRunner, err := azcopy.NewRunner(ctx, "")
+			if err != nil {
+				return fmt.Errorf("failed to initialize azcopy: %w", err)
+			}
+
+			// Single named output path
+			if wantNamed {
+				output, ok := job.Properties.Outputs[outputName]
+				if !ok {
+					return fmt.Errorf(
+						"no output named %q on job %q. Available outputs: %v",
+						outputName, name, listOutputNames(job.Properties.Outputs),
+					)
+				}
+				dest := filepath.Join(destRoot, "named-outputs", outputName)
+				if err := os.MkdirAll(dest, 0o755); err != nil {
+					return fmt.Errorf("failed to create output dir: %w", err)
+				}
+				return downloadNamedOutput(ctx, apiClient, azRunner, outputName, &output, dest)
+			}
+
+			// --all path: every named output (skip "default") + default artifacts
+			if wantAll {
+				for outName, out := range job.Properties.Outputs {
+					if outName == defaultOutputName {
+						continue
+					}
+					out := out
+					dest := filepath.Join(destRoot, "named-outputs", outName)
+					if err := os.MkdirAll(dest, 0o755); err != nil {
+						return fmt.Errorf("failed to create output dir: %w", err)
+					}
+					if err := downloadNamedOutput(ctx, apiClient, azRunner, outName, &out, dest); err != nil {
+						return err
+					}
+				}
+				// Fall through to default artifacts
+			}
+
+			// Default artifacts path (no flags, output-name=default, or --all tail)
+			if wantDefault || wantAll {
+				artifactsDest := filepath.Join(destRoot, "artifacts")
+				if err := os.MkdirAll(artifactsDest, 0o755); err != nil {
+					return fmt.Errorf("failed to create artifacts dir: %w", err)
+				}
+				if err := downloadDefaultArtifacts(ctx, apiClient, job, name, artifactsDest); err != nil {
+					return err
+				}
+			}
+
+			fmt.Printf("\n✓ Download complete: %s\n", destRoot)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&name, "name", "n", "", "Job name (required)")
+	cmd.Flags().BoolVar(&all, "all", false, "Download all named outputs and default artifacts")
+	cmd.Flags().StringVarP(&downloadPath, "download-path", "p", "",
+		"Path to download files to (defaults to the current directory)")
+	cmd.Flags().StringVar(&outputName, "output-name", "",
+		"Name of the user-defined output to download. If omitted (or set to \"default\"), the default artifacts are downloaded")
+
+	cmd.MarkFlagsMutuallyExclusive("all", "output-name")
+
+	return cmd
+}
+
+// newDownloadClient builds an authenticated foundry client from the current azd environment.
+func newDownloadClient(ctx context.Context) (*client.Client, error) {
+	azdClient, err := azdext.NewAzdClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create azd client: %w", err)
+	}
+	defer azdClient.Close()
+
+	envValues, err := utils.GetEnvironmentValues(ctx, azdClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get environment values: %w", err)
+	}
+
+	accountName := envValues[utils.EnvAzureAccountName]
+	projectName := envValues[utils.EnvAzureProjectName]
+	tenantID := envValues[utils.EnvAzureTenantID]
+
+	if accountName == "" || projectName == "" {
+		return nil, fmt.Errorf("environment not configured. Run 'azd ai training init' first")
+	}
+
+	credential, err := azidentity.NewAzureDeveloperCLICredential(
+		&azidentity.AzureDeveloperCLICredentialOptions{
+			TenantID:                   tenantID,
+			AdditionallyAllowedTenants: []string{"*"},
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create azure credential: %w", err)
+	}
+
+	endpoint := buildProjectEndpoint(accountName, projectName)
+	apiClient, err := client.NewClient(endpoint, credential)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create API client: %w", err)
+	}
+	return apiClient, nil
+}
+
+// downloadNamedOutput downloads a single named output (model or data asset) to dest.
+func downloadNamedOutput(
+	ctx context.Context,
+	apiClient *client.Client,
+	azRunner *azcopy.Runner,
+	outputName string,
+	output *models.JobOutput,
+	dest string,
+) error {
+	if output.AssetName == "" || output.AssetVersion == "" {
+		return fmt.Errorf(
+			"output %q is missing assetName/assetVersion; cannot download (jobOutputType=%q)",
+			outputName, output.JobOutputType,
+		)
+	}
+
+	switch output.JobOutputType {
+	case "safetensors_model":
+		return downloadModelAsset(ctx, apiClient, azRunner, outputName, output.AssetName, output.AssetVersion, dest)
+	case "uri_file", "uri_folder":
+		return downloadDataAsset(ctx, apiClient, azRunner, outputName, output.AssetName, output.AssetVersion, dest)
+	default:
+		return fmt.Errorf(
+			"output %q has unsupported jobOutputType %q (supported: safetensors_model, uri_file, uri_folder)",
+			outputName, output.JobOutputType,
+		)
+	}
+}
+
+// downloadModelAsset resolves the SAS URI for a model and copies its container to dest via azcopy.
+func downloadModelAsset(
+	ctx context.Context,
+	apiClient *client.Client,
+	azRunner *azcopy.Runner,
+	outputName, assetName, assetVersion, dest string,
+) error {
+	fmt.Printf("  %s: resolving model %s/v%s...\n", outputName, assetName, assetVersion)
+
+	var modelVer *models.ModelVersion
+	if err := download.WithRetry(ctx, func() (int, error) {
+		mv, err := apiClient.GetModelVersion(ctx, assetName, assetVersion)
+		if err != nil {
+			return 0, err
+		}
+		modelVer = mv
+		return 200, nil
+	}); err != nil {
+		return fmt.Errorf("failed to get model version: %w", err)
+	}
+	if modelVer.BlobURI == "" {
+		return fmt.Errorf("model %s/v%s response missing blobUri", assetName, assetVersion)
+	}
+
+	var creds *models.CredentialsResponse
+	if err := download.WithRetry(ctx, func() (int, error) {
+		c, err := apiClient.GetModelCredentials(ctx, assetName, assetVersion, modelVer.BlobURI)
+		if err != nil {
+			return 0, err
+		}
+		creds = c
+		return 200, nil
+	}); err != nil {
+		return fmt.Errorf("failed to fetch model credentials: %w", err)
+	}
+
+	sasURI := extractSasURI(creds)
+	if sasURI == "" {
+		return fmt.Errorf("model %s/v%s credentials response missing blobReference.credential.sasUri",
+			assetName, assetVersion)
+	}
+
+	fmt.Printf("  %s: downloading model contents...\n", outputName)
+	if err := azRunner.Copy(ctx, sasURI, dest); err != nil {
+		return fmt.Errorf("azcopy failed for output %q: %w", outputName, err)
+	}
+	return nil
+}
+
+// downloadDataAsset resolves the SAS URI for a data asset and copies the container to dest.
+func downloadDataAsset(
+	ctx context.Context,
+	apiClient *client.Client,
+	azRunner *azcopy.Runner,
+	outputName, assetName, assetVersion, dest string,
+) error {
+	fmt.Printf("  %s: resolving data asset %s/v%s...\n", outputName, assetName, assetVersion)
+
+	var creds *models.CredentialsResponse
+	if err := download.WithRetry(ctx, func() (int, error) {
+		c, err := apiClient.GetDatasetCredentials(ctx, assetName, assetVersion)
+		if err != nil {
+			return 0, err
+		}
+		creds = c
+		return 200, nil
+	}); err != nil {
+		return fmt.Errorf("failed to fetch dataset credentials: %w", err)
+	}
+
+	sasURI := extractSasURI(creds)
+	if sasURI == "" {
+		return fmt.Errorf("dataset %s/v%s credentials response missing blobReference.credential.sasUri",
+			assetName, assetVersion)
+	}
+
+	fmt.Printf("  %s: downloading data contents...\n", outputName)
+	if err := azRunner.Copy(ctx, sasURI, dest); err != nil {
+		return fmt.Errorf("azcopy failed for output %q: %w", outputName, err)
+	}
+	return nil
+}
+
+// downloadDefaultArtifacts pulls the run history (for experimentId), pages the artifacts list,
+// fetches contentinfo for each in parallel, then downloads each contentUri in parallel.
+func downloadDefaultArtifacts(
+	ctx context.Context,
+	apiClient *client.Client,
+	job *models.JobResource,
+	jobName, dest string,
+) error {
+	trackingEndpoint, err := extractTrackingEndpoint(job)
+	if err != nil {
+		return err
+	}
+
+	var history *models.RunHistory
+	if err := download.WithRetry(ctx, func() (int, error) {
+		h, err := apiClient.GetRunHistory(ctx, jobName)
+		if err != nil {
+			return 0, err
+		}
+		history = h
+		return 200, nil
+	}); err != nil {
+		return fmt.Errorf("failed to get run history: %w", err)
+	}
+	if history == nil || history.ExperimentID == "" {
+		return fmt.Errorf("run history response missing experimentId for job %q", jobName)
+	}
+	experimentID := history.ExperimentID
+
+	fmt.Printf("  artifacts: listing for experiment %s...\n", experimentID)
+	var artifacts []models.RunArtifact
+	token := ""
+	for {
+		var page *models.RunArtifactList
+		tok := token
+		if err := download.WithRetry(ctx, func() (int, error) {
+			p, err := apiClient.ListRunArtifacts(ctx, trackingEndpoint, experimentID, jobName, tok)
+			if err != nil {
+				return 0, err
+			}
+			page = p
+			return 200, nil
+		}); err != nil {
+			return fmt.Errorf("failed to list run artifacts: %w", err)
+		}
+		artifacts = append(artifacts, page.Value...)
+		if page.ContinuationToken == "" {
+			break
+		}
+		token = page.ContinuationToken
+	}
+
+	if len(artifacts) == 0 {
+		fmt.Println("  artifacts: none found")
+		return nil
+	}
+
+	fmt.Printf("  artifacts: fetching content info for %d artifact(s)...\n", len(artifacts))
+
+	const parallelism = 8
+	infos, err := fetchContentInfosParallel(ctx, apiClient, trackingEndpoint, experimentID, jobName, artifacts, parallelism)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("  artifacts: downloading %d artifact(s) to %s...\n", len(infos), dest)
+	results := download.DownloadArtifacts(ctx, infos, dest, parallelism)
+
+	var failed int
+	var totalBytes int64
+	for _, r := range results {
+		if r.Err != nil {
+			failed++
+			fmt.Fprintf(os.Stderr, "    FAILED: %s — %v\n", r.Path, r.Err)
+			continue
+		}
+		totalBytes += r.Bytes
+	}
+	fmt.Printf("  artifacts: %d/%d succeeded (%s)\n",
+		len(results)-failed, len(results), formatBytes(totalBytes))
+	if failed > 0 {
+		return fmt.Errorf("%d artifact(s) failed to download", failed)
+	}
+	return nil
+}
+
+// fetchContentInfosParallel calls GetRunArtifactContentInfo for each artifact path concurrently.
+func fetchContentInfosParallel(
+	ctx context.Context,
+	apiClient *client.Client,
+	trackingEndpoint, experimentID, runID string,
+	artifacts []models.RunArtifact,
+	parallelism int,
+) ([]*models.RunArtifactContentInfo, error) {
+	infos := make([]*models.RunArtifactContentInfo, len(artifacts))
+	errs := make([]error, len(artifacts))
+
+	sem := make(chan struct{}, parallelism)
+	done := make(chan int, len(artifacts))
+
+	for i, a := range artifacts {
+		i, a := i, a
+		sem <- struct{}{}
+		go func() {
+			defer func() { <-sem; done <- i }()
+			err := download.WithRetry(ctx, func() (int, error) {
+				info, err := apiClient.GetRunArtifactContentInfo(ctx, trackingEndpoint, experimentID, runID, a.Path)
+				if err != nil {
+					return 0, err
+				}
+				infos[i] = info
+				return 200, nil
+			})
+			if err != nil {
+				errs[i] = fmt.Errorf("contentinfo for %s: %w", a.Path, err)
+			}
+		}()
+	}
+	for range artifacts {
+		<-done
+	}
+	for _, e := range errs {
+		if e != nil {
+			return nil, e
+		}
+	}
+	return infos, nil
+}
+
+// extractTrackingEndpoint pulls properties.services.Tracking.endpoint from the job response.
+func extractTrackingEndpoint(job *models.JobResource) (string, error) {
+	if job == nil {
+		return "", fmt.Errorf("job is nil")
+	}
+	tracking, ok := job.Properties.Services["Tracking"]
+	if !ok {
+		return "", fmt.Errorf("job missing properties.services.Tracking; cannot resolve artifacts endpoint")
+	}
+	tmap, ok := tracking.(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("properties.services.Tracking has unexpected shape")
+	}
+	endpoint, ok := tmap["endpoint"].(string)
+	if !ok || endpoint == "" {
+		return "", fmt.Errorf("properties.services.Tracking.endpoint missing or not a string")
+	}
+	return endpoint, nil
+}
+
+// extractSasURI returns the sasUri from a credentials response, or "" if missing.
+func extractSasURI(creds *models.CredentialsResponse) string {
+	if creds == nil || creds.BlobReference == nil {
+		return ""
+	}
+	return creds.BlobReference.Credential.SASUri
+}
+
+// isTerminalStatus reports whether the job state allows downloads.
+func isTerminalStatus(status string) bool {
+	for _, s := range terminalStatuses {
+		if s == status {
+			return true
+		}
+	}
+	return false
+}
+
+// listOutputNames returns the sorted user-defined output names (excluding "default") for error messages.
+func listOutputNames(outputs map[string]models.JobOutput) []string {
+	var names []string
+	for k := range outputs {
+		if k == defaultOutputName {
+			continue
+		}
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// formatBytes returns a human-readable byte size.
+func formatBytes(b int64) string {
+	const (
+		kb = 1024
+		mb = kb * 1024
+		gb = mb * 1024
+	)
+	switch {
+	case b >= gb:
+		return fmt.Sprintf("%.1f GB", float64(b)/float64(gb))
+	case b >= mb:
+		return fmt.Sprintf("%.1f MB", float64(b)/float64(mb))
+	case b >= kb:
+		return fmt.Sprintf("%.1f KB", float64(b)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
@@ -50,14 +50,19 @@ func newJobDownloadCommand() *cobra.Command {
 				return fmt.Errorf("--name (-n) is required")
 			}
 
-			// Resolve destination root
+			// Resolve destination root.
+			//   --download-path / -p provided → used verbatim, exactly as the
+			//     user specified (we don't append the job name; the user is in
+			//     control of the directory layout).
+			//   --download-path / -p omitted   → default to ./<job-name>/ so
+			//     repeated downloads of different jobs don't collide in cwd.
 			destRoot := downloadPath
 			if destRoot == "" {
 				cwd, err := os.Getwd()
 				if err != nil {
 					return fmt.Errorf("failed to resolve current directory: %w", err)
 				}
-				destRoot = cwd
+				destRoot = filepath.Join(cwd, name)
 			}
 			if err := os.MkdirAll(destRoot, 0o755); err != nil {
 				return fmt.Errorf("failed to create download path: %w", err)
@@ -145,7 +150,7 @@ func newJobDownloadCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Job name (required)")
 	cmd.Flags().BoolVar(&all, "all", false, "Download all named outputs and default artifacts")
 	cmd.Flags().StringVarP(&downloadPath, "download-path", "p", "",
-		"Path to download files to (defaults to the current directory)")
+		"Path to download files to (used as-is when provided; defaults to ./<job-name>/ in the current directory)")
 	cmd.Flags().StringVar(&outputName, "output-name", "",
 		"Name of the user-defined output to download. If omitted (or set to \"default\"), the default artifacts are downloaded")
 

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
@@ -359,7 +359,7 @@ func downloadDefaultArtifacts(
 			page = p
 			return 200, nil
 		}); err != nil {
-			return fmt.Errorf("failed to list run artifacts: %w", err)
+			return fmt.Errorf("could not list artifacts for job %q: %w", jobName, err)
 		}
 		if page == nil {
 			break

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
@@ -385,6 +385,9 @@ func downloadDefaultArtifacts(
 	}
 
 	fmt.Printf("  artifacts: downloading %d artifact(s) to %s...\n", len(infos), dest)
+	// Sweep any leftover .tmp files from a previously interrupted run so
+	// users don't see stale scratch files alongside their downloads.
+	download.SweepTempFiles(dest)
 	results := download.DownloadArtifacts(ctx, infos, dest, parallelism)
 
 	var failed int

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
@@ -272,7 +272,7 @@ func downloadModelAsset(
 	}
 
 	fmt.Printf("  %s: downloading model contents...\n", outputName)
-	if err := azRunner.Copy(ctx, sasURI, dest); err != nil {
+	if err := azRunner.CopyContents(ctx, sasURI, dest); err != nil {
 		return fmt.Errorf("azcopy failed for output %q: %w", outputName, err)
 	}
 	return nil
@@ -306,7 +306,7 @@ func downloadDataAsset(
 	}
 
 	fmt.Printf("  %s: downloading data contents...\n", outputName)
-	if err := azRunner.Copy(ctx, sasURI, dest); err != nil {
+	if err := azRunner.CopyContents(ctx, sasURI, dest); err != nil {
 		return fmt.Errorf("azcopy failed for output %q: %w", outputName, err)
 	}
 	return nil

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
@@ -334,10 +334,10 @@ func downloadDefaultArtifacts(
 		history = h
 		return 200, nil
 	}); err != nil {
-		return fmt.Errorf("failed to get run history: %w", err)
+		return fmt.Errorf("could not retrieve run metadata for job %q, please retry: %w", jobName, err)
 	}
-	if history == nil || history.ExperimentID == "" {
-		return fmt.Errorf("run history response missing experimentId for job %q", jobName)
+	if history == nil {
+		return fmt.Errorf("run metadata not found for job %q", jobName)
 	}
 	experimentID := history.ExperimentID
 

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
@@ -88,9 +88,7 @@ func newJobDownloadCommand() *cobra.Command {
 			}
 
 			// Determine mode
-			wantNamed := outputName != "" && outputName != defaultOutputName
-			wantAll := all
-			wantDefault := !wantAll && !wantNamed // covers no flags and output-name=default
+			wantNamed, wantAll, wantDefault := selectDownloadMode(outputName, all)
 
 			azRunner, err := azcopy.NewRunner(ctx, "")
 			if err != nil {
@@ -437,6 +435,23 @@ func fetchContentInfosParallel(
 		}
 	}
 	return infos, nil
+}
+
+// selectDownloadMode resolves the three mutually-related download modes
+// from the user-provided flags. Cobra already enforces that --all and
+// --output-name are mutually exclusive, so this function only encodes the
+// downstream rules:
+//
+//   - --output-name=<name> (anything other than "default")    → named only
+//   - --all                                                   → every named output + default
+//   - no flags / --output-name=default / --output-name=""     → default artifacts only
+//
+// Returns (wantNamed, wantAll, wantDefault).
+func selectDownloadMode(outputName string, all bool) (bool, bool, bool) {
+	wantNamed := outputName != "" && outputName != defaultOutputName
+	wantAll := all
+	wantDefault := !wantAll && !wantNamed
+	return wantNamed, wantAll, wantDefault
 }
 
 // extractTrackingEndpoint pulls properties.services.Tracking.endpoint from the job response.

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
@@ -50,6 +50,12 @@ func newJobDownloadCommand() *cobra.Command {
 			if name == "" {
 				return fmt.Errorf("--name (-n) is required")
 			}
+			if all && outputName != "" {
+				return fmt.Errorf(
+					"--all and --output-name cannot be used together. " +
+						"Use --all to download every named output plus default artifacts, " +
+						"or --output-name <name> to download a single output")
+			}
 
 			// Resolve destination root.
 			//   --download-path / -p provided → used verbatim, exactly as the
@@ -152,8 +158,6 @@ func newJobDownloadCommand() *cobra.Command {
 		"Path to download files to (used as-is when provided; defaults to ./<job-name>/ in the current directory)")
 	cmd.Flags().StringVar(&outputName, "output-name", "",
 		"Name of the user-defined output to download. If omitted (or set to \"default\"), the default artifacts are downloaded")
-
-	cmd.MarkFlagsMutuallyExclusive("all", "output-name")
 
 	return cmd
 }

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"azure.ai.customtraining/internal/azcopy"
 	"azure.ai.customtraining/internal/download"
@@ -82,8 +83,8 @@ func newJobDownloadCommand() *cobra.Command {
 			status := job.Properties.Status
 			if !isTerminalStatus(status) {
 				return fmt.Errorf(
-					"This job is in state %s. Download is allowed only in states %v",
-					status, terminalStatuses,
+					"This job is in state %s. Download is allowed only in states: %s",
+					status, strings.Join(terminalStatuses, ", "),
 				)
 			}
 
@@ -245,6 +246,9 @@ func downloadModelAsset(
 	}); err != nil {
 		return fmt.Errorf("failed to get model version: %w", err)
 	}
+	if modelVer == nil {
+		return fmt.Errorf("model %s/v%s: empty response from API", assetName, assetVersion)
+	}
 	if modelVer.BlobURI == "" {
 		return fmt.Errorf("model %s/v%s response missing blobUri", assetName, assetVersion)
 	}
@@ -353,6 +357,9 @@ func downloadDefaultArtifacts(
 		}); err != nil {
 			return fmt.Errorf("failed to list run artifacts: %w", err)
 		}
+		if page == nil {
+			break
+		}
 		artifacts = append(artifacts, page.Value...)
 		if page.ContinuationToken == "" {
 			break
@@ -367,7 +374,7 @@ func downloadDefaultArtifacts(
 
 	fmt.Printf("  artifacts: fetching content info for %d artifact(s)...\n", len(artifacts))
 
-	const parallelism = 8
+	const parallelism = download.DefaultParallelism
 	infos, err := fetchContentInfosParallel(ctx, apiClient, trackingEndpoint, experimentID, jobName, artifacts, parallelism)
 	if err != nil {
 		return err

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download.go
@@ -389,7 +389,7 @@ func downloadDefaultArtifacts(
 		totalBytes += r.Bytes
 	}
 	fmt.Printf("  artifacts: %d/%d succeeded (%s)\n",
-		len(results)-failed, len(results), formatBytes(totalBytes))
+		len(results)-failed, len(results), utils.FormatBytes(totalBytes))
 	if failed > 0 {
 		return fmt.Errorf("%d artifact(s) failed to download", failed)
 	}
@@ -488,23 +488,4 @@ func listOutputNames(outputs map[string]models.JobOutput) []string {
 	}
 	sort.Strings(names)
 	return names
-}
-
-// formatBytes returns a human-readable byte size.
-func formatBytes(b int64) string {
-	const (
-		kb = 1024
-		mb = kb * 1024
-		gb = mb * 1024
-	)
-	switch {
-	case b >= gb:
-		return fmt.Sprintf("%.1f GB", float64(b)/float64(gb))
-	case b >= mb:
-		return fmt.Sprintf("%.1f MB", float64(b)/float64(mb))
-	case b >= kb:
-		return fmt.Sprintf("%.1f KB", float64(b)/float64(kb))
-	default:
-		return fmt.Sprintf("%d B", b)
-	}
 }

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download_test.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_download_test.go
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azure.ai.customtraining/pkg/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectDownloadMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		outputName  string
+		all         bool
+		wantNamed   bool
+		wantAll     bool
+		wantDefault bool
+	}{
+		{
+			name:        "no flags -> default only",
+			wantDefault: true,
+		},
+		{
+			name:        "output-name=default treated as no flag -> default only",
+			outputName:  "default",
+			wantDefault: true,
+		},
+		{
+			name:        "empty output-name -> default only",
+			outputName:  "",
+			wantDefault: true,
+		},
+		{
+			name:       "named output -> named only",
+			outputName: "my-output",
+			wantNamed:  true,
+		},
+		{
+			name:    "all -> every named + default",
+			all:     true,
+			wantAll: true,
+		},
+		// NB: cobra's MarkFlagsMutuallyExclusive prevents (all && outputName) at
+		// the CLI layer, so we don't test that combination here.
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			named, all, def := selectDownloadMode(tt.outputName, tt.all)
+			assert.Equal(t, tt.wantNamed, named, "wantNamed")
+			assert.Equal(t, tt.wantAll, all, "wantAll")
+			assert.Equal(t, tt.wantDefault, def, "wantDefault")
+		})
+	}
+}
+
+func TestExtractTrackingEndpoint(t *testing.T) {
+	const wantEndpoint = "https://eastus.api.azureml.ms"
+
+	tests := []struct {
+		name      string
+		job       *models.JobResource
+		want      string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:      "nil job",
+			job:       nil,
+			wantErr:   true,
+			errSubstr: "job is nil",
+		},
+		{
+			name: "missing services",
+			job: &models.JobResource{
+				Properties: models.CommandJob{},
+			},
+			wantErr:   true,
+			errSubstr: "missing properties.services.Tracking",
+		},
+		{
+			name: "tracking entry missing",
+			job: &models.JobResource{
+				Properties: models.CommandJob{
+					Services: map[string]any{"Other": map[string]any{"endpoint": "x"}},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "missing properties.services.Tracking",
+		},
+		{
+			name: "tracking has wrong shape (string instead of map)",
+			job: &models.JobResource{
+				Properties: models.CommandJob{
+					Services: map[string]any{"Tracking": "not-a-map"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "unexpected shape",
+		},
+		{
+			name: "endpoint missing inside tracking",
+			job: &models.JobResource{
+				Properties: models.CommandJob{
+					Services: map[string]any{"Tracking": map[string]any{"protocol": "https"}},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "endpoint missing",
+		},
+		{
+			name: "endpoint is empty string",
+			job: &models.JobResource{
+				Properties: models.CommandJob{
+					Services: map[string]any{"Tracking": map[string]any{"endpoint": ""}},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "endpoint missing",
+		},
+		{
+			name: "endpoint is non-string type",
+			job: &models.JobResource{
+				Properties: models.CommandJob{
+					Services: map[string]any{"Tracking": map[string]any{"endpoint": 123}},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "endpoint missing",
+		},
+		{
+			name: "valid endpoint",
+			job: &models.JobResource{
+				Properties: models.CommandJob{
+					Services: map[string]any{"Tracking": map[string]any{"endpoint": wantEndpoint}},
+				},
+			},
+			want: wantEndpoint,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractTrackingEndpoint(tt.job)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/cli/azd/extensions/azure.ai.customtraining/internal/download/download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/download/download.go
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Package download provides helpers for downloading job outputs and artifacts.
+package download
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"azure.ai.customtraining/pkg/models"
+)
+
+// MaxAttempts is the number of attempts for retryable API calls (initial + retries).
+const MaxAttempts = 3
+
+// initialBackoff is the delay before the first retry; subsequent retries double it.
+const initialBackoff = 500 * time.Millisecond
+
+// retryHTTPClient is a dedicated HTTP client used for direct contentUri downloads.
+// No bearer token is needed for those URLs (the SAS in the query string authorizes the read).
+var retryHTTPClient = &http.Client{Timeout: 5 * time.Minute}
+
+// IsRetryable reports whether an error or response status warrants another attempt.
+func IsRetryable(err error, statusCode int) bool {
+	if err != nil {
+		// Transport errors (network, timeout, DNS) are retryable
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			return true
+		}
+		return true
+	}
+	if statusCode == http.StatusTooManyRequests {
+		return true
+	}
+	if statusCode >= 500 && statusCode <= 599 {
+		return true
+	}
+	return false
+}
+
+// WithRetry calls fn up to MaxAttempts times, sleeping with exponential backoff between attempts.
+// fn should return (statusCode, err). If statusCode is 0 the result is judged solely by err.
+// Returns the last error from fn after all attempts are exhausted.
+func WithRetry(ctx context.Context, fn func() (int, error)) error {
+	backoff := initialBackoff
+	var lastErr error
+	for attempt := 1; attempt <= MaxAttempts; attempt++ {
+		status, err := fn()
+		if err == nil && status < 400 {
+			return nil
+		}
+		lastErr = err
+		if err == nil {
+			lastErr = fmt.Errorf("HTTP %d", status)
+		}
+		if attempt == MaxAttempts || !IsRetryable(err, status) {
+			return lastErr
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+	}
+	return lastErr
+}
+
+// ArtifactDownloadResult tracks per-artifact outcome for summary reporting.
+type ArtifactDownloadResult struct {
+	Path  string
+	Bytes int64
+	Err   error
+}
+
+// DownloadArtifacts downloads a list of artifacts in parallel into destDir,
+// preserving each artifact's relative path (from contentinfo.Path).
+// parallelism controls the number of concurrent downloads.
+func DownloadArtifacts(
+	ctx context.Context,
+	infos []*models.RunArtifactContentInfo,
+	destDir string,
+	parallelism int,
+) []ArtifactDownloadResult {
+	if parallelism <= 0 {
+		parallelism = 8
+	}
+
+	results := make([]ArtifactDownloadResult, len(infos))
+	sem := make(chan struct{}, parallelism)
+	var wg sync.WaitGroup
+
+	for i, info := range infos {
+		i, info := i, info
+		if info == nil || info.ContentURI == "" || info.Path == "" {
+			results[i] = ArtifactDownloadResult{Path: "", Err: fmt.Errorf("missing content uri or path")}
+			continue
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			n, err := downloadOne(ctx, info.ContentURI, destDir, info.Path)
+			results[i] = ArtifactDownloadResult{Path: info.Path, Bytes: n, Err: err}
+		}()
+	}
+	wg.Wait()
+	return results
+}
+
+// downloadOne performs a retryable GET on contentURI and writes the body to destDir/relPath.
+// Parent directories are created as needed.
+func downloadOne(ctx context.Context, contentURI, destDir, relPath string) (int64, error) {
+	outPath := filepath.Join(destDir, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return 0, fmt.Errorf("create dir: %w", err)
+	}
+
+	var written int64
+	err := WithRetry(ctx, func() (int, error) {
+		written = 0
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, contentURI, nil)
+		if err != nil {
+			return 0, err
+		}
+		resp, err := retryHTTPClient.Do(req)
+		if err != nil {
+			return 0, err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+			return resp.StatusCode, fmt.Errorf("download %s: HTTP %d: %s",
+				relPath, resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+		f, err := os.Create(outPath)
+		if err != nil {
+			return 0, err
+		}
+		defer f.Close()
+		n, err := io.Copy(f, resp.Body)
+		if err != nil {
+			return 0, err
+		}
+		written = n
+		return resp.StatusCode, nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return written, nil
+}

--- a/cli/azd/extensions/azure.ai.customtraining/internal/download/download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/download/download.go
@@ -23,6 +23,10 @@ import (
 // MaxAttempts is the number of attempts for retryable API calls (initial + retries).
 const MaxAttempts = 3
 
+// DefaultParallelism is the default number of concurrent downloads when the
+// caller doesn't specify one.
+const DefaultParallelism = 8
+
 // initialBackoff is the delay before the first retry; subsequent retries double it.
 const initialBackoff = 500 * time.Millisecond
 
@@ -99,12 +103,18 @@ func DownloadArtifacts(
 	parallelism int,
 ) []ArtifactDownloadResult {
 	if parallelism <= 0 {
-		parallelism = 8
+		parallelism = DefaultParallelism
 	}
 
 	results := make([]ArtifactDownloadResult, len(infos))
 	sem := make(chan struct{}, parallelism)
 	var wg sync.WaitGroup
+
+	// Dedupe by destination path. The history service should not normally
+	// return duplicate artifact paths, but if it does, two goroutines would
+	// race on the same .tmp file and final rename — risking corrupt output.
+	// Keep the first occurrence; mark subsequent duplicates as skipped.
+	seen := make(map[string]struct{}, len(infos))
 
 	for i, info := range infos {
 		i, info := i, info
@@ -112,6 +122,14 @@ func DownloadArtifacts(
 			results[i] = ArtifactDownloadResult{Path: "", Err: fmt.Errorf("missing content uri or path")}
 			continue
 		}
+		if _, dup := seen[info.Path]; dup {
+			results[i] = ArtifactDownloadResult{
+				Path: info.Path,
+				Err:  fmt.Errorf("duplicate artifact path %q in response; skipped", info.Path),
+			}
+			continue
+		}
+		seen[info.Path] = struct{}{}
 		wg.Add(1)
 		sem <- struct{}{}
 		go func() {
@@ -149,9 +167,11 @@ func downloadOne(ctx context.Context, contentURI, destDir, relPath string) (int6
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-			return resp.StatusCode, fmt.Errorf("download %s: HTTP %d: %s",
-				relPath, resp.StatusCode, strings.TrimSpace(string(body)))
+			// Don't echo the response body in user-facing errors: Azure Blob
+			// Storage XML error responses can include request URLs, signature
+			// fragments, or other server-echoed content that may leak SAS
+			// tokens / credentials. Status code alone is enough for triage.
+			return resp.StatusCode, fmt.Errorf("download %s: HTTP %d", relPath, resp.StatusCode)
 		}
 		// Write to a sibling .tmp file and atomically rename on success so a
 		// partial/interrupted download (network drop, ctx canceled, disk full)

--- a/cli/azd/extensions/azure.ai.customtraining/internal/download/download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/download/download.go
@@ -124,12 +124,26 @@ func DownloadArtifacts(
 // Parent directories are created as needed.
 func downloadOne(ctx context.Context, contentURI, destDir, relPath string) (int64, error) {
 	outPath := filepath.Join(destDir, filepath.FromSlash(relPath))
+	// Defense-in-depth: relPath comes from the API response. Reject any path
+	// that resolves outside destDir (e.g., "../../etc/foo" or an absolute path
+	// on Windows like "C:\foo") to prevent path-traversal / Zip-Slip writes.
+	absDest, err := filepath.Abs(destDir)
+	if err != nil {
+		return 0, fmt.Errorf("resolve dest dir: %w", err)
+	}
+	absOut, err := filepath.Abs(outPath)
+	if err != nil {
+		return 0, fmt.Errorf("resolve artifact path: %w", err)
+	}
+	if absOut != absDest && !strings.HasPrefix(absOut, absDest+string(filepath.Separator)) {
+		return 0, fmt.Errorf("artifact path %q escapes destination directory", relPath)
+	}
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		return 0, fmt.Errorf("create dir: %w", err)
 	}
 
 	var written int64
-	err := WithRetry(ctx, func() (int, error) {
+	err = WithRetry(ctx, func() (int, error) {
 		written = 0
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, contentURI, nil)
 		if err != nil {

--- a/cli/azd/extensions/azure.ai.customtraining/internal/download/download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/download/download.go
@@ -145,13 +145,28 @@ func downloadOne(ctx context.Context, contentURI, destDir, relPath string) (int6
 			return resp.StatusCode, fmt.Errorf("download %s: HTTP %d: %s",
 				relPath, resp.StatusCode, strings.TrimSpace(string(body)))
 		}
-		f, err := os.Create(outPath)
+		// Write to a sibling .tmp file and atomically rename on success so a
+		// partial/interrupted download (network drop, ctx canceled, disk full)
+		// never leaves a truncated file at outPath that callers might mistake
+		// for a successful download. os.Rename is atomic on the same filesystem
+		// across Linux, macOS, and Windows; tmp + final live in the same dir.
+		tmpPath := outPath + ".tmp"
+		f, err := os.Create(tmpPath)
 		if err != nil {
 			return 0, err
 		}
-		defer f.Close()
-		n, err := io.Copy(f, resp.Body)
-		if err != nil {
+		n, copyErr := io.Copy(f, resp.Body)
+		closeErr := f.Close()
+		if copyErr != nil {
+			os.Remove(tmpPath)
+			return 0, copyErr
+		}
+		if closeErr != nil {
+			os.Remove(tmpPath)
+			return 0, closeErr
+		}
+		if err := os.Rename(tmpPath, outPath); err != nil {
+			os.Remove(tmpPath)
 			return 0, err
 		}
 		written = n

--- a/cli/azd/extensions/azure.ai.customtraining/internal/download/download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/download/download.go
@@ -128,20 +128,9 @@ func DownloadArtifacts(
 // downloadOne performs a retryable GET on contentURI and writes the body to destDir/relPath.
 // Parent directories are created as needed.
 func downloadOne(ctx context.Context, contentURI, destDir, relPath string) (int64, error) {
-	outPath := filepath.Join(destDir, filepath.FromSlash(relPath))
-	// Defense-in-depth: relPath comes from the API response. Reject any path
-	// that resolves outside destDir (e.g., "../../etc/foo" or an absolute path
-	// on Windows like "C:\foo") to prevent path-traversal / Zip-Slip writes.
-	absDest, err := filepath.Abs(destDir)
+	outPath, err := safeJoin(destDir, relPath)
 	if err != nil {
-		return 0, fmt.Errorf("resolve dest dir: %w", err)
-	}
-	absOut, err := filepath.Abs(outPath)
-	if err != nil {
-		return 0, fmt.Errorf("resolve artifact path: %w", err)
-	}
-	if absOut != absDest && !strings.HasPrefix(absOut, absDest+string(filepath.Separator)) {
-		return 0, fmt.Errorf("artifact path %q escapes destination directory", relPath)
+		return 0, err
 	}
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		return 0, fmt.Errorf("create dir: %w", err)
@@ -195,4 +184,24 @@ func downloadOne(ctx context.Context, contentURI, destDir, relPath string) (int6
 		return 0, err
 	}
 	return written, nil
+}
+
+// safeJoin joins relPath onto destDir while rejecting any path that resolves
+// outside destDir (e.g., "../../etc/foo" or, on Windows, "C:\foo"). This
+// guards against path-traversal / Zip-Slip writes when relPath comes from an
+// untrusted source such as an API response.
+func safeJoin(destDir, relPath string) (string, error) {
+	outPath := filepath.Join(destDir, filepath.FromSlash(relPath))
+	absDest, err := filepath.Abs(destDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve dest dir: %w", err)
+	}
+	absOut, err := filepath.Abs(outPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve artifact path: %w", err)
+	}
+	if absOut != absDest && !strings.HasPrefix(absOut, absDest+string(filepath.Separator)) {
+		return "", fmt.Errorf("artifact path %q escapes destination directory", relPath)
+	}
+	return outPath, nil
 }

--- a/cli/azd/extensions/azure.ai.customtraining/internal/download/download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/download/download.go
@@ -31,20 +31,25 @@ const initialBackoff = 500 * time.Millisecond
 var retryHTTPClient = &http.Client{Timeout: 5 * time.Minute}
 
 // IsRetryable reports whether an error or response status warrants another attempt.
+// Only transient failures retry: transport errors (DNS/connection/timeout),
+// HTTP 429, and 5xx. Auth failures, 4xx, and context cancellation/deadline
+// are non-retryable so we don't waste time or ignore user cancel.
 func IsRetryable(err error, statusCode int) bool {
-	if err != nil {
-		// Transport errors (network, timeout, DNS) are retryable
-		var urlErr *url.Error
-		if errors.As(err, &urlErr) {
-			return true
-		}
-		return true
+	// Never retry on context cancellation/deadline.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
 	}
+	// Retry transient HTTP statuses.
 	if statusCode == http.StatusTooManyRequests {
 		return true
 	}
 	if statusCode >= 500 && statusCode <= 599 {
 		return true
+	}
+	// Retry transport-layer errors (surfaced as *url.Error by net/http).
+	if err != nil {
+		var urlErr *url.Error
+		return errors.As(err, &urlErr)
 	}
 	return false
 }

--- a/cli/azd/extensions/azure.ai.customtraining/internal/download/download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/download/download.go
@@ -183,20 +183,28 @@ func downloadOne(ctx context.Context, contentURI, destDir, relPath string) (int6
 		if err != nil {
 			return 0, err
 		}
+		// Always remove the tmp file unless we successfully rename it. This
+		// covers ctx cancellation mid-Copy, transport errors, and any other
+		// soft-failure path. (Hard process kill on Windows ctrl+C bypasses
+		// defers; SweepTempFiles handles that case on the next run.)
+		renamed := false
+		defer func() {
+			if !renamed {
+				_ = os.Remove(tmpPath)
+			}
+		}()
 		n, copyErr := io.Copy(f, resp.Body)
 		closeErr := f.Close()
 		if copyErr != nil {
-			os.Remove(tmpPath)
 			return 0, copyErr
 		}
 		if closeErr != nil {
-			os.Remove(tmpPath)
 			return 0, closeErr
 		}
 		if err := os.Rename(tmpPath, outPath); err != nil {
-			os.Remove(tmpPath)
 			return 0, err
 		}
+		renamed = true
 		written = n
 		return resp.StatusCode, nil
 	})
@@ -204,6 +212,23 @@ func downloadOne(ctx context.Context, contentURI, destDir, relPath string) (int6
 		return 0, err
 	}
 	return written, nil
+}
+
+// SweepTempFiles removes any leftover *.tmp files under root. We use these as
+// scratch files for atomic download writes; they should never survive a
+// successful run. They can linger if the process is hard-killed (e.g. ctrl+C
+// on Windows bypasses Go defers), so we sweep them at the start of each run
+// to keep the destination tree clean.
+func SweepTempFiles(root string) {
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // best-effort; ignore unreadable dirs
+		}
+		if !d.IsDir() && strings.HasSuffix(path, ".tmp") {
+			_ = os.Remove(path)
+		}
+		return nil
+	})
 }
 
 // safeJoin joins relPath onto destDir while rejecting any path that resolves

--- a/cli/azd/extensions/azure.ai.customtraining/internal/download/download_test.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/download/download_test.go
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package download
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		statusCode int
+		want       bool
+	}{
+		// --- non-retryable: cancellation / deadline ---
+		{
+			name: "context canceled is not retryable",
+			err:  context.Canceled,
+			want: false,
+		},
+		{
+			name: "context deadline exceeded is not retryable",
+			err:  context.DeadlineExceeded,
+			want: false,
+		},
+		{
+			name: "context canceled wrapped in url.Error is still not retryable",
+			err:  &url.Error{Op: "Get", URL: "https://x", Err: context.Canceled},
+			want: false,
+		},
+
+		// --- retryable: transient HTTP statuses ---
+		{
+			name:       "HTTP 429 is retryable",
+			statusCode: http.StatusTooManyRequests,
+			want:       true,
+		},
+		{
+			name:       "HTTP 500 is retryable",
+			statusCode: http.StatusInternalServerError,
+			want:       true,
+		},
+		{
+			name:       "HTTP 503 is retryable",
+			statusCode: http.StatusServiceUnavailable,
+			want:       true,
+		},
+		{
+			name:       "HTTP 599 is retryable (boundary)",
+			statusCode: 599,
+			want:       true,
+		},
+
+		// --- non-retryable: client/auth/redirect statuses ---
+		{
+			name:       "HTTP 200 is not retryable",
+			statusCode: http.StatusOK,
+			want:       false,
+		},
+		{
+			name:       "HTTP 400 is not retryable",
+			statusCode: http.StatusBadRequest,
+			want:       false,
+		},
+		{
+			name:       "HTTP 401 is not retryable",
+			statusCode: http.StatusUnauthorized,
+			want:       false,
+		},
+		{
+			name:       "HTTP 403 is not retryable",
+			statusCode: http.StatusForbidden,
+			want:       false,
+		},
+		{
+			name:       "HTTP 404 is not retryable",
+			statusCode: http.StatusNotFound,
+			want:       false,
+		},
+
+		// --- retryable: transport errors ---
+		{
+			name: "url.Error (transport failure) is retryable",
+			err:  &url.Error{Op: "Get", URL: "https://x", Err: errors.New("dial tcp: i/o timeout")},
+			want: true,
+		},
+
+		// --- non-retryable: arbitrary non-transport errors ---
+		{
+			name: "plain non-transport error is not retryable",
+			err:  errors.New("parse failure"),
+			want: false,
+		},
+
+		// --- nothing went wrong ---
+		{
+			name: "nil err and zero status is not retryable",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsRetryable(tt.err, tt.statusCode)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSafeJoin(t *testing.T) {
+	dest := t.TempDir()
+	sep := string(filepath.Separator)
+
+	tests := []struct {
+		name    string
+		relPath string
+		wantErr bool
+	}{
+		{
+			name:    "simple relative path is allowed",
+			relPath: "outputs/model.bin",
+		},
+		{
+			name:    "nested path is allowed",
+			relPath: "a/b/c/d.txt",
+		},
+		{
+			name:    "single file is allowed",
+			relPath: "log.txt",
+		},
+		{
+			name:    "parent traversal is rejected",
+			relPath: "../escape.txt",
+			wantErr: true,
+		},
+		{
+			name:    "deep parent traversal is rejected",
+			relPath: "../../../etc/passwd",
+			wantErr: true,
+		},
+		{
+			name:    "embedded parent traversal is rejected",
+			relPath: "outputs/../../escape.txt",
+			wantErr: true,
+		},
+		{
+			name:    "current-dir prefix is allowed (resolves inside)",
+			relPath: "./outputs/model.bin",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := safeJoin(dest, tt.relPath)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "escapes destination directory")
+				return
+			}
+			require.NoError(t, err)
+			// Resolved path must live under dest.
+			absDest, _ := filepath.Abs(dest)
+			absGot, _ := filepath.Abs(got)
+			assert.True(t,
+				strings.HasPrefix(absGot, absDest+sep) || absGot == absDest,
+				"expected %q to be under %q", absGot, absDest,
+			)
+		})
+	}
+}
+
+// TestSafeJoin_OSAbsolutePath documents that an OS-absolute path supplied as
+// relPath is *not* treated as an escape: filepath.Join strips the leading
+// separator / drive letter on both POSIX and Windows, so the result is safely
+// re-rooted under destDir. We assert the resolved path stays inside dest.
+func TestSafeJoin_OSAbsolutePath(t *testing.T) {
+	dest := t.TempDir()
+	other := t.TempDir() // a different absolute path
+	abs, err := filepath.Abs(other)
+	require.NoError(t, err)
+
+	got, err := safeJoin(dest, abs)
+	require.NoError(t, err)
+	absDest, _ := filepath.Abs(dest)
+	absGot, _ := filepath.Abs(got)
+	assert.True(t,
+		strings.HasPrefix(absGot, absDest+string(filepath.Separator)) || absGot == absDest,
+		"expected %q to be re-rooted under %q", absGot, absDest,
+	)
+}

--- a/cli/azd/extensions/azure.ai.customtraining/internal/utils/output.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/utils/output.go
@@ -181,3 +181,23 @@ func formatFieldValue(v reflect.Value) string {
 		return fmt.Sprintf("%v", v.Interface())
 	}
 }
+
+// FormatBytes returns a human-readable representation of a byte size
+// (e.g., "1.5 MB", "512 B"). Uses binary units (1 KB = 1024 B).
+func FormatBytes(b int64) string {
+	const (
+		kb = 1024
+		mb = kb * 1024
+		gb = mb * 1024
+	)
+	switch {
+	case b >= gb:
+		return fmt.Sprintf("%.1f GB", float64(b)/float64(gb))
+	case b >= mb:
+		return fmt.Sprintf("%.1f MB", float64(b)/float64(mb))
+	case b >= kb:
+		return fmt.Sprintf("%.1f KB", float64(b)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/cli/azd/extensions/azure.ai.customtraining/pkg/client/client.go
+++ b/cli/azd/extensions/azure.ai.customtraining/pkg/client/client.go
@@ -160,8 +160,21 @@ func (c *Client) HandleError(resp *http.Response) error {
 			Message string `json:"message"`
 		} `json:"error"`
 	}
+	parsed := json.Unmarshal(body, &apiErr) == nil && apiErr.Error.Message != ""
 
-	if json.Unmarshal(body, &apiErr) == nil && apiErr.Error.Message != "" {
+	// 5xx → service-side issue. The server-provided code/message ("ServiceError",
+	// "InternalServerError") is rarely actionable for end-users, so prefer a
+	// retry hint. Keep server detail in -v / debug paths.
+	if resp.StatusCode >= 500 && resp.StatusCode <= 599 {
+		if parsed && c.debugBody {
+			return fmt.Errorf("the service is currently unavailable (HTTP %d), please retry in a moment: %s",
+				resp.StatusCode, apiErr.Error.Message)
+		}
+		return fmt.Errorf("the service is currently unavailable (HTTP %d), please retry in a moment",
+			resp.StatusCode)
+	}
+
+	if parsed {
 		return fmt.Errorf("API error (%d): %s - %s", resp.StatusCode, apiErr.Error.Code, apiErr.Error.Message)
 	}
 

--- a/cli/azd/extensions/azure.ai.customtraining/pkg/client/client.go
+++ b/cli/azd/extensions/azure.ai.customtraining/pkg/client/client.go
@@ -144,7 +144,8 @@ func (c *Client) getToken(ctx context.Context, scope string) (string, error) {
 		Scopes: []string{scope},
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to get access token: %w", err)
+		return "", fmt.Errorf(
+			"authentication failed; check your network connection or run 'azd auth login' and retry: %w", err)
 	}
 	return token.Token, nil
 }

--- a/cli/azd/extensions/azure.ai.customtraining/pkg/client/download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/pkg/client/download.go
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"azure.ai.customtraining/pkg/models"
+)
+
+// GetModelVersion retrieves a model asset version.
+// GET .../models/{name}/versions/{version}
+func (c *Client) GetModelVersion(
+	ctx context.Context, modelName, version string,
+) (*models.ModelVersion, error) {
+	path := fmt.Sprintf("models/%s/versions/%s",
+		url.PathEscape(modelName), url.PathEscape(version))
+
+	resp, err := c.doDataPlane(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get model %s version %s: %w", modelName, version, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.HandleError(resp)
+	}
+
+	var result models.ModelVersion
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode model version response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetModelCredentials fetches a SAS-credential response for a model version.
+// POST .../models/{name}/versions/{version}/credentials
+func (c *Client) GetModelCredentials(
+	ctx context.Context, modelName, version, blobURI string,
+) (*models.CredentialsResponse, error) {
+	path := fmt.Sprintf("models/%s/versions/%s/credentials",
+		url.PathEscape(modelName), url.PathEscape(version))
+
+	body := &models.ModelCredentialsRequest{
+		BlobURI:                  blobURI,
+		GenerateBlobLevelReadSas: true,
+	}
+
+	resp, err := c.doDataPlane(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch model credentials: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.HandleError(resp)
+	}
+
+	var result models.CredentialsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode model credentials response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetDatasetCredentials fetches a SAS-credential response for a data asset version.
+// POST .../datasets/{name}/versions/{version}/credentials
+// Uses the dataset API version (v1).
+func (c *Client) GetDatasetCredentials(
+	ctx context.Context, datasetName, version string,
+) (*models.CredentialsResponse, error) {
+	path := fmt.Sprintf("datasets/%s/versions/%s/credentials",
+		url.PathEscape(datasetName), url.PathEscape(version))
+
+	resp, err := c.doDataPlaneWithVersion(ctx, http.MethodPost, path, DatasetAPIVersion, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch dataset credentials: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.HandleError(resp)
+	}
+
+	var result models.CredentialsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode dataset credentials response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// ListRunArtifacts lists artifacts for a run via the AML history service.
+// GET https://{region}.api.azureml.ms/history/v1.0/{workspacePath}/experimentids/{expId}/runs/{runId}/artifacts[?continuationToken=...]
+func (c *Client) ListRunArtifacts(
+	ctx context.Context, trackingEndpoint, experimentID, runID, continuationToken string,
+) (*models.RunArtifactList, error) {
+	baseURL, workspacePath, err := parseTrackingEndpoint(trackingEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse tracking endpoint: %w", err)
+	}
+
+	reqURL := fmt.Sprintf("%s/history/v1.0%s/experimentids/%s/runs/%s/artifacts",
+		baseURL, workspacePath, url.PathEscape(experimentID), url.PathEscape(runID))
+	if continuationToken != "" {
+		reqURL += "?continuationToken=" + url.QueryEscape(continuationToken)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	if err := c.addAuth(ctx, req, DataPlaneScope); err != nil {
+		return nil, err
+	}
+
+	if c.debugBody {
+		fmt.Printf("[DEBUG] GET %s\n", reqURL)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.HandleError(resp)
+	}
+
+	var result models.RunArtifactList
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode run artifacts response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// GetRunArtifactContentInfo fetches the content info (SAS URI) for a single run artifact.
+// GET https://{region}.api.azureml.ms/history/v1.0/{workspacePath}/experimentids/{expId}/runs/{runId}/artifacts/contentinfo?path={path}
+func (c *Client) GetRunArtifactContentInfo(
+	ctx context.Context, trackingEndpoint, experimentID, runID, artifactPath string,
+) (*models.RunArtifactContentInfo, error) {
+	baseURL, workspacePath, err := parseTrackingEndpoint(trackingEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse tracking endpoint: %w", err)
+	}
+
+	reqURL := fmt.Sprintf("%s/history/v1.0%s/experimentids/%s/runs/%s/artifacts/contentinfo?path=%s",
+		baseURL, workspacePath,
+		url.PathEscape(experimentID), url.PathEscape(runID),
+		url.QueryEscape(artifactPath))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	if err := c.addAuth(ctx, req, DataPlaneScope); err != nil {
+		return nil, err
+	}
+
+	if c.debugBody {
+		fmt.Printf("[DEBUG] GET %s\n", reqURL)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.HandleError(resp)
+	}
+
+	var result models.RunArtifactContentInfo
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode contentinfo response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/cli/azd/extensions/azure.ai.customtraining/pkg/client/history.go
+++ b/cli/azd/extensions/azure.ai.customtraining/pkg/client/history.go
@@ -15,9 +15,9 @@ import (
 )
 
 // GetRunHistory retrieves run history details for a specific job.
-// GET .../history/{runId}
+// GET .../history/runs/{runId}
 func (c *Client) GetRunHistory(ctx context.Context, runID string) (*models.RunHistory, error) {
-	resp, err := c.doDataPlane(ctx, http.MethodGet, fmt.Sprintf("history/%s", runID), nil)
+	resp, err := c.doDataPlane(ctx, http.MethodGet, fmt.Sprintf("history/runs/%s", runID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get run history: %w", err)
 	}

--- a/cli/azd/extensions/azure.ai.customtraining/pkg/models/common.go
+++ b/cli/azd/extensions/azure.ai.customtraining/pkg/models/common.go
@@ -13,9 +13,11 @@ type JobInput struct {
 
 // JobOutput represents a discriminated union for job outputs.
 type JobOutput struct {
-	JobOutputType string `json:"jobOutputType"` // "uri_folder", "uri_file"
+	JobOutputType string `json:"jobOutputType"` // "uri_folder", "uri_file", "safetensors_model"
 	URI           string `json:"uri,omitempty"`
 	Mode          string `json:"mode,omitempty"` // "rw_mount", "upload"
+	AssetName     string `json:"assetName,omitempty"`
+	AssetVersion  string `json:"assetVersion,omitempty"`
 }
 
 // Distribution represents distributed training configuration.

--- a/cli/azd/extensions/azure.ai.customtraining/pkg/models/download.go
+++ b/cli/azd/extensions/azure.ai.customtraining/pkg/models/download.go
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package models
+
+// ModelVersion is the response shape for GET .../models/{name}/versions/{version}.
+// Per the download flow, the BlobURI lives at the root, not nested.
+type ModelVersion struct {
+	BlobURI   string `json:"blobUri,omitempty"`
+	AssetID   string `json:"assetId,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Version   string `json:"version,omitempty"`
+	ModelType string `json:"modelType,omitempty"`
+}
+
+// ModelCredentialsRequest is the body for POST .../models/{name}/versions/{v}/credentials.
+type ModelCredentialsRequest struct {
+	BlobURI                  string `json:"BlobUri"`
+	GenerateBlobLevelReadSas bool   `json:"GenerateBlobLevelReadSas"`
+}
+
+// CredentialsResponse is the response shape for both model and dataset credentials calls.
+// The SAS URI lives at blobReference.credential.sasUri.
+type CredentialsResponse struct {
+	BlobReference *BlobReference `json:"blobReference,omitempty"`
+}
+
+// RunArtifact is a single artifact entry from the AML history artifacts list.
+type RunArtifact struct {
+	ArtifactID  string `json:"artifactId,omitempty"`
+	Origin      string `json:"origin,omitempty"`
+	Container   string `json:"container,omitempty"`
+	Path        string `json:"path,omitempty"`
+	ETag        string `json:"etag,omitempty"`
+	CreatedTime string `json:"createdTime,omitempty"`
+}
+
+// RunArtifactList is the response shape for the AML artifacts list endpoint.
+type RunArtifactList struct {
+	Value             []RunArtifact `json:"value"`
+	ContinuationToken string        `json:"continuationToken,omitempty"`
+}
+
+// RunArtifactContentInfo is the response shape for the AML contentinfo endpoint.
+// ContentURI is a SAS URI that can be downloaded directly with no auth header.
+type RunArtifactContentInfo struct {
+	ArtifactID string `json:"artifactId,omitempty"`
+	Origin     string `json:"origin,omitempty"`
+	Container  string `json:"container,omitempty"`
+	Path       string `json:"path,omitempty"`
+	ContentURI string `json:"contentUri,omitempty"`
+}

--- a/cli/azd/extensions/azure.ai.customtraining/pkg/models/history.go
+++ b/cli/azd/extensions/azure.ai.customtraining/pkg/models/history.go
@@ -8,6 +8,7 @@ type RunHistory struct {
 	RunID           string                     `json:"runId,omitempty"`
 	RunUUID         string                     `json:"runUuid,omitempty"`
 	RootRunID       string                     `json:"rootRunId,omitempty"`
+	ExperimentID    string                     `json:"experimentId,omitempty"`
 	Status          string                     `json:"status,omitempty"`
 	StartTimeUTC    string                     `json:"startTimeUtc,omitempty"`
 	EndTimeUTC      string                     `json:"endTimeUtc,omitempty"`


### PR DESCRIPTION
### Notes
- Add download capability for job artifacts and named outputs. The download is only supported for jobs in terminal states: Completed, Canceled, Failed, Paused, NotResponding
- High level flow
   - Named outputs → resolves the asset's SAS URI via the foundry API and shells out to azcopy for the transfer (handles large blobs and folder containers efficiently).
   - Default artifacts → calls AML history APIs to list artifacts, fetches each one's contentUri, and downloads them in parallel.
  - Downloads run with up to 8 concurrent workers. Retries on transient failures (HTTP 429, 5xx, transport errors) with exponential backoff.
  - Each artifact is written to a sibling .tmp file and atomically renamed on success — partial/interrupted downloads never leave corrupted files at the destination. Stale .tmp files from a prior interrupted run are swept on the next download.
  - Defends against path-traversal: file paths returned by the API are validated to stay inside the destination directory, so a malformed response can't write files outside it.
  - Enhancement - Added job name to download path (if not provided by user) so that we don't override an existing user file by mistake. In case of AML, the override happens silently.


### Testing

Happy paths-

- <img width="2062" height="623" alt="image" src="https://github.com/user-attachments/assets/3bb3602a-5aa1-4b21-b7fa-ce702aadd2f2" />

- <img width="1631" height="925" alt="image" src="https://github.com/user-attachments/assets/f14ed879-0e9d-46a1-a3b7-28fb1d364aca" />

- <img width="1584" height="436" alt="image" src="https://github.com/user-attachments/assets/15452f4c-8f93-4d64-8940-7ac63e5b0cd3" />

- <img width="1357" height="372" alt="image" src="https://github.com/user-attachments/assets/7bb7d104-33e7-4bf5-a5a6-91cd5b1902ff" />

- <img width="1799" height="242" alt="image" src="https://github.com/user-attachments/assets/c4bc7a3c-a5d9-43d8-a80e-a0fbe15d87b4" />

- <img width="1560" height="220" alt="image" src="https://github.com/user-attachments/assets/05972451-6abd-48a2-b565-71ae314e9a77" />

- <img width="2141" height="155" alt="image" src="https://github.com/user-attachments/assets/d79015e6-7329-4292-9cae-8da164e3dfc6" />

- Re-running download to the same path overwrites cleanly

Unhappy paths-
- <img width="2430" height="82" alt="image" src="https://github.com/user-attachments/assets/e6585104-850b-4ab5-9941-74af934dc62d" />

- <img width="1755" height="97" alt="image" src="https://github.com/user-attachments/assets/af9ceaf7-db81-4734-be3a-04bfe0ac9b36" />

- Download interruption via `Ctrl+C` doesn't lead to download of corrupted or temporary files, the operation is atomic