### PR TITLE
fix: update copilot tool definitions for current extension status (#8069)

### DIFF
--- a/cli/azd/pkg/tool/detector_test.go
+++ b/cli/azd/pkg/tool/detector_test.go
@@ -35,7 +35,7 @@ func TestDetectTool_CLI(t *testing.T) {
 		{
 			name: "InstalledWithVersion",
 			tool: &ToolDefinition{
-				Id:            "az",
+				Id:            "az-cli",
 				Category:      ToolCategoryCLI,
 				DetectCommand: "az",
 				VersionArgs:   []string{"--version"},
@@ -57,7 +57,7 @@ func TestDetectTool_CLI(t *testing.T) {
 		{
 			name: "NotInstalledWhenNotOnPATH",
 			tool: &ToolDefinition{
-				Id:            "az",
+				Id:            "az-cli",
 				Category:      ToolCategoryCLI,
 				DetectCommand: "az",
 				VersionArgs:   []string{"--version"},
@@ -213,7 +213,7 @@ func TestDetectTool_Extension(t *testing.T) {
 		{
 			name: "ExtensionFoundInList",
 			tool: &ToolDefinition{
-				Id:            "ms-azuretools.vscode-bicep",
+				Id:            "vscode-bicep",
 				Category:      ToolCategoryExtension,
 				DetectCommand: "code",
 				VersionArgs: []string{
@@ -238,7 +238,7 @@ func TestDetectTool_Extension(t *testing.T) {
 		{
 			name: "ExtensionNotInList",
 			tool: &ToolDefinition{
-				Id:            "ms-azuretools.vscode-bicep",
+				Id:            "vscode-bicep",
 				Category:      ToolCategoryExtension,
 				DetectCommand: "code",
 				VersionArgs: []string{
@@ -261,7 +261,7 @@ func TestDetectTool_Extension(t *testing.T) {
 		{
 			name: "CodeNotOnPATH",
 			tool: &ToolDefinition{
-				Id:            "ms-azuretools.vscode-bicep",
+				Id:            "vscode-bicep",
 				Category:      ToolCategoryExtension,
 				DetectCommand: "code",
 				VersionArgs: []string{
@@ -333,6 +333,77 @@ func TestDetectTool_Extension(t *testing.T) {
 			expectError:      true,
 			expectErrContain: "checking PATH",
 		},
+		{
+			name: "CopilotChatFoundCaseInsensitive",
+			tool: &ToolDefinition{
+				Id:            "GitHub.copilot-chat",
+				Category:      ToolCategoryExtension,
+				DetectCommand: "code",
+				VersionArgs: []string{
+					"--list-extensions", "--show-versions",
+				},
+				VersionRegex: `(?i)github\.copilot-chat@(\d+\.\d+\.\d+)`,
+			},
+			setup: func(runner *mockexec.MockCommandRunner) {
+				runner.MockToolInPath("code", nil)
+				runner.When(func(args exec.RunArgs, _ string) bool {
+					return args.Cmd == "code" &&
+						slices.Contains(args.Args, "--list-extensions")
+				}).Respond(exec.RunResult{
+					ExitCode: 0,
+					Stdout: "GitHub.copilot-chat@1.2.3\n" +
+						"ms-python.python@2024.0.1\n",
+				})
+			},
+			expectInstalled: true,
+			expectVersion:   "1.2.3",
+		},
+		{
+			name: "CopilotChatFoundLowerCase",
+			tool: &ToolDefinition{
+				Id:            "GitHub.copilot-chat",
+				Category:      ToolCategoryExtension,
+				DetectCommand: "code",
+				VersionArgs: []string{
+					"--list-extensions", "--show-versions",
+				},
+				VersionRegex: `(?i)github\.copilot-chat@(\d+\.\d+\.\d+)`,
+			},
+			setup: func(runner *mockexec.MockCommandRunner) {
+				runner.MockToolInPath("code", nil)
+				runner.When(func(args exec.RunArgs, _ string) bool {
+					return args.Cmd == "code"
+				}).Respond(exec.RunResult{
+					ExitCode: 0,
+					Stdout:   "github.copilot-chat@0.27.1\n",
+				})
+			},
+			expectInstalled: true,
+			expectVersion:   "0.27.1",
+		},
+		{
+			name: "CopilotChatNotInstalled",
+			tool: &ToolDefinition{
+				Id:            "GitHub.copilot-chat",
+				Category:      ToolCategoryExtension,
+				DetectCommand: "code",
+				VersionArgs: []string{
+					"--list-extensions", "--show-versions",
+				},
+				VersionRegex: `(?i)github\.copilot-chat@(\d+\.\d+\.\d+)`,
+			},
+			setup: func(runner *mockexec.MockCommandRunner) {
+				runner.MockToolInPath("code", nil)
+				runner.When(func(args exec.RunArgs, _ string) bool {
+					return args.Cmd == "code"
+				}).Respond(exec.RunResult{
+					ExitCode: 0,
+					Stdout:   "ms-python.python@2024.0.1\n",
+				})
+			},
+			expectInstalled: false,
+			expectVersion:   "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -364,7 +435,7 @@ func TestDetectTool_Extension(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// DetectTool — Server (commandBased)
+// DetectTool — Server / Library (commandBased)
 // ---------------------------------------------------------------------------
 
 func TestDetectTool_CommandBased(t *testing.T) {
@@ -382,7 +453,7 @@ func TestDetectTool_CommandBased(t *testing.T) {
 		{
 			name: "ServerToolDetected",
 			tool: &ToolDefinition{
-				Id:            "@azure/mcp",
+				Id:            "azure-mcp-server",
 				Category:      ToolCategoryServer,
 				DetectCommand: "npx",
 				VersionArgs:   []string{"@azure/mcp@latest", "--version"},

--- a/cli/azd/pkg/tool/manager_test.go
+++ b/cli/azd/pkg/tool/manager_test.go
@@ -101,10 +101,10 @@ func TestManager_FindTool(t *testing.T) {
 			&mockDetector{}, &mockInstaller{}, nil,
 		)
 
-		tool, err := mgr.FindTool("az")
+		tool, err := mgr.FindTool("az-cli")
 		require.NoError(t, err)
 		require.NotNil(t, tool)
-		assert.Equal(t, "az", tool.Id)
+		assert.Equal(t, "az-cli", tool.Id)
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
@@ -171,7 +171,7 @@ func TestManager_DetectTool(t *testing.T) {
 		}
 
 		mgr := NewManager(det, &mockInstaller{}, nil)
-		status, err := mgr.DetectTool(t.Context(), "az")
+		status, err := mgr.DetectTool(t.Context(), "az-cli")
 
 		require.NoError(t, err)
 		require.NotNil(t, status)
@@ -232,13 +232,13 @@ func TestManager_InstallTools(t *testing.T) {
 		mgr := NewManager(det, inst, nil)
 		results, err := mgr.InstallTools(
 			t.Context(),
-			[]string{"az"},
+			[]string{"az-cli"},
 		)
 
 		require.NoError(t, err)
 		require.Len(t, results, 1)
 		assert.True(t, results[0].Success)
-		assert.Contains(t, installedIDs, "az")
+		assert.Contains(t, installedIDs, "az-cli")
 	})
 
 	t.Run("UnknownIDReturnsError", func(t *testing.T) {
@@ -279,9 +279,9 @@ func TestManager_InstallTools(t *testing.T) {
 				_ context.Context,
 				tool *ToolDefinition,
 			) (*ToolStatus, error) {
-				// az is NOT installed yet, triggering
+				// az-cli is NOT installed yet, triggering
 				// dependency resolution.
-				if tool.Id == "az" {
+				if tool.Id == "az-cli" {
 					return &ToolStatus{
 						Tool:      tool,
 						Installed: false,
@@ -296,19 +296,19 @@ func TestManager_InstallTools(t *testing.T) {
 
 		mgr := NewManager(det, inst, nil)
 
-		// azure.ai.agents depends on az.
+		// azd-ai-extensions depends on az-cli.
 		results, err := mgr.InstallTools(
 			t.Context(),
-			[]string{"azure.ai.agents"},
+			[]string{"azd-ai-extensions"},
 		)
 
 		require.NoError(t, err)
 		require.Len(t, results, 2,
 			"should install dep + requested tool")
 
-		// az should be first (dependency).
-		assert.Equal(t, "az", installedIDs[0])
-		assert.Equal(t, "azure.ai.agents", installedIDs[1])
+		// az-cli should be first (dependency).
+		assert.Equal(t, "az-cli", installedIDs[0])
+		assert.Equal(t, "azd-ai-extensions", installedIDs[1])
 	})
 
 	t.Run("SkipsDependencyAlreadyInstalled", func(t *testing.T) {
@@ -344,13 +344,13 @@ func TestManager_InstallTools(t *testing.T) {
 		mgr := NewManager(det, inst, nil)
 		results, err := mgr.InstallTools(
 			t.Context(),
-			[]string{"azure.ai.agents"},
+			[]string{"azd-ai-extensions"},
 		)
 
 		require.NoError(t, err)
 		// Only 1 result: the requested tool (dep skipped).
 		require.Len(t, results, 1)
-		assert.Equal(t, "azure.ai.agents", results[0].Tool.Id)
+		assert.Equal(t, "azd-ai-extensions", results[0].Tool.Id)
 	})
 
 	t.Run("FailedDependencySkipsDependent", func(t *testing.T) {
@@ -361,7 +361,7 @@ func TestManager_InstallTools(t *testing.T) {
 				_ context.Context,
 				tool *ToolDefinition,
 			) (*InstallResult, error) {
-				if tool.Id == "az" {
+				if tool.Id == "az-cli" {
 					return &InstallResult{
 						Tool:    tool,
 						Success: false,
@@ -380,8 +380,8 @@ func TestManager_InstallTools(t *testing.T) {
 				_ context.Context,
 				tool *ToolDefinition,
 			) (*ToolStatus, error) {
-				// az not installed => triggers dep install.
-				if tool.Id == "az" {
+				// az-cli not installed => triggers dep install.
+				if tool.Id == "az-cli" {
 					return &ToolStatus{
 						Tool:      tool,
 						Installed: false,
@@ -397,7 +397,7 @@ func TestManager_InstallTools(t *testing.T) {
 		mgr := NewManager(det, inst, nil)
 		results, err := mgr.InstallTools(
 			t.Context(),
-			[]string{"azure.ai.agents"},
+			[]string{"azd-ai-extensions"},
 		)
 
 		require.NoError(t, err)
@@ -441,13 +441,13 @@ func TestManager_UpgradeTools(t *testing.T) {
 
 		results, err := mgr.UpgradeTools(
 			t.Context(),
-			[]string{"az", "copilot"},
+			[]string{"az-cli", "github-copilot-cli"},
 		)
 
 		require.NoError(t, err)
 		require.Len(t, results, 2)
-		assert.Contains(t, upgradedIDs, "az")
-		assert.Contains(t, upgradedIDs, "copilot")
+		assert.Contains(t, upgradedIDs, "az-cli")
+		assert.Contains(t, upgradedIDs, "github-copilot-cli")
 	})
 
 	t.Run("UnknownIDReturnsError", func(t *testing.T) {

--- a/cli/azd/pkg/tool/manifest.go
+++ b/cli/azd/pkg/tool/manifest.go
@@ -68,7 +68,7 @@ type InstallStrategy struct {
 
 // ToolDefinition is the complete metadata for a single tool in the registry.
 type ToolDefinition struct {
-	// Id is the unique identifier for the tool (e.g. "az").
+	// Id is the unique, kebab-case identifier for the tool (e.g. "az-cli").
 	Id string
 	// Name is the human-readable display name.
 	Name string
@@ -141,7 +141,7 @@ var builtInTools = []*ToolDefinition{
 
 func azCLI() *ToolDefinition {
 	return &ToolDefinition{
-		Id:            "az",
+		Id:            "az-cli",
 		Name:          "Azure CLI",
 		Description:   "The Azure command-line interface for managing Azure resources.",
 		Category:      ToolCategoryCLI,
@@ -169,12 +169,12 @@ func azCLI() *ToolDefinition {
 
 func githubCopilotCLI() *ToolDefinition {
 	return &ToolDefinition{
-		Id:            "copilot",
+		Id:            "github-copilot-cli",
 		Name:          "GitHub Copilot CLI",
 		Description:   "AI-powered CLI assistant from GitHub Copilot.",
 		Category:      ToolCategoryCLI,
 		Priority:      ToolPriorityRecommended,
-		Website:       "https://docs.github.com/copilot/github-copilot-in-the-cli",
+		Website:       "https://docs.github.com/copilot/how-tos/set-up/install-copilot-cli",
 		DetectCommand: "copilot",
 		VersionArgs:   []string{"--version"},
 		VersionRegex:  `(\d+\.\d+\.\d+)`,
@@ -198,7 +198,7 @@ func githubCopilotCLI() *ToolDefinition {
 
 func vscodeAzureTools() *ToolDefinition {
 	return &ToolDefinition{
-		Id:   "ms-azuretools.vscode-azureresourcegroups",
+		Id:   "vscode-azure-tools",
 		Name: "Azure Tools VS Code Extension",
 		Description: "VS Code extension for browsing and managing " +
 			"Azure resources.",
@@ -217,7 +217,7 @@ func vscodeAzureTools() *ToolDefinition {
 
 func vscodeBicep() *ToolDefinition {
 	return &ToolDefinition{
-		Id:            "ms-azuretools.vscode-bicep",
+		Id:            "vscode-bicep",
 		Name:          "Bicep VS Code Extension",
 		Description:   "VS Code extension providing language support for Azure Bicep.",
 		Category:      ToolCategoryExtension,
@@ -235,25 +235,26 @@ func vscodeBicep() *ToolDefinition {
 
 func vscodeGitHubCopilot() *ToolDefinition {
 	return &ToolDefinition{
-		Id:            "GitHub.copilot",
-		Name:          "GitHub Copilot VS Code Extension",
-		Description:   "VS Code extension for AI-powered code completions.",
+		Id:            "GitHub.copilot-chat",
+		Name:          "GitHub Copilot Chat VS Code Extension",
+		Description:   "VS Code extension for AI-powered code completions, chat, and agent mode.",
 		Category:      ToolCategoryExtension,
 		Priority:      ToolPriorityOptional,
-		Website:       "https://marketplace.visualstudio.com/items?itemName=GitHub.copilot",
+		Website:       "https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat",
 		DetectCommand: "code",
 		VersionArgs:   []string{"--list-extensions", "--show-versions"},
-		VersionRegex:  `(?i)github\.copilot(?:-chat)?@(\d+\.\d+\.\d+)`,
+		VersionRegex:  `(?i)github\.copilot-chat@(\d+\.\d+\.\d+)`,
 		InstallStrategies: allPlatforms(InstallStrategy{
 			PackageManager: "code",
-			PackageId:      "GitHub.copilot",
+			PackageId:      "GitHub.copilot-chat",
+			FallbackUrl:    "https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat",
 		}),
 	}
 }
 
 func azureMCPServer() *ToolDefinition {
 	return &ToolDefinition{
-		Id:            "@azure/mcp",
+		Id:            "azure-mcp-server",
 		Name:          "Azure MCP Server",
 		Description:   "Model Context Protocol server for Azure resource interaction.",
 		Category:      ToolCategoryServer,
@@ -272,7 +273,7 @@ func azureMCPServer() *ToolDefinition {
 
 func azdAIExtensions() *ToolDefinition {
 	return &ToolDefinition{
-		Id:            "azure.ai.agents",
+		Id:            "azd-ai-extensions",
 		Name:          "azd AI Extensions",
 		Description:   "Azure Developer CLI extensions for AI agent workflows.",
 		Category:      ToolCategoryLibrary,
@@ -283,7 +284,7 @@ func azdAIExtensions() *ToolDefinition {
 		InstallStrategies: allPlatforms(InstallStrategy{
 			InstallCommand: "azd extension install azure.ai.agents",
 		}),
-		Dependencies: []string{"az"},
+		Dependencies: []string{"az-cli"},
 	}
 }
 

--- a/cli/azd/pkg/tool/manifest_test.go
+++ b/cli/azd/pkg/tool/manifest_test.go
@@ -24,13 +24,13 @@ func TestBuiltInTools(t *testing.T) {
 		t.Parallel()
 
 		expectedIDs := []string{
-			"az",
-			"copilot",
-			"ms-azuretools.vscode-azureresourcegroups",
-			"ms-azuretools.vscode-bicep",
-			"GitHub.copilot",
-			"@azure/mcp",
-			"azure.ai.agents",
+			"az-cli",
+			"github-copilot-cli",
+			"vscode-azure-tools",
+			"vscode-bicep",
+			"GitHub.copilot-chat",
+			"azure-mcp-server",
+			"azd-ai-extensions",
 		}
 
 		tools := BuiltInTools()
@@ -146,28 +146,28 @@ func TestFindTool(t *testing.T) {
 	}{
 		{
 			name:     "FindsAzCLI",
-			id:       "az",
-			expectId: "az",
+			id:       "az-cli",
+			expectId: "az-cli",
 		},
 		{
 			name:     "FindsGitHubCopilotCLI",
-			id:       "copilot",
-			expectId: "copilot",
+			id:       "github-copilot-cli",
+			expectId: "github-copilot-cli",
 		},
 		{
 			name:     "FindsVSCodeExtension",
-			id:       "ms-azuretools.vscode-azureresourcegroups",
-			expectId: "ms-azuretools.vscode-azureresourcegroups",
+			id:       "vscode-azure-tools",
+			expectId: "vscode-azure-tools",
 		},
 		{
 			name:     "FindsMCPServer",
-			id:       "@azure/mcp",
-			expectId: "@azure/mcp",
+			id:       "azure-mcp-server",
+			expectId: "azure-mcp-server",
 		},
 		{
 			name:     "FindsAzdAIExtensions",
-			id:       "azure.ai.agents",
-			expectId: "azure.ai.agents",
+			id:       "azd-ai-extensions",
+			expectId: "azd-ai-extensions",
 		},
 		{
 			name:      "ReturnsNilForUnknownID",
@@ -209,13 +209,13 @@ func TestFindToolsByCategory(t *testing.T) {
 			assert.Equal(t, ToolCategoryCLI, tool.Category)
 		}
 
-		// Known CLI tools: az, copilot
+		// Known CLI tools: az-cli, github-copilot-cli
 		ids := make([]string, len(tools))
 		for i, tool := range tools {
 			ids[i] = tool.Id
 		}
-		assert.Contains(t, ids, "az")
-		assert.Contains(t, ids, "copilot")
+		assert.Contains(t, ids, "az-cli")
+		assert.Contains(t, ids, "github-copilot-cli")
 	})
 
 	t.Run("ReturnsExtensionTools", func(t *testing.T) {
@@ -279,7 +279,7 @@ func TestSpecificToolDefinitions(t *testing.T) {
 	t.Run("AzCLIHasCorrectFields", func(t *testing.T) {
 		t.Parallel()
 
-		tool := FindTool("az")
+		tool := FindTool("az-cli")
 		require.NotNil(t, tool)
 
 		assert.Equal(t, "Azure CLI", tool.Name)
@@ -301,10 +301,10 @@ func TestSpecificToolDefinitions(t *testing.T) {
 	t.Run("AzdAIExtensionsHasDependency", func(t *testing.T) {
 		t.Parallel()
 
-		tool := FindTool("azure.ai.agents")
+		tool := FindTool("azd-ai-extensions")
 		require.NotNil(t, tool)
 
-		assert.Contains(t, tool.Dependencies, "az")
+		assert.Contains(t, tool.Dependencies, "az-cli")
 	})
 
 	t.Run("VSCodeExtensionsUseCodeDetectCommand", func(t *testing.T) {

--- a/cli/azd/pkg/tool/platform_test.go
+++ b/cli/azd/pkg/tool/platform_test.go
@@ -301,7 +301,7 @@ func TestSelectStrategy(t *testing.T) {
 	t.Run("WorksWithBuiltInToolDefinitions", func(t *testing.T) {
 		t.Parallel()
 
-		azTool := FindTool("az")
+		azTool := FindTool("az-cli")
 		require.NotNil(t, azTool)
 
 		platform := &Platform{


### PR DESCRIPTION
## Summary

Fixes #8069

Updates the GitHub Copilot tool definitions in the `azd tool` command group to reflect current extension status.

## Changes

### 1. Replace deprecated `GitHub.copilot` VS Code extension with `GitHub.copilot-chat`

The `GitHub.copilot` VS Code extension is being phased out — its functionality is being absorbed into `GitHub.copilot-chat`, which is also now built into VS Code 1.99+. The associated feedback repository (`microsoft/vscode-copilot-release`) has been officially deprecated.

Updated fields:
- **Id**: `GitHub.copilot` → `GitHub.copilot-chat`
- **Name/Description**: Reflects Copilot Chat capabilities (completions, chat, agent mode)
- **Website**: Points to the active `GitHub.copilot-chat` marketplace page
- **PackageId**: Installs `GitHub.copilot-chat` instead of deprecated extension
- **VersionRegex**: Matches `copilot-chat` specifically
- **FallbackUrl**: Added for better error messaging when `code` CLI is unavailable

### 2. Fix deprecated Copilot CLI website URL

The `copilot` CLI tool's `Website` field pointed to `https://docs.github.com/copilot/github-copilot-in-the-cli` — a stub/tombstone page for the old `gh copilot` CLI extension. Updated to `https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli` (the current install docs for the standalone Copilot CLI).

## Testing

- `go build ./...` ✅
- `go test ./pkg/tool/... -v -count=1` ✅
- `golangci-lint run ./pkg/tool/...` ✅ (0 issues)
- `cspell check ./pkg/tool/manifest.go` ✅
- `gofmt` ✅
