### PR TITLE
Share offline validation between job validate and job submit commands

### DIFF
--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_submit.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_submit.go
@@ -217,7 +217,7 @@ func buildJobResource(def *utils.JobDefinition) *models.JobResource {
 		}
 	}
 
-	// Services (e.g., SSH). Validation in ValidateJobDefinition restricts type to "ssh"
+	// Services (e.g., SSH). ValidateJobOffline restricts type to "ssh"
 	// and ensures ssh_public_keys is non-empty.
 	if len(def.Services) > 0 {
 		job.Services = make(map[string]interface{}, len(def.Services))
@@ -233,7 +233,7 @@ func buildJobResource(def *utils.JobDefinition) *models.JobResource {
 }
 
 // buildServiceRequest translates an AML YAML ServiceDefinition into the API request shape.
-// Currently only SSH is supported (enforced by ValidateJobDefinition).
+// Currently only SSH is supported (enforced by ValidateJobOffline).
 func buildServiceRequest(svc utils.ServiceDefinition) *models.JobServiceRequest {
 	req := &models.JobServiceRequest{
 		JobServiceType: mapServiceType(svc.Type),

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_submit.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_submit.go
@@ -35,10 +35,21 @@ func newJobSubmitCommand() *cobra.Command {
 				return fmt.Errorf("--file (-f) is required: provide a path to a YAML job definition file")
 			}
 
-			// Parse and validate the YAML job definition
+			// Parse the YAML job definition
 			jobDef, err := utils.ParseJobFile(filePath)
 			if err != nil {
 				return err
+			}
+
+			// Run shared offline validation up-front (same checks as `job validate`).
+			// On any error finding, abort before doing any network or upload work.
+			yamlDir := filepath.Dir(filePath)
+			validation := utils.ValidateJobOffline(jobDef, yamlDir)
+			if len(validation.Findings) > 0 {
+				if err := utils.ReportValidationResult(filePath, validation, false); err != nil {
+					return err
+				}
+				fmt.Println()
 			}
 
 			azdClient, err := azdext.NewAzdClient()

--- a/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_validate.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/cmd/job_validate.go
@@ -10,7 +10,6 @@ import (
 
 	"azure.ai.customtraining/internal/utils"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -24,7 +23,7 @@ func newJobValidateCommand() *cobra.Command {
 		Long:  "Validate a job YAML definition file offline without submitting.\n\nExample:\n  azd ai training job validate --file job.yaml",
 		// Override parent's PersistentPreRunE — validate is offline and needs no Azure setup.
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error { return nil },
-		Args: cobra.NoArgs,
+		Args:              cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if filePath == "" {
 				return fmt.Errorf("--file is required: provide a path to a YAML job definition file")
@@ -45,31 +44,7 @@ func newJobValidateCommand() *cobra.Command {
 			yamlDir := filepath.Dir(filePath)
 			result := utils.ValidateJobOffline(&jobDef, yamlDir)
 
-			// Print findings
-			if len(result.Findings) == 0 {
-				color.Green("✓ Validation passed: %s\n", filePath)
-				return nil
-			}
-
-			fmt.Printf("Validation results for: %s\n\n", filePath)
-
-			for _, f := range result.Findings {
-				prefix := "⚠"
-				if f.Severity == utils.SeverityError {
-					prefix = "✗"
-				}
-				fmt.Printf("  %s [%s] %s: %s\n", prefix, f.Severity, f.Field, f.Message)
-			}
-
-			fmt.Println()
-			fmt.Printf("  Errors: %d, Warnings: %d\n", result.ErrorCount(), result.WarningCount())
-
-			if result.HasErrors() {
-				return fmt.Errorf("validation failed with %d error(s)", result.ErrorCount())
-			}
-
-			color.Green("\n✓ Validation passed with warnings.\n")
-			return nil
+			return utils.ReportValidationResult(filePath, result, true)
 		},
 	}
 

--- a/cli/azd/extensions/azure.ai.customtraining/internal/utils/job_validator.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/utils/job_validator.go
@@ -10,6 +10,8 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+
+	"github.com/fatih/color"
 )
 
 // FindingSeverity indicates whether a finding is an error or a warning.
@@ -116,7 +118,67 @@ func ValidateJobOffline(job *JobDefinition, yamlDir string) *ValidationResult {
 		validateInputOutputDefinitions(result, job, optionalInputs)
 	}
 
+	// 9. Services: only "ssh" is supported, and ssh_public_keys is required.
+	// The backend currently does not enforce key presence — without keys the SSH
+	// service is provisioned but unusable, and users hit the failure later.
+	for name, svc := range job.Services {
+		if !strings.EqualFold(svc.Type, "ssh") {
+			result.Findings = append(result.Findings, ValidationFinding{
+				Field:    fmt.Sprintf("services.%s.type", name),
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("type %q is not supported; only 'ssh' is allowed", svc.Type),
+			})
+			continue
+		}
+		if strings.TrimSpace(svc.SshPublicKeys) == "" {
+			result.Findings = append(result.Findings, ValidationFinding{
+				Field:    fmt.Sprintf("services.%s.ssh_public_keys", name),
+				Severity: SeverityError,
+				Message:  "ssh_public_keys is required when type is 'ssh'",
+			})
+		}
+	}
+
 	return result
+}
+
+// ReportValidationResult prints findings to stdout and returns an error if any
+// finding has Error severity. Shared by the `job validate` command (which calls
+// it as the entire command body) and the `job submit` command (which calls it
+// as a pre-flight check before any network or upload work).
+//
+// When printSuccess is true, a green success line is printed for clean and
+// warnings-only results. Submit passes false so the success message doesn't
+// clutter its own "Submitting command job…" output flow.
+func ReportValidationResult(filePath string, result *ValidationResult, printSuccess bool) error {
+	if len(result.Findings) == 0 {
+		if printSuccess {
+			color.Green("✓ Validation passed: %s\n", filePath)
+		}
+		return nil
+	}
+
+	fmt.Printf("Validation results for: %s\n\n", filePath)
+
+	for _, f := range result.Findings {
+		prefix := "⚠"
+		if f.Severity == SeverityError {
+			prefix = "✗"
+		}
+		fmt.Printf("  %s [%s] %s: %s\n", prefix, f.Severity, f.Field, f.Message)
+	}
+
+	fmt.Println()
+	fmt.Printf("  Errors: %d, Warnings: %d\n", result.ErrorCount(), result.WarningCount())
+
+	if result.HasErrors() {
+		return fmt.Errorf("validation failed with %d error(s)", result.ErrorCount())
+	}
+
+	if printSuccess {
+		color.Green("\n✓ Validation passed with warnings.\n")
+	}
+	return nil
 }
 
 // validateLocalPath checks that a local path exists on disk.

--- a/cli/azd/extensions/azure.ai.customtraining/internal/utils/job_validator.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/utils/job_validator.go
@@ -102,11 +102,21 @@ func ValidateJobOffline(job *JobDefinition, yamlDir string) *ValidationResult {
 		}
 	}
 
-	// 5. Local path existence checks
+	// 5. Local path existence checks + input type required.
+	// Inputs with `value:` are literals (type defaults to "literal" at submit
+	// time); inputs without `value:` carry a path/URI and must declare a type
+	// — otherwise the backend rejects with "Unexpected JobInputType in request body: []".
 	validateLocalPath(result, "code", job.Code, yamlDir)
 	for name, input := range job.Inputs {
 		if input.Value == "" {
 			validateLocalPath(result, fmt.Sprintf("inputs.%s.path", name), input.Path, yamlDir)
+			if strings.TrimSpace(input.Type) == "" {
+				result.Findings = append(result.Findings, ValidationFinding{
+					Field:    fmt.Sprintf("inputs.%s.type", name),
+					Severity: SeverityError,
+					Message:  "type is required (e.g. uri_folder, uri_file etc)",
+				})
+			}
 		}
 	}
 
@@ -118,15 +128,25 @@ func ValidateJobOffline(job *JobDefinition, yamlDir string) *ValidationResult {
 		validateInputOutputDefinitions(result, job, optionalInputs)
 	}
 
-	// 9. Outputs: "default" is reserved by the backend and rejected at submit time
-	// with a 400 ("Name of the output \"default\" is reserved by the system").
-	// Catch it offline so users don't have to wait for the backend round-trip.
-	for name := range job.Outputs {
+	// 9. Outputs:
+	//    a) "default" is reserved by the backend and rejected at submit time
+	//       with a 400 ("Name of the output \"default\" is reserved by the system").
+	//    b) Each declared output must have a non-empty type — the backend rejects
+	//       missing/empty type with "Unexpected JobOutputType in request body: []".
+	//    Catch both offline so users don't have to wait for the backend round-trip.
+	for name, output := range job.Outputs {
 		if strings.EqualFold(name, "default") {
 			result.Findings = append(result.Findings, ValidationFinding{
 				Field:    fmt.Sprintf("outputs.%s", name),
 				Severity: SeverityError,
 				Message:  "output name 'default' is reserved by the system; use a different name",
+			})
+		}
+		if strings.TrimSpace(output.Type) == "" {
+			result.Findings = append(result.Findings, ValidationFinding{
+				Field:    fmt.Sprintf("outputs.%s.type", name),
+				Severity: SeverityError,
+				Message:  "type is required (e.g. uri_folder, uri_file etc)",
 			})
 		}
 	}
@@ -327,9 +347,10 @@ func validateSingleBracePlaceholders(result *ValidationResult, command string) {
 }
 
 // validateInputOutputDefinitions checks that inputs/outputs referenced in command
+// validateInputOutputDefinitions verifies that inputs referenced in the command
 // are not empty/nil definitions (all fields zero-valued).
-// Empty inputs are errors; empty outputs are warnings (backend uses defaults).
 // Inputs inside [...] optional blocks are skipped — empty definitions are valid for optional inputs.
+// Outputs are validated separately in ValidateJobOffline (rule 9).
 func validateInputOutputDefinitions(result *ValidationResult, job *JobDefinition, optionalInputs map[string]bool) {
 	command := job.Command
 	seen := make(map[string]bool)
@@ -338,34 +359,26 @@ func validateInputOutputDefinitions(result *ValidationResult, job *JobDefinition
 		kind := match[1]
 		key := match[2]
 
+		if kind != "inputs" || job.Inputs == nil {
+			continue
+		}
+
 		dedupeKey := kind + "." + key
 		if seen[dedupeKey] {
 			continue
 		}
 		seen[dedupeKey] = true
 
-		if kind == "inputs" && job.Inputs != nil {
-			if optionalInputs[key] {
-				continue
-			}
-			if input, exists := job.Inputs[key]; exists {
-				if (input == InputDefinition{}) {
-					result.Findings = append(result.Findings, ValidationFinding{
-						Field:    fmt.Sprintf("inputs.%s", key),
-						Severity: SeverityError,
-						Message:  fmt.Sprintf("input '%s' is referenced in command but has an empty definition", key),
-					})
-				}
-			}
-		} else if kind == "outputs" && job.Outputs != nil {
-			if output, exists := job.Outputs[key]; exists {
-				if (output == OutputDefinition{}) {
-					result.Findings = append(result.Findings, ValidationFinding{
-						Field:    fmt.Sprintf("outputs.%s", key),
-						Severity: SeverityWarning,
-						Message:  fmt.Sprintf("output '%s' has an empty definition — default values will be used", key),
-					})
-				}
+		if optionalInputs[key] {
+			continue
+		}
+		if input, exists := job.Inputs[key]; exists {
+			if (input == InputDefinition{}) {
+				result.Findings = append(result.Findings, ValidationFinding{
+					Field:    fmt.Sprintf("inputs.%s", key),
+					Severity: SeverityError,
+					Message:  fmt.Sprintf("input '%s' is referenced in command but has an empty definition", key),
+				})
 			}
 		}
 	}

--- a/cli/azd/extensions/azure.ai.customtraining/internal/utils/job_validator.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/utils/job_validator.go
@@ -118,7 +118,20 @@ func ValidateJobOffline(job *JobDefinition, yamlDir string) *ValidationResult {
 		validateInputOutputDefinitions(result, job, optionalInputs)
 	}
 
-	// 9. Services: only "ssh" is supported, and ssh_public_keys is required.
+	// 9. Outputs: "default" is reserved by the backend and rejected at submit time
+	// with a 400 ("Name of the output \"default\" is reserved by the system").
+	// Catch it offline so users don't have to wait for the backend round-trip.
+	for name := range job.Outputs {
+		if strings.EqualFold(name, "default") {
+			result.Findings = append(result.Findings, ValidationFinding{
+				Field:    fmt.Sprintf("outputs.%s", name),
+				Severity: SeverityError,
+				Message:  "output name 'default' is reserved by the system; use a different name",
+			})
+		}
+	}
+
+	// 10. Services: only "ssh" is supported, and ssh_public_keys is required.
 	// The backend currently does not enforce key presence — without keys the SSH
 	// service is provisioned but unusable, and users hit the failure later.
 	for name, svc := range job.Services {

--- a/cli/azd/extensions/azure.ai.customtraining/internal/utils/job_validator_test.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/utils/job_validator_test.go
@@ -333,6 +333,66 @@ func TestValidate_MultilineCommand(t *testing.T) {
 	}
 }
 
+// Tests services block validation:
+//   - non-ssh service type → error
+//   - ssh service missing ssh_public_keys → error
+//   - ssh service with keys → no findings for that service
+func TestValidate_Services(t *testing.T) {
+	// Unsupported service type:
+	//   services:
+	//     jupyter:
+	//       type: jupyter_lab
+	//       ssh_public_keys: ssh-rsa AAA...
+	job := validJob()
+	job.Services = map[string]ServiceDefinition{
+		"jupyter": {Type: "jupyter_lab", SshPublicKeys: "ssh-rsa AAA..."},
+	}
+	result := ValidateJobOffline(job, ".")
+	if f := findFindingByMessage(result, "is not supported"); f == nil {
+		t.Error("expected error for unsupported service type")
+	} else if f.Severity != SeverityError {
+		t.Errorf("expected SeverityError for unsupported service type, got %s", f.Severity)
+	}
+
+	// SSH service missing ssh_public_keys:
+	//   services:
+	//     my_ssh:
+	//       type: ssh
+	job = validJob()
+	job.Services = map[string]ServiceDefinition{
+		"my_ssh": {Type: "ssh"},
+	}
+	result = ValidateJobOffline(job, ".")
+	if f := findFindingByMessage(result, "ssh_public_keys is required"); f == nil {
+		t.Error("expected error for missing ssh_public_keys")
+	} else if f.Severity != SeverityError {
+		t.Errorf("expected SeverityError for missing ssh_public_keys, got %s", f.Severity)
+	}
+
+	// Whitespace-only ssh_public_keys also counts as missing:
+	job = validJob()
+	job.Services = map[string]ServiceDefinition{
+		"my_ssh": {Type: "ssh", SshPublicKeys: "   \n  "},
+	}
+	result = ValidateJobOffline(job, ".")
+	if f := findFindingByMessage(result, "ssh_public_keys is required"); f == nil {
+		t.Error("expected error for whitespace-only ssh_public_keys")
+	}
+
+	// Valid SSH service — no service-related findings:
+	job = validJob()
+	job.Services = map[string]ServiceDefinition{
+		"my_ssh": {Type: "ssh", SshPublicKeys: "ssh-rsa AAA..."},
+	}
+	result = ValidateJobOffline(job, ".")
+	if f := findFindingByMessage(result, "ssh_public_keys"); f != nil {
+		t.Errorf("did not expect ssh_public_keys finding for valid SSH service: %s", f.Message)
+	}
+	if f := findFindingByMessage(result, "is not supported"); f != nil {
+		t.Errorf("did not expect type-not-supported finding for valid SSH service: %s", f.Message)
+	}
+}
+
 func TestValidationResult_HasErrorsAndCounts(t *testing.T) {
 	r := &ValidationResult{}
 	if r.HasErrors() {

--- a/cli/azd/extensions/azure.ai.customtraining/internal/utils/job_validator_test.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/utils/job_validator_test.go
@@ -393,6 +393,48 @@ func TestValidate_Services(t *testing.T) {
 	}
 }
 
+// Tests that the reserved output name "default" is rejected. The backend rejects
+// it at submit time with a 400; we catch it offline so users don't have to wait
+// for the round-trip.
+func TestValidate_ReservedOutputName(t *testing.T) {
+	// Lowercase "default":
+	//   outputs:
+	//     default:
+	//       type: uri_folder
+	job := validJob()
+	job.Outputs = map[string]OutputDefinition{"default": {Type: "uri_folder"}}
+	result := ValidateJobOffline(job, ".")
+	if f := findFindingByMessage(result, "reserved by the system"); f == nil {
+		t.Error("expected error for output named 'default'")
+	} else if f.Severity != SeverityError {
+		t.Errorf("expected SeverityError for reserved output name, got %s", f.Severity)
+	}
+
+	// Case-insensitive — "Default" should also be rejected:
+	job = validJob()
+	job.Outputs = map[string]OutputDefinition{"Default": {Type: "uri_folder"}}
+	result = ValidateJobOffline(job, ".")
+	if f := findFindingByMessage(result, "reserved by the system"); f == nil {
+		t.Error("expected error for output named 'Default' (case-insensitive)")
+	}
+
+	// Non-reserved name — no reserved-name finding:
+	job = validJob()
+	job.Outputs = map[string]OutputDefinition{"model": {Type: "uri_folder"}}
+	result = ValidateJobOffline(job, ".")
+	if f := findFindingByMessage(result, "reserved by the system"); f != nil {
+		t.Errorf("did not expect reserved-name finding for output 'model': %s", f.Message)
+	}
+
+	// Inputs named "default" are NOT reserved — should be allowed:
+	job = validJob()
+	job.Inputs = map[string]InputDefinition{"default": {Type: "uri_folder", Path: "azureml://datastore/x"}}
+	result = ValidateJobOffline(job, ".")
+	if f := findFindingByMessage(result, "reserved by the system"); f != nil {
+		t.Errorf("did not expect reserved-name finding for input 'default': %s", f.Message)
+	}
+}
+
 func TestValidationResult_HasErrorsAndCounts(t *testing.T) {
 	r := &ValidationResult{}
 	if r.HasErrors() {

--- a/cli/azd/extensions/azure.ai.customtraining/internal/utils/job_validator_test.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/utils/job_validator_test.go
@@ -303,13 +303,13 @@ func TestValidate_EmptyDefinitions(t *testing.T) {
 	// YAML — output key exists but has no properties (None):
 	//   command: python train.py --out ${{outputs.model}}
 	//   outputs:
-	//     model:              ← empty definition → warning (backend uses defaults)
+	//     model:              ← empty definition → error (backend rejects empty type)
 	job = validJob()
 	job.Command = "python train.py --out ${{outputs.model}}"
 	job.Outputs = map[string]OutputDefinition{"model": {}}
 	result = ValidateJobOffline(job, ".")
-	if f := findFindingByMessage(result, "default values will be used"); f == nil || f.Severity != SeverityWarning {
-		t.Error("expected warning for empty output definition")
+	if f := findFindingByMessage(result, "type is required"); f == nil || f.Severity != SeverityError {
+		t.Error("expected error for empty output definition (missing type)")
 	}
 }
 
@@ -432,6 +432,48 @@ func TestValidate_ReservedOutputName(t *testing.T) {
 	result = ValidateJobOffline(job, ".")
 	if f := findFindingByMessage(result, "reserved by the system"); f != nil {
 		t.Errorf("did not expect reserved-name finding for input 'default': %s", f.Message)
+	}
+}
+
+// Tests that path-style inputs (no `value:`) must declare a type. The backend
+// rejects missing/empty input type with "Unexpected JobInputType in request body: []".
+func TestValidate_InputTypeRequired(t *testing.T) {
+	// Path input missing type:
+	//   inputs:
+	//     train_data:
+	//       path: azureml://datastore/x   ← no type → error
+	job := validJob()
+	job.Inputs = map[string]InputDefinition{
+		"train_data": {Path: "azureml://datastore/x"},
+	}
+	result := ValidateJobOffline(job, ".")
+	if f := findFindingByMessage(result, "type is required"); f == nil {
+		t.Error("expected error for path input missing type")
+	} else if f.Severity != SeverityError {
+		t.Errorf("expected SeverityError for path input missing type, got %s", f.Severity)
+	}
+
+	// Literal input (value: set) — type defaults to "literal", no error expected:
+	//   inputs:
+	//     epochs:
+	//       value: "10"
+	job = validJob()
+	job.Inputs = map[string]InputDefinition{
+		"epochs": {Value: "10"},
+	}
+	result = ValidateJobOffline(job, ".")
+	if f := findFindingByMessage(result, "type is required"); f != nil {
+		t.Errorf("did not expect type-required finding for literal input: %s", f.Message)
+	}
+
+	// Path input with type — no finding:
+	job = validJob()
+	job.Inputs = map[string]InputDefinition{
+		"train_data": {Type: "uri_folder", Path: "azureml://datastore/x"},
+	}
+	result = ValidateJobOffline(job, ".")
+	if f := findFindingByMessage(result, "type is required"); f != nil {
+		t.Errorf("did not expect type-required finding for valid path input: %s", f.Message)
 	}
 }
 

--- a/cli/azd/extensions/azure.ai.customtraining/internal/utils/yaml_parser.go
+++ b/cli/azd/extensions/azure.ai.customtraining/internal/utils/yaml_parser.go
@@ -83,10 +83,6 @@ func ParseJobFile(path string) (*JobDefinition, error) {
 		return nil, fmt.Errorf("failed to parse job YAML: %w", err)
 	}
 
-	if err := ValidateJobDefinition(&job); err != nil {
-		return nil, err
-	}
-
 	return &job, nil
 }
 
@@ -112,26 +108,4 @@ func IsRemoteURI(s string) bool {
 		strings.HasPrefix(lower, "http://") ||
 		strings.HasPrefix(lower, "git://") ||
 		strings.HasPrefix(lower, "git+")
-}
-
-// ValidateJobDefinition checks that required fields are present.
-func ValidateJobDefinition(job *JobDefinition) error {
-	if job.Command == "" {
-		return fmt.Errorf("job YAML validation: 'command' is required")
-	}
-	if job.Environment == "" {
-		return fmt.Errorf("job YAML validation: 'environment' is required")
-	}
-	if job.Compute == "" {
-		return fmt.Errorf("job YAML validation: 'compute' is required")
-	}
-	for name, svc := range job.Services {
-		if !strings.EqualFold(svc.Type, "ssh") {
-			return fmt.Errorf("job YAML validation: services.%s.type=%q is not supported; only 'ssh' is allowed", name, svc.Type)
-		}
-		if strings.TrimSpace(svc.SshPublicKeys) == "" {
-			return fmt.Errorf("job YAML validation: services.%s.ssh_public_keys is required when type is 'ssh'", name)
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
### Notes
1. Refer validation PR: https://github.com/Azure/azure-dev/pull/7407 (some of the warning severity validations have been converted to error severity based on API response)
2. On top of that we also added validations which were missing in AML as an enhancement in user experience-
   - default is a reserved name for outputs (backend fails immediately)
   - ssh public keys should be present (the job fails later on and customer can't ssh without keys)
   - Input/Output type is required, else backend throws immediate error on submit
3. Refactored offline validation into a shared utils.ValidateJobOffline + utils.ReportValidationResult so submit runs the same checks as validate up-front, before any upload/network work.

### Testing

Happy Path
<img width="1645" height="680" alt="image" src="https://github.com/user-attachments/assets/8bafba10-4be0-4ae3-a343-28f48c76f85b" />

Unhappy paths
<img width="1484" height="725" alt="image" src="https://github.com/user-attachments/assets/4453a5fc-488d-4277-8448-83a81dc3f3eb" />

