### PR TITLE
Add support for gpuCount for partial SKU scenario

### DIFF
--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_get.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_get.go
@@ -363,6 +363,13 @@ func printJobDetails(d *jobDetails) {
 		w.Flush()
 	}
 
+	if props.GPUCount > 0 {
+		fmt.Println()
+		w = tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintf(w, "GPU Count:\t%d\n", props.GPUCount)
+		w.Flush()
+	}
+
 	// Inputs — merge job inputs with run history inputs for asset IDs
 	printInputsSection(props.Inputs, d.History)
 

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_get.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_get.go
@@ -97,6 +97,7 @@ func newJobShowCommand() *cobra.Command {
 			details.Job = job
 
 			_ = spinner.Stop(ctx)
+			fmt.Println()
 			printJobDetails(details)
 			return nil
 		},
@@ -343,8 +344,10 @@ func printJobDetails(d *jobDetails) {
 		w.Flush()
 	}
 
-	// Resources
-	if props.Resources != nil {
+	// Resources — only show when the user did NOT submit gpuCount.
+	// When gpuCount is set, the backend ignores the resources block (it picks the
+	// SKU based on the compute target), so showing it here would be misleading.
+	if props.GPUCount == 0 && props.Resources != nil {
 		fmt.Println()
 		w = tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		if props.Resources.InstanceCount > 0 {
@@ -360,13 +363,6 @@ func printJobDetails(d *jobDetails) {
 		if props.Resources.ShmSize != "" {
 			fmt.Fprintf(w, "Shared Memory:\t%s\n", props.Resources.ShmSize)
 		}
-		w.Flush()
-	}
-
-	if props.GPUCount > 0 {
-		fmt.Println()
-		w = tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintf(w, "GPU Count:\t%d\n", props.GPUCount)
 		w.Flush()
 	}
 
@@ -450,7 +446,12 @@ func printComputeSection(d *jobDetails) {
 		if c.InstanceCount > 0 {
 			fmt.Fprintf(w, "Nodes:\t%d\n", c.InstanceCount)
 		}
-		if c.GPUCount > 0 {
+		// Prefer the user-submitted gpuCount (from Get Job) when present — for
+		// partial-SKU jobs it reflects the actual allocation. Otherwise fall back
+		// to the SKU GPU count reported by run history.
+		if d.Job.Properties.GPUCount > 0 {
+			fmt.Fprintf(w, "GPUs:\t%d\n", d.Job.Properties.GPUCount)
+		} else if c.GPUCount > 0 {
 			fmt.Fprintf(w, "GPUs:\t%d\n", c.GPUCount)
 		}
 		if c.Priority != "" {

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_submit.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_submit.go
@@ -137,6 +137,7 @@ func buildJobResource(def *utils.JobDefinition) *models.JobResource {
 		Command:                   def.Command,
 		EnvironmentImageReference: def.Environment,
 		ComputeID:                 def.Compute,
+		GPUCount:                  def.GPUCount,
 		UserAssignedIdentityID:    def.Identity,
 		CodeID:                    def.Code,
 		EnvironmentVariables:      def.EnvironmentVariables,

--- a/cli/azd/extensions/azure.ai.customtraining/internal/utils/yaml_parser.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/utils/yaml_parser.go
@@ -29,6 +29,7 @@ type JobDefinition struct {
 	Distribution         string                       `yaml:"distribution"`
 	Resources            *ResourceDefinition          `yaml:"resources"`
 	InstanceCount        int                          `yaml:"instance_count"`
+	GPUCount             int                          `yaml:"gpu_count"`
 	ProcessPerNode       int                          `yaml:"process_per_node"`
 	EnvironmentVariables map[string]string            `yaml:"environment_variables"`
 	Identity             string                       `yaml:"identity"`

--- a/cli/azd/extensions/azure.ai.customtraining/pkg/models/job.go
+++ b/cli/azd/extensions/azure.ai.customtraining/pkg/models/job.go
@@ -23,6 +23,7 @@ type CommandJob struct {
 	EnvironmentImageReference string                 `json:"environmentImageReference,omitempty"`
 	CodeID                    string                 `json:"codeId,omitempty"`
 	ComputeID                 string                 `json:"computeId,omitempty"`
+	GPUCount                  int                    `json:"gpuCount,omitempty"`
 	UserAssignedIdentityID    string                 `json:"userAssignedIdentityId,omitempty"`
 	Inputs                    map[string]JobInput    `json:"inputs,omitempty"`
 	Outputs                   map[string]JobOutput   `json:"outputs,omitempty"`


### PR DESCRIPTION
### Notes
- A new gpuCount field is added by APIs to support partial SKU scenario. Currently partial SKU is only supported for Singularity cluster.
- If customer passes gpuCount, then resources block is ignored by backend, and it intelligently picks the right SKU based on computeId to allocate the number of GPUs supported.
- Currently the support is for 1, 2, 4, 8 and multiples of 8 GPUs only. But backend team will be working on removing this constraint.

### Testing
YAML:
<img width="993" height="1071" alt="image" src="https://github.com/user-attachments/assets/d7392fe4-157e-4155-8ea9-6d58be572be5" />

- GPU Count not supported
<img width="1727" height="370" alt="image" src="https://github.com/user-attachments/assets/1c3e5a85-7ef5-47a3-956d-5f233a5f7f69" />

- Passing GPUCount as 2
<img width="1623" height="898" alt="image" src="https://github.com/user-attachments/assets/f10a1538-267a-4dfe-9bee-c3fd97f24aa4" />

- Passing both GPUCount and Resources (Resources gets ignored)
<img width="1496" height="905" alt="image" src="https://github.com/user-attachments/assets/4d23d978-1a70-434e-b854-f872bab2e3a2" />

- Not a partial SKU scenario i.e. not passing GPUCount
<img width="1450" height="1014" alt="image" src="https://github.com/user-attachments/assets/b0fc14bf-450a-4941-9e26-2bee14135823" />
